### PR TITLE
create a cirque virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ docs/html
 
 # Python venv
 .venv
+cirque_venv
 
 # Documentation
 docs/_build

--- a/scripts/tests/cirque_tests.sh
+++ b/scripts/tests/cirque_tests.sh
@@ -118,8 +118,21 @@ function cirquetest_cachekeyhash() {
 function cirquetest_bootstrap() {
     set -ex
 
+    # Enter virtual environment if not already set. Create cirque_venv if one doesn't exist.
+    if [[ -z "$VIRTUAL_ENV" ]]; then
+        if [[ -d "$REPO_DIR"/cirque_venv ]]; then
+            . "$REPO_DIR"/cirque_venv/bin/activate
+        else
+            if ! command -v virtualenv &>/dev/null; then
+                pip install --break-system-packages virtualenv
+            fi
+            virtualenv cirque_venv
+            . "$REPO_DIR"/cirque_venv/bin/activate
+        fi
+    fi
+
     cd "$REPO_DIR"/third_party/cirque/repo
-    pip3 install --break-system-packages pycodestyle==2.5.0 wheel
+    pip3 install pycodestyle==2.5.0 wheel paramiko
 
     make NO_GRPC=1 install -j
 
@@ -128,7 +141,7 @@ function cirquetest_bootstrap() {
     "$REPO_DIR"/integrations/docker/images/stage-2/chip-cirque-device-base/build.sh --build-arg OT_BR_POSIX_CHECKOUT="$OT_BR_POSIX_CHECKOUT"
 
     __cirquetest_build_ot_lazy
-    pip3 install --break-system-packages -r requirements_nogrpc.txt
+    pip3 install -r requirements_nogrpc.txt
 
     echo "OpenThread Version: $OPENTHREAD_CHECKOUT"
     echo "ot-br-posix Version: $OT_BR_POSIX_CHECKOUT"

--- a/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
@@ -91,15 +91,12 @@ class TestCommissioningFailure(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 -a {} --paa-trust-store-path {} --fail-on-report").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_failure_test.py"),
             ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/CommissioningFailureTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureTest.py
@@ -91,14 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
+        command = "gdb -return-child-result -q -ex run -ex bt --args {}/python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_failure_test.py"),
             ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -132,15 +132,12 @@ class TestCommissioner(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 -a {} --paa-trust-store-path {} --discriminator {} --nodeid {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
             servers[0]['ip'],
@@ -152,8 +149,10 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
@@ -166,8 +165,10 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
@@ -180,8 +181,10 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 --paa-trust-store-path {} --discriminator {} --setup-payload {} --nodeid {} --discovery-type {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_test.py"),
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),

--- a/src/test_driver/linux-cirque/CommissioningWindowTest.py
+++ b/src/test_driver/linux-cirque/CommissioningWindowTest.py
@@ -95,15 +95,12 @@ class TestCommissioningWindow(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
         command = ("gdb -return-child-result -q -ex run -ex bt "
-                   "--args python3 {} -t 150 --address {} --paa-trust-store-path {}").format(
+                   "--args {}/python3 {} -t 150 --address {} --paa-trust-store-path {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/commissioning_window_test.py"),
             servers[0]['ip'],

--- a/src/test_driver/linux-cirque/FailsafeTest.py
+++ b/src/test_driver/linux-cirque/FailsafeTest.py
@@ -91,14 +91,11 @@ class TestFailsafe(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
+        command = "gdb -return-child-result -q -ex run -ex bt --args {}/python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/failsafe_tests.py"),
             ethernet_ip,

--- a/src/test_driver/linux-cirque/IcdWaitForActiveTest.py
+++ b/src/test_driver/linux-cirque/IcdWaitForActiveTest.py
@@ -95,15 +95,12 @@ class TestCommissioner(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+                   "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/icd_wait_for_device_test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -91,15 +91,12 @@ class TestPythonController(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+                   "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/mobile-device-test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/PythonCommissioningTest.py
+++ b/src/test_driver/linux-cirque/PythonCommissioningTest.py
@@ -104,14 +104,11 @@ class TestCommissioner(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -d {} --paa-trust-store-path {} --nodeid {}".format(
+        command = "gdb -return-child-result -q -ex run -ex bt --args {}/python3 {} -t 150 -d {} --paa-trust-store-path {} --nodeid {}".format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/python_commissioning_flow_test.py"),
             TEST_DISCRIMINATOR,
@@ -122,7 +119,9 @@ class TestCommissioner(CHIPVirtualHome):
         self.assertEqual(ret['return_code'], '0',
                          "Test failed: non-zero return code")
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -d {} --paa-trust-store-path {} --nodeid {} --bad-cert-issuer".format(
+        command = "gdb -return-child-result -q -ex run -ex bt --args {}/python3 {} -t 150 -d {} --paa-trust-store-path {} --nodeid {} --bad-cert-issuer".format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/python_commissioning_flow_test.py"),
             TEST_DISCRIMINATOR2,

--- a/src/test_driver/linux-cirque/SplitCommissioningTest.py
+++ b/src/test_driver/linux-cirque/SplitCommissioningTest.py
@@ -98,15 +98,12 @@ class TestSplitCommissioning(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
-        command = ("gdb -return-child-result -q -ex run -ex bt --args python3 "
+        command = ("gdb -return-child-result -q -ex run -ex bt --args {}/python3 "
                    "{} -t 150 --address1 {} --address2 {} --paa-trust-store-path {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/split_commissioning_test.py"),
             ethernet_ips[0], ethernet_ips[1], os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionCapacityTest.py
@@ -125,15 +125,12 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
         self.reset_thread_devices(server_ids)
 
         for req_device_id in req_ids:
-            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-            self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-                CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+            self.install_package(req_device_id, CHIP_REPO)
 
         command1 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                    "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --subscription-capacity {}").format(
+                    "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {} --subscription-capacity {}").format(
+                        os.path.join(
+                            CHIP_REPO, "cirque_venv/bin"),
                         os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
                                      "subscription_resumption_capacity_test_ctrl1.py"),
                         ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
@@ -144,8 +141,10 @@ class TestSubscriptionResumptionCapacity(CHIPVirtualHome):
                          "Test failed: non-zero return code")
 
         command2 = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                    "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {} "
+                    "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {} "
                     "--subscription-capacity {}").format(
+                        os.path.join(
+                            CHIP_REPO, "cirque_venv/bin"),
                         os.path.join(CHIP_REPO, "src/controller/python/test/test_scripts",
                                      "subscription_resumption_capacity_test_ctrl2.py"),
                         ethernet_ip, os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTest.py
@@ -102,15 +102,12 @@ class TestSubscriptionResumption(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {}").format(
+                   "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {} --remote-server-app {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/subscription_resumption_test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS), TEST_END_DEVICE_APP)

--- a/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
+++ b/src/test_driver/linux-cirque/SubscriptionResumptionTimeoutTest.py
@@ -103,15 +103,12 @@ class TestSubscriptionResumptionTimeout(CHIPVirtualHome):
 
         req_device_id = req_ids[0]
 
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
-        self.execute_device_cmd(req_device_id, "pip3 install --break-system-packages {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+        self.install_package(req_device_id, CHIP_REPO)
 
         command = ("gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" "
-                   "--args python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+                   "--args {}/python3 {} -t 300 -a {} --paa-trust-store-path {}").format(
+            os.path.join(
+                CHIP_REPO, "cirque_venv/bin"),
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -369,6 +369,23 @@ class CHIPVirtualHome:
         self.ap_devices = [device for device in self.device_config.values()
                            if device['type'] == 'wifi_ap']
 
+    def install_package(self, device_id, chip_repo):
+        self.execute_device_cmd(device_id, "{}/pip3 install {}".format(
+            os.path.join(
+                chip_repo, "cirque_venv/bin"),
+            os.path.join(
+                chip_repo, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
+        self.execute_device_cmd(device_id, "{}/pip3 install {}".format(
+            os.path.join(
+                chip_repo, "cirque_venv/bin"),
+            os.path.join(
+                chip_repo, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(device_id, "{}/pip3 install {}".format(
+            os.path.join(
+                chip_repo, "cirque_venv/bin"),
+            os.path.join(
+                chip_repo, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
+
     def save_device_logs(self):
         timestamp = int(time.time())
         log_dir = os.environ.get("DEVICE_LOG_DIR", None)


### PR DESCRIPTION
Fixes #33950 [Cirque] use virtualenv
create a cirque virtualenv for every pip package installation without the break-system-packages option.
