### PR TITLE
Fix name of the Secondary Network Interface device type in the XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2612,7 +2612,7 @@ limitations under the License.
     <deviceType>
         <name>MA-secondary-network-interface</name>
         <domain>CHIP</domain>
-        <typeName>Matter Secondary Network Interface Device Type</typeName>
+        <typeName>Matter Secondary Network Interface</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0019</deviceId>
         <class>Utility</class>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -44,7 +44,7 @@ constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x00000014, DeviceTypeClass::Utility, "Matter OTA Provider" },
     { 0x00000015, DeviceTypeClass::Simple, "Matter Contact Sensor" },
     { 0x00000016, DeviceTypeClass::Node, "Matter Root Node" },
-    { 0x00000019, DeviceTypeClass::Utility, "Matter Secondary Network Interface Device Type" },
+    { 0x00000019, DeviceTypeClass::Utility, "Matter Secondary Network Interface" },
     { 0x00000022, DeviceTypeClass::Simple, "Matter Speaker" },
     { 0x00000023, DeviceTypeClass::Simple, "Matter Casting Video Player" },
     { 0x00000024, DeviceTypeClass::Simple, "Matter Content App" },

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6438,7 +6438,7 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
     case 0x00000016:
         return "Matter Root Node";
     case 0x00000019:
-        return "Matter Secondary Network Interface Device Type";
+        return "Matter Secondary Network Interface";
     case 0x00000022:
         return "Matter Speaker";
     case 0x00000023:


### PR DESCRIPTION
The name does not include "Device Type" in it.
