### PR TITLE
[Matter.framework] When the device is entering suspended state and at…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -2404,8 +2404,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                            NSNumber * _Nullable retryDelay) {
                            if (error != nil) {
                                MTR_LOG_ERROR("%@ getSessionForNode error %@", self, error);
-                               [self _handleSubscriptionError:error];
-                               [self _handleSubscriptionReset:retryDelay];
+                               [self->_deviceController asyncDispatchToMatterQueue:^{
+                                   [self _handleSubscriptionError:error];
+                                   [self _handleSubscriptionReset:retryDelay];
+                               } errorHandler:nil];
                                return;
                            }
 


### PR DESCRIPTION
… the same time _ensureSubscriptionForExistingDelegates is called with an error from getting a session it crashes with _os_unfair_lock_recursive_abort since it is called on the same thread and the error handling code also try to get a lock

#### Problem

While attempting to reproduce a specific memory leak with Darwin-framework-tool, I encountered a crash caused by a recursive lock issue.

In essence, this occurs because, when the tool is suspended, directlyGetSessionForNode returns synchronously. However, the code that triggered this behavior already held the lock, and the code managing subscription errors also attempts to acquire the same lock.

When this happens, the thread states are as follows:
```
thread #1, queue = 'com.apple.main-thread'
    frame #0: 0x000000018c3a3c7c libsystem_kernel.dylib`__ulock_wait2 + 8
    frame #1: 0x000000018c409e4c libsystem_platform.dylib`_os_unfair_lock_lock_slow + 180
    frame #2: 0x00000001056849a4 Matter`std::__1::lock_guard<os_unfair_lock_s>::lock_guard(this=0x000000016fdfd968, lock=0x0000000137f04e48) at MTRUnfairLock.h:29:64
    frame #3: 0x000000010568089c Matter`std::__1::lock_guard<os_unfair_lock_s>::lock_guard(this=0x000000016fdfd968, lock=0x0000000137f04e48) at MTRUnfairLock.h:29:62
    frame #4: 0x000000010647c658 Matter`-[MTRDevice_Concrete controllerSuspended](self=0x0000000137f04e40, _cmd="controllerSuspended") at MTRDevice_Concrete.mm:4132:21
    frame #5: 0x00000001059e6390 Matter`-[MTRDeviceController suspend](self=0x0000000148033c00, _cmd="suspend") at MTRDeviceController.mm:256:9
    frame #6: 0x000000010007e130 darwin-framework-tool`CHIPCommandBridge::MaybeSetUpStack(this=0x0000000137e20c20) at CHIPCommandBridge.mm:249:5
    frame #7: 0x000000010007d134 darwin-framework-tool`CHIPCommandBridge::Run(this=0x0000000137e20c20) at CHIPCommandBridge.mm:101:5
    frame #8: 0x000000010003ce44 darwin-framework-tool`Commands::RunCommand(this=0x000000016fdfea90, argc=10, argv=0x000000016fdfed20, interactive=false, interactiveStorageDirectory=0x000000016fdfe938, interactiveAdvertiseOperational=false) at Commands.cpp:331:21
    frame #9: 0x000000010003bf18 darwin-framework-tool`Commands::Run(this=0x000000016fdfea90, argc=10, argv=0x000000016fdfed20) at Commands.cpp:178:11
    frame #10: 0x000000010016e89c darwin-framework-tool`main(argc=10, argv=0x000000016fdfed20) at main.mm:55:29
    frame #11: 0x000000018c054274 dyld`start + 2840

* thread #2, queue = 'org.csa-iot.matter.workqueue', stop reason = EXC_BREAKPOINT (code=1, subcode=0x18c40f04c)
    frame #0: 0x000000018c40f04c libsystem_platform.dylib`_os_unfair_lock_recursive_abort + 36
    frame #1: 0x000000018c409ecc libsystem_platform.dylib`_os_unfair_lock_lock_slow + 308
    frame #2: 0x00000001056849a4 Matter`std::__1::lock_guard<os_unfair_lock_s>::lock_guard(this=0x000000016fe85b60, lock=0x0000000137f04e48) at MTRUnfairLock.h:29:64
    frame #3: 0x000000010568089c Matter`std::__1::lock_guard<os_unfair_lock_s>::lock_guard(this=0x000000016fe85b60, lock=0x0000000137f04e48) at MTRUnfairLock.h:29:62
    frame #4: 0x000000010645abcc Matter`-[MTRDevice_Concrete _handleSubscriptionError:](self=0x0000000137f04e40, _cmd="_handleSubscriptionError:", error=domain: "MTRErrorDomain" - code: 6) at MTRDevice_Concrete.mm:1082:21
  * frame #5: 0x0000000106467b70 Matter`__51-[MTRDevice_Concrete _setupSubscriptionWithReason:]_block_invoke.214(.block_descriptor=0x000000016fe86590, exchangeManager=0x0000000000000000, session=0x000000016fe86380, error=domain: "MTRErrorDomain" - code: 6, retryDelay=0x0000000000000000) at MTRDevice_Concrete.mm:2400:32
    frame #6: 0x0000000106228ccc Matter`-[MTRDeviceController_Concrete directlyGetSessionForNode:completion:](self=0x0000000148033c00, _cmd="directlyGetSessionForNode:completion:", nodeID=305414945, completion=0x00000001064679c8) at MTRDeviceController_Concrete.mm:1421:9
    frame #7: 0x00000001064674ec Matter`-[MTRDevice_Concrete _setupSubscriptionWithReason:](self=0x0000000137f04e40, _cmd="_setupSubscriptionWithReason:", reason="delegate is set and scheduled subscription is happening") at MTRDevice_Concrete.mm:2393:5
    frame #8: 0x0000000106458b80 Matter`__62-[MTRDevice_Concrete _ensureSubscriptionForExistingDelegates:]_block_invoke_2(.block_descriptor=0x0000600003e2cf60) at MTRDevice_Concrete.mm:763:21
    frame #9: 0x0000000106229f5c Matter`__72-[MTRDeviceController_Concrete asyncDispatchToMatterQueue:errorHandler:]_block_invoke(.block_descriptor=0x0000600003e2cf30, (null)=0x0000000148037e00) at MTRDeviceController_Concrete.mm:1513:9
    frame #10: 0x0000000106229d54 Matter`__79-[MTRDeviceController_Concrete asyncGetCommissionerOnMatterQueue:errorHandler:]_block_invoke(.block_descriptor=0x000060000252c600) at MTRDeviceController_Concrete.mm:1506:9
    frame #11: 0x000000018c2228f8 libdispatch.dylib`_dispatch_call_block_and_release + 32
    frame #12: 0x000000018c224658 libdispatch.dylib`_dispatch_client_callout + 20
    frame #13: 0x000000018c22bc60 libdispatch.dylib`_dispatch_lane_serial_drain + 744
    frame #14: 0x000000018c22c79c libdispatch.dylib`_dispatch_lane_invoke + 432
    frame #15: 0x000000018c2377e8 libdispatch.dylib`_dispatch_root_queue_drain_deferred_wlh + 288
    frame #16: 0x000000018c237034 libdispatch.dylib`_dispatch_workloop_worker_thread + 540
    frame #17: 0x000000018c3d33d8 libsystem_pthread.dylib`_pthread_wqthread + 288
```