### PR TITLE
[Fabric-Bridge] Cleanup unused flag

### DIFF
--- a/examples/fabric-bridge-app/fabric-bridge-common/BUILD.gn
+++ b/examples/fabric-bridge-app/fabric-bridge-common/BUILD.gn
@@ -22,7 +22,6 @@ config("config") {
 chip_data_model("fabric-bridge-common-zap") {
   zap_file = "fabric-bridge-app.zap"
   is_server = true
-  cflags = [ "-DDYNAMIC_ENDPOINT_COUNT=16" ]
 }
 
 # This includes all the clusters that only exist on the dynamic endpoint.

--- a/examples/fabric-bridge-app/fabric-bridge-common/include/CHIPProjectAppConfig.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/CHIPProjectAppConfig.h
@@ -30,8 +30,8 @@
 // overrides CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT in CHIPProjectConfig
 #define CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT 16
 
-// include the CHIPProjectConfig from config/standalone
-#include <CHIPProjectConfig.h>
-
 // Allows app options (ports) to be configured on launch of app
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1
+
+// Include the CHIPProjectConfig from platform implementation config
+#include <CHIPProjectConfig.h>


### PR DESCRIPTION
The build flag defined in the gn is not used at all, removed.

