### PR TITLE
QPG fix for OpenThread bump compile error

### DIFF
--- a/examples/platform/qpg/project_include/OpenThreadConfig.h
+++ b/examples/platform/qpg/project_include/OpenThreadConfig.h
@@ -80,6 +80,8 @@
 #define OPENTHREAD_EXAMPLES_SIMULATION 0
 #define OPENTHREAD_CONFIG_PLATFORM_BOOTLOADER_MODE_ENABLE 0
 
+#define OPENTHREAD_PLATFORM_NEXUS 0
+
 // Use the Qorvo-supplied default platform configuration for remainder
 // of OpenThread config options.
 //


### PR DESCRIPTION
Added explicit define for OPENTHREAD_PLATFORM_NEXUS to validate it to 0 to fix -Werror=undef compilation error

