### PR TITLE
Fix dependency requirement for CI cancel

### DIFF
--- a/.github/workflows/cancel_workflows_for_pr.yaml
+++ b/.github/workflows/cancel_workflows_for_pr.yaml
@@ -35,10 +35,11 @@ jobs:
                 python-version: '3.12'
             - name: Setup pip modules we use
               run: |
-                  pip install     \
-                      click       \
-                      coloredlogs \
-                      pygithub    \
+                  pip install         \
+                      click           \
+                      coloredlogs     \
+                      python-dateutil \
+                      pygithub        \
                       && echo "DONE installint python prerequisites"
             - name: Cancel runs
               run: |


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/actions/runs/11293251215/job/31410960679 failed with

```
Traceback (most recent call last):
  File "/home/runner/work/connectedhomeip/connectedhomeip/scripts/tools/cancel_workflows_for_pr.py", line 25, in <module>
    from dateutil.tz import tzlocal
ModuleNotFoundError: No module named 'dateutil'
```

So add this to PIP install