### PR TITLE
[Matter.framework] Prevent a leak when using the _subscriptionPoolWor…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -757,7 +757,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         }
         if ([self _deviceUsesThread]) {
             MTR_LOG(" => %@ - device is a thread device, scheduling in pool", self);
+            mtr_weakify(self);
             [self _scheduleSubscriptionPoolWork:^{
+                mtr_strongify(self);
                 [self->_deviceController asyncDispatchToMatterQueue:^{
                     std::lock_guard lock(self->_lock);
                     [self _setupSubscriptionWithReason:[NSString stringWithFormat:@"%@ and scheduled subscription is happening", reason]];
@@ -1165,10 +1167,13 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         return;
     }
 
+    mtr_weakify(self);
     dispatch_block_t workBlockToQueue = ^{
+        mtr_strongify(self);
         // In the case where a resubscription triggering event happened and already established, running the work block should result in a no-op
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull completion) {
+            mtr_strongify(self);
             MTR_LOG("%@ - work item is ready to attempt pooled subscription", self);
             os_unfair_lock_lock(&self->_lock);
 #ifdef DEBUG
@@ -1246,7 +1251,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     // Use the existing _triggerResubscribeWithReason mechanism, which does the right checks when
     // this block is run -- if other triggering events had happened, this would become a no-op.
+    mtr_weakify(self);
     auto resubscriptionBlock = ^{
+        mtr_strongify(self);
         [self->_deviceController asyncDispatchToMatterQueue:^{
             [self _triggerResubscribeWithReason:@"ResubscriptionNeeded timer fired" nodeLikelyReachable:NO];
         } errorHandler:^(NSError * _Nonnull error) {
@@ -1357,7 +1364,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     // Call _reattemptSubscriptionNowIfNeededWithReason when timer fires - if subscription is
     // in a better state at that time this will be a no-op.
+    mtr_weakify(self);
     auto resubscriptionBlock = ^{
+        mtr_strongify(self);
         [self->_deviceController asyncDispatchToMatterQueue:^{
             std::lock_guard lock(self->_lock);
             [self _reattemptSubscriptionNowIfNeededWithReason:@"got subscription reset"];


### PR DESCRIPTION
…kCompletionBlock

#### Problem

Using the subscription pools introduces a reference cycle, which eventually leads to a memory leak.

```
Process 99678: 2446 nodes malloced for 427 KB
Process 99678: 27 leaks for 5488 total leaked bytes.

    27 (5.36K) ROOT CYCLE: <MTRDeviceController_Concrete 0x122029a00> [3584]
       14 (1.08K) __strong _concurrentSubscriptionPool --> ROOT CYCLE: <MTRAsyncWorkQueue 0x6000000f9710> [48]
          13 (1.03K) __strong _items --> ROOT CYCLE: <NSMutableArray 0x6000000f9800> [48]  item count: 1
             12 (1008 bytes) ROOT CYCLE: <NSMutableArray (Storage) 0x600000cf0820> [16]
                11 (992 bytes) ROOT CYCLE: <MTRAsyncWorkItem 0x600002aff9c0> [96]
                   10 (896 bytes) __strong _readyHandler --> ROOT CYCLE: <__NSMallocBlock__ 0x600001bfcf00> [64]  Matter  __78-[MTRDevice_Concrete _scheduleSubscriptionPoolWork:inNanoseconds:description:]_block..."
                      8 (784 bytes) __strong [capture] --> ROOT CYCLE: <MTRDevice_Concrete 0x123519f00> [512]
                         __strong _deviceController --> CYCLE BACK TO <MTRDeviceController_Concrete 0x122029a00> [3584]
                         1 (48 bytes) __strong _subscriptionPoolWorkCompletionBlock --> ROOT CYCLE: <__NSMallocBlock__ 0x6000000e8060> [48]  Matter  __47-[MTRAsyncWorkQueue _callWorkItem:withContext:]_block_invoke  0x10648b598  /Users/vn..."
                         2 (96 bytes) __strong _asyncWorkQueue --> <MTRAsyncWorkQueue 0x6000000fe1f0> [48]
                            1 (48 bytes) __strong _items --> <NSMutableArray 0x6000000fe280> [48]  item count: 0
                         2 (64 bytes) __strong _delegates --> <NSMutableSet 0x600000efec80> [32]  item count: 0
                            1 (32 bytes) <NSMutableSet (Storage) 0x600000eff400> [32]
                         1 (32 bytes) __strong _expectedValueCache --> <NSMutableDictionary 0x600000eff020> [32]  item count: 0
                         1 (32 bytes) __strong _persistedClusters --> <NSMutableSet 0x600000efee80> [32]  item count: 0
                      1 (48 bytes) __strong [capture] --> ROOT CYCLE: <__NSMallocBlock__ 0x6000000fe3a0> [48]  Matter  __49-[MTRDevice_Concrete _doHandleSubscriptionReset:]_block_invoke  0x10645d48c  /Users/..."
       3 (384 bytes) __strong _nodeIDToDeviceMap --> <NSMapTable 0x6000020f8700> [128]
          1 (128 bytes) <NSMapTable (Key Storage) 0x6000020f8780> [128]
          1 (128 bytes) <NSMapTable (Weak Value Storage) 0x6000020f8800> [128]
       6 (288 bytes) __strong _controllerDataStore --> <MTRDeviceControllerDataStore 0x6000000fc3f0> [48]
          1 (128 bytes) __strong _storageDelegateQueue --> <dispatch_queue_t (serial) 0x6000020f9200> [128]  "com.chip.storage" (from darwin-framework-tool)
          2 (64 bytes) __strong _nodesWithResumptionInfo --> <NSMutableArray 0x6000000f9830> [48]  item count: 1
             1 (16 bytes) <NSMutableArray (Storage) 0x600000cfc220> [16]
          2 (48 bytes) __strong _storageDelegate --> <MTRTestControllerStorage 0x600000efb7e0> [32]
             1 (16 bytes) __strong _storage --> <PreferencesDictionary 0x600000cfc2a0> [16]
       1 (48 bytes) __strong _delegates --> <NSMutableArray 0x6000000f94a0> [48]  item count: 0
       1 (48 bytes) __strong _serverEndpoints --> <NSMutableArray 0x6000000f97d0> [48]  item count: 0
       1 (32 bytes) __strong _uniqueIdentifier --> <NSUUID 0x600000efb2e0> [32]
```