### PR TITLE
Update stalebot settings - do not close things, make 6 months as a stale threshold.

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -16,27 +16,17 @@ jobs:
               with:
                   stale-issue-message:
                       "This issue has been automatically marked as stale because
-                      it has not had recent activity. It will be closed if no
-                      further activity occurs. Remove stale label or comment or
-                      this will be closed in 30 days."
+                      it has not had recent activity."
                   stale-pr-message:
                       "This pull request has been automatically marked as stale
-                      because it has not had recent activity. It will be closed
-                      if no further activity occurs. Remove stale label or
-                      comment or this will be closed in 10 days."
+                      because it has not had recent activity."
                   close-issue-message:
                       "This stale issue has been automatically closed. Thank you
                       for your contributions."
                   close-pr-message:
                       "This stale pull request has been automatically closed.
                       Thank you for your contributions."
-                  days-before-issue-stale: 30
-                  days-before-issue-close: -1 # Don't close them for now
-                  days-before-pr-stale: 90
-                  days-before-pr-close: 10
-                  exempt-issue-labels:
-                      "security,blocked,cert blocker,build issue,Spec XML
-                      align,CI/CD improvements,memory"
-                  exempt-pr-labels:
-                      "security,blocked,cert blocker,build issue,Spec XML
-                      align,CI/CD improvements,memory"
+                  days-before-issue-stale: 180
+                  days-before-issue-close: -1 # Don't close stale issues
+                  days-before-pr-stale: 180
+                  days-before-pr-close: -1 # Don't close stale PRs


### PR DESCRIPTION
Do not close PRs nor Issues
Make the stale threshold to about 6 months, to match general release cycle for CHIP. Even if this changes at some point to anually, this still seems to be a more reasonable default if we actively triage and manage issues and PRs.

