### PR TITLE
Attempt to fix ESP32 builds by adding an extra dependency

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -17,20 +17,22 @@ dependencies:
         rules:
             - if: "idf_version >=4.4"
 
-    # TODO:
-    #   - Insights compilation fails seemingly after
-    #     https://github.com/espressif/esp-insights/pull/47
-    #   - Switching version to 1.0.2 does not seem to work (it says version not found)
-    #     while 1.0.1 pulls in a esp_insights_cbor_encoder.c that uses SHA_SIZE which is
-    #     undefined (unclear why c and header differ)
-    # espressif/esp_insights:
-    #     version: "1.0.1"
-    #     require: public
-    #     # There is an issue with IDF-Component-Manager when ESP Insights is included.
-    #     # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
-    #     rules:
-    #         - if: "idf_version >=5.0"
-    #         - if: "target != esp32h2"
+    espressif/esp_insights:
+        version: "1.0.1"
+        require: public
+        # There is an issue with IDF-Component-Manager when ESP Insights is included.
+        # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
+        rules:
+            - if: "idf_version >=5.0"
+            - if: "target != esp32h2"
+
+    # This matches the dependency of esp_insights
+    espressif/esp_diag_data_store:
+        version: "1.0.1"
+        require: public
+        rules:
+            - if: "idf_version >=5.0"
+            - if: "target != esp32h2"
 
     espressif/esp_rcp_update:
         version: "1.2.0"

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -21,7 +21,7 @@ dependencies:
     #   - Insights compilation fails seemingly after
     #     https://github.com/espressif/esp-insights/pull/47
     #   - Switching version to 1.0.2 does not seem to work (it says version not found)
-    #     wile 1.0.1 pulls in a esp_insights_cbor_encoder.c that uses SHA_SIZE which is
+    #     while 1.0.1 pulls in a esp_insights_cbor_encoder.c that uses SHA_SIZE which is
     #     undefined (unclear why c and header differ)
     # espressif/esp_insights:
     #     version: "1.0.1"

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -17,14 +17,20 @@ dependencies:
         rules:
             - if: "idf_version >=4.4"
 
-    espressif/esp_insights:
-        version: "1.0.1"
-        require: public
-        # There is an issue with IDF-Component-Manager when ESP Insights is included.
-        # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
-        rules:
-            - if: "idf_version >=5.0"
-            - if: "target != esp32h2"
+    # TODO:
+    #   - Insights compilation fails seemingly after
+    #     https://github.com/espressif/esp-insights/pull/47
+    #   - Switching version to 1.0.2 does not seem to work (it says version not found)
+    #     wile 1.0.1 pulls in a esp_insights_cbor_encoder.c that uses SHA_SIZE which is
+    #     undefined (unclear why c and header differ)
+    # espressif/esp_insights:
+    #     version: "1.0.1"
+    #     require: public
+    #     # There is an issue with IDF-Component-Manager when ESP Insights is included.
+    #     # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
+    #     rules:
+    #         - if: "idf_version >=5.0"
+    #         - if: "target != esp32h2"
 
     espressif/esp_rcp_update:
         version: "1.2.0"


### PR DESCRIPTION
CI fails after https://github.com/espressif/esp-insights/pull/47

It seems that insights 1.0.1 depends on a header in esp_diag_data_store that we did not fix the version for (and were pulling latest as a result). This gives a compile failure.