### PR TITLE
[SILABS] : using dynamic initialization for identify endpoints

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -438,7 +438,6 @@ bool BaseApplication::ActivateStatusLedPatterns()
             }
             isPatternSet = true;
         }
-        break;
     }
 #endif // MATTER_DM_PLUGIN_IDENTIFY_SERVER
 

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -715,7 +715,7 @@ void BaseApplication::OnTriggerIdentifyEffectCompleted(chip::System::Layer * sys
 
 void BaseApplication::OnTriggerIdentifyEffect(Identify * identify)
 {
-    sIdentifyEffect        = identify->mCurrentEffectIdentifier;
+    sIdentifyEffect = identify->mCurrentEffectIdentifier;
 
     if (identify->mEffectVariant != Clusters::Identify::EffectVariantEnum::kDefault)
     {


### PR DESCRIPTION
### Summary
**Description of Problem/Feature:**
1. Identify cluster is not handled for multiple endpoints, causing failure to run identifytime in endpoints 2,3 ofthe  sensor app

**Description of Fix/Solution:**
1. Implemented initialization and LED blinking for the Identify cluster for all the endpoints dynamically. 

### Testing
Commissioned and tested with ep 2 on the window app

