### PR TITLE
Matter framework safe conversion for known enum

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1894,7 +1894,7 @@ NSTimeInterval MTRTimeIntervalForEventTimestampValue(uint64_t timeValue)
     uint64_t eventTimestampValueSeconds = timeValue / chip::kMillisecondsPerSecond;
     uint64_t eventTimestampValueRemainderMilliseconds = timeValue % chip::kMillisecondsPerSecond;
     NSTimeInterval eventTimestampValueRemainder
-        = NSTimeInterval(eventTimestampValueRemainderMilliseconds) / chip::kMillisecondsPerSecond;
+        = NSTimeInterval(eventTimestampValueRemainderMilliseconds / static_cast<uint64_t>(chip::kMillisecondsPerSecond));
     NSTimeInterval eventTimestampValue = eventTimestampValueSeconds + eventTimestampValueRemainder;
 
     return eventTimestampValue;

--- a/src/darwin/Framework/CHIP/MTRConversion.h
+++ b/src/darwin/Framework/CHIP/MTRConversion.h
@@ -38,7 +38,8 @@ AsNumber(chip::Optional<T> optional)
 
 inline NSDate * MatterEpochSecondsAsDate(uint32_t matterEpochSeconds)
 {
-    return [NSDate dateWithTimeIntervalSince1970:(chip::kChipEpochSecondsSinceUnixEpoch + (NSTimeInterval) matterEpochSeconds)];
+    const uint64_t interval = static_cast<uint32_t>(chip::kChipEpochSecondsSinceUnixEpoch) + matterEpochSeconds;
+    return [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval) interval];
 }
 
 template <typename Rep, typename Period>

--- a/src/darwin/Framework/CHIP/MTRConversion.mm
+++ b/src/darwin/Framework/CHIP/MTRConversion.mm
@@ -92,7 +92,7 @@ bool DateToMatterEpochMilliseconds(NSDate * date, uint64_t & matterEpochMillisec
 
 bool DateToMatterEpochMicroseconds(NSDate * date, uint64_t & matterEpochMicroseconds)
 {
-    uint64_t timeSinceUnixEpoch = static_cast<uint64_t>(date.timeIntervalSince1970 * chip::kMicrosecondsPerSecond);
+    uint64_t timeSinceUnixEpoch = static_cast<uint64_t>(date.timeIntervalSince1970 * static_cast<double>(chip::kMicrosecondsPerSecond));
     if (timeSinceUnixEpoch < chip::kChipEpochUsSinceUnixEpoch) {
         // This is a pre-Matter-epoch time, and cannot be represented as an epoch time value.
         return false;


### PR DESCRIPTION

#### Problem

There are conversion issues in `Matter.framework` when building with the `-Wenum-float-conversion` flag enabled. These issues are due to constants that are unlikely to change, so it should be safe to use `static_cast` to address them:

1.  **chip::kMicrosecondsPerSecond**
2. **chip::kMillisecondsPerSecond**
3. **chip::kChipEpochSecondsSinceUnixEpoch**