### PR TITLE
Improve Exit Error Handling for failures in PASE pairing requests

### DIFF
--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -232,18 +232,15 @@ CHIP_ERROR PASESession::Pair(SessionManager & sessionManager, uint32_t peerSetUp
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        // If a failure happens in PASESession::Init, we need to ensure that the passed exchange context is closed to prevent
-        // resource leaks.
-        exchangeCtxt->Close();
-
-        // If a failure happens in SendPBKDFParamRequest, we need to Discard the exchange (mExchangeCtxt) so that Clear() doesn't
-        // try closing it.  The exchange will handle that.
-        DiscardExchange();
+        // If a failure happens before we have placed the incoming exchange into `mExchangeCtxt`, we need to make
+        // sure to close the exchange to fulfill our API contract.
+        if (!mExchangeCtxt.HasValue())
+        {
+            exchangeCtxt->Close();
+        }
         Clear();
         ChipLogError(SecureChannel, "Failed during PASE session pairing request: %" CHIP_ERROR_FORMAT, err.Format());
         MATTER_TRACE_COUNTER("PASEFail");
-        // Do this last in case the delegate frees us.
-        NotifySessionEstablishmentError(err);
     }
     return err;
 }

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -99,6 +99,10 @@ public:
      *                            ownership of the exchangeCtxt to PASESession object. PASESession
      *                            will close the exchange on (successful/failed) handshake completion.
      * @param delegate            Callback object
+     *                            Note: The delegate will not be notified if a failure occurs at this stage.
+     *                            The delegate will only be notified of an error during session establishment
+     *                            if it happens after the Pair() call succeeds and the PBKDFParamRequest
+     *                            is sent; i.e., after the session establishment process has started.
      *
      * @return CHIP_ERROR      The result of initialization
      */

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -99,10 +99,8 @@ public:
      *                            ownership of the exchangeCtxt to PASESession object. PASESession
      *                            will close the exchange on (successful/failed) handshake completion.
      * @param delegate            Callback object
-     *                            Note: The delegate will not be notified if a failure occurs at this stage.
-     *                            The delegate will only be notified of an error during session establishment
-     *                            if it happens after the Pair() call succeeds and the PBKDFParamRequest
-     *                            is sent; i.e., after the session establishment process has started.
+     *                            The delegate will be notified if and only if Pair() returns success. Errors occurring after Pair()
+     *                            returns success will be reported via the delegate.
      *
      * @return CHIP_ERROR      The result of initialization
      */


### PR DESCRIPTION
- In the event of failures in Pairing Requests, in the method `PASESession::Pair`, the exit is not as clean as it should be.
- this was discovered while fuzzing; Sanitizer Crashes resulted before the below fix was integrated.

---
If a failure happens in the call to `PASESession::Init` , (triggered by passing a bigger setup passcode when fuzzing), the Exchange Context is not properly destructed becuase the `ReferenceCount` is not equal to 0.
- This happens before the PASESession takes ownership of the passed exchange context.
- Fix: Close the exchange context that is passed as a pointer using `exchangeCtxt->Close();`

Error Log before Fix:
```cpp
[1729359422.539] [2090338:2090338] [IN] SecureSession[0x512000000940]: Released - Type:1 LSID:45924
[1729359422.539] [2090338:2090338] [FP] Shutting down FabricTable
[1729359422.539] [2090338:2090338] [TS] Pending Last Known Good Time: 2023-10-14T01:16:48
[1729359422.539] [2090338:2090338] [TS] Previous Last Known Good Time: 2023-10-14T01:16:48
[1729359422.539] [2090338:2090338] [TS] Reverted Last Known Good Time to previous value
//The following two lines are error codes
[1729359422.539] [2090338:2090338] [EM] ExchangeContext: 7302i delegate=?
[1729359422.539] [2090338:2090338] [SPT] VerifyOrDie failure at src/messaging/ExchangeContext.cpp:337: mExchangeMgr != nullptr && GetReferenceCount() == 0

```
