### PR TITLE
[NXP][common][mcxw71_k32w1] Update ButtonApp::HandleLongPress and PlatformManagerImpl

### DIFF
--- a/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
+++ b/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
@@ -50,12 +50,12 @@ void chip::NXP::App::ButtonApp::HandleLongPress()
 {
     // Execute "clean" reset
     chip::DeviceLayer::PlatformMgr().ScheduleWork(
-    [](intptr_t arg) {
-        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
-        chip::DeviceLayer::PlatformMgr().Shutdown();
-        chip::DeviceLayer::PlatformMgrImpl().Reset();
-    },
-    (intptr_t) nullptr);
+        [](intptr_t arg) {
+            chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+            chip::DeviceLayer::PlatformMgr().Shutdown();
+            chip::DeviceLayer::PlatformMgrImpl().Reset();
+        },
+        (intptr_t) nullptr);
 }
 
 void chip::NXP::App::ButtonApp::HandleDoubleClick()

--- a/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
+++ b/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
@@ -48,7 +48,14 @@ void chip::NXP::App::ButtonApp::HandleShortPress()
 
 void chip::NXP::App::ButtonApp::HandleLongPress()
 {
-    chip::DeviceLayer::PlatformMgrImpl().CleanReset();
+    // Execute "clean" reset
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(
+    [](intptr_t arg) {
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+        chip::DeviceLayer::PlatformMgr().Shutdown();
+        chip::DeviceLayer::PlatformMgrImpl().Reset();
+    },
+    (intptr_t) nullptr);
 }
 
 void chip::NXP::App::ButtonApp::HandleDoubleClick()

--- a/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.cpp
@@ -99,7 +99,9 @@ void PlatformManagerImpl::Reset()
 #endif
     // Restart the system.
     NVIC_SystemReset();
-    while (1) {}
+    while (1)
+    {
+    }
 }
 
 void PlatformManagerImpl::ScheduleResetInIdle(void)

--- a/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.cpp
@@ -48,7 +48,6 @@
 
 #include <mbedtls/platform.h>
 
-extern "C" void HAL_ResetMCU(void);
 extern "C" void freertos_mbedtls_mutex_init(void);
 
 extern uint8_t __data_end__[], m_data0_end[];
@@ -93,14 +92,14 @@ CHIP_ERROR PlatformManagerImpl::ServiceInit(void)
     return CHIP_NO_ERROR;
 }
 
-void PlatformManagerImpl::CleanReset()
+void PlatformManagerImpl::Reset()
 {
-    StopEventLoopTask();
-    Shutdown();
 #if (CHIP_PLAT_NVM_SUPPORT == 1)
     NvCompletePendingOperations();
 #endif
-    HAL_ResetMCU();
+    // Restart the system.
+    NVIC_SystemReset();
+    while (1) {}
 }
 
 void PlatformManagerImpl::ScheduleResetInIdle(void)
@@ -200,6 +199,10 @@ void PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
+    /* Handle the server shutting down & emit the ShutDown event */
+    /* Make sure to call this function from Matter Task */
+    PlatformMgr().HandleServerShuttingDown();
+    /* Shutdown all layers */
     Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 

--- a/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.h
+++ b/src/platform/nxp/mcxw71_k32w1/PlatformManagerImpl.h
@@ -51,7 +51,7 @@ public:
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
     void HardwareInit(void);
     CHIP_ERROR ServiceInit(void);
-    void CleanReset();
+    void Reset();
     void StopBLEConnectivity() {}
     void ScheduleResetInIdle(void);
     bool GetResetInIdleValue(void);


### PR DESCRIPTION
  [nxp][platform][mcxw71_k32w1] Update PlatformManagerImpl.cpp
  
   * Add .HandleServerShuttingDown PlatformManagerImpl::_Shutdown()
   * Use NVIC_SystemReset instead of HAL_ResetMCU
   * Rename CleanReset to Reset
   
 [nxp][examples][common] Schedule ButtonApp::HandleLongPress on Matter task
     * Remove CleanReset call
     * Schedule button work on matter task. This code is run from interrupt and
       Reset might call some functions (e.g. LogEvent) that must be run
       from matter task. See PlatformMgr().HandleServerShuttingDown() from
       PlatformManagerImpl::_Shutdown.
