### PR TITLE
[ESP32] Update esp-insights component to latest version

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -18,18 +18,10 @@ dependencies:
             - if: "idf_version >=4.4"
 
     espressif/esp_insights:
-        version: "1.0.1"
+        version: "1.2.2"
         require: public
         # There is an issue with IDF-Component-Manager when ESP Insights is included.
         # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
-        rules:
-            - if: "idf_version >=5.0"
-            - if: "target != esp32h2"
-
-    # This matches the dependency of esp_insights
-    espressif/esp_diag_data_store:
-        version: "1.0.1"
-        require: public
         rules:
             - if: "idf_version >=5.0"
             - if: "target != esp32h2"


### PR DESCRIPTION
**Problem**
-  With reference to PR[ #36031](https://github.com/project-chip/connectedhomeip/pull/36031), to get rid of the extra pinned dependency.

**Change Overview**
- Updated esp-insights component to the latest version 1.2.2 which contains pinned version for component dependencies.

**Testing**
- Tested lighting-app esp32 with esp-insights enabled.
