### PR TITLE
[Matter.framework] MTRAsyncWorkItem::initWithQueue will assert when t…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1170,6 +1170,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     mtr_weakify(self);
     dispatch_block_t workBlockToQueue = ^{
         mtr_strongify(self);
+        if (nil == self) {
+            // This block may be delayed by a specified number of nanoseconds, potentially running after the device is deallocated.
+            // If so, MTRAsyncWorkItem::initWithQueue will assert on a nil queue, which will cause a crash.
+            return;
+        }
+
         // In the case where a resubscription triggering event happened and already established, running the work block should result in a no-op
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull completion) {


### PR DESCRIPTION
…he delayed scheduleSubscriptionPool fires after the deallocation of the MTRDevice

#### Problem

If a delayed subscription is triggered after the device is deallocated, it can result in a crash. This PR makes sure the device is still valid before continuing.

```
2024-10-09 13:29:29.166 [73357:4099] [TOO]: -[MTRDevice_Concrete _scheduleSubscriptionPoolWork:inNanoseconds:description:]_block_invoke: 1000000000 nanoseconds with description: MTRDevice resubscription ((null))
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Invalid parameter not satisfying: queue'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000018c530300 __exceptionPreprocess + 176
	1   libobjc.A.dylib                     0x000000018c016cd8 objc_exception_throw + 88
	2   Foundation                          0x000000018d72c288 -[NSCalendarDate initWithCoder:] + 0
	3   Matter                              0x0000000108fc45c8 -[MTRAsyncWorkItem initWithQueue:] + 156
	4   Matter                              0x0000000108f97c40 __78-[MTRDevice_Concrete _scheduleSubscriptionPoolWork:inNanoseconds:description:]_block_invoke + 620
	5   libdispatch.dylib                   0x000000018c224658 _dispatch_client_callout + 20
	6   libdispatch.dylib                   0x000000018c227b08 _dispatch_continuation_pop + 596
	7   libdispatch.dylib                   0x000000018c23bad8 _dispatch_source_latch_and_call + 420
	8   libdispatch.dylib                   0x000000018c23a6a0 _dispatch_source_invoke + 836
	9   libdispatch.dylib                   0x000000018c22bae8 _dispatch_lane_serial_drain + 368
	10  libdispatch.dylib                   0x000000018c22c79c _dispatch_lane_invoke + 432
	11  libdispatch.dylib                   0x000000018c2377e8 _dispatch_root_queue_drain_deferred_wlh + 288
	12  libdispatch.dylib                   0x000000018c237034 _dispatch_workloop_worker_thread + 540
	13  libsystem_pthread.dylib             0x000000018c3d33d8 _pthread_wqthread + 288
	14  libsystem_pthread.dylib             0x000000018c3d20f0 start_wqthread + 8
)
libc++abi: terminating due to uncaught exception of type NSException

```