### PR TITLE
Decouple PumpConfigurationAndControl from EmberCompat

### DIFF
--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -81,8 +81,8 @@ static void setEffectiveModes(EndpointId endpoint)
         // if this is not suitable, the application should override this value in
         // the post attribute change callback for the operation mode attribute
         const EmberAfAttributeMetadata * effectiveControlModeMetaData;
-        effectiveControlModeMetaData = GetAttributeMetadata(
-            app::ConcreteAttributePath(endpoint, PumpConfigurationAndControl::Id, Attributes::EffectiveControlMode::Id));
+        effectiveControlModeMetaData =
+            emberAfLocateAttributeMetadata(endpoint, PumpConfigurationAndControl::Id, Attributes::EffectiveControlMode::Id);
         controlMode = static_cast<ControlModeEnum>(effectiveControlModeMetaData->defaultValue.defaultValue);
     }
 


### PR DESCRIPTION
This uses the ember internal function instead of the ember compatibility functions override. It is somewhat unclear why we have an override that replaces one method with a single method that is identical except arguments.

clusters implementations are often coupled to ember, however they should not be coupled to ember-compatibility-functions.cpp 

We should also figure out if there is some other way updating things as relying that we have a "ember default" is somewhat odd here.