### PR TITLE
Making credential unit test binaries output in out/tests folder

### DIFF
--- a/examples/energy-management-app/energy-management-common/tests/BUILD.gn
+++ b/examples/energy-management-app/energy-management-common/tests/BUILD.gn
@@ -23,7 +23,6 @@ config("tests_config") {
 
 chip_test_suite("tests") {
   output_name = "libEnergyTest"
-  output_dir = "${root_out_dir}/lib"
 
   public_configs = [ ":tests_config" ]
 

--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -43,7 +43,6 @@ static_library("cert_test_vectors") {
 
 chip_test_suite("tests") {
   output_name = "libCredentialsTest"
-  output_dir = "${root_out_dir}/lib"
 
   test_sources = [
     "TestCertificationDeclaration.cpp",


### PR DESCRIPTION
- It seems that for credential unit tests, the output directory is `${root_out_dir}/lib` instead of the default `${root_out_dir}/tests` folder.
- same goes for `examples/energy-management-app/energy-management-common/tests`
- Fix: make them go to the default `output_dir` which is `${root_out_dir}/tests` 
