### PR TITLE
[YAML] Add _ById commands support for darwin-framework-tool

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -155,6 +155,7 @@ class Converter():
     def __init__(self, specifications):
         self.__specs = specifications
         self.__converters = [
+            DarwinAnyFormatConverter(),
             StructFieldsNameConverter(),
             FloatConverter(),
             OctetStringConverter()
@@ -249,6 +250,43 @@ class BaseConverter:
         return value
 
     def maybe_convert(self, typename: str, value):
+        return value
+
+
+class DarwinAnyFormatConverter(BaseConverter):
+    """
+    Darwin payloads format for *ById commands is different from the base
+    format used for other commands.
+    """
+
+    def run(self, specs, value, cluster_name: str, typename: str, array: bool):
+        if isinstance(value, list) and len(value) >= 1 and isinstance(value[0], dict) and value[0].get('data') is not None:
+            value = [self.__convert(item_value) for item_value in value]
+        return value
+
+    def __convert(self, value):
+        if not isinstance(value, dict):
+            return value
+
+        data = value.get('data')
+        if not isinstance(data, dict):
+            return value
+
+        value = data.get('value')
+        if not isinstance(value, list):
+            return value
+
+        value_type = data.get('type')
+
+        if value_type == 'Structure':
+            struct = {}
+            for field in value:
+                context_tag = field.get('contextTag')
+                struct[str(context_tag)] = self.__convert(field)
+            value = struct
+        elif value_type == 'Array':
+            value = [self.__convert(item_value) for item_value in value]
+
         return value
 
 
@@ -348,7 +386,7 @@ class StructFieldsNameConverter():
                 del value[key_name]
 
         elif isinstance(value, list) and array:
-            value = [self.run(specs, v, cluster_name, typename, False)
+            value = [self.run(specs, v, cluster_name, typename, isinstance(v, list))
                      for v in value]
 
         return value

--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -510,7 +510,16 @@ class Encoder:
         if aliases is None or aliases.get(argument_name) is None:
             return None
 
-        return aliases.get(argument_name)
+        value = aliases.get(argument_name)
+
+        if cluster_name == '*' and self.__is_darwin_framework_tool:
+            if argument_name == 'AttributeId':
+                return 'attribute-id'
+            elif argument_name == 'ClusterId':
+                return 'cluster-id'
+            elif argument_name == 'Value':
+                return 'attribute-value'
+        return value
 
     def _supports_endpoint(self, request):
         return self._has_support(request, 'has_endpoint')

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -73,10 +73,13 @@ public:
         uint16_t __block responsesNeeded = repeatCount;
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
+        __auto_type * endpoint = @(endpointId);
+        __auto_type * cluster = @(clusterId);
+        __auto_type * command = @(commandId);
         while (repeatCount--) {
-            [device invokeCommandWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
-                                      clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
-                                      commandID:[NSNumber numberWithUnsignedInteger:commandId]
+            [device invokeCommandWithEndpointID:endpoint
+                                      clusterID:cluster
+                                      commandID:command
                                   commandFields:commandFields
                              timedInvokeTimeout:mTimedInteractionTimeoutMs.HasValue()
                                  ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]
@@ -88,6 +91,9 @@ public:
                                          if (error != nil) {
                                              mError = error;
                                              LogNSError("Error", error);
+                                             RemoteDataModelLogger::LogCommandErrorAsJSON(endpoint, cluster, command, error);
+                                         } else {
+                                             RemoteDataModelLogger::LogCommandAsJSON(endpoint, cluster, command, values);
                                          }
                                          if (responsesNeeded == 0) {
                                              SetCommandExitStatus(mError);

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -74,10 +74,13 @@ public:
     {
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
+        __auto_type * endpoint = @(endpointId);
+        __auto_type * cluster = @(mClusterId);
+        __auto_type * attribute = @(mAttributeId);
         [device
-            writeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
-                               clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
-                             attributeID:[NSNumber numberWithUnsignedInteger:attributeId]
+            writeAttributeWithEndpointID:endpoint
+                               clusterID:cluster
+                             attributeID:attribute
                                    value:value
                        timedWriteTimeout:mTimedInteractionTimeoutMs.HasValue()
                            ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]
@@ -86,11 +89,13 @@ public:
                               completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                   if (error != nil) {
                                       LogNSError("Error writing attribute", error);
+                                      RemoteDataModelLogger::LogAttributeErrorAsJSON(endpoint, cluster, attribute, error);
                                   }
                                   if (values) {
                                       for (id item in values) {
                                           NSLog(@"Response Item: %@", [item description]);
                                       }
+                                      RemoteDataModelLogger::LogAttributeAsJSON(endpoint, cluster, attribute, values);
                                   }
                                   SetCommandExitStatus(error);
                               }];


### PR DESCRIPTION
#### Problem

This PR introduces partial support for *ById YAML commands in the `darwin-framework-tool` backend.
By **partial** I mean that while basic tests can be written, the complete tests (such as **TestAttributesById.yaml** and **TestCommandsById.yaml**) are not fully supported.
This is because `darwin-framework-tool` currently lacks features like handling multiple attributes, as well as the ability to return  `UNSUPPORTED_ENDPOINT` when targeting a nonexistent endpoint.

For now, this is mainly useful for testing specific code paths under certain scenarios that uses those commands.
