### PR TITLE
Fix DevicePairingDelegate::OnPairingComplete is not called if pairing code is wrong

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1141,11 +1141,10 @@ void DeviceCommissioner::RendezvousCleanup(CHIP_ERROR status)
         // for IP commissioning, we have taken a reference to the
         // operational node to send the completion command.
         ReleaseCommissioneeDevice(mDeviceInPASEEstablishment);
-
-        if (mPairingDelegate != nullptr)
-        {
-            mPairingDelegate->OnPairingComplete(status);
-        }
+    }
+    if (CHIP_NO_ERROR != status && mPairingDelegate != nullptr)
+    {
+        mPairingDelegate->OnPairingComplete(status);
     }
 }
 


### PR DESCRIPTION
Only the `DevicePairingDelegate::OnStatusUpdate(Status::SecurePairingFailed)` callback will be called in case of pairing device with wrong manual code. The signature of OnStatusUpdate() does not include CHIP_ERROR.

Seems that the correct behavior is to call DevicePairingDelegate::OnPairingComplete(error) as well. 
Error will likely hold `CHIP Error 0x00000032: Timeout`.

This way looking at `OnPairingComplete`, `OnCommissioningSuccess` and `OnCommissioningFailure` is enough to keep track on commissioning process. And all of them provide CHIP_ERROR for diagnostics.