### PR TITLE
[Tizen] Pass runner's path as QEMU argument

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-85 : [Silabs] Update Silabs docker Simplicity SDK v2024.6.2
+86 : [Tizen] Pass runner's path as QEMU argument

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -182,9 +182,13 @@ RUN set -x \
     && echo -n \
     "#!/bin/bash\n" \
     "grep -q 'rootshell' /proc/cmdline && exit\n" \
-    "if [[ -x /mnt/chip/runner.sh ]]; then\n" \
+    "runner=\$(grep -o 'runner=[^ ]*' /proc/cmdline | sed 's/runner=//')\n" \
+    "if [[ -z \"\$runner\" ]]; then\n" \
+    "  runner='/mnt/chip/runner.sh' \n" \
+    "fi\n" \
+    "if [[ -x \"\$runner\" ]]; then\n" \
     "  echo '### RUNNER START ###'\n" \
-    "  /mnt/chip/runner.sh\n" \
+    "  \"\$runner\"\n" \
     "  echo '### RUNNER STOP:' \$?\n" \
     "else\n" \
     "  read -r -t 5 -p 'Press ENTER to access root shell...' && exit || echo ' timeout.'\n" \


### PR DESCRIPTION
### Issue

When doing code coverage for Tizen QEMU tests `runner.sh`'s path is required to be passed as an argument.

### Solution

`tizen_qemu.py` can easily pass `runner=/path/to/runner.sh` the same way as it does pass `rootshell` into `/proc/cmdline`. So a Dockerfile part for this feature is offered in this PR.

### Extra notes

This PR is a prerequisite to the next one adding nearly full code coverage to tests to the before mentioned platform.