### PR TITLE
[Fabric-Admin] Cleanup AutoSync command

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/Commands.h
+++ b/examples/fabric-admin/commands/fabric-sync/Commands.h
@@ -31,7 +31,6 @@ void registerCommandsFabricSync(Commands & commands, CredentialIssuerCommands * 
         make_unique<FabricSyncAddLocalBridgeCommand>(credsIssuerConfig),
         make_unique<FabricSyncRemoveLocalBridgeCommand>(credsIssuerConfig),
         make_unique<FabricSyncDeviceCommand>(credsIssuerConfig),
-        make_unique<FabricAutoSyncCommand>(credsIssuerConfig),
     };
 
     commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for fabric synchronization.");

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -305,15 +305,3 @@ CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteId)
 
     return CHIP_NO_ERROR;
 }
-
-CHIP_ERROR FabricAutoSyncCommand::RunCommand(bool enableAutoSync)
-{
-    DeviceMgr().EnableAutoSync(enableAutoSync);
-
-    // print to console
-    fprintf(stderr, "Auto Fabric Sync is %s.\n", enableAutoSync ? "enabled" : "disabled");
-    fprintf(stderr,
-            "WARNING: The auto-sync command is currently under development and may contain bugs. Use it at your own risk.\n");
-
-    return CHIP_NO_ERROR;
-}

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -136,22 +136,3 @@ private:
 
     CHIP_ERROR RunCommand(chip::EndpointId remoteId);
 };
-
-class FabricAutoSyncCommand : public CHIPCommand
-{
-public:
-    FabricAutoSyncCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("enable-auto-sync", credIssuerCommands)
-    {
-        AddArgument("state", 0, 1, &mEnableAutoSync, "Set to true to enable auto Fabric Sync, false to disable.");
-    }
-
-    /////////// CHIPCommand Interface /////////
-    CHIP_ERROR RunCommand() override { return RunCommand(mEnableAutoSync); }
-
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
-
-private:
-    bool mEnableAutoSync;
-
-    CHIP_ERROR RunCommand(bool enableAutoSync);
-};

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -346,14 +346,6 @@ void DeviceManager::HandleAttributePartsListUpdate(TLV::TLVReader & data)
     {
         // print to console
         fprintf(stderr, "A new device is added on Endpoint: %u\n", endpoint);
-
-        if (mAutoSyncEnabled)
-        {
-            StringBuilder<kMaxCommandSize> commandBuilder;
-            commandBuilder.Add("fabricsync sync-device ");
-            commandBuilder.AddFormat("%d", endpoint);
-            PushCommand(commandBuilder.c_str());
-        }
     }
 
     // Process removed endpoints
@@ -367,19 +359,6 @@ void DeviceManager::HandleAttributePartsListUpdate(TLV::TLVReader & data)
         {
             ChipLogProgress(NotSpecified, "No device on Endpoint: %u", endpoint);
             continue;
-        }
-
-        if (mAutoSyncEnabled)
-        {
-            NodeId nodeId = device->GetNodeId();
-            if (PairingManager::Instance().UnpairDevice(nodeId) != CHIP_NO_ERROR)
-            {
-                ChipLogError(NotSpecified, "Failed to unpair device " ChipLogFormatX64, ChipLogValueX64(nodeId));
-            }
-            else
-            {
-                PairingManager::Instance().SetPairingDelegate(this);
-            }
         }
     }
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -68,13 +68,9 @@ public:
     void SetLocalBridgeSetupPinCode(uint32_t pinCode) { mLocalBridgeSetupPinCode = pinCode; }
     void SetLocalBridgeNodeId(chip::NodeId nodeId) { mLocalBridgeNodeId = nodeId; }
 
-    bool IsAutoSyncEnabled() const { return mAutoSyncEnabled; }
-
     bool IsFabricSyncReady() const { return mRemoteBridgeNodeId != chip::kUndefinedNodeId; }
 
     bool IsLocalBridgeReady() const { return mLocalBridgeNodeId != chip::kUndefinedNodeId; }
-
-    void EnableAutoSync(bool state) { mAutoSyncEnabled = state; }
 
     void AddSyncedDevice(const Device & device);
 
@@ -207,9 +203,8 @@ private:
     chip::NodeId mLocalBridgeNodeId = chip::kUndefinedNodeId;
 
     std::set<Device> mSyncedDevices;
-    bool mAutoSyncEnabled = false;
-    bool mInitialized     = false;
-    uint64_t mRequestId   = 0;
+    bool mInitialized   = false;
+    uint64_t mRequestId = 0;
 
     BridgeSubscription mBridgeSubscriber;
 };


### PR DESCRIPTION
The AutoSync command is no longer officially supported and is currently non-functional. We have already removed references to this feature from the Fabric-Sync guide. 

As we are transitioning all text-based commands to API-based function calls, rather than investing further in fixing this command, it should be removed from the codebase.

Fixes https://github.com/project-chip/connectedhomeip/issues/34910

