### PR TITLE
[NXP] Fix mDNS issue with RW61x ethernet board

### DIFF
--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -336,6 +336,9 @@ choice NXP_ENET_DRIVER
 	default ETH_NXP_ENET
 endchoice
 
+config NET_SOCKETS_POLL_MAX
+	default 7
+
 endif
 
 # Configure MBEDTLS lib

--- a/config/nxp/chip-module/Kconfig.features
+++ b/config/nxp/chip-module/Kconfig.features
@@ -95,6 +95,8 @@ config CHIP_ETHERNET
 	select NET_TCP
 	select DNS_RESOLVER
 	select MDNS_RESOLVER
+	select MDNS_RESPONDER
+	select DNS_SD
 	select MBEDTLS_PKCS5_C
 	select MBEDTLS_HKDF_C
 	select MBEDTLS_ECDSA_C


### PR DESCRIPTION
Noticing that mDNS resolution from the controller
is failing some time after the board is commissioned. This is due to the board not responding to the mDNS queries.

