### PR TITLE
[Fabric Sync] Update test to run a little faster

### DIFF
--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -122,8 +122,7 @@ class TC_CCTRL_2_3(MatterBaseTest):
                  TestStep(8, "Send CommissionNode command to DUT with CASE session, with valid parameters"),
                  TestStep(9, "Send another CommissionNode command to DUT with CASE session, with with same RequestId as the previous one"),
                  TestStep(10, "Send OpenCommissioningWindow command on Administrator Commissioning Cluster sent to TH_SERVER"),
-                 TestStep(11, "Wait for DUT to successfully commission TH_SERVER, 30 seconds"),
-                 TestStep(12, "Get number of fabrics from TH_SERVER, verify DUT successfully commissioned TH_SERVER")]
+                 TestStep(11, "Get number of fabrics from TH_SERVER, verify DUT successfully commissioned TH_SERVER (up to 30 seconds)")]
 
         return steps
 
@@ -196,11 +195,23 @@ class TC_CCTRL_2_3(MatterBaseTest):
         await self.send_single_cmd(cmd, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, timedRequestTimeoutMs=5000)
 
         self.step(11)
-        time.sleep(5 if self.is_pics_sdk_ci_only else 30)
+        max_wait_time_sec = 30
+        start_time = time.time()
+        elapsed = 0
+        time_remaining = max_wait_time_sec
+        previous_number_th_server_fabrics = len(th_server_fabrics)
 
-        self.step(12)
-        th_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
-        asserts.assert_equal(len(th_server_fabrics) + 1, len(th_server_fabrics_new),
+        th_server_fabrics_new = None
+        while time_remaining > 0:
+            time.sleep(2)
+            th_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
+            if previous_number_th_server_fabrics != len(th_server_fabrics_new):
+                break
+            elapsed = time.time() - start_time
+            time_remaining = max_wait_time_sec - elapsed
+
+        asserts.assert_not_equal(th_server_fabrics_new, None, "Failed to read Fabrics attribute")
+        asserts.assert_equal(previous_number_th_server_fabrics + 1, len(th_server_fabrics_new),
                              "Unexpected number of fabrics on TH_SERVER")
 
 

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -198,6 +198,7 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
                                                                                    iterations=resp.iterations, salt=resp.salt)
         await self.send_single_cmd(cmd, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, timedRequestTimeoutMs=5000)
 
+        # TODO(#35229)
         self.step("3c")
         if not self.is_pics_sdk_ci_only:
             time.sleep(30)

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -198,16 +198,25 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
                                                                                    iterations=resp.iterations, salt=resp.salt)
         await self.send_single_cmd(cmd, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, timedRequestTimeoutMs=5000)
 
-        # TODO(#35229)
         self.step("3c")
-        if not self.is_pics_sdk_ci_only:
-            time.sleep(30)
+        max_wait_time_sec = 30
+        start_time = time.time()
+        elapsed = 0
+        time_remaining = max_wait_time_sec
+        previous_number_th_server_fabrics = len(th_fsa_server_fabrics)
 
-        th_fsa_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
-        # TODO: this should be mocked too.
-        if not self.is_pics_sdk_ci_only:
-            asserts.assert_equal(len(th_fsa_server_fabrics) + 1, len(th_fsa_server_fabrics_new),
-                                 "Unexpected number of fabrics on TH_SERVER")
+        th_fsa_server_fabrics_new = None
+        while time_remaining > 0:
+            time.sleep(2)
+            th_fsa_server_fabrics_new = await self.read_single_attribute_check_success(cluster=Clusters.OperationalCredentials, attribute=Clusters.OperationalCredentials.Attributes.Fabrics, dev_ctrl=self.TH_server_controller, node_id=self.server_nodeid, endpoint=0, fabric_filtered=False)
+            if previous_number_th_server_fabrics != len(th_fsa_server_fabrics_new):
+                break
+            elapsed = time.time() - start_time
+            time_remaining = max_wait_time_sec - elapsed
+
+        asserts.assert_not_equal(th_fsa_server_fabrics_new, None, "Failed to read Fabrics attribute")
+        asserts.assert_equal(previous_number_th_server_fabrics + 1, len(th_fsa_server_fabrics_new),
+                             "Unexpected number of fabrics on TH_SERVER")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We are now waiting up to 30 seconds and are polling every couple of seconds for some fabric sync checks when we are checking to see if there if device has properly been added.

Alternative considered: Instead of polling we could subscribe to the attribute. This approach was not taken as the amount of code to setup and tear down is more. While from a optics perspective subscription is the more technically "right" option, it offers no additional value and the polling approach taken now results in tests running faster if the device is commissioned right away.

Testplan change that should go in first https://github.com/CHIP-Specifications/chip-test-plans/pull/4752

Fixes: https://github.com/project-chip/connectedhomeip/issues/35229

Tests:
* Ran updated test locally confirmed they pass
* CI passes.
