### PR TITLE
[ICD] Store icdClientInfo after completing check-in message validation

### DIFF
--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -130,6 +130,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
     }
     else
     {
+        mpICDClientStorage->StoreEntry(clientInfo);
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
         mpImEngine->OnActiveModeNotification(clientInfo.peer_node);


### PR DESCRIPTION
Issue: Currently offset in icdClientInfo has not yet updated after completing check-in message validation so that duplicate icd check-in message cannot be detected. 
Fix: Store IcdClientInfo when completing check-in message validation.
locally validated using chip-tool