### PR TITLE
Attempt to fix ESP32 builds by adding an extra dependency (#36025)

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -26,6 +26,14 @@ dependencies:
             - if: "idf_version >=5.0"
             - if: "target != esp32h2"
 
+    # This matches the dependency of esp_insights
+    espressif/esp_diag_data_store:
+        version: "1.0.1"
+        require: public
+        rules:
+            - if: "idf_version >=5.0"
+            - if: "target != esp32h2"
+
     espressif/esp_rcp_update:
         version: "1.2.0"
         rules:


### PR DESCRIPTION
* Attempt to fix ESP32 builds by not compiling insights at all. This breaks insights, but should make CI pass

* Fix typo

* Another better fix: pull in the other dependency too

Cherrypicks #36025 on the v1.4 branch

