### PR TITLE
[Silabs] Fixing hardfault issue with RS9116 ble manager

### DIFF
--- a/src/platform/silabs/rs911x/wfx_sl_ble_init.cpp
+++ b/src/platform/silabs/rs911x/wfx_sl_ble_init.cpp
@@ -294,6 +294,7 @@ void SilabsBleWrapper::rsi_ble_add_char_val_att(void * serv_handler, uint16_t ha
 
 uint32_t SilabsBleWrapper::rsi_ble_add_matter_service(void)
 {
+    bleEvent.eventData                                      = new SilabsBleWrapper::sl_wfx_msg_t();
     uuid_t custom_service                                   = { RSI_BLE_MATTER_CUSTOM_SERVICE_UUID };
     custom_service.size                                     = RSI_BLE_MATTER_CUSTOM_SERVICE_SIZE;
     custom_service.val.val16                                = RSI_BLE_MATTER_CUSTOM_SERVICE_VALUE_16;


### PR DESCRIPTION
**Problem:**
The Ble manager for Rs911x devices code refactored by below PR and in this no where the memory is not allocated for _bleEvent.eventData_ member.
https://github.com/project-chip/connectedhomeip/pull/35522
Due to which hardfault is coming when this struct member is getting defined.

**Fix**
Fixed the issue by allocating

**Testing**
Tested commissioning with 917 SoC, RS9116+EFR mg24.

