### PR TITLE
Fix device type metadata for bridge device types.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -177,7 +177,7 @@ limitations under the License.
         <typeName>Matter Aggregator</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x000e</deviceId>
-        <class>Dynamic Utility</class>
+        <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -190,9 +190,9 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
-        <name>MA-bridgeddevice</name>
+        <name>MA-bridgednode</name>
         <domain>CHIP</domain>
-        <typeName>Matter Bridged Device</typeName>
+        <typeName>Matter Bridged Node</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x0013</deviceId>
         <class>Utility</class>

--- a/src/darwin/Framework/CHIP/templates/MTRDeviceTypeMetadata-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRDeviceTypeMetadata-src.zapt
@@ -21,9 +21,7 @@ struct DeviceTypeData {
 constexpr DeviceTypeData knownDeviceTypes[] = {
   {{#zcl_device_types}}
   {{#if class}}
-  {{! For now work around the "Dynamic Utility" thing on Aggregator by just
-      taking the last word. }}
-  { {{asHex code 8}}, DeviceTypeClass::{{asLastWord class}}, "{{caption}}" },
+  { {{asHex code 8}}, DeviceTypeClass::{{class}}, "{{caption}}" },
   {{/if}}
   {{/zcl_device_types}}
 };

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -36,11 +36,11 @@ struct DeviceTypeData {
 constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x0000000A, DeviceTypeClass::Simple, "Matter Door Lock" },
     { 0x0000000B, DeviceTypeClass::Simple, "Matter Door Lock Controller" },
-    { 0x0000000E, DeviceTypeClass::Utility, "Matter Aggregator" },
+    { 0x0000000E, DeviceTypeClass::Simple, "Matter Aggregator" },
     { 0x0000000F, DeviceTypeClass::Simple, "Matter Generic Switch" },
     { 0x00000011, DeviceTypeClass::Utility, "Matter Power Source" },
     { 0x00000012, DeviceTypeClass::Utility, "Matter OTA Requestor" },
-    { 0x00000013, DeviceTypeClass::Utility, "Matter Bridged Device" },
+    { 0x00000013, DeviceTypeClass::Utility, "Matter Bridged Node" },
     { 0x00000014, DeviceTypeClass::Utility, "Matter OTA Provider" },
     { 0x00000015, DeviceTypeClass::Simple, "Matter Contact Sensor" },
     { 0x00000016, DeviceTypeClass::Node, "Matter Root Node" },

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6430,7 +6430,7 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
     case 0x00000012:
         return "Matter OTA Requestor";
     case 0x00000013:
-        return "Matter Bridged Device";
+        return "Matter Bridged Node";
     case 0x00000014:
         return "Matter OTA Provider";
     case 0x00000015:


### PR DESCRIPTION
* Bridged Node was named wrong.
* Aggregator had a class listed that did not match the spec.
