### PR TITLE
[CI] Add a step in CI to ensure darwin-framework-tool can be built on iOS.

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -73,6 +73,10 @@ jobs:
                 platform: darwin
                 bootstrap-log-name: bootstrap-logs-darwin-${{ matrix.build_variant }}
 
+            - name: Build iOS Darwin Framework Tool Build Debug
+              working-directory: src/darwin/Framework
+              run: xcodebuild -target "darwin-framework-tool" -sdk iphoneos -configuration Debug AD_HOC_CODE_SIGNING_ALLOWED=YES
+
             - name: Run macOS Darwin Framework Tool Build Debug
               working-directory: src/darwin/Framework
               run: xcodebuild -target "darwin-framework-tool" -sdk macosx -configuration Debug

--- a/examples/darwin-framework-tool/commands/memory/LeaksTool.mm
+++ b/examples/darwin-framework-tool/commands/memory/LeaksTool.mm
@@ -31,6 +31,7 @@ constexpr const char * kDefaultOutputGraphPath = "darwin-framework-tool.memgraph
 
 - (BOOL)runWithArguments:(NSArray<NSString *> * _Nullable)arguments
 {
+#if TARGET_OS_OSX
     pid_t pid = getpid();
     __auto_type * pidString = [NSString stringWithFormat:@"%d", pid];
 
@@ -59,6 +60,10 @@ constexpr const char * kDefaultOutputGraphPath = "darwin-framework-tool.memgraph
     NSLog(@"%@", output);
 
     return YES;
+#else
+    NSLog(@"Running leaks as a task is supported on this platform.");
+    return NO;
+#endif // TARGET_OS_OSX
 }
 
 @end

--- a/examples/darwin-framework-tool/debug/LeakChecker.mm
+++ b/examples/darwin-framework-tool/debug/LeakChecker.mm
@@ -29,6 +29,7 @@
 
 - (BOOL)hasMemoryLeaks
 {
+#if TARGET_OS_OSX
     pid_t pid = getpid();
     auto * pidString = [NSString stringWithFormat:@"%d", pid];
 
@@ -51,6 +52,9 @@
         NSLog(@"%@", output);
         return YES;
     }
+#else
+    NSLog(@"Running leaks as a task is supported on this platform.");
+#endif // TARGET_OS_OSX
 
     return NO;
 }

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -2242,7 +2242,12 @@
 					"$(CONFIGURATION_TEMP_DIR)/Matter.build/out/obj/src/app/lib",
 				);
 				OTHER_CFLAGS = "-DLWS_PLAT_UNIX";
+				"OTHER_CFLAGS[sdk=iphoneos*]" = (
+					"-DLWS_PLAT_UNIX",
+					"-DLWS_DETECTED_PLAT_IOS",
+				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
@@ -2315,7 +2320,12 @@
 					"$(CONFIGURATION_TEMP_DIR)/Matter.build/out/obj/src/app/lib",
 				);
 				OTHER_CFLAGS = "-DLWS_PLAT_UNIX";
+				"OTHER_CFLAGS[sdk=iphoneos*]" = (
+					"-DLWS_PLAT_UNIX",
+					"-DLWS_DETECTED_PLAT_IOS",
+				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = "$(OTHER_CFLAGS)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;

--- a/third_party/libwebsockets/BUILD.gn
+++ b/third_party/libwebsockets/BUILD.gn
@@ -106,6 +106,10 @@ source_set("libwebsockets") {
     ]
 
     cflags = [ "-DLWS_PLAT_UNIX" ]
+
+    if (target_os == "ios") {
+      cflags += [ "-DLWS_DETECTED_PLAT_IOS" ]
+    }
   }
 
   public_configs = [ ":libwebsockets_config" ]


### PR DESCRIPTION
#### Problem

There were some build system issues with `darwin-framework-tool` and `NSTask`.

This PR resolves those issues and adds a CI step for building on iOS.

