### PR TITLE
[ICD] Add subscriber request max interval getter (#36021)

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -741,7 +741,9 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     ReturnErrorOnFailure(err);
 
     ReturnErrorOnFailure(subscribeRequestParser.GetMinIntervalFloorSeconds(&mMinIntervalFloorSeconds));
-    ReturnErrorOnFailure(subscribeRequestParser.GetMaxIntervalCeilingSeconds(&mMaxInterval));
+    ReturnErrorOnFailure(subscribeRequestParser.GetMaxIntervalCeilingSeconds(&mSubscriberRequestedMaxInterval));
+    mMaxInterval = mSubscriberRequestedMaxInterval;
+
     VerifyOrReturnError(mMinIntervalFloorSeconds <= mMaxInterval, CHIP_ERROR_INVALID_ARGUMENT);
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER


### PR DESCRIPTION
Description

This PR is a cherry-pick of #36021.

When https://github.com/project-chip/connectedhomeip/pull/28375 was merged to add a default subscription behavior to the subscription establishment, the MaxInterval of the readhandler is changed to the default ICD behavior with the expectation that this behavior can be changed with the OnSubscriptionEstablished callback.

The issue is that since we overrule the request MaxInterval, the application API doesn't have a way of knowing the requested max interval from the subscriber to do its decision making. This also impacted the SetMaxInterval function where we were changing the allow maximum which could decrease the spec allowed max interval selection.

PR adds a member that stores the subscriber max interval that can be accessed by the application without impacting the SetMaxInterval function

Fixes https://github.com/project-chip/connectedhomeip/issues/35991

Tests
Added a unit test to validate the SetMaxInterval readhandler function