### PR TITLE
Handle typedef in zapt templates & matter_idl

### DIFF
--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -223,29 +223,14 @@ public:
         params.timedWriteTimeout = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
         params.dataVersion = mDataVersion.HasValue() ? [NSNumber numberWithUnsignedInt:mDataVersion.Value()] : nil;
         {{#if_chip_complex}}
-        {{asObjectiveCType type parent.name}} value;
-        {{>decodable_value target="value" source="mValue" cluster=parent.name errorCode="return err;" depth=0}}
+          {{asObjectiveCType type parent.name}} value;
+          {{>decodable_value target="value" source="mValue" cluster=parent.name errorCode="return err;" depth=0}}
+        {{else if isNullable}}
+          {{asObjectiveCType type parent.name}} value;
+          {{>decodable_value target="value" source="mValue" cluster=parent.name isOptional=false isArray=false errorCode="return err;" depth=0}}
         {{else}}
-          {{#if isNullable}}
-            {{asObjectiveCType type parent.name}} value = nil;
-            if (!mValue.IsNull()) {
-              {{#if (isOctetString type)}}
-                value = [[NSData alloc] initWithBytes:mValue.Value().data() length:mValue.Value().size()];
-              {{else if (isString type)}}
-                value = [[NSString alloc] initWithBytes:mValue.Value().data() length:mValue.Value().size() encoding:NSUTF8StringEncoding];
-              {{else}}
-                value = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:mValue.Value()];
-              {{/if}}
-            }
-          {{else}}
-            {{#if (isOctetString type)}}
-              {{asObjectiveCType type parent.name}} value = [[NSData alloc] initWithBytes:mValue.data() length:mValue.size()];
-            {{else if (isString type)}}
-              {{asObjectiveCType type parent.name}} value = [[NSString alloc] initWithBytes:mValue.data() length:mValue.size() encoding:NSUTF8StringEncoding];
-            {{else}}
-              {{asObjectiveCType type parent.name}} value = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:mValue{{#if isNullable}}.Value(){{/if}}];
-            {{/if}}
-          {{/if}}
+          {{asObjectiveCType type parent.name}}
+          {{>decodable_value target="value" source="mValue" cluster=parent.name isOptional=false isArray=false errorCode="return err;" depth=0}}
         {{/if_chip_complex}}
 
         [cluster write{{>attribute}}WithValue:value params:params completion:^(NSError * _Nullable error) {

--- a/examples/darwin-framework-tool/templates/partials/decodable_value.zapt
+++ b/examples/darwin-framework-tool/templates/partials/decodable_value.zapt
@@ -27,18 +27,24 @@
       {{>decodable_value target=(concat ../target "." (asStructPropertyName label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster depth=(incrementDepth ../depth) }}
     {{/zcl_struct_items_by_struct_and_cluster_name}}
   {{else}}
-    {{#if_is_strongly_typed_chip_enum type}}
-      {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:chip::to_underlying({{source}})];
+  {{#if_is_typedef type}}
+    {{#zcl_typedef_by_typedef_and_cluster_name type cluster}}
+      {{>decodable_value target=../target source=../source errorCode=../errorCode cluster=../cluster depth=../depth }}
+    {{/zcl_typedef_by_typedef_and_cluster_name}}
     {{else}}
-      {{#if_is_strongly_typed_bitmap type}}
-        {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}.Raw()];
-      {{else if (isOctetString type)}}
-        {{target}} = [NSData dataWithBytes:{{source}}.data() length:{{source}}.size()];
-      {{else if (isCharString type)}}
-        {{target}} = [[NSString alloc] initWithBytes:{{source}}.data() length:{{source}}.size() encoding:NSUTF8StringEncoding];
+      {{#if_is_strongly_typed_chip_enum type}}
+        {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:chip::to_underlying({{source}})];
       {{else}}
-        {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
-      {{/if_is_strongly_typed_bitmap}}
-    {{/if_is_strongly_typed_chip_enum}}
+        {{#if_is_strongly_typed_bitmap type}}
+          {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}.Raw()];
+        {{else if (isOctetString type)}}
+          {{target}} = [NSData dataWithBytes:{{source}}.data() length:{{source}}.size()];
+        {{else if (isCharString type)}}
+          {{target}} = [[NSString alloc] initWithBytes:{{source}}.data() length:{{source}}.size() encoding:NSUTF8StringEncoding];
+        {{else}}
+          {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
+        {{/if_is_strongly_typed_bitmap}}
+      {{/if_is_strongly_typed_chip_enum}}
+    {{/if_is_typedef}}
   {{/if_is_struct}}
 {{/if}}

--- a/scripts/py_matter_idl/matter_idl/generators/idl/MatterIdl.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/idl/MatterIdl.jinja
@@ -55,6 +55,10 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
 
 {% endfor %}
 
+{%- for typedef in idl.global_typedefs %}
+typedef {{typedef.name}} : {{ typedef.base_type}};
+{% endfor %}
+
 {%- for cluster in idl.clusters %}
 {% if cluster.description %}/** {{cluster.description}} */
 {% endif %}
@@ -79,6 +83,13 @@ bitmap {{bitmap.name}} : {{ bitmap.base_type}} {
     {{entry.name}} = 0x{{"%X" | format(entry.code)}};
     {% endfor %}
   }
+  */
+
+  {% endfor %}
+
+  {%- for typedef in cluster.typedefs | selectattr("is_global")%}
+  /* GLOBAL:
+  typedef {{typedef.name}} : {{ typedef.base_type}};
   */
 
   {% endfor %}

--- a/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/generators/kotlin/__init__.py
@@ -420,7 +420,7 @@ class EncodableValue:
 
     @property
     def kotlin_type(self):
-        t = ParseDataType(self.data_type, self.context)
+        t = ParseDataType(self.data_type, self.context, desugar_typedef=True)
 
         if isinstance(t, FundamentalType):
             if t == FundamentalType.BOOL:
@@ -507,7 +507,7 @@ class EncodableValue:
         if self.is_list:
             return "Ljava/util/ArrayList;"
 
-        t = ParseDataType(self.data_type, self.context)
+        t = ParseDataType(self.data_type, self.context, desugar_typedef=True)
 
         if isinstance(t, FundamentalType):
             if t == FundamentalType.BOOL:

--- a/scripts/py_matter_idl/matter_idl/matter_grammar.lark
+++ b/scripts/py_matter_idl/matter_idl/matter_grammar.lark
@@ -12,6 +12,7 @@ struct_qualities: struct_quality*
 
 enum: "enum"i id ":" type "{" constant_entry* "}"
 bitmap: "bitmap"i id ":" type "{" constant_entry* "}"
+typedef: "typedef"i id ":" type ";"
 
 ?access_privilege: "view"i       -> view_privilege
                  | "operate"i    -> operate_privilege
@@ -68,7 +69,7 @@ cluster_revision: "revision"i positive_integer ";"
 //   no direct meaning currently
 cluster: [maturity] ( "client" | "server" )? "cluster"i id "=" positive_integer "{" [cluster_revision] cluster_content* "}"
 
-?cluster_content: [maturity] (enum|bitmap|event|attribute|struct|request_struct|response_struct|command)
+?cluster_content: [maturity] (enum|bitmap|event|attribute|struct|request_struct|response_struct|command|typedef)
 
 endpoint: "endpoint"i positive_integer "{" endpoint_content* "}"
 ?endpoint_content: endpoint_cluster_binding | endpoint_server_cluster | endpoint_device_type
@@ -116,7 +117,7 @@ POSITIVE_INTEGER: /\d+/
 HEX_INTEGER: /0x[A-Fa-f0-9]+/
 ID: /[a-zA-Z_][a-zA-Z0-9_]*/
 
-idl: (struct|enum|bitmap|cluster|endpoint)*
+idl: (struct|enum|bitmap|cluster|endpoint|typedef)*
 
 %import common.ESCAPED_STRING
 %import common.WS

--- a/scripts/py_matter_idl/matter_idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter_idl/matter_idl_types.py
@@ -207,6 +207,13 @@ class Bitmap:
 
 
 @dataclass
+class Typedef:
+    name: str
+    base_type: str
+    api_maturity: ApiMaturity = ApiMaturity.STABLE
+    is_global: bool = False
+
+@dataclass
 class Command:
     name: str
     code: int
@@ -235,6 +242,7 @@ class Cluster:
     events: List[Event] = field(default_factory=list)
     attributes: List[Attribute] = field(default_factory=list)
     structs: List[Struct] = field(default_factory=list)
+    typedefs: List[Typedef] = field(default_factory=list)
     commands: List[Command] = field(default_factory=list)
     description: Optional[str] = None
     api_maturity: ApiMaturity = ApiMaturity.STABLE
@@ -297,6 +305,7 @@ class Idl:
     global_bitmaps: List[Bitmap] = field(default_factory=list)
     global_enums: List[Enum] = field(default_factory=list)
     global_structs: List[Struct] = field(default_factory=list)
+    global_typedefs: List[Typedef] = field(default_factory=list)
 
     # IDL file name is available only if parsing provides a file name
     parse_file_name: Optional[str] = field(default=None)

--- a/scripts/py_matter_idl/matter_idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter_idl/test_matter_idl_parser.py
@@ -34,7 +34,7 @@ from matter_idl.generators.idl import IdlGenerator
 from matter_idl.matter_idl_types import (AccessPrivilege, ApiMaturity, Attribute, AttributeInstantiation, AttributeQuality,
                                          AttributeStorage, Bitmap, Cluster, Command, CommandInstantiation, CommandQuality,
                                          ConstantEntry, DataType, DeviceType, Endpoint, Enum, Event, EventPriority, EventQuality,
-                                         Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct, StructTag)
+                                         Field, FieldQuality, Idl, ParseMetaData, ServerClusterInstantiation, Struct, StructTag, Typedef)
 
 
 class GeneratorContentStorage(GeneratorStorage):
@@ -335,6 +335,20 @@ class TestParser(unittest.TestCase):
                              ])],
                     )])
         self.assertIdlEqual(actual, expected)
+
+    def test_cluster_typedef(self):
+      actual = parseText("""
+            client cluster WithTypedefs = 0xab {
+                typedef TestTypedef : int16u;
+            }
+        """)
+      expected = Idl(clusters=[
+          Cluster(name="WithTypedefs",
+                  code=0xab,
+                  typedefs=[
+                      Typedef(name="TestTypedef", base_type="int16u")],
+                  )])
+      self.assertIdlEqual(actual, expected)
 
     def test_event_field_api_maturity(self):
         actual = parseText("""

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -312,6 +312,8 @@ class JinjaCodegenTarget():
     def generate(self) -> TargetRunStats:
         generate_start = time.time()
 
+        logging.info("Executing: %s" % self.command)
+
         subprocess.check_call(self.command)
 
         self.codeFormat()

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -68,3 +68,9 @@ source_set("enums") {
 
   public_configs = [ ":includes" ]
 }
+
+source_set("typedefs") {
+  sources = [ "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-typedefs.h" ]
+
+  public_configs = [ ":includes" ]
+}

--- a/src/app/common/templates/templates.json
+++ b/src/app/common/templates/templates.json
@@ -26,6 +26,10 @@
             "path": "../../zap-templates/partials/cluster-enums-enum.zapt"
         },
         {
+            "name": "cluster_typedefs_typedef",
+            "path": "../../zap-templates/partials/cluster-typedefs-typedef.zapt"
+        },
+        {
             "name": "cluster_enums_ensure_known_value",
             "path": "../../zap-templates/partials/cluster-enums-ensure-known-value.zapt"
         },
@@ -98,6 +102,11 @@
             "path": "../../zap-templates/templates/app/cluster-enums-check.zapt",
             "name": "Enum and bitmap method check header for clusters",
             "output": "cluster-enums-check.h"
+        },
+        {
+            "path": "../../zap-templates/templates/app/cluster-typedefs.zapt",
+            "name": "Typedef header for clusters",
+            "output": "cluster-typedefs.h"
         }
     ]
 }

--- a/src/app/zap-templates/partials/cluster-typedefs-typedef.zapt
+++ b/src/app/zap-templates/partials/cluster-typedefs-typedef.zapt
@@ -1,0 +1,2 @@
+// Typedef for {{label}}
+using {{asType label}} = {{zapTypeToEncodableClusterObjectType type}};

--- a/src/app/zap-templates/partials/idl/cluster_definition.zapt
+++ b/src/app/zap-templates/partials/idl/cluster_definition.zapt
@@ -22,6 +22,10 @@ cluster {{asUpperCamelCase name}} = {{!}}
   }
 
   {{/zcl_enums}}
+  {{#zcl_typedefs}}
+  typedef {{asUpperCamelCase name preserveAcronyms=true}} : {{type}};
+
+  {{/zcl_typedefs}}
   {{#zcl_bitmaps}}
   bitmap {{asUpperCamelCase name preserveAcronyms=true}} : bitmap{{multiply size 8}} {
     {{#zcl_bitmap_items}}

--- a/src/app/zap-templates/partials/idl/global_types.zapt
+++ b/src/app/zap-templates/partials/idl/global_types.zapt
@@ -8,6 +8,12 @@ enum {{asUpperCamelCase name preserveAcronyms=true}} : enum{{multiply size 8}} {
 
 {{/if}}
 {{/zcl_enums}}
+{{#zcl_typedefs}}
+{{#if has_no_clusters}}
+typedef {{asUpperCamelCase name preserveAcronyms=true}} : {{type}};
+
+{{/if}}
+{{/zcl_typedefs}}
 {{#zcl_bitmaps}}
 {{#if has_no_clusters}}
 {{#if_is_atomic name}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -13,6 +13,7 @@
 #include <lib/core/ClusterEnums.h>
 #include <lib/support/BitMask.h>
 #include <protocols/interaction_model/Constants.h>
+#include <app-common/zap-generated/cluster-typedefs.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app-common/zap-generated/ids/Commands.h>

--- a/src/app/zap-templates/templates/app/cluster-typedefs.zapt
+++ b/src/app/zap-templates/templates/app/cluster-typedefs.zapt
@@ -1,0 +1,53 @@
+{{> header}}
+
+#pragma once
+
+#include <stdint.h>
+
+
+namespace chip {
+namespace app {
+namespace Clusters {
+
+namespace detail {
+// typedefs shared across multiple clusters.
+{{#zcl_typedefs}}
+
+{{#if has_more_than_one_cluster}}
+
+{{> cluster_typedefs_typedef ns=""}}
+
+{{/if}}
+{{/zcl_typedefs}}
+
+} // namespace detail
+
+namespace Globals {
+// Global typedefs.
+{{#zcl_typedefs}}
+
+{{#if has_no_clusters}}
+
+{{> cluster_typedefs_typedef ns=""}}
+
+{{/if}}
+{{/zcl_typedefs}}
+} // namespace Globals
+
+{{#zcl_clusters}}
+namespace {{asUpperCamelCase name}} {
+{{#zcl_typedefs}}
+
+{{#if has_more_than_one_cluster}}
+using {{asUpperCamelCase name}} = Clusters::detail::{{asUpperCamelCase name}};
+{{else}}
+{{> cluster_typedefs_typedef ns=(asUpperCamelCase ../name)}}
+
+{{/if}}
+{{/zcl_typedefs}}
+} // namespace {{asUpperCamelCase name}}
+
+{{/zcl_clusters}}
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/zap-templates/zcl/data-model/chip/global-structs.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/global-structs.xml
@@ -38,5 +38,6 @@ limitations under the License.
     <item fieldId="0" name="Name" type="char_string" length="128" isNullable="false" optional="false"/>
     <item fieldId="1" name="MyBitmap" type="TestGlobalBitmap" isNullable="true" optional="false"/>
     <item fieldId="2" name="MyEnum" type="TestGlobalEnum" isNullable="true" optional="true"/>
+    <item fieldId="3" name="MyTypedef" type="TestGlobalTypedef" isNullable="true" optional="true"/>
   </struct>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/global-typedefs.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/global-typedefs.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+Copyright (c) 2024 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!--
+TODO: Make these structures global rather than defining them for each cluster.
+ This depends on the ability to define global structs via XML tags.
+ see: https://github.com/project-chip/connectedhomeip/issues/29818
+-->
+<configurator>
+  <domain name="CHIP"/>
+  <!--
+    These are test global items (no cluster attached) for testing only.
+    Their usage is defined for UnitTestCluster only.
+  -->
+  <typedef name="TestGlobalTypedef" type="int32u" />
+</configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -59,7 +59,13 @@ limitations under the License.
     <item name="g" type="single" optional="false"/>
     <item name="h" type="double" optional="false"/>
     <item name="i" type="TestGlobalEnum" optional="true"/>
+    <item name="j" type="SimpleTypedef" optional="true"/>
+    <item name="k" type="TestGlobalTypedef" optional="false"/>
   </struct>
+
+  <typedef name="SimpleTypedef" type="int64u">
+    <cluster code="0xFFF1FC05"/>
+  </typedef>
 
   <struct name="NestedStruct">
     <cluster code="0xFFF1FC05"/>
@@ -104,6 +110,10 @@ limitations under the License.
     <item name="OptionalList" type="SimpleEnum" optional="true" array="true"/>
     <item name="NullableOptionalList" type="SimpleEnum" isNullable="true"
           array="true" optional="true"/>
+    <item name="NullableTypedef" type="SimpleTypedef" isNullable="true"/>
+    <item name="OptionalTypedef" type="SimpleTypedef" optional="true"/>
+    <item name="NullableOptionalTypedef" type="SimpleTypedef" isNullable="true"
+        optional="true"/>
   </struct>
 
     <bitmap name="Bitmap8MaskMap" type="bitmap8">
@@ -202,6 +212,8 @@ limitations under the License.
 
     <attribute side="server" code="0x0033" define="GLOBAL_ENUM" type="TestGlobalEnum" writable="true">global_enum</attribute>
     <attribute side="server" code="0x0034" define="GLOBAL_STRUCT" type="TestGlobalStruct" writable="true">global_struct</attribute>
+    <attribute side="server" code="0x0024" define="SIMPLE_TYPEDEF" type="SimpleTypedef" writable="true" optional="false">typedef_attr</attribute>
+    <attribute side="server" code="0x0033" define="GLOBAL_TYPEDEF" type="TestGlobalTypedef" writable="true">global_typedef</attribute>
 
     <!-- These attributes are intended to return internal failures when read.
          They are internal SDK-test code that are intended to only run through EMBER interfaces instead of
@@ -252,6 +264,8 @@ limitations under the License.
 
     <attribute side="server" code="0x4033" define="NULLABLE_GLOBAL_ENUM" type="TestGlobalEnum" isNullable="true" writable="true">nullable_global_enum</attribute>
     <attribute side="server" code="0x4034" define="NULLABLE_GLOBAL_STRUCT" type="TestGlobalStruct" isNullable="true" writable="true">nullable_global_struct</attribute>
+    <attribute side="server" code="0x4035" define="NULLABLE_SIMPLE_TYPEDEF" type="SimpleTypedef" writable="true" isNullable="true" optional="false">nullable_typedef_attr</attribute>
+    <attribute side="server" code="0x4036" define="NULLABLE_GLOBAL_TYPEDEF" type="TestGlobalTypedef" isNullable="true" writable="true">nullable_global_typedef</attribute>
 
     <!-- Attribute MEI sample having a different vendor ID than the cluster. -->
     <attribute side="server" code="0xFFF24F01" define="MEI_INT8U" type="int8u" writable="true" default="0" optional="false">mei_int8u</attribute>
@@ -310,6 +324,7 @@ limitations under the License.
       <arg name="arg4" type="boolean" array="true"/>
       <arg name="arg5" type="SimpleEnum"/>
       <arg name="arg6" type="boolean"/>
+      <arg name="arg7" type="SimpleTypedef" array="true"/>
     </command>
 
     <command source="client" code="0x07" name="TestStructArgumentRequest"
@@ -501,6 +516,7 @@ limitations under the License.
       </description>
       <arg name="field1" type="TestGlobalStruct"/>
       <arg name="field2" type="TestGlobalEnum"/>
+      <arg name="field3" type="TestGlobalTypedef"/>
     </command>
 
     <command source="client" code="0xFFF200AA" name="TestDifferentVendorMeiRequest"
@@ -542,6 +558,7 @@ limitations under the License.
       <arg name="arg4" type="boolean" array="true"/>
       <arg name="arg5" type="SimpleEnum"/>
       <arg name="arg6" type="boolean"/>
+      <arg name="arg7" type="SimpleTypedef" array="true"/>
     </command>
 
     <command source="server" code="0x04" name="TestListInt8UReverseResponse" optional="true" disableDefaultResponse="true">
@@ -605,6 +622,12 @@ limitations under the License.
       <arg name="NullableOptionalListWasNull" type="boolean" optional="true"/>
       <arg name="NullableOptionalListValue" type="SimpleEnum" array="true"
            optional="true"/>
+      <arg name="NullableTypedefWasNull" type="boolean"/>
+      <arg name="NullableTypedefValue" type="SimpleTypedef" optional="true"/>
+      <arg name="OptionalTypedefWasPresent" type="boolean"/>
+      <arg name="OptionalTypedefValue" type="SimpleTypedef" optional="true"/>
+      <arg name="NullableOptionalTypedefWasPresent" type="boolean"/>
+      <arg name="NullableOptionalTypedefWasNull" type="boolean" optional="true"/>
     </command>
 
     <command source="server" code="0x08" name="BooleanResponse" optional="true" disableDefaultResponse="true">
@@ -657,6 +680,7 @@ limitations under the License.
       </description>
       <arg name="field1" type="TestGlobalStruct"/>
       <arg name="field2" type="TestGlobalEnum"/>
+      <arg name="field3" type="TestGlobalTypedef"/>
     </command>
 
     <command source="server" code="0xFFF200BB" name="TestDifferentVendorMeiResponse" optional="true" disableDefaultResponse="true">

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -66,6 +66,7 @@
         "global-bitmaps.xml",
         "global-enums.xml",
         "global-structs.xml",
+        "global-typedefs.xml",
         "groups-cluster.xml",
         "group-key-mgmt-cluster.xml",
         "icd-management-cluster.xml",
@@ -692,7 +693,15 @@
     },
     "mandatoryDeviceTypes": "0x0016",
     "defaultReportingPolicy": "mandatory",
-    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
+    "ZCLDataTypes": [
+        "ARRAY",
+        "BITMAP",
+        "ENUM",
+        "NUMBER",
+        "STRING",
+        "STRUCT",
+        "TYPEDEF"
+    ],
     "fabricHandling": {
         "automaticallyCreateFields": true,
         "indexFieldId": 254,

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -60,6 +60,7 @@
         "global-bitmaps.xml",
         "global-enums.xml",
         "global-structs.xml",
+        "global-typedefs.xml",
         "groups-cluster.xml",
         "group-key-mgmt-cluster.xml",
         "icd-management-cluster.xml",
@@ -686,7 +687,15 @@
     },
     "mandatoryDeviceTypes": "0x0016",
     "defaultReportingPolicy": "mandatory",
-    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
+    "ZCLDataTypes": [
+        "ARRAY",
+        "BITMAP",
+        "ENUM",
+        "NUMBER",
+        "STRING",
+        "STRUCT",
+        "TYPEDEF"
+    ],
     "fabricHandling": {
         "automaticallyCreateFields": true,
         "indexFieldId": 254,

--- a/src/app/zap-templates/zcl/zcl.xsd
+++ b/src/app/zap-templates/zcl/zcl.xsd
@@ -147,6 +147,7 @@ This schema describes the format of the XML files, that describe the ZCL specifi
           <xs:element ref="clusterExtension"/>
           <xs:element ref="enum"/>
           <xs:element ref="struct"/>
+          <xs:element ref="typedef"/>
           <xs:element ref="domain"/>
           <xs:element ref="global"/>
           <xs:element ref="tag"/>
@@ -157,7 +158,7 @@ This schema describes the format of the XML files, that describe the ZCL specifi
     </xs:complexType>
 
     <xs:unique name="structNameKey">
-      <xs:selector xpath="./struct|enum" />
+      <xs:selector xpath="./struct|enum|typedef" />
       <xs:field xpath="@name" />
     </xs:unique>
   </xs:element>
@@ -385,6 +386,16 @@ This schema describes the format of the XML files, that describe the ZCL specifi
       <xs:sequence>
         <xs:element minOccurs="0" maxOccurs="unbounded" name="cluster" type="clusterRef"/>
         <xs:element maxOccurs="unbounded" name="item" type="item"/>
+      </xs:sequence>
+      <xs:attribute name="description"/>
+      <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute name="type" use="required" type="xs:string"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="typedef">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="cluster" type="clusterRef"/>
       </xs:sequence>
       <xs:attribute name="description"/>
       <xs:attribute name="name" use="required" type="xs:string"/>

--- a/src/controller/java/templates/partials/decode_value.zapt
+++ b/src/controller/java/templates/partials/decode_value.zapt
@@ -25,60 +25,58 @@ if ({{source}}.IsNull()) {
     {{>decode_value target=(concat "newElement_" depth) source=(concat "entry_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false forceNotList=true omitDeclaration=false earlyReturn=earlyReturn}}
     chip::JniReferences::GetInstance().AddToList({{target}}, newElement_{{depth}});
   }
-{{else}}
-  {{#if_is_struct type}}
+{{else if_is_typedef type}}
+  {{#zcl_typedef_by_typedef_and_cluster_name type cluster}}
+    {{>decode_value target=../target source=../source cluster=../cluster errorCode=../errorCode depth=../depth isNullable=../isNullable omitDeclaration=../omitDeclaration earlyReturn=../earlyReturn }}
+  {{/zcl_typedef_by_typedef_and_cluster_name}}
+{{else if_is_struct type}}
+  {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
+    {{>decode_value target=(concat ../target "_" (asLowerCamelCase label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster depth=(incrementDepth ../depth) omitDeclaration=false earlyReturn=../earlyReturn}}
+  {{/zcl_struct_items_by_struct_and_cluster_name}}
+
+  {
+    jclass {{asLowerCamelCase type}}StructClass_{{depth}};
+    err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}", {{asLowerCamelCase type}}StructClass_{{depth}});
+    if (err != CHIP_NO_ERROR) {
+      ChipLogError(Zcl, "Could not find class ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}");
+      return {{earlyReturn}};
+    }
+
+    jmethodID {{asLowerCamelCase type}}StructCtor_{{depth}};
+    err = chip::JniReferences::GetInstance().FindMethod(
+        env, {{asLowerCamelCase type}}StructClass_{{depth}}, "<init>",
+        "({{#zcl_struct_items_by_struct_and_cluster_name type cluster}}{{asJniSignature type null (asUpperCamelCase ../cluster) true}}{{/zcl_struct_items_by_struct_and_cluster_name}})V",
+        &{{asLowerCamelCase type}}StructCtor_{{depth}});
+    if (err != CHIP_NO_ERROR || {{asLowerCamelCase type}}StructCtor_{{depth}} == nullptr) {
+      ChipLogError(Zcl, "Could not find ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}} constructor");
+      return {{earlyReturn}};
+    }
+
+  {{target}} = env->NewObject({{asLowerCamelCase type}}StructClass_{{depth}}, {{asLowerCamelCase type}}StructCtor_{{depth}}
     {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
-      {{>decode_value target=(concat ../target "_" (asLowerCamelCase label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster depth=(incrementDepth ../depth) omitDeclaration=false earlyReturn=../earlyReturn}}
-    {{/zcl_struct_items_by_struct_and_cluster_name}}
-
-    {
-      jclass {{asLowerCamelCase type}}StructClass_{{depth}};
-      err = chip::JniReferences::GetInstance().GetLocalClassRef(env, "chip/devicecontroller/ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}", {{asLowerCamelCase type}}StructClass_{{depth}});
-      if (err != CHIP_NO_ERROR) {
-        ChipLogError(Zcl, "Could not find class ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}}");
-        return {{earlyReturn}};
-      }
-
-      jmethodID {{asLowerCamelCase type}}StructCtor_{{depth}};
-      err = chip::JniReferences::GetInstance().FindMethod(
-          env, {{asLowerCamelCase type}}StructClass_{{depth}}, "<init>",
-          "({{#zcl_struct_items_by_struct_and_cluster_name type cluster}}{{asJniSignature type null (asUpperCamelCase ../cluster) true}}{{/zcl_struct_items_by_struct_and_cluster_name}})V",
-          &{{asLowerCamelCase type}}StructCtor_{{depth}});
-      if (err != CHIP_NO_ERROR || {{asLowerCamelCase type}}StructCtor_{{depth}} == nullptr) {
-        ChipLogError(Zcl, "Could not find ChipStructs${{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase type}} constructor");
-        return {{earlyReturn}};
-      }
-
-      {{target}} = env->NewObject({{asLowerCamelCase type}}StructClass_{{depth}}, {{asLowerCamelCase type}}StructCtor_{{depth}}
-        {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
-        , {{../target}}_{{asLowerCamelCase label}}
+    , {{../target}}_{{asLowerCamelCase label}}
         {{/zcl_struct_items_by_struct_and_cluster_name}}
       );
-    }
+}
+{{else if_is_strongly_typed_chip_enum type}}
+  std::string {{target}}ClassName = "{{asJniClassName type null (asUpperCamelCase cluster)}}";
+  std::string {{target}}CtorSignature = "({{asJniSignature type null (asUpperCamelCase cluster) false}})V";
+  {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}});
+  chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
+{{else if (isOctetString type)}}
+  jbyteArray {{target}}ByteArray = env->NewByteArray(static_cast<jsize>({{source}}.size()));
+  env->SetByteArrayRegion({{target}}ByteArray, 0, static_cast<jsize>({{source}}.size()), reinterpret_cast<const jbyte *>({{source}}.data()));
+  {{target}} = {{target}}ByteArray;
+{{else if (isCharString type)}}
+  LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF({{source}}, {{target}}));
+{{else}}
+  std::string {{target}}ClassName = "{{asJniClassName type null (asUpperCamelCase cluster)}}";
+  std::string {{target}}CtorSignature = "({{asJniSignature type null (asUpperCamelCase cluster) false}})V";
+  {{#if_is_strongly_typed_bitmap type}}
+    {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}}.Raw());
+    chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
   {{else}}
-    {{#if_is_strongly_typed_chip_enum type}}
-      std::string {{target}}ClassName = "{{asJniClassName type null (asUpperCamelCase cluster)}}";
-      std::string {{target}}CtorSignature = "({{asJniSignature type null (asUpperCamelCase cluster) false}})V";
-      {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}});
-      chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
-    {{else}}
-      {{#if (isOctetString type)}}
-        jbyteArray {{target}}ByteArray = env->NewByteArray(static_cast<jsize>({{source}}.size()));
-        env->SetByteArrayRegion({{target}}ByteArray, 0, static_cast<jsize>({{source}}.size()), reinterpret_cast<const jbyte *>({{source}}.data()));
-        {{target}} = {{target}}ByteArray;
-      {{else if (isCharString type)}}
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF({{source}}, {{target}}));
-      {{else}}
-        std::string {{target}}ClassName = "{{asJniClassName type null (asUpperCamelCase cluster)}}";
-        std::string {{target}}CtorSignature = "({{asJniSignature type null (asUpperCamelCase cluster) false}})V";
-        {{#if_is_strongly_typed_bitmap type}}
-          {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}}.Raw());
-          chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
-        {{else}}
-          {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}});
-          chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
-        {{/if_is_strongly_typed_bitmap}}
-      {{/if}}
-    {{/if_is_strongly_typed_chip_enum}}
-  {{/if_is_struct}}
+    {{asJniBasicType type false}} jni{{target}} = static_cast<{{asJniBasicType type false}}>({{source}});
+    chip::JniReferences::GetInstance().CreateBoxedObject<{{asJniBasicType type false}}>({{target}}ClassName.c_str(), {{target}}CtorSignature.c_str(), jni{{target}}, {{target}});
+  {{/if_is_strongly_typed_bitmap}}
 {{/if}}

--- a/src/controller/java/templates/templates.json
+++ b/src/controller/java/templates/templates.json
@@ -25,10 +25,6 @@
             "path": "../../../app/zap-templates/partials/cluster_header.zapt"
         },
         {
-            "name": "encode_value",
-            "path": "partials/encode_value.zapt"
-        },
-        {
             "name": "decode_value",
             "path": "partials/decode_value.zapt"
         }

--- a/src/controller/python/templates/partials/typedef_def.zapt
+++ b/src/controller/python/templates/partials/typedef_def.zapt
@@ -1,0 +1,1 @@
+        {{asType label}} = '{{zapTypeToPythonClusterObjectType type ns=../cluster}}'

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -26,9 +26,11 @@ class ChipClusters:
 {{#zcl_command_arguments}}
      {{#if_is_struct type}}
                     "{{asLowerCamelCase label}}": "{{type}}",
-    {{else}}
+     {{else if_is_typedef type}}
+                    "{{asLowerCamelCase label}}": "{{type}}",
+     {{else}}
                     "{{asLowerCamelCase label}}": "{{#if (isCharString type)}}str{{else}}{{as_underlying_python_zcl_type type ../../id}}{{/if}}",
-    {{/if_is_struct}}
+     {{/if_is_struct}}
 {{/zcl_command_arguments}}
                 },
             },

--- a/src/controller/python/templates/python-cluster-Objects-py.zapt
+++ b/src/controller/python/templates/python-cluster-Objects-py.zapt
@@ -2,7 +2,7 @@
 {{> header}}
 '''
 
-# This file contains generated struct, enum, command definition.
+# This file contains generated struct, enum, typedef, and command definition.
 # Users are not expected to import this file, instead, users can use import chip.clusters,
 # which will import all symbols from this file and can get a readable, pretty naming like
 # clusters.OnOff.commands.OnCommand
@@ -55,6 +55,13 @@ class Globals:
 
 {{/if}}
 {{/zcl_structs}}
+    class Typedefs:
+{{#zcl_typedefs}}
+{{#if has_no_clusters}}
+{{> typedef_def cluster="Globals"}}
+
+{{/if}}
+{{/zcl_typedefs}}
 
 {{#zcl_clusters}}
 
@@ -106,6 +113,13 @@ class {{asUpperCamelCase name}}(Cluster):
 {{> struct_def cluster=(asUpperCamelCase parent.name) }}
 
 {{/zcl_structs}}
+{{#zcl_typedefs}}
+{{#first}}
+    class Typedefs:
+{{/first}}
+{{> typedef_def cluster=(asUpperCamelCase parent.name) }}
+
+{{/zcl_typedefs}}
 {{#zcl_commands}}
 {{#first}}
     class Commands:

--- a/src/controller/python/templates/templates.json
+++ b/src/controller/python/templates/templates.json
@@ -32,6 +32,10 @@
         {
             "name": "struct_def",
             "path": "partials/struct_def.zapt"
+        },
+        {
+            "name": "typedef_def",
+            "path": "partials/typedef_def.zapt"
         }
     ],
     "templates": [

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -114,6 +114,13 @@ subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptio
 {{/if}}
 {{/zcl_enums}}
 
+{{#zcl_typedefs}}
+{{#if has_no_clusters}}
+{{> typedef_decl cluster="Globals" name=name typedefLabel=label}}
+
+{{/if}}
+{{/zcl_typedefs}}
+
 {{#zcl_clusters}}
 {{#zcl_enums}}
 {{> enum_decl cluster=../name name=name enumLabel=label}}
@@ -167,6 +174,10 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
 
 
 {{/zcl_bitmaps}}
+{{#zcl_typedefs}}
+{{> typedef_decl cluster=../name name=name typedefLabel=label}}
+
+{{/zcl_typedefs}}
 {{/zcl_clusters}}
 
 {{#zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/decode_value.zapt
@@ -26,32 +26,30 @@
     }
     {{target}} = array_{{depth}};
   }
+{{else if_is_typedef type}}
+  {{#zcl_typedef_by_typedef_and_cluster_name type cluster}}
+    {{>decode_value target=../target cluster=../cluster source=../source errorCode=../errorCode depth=(incrementDepth ../depth) }}
+  {{/zcl_typedef_by_typedef_and_cluster_name}}
+{{else if_is_struct type}}
+  {{target}} = [{{asObjectiveCClass type cluster forceNotList=true}} new];
+  {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
+    {{#if (isSupported (asUpperCamelCase ../cluster preserveAcronyms=true) struct=(asUpperCamelCase ../type preserveAcronyms=true) structField=(asStructPropertyName label))}}
+    {{>decode_value target=(concat ../target "." (asStructPropertyName label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth) }}
+    {{/if}}
+  {{/zcl_struct_items_by_struct_and_cluster_name}}
+{{else if_is_strongly_typed_chip_enum type}}
+  {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:chip::to_underlying({{source}})];
+{{else if_is_strongly_typed_bitmap type}}
+  {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}.Raw()];
+{{else if (isOctetString type)}}
+  {{target}} = AsData({{source}});
+{{else if (isCharString type)}}
+  {{target}} = AsString({{source}});
+  if ({{target}} == nil) {
+    {{! Invalid UTF-8.  Just make up an error for now. }}
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
+    {{errorCode}}
+  }
 {{else}}
-  {{#if_is_struct type}}
-    {{target}} = [{{asObjectiveCClass type cluster forceNotList=true}} new];
-    {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
-      {{#if (isSupported (asUpperCamelCase ../cluster preserveAcronyms=true) struct=(asUpperCamelCase ../type preserveAcronyms=true) structField=(asStructPropertyName label))}}
-      {{>decode_value target=(concat ../target "." (asStructPropertyName label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth) }}
-      {{/if}}
-    {{/zcl_struct_items_by_struct_and_cluster_name}}
-  {{else}}
-    {{#if_is_strongly_typed_chip_enum type}}
-      {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:chip::to_underlying({{source}})];
-    {{else}}
-      {{#if_is_strongly_typed_bitmap type}}
-          {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}.Raw()];
-      {{else if (isOctetString type)}}
-        {{target}} = AsData({{source}});
-      {{else if (isCharString type)}}
-        {{target}} = AsString({{source}});
-        if ({{target}} == nil) {
-          {{! Invalid UTF-8.  Just make up an error for now. }}
-          CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
-          {{errorCode}}
-        }
-      {{else}}
-        {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
-      {{/if_is_strongly_typed_bitmap}}
-    {{/if_is_strongly_typed_chip_enum}}
-  {{/if_is_struct}}
+  {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/encode_value.zapt
@@ -44,22 +44,20 @@
   {{target}} = AsByteSpan({{source}});
 {{else if (isCharString type)}}
   {{target}} = AsCharSpan({{source}});
+{{else if_is_typedef type}}
+  {{#zcl_typedef_by_typedef_and_cluster_name type cluster}}
+    {{>encode_value target=../target source=../source cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth) }}
+  {{/zcl_typedef_by_typedef_and_cluster_name}}
+{{else if_is_struct type}}
+  {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
+   {{#if (isSupported (asUpperCamelCase ../cluster preserveAcronyms=true) struct=(asUpperCamelCase ../type preserveAcronyms=true) structField=(asStructPropertyName label))}}
+   {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asStructPropertyName label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth)}}
+   {{/if}}
+  {{/zcl_struct_items_by_struct_and_cluster_name}}
+{{else if_is_strongly_typed_chip_enum type}}
+  {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
+{{else if_is_strongly_typed_bitmap type}}
+  {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
 {{else}}
-  {{#if_is_struct type}}
-    {{#zcl_struct_items_by_struct_and_cluster_name type cluster}}
-     {{#if (isSupported (asUpperCamelCase ../cluster preserveAcronyms=true) struct=(asUpperCamelCase ../type preserveAcronyms=true) structField=(asStructPropertyName label))}}
-     {{>encode_value target=(concat ../target "." (asLowerCamelCase label)) source=(concat ../source "." (asStructPropertyName label)) cluster=../cluster errorCode=../errorCode depth=(incrementDepth ../depth)}}
-     {{/if}}
-    {{/zcl_struct_items_by_struct_and_cluster_name}}
-  {{else}}
-    {{#if_is_strongly_typed_chip_enum type}}
-      {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
-    {{else}}
-      {{#if_is_strongly_typed_bitmap type}}
-        {{target}} = static_cast<std::remove_reference_t<decltype({{target}})>>({{source}}.{{asObjectiveCNumberType source type true}}Value);
-      {{else}}
-        {{target}} = {{source}}.{{asObjectiveCNumberType source type true}}Value;
-      {{/if_is_strongly_typed_bitmap}}
-    {{/if_is_strongly_typed_chip_enum}}
-  {{/if_is_struct}}
+  {{target}} = {{source}}.{{asObjectiveCNumberType source type true}}Value;
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/typedef_decl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/typedef_decl.zapt
@@ -1,0 +1,2 @@
+{{! Arguments: cluster (might be "Globals", is not case-canonicalized), name, typedefLabel }}
+typedef {{asObjectiveCType type cluster}} {{asUnderlyingZclType name}};

--- a/src/darwin/Framework/CHIP/templates/templates.json
+++ b/src/darwin/Framework/CHIP/templates/templates.json
@@ -57,6 +57,10 @@
             "path": "partials/enum_decl.zapt"
         },
         {
+            "name": "typedef_decl",
+            "path": "partials/typedef_decl.zapt"
+        },
+        {
             "name": "renamed_struct_field_impl",
             "path": "partials/renamed_struct_field_impl.zapt"
         },

--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -190,6 +190,7 @@ static_library("core") {
     ":chip_config_header",
     ":error",
     "${chip_root}/src/app/common:enums",
+    "${chip_root}/src/app/common:typedefs",
     "${chip_root}/src/ble",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/support",


### PR DESCRIPTION
Dependent on zap updates at https://github.com/project-chip/zap/pull/1458

Update zap templaets to process`typedef` in zap, supporting things like defining a `VideoStreamID` as a `uint16`, see the camera spec: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10004

This should also eliminate the need for many of the things in [`chip-types.xml`](https://github.com/project-chip/connectedhomeip/blob/d7f99c7b17ab42148528f82695e72c8e950cbc8d/src/app/zap-templates/zcl/data-model/chip/chip-types.xml#L4), which can now be simply defined in the XML files as a simple `typedef`

See also discussion with @bzbarsky-apple: https://github.com/project-chip/connectedhomeip/pull/35773#discussion_r1775652745

#### Testing
Verified by CI