### PR TITLE
Update docker image to pull latest simplicity sdk

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-84 : [Silabs] Update Silabs docker WiseConnect-wifi-bt-sdk 2.10.3
+85 : [Silabs] Update Silabs docker Simplicity SDK v2024.6.2

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -13,8 +13,8 @@ RUN set -x \
     && : # last line
 
 
-# Download Simplicity SDK v2024.6.1 (a1a37fa)
-RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6.1-0/sisdk-sdk.zip -O /tmp/simplicity_sdk.zip \
+# Download Simplicity SDK v2024.6.2 (36e12f0)
+RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6.2/gecko-sdk.zip -O /tmp/simplicity_sdk.zip \
     && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
     && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space


### PR DESCRIPTION
#### Description
Update Silabs docker image to pull latest simplicity sdk

#### Note to reviewers 
It is normal that the artifact is named gecko_sdk this time around
