### PR TITLE
[LVL] Add a check for Lvl command's OptionsBitmap arguments

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -910,7 +910,7 @@ static Status moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8
     }
 
     Status status = VerifyOptionsBitmap(optionsMask, optionsOverride);
-    if (status != Status::Success)
+    VerifyOrReturnError(Status::Success == status, status);
     {
         return status;
     }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -911,9 +911,6 @@ static Status moveToLevelHandler(EndpointId endpoint, CommandId commandId, uint8
 
     Status status = VerifyOptionsBitmap(optionsMask, optionsOverride);
     VerifyOrReturnError(Status::Success == status, status);
-    {
-        return status;
-    }
 
     if (!shouldExecuteIfOff(endpoint, commandId, optionsMask, optionsOverride))
     {


### PR DESCRIPTION
Fixes #34554

**Changes**
Add a check in all LVL command handlers that validates if the received `optionsMask` and `optionsOverride` arguments are within the expected values range. Return ConstraintError when they are not.

MISC: change ChipLogProgress to -> ChipLogError for some error message in the lvl cluster server implementation.

Open question; Based on spec, optionsMask and optionsOverride shall be provided.  However, the SDK implementation has allowed omitting them, at the command parsing stage and in the cluster server implementation. This PR doesn't change this behaviour.


**Tests**
Manually tested the out-of-range check.
CI test can validate for regressions.

Should test plan steps be added to test out-of-range argument values? 

