### PR TITLE
Fix unmatched Register/UnregisterReadHandlerAppCallback calls

### DIFF
--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4641,8 +4641,8 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
 
     readParam.mAttributePathParamsListSize = 0;
     readClient                             = std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                                                               app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                                               app::ReadClient::InteractionType::Subscribe);
+                                                   app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                                   app::ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1811,11 +1811,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
         numSubscriptionEstablishedCalls++;
     };
 
-    //
-    // Test the server-side application altering the subscription intervals.
-    //
-    mAlterSubscriptionIntervals = false;
-
     EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                   &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 5, 5,
                   onSubscriptionEstablishedCb, nullptr, true),
@@ -1837,8 +1832,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 // Subscriber sends the request with particular max-interval value:
@@ -1879,11 +1872,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
         numSubscriptionEstablishedCalls++;
     };
 
-    //
-    // Test the server-side application altering the subscription intervals.
-    //
-    mAlterSubscriptionIntervals = false;
-
     EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                   &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 0, 10,
                   onSubscriptionEstablishedCb, nullptr, true),
@@ -1905,8 +1893,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 // Subscriber sends the request with particular max-interval value:
@@ -1973,8 +1959,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -2033,8 +2017,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER != 1
@@ -2077,11 +2059,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
         numSubscriptionEstablishedCalls++;
     };
 
-    //
-    // Test the server-side application altering the subscription intervals.
-    //
-    mAlterSubscriptionIntervals = false;
-
     EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                   &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 0, 4000,
                   onSubscriptionEstablishedCb, nullptr, true),
@@ -2103,8 +2080,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 // Subscriber sends the request with particular max-interval value:
@@ -2171,8 +2146,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 // Subscriber sends the request with particular max-interval value:
@@ -2239,8 +2212,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -2299,8 +2270,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 // Subscriber sends the request with particular max-interval value:
@@ -2331,11 +2300,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
         numSubscriptionEstablishedCalls++;
     };
 
-    //
-    // Test the server-side application altering the subscription intervals.
-    //
-    mAlterSubscriptionIntervals = false;
-
     EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                   &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 5, 4,
                   onSubscriptionEstablishedCb, nullptr, true),
@@ -2354,8 +2318,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-
-    mAlterSubscriptionIntervals = false;
 }
 
 /**

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -118,6 +118,9 @@ protected:
     void SetUp() override
     {
         chip::Test::AppContext::SetUp();
+        // Register app callback, so we can test it as well to ensure we get the right
+        // number of SubscriptionEstablishment/Termination callbacks.
+        InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
         mOldProvider = InteractionModelEngine::GetInstance()->SetDataModelProvider(&CustomDataModel::Instance());
         chip::Test::SetMockNodeConfig(TestMockNodeConfig());
     }
@@ -127,6 +130,7 @@ protected:
     {
         chip::Test::ResetMockNodeConfig();
         InteractionModelEngine::GetInstance()->SetDataModelProvider(mOldProvider);
+        InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
         chip::Test::AppContext::TearDown();
     }
 
@@ -270,11 +274,6 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithVersionOnlyCache)
     chip::app::ClusterStateCache cache(delegate, Optional<EventNumber>::Missing(), false /*cachedData*/);
 
     chip::app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
-    //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
 
     // read of E2C2A* and E3C2A2. Expect cache E2C2 version
     {
@@ -352,11 +351,6 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     chip::app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 4;
-    //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
 
     [[maybe_unused]] int testId = 0;
 
@@ -1692,12 +1686,6 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Try to issue parallel subscriptions that will exceed the value for app::InteractionModelEngine::kReadHandlerPoolSize.
     // If heap allocation is correctly setup, this should result in it successfully servicing more than the number
     // present in that define.
@@ -1727,7 +1715,6 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
     SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
 }
 
 TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
@@ -1757,12 +1744,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the application rejecting subscriptions.
     //
     mEmitSubscriptionError = true;
@@ -1788,7 +1769,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mEmitSubscriptionError = false;
 }
 
@@ -1832,12 +1812,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = false;
@@ -1864,7 +1838,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -1907,12 +1880,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = false;
@@ -1939,7 +1906,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -1982,12 +1948,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = true;
@@ -2014,7 +1974,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2050,12 +2009,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = true;
@@ -2081,7 +2034,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2126,12 +2078,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = false;
@@ -2158,7 +2104,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2201,12 +2146,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = true;
@@ -2233,7 +2172,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2274,11 +2212,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
 
         numSubscriptionEstablishedCalls++;
     };
-    //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
 
     //
     // Test the server-side application altering the subscription intervals.
@@ -2307,7 +2240,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2341,11 +2273,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
-    //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
 
     //
     // Test the server-side application altering the subscription intervals.
@@ -2373,7 +2300,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -2406,12 +2332,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
     };
 
     //
-    // Test the application callback as well to ensure we get the right number of SubscriptionEstablishment/Termination
-    // callbacks.
-    //
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
-    //
     // Test the server-side application altering the subscription intervals.
     //
     mAlterSubscriptionIntervals = false;
@@ -2435,7 +2355,6 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
     mAlterSubscriptionIntervals = false;
 }
 
@@ -3291,8 +3210,6 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
         app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
     const auto kExpectedParallelPaths = kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription;
 
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
     // Here, we set up two background perpetual read requests to simulate parallel Read + Subscriptions.
     // We don't care about the data read, we only care about the existence of such read transactions.
     TestReadCallback readCallback;
@@ -3502,8 +3419,6 @@ TEST_F(TestRead, TestReadHandler_KillOldestSubscriptions)
         app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
     const auto kExpectedParallelPaths = kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription;
 
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-
     TestReadCallback readCallback;
     std::vector<std::unique_ptr<app::ReadClient>> readClients;
 
@@ -3620,8 +3535,6 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     using Params = TestReadHandler_ParallelReads_TestCase_Parameters;
 
     auto sessionHandle = GetSessionBobToAlice();
-
-    app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
 
     auto TestCase = [&](const TestReadHandler_ParallelReads_TestCase_Parameters & params, std::function<void()> body) {
         TestReadHandler_ParallelReads_TestCase(this, params, body);
@@ -4766,8 +4679,8 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
 
     readParam.mAttributePathParamsListSize = 0;
     readClient                             = std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                                   app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                   app::ReadClient::InteractionType::Subscribe);
+                                                                               app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                                                               app::ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();


### PR DESCRIPTION
### Problem

Running `TestRead` with googletest backend segfaults because of reuse-after-free.

### Changes

- Move register/unregister calls to SetUp/TearDown to ensure that tests will not reuse stale global state from previous test case
- Cleanup misleading `mAlterSubscriptionIntervals = false;` statements and comments

### Testing

Verified that it is possible to run test with googletest backend.
CI will also verify 