### PR TITLE
[Matter.framework] Backtrace logging for MTRDeviceControllerFactory::…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -327,6 +327,7 @@ MTR_DIRECT_MEMBERS
                           error:(NSError * __autoreleasing *)error
 {
     [self _assertCurrentQueueIsNotMatterQueue];
+    [self _maybeLogBacktrace:@"Controller Factory Start"];
 
     __block CHIP_ERROR err = CHIP_ERROR_INTERNAL;
     dispatch_sync(_chipWorkQueue, ^{
@@ -418,6 +419,7 @@ MTR_DIRECT_MEMBERS
 - (void)stopControllerFactory
 {
     [self _assertCurrentQueueIsNotMatterQueue];
+    [self _maybeLogBacktrace:@"Controller Factory Stop"];
 
     for (MTRDeviceController * controller in [_controllers copy]) {
         [controller shutdown];
@@ -1243,6 +1245,15 @@ MTR_DIRECT_MEMBERS
     }
 
     return systemState->Fabrics();
+}
+
+- (void)_maybeLogBacktrace:(NSString *)message
+{
+#ifdef DEBUG
+    @autoreleasepool {
+        MTR_LOG("[%@]: %@", message, [NSThread callStackSymbols]);
+    }
+#endif // DEBUG
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1249,11 +1249,9 @@ MTR_DIRECT_MEMBERS
 
 - (void)_maybeLogBacktrace:(NSString *)message
 {
-#ifdef DEBUG
     @autoreleasepool {
         MTR_LOG("[%@]: %@", message, [NSThread callStackSymbols]);
     }
-#endif // DEBUG
 }
 
 @end


### PR DESCRIPTION
…startControllerFactory/stopControllerFactory

#### Problem

For debugging, log backtraces when the device controller factory starts or stops.