### PR TITLE
Fix constraint check in thermostat cluster to follow the spec.

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -235,6 +235,7 @@ def _GetChipReplUnsupportedTests() -> Set[str]:
         "TestReadNoneSubscribeNone.yaml",    # chip-repl does not support AnyCommands (07/27/2023)
         "Test_TC_IDM_1_2.yaml",              # chip-repl does not support AnyCommands (19/07/2023)
         "Test_TC_BRBINFO_2_1.yaml",          # chip-repl does not support AnyCommands (24/07/2024)
+        "TestThermostat.yaml",               # chip-repl does not support AnyCommands (14/10/2024)
         "TestIcdManagementCluster.yaml",   # TODO(#30430): add ICD registration support in chip-repl
         "Test_TC_ICDM_3_4.yaml",           # chip-repl does not support ICD registration
         # chip-repl and chip-tool disagree on what the YAML here should look like: https://github.com/project-chip/connectedhomeip/issues/29110

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -778,8 +778,8 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
             return Status::InvalidValue;
         }
         auto RequestedSystemMode = static_cast<SystemModeEnum>(*value);
-        if (ControlSequenceOfOperation > ControlSequenceOfOperationEnum::kCoolingAndHeatingWithReheat ||
-            RequestedSystemMode > SystemModeEnum::kFanOnly)
+        if (ControlSequenceOfOperation == ControlSequenceOfOperationEnum::kUnknownEnumValue ||
+            RequestedSystemMode == SystemModeEnum::kUnknownEnumValue)
         {
             return Status::InvalidValue;
         }

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -778,8 +778,8 @@ MatterThermostatClusterServerPreAttributeChangedCallback(const app::ConcreteAttr
             return Status::InvalidValue;
         }
         auto RequestedSystemMode = static_cast<SystemModeEnum>(*value);
-        if (ControlSequenceOfOperation == ControlSequenceOfOperationEnum::kUnknownEnumValue ||
-            RequestedSystemMode == SystemModeEnum::kUnknownEnumValue)
+        if (EnsureKnownEnumValue(ControlSequenceOfOperation) == ControlSequenceOfOperationEnum::kUnknownEnumValue ||
+            EnsureKnownEnumValue(RequestedSystemMode) == SystemModeEnum::kUnknownEnumValue)
         {
             return Status::InvalidValue;
         }

--- a/src/app/tests/suites/TestThermostat.yaml
+++ b/src/app/tests/suites/TestThermostat.yaml
@@ -46,6 +46,47 @@ tests:
       response:
           value: SystemModeEnum.Sleep
 
+    - label: "Try to set SystemMode to an invalid value"
+      # Have to use WriteById, because normal write enforces valid values for enums.
+      cluster: "AnyCommands"
+      command: "WriteById"
+      attribute: "SystemMode"
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: 0x0201 # Thermostat
+              - name: "AttributeId"
+                value: 0x001C # SystemMode
+              - name: "Value"
+                # Note: At some point this might become a valid value,
+                # and then this test will need to be adjusted, but that
+                # seems fairly low-probability.
+                value: 254
+      response:
+          error: CONSTRAINT_ERROR
+
+    - label: "Verify that WriteById would work correctly with a valid value"
+      cluster: "AnyCommands"
+      command: "WriteById"
+      attribute: "SystemMode"
+      arguments:
+          values:
+              - name: "ClusterId"
+                value: 0x0201 # Thermostat
+              - name: "AttributeId"
+                value: 0x001C # SystemMode
+              - name: "Value"
+                # Note: At some point this might become a valid value,
+                # and then this test will need to be adjusted, but that
+                # seems fairly low-probability.
+                value: 8 # SystemModeEnum.Dry
+
+    - label: "Check that the new value is set by id"
+      command: "readAttribute"
+      attribute: "SystemMode"
+      response:
+          value: SystemModeEnum.Dry
+
     - label: "reset SystemMode to original value"
       command: "writeAttribute"
       attribute: "SystemMode"

--- a/src/app/tests/suites/TestThermostat.yaml
+++ b/src/app/tests/suites/TestThermostat.yaml
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Thermostat basic functionality tests
+
+config:
+    nodeId: 0x12344321
+    cluster: "Thermostat"
+    endpoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Read current SystemMode value"
+      command: "readAttribute"
+      attribute: "SystemMode"
+      response:
+          saveAs: originalSystemMode
+
+    - label: "Try to set SystemMode to Sleep"
+      command: "writeAttribute"
+      attribute: "SystemMode"
+      arguments:
+          value: SystemModeEnum.Sleep
+
+    - label: "Check that the new value is set now"
+      command: "readAttribute"
+      attribute: "SystemMode"
+      response:
+          value: SystemModeEnum.Sleep
+
+    - label: "reset SystemMode to original value"
+      command: "writeAttribute"
+      attribute: "SystemMode"
+      arguments:
+          value: originalSystemMode

--- a/src/app/tests/suites/TestThermostat.yaml
+++ b/src/app/tests/suites/TestThermostat.yaml
@@ -76,9 +76,6 @@ tests:
               - name: "AttributeId"
                 value: 0x001C # SystemMode
               - name: "Value"
-                # Note: At some point this might become a valid value,
-                # and then this test will need to be adjusted, but that
-                # seems fairly low-probability.
                 value: 8 # SystemModeEnum.Dry
 
     - label: "Check that the new value is set by id"


### PR DESCRIPTION
The cluster was excluding valid SystemMode values.
