### PR TITLE
Refactoring random SetupPinCode generation into a method.

### DIFF
--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -139,10 +139,7 @@ CHIP_ERROR PASESession::GeneratePASEVerifier(Spake2pVerifier & verifier, uint32_
 
     if (useRandomPIN)
     {
-        ReturnErrorOnFailure(DRBG_get_bytes(reinterpret_cast<uint8_t *>(&setupPINCode), sizeof(setupPINCode)));
-
-        // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
-        setupPINCode = (setupPINCode % kSetupPINCodeMaximumValue) + 1;
+        SetupPayload::generateRandomSetupPin(setupPINCode);
     }
 
     return verifier.Generate(pbkdf2IterCount, salt, setupPINCode);

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR PASESession::GeneratePASEVerifier(Spake2pVerifier & verifier, uint32_
 
     if (useRandomPIN)
     {
-        SetupPayload::generateRandomSetupPin(setupPINCode);
+        ReturnErrorOnFailure(SetupPayload::generateRandomSetupPin(setupPINCode));
     }
 
     return verifier.Generate(pbkdf2IterCount, salt, setupPINCode);

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -211,16 +211,17 @@ CHIP_ERROR SetupPayload::removeSerialNumber()
 CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
 {
     uint8_t retries          = 0;
-    const uint8_t maxRetries = 255;
+    const uint8_t maxRetries = 10;
 
     do
     {
         ReturnErrorOnFailure(Crypto::DRBG_get_bytes(reinterpret_cast<uint8_t *>(&setupPINCode), sizeof(setupPINCode)));
 
         // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
+        // TODO: Consider revising this method to ensure uniform distribution of setup PIN codes
         setupPINCode = (setupPINCode % kSetupPINCodeMaximumValue) + 1;
 
-        // To make sure that the Generated Setup Pin code is not one of the invalid passcodes/pin codes defined in the
+        // Make sure that the Generated Setup Pin code is not one of the invalid passcodes/pin codes defined in the
         // specification.
         if (IsValidSetupPIN(setupPINCode))
         {

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -23,6 +23,7 @@
 
 #include "SetupPayload.h"
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/TLV.h>
@@ -205,6 +206,32 @@ CHIP_ERROR SetupPayload::removeSerialNumber()
     optionalExtensionData.erase(kSerialNumberTag);
 
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
+{
+    uint8_t retries    = 0;
+    uint8_t maxRetries = 255;
+
+    do
+    {
+        ReturnErrorOnFailure(Crypto::DRBG_get_bytes(reinterpret_cast<uint8_t *>(&setupPINCode), sizeof(setupPINCode)));
+
+        // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
+        setupPINCode = (setupPINCode % kSetupPINCodeMaximumValue) + 1;
+
+        // To make sure that the Generated Setup Pin code is not one of the invalid passcodes/pin codes
+        if (IsValidSetupPIN(setupPINCode))
+        {
+            return CHIP_NO_ERROR;
+        }
+
+        retries++;
+        // We got pretty unlucky with the random number generator, Just try again.
+        // This shouldn't take many retries assuming DRBG_get_bytes is not broken.
+    } while (retries < maxRetries);
+
+    return CHIP_ERROR_INTERNAL;
 }
 
 CHIP_ERROR SetupPayload::addOptionalVendorData(const OptionalQRCodeInfo & info)

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -210,8 +210,8 @@ CHIP_ERROR SetupPayload::removeSerialNumber()
 
 CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
 {
-    uint8_t retries    = 0;
-    uint8_t maxRetries = 255;
+    uint8_t retries          = 0;
+    const uint8_t maxRetries = 255;
 
     do
     {
@@ -220,7 +220,8 @@ CHIP_ERROR SetupPayload::generateRandomSetupPin(uint32_t & setupPINCode)
         // Passcodes shall be restricted to the values 00000001 to 99999998 in decimal, see 5.1.1.6
         setupPINCode = (setupPINCode % kSetupPINCodeMaximumValue) + 1;
 
-        // To make sure that the Generated Setup Pin code is not one of the invalid passcodes/pin codes
+        // To make sure that the Generated Setup Pin code is not one of the invalid passcodes/pin codes defined in the
+        // specification.
         if (IsValidSetupPIN(setupPINCode))
         {
             return CHIP_NO_ERROR;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -265,7 +265,8 @@ public:
      * It also checks that the generated passcode is not equal to any invalid passcode values as defined in 5.1.7.1.
      *
      * @param[out] setupPINCode The generated random setup PIN code.
-     * @return Returns a CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
+     * @return Returns a CHIP_ERROR_INTERNAL if unable to generate a valid passcode within a reasonable number of attempts,
+     * CHIP_NO_ERROR otherwise
      **/
     static CHIP_ERROR generateRandomSetupPin(uint32_t & setupPINCode);
 

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -259,6 +259,8 @@ public:
      **/
     static bool IsVendorTag(uint8_t tag) { return !IsCommonTag(tag); }
 
+    static CHIP_ERROR generateRandomSetupPin(uint32_t & setupPINCode);
+
 private:
     std::map<uint8_t, OptionalQRCodeInfo> optionalVendorData;
     std::map<uint8_t, OptionalQRCodeInfoExtension> optionalExtensionData;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -259,6 +259,14 @@ public:
      **/
     static bool IsVendorTag(uint8_t tag) { return !IsCommonTag(tag); }
 
+    /** @brief Generate a Random Setup Pin Code (Passcode)
+     *
+     * This function generates a random passcode within the defined limits (00000001 to 99999998)
+     * It also checks that the generated passcode is not equal to any invalid passcode values as defined in 5.1.7.1.
+     *
+     * @param[out] setupPINCode The generated random setup PIN code.
+     * @return Returns a CHIP_ERROR_INTERNAL on error, CHIP_NO_ERROR otherwise
+     **/
     static CHIP_ERROR generateRandomSetupPin(uint32_t & setupPINCode);
 
 private:


### PR DESCRIPTION
- Previously in ` PASESession::GeneratePASEVerifier` we were generating random setup pin code without checking if the generated code is valid (in accordance with spec 5.1.7.1. Invalid Passcodes).
- refactoring random setup code generation into a separate method and making sure it is valid. 
