### PR TITLE
Moving more stuff out of the MTRDevice

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -541,35 +541,7 @@ using namespace chip::Tracing::DarwinFramework;
 // method will need to be updated to reflect that.
 - (BOOL)_deviceUsesThread
 {
-    os_unfair_lock_assert_owner(&self->_lock);
-
-#ifdef DEBUG
-    // Note: This is a hack to allow our unit tests to test the subscription pooling behavior we have implemented for thread, so we mock devices to be a thread device
-    __block BOOL pretendThreadEnabled = NO;
-    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
-        if ([testDelegate respondsToSelector:@selector(unitTestPretendThreadEnabled:)]) {
-            pretendThreadEnabled = [testDelegate unitTestPretendThreadEnabled:self];
-        }
-    }];
-    if (pretendThreadEnabled) {
-        return YES;
-    }
-#endif
-
-    MTRClusterPath * networkCommissioningClusterPath = [MTRClusterPath clusterPathWithEndpointID:@(kRootEndpointId) clusterID:@(MTRClusterIDTypeNetworkCommissioningID)];
-    MTRDeviceClusterData * networkCommissioningClusterData = [self _clusterDataForPath:networkCommissioningClusterPath];
-    NSNumber * networkCommissioningClusterFeatureMapValueNumber = networkCommissioningClusterData.attributes[@(MTRClusterGlobalAttributeFeatureMapID)][MTRValueKey];
-
-    if (networkCommissioningClusterFeatureMapValueNumber == nil)
-        return NO;
-    if (![networkCommissioningClusterFeatureMapValueNumber isKindOfClass:[NSNumber class]]) {
-        MTR_LOG_ERROR("%@ Unexpected NetworkCommissioning FeatureMap value %@", self, networkCommissioningClusterFeatureMapValueNumber);
-        return NO;
-    }
-
-    uint32_t networkCommissioningClusterFeatureMapValue = static_cast<uint32_t>(networkCommissioningClusterFeatureMapValueNumber.unsignedLongValue);
-
-    return (networkCommissioningClusterFeatureMapValue & MTRNetworkCommissioningFeatureThreadNetworkInterface) != 0 ? YES : NO;
+    return NO;
 }
 
 - (NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)_clusterDataToPersistSnapshot

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1646,11 +1646,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     }
     [_mostRecentReportTimes addObject:[NSDate now]];
 
-    {
-        std::lock_guard lock(_descriptionLock);
-        _mostRecentReportTimeForDescription = [_mostRecentReportTimes lastObject];
-    }
-
     // Calculate running average and update multiplier - need at least 2 items to calculate intervals
     if (_mostRecentReportTimes.count > 2) {
         NSTimeInterval cumulativeIntervals = 0;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -309,4 +309,44 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 // Not Supported via XPC
 // - (oneway void)downloadLogOfType:(MTRDiagnosticLogType)type nodeID:(NSNumber *)nodeID timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
+
+#pragma mark - Storage Overrides
+
+- (NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)_clusterDataToPersistSnapshot
+{
+    return nil;
+}
+
+
+- (BOOL)_dataStoreExists
+{
+    return NO;
+}
+
+- (void)_persistClusterData
+{
+
+}
+
+- (BOOL)_deviceIsReportingExcessively
+{
+    return NO;
+}
+
+- (void)_persistClusterDataAsNeeded
+{
+}
+
+- (void)_scheduleClusterDataPersistence
+{
+}
+
+- (void)_resetStorageBehaviorState
+{
+}
+
+- (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration
+{
+}
+
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -309,14 +309,12 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 // Not Supported via XPC
 // - (oneway void)downloadLogOfType:(MTRDiagnosticLogType)type nodeID:(NSNumber *)nodeID timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
-
 #pragma mark - Storage Overrides
 
 - (NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)_clusterDataToPersistSnapshot
 {
     return nil;
 }
-
 
 - (BOOL)_dataStoreExists
 {
@@ -325,7 +323,6 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 
 - (void)_persistClusterData
 {
-
 }
 
 - (BOOL)_deviceIsReportingExcessively


### PR DESCRIPTION
MTRDevice is still using some basic C++ stuff here, we should be not doing this in MTRDevice_XPC, I did a quick and simple hack here. @bzbarsky-apple 