### PR TITLE
Silabs] Update brd2605a rgb led 

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -38,7 +38,7 @@ extern "C" {
 #include "rsi_board.h"
 #include "rsi_debug.h"
 #include "rsi_rom_egpio.h"
-#include "sl_si91x_usart.h"
+// #include "sl_si91x_usart.h"
 #else // For EFR32
 #if (_SILICON_LABS_32B_SERIES < 3)
 #include "em_core.h"

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -36,8 +36,15 @@ extern "C" {
 #include "sl_event_handler.h"
 #include "sl_si91x_button.h"
 #include "sl_si91x_button_pin_config.h"
+#ifndef SI917_DEVKIT
 #include "sl_si91x_led.h"
 #include "sl_si91x_led_config.h"
+#include "sl_si91x_led_instances.h"
+#else
+#include "sl_si91x_rgb_led.h"
+#include "sl_si91x_rgb_led_config.h"
+#include "sl_si91x_rgb_led_instances.h"
+#endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER == 0
 void soc_pll_config(void);
@@ -54,7 +61,7 @@ void soc_pll_config(void);
 // TODO Remove this when SI91X-16606 is addressed
 #ifdef SI917_DEVKIT
 #define SL_LED_COUNT 1
-uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LEDB_PIN };
+// uint8_t ledPinArray[SL_LED_COUNT] = {SL_LED_LEDB_PIN};
 #else
 #define SL_LED_COUNT SL_SI91x_LED_COUNT
 uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
@@ -111,7 +118,11 @@ void SilabsPlatform::InitLed(void)
 CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
 {
     VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
+#ifndef RGB_LED_ENABLED
     (state) ? sl_si91x_led_set(ledPinArray[led]) : sl_si91x_led_clear(ledPinArray[led]);
+#else
+    (state) ? sl_si91x_simple_rgb_led_on(&led_led0) : sl_si91x_simple_rgb_led_off(&led_led0);
+#endif
     return CHIP_NO_ERROR;
 }
 
@@ -124,7 +135,11 @@ bool SilabsPlatform::GetLedState(uint8_t led)
 CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 {
     VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
+#ifndef RGB_LED_ENABLED
     sl_si91x_led_toggle(ledPinArray[led]);
+#else
+    sl_si91x_simple_rgb_led_toggle(&led_led0);
+#endif
     return CHIP_NO_ERROR;
 }
 #endif // ENABLE_WSTK_LEDS

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -36,7 +36,7 @@ extern "C" {
 #include "sl_event_handler.h"
 #include "sl_si91x_button.h"
 #include "sl_si91x_button_pin_config.h"
-#ifndef SI917_DEVKIT
+#ifndef RGB_LED_ENABLED
 #include "sl_si91x_led.h"
 #include "sl_si91x_led_config.h"
 #include "sl_si91x_led_instances.h"
@@ -59,9 +59,10 @@ void soc_pll_config(void);
 #include "uart.h"
 #endif
 // TODO Remove this when SI91X-16606 is addressed
-#ifdef SI917_DEVKIT
-#define SL_LED_COUNT 1
-// uint8_t ledPinArray[SL_LED_COUNT] = {SL_LED_LEDB_PIN};
+#ifdef RGB_LED_ENABLED
+#define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
+const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
+#define SL_RGB_LED_INSTANCE(n) (ledPinArray[n])
 #else
 #define SL_LED_COUNT SL_SI91x_LED_COUNT
 uint8_t ledPinArray[SL_LED_COUNT] = { SL_LED_LED0_PIN, SL_LED_LED1_PIN };
@@ -121,7 +122,7 @@ CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
 #ifndef RGB_LED_ENABLED
     (state) ? sl_si91x_led_set(ledPinArray[led]) : sl_si91x_led_clear(ledPinArray[led]);
 #else
-    (state) ? sl_si91x_simple_rgb_led_on(&led_led0) : sl_si91x_simple_rgb_led_off(&led_led0);
+    (state) ? sl_si91x_simple_rgb_led_on(SL_RGB_LED_INSTANCE(led)) : sl_si91x_simple_rgb_led_off(SL_RGB_LED_INSTANCE(led));
 #endif
     return CHIP_NO_ERROR;
 }
@@ -138,7 +139,7 @@ CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 #ifndef RGB_LED_ENABLED
     sl_si91x_led_toggle(ledPinArray[led]);
 #else
-    sl_si91x_simple_rgb_led_toggle(&led_led0);
+    sl_si91x_simple_rgb_led_toggle(SL_RGB_LED_INSTANCE(led));
 #endif
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
+++ b/src/platform/silabs/platformAbstraction/WiseMcuSpam.cpp
@@ -36,7 +36,7 @@ extern "C" {
 #include "sl_event_handler.h"
 #include "sl_si91x_button.h"
 #include "sl_si91x_button_pin_config.h"
-#ifndef RGB_LED_ENABLED
+#ifndef SI917_DEVKIT
 #include "sl_si91x_led.h"
 #include "sl_si91x_led_config.h"
 #include "sl_si91x_led_instances.h"
@@ -59,7 +59,7 @@ void soc_pll_config(void);
 #include "uart.h"
 #endif
 // TODO Remove this when SI91X-16606 is addressed
-#ifdef RGB_LED_ENABLED
+#ifdef SI917_DEVKIT
 #define SL_LED_COUNT SL_SI91X_RGB_LED_COUNT
 const sl_rgb_led_t * ledPinArray[SL_LED_COUNT] = { &led_led0 };
 #define SL_RGB_LED_INSTANCE(n) (ledPinArray[n])
@@ -119,7 +119,7 @@ void SilabsPlatform::InitLed(void)
 CHIP_ERROR SilabsPlatform::SetLed(bool state, uint8_t led)
 {
     VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
-#ifndef RGB_LED_ENABLED
+#ifndef SI917_DEVKIT
     (state) ? sl_si91x_led_set(ledPinArray[led]) : sl_si91x_led_clear(ledPinArray[led]);
 #else
     (state) ? sl_si91x_simple_rgb_led_on(SL_RGB_LED_INSTANCE(led)) : sl_si91x_simple_rgb_led_off(SL_RGB_LED_INSTANCE(led));
@@ -136,7 +136,7 @@ bool SilabsPlatform::GetLedState(uint8_t led)
 CHIP_ERROR SilabsPlatform::ToggleLed(uint8_t led)
 {
     VerifyOrReturnError(led < SL_LED_COUNT, CHIP_ERROR_INVALID_ARGUMENT);
-#ifndef RGB_LED_ENABLED
+#ifndef SI917_DEVKIT
     sl_si91x_led_toggle(ledPinArray[led]);
 #else
     sl_si91x_simple_rgb_led_toggle(SL_RGB_LED_INSTANCE(led));

--- a/src/platform/silabs/rs911x/wfx_sl_ble_init.cpp
+++ b/src/platform/silabs/rs911x/wfx_sl_ble_init.cpp
@@ -294,6 +294,7 @@ void SilabsBleWrapper::rsi_ble_add_char_val_att(void * serv_handler, uint16_t ha
 
 uint32_t SilabsBleWrapper::rsi_ble_add_matter_service(void)
 {
+    bleEvent.eventData                                      = new SilabsBleWrapper::sl_wfx_msg_t();
     uuid_t custom_service                                   = { RSI_BLE_MATTER_CUSTOM_SERVICE_UUID };
     custom_service.size                                     = RSI_BLE_MATTER_CUSTOM_SERVICE_SIZE;
     custom_service.val.val16                                = RSI_BLE_MATTER_CUSTOM_SERVICE_VALUE_16;

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -137,8 +137,9 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/platform/service/iostream/inc",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/inc",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/config",
-      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/inc",
-      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/config",
+
+      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/inc",
+      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/config",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/core/config",
 
       # sl memory manager
@@ -155,6 +156,17 @@ template("siwx917_sdk") {
 
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/power_manager/inc",
     ]
+
+    if (rgb_led) {
+      _include_dirs += [
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/inc",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/config",
+      ]
+      defines += [
+        "RGB_LED_ENABLED",
+        "SI917_DEVKIT",
+      ]
+    }
 
     if (use_system_view) {
       _include_dirs += [
@@ -649,7 +661,8 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_temp_sensor.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ulpss_clk.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_driver_gpio.c",
-      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_usart.c",
+
+      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_usart.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c",
@@ -687,11 +700,13 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_event_handler.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_button_instances.c",
-      "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
+
+      #  "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_ulp_timer_init.c",
       "${sdk_support_root}/matter/si91x/support/hal/rsi_hal_mcu_m4.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/src/sl_si91x_button.c",
-      "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
+
+      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_nvm3_hal_flash.c",
 
       # sl memory manager
@@ -715,6 +730,13 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/hal/src/sl_si91x_hal_soc_soft_reset.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/firmware_upgrade/firmware_upgradation.c",
     ]
+
+    if (rgb_led) {
+      sources += [
+        "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_rgb_led_instances.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/src/sl_si91x_rgb_led.c",
+      ]
+    }
 
     if (use_system_view) {
       sources += [

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -138,8 +138,6 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/inc",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/config",
 
-      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/inc",
-      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/config",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/core/config",
 
       # sl memory manager
@@ -162,10 +160,7 @@ template("siwx917_sdk") {
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/inc",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/config",
       ]
-      defines += [
-        "RGB_LED_ENABLED",
-        "SI917_DEVKIT",
-      ]
+      defines += [ "SI917_DEVKIT" ]
     } else {
       _include_dirs += [
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/inc",
@@ -703,13 +698,9 @@ template("siwx917_sdk") {
       "${efr32_sdk_root}/util/third_party/freertos/kernel/timers.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_event_handler.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_button_instances.c",
-
-      #  "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
       "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_ulp_timer_init.c",
       "${sdk_support_root}/matter/si91x/support/hal/rsi_hal_mcu_m4.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/button/src/sl_si91x_button.c",
-
-      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/service/nvm3/src/sl_si91x_nvm3_hal_flash.c",
 
       # sl memory manager

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -166,6 +166,11 @@ template("siwx917_sdk") {
         "RGB_LED_ENABLED",
         "SI917_DEVKIT",
       ]
+    } else {
+      _include_dirs += [
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/inc",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/config",
+      ]
     }
 
     if (use_system_view) {
@@ -661,8 +666,6 @@ template("siwx917_sdk") {
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_temp_sensor.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/systemlevel/src/rsi_ulpss_clk.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_driver_gpio.c",
-
-      #  "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_usart.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/unified_peripheral_drivers/src/sl_si91x_peripheral_gpio.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_ram.c",
       "${wifi_sdk_root}/components/device/silabs/si91x/wireless/ahb_interface/src/rsi_hal_mcu_m4_rom.c",
@@ -735,6 +738,11 @@ template("siwx917_sdk") {
       sources += [
         "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_rgb_led_instances.c",
         "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/rgb_led/src/sl_si91x_rgb_led.c",
+      ]
+    } else {
+      sources += [
+        "${sdk_support_root}/matter/si91x/siwx917/${silabs_board}/autogen/sl_si91x_led_instances.c",
+        "${wifi_sdk_root}/components/device/silabs/si91x/mcu/drivers/hardware_drivers/led/src/sl_si91x_led.c",
       ]
     }
 

--- a/third_party/silabs/silabs_board.gni
+++ b/third_party/silabs/silabs_board.gni
@@ -56,6 +56,9 @@ declare_args() {
 
   # Temperature Sensor support
   sl_enable_si70xx_sensor = false
+
+  #RGB LED support
+  rgb_led = false
 }
 
 declare_args() {
@@ -71,6 +74,10 @@ if (silabs_board == "") {
 }
 
 assert(silabs_board != "", "silabs_board must be specified")
+
+if (silabs_board == "BRD2605A") {
+  rgb_led = true
+}
 
 # Si917 WIFI board ----------
 if (silabs_board == "BRD4338A" || silabs_board == "BRD2605A") {


### PR DESCRIPTION
**Change**
Changes added for RGB LED with wifi_sdk 3.3.3
**Testing**
Validated that lighting-app and lock-app compile and run successfully on BRD4338A and BRD2605A
Commissioning and led(s) are working

