### PR TITLE
[Tizen] Enable QEMU RTC driver to sync time on boot

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-81 : [Telink] Update Docker image (Zephyr update)
+82 : [Tizen] Enable RTC driver to sync time on boot

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -46,23 +46,25 @@ RUN set -x \
     && cd *linux-kernel-* \
     && zcat ../*-to-*.diff.gz | patch -p1 \
     && patch -p1 < $TIZEN_SDK_ROOT/files/0001-smack-add-permissive-mode.patch \
-    # Compile
+    # Configure
     && export MAKEFLAGS=-j$(nproc) \
     && export ARCH=arm CROSS_COMPILE=arm-linux-gnueabi- \
     && make tizen_bcm2711_defconfig \
-    && ./scripts/config -e ARCH_VIRT \
-    && ./scripts/config -e VIRTIO_MMIO -e HW_RANDOM_VIRTIO \
+    # Add support for QEMU VirtIO devices
+    && ./scripts/config -e ARCH_VIRT -e VIRTIO_MMIO \
     && ./scripts/config -e VIRTIO_PCI -e VIRTIO_BLK \
     && ./scripts/config -e VIRTIO_NET -e VETH \
-    && ./scripts/config -e IKCONFIG -e IKCONFIG_PROC \
+    && ./scripts/config -e HW_RANDOM_VIRTIO \
+    # Use ARM PL031 RTC and synchronize time during boot
+    && ./scripts/config -e RTC_DRV_PL031 -e RTC_HCTOSYS \
+    # Enable vHCI driver to add support for Bluetooth virtualization
     && ./scripts/config -e BT_HCIVHCI -e CRYPTO_USER_API_HASH -e CRYPTO_USER_API_SKCIPHER \
-    && ./scripts/config -e OVERLAY_FS \
-    && ./scripts/config -e SECURITY_SMACK_PERMISSIVE_MODE \
-    && ./scripts/config -e NET_9P -e NET_9P_VIRTIO \
-    && ./scripts/config -e INET \
-    && ./scripts/config -e 9P_FS -e 9P_FS_POSIX_ACL \
-    && ./scripts/config -e PCI_HOST_GENERIC \
+    # Enable overlay FS and disable SMACK to workaround permission issues
+    && ./scripts/config -e OVERLAY_FS -e SECURITY_SMACK_PERMISSIVE_MODE \
+    # Enable 9P filesystem support to share files between host and guest
+    && ./scripts/config -e INET -e PCI_HOST_GENERIC -e NET_9P -e NET_9P_VIRTIO -e 9P_FS \
     && make olddefconfig \
+    # Compile
     && make -j$(nproc) zImage \
     && mv arch/arm/boot/zImage $TIZEN_IOT_QEMU_KERNEL \
     # Cleanup


### PR DESCRIPTION
### Problem

Tizen QEMU test sometimes fails because during commissioning it's not possible to verify certificate. That happens because Tizen QEMU guest is too slow to synchronize time over NTP.

### Changes

- Synchronize system time with QEMU provided RTC on boot time, instead of using NTP

### Testing

Verified locally that guest has recent date without network enabled.