### PR TITLE
Add `emberAfMetadataStructureGeneration` for codegen data model.

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -619,8 +619,9 @@ std::optional<unsigned> CodegenDataModelProvider::TryFindAttributeIndex(const Em
 
 const EmberAfCluster * CodegenDataModelProvider::FindServerCluster(const ConcreteClusterPath & path)
 {
-    // cache things
-    if (mPreviouslyFoundCluster.has_value() && (mPreviouslyFoundCluster->path == path))
+    if (mPreviouslyFoundCluster.has_value() && (mPreviouslyFoundCluster->path == path) &&
+        (mEmberMetadataStructureGeneration == emberAfMetadataStructureGeneration()))
+
     {
         return mPreviouslyFoundCluster->cluster;
     }
@@ -628,7 +629,8 @@ const EmberAfCluster * CodegenDataModelProvider::FindServerCluster(const Concret
     const EmberAfCluster * cluster = emberAfFindServerCluster(path.mEndpointId, path.mClusterId);
     if (cluster != nullptr)
     {
-        mPreviouslyFoundCluster = std::make_optional<ClusterReference>(path, cluster);
+        mPreviouslyFoundCluster           = std::make_optional<ClusterReference>(path, cluster);
+        mEmberMetadataStructureGeneration = emberAfMetadataStructureGeneration();
     }
     return cluster;
 }

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
@@ -137,6 +137,7 @@ private:
         ClusterReference(const ConcreteClusterPath p, const EmberAfCluster * c) : path(p), cluster(c) {}
     };
     std::optional<ClusterReference> mPreviouslyFoundCluster;
+    unsigned mEmberMetadataStructureGeneration = 0;
 
     /// Finds the specified ember cluster
     ///

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -93,6 +93,11 @@ uint8_t singletonAttributeData[ACTUAL_SINGLETONS_SIZE];
 
 uint16_t emberEndpointCount = 0;
 
+/// Determines a incremental unique index for ember
+/// metadata that is increased whenever a structural change is made to the
+/// ember metadata (e.g. changing dynamic endpoints or enabling/disabling endpoints)
+unsigned emberMetadataStructureGeneration = 0;
+
 // If we have attributes that are more than 4 bytes, then
 // we need this data block for the defaults
 #if (defined(GENERATED_DEFAULTS) && GENERATED_DEFAULTS_COUNT)
@@ -315,6 +320,7 @@ CHIP_ERROR emberAfSetDynamicEndpoint(uint16_t index, EndpointId id, const EmberA
     // Now enable the endpoint.
     emberAfEndpointEnableDisable(id, true);
 
+    emberMetadataStructureGeneration++;
     return CHIP_NO_ERROR;
 }
 
@@ -332,6 +338,7 @@ EndpointId emberAfClearDynamicEndpoint(uint16_t index)
         emAfEndpoints[index].endpoint = kInvalidEndpointId;
     }
 
+    emberMetadataStructureGeneration++;
     return ep;
 }
 
@@ -944,7 +951,13 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
                                 emberAfGlobalInteractionModelAttributesChangedListener());
     }
 
+    emberMetadataStructureGeneration++;
     return true;
+}
+
+unsigned emberAfMetadataStructureGeneration()
+{
+    return emberMetadataStructureGeneration;
 }
 
 // Returns the index of a given endpoint.  Does not consider disabled endpoints.

--- a/src/app/util/attribute-storage.h
+++ b/src/app/util/attribute-storage.h
@@ -312,6 +312,14 @@ void emberAfAttributeChanged(chip::EndpointId endpoint, chip::ClusterId clusterI
 /// any cluster data versions.
 void emberAfEndpointChanged(chip::EndpointId endpoint, chip::app::AttributesChangedListener * listener);
 
+/// Maintains a increasing index of structural changes within ember
+/// that determine if existing "indexes" and metadata pointers within ember
+/// are still valid or not.
+///
+/// Changes to metadata structure (e.g. endpoint enable/disable and dynamic endpoint changes)
+/// are reflected in this generation count changing.
+unsigned emberAfMetadataStructureGeneration();
+
 namespace chip {
 namespace app {
 

--- a/src/app/util/mock/attribute-storage.cpp
+++ b/src/app/util/mock/attribute-storage.cpp
@@ -61,8 +61,9 @@ using namespace Clusters::Globals::Attributes;
 
 namespace {
 
-DataVersion dataVersion           = 0;
-const MockNodeConfig * mockConfig = nullptr;
+unsigned metadataStructureGeneration = 0;
+DataVersion dataVersion              = 0;
+const MockNodeConfig * mockConfig    = nullptr;
 
 const MockNodeConfig & DefaultMockNodeConfig()
 {
@@ -342,6 +343,11 @@ void emberAfAttributeChanged(EndpointId endpoint, ClusterId clusterId, Attribute
     listener->MarkDirty(AttributePathParams(endpoint, clusterId, attributeId));
 }
 
+unsigned emberAfMetadataStructureGeneration()
+{
+    return metadataStructureGeneration;
+}
+
 namespace chip {
 namespace app {
 
@@ -494,12 +500,14 @@ CHIP_ERROR ReadSingleMockClusterData(FabricIndex aAccessingFabricIndex, const Co
 
 void SetMockNodeConfig(const MockNodeConfig & config)
 {
+    metadataStructureGeneration++;
     mockConfig = &config;
 }
 
 /// Resets the mock attribute storage to the default configuration.
 void ResetMockNodeConfig()
 {
+    metadataStructureGeneration++;
     mockConfig = nullptr;
 }
 


### PR DESCRIPTION
CodegenDataModel is using caching to speed up queries on clusters. However dynamic endpoints can be created/removed at will and in those cases old cluster pointers should not be re-used.

### Changes

- introduce an ember `metadata structure generation` number that increases on every dynamic module change. Did not worry about overflow as even 32-bit integers should last a sufficient amount of time to not introduce caching issues.
- Cluster cache in codegen data model uses the generation number to decide if a cached pointer is likely valid or not.