### PR TITLE
[Fabric-Sync] Use aggregator endpoint instead of root endpoint for CCTRL

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -30,6 +30,7 @@ using namespace chip::app::Clusters;
 
 namespace {
 
+constexpr EndpointId kAggregatorEndpointId = 1;
 constexpr uint16_t kWindowTimeout          = 300;
 constexpr uint16_t kIteration              = 1000;
 constexpr uint16_t kSubscribeMinInterval   = 0;
@@ -207,7 +208,7 @@ void DeviceManager::SubscribeRemoteFabricBridge()
     // Prepare and push the commissioner control subscribe command
     commandBuilder.Add("commissionercontrol subscribe-event commissioning-request-result ");
     commandBuilder.AddFormat("%d %d %lu %d --is-urgent true --keepSubscriptions true", kSubscribeMinInterval, kSubscribeMaxInterval,
-                             mRemoteBridgeNodeId, kRootEndpointId);
+                             mRemoteBridgeNodeId, kAggregatorEndpointId);
     PushCommand(commandBuilder.c_str());
 }
 
@@ -224,7 +225,7 @@ void DeviceManager::ReadSupportedDeviceCategories()
 
     commandBuilder.Add("commissionercontrol read supported-device-categories ");
     commandBuilder.AddFormat("%ld ", mRemoteBridgeNodeId);
-    commandBuilder.AddFormat("%d", kRootEndpointId);
+    commandBuilder.AddFormat("%d", kAggregatorEndpointId);
 
     PushCommand(commandBuilder.c_str());
 }
@@ -259,7 +260,7 @@ void DeviceManager::RequestCommissioningApproval()
 
     StringBuilder<kMaxCommandSize> commandBuilder;
     commandBuilder.Add("commissionercontrol request-commissioning-approval ");
-    commandBuilder.AddFormat("%lu %u %u %lu %d", requestId, vendorId, productId, mRemoteBridgeNodeId, kRootEndpointId);
+    commandBuilder.AddFormat("%lu %u %u %lu %d", requestId, vendorId, productId, mRemoteBridgeNodeId, kAggregatorEndpointId);
 
     mRequestId = requestId;
     PushCommand(commandBuilder.c_str());
@@ -398,7 +399,7 @@ void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t respo
 
     StringBuilder<kMaxCommandSize> commandBuilder;
     commandBuilder.Add("commissionercontrol commission-node ");
-    commandBuilder.AddFormat("%lu %u %lu %d", requestId, responseTimeoutSeconds, mRemoteBridgeNodeId, kRootEndpointId);
+    commandBuilder.AddFormat("%lu %u %lu %d", requestId, responseTimeoutSeconds, mRemoteBridgeNodeId, kAggregatorEndpointId);
 
     PushCommand(commandBuilder.c_str());
 }

--- a/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
+++ b/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.matter
@@ -2059,21 +2059,6 @@ endpoint 0 {
     handle command KeySetReadAllIndices;
     handle command KeySetReadAllIndicesResponse;
   }
-
-  server cluster CommissionerControl {
-    emits event CommissioningRequestResult;
-    ram      attribute supportedDeviceCategories default = 0;
-    callback attribute generatedCommandList;
-    callback attribute acceptedCommandList;
-    callback attribute eventList;
-    callback attribute attributeList;
-    ram      attribute featureMap default = 0;
-    ram      attribute clusterRevision default = 1;
-
-    handle command RequestCommissioningApproval;
-    handle command CommissionNode;
-    handle command ReverseOpenCommissioningWindow;
-  }
 }
 endpoint 1 {
   device type ma_aggregator = 14, version 1;
@@ -2102,6 +2087,21 @@ endpoint 1 {
     callback attribute attributeList;
     callback attribute featureMap;
     callback attribute clusterRevision;
+  }
+
+  server cluster CommissionerControl {
+    emits event CommissioningRequestResult;
+    ram      attribute supportedDeviceCategories default = 0;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute eventList;
+    callback attribute attributeList;
+    ram      attribute featureMap default = 0;
+    ram      attribute clusterRevision default = 1;
+
+    handle command RequestCommissioningApproval;
+    handle command CommissionNode;
+    handle command ReverseOpenCommissioningWindow;
   }
 }
 

--- a/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.zap
+++ b/examples/fabric-bridge-app/fabric-bridge-common/fabric-bridge-app.zap
@@ -3969,164 +3969,6 @@
               "reportableChange": 0
             }
           ]
-        },
-        {
-          "name": "Commissioner Control",
-          "code": 1873,
-          "mfgCode": null,
-          "define": "COMMISSIONER_CONTROL_CLUSTER",
-          "side": "server",
-          "enabled": 1,
-          "apiMaturity": "provisional",
-          "commands": [
-            {
-              "name": "RequestCommissioningApproval",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
-              "name": "CommissionNode",
-              "code": 1,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
-              "name": "ReverseOpenCommissioningWindow",
-              "code": 2,
-              "mfgCode": null,
-              "source": "server",
-              "isIncoming": 0,
-              "isEnabled": 1
-            }
-          ],
-          "attributes": [
-            {
-              "name": "SupportedDeviceCategories",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "type": "SupportedDeviceCategoryBitmap",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "GeneratedCommandList",
-              "code": 65528,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": null,
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "AcceptedCommandList",
-              "code": 65529,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": null,
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "EventList",
-              "code": 65530,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": null,
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "AttributeList",
-              "code": 65531,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": null,
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "FeatureMap",
-              "code": 65532,
-              "mfgCode": null,
-              "side": "server",
-              "type": "bitmap32",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "ClusterRevision",
-              "code": 65533,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int16u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "1",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            }
-          ],
-          "events": [
-            {
-              "name": "CommissioningRequestResult",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "included": 1
-            }
-          ]
         }
       ]
     },
@@ -4448,6 +4290,163 @@
               "minInterval": 1,
               "maxInterval": 65534,
               "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Commissioner Control",
+          "code": 1873,
+          "mfgCode": null,
+          "define": "COMMISSIONER_CONTROL_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "RequestCommissioningApproval",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "CommissionNode",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "ReverseOpenCommissioningWindow",
+              "code": 2,
+              "mfgCode": null,
+              "source": "server",
+              "isIncoming": 0,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "SupportedDeviceCategories",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "SupportedDeviceCategoryBitmap",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ],
+          "events": [
+            {
+              "name": "CommissioningRequestResult",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "included": 1
             }
           ]
         }

--- a/examples/fabric-bridge-app/linux/CommissionerControl.cpp
+++ b/examples/fabric-bridge-app/linux/CommissionerControl.cpp
@@ -116,7 +116,7 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissioningApprovalRequest(const
         mLabel.ClearValue();
     }
 
-    CHIP_ERROR err = CommissionerControlServer::Instance().GenerateCommissioningRequestResultEvent(result);
+    CHIP_ERROR err = CommissionerControlServer::Instance().GenerateCommissioningRequestResultEvent(kAggregatorEndpointId, result);
 
     if (err == CHIP_NO_ERROR)
     {
@@ -241,7 +241,7 @@ CHIP_ERROR CommissionerControlInit()
 
     Protocols::InteractionModel::Status status =
         Clusters::CommissionerControl::CommissionerControlServer::Instance().SetSupportedDeviceCategoriesValue(
-            kRootEndpointId, supportedDeviceCategories);
+            Clusters::CommissionerControl::kAggregatorEndpointId, supportedDeviceCategories);
 
     if (status != Protocols::InteractionModel::Status::Success)
     {

--- a/examples/fabric-bridge-app/linux/include/CommissionerControl.h
+++ b/examples/fabric-bridge-app/linux/include/CommissionerControl.h
@@ -26,6 +26,8 @@ namespace app {
 namespace Clusters {
 namespace CommissionerControl {
 
+inline constexpr EndpointId kAggregatorEndpointId = 1;
+
 class CommissionerControlDelegate : public Delegate
 {
 public:

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
@@ -132,10 +132,11 @@ CommissionerControlServer::SetSupportedDeviceCategoriesValue(EndpointId endpoint
 }
 
 CHIP_ERROR
-CommissionerControlServer::GenerateCommissioningRequestResultEvent(const Events::CommissioningRequestResult::Type & result)
+CommissionerControlServer::GenerateCommissioningRequestResultEvent(EndpointId endpoint,
+                                                                   const Events::CommissioningRequestResult::Type & result)
 {
     EventNumber eventNumber;
-    CHIP_ERROR error = LogEvent(result, kRootEndpointId, eventNumber);
+    CHIP_ERROR error = LogEvent(result, endpoint, eventNumber);
     if (CHIP_NO_ERROR != error)
     {
         ChipLogError(Zcl, "CommissionerControl: Unable to emit CommissioningRequestResult event: %" CHIP_ERROR_FORMAT,

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.h
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.h
@@ -120,7 +120,8 @@ public:
      * @brief
      *   Called after the server return SUCCESS to a correctly formatted RequestCommissioningApproval command.
      */
-    CHIP_ERROR GenerateCommissioningRequestResultEvent(const Events::CommissioningRequestResult::Type & result);
+    CHIP_ERROR GenerateCommissioningRequestResultEvent(EndpointId endpoint,
+                                                       const Events::CommissioningRequestResult::Type & result);
 
 private:
     CommissionerControlServer()  = default;

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -194,7 +194,7 @@ class TC_CCTRL_2_2(MatterBaseTest):
         self.step(9)
         cmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
         # If no exception is raised, this is success
-        await self.send_single_cmd(cmd, timedRequestTimeoutMs=5000)
+        await self.send_single_cmd(cmd, endpoint=0, timedRequestTimeoutMs=5000)
 
         self.step(10)
         if not events:

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -125,7 +125,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
     @async_test_body
     async def test_TC_MCORE_FS_1_1(self):
         # TODO this value should either be determined or passed in from command line
-        dut_commissioning_control_endpoint = 0
+        dut_commissioning_control_endpoint = 1
         self.step(1)
         self.step(2)
         self.step(3)

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -54,6 +54,8 @@ from chip.testing.apps import AppServerSubprocess
 from matter_testing_support import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
 from mobly import asserts
 
+_DEVICE_TYPE_AGGREGATOR = 0x000E
+
 
 class TC_MCORE_FS_1_3(MatterBaseTest):
 
@@ -109,8 +111,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
                      "TH verifies a value is visible for the UniqueID from the DUT_FSA's Bridged Device Basic Information Cluster."),
         ]
 
-    # TODO: Dynamically identify the endpoint hosting the aggregator at runtime. (#35976)
-    async def commission_via_commissioner_control(self, controller_node_id: int, device_node_id: int):
+    async def commission_via_commissioner_control(self, controller_node_id: int, device_node_id: int, endpoint_id: int):
         """Commission device_node_id to controller_node_id using CommissionerControl cluster."""
 
         request_id = random.randint(0, 0xFFFFFFFFFFFFFFFF)
@@ -129,7 +130,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
 
         await self.send_single_cmd(
             node_id=controller_node_id,
-            endpoint=1,
+            endpoint=endpoint_id,
             cmd=Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
                 requestID=request_id,
                 vendorID=vendor_id,
@@ -142,7 +143,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
 
         resp = await self.send_single_cmd(
             node_id=controller_node_id,
-            endpoint=1,
+            endpoint=endpoint_id,
             cmd=Clusters.CommissionerControl.Commands.CommissionNode(
                 requestID=request_id,
                 responseTimeoutSeconds=30,
@@ -197,9 +198,30 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
             endpoint=0,
         ))
 
+        aggregator_endpoint = 0
+
+        # Iterate through the endpoints on the DUT_FSA_BRIDGE
+        for endpoint in dut_fsa_bridge_endpoints:
+            # Read the DeviceTypeList attribute for the current endpoint
+            device_type_list = await self.read_single_attribute_check_success(
+                cluster=Clusters.Descriptor,
+                attribute=Clusters.Descriptor.Attributes.DeviceTypeList,
+                node_id=self.dut_node_id,
+                endpoint=endpoint
+            )
+
+            # Check if any of the device types is an AGGREGATOR
+            if any(device_type.deviceType == _DEVICE_TYPE_AGGREGATOR for device_type in device_type_list):
+                aggregator_endpoint = endpoint
+                logging.info(f"Aggregator endpoint found: {aggregator_endpoint}")
+                break
+
+        asserts.assert_not_equal(aggregator_endpoint, 0, "Invalid aggregator endpoint. Cannot proceed with commissioning.")
+
         await self.commission_via_commissioner_control(
             controller_node_id=self.dut_node_id,
-            device_node_id=th_server_th_node_id)
+            device_node_id=th_server_th_node_id,
+            endpoint_id=aggregator_endpoint)
 
         # Wait for the device to appear on the DUT_FSA_BRIDGE.
         await asyncio.sleep(2 if self.is_pics_sdk_ci_only else 30)

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -109,6 +109,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
                      "TH verifies a value is visible for the UniqueID from the DUT_FSA's Bridged Device Basic Information Cluster."),
         ]
 
+    # TODO: Dynamically identify the endpoint hosting the aggregator at runtime. (#35976)
     async def commission_via_commissioner_control(self, controller_node_id: int, device_node_id: int):
         """Commission device_node_id to controller_node_id using CommissionerControl cluster."""
 
@@ -128,6 +129,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
 
         await self.send_single_cmd(
             node_id=controller_node_id,
+            endpoint=1,
             cmd=Clusters.CommissionerControl.Commands.RequestCommissioningApproval(
                 requestID=request_id,
                 vendorID=vendor_id,
@@ -140,6 +142,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
 
         resp = await self.send_single_cmd(
             node_id=controller_node_id,
+            endpoint=1,
             cmd=Clusters.CommissionerControl.Commands.CommissionNode(
                 requestID=request_id,
                 responseTimeoutSeconds=30,


### PR DESCRIPTION
With the latest update to the FS system diagram in the specification, it is now explicitly required that CCTRL be enabled on the endpoint hosting the aggregator.

CCTRL is a feature of the Aggregator device type when FS is enabled and must be activated on the corresponding endpoint. 

In the example apps, the Aggregator is statically configured on Endpoint 1 using zap, and the Aggregator endpoint is statically set. The next optimization should enable the Fabric-Admin to dynamically identify the endpoint hosting the aggregator at runtime. (https://github.com/project-chip/connectedhomeip/issues/35976)