### PR TITLE
[darwin-framework-tool] Add missing autoreleasepool before checking f…

### DIFF
--- a/examples/darwin-framework-tool/debug/LeakChecker.mm
+++ b/examples/darwin-framework-tool/debug/LeakChecker.mm
@@ -60,9 +60,11 @@
 int ConditionalLeaksCheck(int exitCode)
 {
 #ifdef DFT_ENABLE_LEAK_CHECKING
-    auto * leakChecker = [[LeakChecker alloc] init];
-    if ([leakChecker hasMemoryLeaks]) {
-        return EXIT_FAILURE;
+    @autoreleasepool {
+        auto * leakChecker = [[LeakChecker alloc] init];
+        if ([leakChecker hasMemoryLeaks]) {
+            return EXIT_FAILURE;
+        }
     }
 #endif // DFT_ENABLE_LEAK_CHECKING
 


### PR DESCRIPTION
…or leaks

#### Problem

While inspecting missing autorelease pools, I noticed that I forgot to add a pool to the code that checks for leaks after the main autorelease pool has been drained. Apologies for the oversight!