### PR TITLE
[YAML] Add _ById commands support for darwin-framework-tool - Followu…

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/decoder.py
@@ -386,6 +386,13 @@ class StructFieldsNameConverter():
                 del value[key_name]
 
         elif isinstance(value, list) and array:
+            # Instead of using `False` for the last parameter (array), `isinstance(v, list)` is used.
+            # While the data model specification does not include lists of lists, the format returned
+            # by the Matter.framework for *ById APIs may contain them.
+            # For example, the command:
+            # darwin-framework-tool any read-by-id 29 0 0x12344321 65535
+            # returns value such as:
+            # [[{'DeviceType': 17, 'Revision': 1}, {'DeviceType': 22, 'Revision': 1}], ...]
             value = [self.run(specs, v, cluster_name, typename, isinstance(v, list))
                      for v in value]
 


### PR DESCRIPTION
…p: Add comment explaining the use of isinstance for list detection

#### Problem

I forgot to add a comment explaining the reasoning behind a particular use of `isinstance` in #35996  that may be unclear. This PR adds the missing explanation as a follow-up.