### PR TITLE
Use standard std::min std::max functions

### DIFF
--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -29,7 +29,7 @@
 class Commands
 {
 public:
-    using CommandsVector = ::std::vector<std::unique_ptr<Command>>;
+    using CommandsVector = std::vector<std::unique_ptr<Command>>;
 
     void RegisterCluster(const char * clusterName, commands_list commandsList)
     {

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -934,10 +934,10 @@ Status EnergyEvseDelegate::ComputeMaxChargeCurrentLimit()
 
     oldValue                    = mActualChargingCurrentLimit;
     mActualChargingCurrentLimit = mMaxHardwareCurrentLimit;
-    mActualChargingCurrentLimit = min(mActualChargingCurrentLimit, mCircuitCapacity);
-    mActualChargingCurrentLimit = min(mActualChargingCurrentLimit, mCableAssemblyCurrentLimit);
-    mActualChargingCurrentLimit = min(mActualChargingCurrentLimit, mMaximumChargingCurrentLimitFromCommand);
-    mActualChargingCurrentLimit = min(mActualChargingCurrentLimit, mUserMaximumChargeCurrent);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mCircuitCapacity);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mCableAssemblyCurrentLimit);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mMaximumChargingCurrentLimitFromCommand);
+    mActualChargingCurrentLimit = std::min(mActualChargingCurrentLimit, mUserMaximumChargeCurrent);
 
     /* Set the actual max charging current attribute */
     mMaximumChargeCurrent = mActualChargingCurrentLimit;

--- a/examples/fabric-admin/commands/common/Commands.h
+++ b/examples/fabric-admin/commands/common/Commands.h
@@ -29,7 +29,7 @@
 class Commands
 {
 public:
-    using CommandsVector = ::std::vector<std::unique_ptr<Command>>;
+    using CommandsVector = std::vector<std::unique_ptr<Command>>;
 
     void RegisterCluster(const char * clusterName, commands_list commandsList)
     {

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -61,7 +61,7 @@ constexpr uint32_t kBdxServerPollIntervalMillis    = 50;                        
 void GetUpdateTokenString(const chip::ByteSpan & token, char * buf, size_t bufSize)
 {
     const uint8_t * tokenData = static_cast<const uint8_t *>(token.data());
-    size_t minLength          = chip::min(token.size(), bufSize);
+    size_t minLength          = std::min(token.size(), bufSize);
     for (size_t i = 0; i < (minLength / 2) - 1; ++i)
     {
         snprintf(&buf[i * 2], bufSize, "%02X", tokenData[i]);

--- a/examples/platform/nrfconnect/util/PWMDevice.cpp
+++ b/examples/platform/nrfconnect/util/PWMDevice.cpp
@@ -18,6 +18,8 @@
 
 #include "PWMDevice.h"
 
+#include <algorithm>
+
 #include "AppConfig.h"
 
 #include <lib/support/CodeUtils.h>

--- a/examples/platform/nrfconnect/util/PWMDevice.cpp
+++ b/examples/platform/nrfconnect/util/PWMDevice.cpp
@@ -129,7 +129,7 @@ void PWMDevice::SuppressOutput()
 void PWMDevice::ApplyLevel()
 {
     const uint8_t maxEffectiveLevel = mMaxLevel - mMinLevel;
-    const uint8_t effectiveLevel    = mState == kState_On ? chip::min<uint8_t>(mLevel - mMinLevel, maxEffectiveLevel) : 0;
+    const uint8_t effectiveLevel    = mState == kState_On ? std::min<uint8_t>(mLevel - mMinLevel, maxEffectiveLevel) : 0;
 
     pwm_set_pulse_dt(mPwmDevice,
                      static_cast<uint32_t>(static_cast<const uint64_t>(mPwmDevice->period) * effectiveLevel / maxEffectiveLevel));

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -94,10 +94,6 @@ bool ps_requirement_added = false;
 // TODO: Figure out why we actually need this, we are already handling failure and retries somewhere else.
 #define WIFI_SCAN_TIMEOUT_TICK 10000
 
-#if !defined(MIN)
-#define MIN(A, B) ((A) < (B) ? (A) : (B))
-#endif
-
 WfxRsi_t wfx_rsi;
 
 bool hasNotifiedIPV6 = false;
@@ -541,12 +537,12 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
         memset(&cur_scan_result, 0, sizeof(cur_scan_result));
 
         cur_scan_result.ssid_length = strnlen((char *) scan_result->scan_info[idx].ssid,
-                                              chip::min<size_t>(sizeof(scan_result->scan_info[idx].ssid), WFX_MAX_SSID_LENGTH));
+                                              std::min<size_t>(sizeof(scan_result->scan_info[idx].ssid), WFX_MAX_SSID_LENGTH));
         chip::Platform::CopyString(cur_scan_result.ssid, cur_scan_result.ssid_length, (char *) scan_result->scan_info[idx].ssid);
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
         if (wfx_rsi.scan_ssid != NULL &&
-            (strncmp(wfx_rsi.scan_ssid, cur_scan_result.ssid, MIN(strlen(wfx_rsi.scan_ssid), strlen(cur_scan_result.ssid))) ==
+            (strncmp(wfx_rsi.scan_ssid, cur_scan_result.ssid, std::min(strlen(wfx_rsi.scan_ssid), strlen(cur_scan_result.ssid))) ==
              CMP_SUCCESS))
         {
             continue;
@@ -643,7 +639,7 @@ static sl_status_t wfx_rsi_do_join(void)
     case WFX_SEC_WPA3:
         ap.security = SL_WIFI_WPA3_TRANSITION;
 #else
-        ap.security          = SL_WIFI_WPA_WPA2_MIXED;
+        ap.security = SL_WIFI_WPA_WPA2_MIXED;
 #endif // WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         break;
     case WFX_SEC_NONE:

--- a/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
+++ b/examples/platform/silabs/SiWx917/SiWx917/sl_wifi_if.cpp
@@ -639,7 +639,7 @@ static sl_status_t wfx_rsi_do_join(void)
     case WFX_SEC_WPA3:
         ap.security = SL_WIFI_WPA3_TRANSITION;
 #else
-        ap.security = SL_WIFI_WPA_WPA2_MIXED;
+        ap.security          = SL_WIFI_WPA_WPA2_MIXED;
 #endif // WIFI_ENABLE_SECURITY_WPA3_TRANSITION
         break;
     case WFX_SEC_NONE:

--- a/examples/platform/silabs/efr32/rs911x/rsi_if.cpp
+++ b/examples/platform/silabs/efr32/rs911x/rsi_if.cpp
@@ -752,7 +752,7 @@ void ProcessEvent(WfxEvent_t inEvent)
             // clear structure and calculate size of SSID
             memset(&ap, 0, sizeof(ap));
             ap.ssid_length =
-                strnlen(reinterpret_cast<char *>(scan->ssid), chip::min<size_t>(sizeof(scan->ssid), WFX_MAX_SSID_LENGTH));
+                strnlen(reinterpret_cast<char *>(scan->ssid), std::min<size_t>(sizeof(scan->ssid), WFX_MAX_SSID_LENGTH));
             chip::Platform::CopyString(ap.ssid, ap.ssid_length, reinterpret_cast<char *>(scan->ssid));
 
             // check if the scanned ssid is the one we are looking for

--- a/examples/platform/silabs/efr32/wf200/host_if.cpp
+++ b/examples/platform/silabs/efr32/wf200/host_if.cpp
@@ -736,7 +736,7 @@ int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
 {
     int32_t signal_strength;
 
-    ap->ssid_length = strnlen(ap_info.ssid, chip::min<size_t>(sizeof(ap_info.ssid), WFX_MAX_SSID_LENGTH));
+    ap->ssid_length = strnlen(ap_info.ssid, std::min<size_t>(sizeof(ap_info.ssid), WFX_MAX_SSID_LENGTH));
     chip::Platform::CopyString(ap->ssid, ap->ssid_length, ap_info.ssid);
     memcpy(ap->bssid, ap_info.bssid, sizeof(ap_info.bssid));
     ap->security = ap_info.security;

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -65,10 +65,6 @@ extern "C" {
 #include "sl_power_manager.h"
 #endif
 
-#if !defined(MIN)
-#define MIN(A, B) ((A) < (B) ? (A) : (B))
-#endif
-
 #ifdef SL_CATALOG_UARTDRV_EUSART_PRESENT
 #define HELPER1(x) EUSART##x##_RX_IRQn
 #else
@@ -278,7 +274,7 @@ static uint16_t RetrieveFromFifo(Fifo_t * fifo, uint8_t * pData, uint16_t SizeTo
     VerifyOrDie(pData != nullptr);
     VerifyOrDie(SizeToRead <= fifo->MaxSize);
 
-    uint16_t ReadSize        = MIN(SizeToRead, AvailableDataCount(fifo));
+    uint16_t ReadSize        = std::min(SizeToRead, AvailableDataCount(fifo));
     uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Head);
 
     if (ReadSize > nBytesBeforWrap)

--- a/examples/platform/silabs/wifi/wfx_rsi_host.cpp
+++ b/examples/platform/silabs/wifi/wfx_rsi_host.cpp
@@ -369,7 +369,7 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     wfx_rsi.scan_cb = callback;
 
     VerifyOrReturnError(ssid != nullptr, false);
-    wfx_rsi.scan_ssid_length = strnlen(ssid, chip::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
+    wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
     wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
     VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
     chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);

--- a/src/app/DefaultAttributePersistenceProvider.cpp
+++ b/src/app/DefaultAttributePersistenceProvider.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR DefaultAttributePersistenceProvider::InternalReadValue(const StorageK
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    uint16_t size = static_cast<uint16_t>(min(aValue.size(), static_cast<size_t>(UINT16_MAX)));
+    uint16_t size = static_cast<uint16_t>(std::min(aValue.size(), static_cast<size_t>(UINT16_MAX)));
     ReturnErrorOnFailure(mStorage->SyncGetKeyValue(aKey.KeyName(), aValue.data(), size));
     aValue.reduce_size(size);
     return CHIP_NO_ERROR;

--- a/src/app/DeferredAttributePersistenceProvider.cpp
+++ b/src/app/DeferredAttributePersistenceProvider.cpp
@@ -81,7 +81,7 @@ void DeferredAttributePersistenceProvider::FlushAndScheduleNext()
         }
         else
         {
-            nextFlushTime = chip::min(nextFlushTime, da.GetFlushTime());
+            nextFlushTime = std::min(nextFlushTime, da.GetFlushTime());
         }
     }
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1929,7 +1929,7 @@ uint16_t InteractionModelEngine::GetMinGuaranteedSubscriptionsPerFabric() const
     return UINT16_MAX;
 #else
     return static_cast<uint16_t>(
-        min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(), static_cast<size_t>(UINT16_MAX)));
+        std::min(GetReadHandlerPoolCapacityForSubscriptions() / GetConfigMaxFabrics(), static_cast<size_t>(UINT16_MAX)));
 #endif
 }
 

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -168,7 +168,7 @@ bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     // formatted string, as long as we account for the possible string formats.
     constexpr size_t statusNameMaxLength =
 #define CHIP_IM_STATUS_CODE(name, spec_name, value)                                                                                \
-        max(sizeof(#spec_name),
+        std::max(sizeof(#spec_name),
 #include <protocols/interaction_model/StatusCodeList.h>
 #undef CHIP_IM_STATUS_CODE
         static_cast<size_t>(0)
@@ -177,7 +177,7 @@ bool FormatStatusIBError(char * buf, uint16_t bufSize, CHIP_ERROR err)
 #include <protocols/interaction_model/StatusCodeList.h>
 #undef CHIP_IM_STATUS_CODE
         ;
-    constexpr size_t formattedSize = max(sizeof(generalFormat) + statusNameMaxLength, sizeof(clusterFormat));
+    constexpr size_t formattedSize = std::max(sizeof(generalFormat) + statusNameMaxLength, sizeof(clusterFormat));
     char formattedString[formattedSize];
 
     StatusIB status(err);

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -744,7 +744,7 @@ CHIP_ERROR OperationalSessionSetup::ScheduleSessionSetupReattempt(System::Clock:
                   "Our backoff calculation will overflow.");
     System::Clock::Timeout actualTimerDelay = System::Clock::Seconds16(
         static_cast<uint16_t>(CHIP_DEVICE_CONFIG_AUTOMATIC_CASE_RETRY_INITIAL_DELAY_SECONDS
-                              << min((mAttemptsDone - 1), CHIP_DEVICE_CONFIG_AUTOMATIC_CASE_RETRY_MAX_BACKOFF)));
+                              << std::min((mAttemptsDone - 1), CHIP_DEVICE_CONFIG_AUTOMATIC_CASE_RETRY_MAX_BACKOFF)));
     const bool responseWasBusy = mRequestedBusyDelay != System::Clock::kZero;
     if (responseWasBusy)
     {

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1283,7 +1283,7 @@ Status ColorControlServer::moveToSaturation(uint8_t saturation, uint16_t transit
     // now, kick off the state machine.
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
     colorSaturationTransitionState->finalValue     = saturation;
-    colorSaturationTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorSaturationTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorSaturationTransitionState->stepsTotal     = colorSaturationTransitionState->stepsRemaining;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
     colorSaturationTransitionState->transitionTime = transitionTime;
@@ -1363,7 +1363,7 @@ Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturati
     }
 
     colorHueTransitionState->up             = moveUp;
-    colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorHueTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
     colorHueTransitionState->transitionTime = transitionTime;
@@ -1614,7 +1614,7 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
         colorHueTransitionState->finalHue = static_cast<uint8_t>(hue);
     }
 
-    colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorHueTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
     colorHueTransitionState->transitionTime = transitionTime;
@@ -1758,7 +1758,7 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
         }
     }
 
-    colorHueTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorHueTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorHueTransitionState->stepsTotal     = colorHueTransitionState->stepsRemaining;
     colorHueTransitionState->timeRemaining  = transitionTime;
     colorHueTransitionState->transitionTime = transitionTime;
@@ -1934,7 +1934,7 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
     {
         colorSaturationTransitionState->finalValue = subtractSaturation(currentSaturation, stepSize);
     }
-    colorSaturationTransitionState->stepsRemaining = max<uint8_t>(transitionTime, 1);
+    colorSaturationTransitionState->stepsRemaining = std::max<uint8_t>(transitionTime, 1);
     colorSaturationTransitionState->stepsTotal     = colorSaturationTransitionState->stepsRemaining;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
     colorSaturationTransitionState->transitionTime = transitionTime;
@@ -2276,7 +2276,7 @@ Status ColorControlServer::moveToColor(uint16_t colorX, uint16_t colorY, uint16_
     Attributes::CurrentX::Get(endpoint, &(colorXTransitionState->initialValue));
     Attributes::CurrentX::Get(endpoint, &(colorXTransitionState->currentValue));
     colorXTransitionState->finalValue     = colorX;
-    colorXTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorXTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorXTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorXTransitionState->timeRemaining  = transitionTime;
     colorXTransitionState->transitionTime = transitionTime;
@@ -2463,7 +2463,7 @@ bool ColorControlServer::stepColorCommand(app::CommandHandler * commandObj, cons
     colorXTransitionState->initialValue   = currentColorX;
     colorXTransitionState->currentValue   = currentColorX;
     colorXTransitionState->finalValue     = colorX;
-    colorXTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorXTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorXTransitionState->stepsTotal     = colorXTransitionState->stepsRemaining;
     colorXTransitionState->timeRemaining  = transitionTime;
     colorXTransitionState->transitionTime = transitionTime;
@@ -2607,7 +2607,7 @@ Status ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorT
     Attributes::ColorTemperatureMireds::Get(endpoint, &(colorTempTransitionState->currentValue));
 
     colorTempTransitionState->finalValue     = colorTemperature;
-    colorTempTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorTempTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorTempTransitionState->stepsTotal     = colorTempTransitionState->stepsRemaining;
     colorTempTransitionState->timeRemaining  = transitionTime;
     colorTempTransitionState->transitionTime = transitionTime;
@@ -2990,7 +2990,7 @@ bool ColorControlServer::stepColorTempCommand(app::CommandHandler * commandObj, 
             colorTempTransitionState->finalValue = static_cast<uint16_t>(finalValue32u);
         }
     }
-    colorTempTransitionState->stepsRemaining = max<uint16_t>(transitionTime, 1);
+    colorTempTransitionState->stepsRemaining = std::max<uint16_t>(transitionTime, 1);
     colorTempTransitionState->stepsTotal     = colorTempTransitionState->stepsRemaining;
     colorTempTransitionState->timeRemaining  = transitionTime;
     colorTempTransitionState->transitionTime = transitionTime;

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1093,7 +1093,7 @@ void ColorControlServer::SetHSVRemainingTime(chip::EndpointId endpoint)
     {
         bool hsvTransitionStart = (hueTransitionState->stepsRemaining == hueTransitionState->stepsTotal) ||
             (saturationTransitionState->stepsRemaining == saturationTransitionState->stepsTotal);
-        SetQuietReportRemainingTime(endpoint, max(hueTransitionState->timeRemaining, saturationTransitionState->timeRemaining),
+        SetQuietReportRemainingTime(endpoint, std::max(hueTransitionState->timeRemaining, saturationTransitionState->timeRemaining),
                                     hsvTransitionStart);
     }
 }
@@ -2402,7 +2402,7 @@ bool ColorControlServer::moveColorCommand(app::CommandHandler * commandObj, cons
     colorYTransitionState->lowLimit       = MIN_CIE_XY_VALUE;
     colorYTransitionState->highLimit      = MAX_CIE_XY_VALUE;
 
-    SetQuietReportRemainingTime(endpoint, max(transitionTimeX, transitionTimeY), true /* isNewTransition */);
+    SetQuietReportRemainingTime(endpoint, std::max(transitionTimeX, transitionTimeY), true /* isNewTransition */);
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureXYEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
@@ -2507,7 +2507,7 @@ void ColorControlServer::updateXYCommand(EndpointId endpoint)
     bool isXTransitionDone = computeNewColor16uValue(colorXTransitionState);
     bool isYTransitionDone = computeNewColor16uValue(colorYTransitionState);
 
-    SetQuietReportRemainingTime(endpoint, max(colorXTransitionState->timeRemaining, colorYTransitionState->timeRemaining));
+    SetQuietReportRemainingTime(endpoint, std::max(colorXTransitionState->timeRemaining, colorYTransitionState->timeRemaining));
 
     if (isXTransitionDone && isYTransitionDone)
     {

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -233,7 +233,7 @@ private:
 CHIP_ERROR ThreadScanResponseToTLV::LoadResponses(Platform::ScopedMemoryBuffer<ThreadScanResponse> & scanResponseArray,
                                                   Span<ThreadScanResponse> & validResponses) const
 {
-    VerifyOrReturnError(scanResponseArray.Alloc(chip::min(mNetworks->Count(), kMaxNetworksInScanResponse)), CHIP_ERROR_NO_MEMORY);
+    VerifyOrReturnError(scanResponseArray.Alloc(std::min(mNetworks->Count(), kMaxNetworksInScanResponse)), CHIP_ERROR_NO_MEMORY);
 
     ThreadScanResponse scanResponse;
     size_t scanResponseArrayLength = 0;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -219,17 +219,17 @@ CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason
     case UpdateNotFoundReason::kUpToDate:
         break;
     case UpdateNotFoundReason::kBusy: {
-        status = ScheduleQueryRetry(true, chip::max(kDefaultDelayedActionTime, delay));
+        status = ScheduleQueryRetry(true, std::max(kDefaultDelayedActionTime, delay));
         if (status == CHIP_ERROR_MAX_RETRY_EXCEEDED)
         {
             // If max retry exceeded with current provider, try a different provider
-            status = ScheduleQueryRetry(false, chip::max(kDefaultDelayedActionTime, delay));
+            status = ScheduleQueryRetry(false, std::max(kDefaultDelayedActionTime, delay));
         }
         break;
     }
     case UpdateNotFoundReason::kNotAvailable: {
         // Schedule a query only if a different provider is available
-        status = ScheduleQueryRetry(false, chip::max(kDefaultDelayedActionTime, delay));
+        status = ScheduleQueryRetry(false, std::max(kDefaultDelayedActionTime, delay));
         break;
     }
     }

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -210,8 +210,8 @@ struct FabricSceneData : public PersistentData<kPersistentFabricBufferMax>
 
     FabricSceneData(EndpointId endpoint = kInvalidEndpointId, FabricIndex fabric = kUndefinedFabricIndex,
                     uint16_t maxScenesPerFabric = kMaxScenesPerFabric, uint16_t maxScenesPerEndpoint = kMaxScenesPerEndpoint) :
-        endpoint_id(endpoint),
-        fabric_index(fabric), max_scenes_per_fabric(maxScenesPerFabric), max_scenes_per_endpoint(maxScenesPerEndpoint)
+        endpoint_id(endpoint), fabric_index(fabric), max_scenes_per_fabric(maxScenesPerFabric),
+        max_scenes_per_endpoint(maxScenesPerEndpoint)
     {}
 
     CHIP_ERROR UpdateKey(StorageKeyName & key) override
@@ -276,7 +276,7 @@ struct FabricSceneData : public PersistentData<kPersistentFabricBufferMax>
         ReturnErrorOnFailure(reader.EnterContainer(fabricSceneContainer));
         ReturnErrorOnFailure(reader.Next(TLV::ContextTag(TagScene::kSceneCount)));
         ReturnErrorOnFailure(reader.Get(scene_count));
-        scene_count = min(scene_count, static_cast<uint8_t>(max_scenes_per_fabric));
+        scene_count = std::min(scene_count, static_cast<uint8_t>(max_scenes_per_fabric));
         ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Array, TLV::ContextTag(TagScene::kStorageIDArray)));
         TLV::TLVType sceneMapContainer;
         ReturnErrorOnFailure(reader.EnterContainer(sceneMapContainer));
@@ -577,7 +577,7 @@ CHIP_ERROR DefaultSceneTableImpl::GetRemainingCapacity(FabricIndex fabric_index,
         remaining_capacity_fabric = static_cast<uint8_t>(mMaxScenesPerFabric - fabric.scene_count);
     }
 
-    capacity = min(remaining_capacity_fabric, remaining_capacity_global);
+    capacity = std::min(remaining_capacity_fabric, remaining_capacity_global);
 
     return CHIP_NO_ERROR;
 }
@@ -893,8 +893,8 @@ DefaultSceneTableImpl::SceneEntryIterator * DefaultSceneTableImpl::IterateSceneE
 DefaultSceneTableImpl::SceneEntryIteratorImpl::SceneEntryIteratorImpl(DefaultSceneTableImpl & provider, FabricIndex fabricIdx,
                                                                       EndpointId endpoint, uint16_t maxScenesPerFabric,
                                                                       uint16_t maxScenesEndpoint) :
-    mProvider(provider),
-    mFabric(fabricIdx), mEndpoint(endpoint), mMaxScenesPerFabric(maxScenesPerFabric), mMaxScenesPerEndpoint(maxScenesEndpoint)
+    mProvider(provider), mFabric(fabricIdx), mEndpoint(endpoint), mMaxScenesPerFabric(maxScenesPerFabric),
+    mMaxScenesPerEndpoint(maxScenesEndpoint)
 {
     FabricSceneData fabric(mEndpoint, fabricIdx, mMaxScenesPerFabric, mMaxScenesPerEndpoint);
     ReturnOnFailure(fabric.Load(provider.mStorage));

--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -210,8 +210,8 @@ struct FabricSceneData : public PersistentData<kPersistentFabricBufferMax>
 
     FabricSceneData(EndpointId endpoint = kInvalidEndpointId, FabricIndex fabric = kUndefinedFabricIndex,
                     uint16_t maxScenesPerFabric = kMaxScenesPerFabric, uint16_t maxScenesPerEndpoint = kMaxScenesPerEndpoint) :
-        endpoint_id(endpoint), fabric_index(fabric), max_scenes_per_fabric(maxScenesPerFabric),
-        max_scenes_per_endpoint(maxScenesPerEndpoint)
+        endpoint_id(endpoint),
+        fabric_index(fabric), max_scenes_per_fabric(maxScenesPerFabric), max_scenes_per_endpoint(maxScenesPerEndpoint)
     {}
 
     CHIP_ERROR UpdateKey(StorageKeyName & key) override
@@ -893,8 +893,8 @@ DefaultSceneTableImpl::SceneEntryIterator * DefaultSceneTableImpl::IterateSceneE
 DefaultSceneTableImpl::SceneEntryIteratorImpl::SceneEntryIteratorImpl(DefaultSceneTableImpl & provider, FabricIndex fabricIdx,
                                                                       EndpointId endpoint, uint16_t maxScenesPerFabric,
                                                                       uint16_t maxScenesEndpoint) :
-    mProvider(provider), mFabric(fabricIdx), mEndpoint(endpoint), mMaxScenesPerFabric(maxScenesPerFabric),
-    mMaxScenesPerEndpoint(maxScenesEndpoint)
+    mProvider(provider),
+    mFabric(fabricIdx), mEndpoint(endpoint), mMaxScenesPerFabric(maxScenesPerFabric), mMaxScenesPerEndpoint(maxScenesEndpoint)
 {
     FabricSceneData fabric(mEndpoint, fabricIdx, mMaxScenesPerFabric, mMaxScenesPerEndpoint);
     ReturnOnFailure(fabric.Load(provider.mStorage));

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -214,7 +214,7 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
                 }
                 else
                 {
-                    lastRssi.SetNonNull(min(static_cast<int8_t>(0), neighInfo.mLastRssi));
+                    lastRssi.SetNonNull(std::min(static_cast<int8_t>(0), neighInfo.mLastRssi));
                 }
 
                 neighborTable.averageRssi      = averageRssi;

--- a/src/ble/BLEEndPoint.cpp
+++ b/src/ble/BLEEndPoint.cpp
@@ -1001,7 +1001,7 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBufferHandle && 
     if (mtu > 0) // If one or both device knows connection's MTU...
     {
         resp.mFragmentSize =
-            chip::min(static_cast<uint16_t>(mtu - 3), BtpEngine::sMaxFragmentSize); // Reserve 3 bytes of MTU for ATT header.
+            std::min(static_cast<uint16_t>(mtu - 3), BtpEngine::sMaxFragmentSize); // Reserve 3 bytes of MTU for ATT header.
     }
     else // Else, if neither device knows MTU...
     {
@@ -1012,7 +1012,7 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesRequestReceived(PacketBufferHandle && 
     // Select local and remote max receive window size based on local resources available for both incoming writes AND
     // GATT confirmations.
     mRemoteReceiveWindowSize = mLocalReceiveWindowSize = mReceiveWindowMaxSize =
-        chip::min(req.mWindowSize, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE));
+        std::min(req.mWindowSize, static_cast<uint8_t>(BLE_MAX_RECEIVE_WINDOW_SIZE));
     resp.mWindowSize = mReceiveWindowMaxSize;
 
     ChipLogProgress(Ble, "local and remote recv window sizes = %u", resp.mWindowSize);
@@ -1068,7 +1068,7 @@ CHIP_ERROR BLEEndPoint::HandleCapabilitiesResponseReceived(PacketBufferHandle &&
     }
 
     // Set fragment size as minimum of (reported ATT MTU, BTP characteristic size)
-    resp.mFragmentSize = chip::min(resp.mFragmentSize, BtpEngine::sMaxFragmentSize);
+    resp.mFragmentSize = std::min(resp.mFragmentSize, BtpEngine::sMaxFragmentSize);
 
     mBtpEngine.SetRxFragmentSize(resp.mFragmentSize);
     mBtpEngine.SetTxFragmentSize(resp.mFragmentSize);

--- a/src/ble/BtpEngine.cpp
+++ b/src/ble/BtpEngine.cpp
@@ -274,7 +274,7 @@ CHIP_ERROR BtpEngine::HandleCharacteristicReceived(System::PacketBufferHandle &&
         // mRxFragmentSize may be smaller than the characteristic size.  Make sure
         // we're not truncating to a data length smaller than what we have already consumed.
         VerifyOrExit(reader.OctetsRead() <= mRxFragmentSize, err = BLE_ERROR_REASSEMBLER_INCORRECT_STATE);
-        data->SetDataLength(chip::min(data->DataLength(), static_cast<size_t>(mRxFragmentSize)));
+        data->SetDataLength(std::min(data->DataLength(), static_cast<size_t>(mRxFragmentSize)));
 
         // Now mark the bytes we consumed as consumed.
         data->ConsumeHead(static_cast<uint16_t>(reader.OctetsRead()));

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -472,7 +472,7 @@ exit:
 
     for (uint32_t blockNo = 1; key_length != 0; ++blockNo)
     {
-        uint8_t in[chip::max(kMacLength, kSpake2p_Max_PBKDF_Salt_Length + 4)];
+        uint8_t in[std::max(kMacLength, kSpake2p_Max_PBKDF_Salt_Length + 4)];
         size_t inLength = salt_length + 4;
         uint8_t out[kMacLength];
         size_t outLength;
@@ -495,7 +495,7 @@ exit:
             inLength = outLength;
         }
 
-        const size_t usedKeyLength = chip::min<size_t>(key_length, kMacLength);
+        const size_t usedKeyLength = std::min<size_t>(key_length, kMacLength);
         memcpy(key, result, usedKeyLength);
         key += usedKeyLength;
         key_length -= usedKeyLength;

--- a/src/inet/IPAddress-StringFuncts.cpp
+++ b/src/inet/IPAddress-StringFuncts.cpp
@@ -23,6 +23,7 @@
  *
  */
 
+#include <algorithm>
 #include <limits>
 #include <stdint.h>
 #include <stdio.h>
@@ -57,8 +58,8 @@ char * IPAddress::ToString(char * buf, uint32_t bufSize) const
     // socklen_t is sometimes signed, sometimes not, so the only safe way to do
     // this is to promote everything to an unsigned type that's known to be big
     // enough for everything, then cast back to uint32_t after taking the min.
-    bufSize =
-        static_cast<uint32_t>(min(static_cast<uintmax_t>(std::numeric_limits<socklen_t>::max()), static_cast<uintmax_t>(bufSize)));
+    bufSize = static_cast<uint32_t>(
+        std::min(static_cast<uintmax_t>(std::numeric_limits<socklen_t>::max()), static_cast<uintmax_t>(bufSize)));
 #if INET_CONFIG_ENABLE_IPV4
     if (IsIPv4())
     {

--- a/src/inet/tests/TestInetLayerCommon.cpp
+++ b/src/inet/tests/TestInetLayerCommon.cpp
@@ -164,7 +164,7 @@ static PacketBufferHandle MakeDataBuffer(size_t aDesiredLength, size_t aPatternS
     PacketBufferHandle lBuffer = PacketBufferHandle::New(aDesiredLength);
     VerifyOrReturnError(!lBuffer.IsNull(), lBuffer);
 
-    aDesiredLength = min(lBuffer->MaxDataLength(), aDesiredLength);
+    aDesiredLength = std::min(lBuffer->MaxDataLength(), aDesiredLength);
 
     FillDataBufferPattern(lBuffer->Start(), aDesiredLength, aPatternStartOffset, aFirstValue);
 

--- a/src/inet/tests/inet-layer-test-tool.cpp
+++ b/src/inet/tests/inet-layer-test-tool.cpp
@@ -777,7 +777,7 @@ void DriveSend()
         if (sTestState.mStats.mTransmit.mActual < sTestState.mStats.mTransmit.mExpected)
         {
             const uint32_t lRemaining = (sTestState.mStats.mTransmit.mExpected - sTestState.mStats.mTransmit.mActual);
-            const uint32_t lSendSize  = chip::min(lRemaining, static_cast<uint32_t>(gSendSize));
+            const uint32_t lSendSize  = std::min(lRemaining, static_cast<uint32_t>(gSendSize));
 
             // gSendSize is uint16_t, so this cast is safe: the value has to be
             // in the uint16_t range.

--- a/src/lib/core/OTAImageHeader.cpp
+++ b/src/lib/core/OTAImageHeader.cpp
@@ -102,7 +102,7 @@ CHIP_ERROR OTAImageHeaderParser::AccumulateAndDecode(ByteSpan & buffer, OTAImage
 
 void OTAImageHeaderParser::Append(ByteSpan & buffer, uint32_t numBytes)
 {
-    numBytes = chip::min(numBytes, static_cast<uint32_t>(buffer.size()));
+    numBytes = std::min(numBytes, static_cast<uint32_t>(buffer.size()));
     memcpy(&mBuffer[mBufferOffset], buffer.data(), numBytes);
     mBufferOffset += numBytes;
     buffer = buffer.SubSpan(numBytes);

--- a/src/lib/core/tests/TestOTAImageHeader.cpp
+++ b/src/lib/core/tests/TestOTAImageHeader.cpp
@@ -167,7 +167,7 @@ TEST_F(TestOTAImageHeader, TestSmallBlocks)
 
         for (size_t offset = 0; offset < kImageSize && error == CHIP_ERROR_BUFFER_TOO_SMALL; offset += blockSize)
         {
-            ByteSpan block(&kOtaImage[offset], chip::min(kImageSize - offset, blockSize));
+            ByteSpan block(&kOtaImage[offset], std::min(kImageSize - offset, blockSize));
             error = parser.AccumulateAndDecode(block, header);
         }
 

--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -63,7 +63,7 @@ CHIP_ERROR ExtractIdFromInstanceName(const char * name, PeerId * peerId)
     // Check what we have a separator where we expect.
     ReturnErrorCodeIf(name[fabricIdStringLength] != '-', CHIP_ERROR_WRONG_NODE_ID);
 
-    static constexpr size_t bufferSize = max(fabricIdByteLength, nodeIdByteLength);
+    static constexpr size_t bufferSize = std::max(fabricIdByteLength, nodeIdByteLength);
     uint8_t buf[bufferSize];
 
     ReturnErrorCodeIf(Encoding::HexToBytes(name, fabricIdStringLength, buf, bufferSize) == 0, CHIP_ERROR_WRONG_NODE_ID);

--- a/src/lib/support/BufferReader.h
+++ b/src/lib/support/BufferReader.h
@@ -302,7 +302,7 @@ public:
      */
     Reader & Skip(size_t len)
     {
-        len = ::chip::min(len, mAvailable);
+        len = std::min(len, mAvailable);
         mReadPtr += len;
         mAvailable = static_cast<size_t>(mAvailable - len);
         return *this;

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -131,30 +131,6 @@
 
 #include <nlassert.h>
 
-namespace chip {
-
-// Generic min() and max() functions
-//
-template <typename _T>
-constexpr inline const _T & min(const _T & a, const _T & b)
-{
-    if (b < a)
-        return b;
-
-    return a;
-}
-
-template <typename _T>
-constexpr inline const _T & max(const _T & a, const _T & b)
-{
-    if (a < b)
-        return b;
-
-    return a;
-}
-
-} // namespace chip
-
 /**
  *  @def ReturnErrorOnFailure(expr)
  *

--- a/src/lib/support/SafeString.h
+++ b/src/lib/support/SafeString.h
@@ -23,8 +23,10 @@
 
 #pragma once
 
-#include <lib/support/CodeUtils.h>
+#include <algorithm>
 #include <utility>
+
+#include <lib/support/CodeUtils.h>
 
 namespace chip {
 
@@ -48,7 +50,7 @@ template <size_t FirstLength, typename... RestOfTypes>
 constexpr size_t MaxStringLength(const char (&)[FirstLength], RestOfTypes &&... aArgs)
 {
     // Subtract 1 because we are not counting the null-terminator.
-    return max(FirstLength - 1, MaxStringLength(std::forward<RestOfTypes>(aArgs)...));
+    return std::max(FirstLength - 1, MaxStringLength(std::forward<RestOfTypes>(aArgs)...));
 }
 
 /**

--- a/src/lib/support/ZclString.cpp
+++ b/src/lib/support/ZclString.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR MakeZclCharString(MutableByteSpan & buffer, const char * cString)
         return CHIP_ERROR_INBOUND_MESSAGE_TOO_BIG;
     }
     size_t len              = strlen(cString);
-    size_t availableStorage = min(buffer.size() - 1, kBufferMaximumSize);
+    size_t availableStorage = std::min(buffer.size() - 1, kBufferMaximumSize);
     if (len > availableStorage)
     {
         buffer.data()[0] = 0;

--- a/src/platform/ASR/ASRUtils.cpp
+++ b/src/platform/ASR/ASRUtils.cpp
@@ -243,7 +243,7 @@ CHIP_ERROR ASRUtils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & netIn
     if (includeCredentials)
     {
         static_assert(sizeof(netInfo.WiFiKey) < 255, "Our min might not fit in netInfo.WiFiKeyLen");
-        netInfo.WiFiKeyLen = static_cast<uint8_t>(min(strlen((char *) stationConfig.wifi_key), sizeof(netInfo.WiFiKey)));
+        netInfo.WiFiKeyLen = static_cast<uint8_t>(std::min(strlen((char *) stationConfig.wifi_key), sizeof(netInfo.WiFiKey)));
         memcpy(netInfo.WiFiKey, stationConfig.wifi_key, netInfo.WiFiKeyLen);
     }
 

--- a/src/platform/ASR/ASRUtils.cpp
+++ b/src/platform/ASR/ASRUtils.cpp
@@ -235,7 +235,7 @@ CHIP_ERROR ASRUtils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & netIn
     netInfo.NetworkId              = kWiFiStationNetworkId;
     netInfo.FieldPresent.NetworkId = true;
     memcpy(netInfo.WiFiSSID, stationConfig.wifi_ssid,
-           min(strlen(reinterpret_cast<char *>(stationConfig.wifi_ssid)) + 1, sizeof(netInfo.WiFiSSID)));
+           std::min(strlen(reinterpret_cast<char *>(stationConfig.wifi_ssid)) + 1, sizeof(netInfo.WiFiSSID)));
 
     // Enforce that netInfo wifiSSID is null terminated
     netInfo.WiFiSSID[kMaxWiFiSSIDLength] = '\0';

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -472,8 +472,7 @@ void BrowseWithDelegateContext::OnBrowseRemove(const char * name, const char * t
 
 ResolveContext::ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::Inet::IPAddressType cbAddressType,
                                const char * instanceNameToResolve, BrowseContext * browseCausingResolve,
-                               std::shared_ptr<uint32_t> && consumerCounterToUse) :
-    browseThatCausedResolve(browseCausingResolve)
+                               std::shared_ptr<uint32_t> && consumerCounterToUse) : browseThatCausedResolve(browseCausingResolve)
 {
     type            = ContextType::Resolve;
     context         = cbContext;
@@ -722,7 +721,7 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
         size_t len = *txtRecordIter;
         ++txtRecordIter;
         --remainingLen;
-        len = min(len, remainingLen);
+        len = std::min(len, remainingLen);
         chip::Span<const unsigned char> bytes(txtRecordIter, len);
         if (txtString.size() > 0)
         {

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -472,7 +472,8 @@ void BrowseWithDelegateContext::OnBrowseRemove(const char * name, const char * t
 
 ResolveContext::ResolveContext(void * cbContext, DnssdResolveCallback cb, chip::Inet::IPAddressType cbAddressType,
                                const char * instanceNameToResolve, BrowseContext * browseCausingResolve,
-                               std::shared_ptr<uint32_t> && consumerCounterToUse) : browseThatCausedResolve(browseCausingResolve)
+                               std::shared_ptr<uint32_t> && consumerCounterToUse) :
+    browseThatCausedResolve(browseCausingResolve)
 {
     type            = ContextType::Resolve;
     context         = cbContext;

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -260,7 +260,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             }
             else
             {
-                ipv6_addr_count = static_cast<uint8_t>(min(addr_count, static_cast<int>(kMaxIPv6AddrCount)));
+                ipv6_addr_count = static_cast<uint8_t>(std::min(addr_count, static_cast<int>(kMaxIPv6AddrCount)));
             }
             for (uint8_t idx = 0; idx < ipv6_addr_count; ++idx)
             {

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -249,7 +249,7 @@ CHIP_ERROR ESP32Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & net
     if (includeCredentials)
     {
         static_assert(sizeof(netInfo.WiFiKey) < 255, "Our min might not fit in netInfo.WiFiKeyLen");
-        netInfo.WiFiKeyLen = static_cast<uint8_t>(min(strlen((char *) stationConfig.sta.password), sizeof(netInfo.WiFiKey)));
+        netInfo.WiFiKeyLen = static_cast<uint8_t>(std::min(strlen((char *) stationConfig.sta.password), sizeof(netInfo.WiFiKey)));
         memcpy(netInfo.WiFiKey, stationConfig.sta.password, netInfo.WiFiKeyLen);
     }
 

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -241,7 +241,7 @@ CHIP_ERROR ESP32Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & net
     netInfo.NetworkId              = kWiFiStationNetworkId;
     netInfo.FieldPresent.NetworkId = true;
     memcpy(netInfo.WiFiSSID, stationConfig.sta.ssid,
-           min(strlen(reinterpret_cast<char *>(stationConfig.sta.ssid)) + 1, sizeof(netInfo.WiFiSSID)));
+           std::min(strlen(reinterpret_cast<char *>(stationConfig.sta.ssid)) + 1, sizeof(netInfo.WiFiSSID)));
 
     // Enforce that netInfo wifiSSID is null terminated
     netInfo.WiFiSSID[kMaxWiFiSSIDLength] = '\0';
@@ -268,7 +268,7 @@ CHIP_ERROR ESP32Utils::SetWiFiStationProvision(const Internal::DeviceNetworkInfo
     ReturnErrorOnFailure(ESP32Utils::EnableStationMode());
 
     // Enforce that wifiSSID is null terminated before copying it
-    memcpy(wifiSSID, netInfo.WiFiSSID, min(netInfoSSIDLen + 1, sizeof(wifiSSID)));
+    memcpy(wifiSSID, netInfo.WiFiSSID, std::min(netInfoSSIDLen + 1, sizeof(wifiSSID)));
     if (netInfoSSIDLen + 1 < sizeof(wifiSSID))
     {
         wifiSSID[netInfoSSIDLen] = '\0';
@@ -280,8 +280,8 @@ CHIP_ERROR ESP32Utils::SetWiFiStationProvision(const Internal::DeviceNetworkInfo
 
     // Initialize an ESP wifi_config_t structure based on the new provision information.
     memset(&wifiConfig, 0, sizeof(wifiConfig));
-    memcpy(wifiConfig.sta.ssid, wifiSSID, min(strlen(wifiSSID) + 1, sizeof(wifiConfig.sta.ssid)));
-    memcpy(wifiConfig.sta.password, netInfo.WiFiKey, min((size_t) netInfo.WiFiKeyLen, sizeof(wifiConfig.sta.password)));
+    memcpy(wifiConfig.sta.ssid, wifiSSID, std::min(strlen(wifiSSID) + 1, sizeof(wifiConfig.sta.ssid)));
+    memcpy(wifiConfig.sta.password, netInfo.WiFiKey, std::min((size_t) netInfo.WiFiKeyLen, sizeof(wifiConfig.sta.password)));
     wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 

--- a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
@@ -229,9 +229,9 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
             wifi_config_t wifiConfig;
             memset(&wifiConfig, 0, sizeof(wifiConfig));
             memcpy(wifiConfig.sta.ssid, CHIP_DEVICE_CONFIG_DEFAULT_STA_SSID,
-                   min(strlen(CHIP_DEVICE_CONFIG_DEFAULT_STA_SSID), sizeof(wifiConfig.sta.ssid)));
+                   std::min(strlen(CHIP_DEVICE_CONFIG_DEFAULT_STA_SSID), sizeof(wifiConfig.sta.ssid)));
             memcpy(wifiConfig.sta.password, CHIP_DEVICE_CONFIG_DEFAULT_STA_PASSWORD,
-                   min(strlen(CHIP_DEVICE_CONFIG_DEFAULT_STA_PASSWORD), sizeof(wifiConfig.sta.password)));
+                   std::min(strlen(CHIP_DEVICE_CONFIG_DEFAULT_STA_PASSWORD), sizeof(wifiConfig.sta.password)));
             wifiConfig.sta.security = CHIP_DEVICE_CONFIG_DEFAULT_STA_SECURITY;
             err                     = Internal::PSOC6Utils::p6_wifi_set_config(WIFI_IF_STA, &wifiConfig);
             SuccessOrExit(err);

--- a/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
+++ b/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
@@ -343,7 +343,7 @@ CHIP_ERROR PSOC6Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & net
     if (includeCredentials)
     {
         static_assert(sizeof(netInfo.WiFiKey) < 255, "Our min might not fit in netInfo.WiFiKeyLen");
-        netInfo.WiFiKeyLen = static_cast<uint8_t>(min(strlen((char *) stationConfig.sta.password), sizeof(netInfo.WiFiKey)));
+        netInfo.WiFiKeyLen = static_cast<uint8_t>(std::min(strlen((char *) stationConfig.sta.password), sizeof(netInfo.WiFiKey)));
         memcpy(netInfo.WiFiKey, stationConfig.sta.password, netInfo.WiFiKeyLen);
     }
 

--- a/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
+++ b/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
@@ -335,7 +335,7 @@ CHIP_ERROR PSOC6Utils::GetWiFiStationProvision(Internal::DeviceNetworkInfo & net
     netInfo.NetworkId              = kWiFiStationNetworkId;
     netInfo.FieldPresent.NetworkId = true;
     memcpy(netInfo.WiFiSSID, stationConfig.sta.ssid,
-           min(strlen(reinterpret_cast<char *>(stationConfig.sta.ssid)) + 1, sizeof(netInfo.WiFiSSID)));
+           std::min(strlen(reinterpret_cast<char *>(stationConfig.sta.ssid)) + 1, sizeof(netInfo.WiFiSSID)));
 
     // Enforce that netInfo wifiSSID is null terminated
     netInfo.WiFiSSID[kMaxWiFiSSIDLength] = '\0';
@@ -365,7 +365,7 @@ CHIP_ERROR PSOC6Utils::SetWiFiStationProvision(const Internal::DeviceNetworkInfo
     SuccessOrExit(err);
 
     // Enforce that wifiSSID is null terminated before copying it
-    memcpy(wifiSSID, netInfo.WiFiSSID, min(netInfoSSIDLen + 1, sizeof(wifiSSID)));
+    memcpy(wifiSSID, netInfo.WiFiSSID, std::min(netInfoSSIDLen + 1, sizeof(wifiSSID)));
     if (netInfoSSIDLen + 1 < sizeof(wifiSSID))
     {
         wifiSSID[netInfoSSIDLen] = '\0';
@@ -505,16 +505,16 @@ void PSOC6Utils::populate_wifi_config_t(wifi_config_t * wifi_config, wifi_interf
     if (interface == WIFI_IF_STA || interface == WIFI_IF_STA_AP)
     {
         memset(&wifi_config->sta, 0, sizeof(wifi_config_sta_t));
-        memcpy(wifi_config->sta.ssid, ssid, chip::min(strlen((char *) ssid) + 1, sizeof(cy_wcm_ssid_t)));
-        memcpy(wifi_config->sta.password, password, chip::min(strlen((char *) password) + 1, sizeof(cy_wcm_ssid_t)));
+        memcpy(wifi_config->sta.ssid, ssid, std::min(strlen((char *) ssid) + 1, sizeof(cy_wcm_ssid_t)));
+        memcpy(wifi_config->sta.password, password, std::min(strlen((char *) password) + 1, sizeof(cy_wcm_ssid_t)));
         wifi_config->sta.security = security;
     }
 
     if (interface == WIFI_IF_AP || interface == WIFI_IF_STA_AP)
     {
         memset(&wifi_config->ap, 0, sizeof(wifi_config_ap_t));
-        memcpy(wifi_config->ap.ssid, ssid, chip::min(strlen((char *) ssid) + 1, sizeof(cy_wcm_ssid_t)));
-        memcpy(wifi_config->ap.password, password, chip::min(strlen((char *) password) + 1, sizeof(cy_wcm_ssid_t)));
+        memcpy(wifi_config->ap.ssid, ssid, std::min(strlen((char *) ssid) + 1, sizeof(cy_wcm_ssid_t)));
+        memcpy(wifi_config->ap.password, password, std::min(strlen((char *) password) + 1, sizeof(cy_wcm_ssid_t)));
         wifi_config->ap.security = security;
     }
 }

--- a/src/platform/android/AndroidConfig.cpp
+++ b/src/platform/android/AndroidConfig.cpp
@@ -280,7 +280,7 @@ CHIP_ERROR AndroidConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufS
     }
 
     outLen = static_cast<size_t>(env->GetArrayLength(javaValue));
-    memcpy(buf, elements, min(outLen, bufSize));
+    memcpy(buf, elements, std::min(outLen, bufSize));
 
     env->ReleaseByteArrayElements(javaValue, elements, 0);
 

--- a/src/platform/mt793x/DnssdContexts.cpp
+++ b/src/platform/mt793x/DnssdContexts.cpp
@@ -451,7 +451,7 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
         size_t len = *txtRecordIter;
         ++txtRecordIter;
         --remainingLen;
-        len = min(len, remainingLen);
+        len = std::min(len, remainingLen);
         chip::Span<const unsigned char> bytes(txtRecordIter, len);
         if (txtString.size() > 0)
         {

--- a/src/platform/nxp/common/ota/OTATlvProcessor.cpp
+++ b/src/platform/nxp/common/ota/OTATlvProcessor.cpp
@@ -40,7 +40,7 @@ CHIP_ERROR OTATlvProcessor::ApplyAction()
 CHIP_ERROR OTATlvProcessor::Process(ByteSpan & block)
 {
     CHIP_ERROR status     = CHIP_NO_ERROR;
-    uint32_t bytes        = chip::min(mLength - mProcessedLength, static_cast<uint32_t>(block.size()));
+    uint32_t bytes        = std::min(mLength - mProcessedLength, static_cast<uint32_t>(block.size()));
     ByteSpan relevantData = block.SubSpan(0, bytes);
 
     status = ProcessInternal(relevantData);
@@ -96,7 +96,7 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
-    uint32_t numBytes = chip::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
+    uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
     memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
     mBufferOffset += numBytes;
     block = block.SubSpan(numBytes);

--- a/src/platform/silabs/MigrationManager.cpp
+++ b/src/platform/silabs/MigrationManager.cpp
@@ -57,7 +57,7 @@ void MigrationManager::applyMigrations()
         if (lastMigationGroupDone < migrationTable[i].migrationGroup)
         {
             (*migrationTable[i].migrationFunc)();
-            completedMigrationGroup = max(migrationTable[i].migrationGroup, completedMigrationGroup);
+            completedMigrationGroup = std::max(migrationTable[i].migrationGroup, completedMigrationGroup);
         }
     }
     SilabsConfig::WriteConfigValue(SilabsConfig::kConfigKey_MigrationCounter, completedMigrationGroup);

--- a/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTATlvProcessor.cpp
@@ -37,7 +37,7 @@ constexpr uint8_t au8Iv[] = { 0x00, 0x00, 0x00, 0x10, 0x11, 0x12, 0x13, 0x14, 0x
 CHIP_ERROR OTATlvProcessor::Process(ByteSpan & block)
 {
     CHIP_ERROR status     = CHIP_NO_ERROR;
-    uint32_t bytes        = chip::min(mLength - mProcessedLength, static_cast<uint32_t>(block.size()));
+    uint32_t bytes        = std::min(mLength - mProcessedLength, static_cast<uint32_t>(block.size()));
     ByteSpan relevantData = block.SubSpan(0, bytes);
 
     status = ProcessInternal(relevantData);
@@ -92,7 +92,7 @@ void OTADataAccumulator::Clear()
 
 CHIP_ERROR OTADataAccumulator::Accumulate(ByteSpan & block)
 {
-    uint32_t numBytes = chip::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
+    uint32_t numBytes = std::min(mThreshold - mBufferOffset, static_cast<uint32_t>(block.size()));
     memcpy(&mBuffer[mBufferOffset], block.data(), numBytes);
     mBufferOffset += numBytes;
     block = block.SubSpan(numBytes);

--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -249,7 +249,7 @@ TEST_F(TestKeyValueStoreMgr, AllCharactersKey)
     for (size_t charId = 0; charId < sizeof(allChars); charId += kKeyLength)
     {
         char testKey[kKeyLength + 1] = {};
-        memcpy(testKey, &allChars[charId], chip::min(sizeof(allChars) - charId, kKeyLength));
+        memcpy(testKey, &allChars[charId], std::min(sizeof(allChars) - charId, kKeyLength));
 
         CHIP_ERROR err = KeyValueStoreMgr().Put(testKey, kTestValue);
         EXPECT_EQ(err, CHIP_NO_ERROR);

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -559,8 +559,8 @@ void TransferSession::HandleTransferInit(MessageType msgType, System::PacketBuff
     VerifyOrReturn(err == CHIP_NO_ERROR, PrepareStatusReport(StatusCode::kBadMessageContents));
 
     ResolveTransferControlOptions(transferInit.TransferCtlOptions);
-    mTransferVersion      = ::chip::min(kBdxVersion, transferInit.Version);
-    mTransferMaxBlockSize = ::chip::min(mMaxSupportedBlockSize, transferInit.MaxBlockSize);
+    mTransferVersion      = std::min(kBdxVersion, transferInit.Version);
+    mTransferMaxBlockSize = std::min(mMaxSupportedBlockSize, transferInit.MaxBlockSize);
 
     // Accept for now, they may be changed or rejected by the peer if this is a ReceiveInit
     mStartOffset    = transferInit.StartOffset;

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -114,7 +114,7 @@ private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static constexpr size_t kStructureSize = LWIP_MEM_ALIGN_SIZE(sizeof(struct ::pbuf));
 #else  // CHIP_SYSTEM_CONFIG_USE_LWIP
-    static constexpr size_t kStructureSize         = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), 4u);
+    static constexpr size_t kStructureSize = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), 4u);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 public:
@@ -155,7 +155,7 @@ public:
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     static constexpr size_t kMaxAllocSize = kLargeBufMaxSizeWithoutReserve;
 #else
-    static constexpr size_t kMaxAllocSize          = kMaxSizeWithoutReserve;
+    static constexpr size_t kMaxAllocSize = kMaxSizeWithoutReserve;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**
@@ -784,7 +784,7 @@ public:
      *  @param[in]  aSize   Maximum number of octects to write into the packet buffer.
      */
     PacketBufferWriterBase(System::PacketBufferHandle && aPacket, size_t aSize) :
-        Writer(aPacket->Start() + aPacket->DataLength(), chip::min(aSize, static_cast<size_t>(aPacket->AvailableDataLength())))
+        Writer(aPacket->Start() + aPacket->DataLength(), std::min(aSize, static_cast<size_t>(aPacket->AvailableDataLength())))
     {
         mPacket = std::move(aPacket);
     }

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -114,7 +114,7 @@ private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static constexpr size_t kStructureSize = LWIP_MEM_ALIGN_SIZE(sizeof(struct ::pbuf));
 #else  // CHIP_SYSTEM_CONFIG_USE_LWIP
-    static constexpr size_t kStructureSize = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), 4u);
+    static constexpr size_t kStructureSize         = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), 4u);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 public:
@@ -155,7 +155,7 @@ public:
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     static constexpr size_t kMaxAllocSize = kLargeBufMaxSizeWithoutReserve;
 #else
-    static constexpr size_t kMaxAllocSize = kMaxSizeWithoutReserve;
+    static constexpr size_t kMaxAllocSize          = kMaxSizeWithoutReserve;
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -59,7 +59,7 @@ static constexpr size_t kMaxPerSpecApplicationPayloadAndMICSizeBytes =
 static constexpr size_t kMaxPacketBufferApplicationPayloadAndMICSizeBytes = System::PacketBuffer::kMaxSize;
 
 static constexpr size_t kMaxApplicationPayloadAndMICSizeBytes =
-    min(kMaxPerSpecApplicationPayloadAndMICSizeBytes, kMaxPacketBufferApplicationPayloadAndMICSizeBytes);
+    std::min(kMaxPerSpecApplicationPayloadAndMICSizeBytes, kMaxPacketBufferApplicationPayloadAndMICSizeBytes);
 } // namespace detail
 
 static constexpr size_t kMaxTagLen = 16;


### PR DESCRIPTION
### Problem

There is no reason to keep custom implementation for min/max

### Testing

CI will verify