### PR TITLE
Fix attr read overflows

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -293,23 +293,27 @@ CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberA
         }
     }
 
-    for (uint8_t i = 0; ep && (i < ep->clusterCount); i++) {
-        if (!ep->cluster) {
+    for (uint8_t i = 0; ep && (i < ep->clusterCount); i++)
+    {
+        if (!ep->cluster)
+        {
             continue;
         }
 
         const EmberAfCluster * cluster = &(ep->cluster[i]);
-        if (!cluster->attributes) {
+        if (!cluster->attributes)
+        {
             continue;
         }
 
-        for (uint16_t j = 0; j < cluster->attributeCount; j++) {
+        for (uint16_t j = 0; j < cluster->attributeCount; j++)
+        {
             const EmberAfAttributeMetadata * attr = &(cluster->attributes[j]);
-            if (emberAfAttributeSize(attr) > gEmberAttributeIOBufferSpan.size()) {
-                ChipLogError(
-                    DataManagement,
-                    "Attribute %u (id=" ChipLogFormatMEI ") of Cluster %u (id=" ChipLogFormatMEI ") too large",
-                    j, ChipLogValueMEI(attr->attributeId), i, ChipLogValueMEI(cluster->clusterId));
+            if (emberAfAttributeSize(attr) > chip::app::Compatibility::Internal::gEmberAttributeIOBufferSpan.size())
+            {
+                ChipLogError(DataManagement,
+                             "Attribute %u (id=" ChipLogFormatMEI ") of Cluster %u (id=" ChipLogFormatMEI ") too large", j,
+                             ChipLogValueMEI(attr->attributeId), i, ChipLogValueMEI(cluster->clusterId));
                 return CHIP_ERROR_NO_MEMORY;
             }
         }
@@ -664,18 +668,20 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                                 // Is the attribute externally stored?
                                 if (am->mask & MATTER_ATTRIBUTE_FLAG_EXTERNAL_STORAGE)
                                 {
-                                    if (write) {
-                                        return emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                     am, buffer);
+                                    if (write)
+                                    {
+                                        return emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId, am,
+                                                                                     buffer);
                                     }
 
-                                    if (readLength < emberAfAttributeSize(am)) {
+                                    if (readLength < emberAfAttributeSize(am))
+                                    {
                                         // Prevent a potential buffer overflow
                                         return Status::ResourceExhausted;
                                     }
 
-                                    return emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                am, buffer, emberAfAttributeSize(am));
+                                    return emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId, am,
+                                                                                buffer, emberAfAttributeSize(am));
                                 }
 
                                 // Internal storage is only supported for fixed endpoints

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -24,6 +24,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <app/util/config.h>
+#include <app/util/ember-io-storage.h>
 #include <app/util/ember-strings.h>
 #include <app/util/endpoint-config-api.h>
 #include <app/util/generic-callbacks.h>
@@ -33,7 +34,6 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/LockTracker.h>
 #include <protocols/interaction_model/StatusCode.h>
-#include <app/util/ember-io-storage.h>
 
 using chip::Protocols::InteractionModel::Status;
 

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -33,6 +33,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/LockTracker.h>
 #include <protocols/interaction_model/StatusCode.h>
+#include <app/util/ember-io-storage.h>
 
 using chip::Protocols::InteractionModel::Status;
 
@@ -292,6 +293,27 @@ CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberA
         }
     }
 
+    for (uint8_t i = 0; ep && (i < ep->clusterCount); i++) {
+        if (!ep->cluster) {
+            continue;
+        }
+
+        const EmberAfCluster * cluster = &(ep->cluster[i]);
+        if (!cluster->attributes) {
+            continue;
+        }
+
+        for (uint16_t j = 0; j < cluster->attributeCount; j++) {
+            const EmberAfAttributeMetadata * attr = &(cluster->attributes[j]);
+            if (emberAfAttributeSize(attr) > gEmberAttributeIOBufferSpan.size()) {
+                ChipLogError(
+                    DataManagement,
+                    "Attribute %u (id=" ChipLogFormatMEI ") of Cluster %u (id=" ChipLogFormatMEI ") too large",
+                    j, ChipLogValueMEI(attr->attributeId), i, ChipLogValueMEI(cluster->clusterId));
+                return CHIP_ERROR_NO_MEMORY;
+            }
+        }
+    }
     emAfEndpoints[index].endpoint       = id;
     emAfEndpoints[index].deviceTypeList = deviceTypeList;
     emAfEndpoints[index].endpointType   = ep;
@@ -642,10 +664,18 @@ Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord, 
                                 // Is the attribute externally stored?
                                 if (am->mask & MATTER_ATTRIBUTE_FLAG_EXTERNAL_STORAGE)
                                 {
-                                    return (write ? emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                          am, buffer)
-                                                  : emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
-                                                                                         am, buffer, emberAfAttributeSize(am)));
+                                    if (write) {
+                                        return emberAfExternalAttributeWriteCallback(attRecord->endpoint, attRecord->clusterId,
+                                                                                     am, buffer);
+                                    }
+
+                                    if (readLength < emberAfAttributeSize(am)) {
+                                        // Prevent a potential buffer overflow
+                                        return Status::ResourceExhausted;
+                                    }
+
+                                    return emberAfExternalAttributeReadCallback(attRecord->endpoint, attRecord->clusterId,
+                                                                                am, buffer, emberAfAttributeSize(am));
                                 }
 
                                 // Internal storage is only supported for fixed endpoints

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -215,7 +215,8 @@ TEST_F(TestServerCommandDispatch, TestNoHandler)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
-static const int kDescriptorAttributeArraySize = 254;
+// Use 8 so that we don't exceed the size of ATTRIBUTE_LARGEST defined by ZAP
+static const int kDescriptorAttributeArraySize = 8;
 
 // Declare Descriptor cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(descriptorAttrs)


### PR DESCRIPTION
Fixes 34937

* Prevent buffer overflows by blocking creation of dynamic endpoints with attributes that would overflow the static attribute buffer
* Added additional sanity checks to block reads of attributes that would overflow the attribute reads; return `RESOURCE_EXHAUSTED` instead

#### Testing
* Validated via manual tests (see below) and via required changes to unit tests that attempting to publish a dynamic endpoint with an attribute size that exceeds the value of `ATTRIBUTE_LARGEST` provided by the ZAP headers results in an error being returned and that endpoint not being published on the node.
* Using manual tests (see below), validated that attempts to read data beyond the end of the attribute data buffer would result in an error being returned by the SDK

#### Manual Tests
Performed A/B testing on my devices and confirmed that the fix worked as expected. Specifically:
The way this bug manifested for me was that the buffer was defaulting to size 8, I'd send a read for some external attributes (these were 32 bytes) from one device running the SDK (local) to another (remote). On the remote, I'd fill the buffer + size provided to me by `emberAfExternalAttributeReadCallback`, this resulted in me unknowingly overflowing said buffer. Back on the local, after reading an external attribute, I'd try to subscribe to the parts list on the remote's EP0 and that would cause the remote's CHIP SDK to crash. After a bunch of painstaking debugging I finally traced it to the buffer overflow. These were my logs:
```
CHIP DMG: AttributeData=0xb23142b8,sizeof(attributeData)=8 // CHIP SDK layer, buffer is only 8 bytes
onExternalAttributeRead:buffer=0xb23142b8, maxReadLength=32  // my application layer, fills 32 bytes as told by the SDK
CHIP DMG: <RE> Sending report (payload has 41 bytes)...
// end of read

CHIP EM : >>> [E:60205r S:10395 M:134389711] (S) Msg RX from 1:01B98783B9C5A511 [5FCA] --- Type 0001:03 (IM:SubscribeRequest)
// ... omitted for brevity
CHIP DMG: just before aAccessInterface->Read call, aAccessInterface=0xb23142d4
```
Basically: `0xb23142b8 + 0x20 = 0xb23142d8`, and `0xb23142d8 > 0xb23142d4`
So by writing the amount of data the CHIP SDK told me was available for writing, I had actually overwritten part of the buffer that was storing the pre-defined attribute access interface for Endpoint 0, thereby resulting in the crash since the memory stored in that buffer was no longer valid.