### PR TITLE
tv-casting-app fix CloseCommissioningWindow upon unexpected CDC Commi…

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -29,6 +29,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import com.R;
 import com.matter.casting.core.CastingPlayer;
 import com.matter.casting.support.CommissionerDeclaration;
@@ -208,36 +209,41 @@ public class ConnectionExampleFragment extends Fragment {
                       Log.i(TAG, "CastingPlayer CommissionerDeclaration message received: ");
                       cd.logDetail();
 
-                      getActivity()
-                          .runOnUiThread(
-                              () -> {
+                      FragmentActivity activity = getActivity();
+                      // Prevent possible NullPointerException. This callback could be called when
+                      // this Fragment is not attached to its host activity or when the fragment's
+                      // lifecycle is not in a valid state for interacting with the activity.
+                      if (activity != null && !activity.isFinishing()) {
+                        activity.runOnUiThread(
+                            () -> {
+                              connectionFragmentStatusTextView.setText(
+                                  "CommissionerDeclaration message received from Casting Player: \n\n");
+                              if (cd.getCommissionerPasscode()) {
+
+                                displayPasscodeInputDialog(activity);
+
                                 connectionFragmentStatusTextView.setText(
-                                    "CommissionerDeclaration message received from Casting Player: \n\n");
-                                if (cd.getCommissionerPasscode()) {
-
-                                  displayPasscodeInputDialog(getActivity());
-
+                                    "CommissionerDeclaration message received from Casting Player: A passcode is now displayed for the user by the Casting Player. \n\n");
+                              }
+                              if (cd.getCancelPasscode()) {
+                                if (useCommissionerGeneratedPasscode) {
                                   connectionFragmentStatusTextView.setText(
-                                      "CommissionerDeclaration message received from Casting Player: A passcode is now displayed for the user by the Casting Player. \n\n");
+                                      "CastingPlayer/Commissioner-Generated passcode connection attempt cancelled by the CastingPlayer/Commissioner user. \n\nRoute back to exit. \n\n");
+                                } else {
+                                  connectionFragmentStatusTextView.setText(
+                                      "Connection attempt cancelled by the CastingPlayer/Commissioner user. \n\nRoute back to exit. \n\n");
                                 }
-                                if (cd.getCancelPasscode()) {
-                                  if (useCommissionerGeneratedPasscode) {
-                                    connectionFragmentStatusTextView.setText(
-                                        "CastingPlayer/Commissioner-Generated passcode connection attempt cancelled by the CastingPlayer/Commissioner user. \n\nRoute back to exit. \n\n");
-                                  } else {
-                                    connectionFragmentStatusTextView.setText(
-                                        "Connection attempt cancelled by the CastingPlayer/Commissioner user. \n\nRoute back to exit. \n\n");
-                                  }
-                                  if (passcodeDialog != null && passcodeDialog.isShowing()) {
-                                    passcodeDialog.dismiss();
-                                  }
+                                if (passcodeDialog != null && passcodeDialog.isShowing()) {
+                                  passcodeDialog.dismiss();
                                 }
-                                if (cd.getErrorCode() != CommissionerDeclaration.CdError.noError) {
-                                  commissionerDeclarationErrorTextView.setText(
-                                      "CommissionerDeclaration error from CastingPlayer: "
-                                          + cd.getErrorCode().getDescription());
-                                }
-                              });
+                              }
+                              if (cd.getErrorCode() != CommissionerDeclaration.CdError.noError) {
+                                commissionerDeclarationErrorTextView.setText(
+                                    "CommissionerDeclaration error from CastingPlayer: "
+                                        + cd.getErrorCode().getDescription());
+                              }
+                            });
+                      }
                     }
                   };
 

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -289,7 +289,7 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
                         kDesiredEndpointVendorId);
     }
 
-    ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler(): Getting endpoints avaiable for demo interactions");
+    ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler(): Getting endpoints available for demo interactions");
     std::vector<matter::casting::memory::Strong<matter::casting::core::Endpoint>> endpoints = castingPlayer->GetEndpoints();
     LogEndpointsDetails(endpoints);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -85,8 +85,11 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
                     "%" CHIP_ERROR_FORMAT,
                     err.Format());
             }
-        } else {
-            ChipLogError(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
+        }
+        else
+        {
+            ChipLogError(AppServer,
+                         "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
         }
     }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -42,12 +42,6 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
     const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
 {
     ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage()");
-    CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
-    if (targetCastingPlayer == nullptr)
-    {
-        ChipLogError(AppServer,
-                     "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
-    }
 
     // During UDC with CastingPlayer/Commissioner-Generated Passcode, the Commissioner responds with a CommissionerDeclaration
     // message with CommissionerPasscode set to true. The CommissionerPasscode flag indicates that a Passcode is now displayed for
@@ -78,6 +72,7 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
         // CastingPlayer/Commissioner user and the Casting Client/Commissionee user are not necessarily the same user. For example,
         // in an enviroment with multiple CastingPlayer/Commissioner TVs, one user 1 might be controlling the Client/Commissionee
         // and user 2 might be controlling the CastingPlayer/Commissioner TV.
+        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
         // Avoid crashing if we recieve this CommissionerDeclaration message when targetCastingPlayer is nullptr.
         if (targetCastingPlayer != nullptr)
         {
@@ -90,6 +85,8 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
                     "%" CHIP_ERROR_FORMAT,
                     err.Format());
             }
+        } else {
+            ChipLogError(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
         }
     }
 

--- a/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp
@@ -38,18 +38,30 @@ CommissionerDeclarationHandler * CommissionerDeclarationHandler::GetInstance()
     return sCommissionerDeclarationHandler_;
 }
 
-// TODO: In the following PRs. Implement setHandler() for CommissionerDeclaration messages and expose messages to higher layers for
-// Linux, Android and iOS.
 void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
     const chip::Transport::PeerAddress & source, chip::Protocols::UserDirectedCommissioning::CommissionerDeclaration cd)
 {
-    ChipLogProgress(AppServer,
-                    "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(), calling CloseCommissioningWindow()");
-    // Close the commissioning window. Since we recived a CommissionerDeclaration message from the Commissioner, we know that
-    // commissioning via AccountLogin cluster failed. We will open a new commissioningWindow prior to sending the next
-    // IdentificationDeclaration Message to the Commissioner.
-    chip::Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
-    support::ChipDeviceEventHandler::SetUdcStatus(false);
+    ChipLogProgress(AppServer, "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage()");
+    CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
+    if (targetCastingPlayer == nullptr)
+    {
+        ChipLogError(AppServer,
+                     "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
+    }
+
+    // During UDC with CastingPlayer/Commissioner-Generated Passcode, the Commissioner responds with a CommissionerDeclaration
+    // message with CommissionerPasscode set to true. The CommissionerPasscode flag indicates that a Passcode is now displayed for
+    // the user by the CastingPlayer /Commissioner. With this CommissionerDeclaration message, we also know that commissioning via
+    // AccountLogin cluster has failed. Therefore, we close the commissioning window. We will open a new commissioning window prior
+    // to sending the next/2nd IdentificationDeclaration message to the Commissioner.
+    if (cd.GetCommissionerPasscode())
+    {
+        ChipLogProgress(AppServer,
+                        "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(), calling CloseCommissioningWindow()");
+        // Close the commissioning window.
+        chip::Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
+        support::ChipDeviceEventHandler::SetUdcStatus(false);
+    }
 
     // Flag to indicate when the CastingPlayer/Commissioner user has decided to exit the commissioning process.
     if (cd.GetCancelPasscode())
@@ -57,20 +69,17 @@ void CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(
         ChipLogProgress(AppServer,
                         "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage(), Got CancelPasscode parameter, "
                         "CastingPlayer/Commissioner user has decided to exit the commissioning attempt. Connection aborted.");
+        // Close the commissioning window.
+        chip::Server::GetInstance().GetCommissioningWindowManager().CloseCommissioningWindow();
+        support::ChipDeviceEventHandler::SetUdcStatus(false);
         // Since the CastingPlayer/Commissioner user has decided to exit the commissioning process, we cancel the ongoing
         // connection attempt without notifying the CastingPlayer/Commissioner. Therefore the
         // shouldSendIdentificationDeclarationMessage flag in the internal StopConnecting() API call is set to false. The
         // CastingPlayer/Commissioner user and the Casting Client/Commissionee user are not necessarily the same user. For example,
         // in an enviroment with multiple CastingPlayer/Commissioner TVs, one user 1 might be controlling the Client/Commissionee
         // and user 2 might be controlling the CastingPlayer/Commissioner TV.
-        CastingPlayer * targetCastingPlayer = CastingPlayer::GetTargetCastingPlayer();
         // Avoid crashing if we recieve this CommissionerDeclaration message when targetCastingPlayer is nullptr.
-        if (targetCastingPlayer == nullptr)
-        {
-            ChipLogError(AppServer,
-                         "CommissionerDeclarationHandler::OnCommissionerDeclarationMessage() targetCastingPlayer is nullptr");
-        }
-        else
+        if (targetCastingPlayer != nullptr)
         {
             CHIP_ERROR err = targetCastingPlayer->StopConnecting(false);
             if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
A fix for Github [BUG] Can't connect Android CHPTVCastingApp with Android MatterTvServer #33842: 
https://github.com/project-chip/connectedhomeip/issues/33842

**Change summary**
1.	Updated connectedhomeip/examples/tv-casting-app/tv-casting-common/core/CommissionerDeclarationHandler.cpp to only close the commissioning window upon CDC CommissionerDeclaration message with CommissionerPasscode == true or CancelPasscode == true. The client should handle CDC CommissionerDeclaration ErrorCode appropriately. 

**Testing**
Verified and tested locally with the Linux, Android and iOS tv-casting-app example mobile apps, and the Linux tv-app (CastingPlayer). Able to build and commission with the example apps using both the commissionee and commissioner generated passcode flows. 
