### PR TITLE
[NXP] Make button components configurable

### DIFF
--- a/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
+++ b/examples/platform/nxp/common/matter_button/source/ButtonApp.cpp
@@ -24,11 +24,30 @@ extern "C" {
 #include "board_comp.h"
 }
 
+/**
+ * @brief Flag to describe if the button handles are predefined in SDK.
+ *
+ * Set to true by default. Platforms that do not have this support should
+ * disable the flag, which will enable handle definition in this file.
+ */
+#ifndef CONFIG_APP_BUTTON_HANDLE_SDK_PREDEFINED
+#define CONFIG_APP_BUTTON_HANDLE_SDK_PREDEFINED 1
+#endif
+
+#if !CONFIG_APP_BUTTON_HANDLE_SDK_PREDEFINED
+BUTTON_HANDLE_ARRAY_DEFINE(g_buttonHandle, gAppButtonCnt_c);
+#endif
+
 CHIP_ERROR chip::NXP::App::ButtonApp::Init()
 {
-    // Button is initialized in otSysInit, when APP_InitServices is called.
-    // Overwrite the handle to reference the SDK handle.
+#if CONFIG_APP_BUTTON_HANDLE_SDK_PREDEFINED
+    // Button is defined in the SDK and initialized in otSysInit, when APP_InitServices is called.
     handle = &g_buttonHandle[1];
+#else
+    // Button handle is defined in this file and it should be initialized here.
+    handle = &g_buttonHandle[0];
+    BOARD_InitButton0(handle);
+#endif
 
     return CHIP_NO_ERROR;
 }

--- a/examples/platform/nxp/common/matter_button/source/ButtonManager.cpp
+++ b/examples/platform/nxp/common/matter_button/source/ButtonManager.cpp
@@ -17,7 +17,10 @@
  */
 
 #include "ButtonManager.h"
+
+extern "C" {
 #include "fwk_platform.h"
+}
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/CodeUtils.h>

--- a/examples/platform/nxp/common/matter_button/source/ButtonRegistrationAppAndBle.cpp
+++ b/examples/platform/nxp/common/matter_button/source/ButtonRegistrationAppAndBle.cpp
@@ -24,14 +24,37 @@
 
 #include <lib/support/CodeUtils.h>
 
-static chip::NXP::App::ButtonApp sAppButton;
-static chip::NXP::App::ButtonBle sBleButton;
+/**
+ * @brief Flag to configure if the app button is enabled.
+ *
+ * Enabled by default.
+ */
+#ifndef CONFIG_APP_BUTTON_ENABLED
+#define CONFIG_APP_BUTTON_ENABLED 1
+#endif
+
+/**
+ * @brief Flag to configure if the BLE button is enabled.
+ *
+ * Enabled by default.
+ */
+#ifndef CONFIG_BLE_BUTTON_ENABLED
+#define CONFIG_BLE_BUTTON_ENABLED 1
+#endif
 
 CHIP_ERROR chip::NXP::App::RegisterButtons(void)
 {
     ReturnErrorOnFailure(ButtonMgr().Init());
+
+#if CONFIG_BLE_BUTTON_ENABLED
+    static chip::NXP::App::ButtonBle sBleButton;
     ReturnErrorOnFailure(ButtonMgr().RegisterButton(sBleButton));
+#endif
+
+#if CONFIG_APP_BUTTON_ENABLED
+    static chip::NXP::App::ButtonApp sAppButton;
     ReturnErrorOnFailure(ButtonMgr().RegisterButton(sAppButton));
+#endif
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
Introduce the following flags:
- `CONFIG_APP_BUTTON_ENABLED` - flag to configure if `ButtonApp` instance is registered.
- `CONFIG_BLE_BUTTON_ENABLED` - flag to configure if `ButtonBle` instance is registered.
- `CONFIG_APP_BUTTON_HANDLE_SDK_PREDEFINED` - flag to configure if the button handle is predefined in the SDK or not. If not set, the handle will be defined and initialized explicitly in the file.
