### PR TITLE
Prevent Buffer Overflows with External Attribute Reads

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -292,23 +292,27 @@ CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberA
         }
     }
 
-    for (uint8_t i = 0; ep && (i < ep->clusterCount); i++) {
-        if (!ep->cluster) {
+    for (uint8_t i = 0; ep && (i < ep->clusterCount); i++)
+    {
+        if (!ep->cluster)
+        {
             continue;
         }
 
         const EmberAfCluster * cluster = &(ep->cluster[i]);
-        if (!cluster->attributes) {
+        if (!cluster->attributes)
+        {
             continue;
         }
 
-        for (uint16_t j = 0; j < cluster->attributeCount; j++) {
+        for (uint16_t j = 0; j < cluster->attributeCount; j++)
+        {
             const EmberAfAttributeMetadata * attr = &(cluster->attributes[j]);
-            if (emberAfAttributeSize(attr) > gEmberAttributeIOBufferSpan.size()) {
-                ChipLogError(
-                    DataManagement,
-                    "Attribute %u (id=" ChipLogFormatMEI ") of Cluster %u (id=" ChipLogFormatMEI ") too large",
-                    j, ChipLogValueMEI(attr->attributeId), i, ChipLogValueMEI(cluster->clusterId));
+            if (emberAfAttributeSize(attr) > chip::app::Compatibility::Internal::gEmberAttributeIOBufferSpan.size())
+            {
+                ChipLogError(DataManagement,
+                             "Attribute %u (id=" ChipLogFormatMEI ") of Cluster %u (id=" ChipLogFormatMEI ") too large", j,
+                             ChipLogValueMEI(attr->attributeId), i, ChipLogValueMEI(cluster->clusterId));
                 return CHIP_ERROR_NO_MEMORY;
             }
         }
@@ -661,18 +665,20 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                                 // Is the attribute externally stored?
                                 if (am->mask & ATTRIBUTE_MASK_EXTERNAL_STORAGE)
                                 {
-                                    if (write) {
-                                        return emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                     am, buffer);
+                                    if (write)
+                                    {
+                                        return emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId, am,
+                                                                                     buffer);
                                     }
 
-                                    if (readLength < emberAfAttributeSize(am)) {
+                                    if (readLength < emberAfAttributeSize(am))
+                                    {
                                         // Prevent a potential buffer overflow
                                         return Status::ResourceExhausted;
                                     }
 
-                                    return emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                am, buffer, emberAfAttributeSize(am));
+                                    return emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId, am,
+                                                                                buffer, emberAfAttributeSize(am));
                                 }
 
                                 // Internal storage is only supported for fixed endpoints


### PR DESCRIPTION
Fixes #34937

* Prevent buffer overflows by blocking creation of dynamic endpoints with attributes that would overflow the static attribute buffer
* Added additional sanity checks to block reads of attributes that would overflow the attribute reads; return `RESOURCE_EXHAUSTED` instead
