### PR TITLE
Start an issue triage document to describe issue owners and maintainance

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1453,6 +1453,7 @@ TransferSession
 transitionTime
 TransportMgrBase
 triaged
+triaging
 TriggerEffect
 TRNG
 trustm

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1452,6 +1452,7 @@ trackFree
 TransferSession
 transitionTime
 TransportMgrBase
+triaged
 TriggerEffect
 TRNG
 trustm

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -65,7 +65,7 @@ matrix:
       # converts markdown to HTML
       - pyspelling.filters.markdown:
     sources:
-      - '**/*.md|!third_party/**|!examples/common/**/repo/**|!docs/ERROR_CODES.md|!docs/clusters.md|!docs/testing/yaml_schema.md|!docs/testing/yaml_pseudocluster.md | !docs/testing/python.md | !docs/testing/ChipDeviceCtrlAPI.md'
+      - '**/*.md|!third_party/**|!examples/common/**/repo/**|!docs/ERROR_CODES.md|!docs/clusters.md|!docs/testing/yaml_schema.md|!docs/testing/yaml_pseudocluster.md | !docs/testing/python.md | !docs/testing/ChipDeviceCtrlAPI.md | !docs/issue_triage.md'
     aspell:
       ignore-case: true
       camel-case: true

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -65,7 +65,7 @@ matrix:
       # converts markdown to HTML
       - pyspelling.filters.markdown:
     sources:
-      - '**/*.md|!third_party/**|!examples/common/**/repo/**|!docs/ERROR_CODES.md|!docs/clusters.md|!docs/testing/yaml_schema.md|!docs/testing/yaml_pseudocluster.md | !docs/testing/python.md | !docs/testing/ChipDeviceCtrlAPI.md | !docs/issue_triage.md'
+      - '**/*.md|!third_party/**|!examples/common/**/repo/**|!docs/ERROR_CODES.md|!docs/clusters.md|!docs/testing/yaml_schema.md|!docs/testing/yaml_pseudocluster.md|!docs/testing/python.md|!docs/testing/ChipDeviceCtrlAPI.md|!docs/issue_triage.md'
     aspell:
       ignore-case: true
       camel-case: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,34 +2,39 @@
 
 ## Building and Developing
 
--   A quick start guide to building a demo application and controller is
+- A quick start guide to building a demo application and controller is
     available in the [Getting started](./getting_started/) guide
--   A guide to new cluster and device type development is available in the
+- A guide to new cluster and device type development is available in the
     [New Cluster and Device Type Developement Guide](./cluster_and_device_type_dev/)
--   Documentation about building from the command line can be found in
+- Documentation about building from the command line can be found in
     [the build guide](guides/BUILDING.md)
--   Documentation about running [cirque](https://github.com/openweave/cirque)
+- Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
     [the cirque test guide](../src/test_driver/linux-cirque/README.md)
--   Documentation about standard build & development flows using
+- Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)
 
+## Issue triage
+
+Project issues are triaged and maintained according to the
+[issue triage](./guides/issue_triage.md) guide.
+
 ## Platform Guides
 
--   Various guides are available [here](./guides/README.md) that cover platform
+- Various guides are available [here](./guides/README.md) that cover platform
     bring up, testing, and various troubleshooting things.
 
 ## Project Flow
 
--   Documentation about general project usage of GitHub, and project tools is
+- Documentation about general project usage of GitHub, and project tools is
     documented in [the project flow](./PROJECT_FLOW.md)
 
 ## Style Guide
 
--   Documentation about style is documented in
+- Documentation about style is documented in
     [the style guide](./style/style_guide.md)
--   Additional documentation about more specific files are in the
+- Additional documentation about more specific files are in the
     [style folder](./style/)
 
 ## Third Party Tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,39 +2,39 @@
 
 ## Building and Developing
 
--   A quick start guide to building a demo application and controller is
+- A quick start guide to building a demo application and controller is
     available in the [Getting started](./getting_started/) guide
--   A guide to new cluster and device type development is available in the
+- A guide to new cluster and device type development is available in the
     [New Cluster and Device Type Developement Guide](./cluster_and_device_type_dev/)
--   Documentation about building from the command line can be found in
+- Documentation about building from the command line can be found in
     [the build guide](guides/BUILDING.md)
--   Documentation about running [cirque](https://github.com/openweave/cirque)
+- Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
     [the cirque test guide](../src/test_driver/linux-cirque/README.md)
--   Documentation about standard build & development flows using
+- Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)
 
 ## Issue triage
 
 Project issues are triaged and maintained according to the
-[issue triage](./guides/issue_triage.md) guide.
+[issue triage](./issue_triage.md) guide.
 
 ## Platform Guides
 
--   Various guides are available [here](./guides/README.md) that cover platform
+- Various guides are available [here](./guides/README.md) that cover platform
     bring up, testing, and various troubleshooting things.
 
 ## Project Flow
 
--   Documentation about general project usage of GitHub, and project tools is
+- Documentation about general project usage of GitHub, and project tools is
     documented in [the project flow](./PROJECT_FLOW.md)
 
 ## Style Guide
 
--   Documentation about style is documented in
+- Documentation about style is documented in
     [the style guide](./style/style_guide.md)
--   Additional documentation about more specific files are in the
+- Additional documentation about more specific files are in the
     [style folder](./style/)
 
 ## Third Party Tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,16 +2,16 @@
 
 ## Building and Developing
 
-- A quick start guide to building a demo application and controller is
+-   A quick start guide to building a demo application and controller is
     available in the [Getting started](./getting_started/) guide
-- A guide to new cluster and device type development is available in the
+-   A guide to new cluster and device type development is available in the
     [New Cluster and Device Type Developement Guide](./cluster_and_device_type_dev/)
-- Documentation about building from the command line can be found in
+-   Documentation about building from the command line can be found in
     [the build guide](guides/BUILDING.md)
-- Documentation about running [cirque](https://github.com/openweave/cirque)
+-   Documentation about running [cirque](https://github.com/openweave/cirque)
     tests can be found in
     [the cirque test guide](../src/test_driver/linux-cirque/README.md)
-- Documentation about standard build & development flows using
+-   Documentation about standard build & development flows using
     [Visual Studio Code](https://code.visualstudio.com/) can be found in
     [the development guide](./VSCODE_DEVELOPMENT.md)
 
@@ -22,19 +22,19 @@ Project issues are triaged and maintained according to the
 
 ## Platform Guides
 
-- Various guides are available [here](./guides/README.md) that cover platform
+-   Various guides are available [here](./guides/README.md) that cover platform
     bring up, testing, and various troubleshooting things.
 
 ## Project Flow
 
-- Documentation about general project usage of GitHub, and project tools is
+-   Documentation about general project usage of GitHub, and project tools is
     documented in [the project flow](./PROJECT_FLOW.md)
 
 ## Style Guide
 
-- Documentation about style is documented in
+-   Documentation about style is documented in
     [the style guide](./style/style_guide.md)
-- Additional documentation about more specific files are in the
+-   Additional documentation about more specific files are in the
     [style folder](./style/)
 
 ## Third Party Tools

--- a/docs/guides/issue_triage.md
+++ b/docs/guides/issue_triage.md
@@ -19,20 +19,20 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
-- General integration link: <https://developers.home.google.com/matter>
-- Support via the communities areas:
-  - Stack overflow:
+-   General integration link: <https://developers.home.google.com/matter>
+-   Support via the communities areas:
+    -   Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-  - Google Nest Community:
+    -   Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Environments not currently supported / not maintained
 
 Some items are explicitly not maintained currently
 
-- Windows integration: no official maintainer for this so currently not
+-   Windows integration: no official maintainer for this so currently not
     supported
-- Old compiler support: CHIP requires a C++17 or higher compiler.
+-   Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 

--- a/docs/guides/issue_triage.md
+++ b/docs/guides/issue_triage.md
@@ -1,0 +1,135 @@
+# Project issues
+
+General issues are listed at
+<https://github.com/project-chip/connectedhomeip/issues> .
+
+In order to be able to effectively follow up on these issues, they are separated
+into groups for further review and fixing based on current maintainers on
+specific areas of the code. The separation is done via `labels`.
+
+Issues that still need triaging are labeled as `needs triage`:
+
+<https://github.com/project-chip/connectedhomeip/issues?q=is%3Aissue+is%3Aopen+label%3A%22needs+triage%22>
+
+## Non-SDK issues
+
+In some cases the issue is integrating with ecosystems or environments are not
+supported. In these cases, issues can be re-directed to specific support pages
+rather than the SDK GitHub issues.
+
+### Google Integration
+
+- General integration link: <https://developers.home.google.com/matter>
+- Support via the communities areas:
+  - Stack overflow:
+        <https://stackoverflow.com/questions/tagged/google-smart-home>
+  - Google Nest Community:
+        <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
+
+### Environments not currently supported / not maintained
+
+Some items are explicitly not maintained currently
+
+- Windows integration: no official maintainer for this so currently not
+    supported
+- Old compiler support: CHIP requires a C++17 or higher compiler.
+
+## Platform maintainers
+
+This level of separation is generally for platform-specific issues (e.g. failure
+to commission for one specific platform, failure to run on some specific
+operating system).
+
+Contact is generally done on slack. E-mail addresses are not added here on
+purpose in order to avoid spam.
+
+| Platform     | Contact                                 | Label                                                                                                    | Note(s) |
+| ------------ | --------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- |
+| Android      | Andrei Litvin, Yunhan Wang, Yufeng Wang | [android](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Aandroid) |         |
+| Darwin       | Boris Zbarsky, Justin Wood              | [darwin](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Adarwin)   |         |
+| Espressif    | Hrishikesh Dhayagude                    | [esp32](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Aesp32)     |         |
+| Linux        | Andrei Litvin                           | [linux](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Alinux)     |         |
+| Nordic       | Lucasz Duda                             | [nrf](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Anrf)         |         |
+| NXP          | Doru Gucea                              | [nxp](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Anxp)         |         |
+| Silabs/EFR32 | Jean Francois Penven, Junior Martinez   | [efr32](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Aefr32)     |         |
+
+## Code areas
+
+The following people can be contacted about issues in specific area of code are
+affected that are not platform-specific.
+
+| Code area                    | Contact                          | Label                                                                                            | Note(s)                                                                                                                              |
+| ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| ARM cross-compile            | Andrei Litvin                    | N/A                                                                                              | Some support for cross-compiling on x64 linux for arm64 linux (like Raspberry PI)                                                    |
+| Build system (darwin, xcode) | Boris Zbarsky, Justin Wood       | N/A                                                                                              | darwin specific builds, xcode connector                                                                                              |
+| Build system (gn, ninja)     | Andrei Litvin                    | N/A                                                                                              | General build system questions and gn support, generally on Linux                                                                    |
+| MatterIDL                    | Andrei Litvin                    | N/A                                                                                              | General .matter files and code generation based on it                                                                                |
+| Minimal MDNS                 | Andrei Litvin                    | N/A                                                                                              | mdns specfic. Note that platformdns also exists and issues are often "DNSSD" rather than minmdns specific                            |
+| Python tests scripts         | Cecille Freeman                  | N/A                                                                                              | Writing tests cases in python                                                                                                        |
+| ZAP Code Generation          | Boris Zbarsky, Bharat Raju Dandu | [zap](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Azap) | Some issues may be in the zap project itself. This is for generic code generation issues and help, often regarding `.zapt` templates |
+
+## Example maintenance
+
+Examples often correspond to specific device types. We have split the contact
+per device type regardless of example (e.g. all-clusters will contain all device
+types or functionality) as well as individual examples.
+
+### Per device type
+
+| Device Type(s) | Contact                      | Label | Note(s) |
+| -------------- | ---------------------------- | ----- | ------- |
+| Fabric Bridge  | Yufeng Wang, Terence Hampson |       |         |
+
+### Per example
+
+| Example path                                   | Contact                      | Note(s)      |
+| ---------------------------------------------- | ---------------------------- | ------------ |
+| `examples/air-purifier-app`                    |                              | UNMAINTAINED |
+| `examples/air-quality-sensor-app`              |                              | UNMAINTAINED |
+| `examples/all-clusters-app`                    |                              | UNMAINTAINED |
+| `examples/all-clusters-minimal-app`            |                              | UNMAINTAINED |
+| `examples/android`                             | Yunhan Wang                  |              |
+| `examples/bridge-app`                          |                              | UNMAINTAINED |
+| `examples/build_overrides`                     |                              | UNMAINTAINED |
+| `examples/chef`                                | Andrei Litvin                |              |
+| `examples/chip-tool`                           |                              | UNMAINTAINED |
+| `examples/contact-sensor-app`                  |                              | UNMAINTAINED |
+| `examples/darwin-framework-tool`               | Boris Zbarsky                |              |
+| `examples/dishwasher-app`                      |                              | UNMAINTAINED |
+| `examples/energy-management-app`               |                              | UNMAINTAINED |
+| `examples/fabric-admin`                        | Yufeng Wang, Terence Hampson |              |
+| `examples/fabric-bridge-app`                   | Yufeng Wang, Terence Hampson |              |
+| `examples/java-matter-controller`              | Yunhan Wang, Yufeng Wang     |              |
+| `examples/kotlin-matter-controller`            | Yunhan Wang, Yufeng Wang     |              |
+| `examples/laundry-washer-app`                  |                              | UNMAINTAINED |
+| `examples/lighting-app`                        |                              | UNMAINTAINED |
+| `examples/lighting-app-data-mode-no-unique-id` |                              | UNMAINTAINED |
+| `examples/light-switch-app`                    |                              | UNMAINTAINED |
+| `examples/lit-icd-app`                         | Yunhan Wang                  |              |
+| `examples/lock-app`                            |                              | UNMAINTAINED |
+| `examples/log-source-app`                      |                              | UNMAINTAINED |
+| `examples/microwave-oven-app`                  |                              | UNMAINTAINED |
+| `examples/minimal-mdns`                        | Andrei Litvin                |              |
+| `examples/network-manager-app`                 |                              | UNMAINTAINED |
+| `examples/ota-provider-app`                    |                              | UNMAINTAINED |
+| `examples/ota-requestor-app`                   |                              | UNMAINTAINED |
+| `examples/persistent-storage`                  |                              | UNMAINTAINED |
+| `examples/pigweed-app`                         |                              | UNMAINTAINED |
+| `examples/placeholder`                         |                              | UNMAINTAINED |
+| `examples/platform`                            |                              | UNMAINTAINED |
+| `examples/providers`                           |                              | UNMAINTAINED |
+| `examples/pump-app`                            |                              | UNMAINTAINED |
+| `examples/pump-controller-app`                 |                              | UNMAINTAINED |
+| `examples/refrigerator-app`                    |                              | UNMAINTAINED |
+| `examples/resource-monitoring-app`             |                              | UNMAINTAINED |
+| `examples/rvc-app`                             |                              | UNMAINTAINED |
+| `examples/shell`                               |                              | UNMAINTAINED |
+| `examples/smoke-co-alarm-app`                  |                              | UNMAINTAINED |
+| `examples/temperature-measurement-app`         |                              | UNMAINTAINED |
+| `examples/thermostat`                          |                              | UNMAINTAINED |
+| `examples/thread-br-app`                       |                              | UNMAINTAINED |
+| `examples/tv-app`                              | Chris DeCenzo, Lazar Kovacic |              |
+| `examples/tv-casting-app`                      | Chris DeCenzo, Lazar Kovacic |              |
+| `examples/virtual-device-app`                  |                              | UNMAINTAINED |
+| `examples/water-leak-detector-app`             |                              | UNMAINTAINED |
+| `examples/window-app`                          |                              | UNMAINTAINED |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Welcome to Matter's documentation!
+# Welcome to Matter's documentation
 
 ```{toctree}
 :maxdepth: 2
@@ -25,6 +25,7 @@ zap_clusters
 spec_clusters
 upgrading
 ERROR_CODES
+issue_triage
 
 ```
 

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,20 +19,20 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
-- General integration link: <https://developers.home.google.com/matter>
-- Support via the communities areas:
-  - Stack overflow:
+-   General integration link: <https://developers.home.google.com/matter>
+-   Support via the communities areas:
+    -   Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-  - Google Nest Community:
+    -   Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Environments not currently supported / not maintained
 
 Some items are explicitly not maintained currently
 
-- Windows integration: no official maintainer for this so currently not
+-   Windows integration: no official maintainer for this so currently not
     supported
-- Old compiler support: CHIP requires a C++17 or higher compiler.
+-   Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,20 +19,20 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
--   General integration link: <https://developers.home.google.com/matter>
--   Support via the communities areas:
-    -   Stack overflow:
+- General integration link: <https://developers.home.google.com/matter>
+- Support via the communities areas:
+  - Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-    -   Google Nest Community:
+  - Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Environments not currently supported / not maintained
 
 Some items are explicitly not maintained currently
 
--   Windows integration: no official maintainer for this so currently not
+- Windows integration: no official maintainer for this so currently not
     supported
--   Old compiler support: CHIP requires a C++17 or higher compiler.
+- Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 
@@ -58,15 +58,15 @@ purpose in order to avoid spam.
 The following people can be contacted about issues in specific area of code are
 affected that are not platform-specific.
 
-| Code area                    | Contact                          | Label                                                                                            | Note(s)                                                                                                                              |
-| ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
-| ARM cross-compile            | Andrei Litvin                    | N/A                                                                                              | Some support for cross-compiling on x64 linux for arm64 linux (like Raspberry PI)                                                    |
-| Build system (darwin, xcode) | Boris Zbarsky, Justin Wood       | N/A                                                                                              | darwin specific builds, xcode connector                                                                                              |
-| Build system (gn, ninja)     | Andrei Litvin                    | N/A                                                                                              | General build system questions and gn support, generally on Linux                                                                    |
-| MatterIDL                    | Andrei Litvin                    | N/A                                                                                              | General .matter files and code generation based on it                                                                                |
-| Minimal MDNS                 | Andrei Litvin                    | N/A                                                                                              | mdns specfic. Note that platformdns also exists and issues are often "DNSSD" rather than minmdns specific                            |
-| Python tests scripts         | Cecille Freeman                  | N/A                                                                                              | Writing tests cases in python                                                                                                        |
-| ZAP Code Generation          | Boris Zbarsky, Bharat Raju Dandu | [zap](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Azap) | Some issues may be in the zap project itself. This is for generic code generation issues and help, often regarding `.zapt` templates |
+| Code area                             | Contact                          | Label                                                                                            | Note(s)                                                                                                                                                                                    |
+| ------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ARM cross-compile                     | Andrei Litvin                    | N/A                                                                                              | Some support for cross-compiling on x64 linux for arm64 linux (like Raspberry PI)                                                                                                          |
+| Build system (darwin, xcode)          | Boris Zbarsky, Justin Wood       | N/A                                                                                              | darwin specific builds, xcode connector                                                                                                                                                    |
+| Build system (gn, ninja)              | Andrei Litvin                    | N/A                                                                                              | General build system questions and gn support, generally on Linux                                                                                                                          |
+| MatterIDL                             | Andrei Litvin                    | N/A                                                                                              | General .matter files and code generation based on it                                                                                                                                      |
+| Minimal MDNS                          | Andrei Litvin                    | N/A                                                                                              | mdns specfic. Note that platformdns also exists and issues are often "DNSSD" rather than minmdns specific                                                                                  |
+| Python testing infrastructure/helpers | Cecille Freeman                  | N/A                                                                                              | Writing tests cases in python. **NOTE** this is for test infrastrure and NOT for individual test issues. Test case failures are associated with test applications or the test case script. |
+| ZAP Code Generation                   | Boris Zbarsky, Bharat Raju Dandu | [zap](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Azap) | Some issues may be in the zap project itself. This is for generic code generation issues and help, often regarding `.zapt` templates                                                       |
 
 ## Example maintenance
 

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -32,9 +32,8 @@ This applies if there is an issue with Home interacting with a device (as
 opposed to an issue with Matter.framework or the SDK that is encountered by code
 actually running on darwin).
 
-General instructions available at
-<https://project-chip.github.io/connectedhomeip-doc/guides/darwin.html#providing-feedback-to-apple>
-(or specifically [here](./guides/darwin.md))
+General instructions available at [here](./guides/darwin.md) in the
+`Providing feedback to Apple` section.
 
 Once a Feedback Assistant ticket is filed, the ticket ID can be sent to Boris
 Zbkarsky to ensure it is noticed by the right people

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,20 +19,20 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
--   General integration link: <https://developers.home.google.com/matter>
--   Support via the communities areas:
-    -   Stack overflow:
+- General integration link: <https://developers.home.google.com/matter>
+- Support via the communities areas:
+  - Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-    -   Google Nest Community:
+  - Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Environments not currently supported / not maintained
 
 Some items are explicitly not maintained currently
 
--   Windows integration: no official maintainer for this so currently not
+- Windows integration: no official maintainer for this so currently not
     supported
--   Old compiler support: CHIP requires a C++17 or higher compiler.
+- Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 
@@ -67,6 +67,7 @@ affected that are not platform-specific.
 | Minimal MDNS                          | Andrei Litvin                    | N/A                                                                                              | mdns specfic. Note that platformdns also exists and issues are often "DNSSD" rather than minmdns specific                                                                                  |
 | Python testing infrastructure/helpers | Cecille Freeman                  | N/A                                                                                              | Writing tests cases in python. **NOTE** this is for test infrastrure and NOT for individual test issues. Test case failures are associated with test applications or the test case script. |
 | ZAP Code Generation                   | Boris Zbarsky, Bharat Raju Dandu | [zap](https://github.com/project-chip/connectedhomeip/issues?q=is%3Aopen+is%3Aissue+label%3Azap) | Some issues may be in the zap project itself. This is for generic code generation issues and help, often regarding `.zapt` templates                                                       |
+| src/crypto, src/credentials           | Tennessee Carmel-Veilleux        | N/A                                                                                              |                                                                                                                                                                                            |
 
 ## Example maintenance
 
@@ -76,9 +77,9 @@ types or functionality) as well as individual examples.
 
 ### Per device type
 
-| Device Type(s) | Contact                      | Label | Note(s) |
-| -------------- | ---------------------------- | ----- | ------- |
-| Fabric Bridge  | Yufeng Wang, Terence Hampson |       |         |
+| Device Type(s)             | Contact                      | Label                                                                                                        | Note(s) |
+| -------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
+| Fabric Bridge, Fabric Sync | Yufeng Wang, Terence Hampson | [fabric-sync](https://github.com/project-chip/connectedhomeip/pulls?q=is%3Aopen+is%3Apr+label%3Afabric-sync) |         |
 
 ### Per example
 
@@ -102,28 +103,26 @@ types or functionality) as well as individual examples.
 | `examples/java-matter-controller`              | Yunhan Wang, Yufeng Wang     |              |
 | `examples/kotlin-matter-controller`            | Yunhan Wang, Yufeng Wang     |              |
 | `examples/laundry-washer-app`                  |                              | UNMAINTAINED |
-| `examples/lighting-app`                        |                              | UNMAINTAINED |
+| `examples/lighting-app`                        | Junior Martinez              |              |
 | `examples/lighting-app-data-mode-no-unique-id` |                              | UNMAINTAINED |
 | `examples/light-switch-app`                    |                              | UNMAINTAINED |
 | `examples/lit-icd-app`                         | Yunhan Wang                  |              |
 | `examples/lock-app`                            |                              | UNMAINTAINED |
 | `examples/log-source-app`                      |                              | UNMAINTAINED |
-| `examples/microwave-oven-app`                  |                              | UNMAINTAINED |
+| `examples/microwave-oven-app`                  | Rob Bultman                  |              |
 | `examples/minimal-mdns`                        | Andrei Litvin                |              |
-| `examples/network-manager-app`                 |                              | UNMAINTAINED |
+| `examples/network-manager-app`                 | Thomas Lea                   |              |
 | `examples/ota-provider-app`                    |                              | UNMAINTAINED |
 | `examples/ota-requestor-app`                   |                              | UNMAINTAINED |
 | `examples/persistent-storage`                  |                              | UNMAINTAINED |
 | `examples/pigweed-app`                         |                              | UNMAINTAINED |
 | `examples/placeholder`                         |                              | UNMAINTAINED |
-| `examples/platform`                            |                              | UNMAINTAINED |
 | `examples/providers`                           |                              | UNMAINTAINED |
 | `examples/pump-app`                            |                              | UNMAINTAINED |
 | `examples/pump-controller-app`                 |                              | UNMAINTAINED |
 | `examples/refrigerator-app`                    |                              | UNMAINTAINED |
 | `examples/resource-monitoring-app`             |                              | UNMAINTAINED |
 | `examples/rvc-app`                             |                              | UNMAINTAINED |
-| `examples/shell`                               |                              | UNMAINTAINED |
 | `examples/smoke-co-alarm-app`                  |                              | UNMAINTAINED |
 | `examples/temperature-measurement-app`         |                              | UNMAINTAINED |
 | `examples/thermostat`                          |                              | UNMAINTAINED |

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,11 +19,11 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
-- General integration link: <https://developers.home.google.com/matter>
-- Support via the communities areas:
-  - Stack overflow:
+-   General integration link: <https://developers.home.google.com/matter>
+-   Support via the communities areas:
+    -   Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-  - Google Nest Community:
+    -   Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Apple Integration
@@ -43,9 +43,9 @@ Zbkarsky to ensure it is noticed by the right people
 
 Some items are explicitly not maintained currently
 
-- Windows integration: no official maintainer for this so currently not
+-   Windows integration: no official maintainer for this so currently not
     supported
-- Old compiler support: CHIP requires a C++17 or higher compiler.
+-   Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,11 +19,11 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
--   General integration link: <https://developers.home.google.com/matter>
--   Support via the communities areas:
-    -   Stack overflow:
+- General integration link: <https://developers.home.google.com/matter>
+- Support via the communities areas:
+  - Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-    -   Google Nest Community:
+  - Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
 
 ### Apple Integration
@@ -34,7 +34,7 @@ actually running on darwin).
 
 General instructions available at
 <https://project-chip.github.io/connectedhomeip-doc/guides/darwin.html#providing-feedback-to-apple>
-(or specifically [here](./docs/guides/darwin.md))
+(or specifically [here](./guides/darwin.md))
 
 Once a Feedback Assistant ticket is filed, the ticket ID can be sent to Boris
 Zbkarsky to ensure it is noticed by the right people
@@ -43,9 +43,9 @@ Zbkarsky to ensure it is noticed by the right people
 
 Some items are explicitly not maintained currently
 
--   Windows integration: no official maintainer for this so currently not
+- Windows integration: no official maintainer for this so currently not
     supported
--   Old compiler support: CHIP requires a C++17 or higher compiler.
+- Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -96,7 +96,7 @@ types or functionality) as well as individual examples.
 | `examples/contact-sensor-app`                  |                              | UNMAINTAINED |
 | `examples/darwin-framework-tool`               | Boris Zbarsky                |              |
 | `examples/dishwasher-app`                      |                              | UNMAINTAINED |
-| `examples/energy-management-app`               |                              | UNMAINTAINED |
+| `examples/energy-management-app`               | James Harrow                 |              |
 | `examples/fabric-admin`                        | Yufeng Wang, Terence Hampson |              |
 | `examples/fabric-bridge-app`                   | Yufeng Wang, Terence Hampson |              |
 | `examples/java-matter-controller`              | Yunhan Wang, Yufeng Wang     |              |

--- a/docs/issue_triage.md
+++ b/docs/issue_triage.md
@@ -19,20 +19,33 @@ rather than the SDK GitHub issues.
 
 ### Google Integration
 
--   General integration link: <https://developers.home.google.com/matter>
--   Support via the communities areas:
-    -   Stack overflow:
+- General integration link: <https://developers.home.google.com/matter>
+- Support via the communities areas:
+  - Stack overflow:
         <https://stackoverflow.com/questions/tagged/google-smart-home>
-    -   Google Nest Community:
+  - Google Nest Community:
         <https://www.googlenestcommunity.com/t5/Smart-Home-Developer-Forum/bd-p/Smart-Home-Developer-Forum>
+
+### Apple Integration
+
+This applies if there is an issue with Home interacting with a device (as
+opposed to an issue with Matter.framework or the SDK that is encountered by code
+actually running on darwin).
+
+General instructions available at
+<https://project-chip.github.io/connectedhomeip-doc/guides/darwin.html#providing-feedback-to-apple>
+(or specifically [here](./docs/guides/darwin.md))
+
+Once a Feedback Assistant ticket is filed, the ticket ID can be sent to Boris
+Zbkarsky to ensure it is noticed by the right people
 
 ### Environments not currently supported / not maintained
 
 Some items are explicitly not maintained currently
 
--   Windows integration: no official maintainer for this so currently not
+- Windows integration: no official maintainer for this so currently not
     supported
--   Old compiler support: CHIP requires a C++17 or higher compiler.
+- Old compiler support: CHIP requires a C++17 or higher compiler.
 
 ## Platform maintainers
 


### PR DESCRIPTION
This is a work in progress and contains only a small subset of issues. I expect it to be expanded as we find more owners and buckets. 

For now I plan to only start pinging people for the "platform labels". 