### PR TITLE
[Darwin] Implemented download diagnostics log for MTRDevice_XPC

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -283,17 +283,17 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
                 completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             });
         }] deviceController:[[self deviceController] uniqueIdentifier]
-                     nodeID:[self nodeID]
-          downloadLogOfType:type
-                    timeout:timeout
-                 completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
-            dispatch_async(queue, ^{
-                completion(url, error);
-                if (url) {
-                    [[NSFileManager defaultManager] removeItemAtPath:url.path error:nil];
-                }
-            });
-        }];
+                       nodeID:[self nodeID]
+            downloadLogOfType:type
+                      timeout:timeout
+                   completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                       dispatch_async(queue, ^{
+                           completion(url, error);
+                           if (url) {
+                               [[NSFileManager defaultManager] removeItemAtPath:url.path error:nil];
+                           }
+                       });
+                   }];
     } @catch (NSException * exception) {
         MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);
         dispatch_async(queue, ^{

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -39,9 +39,9 @@ MTR_NEWLY_AVAILABLE
 - (oneway void)downloadLogOfType:(MTRDiagnosticLogType)type nodeID:(NSNumber *)nodeID timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 @optional
- /* Note: The consumer of the completion block should move the file that the url points to or open it for reading before the
-  * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
-  */
+/* Note: The consumer of the completion block should move the file that the url points to or open it for reading before the
+ * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
+ */
 - (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID downloadLogOfType:(MTRDiagnosticLogType)type timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 @end

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -39,6 +39,9 @@ MTR_NEWLY_AVAILABLE
 - (oneway void)downloadLogOfType:(MTRDiagnosticLogType)type nodeID:(NSNumber *)nodeID timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 @optional
+ /* Note: The consumer of the completion block should move the file that the url points to or open it for reading before the
+  * completion handler returns. Otherwise, the file will be deleted, and the data will be lost.
+  */
 - (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID downloadLogOfType:(MTRDiagnosticLogType)type timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 @end

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -37,6 +37,10 @@ MTR_NEWLY_AVAILABLE
 - (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID openCommissioningWindowWithSetupPasscode:(NSNumber *)setupPasscode discriminator:(NSNumber *)discriminator duration:(NSNumber *)duration completion:(MTRDeviceOpenCommissioningWindowHandler)completion;
 
 - (oneway void)downloadLogOfType:(MTRDiagnosticLogType)type nodeID:(NSNumber *)nodeID timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
+
+@optional
+- (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID downloadLogOfType:(MTRDiagnosticLogType)type timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
+
 @end
 
 MTR_NEWLY_AVAILABLE


### PR DESCRIPTION
- Implemented the downloadLogOfType API on MTRDevice_XPC to call into XPC server to forward the request
- Fixed the protocol to take controllerID which is missing from existing protocol

