### PR TITLE
Use GoogleTest back-end for unit tests running on host

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -340,7 +340,7 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest
-	platforms = linux,darwin
+	platforms = linux,android,darwin,tizen
 [submodule "third_party/re2/src"]
 	path = third_party/re2/src
 	url = https://github.com/google/re2.git

--- a/.gn
+++ b/.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/build.gni")
+import("//build_overrides/googletest.gni")
 import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
@@ -32,6 +33,11 @@ default_args = {
 
   # GN target to use for the default Python build venv.
   pw_build_PYTHON_BUILD_VENV = "//:matter_build_venv"
+
+  # Use the GoogleTest backend for unit tests running on host.
+  pw_unit_test_BACKEND = "$dir_pw_unit_test:googletest"
+  pw_unit_test_MAIN = "$dir_pigweed/third_party/googletest:gmock_main"
+  dir_pw_third_party_googletest = "$dir_googletest"
 
   # Required for pw_unit_test
   pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"

--- a/build/toolchain/pw_fuzzer/BUILD.gn
+++ b/build/toolchain/pw_fuzzer/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build_overrides/build.gni")
+import("//build_overrides/googletest.gni")
 import("//build_overrides/pigweed.gni")
 
 import("$dir_pigweed/targets/host/target_toolchains.gni")
@@ -61,7 +62,7 @@ gcc_toolchain("chip_pw_fuzztest") {
 
     dir_pw_third_party_abseil_cpp = "//third_party/abseil-cpp/src"
     dir_pw_third_party_fuzztest = "//third_party/fuzztest"
-    dir_pw_third_party_googletest = "//third_party/googletest"
+    dir_pw_third_party_googletest = "$dir_googletest"
 
     # TODO: Seems that re2 support within FuzzTest was deprecated, keeping it defined is triggering warning
     # Remove if re2 is indeed not needed

--- a/build_overrides/googletest.gni
+++ b/build_overrides/googletest.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Location of the GoogleTest repository.
+  dir_googletest = "//third_party/googletest"
+}

--- a/examples/build_overrides/googletest.gni
+++ b/examples/build_overrides/googletest.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Location of the GoogleTest repository.
+  dir_googletest = "//third_party/connectedhomeip/third_party/googletest"
+}

--- a/src/test_driver/tizen/.gn
+++ b/src/test_driver/tizen/.gn
@@ -14,6 +14,7 @@
 
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
+import("//build_overrides/googletest.gni")
 import("//build_overrides/pigweed.gni")
 
 # The location of the build configuration file.
@@ -29,7 +30,9 @@ default_args = {
   pw_assert_BACKEND = "$dir_pw_assert_log"
   pw_log_BACKEND = "$dir_pw_log_basic"
 
-  pw_unit_test_BACKEND = "$dir_pw_unit_test:light"
+  pw_unit_test_BACKEND = "$dir_pw_unit_test:googletest"
+  pw_unit_test_MAIN = "$dir_pigweed/third_party/googletest:gmock_main"
+  dir_pw_third_party_googletest = "$dir_googletest"
 
   # TODO: Make sure only unit tests link against this
   pw_build_LINK_DEPS = [


### PR DESCRIPTION
### Rationale

Now, in case of debugging failure, it will be possible to run a single test case from a group, e.g.:

```sh
./out/linux-x64-tests/tests/TestRead --gtest_filter=TestRead.TestResubscribeAttributeTimeout
```

### Testing

CI will verify