### PR TITLE
Remove the linux auto-label.

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -12,8 +12,18 @@ darwin:
   # (?![a-z]) means "there is no next char in the range a-z".
   - "/(\\b[Ii][Oo][Ss](?![a-zA-Z])|[Hh][Oo][Mm][Ee][Pp][Oo][Dd]|[Dd][Aa][Rr][Ww][Ii][Nn]|\\bm[Aa][Cc]\\b|\\bMa[Cc]\\b|\\bM[Aa]c\\b|[Mm][Aa][Cc][Oo][Ss])/"
 
-linux:
-  - "/(linux)/i"
+
+# NOTE:
+# Linux intentionally disabled: most people compile either on linux or darwin and
+# as a result a lot of issues get tagged as such even though they are not platform specific
+# (e.g. we get test case failures reported as linux even though they are just normal
+# test runs)
+#
+# Linux label should be reserved to platform-specific problems (usually bootstrap/packages
+# or integration with wifi/ethernet/bluetootn/etc.)
+#
+# linux:
+#   - "/(linux)/i"
 
 # Special Keywords for Cert Blockers
 air purifiers:


### PR DESCRIPTION
It tends to mark a lot of issues as 'linux' even though they are not.

Examples:
  - #35581 was cirque CI (borderline though)
  - #35663 is a chiptool feature request
  - #35623 is a test case bug (or example bug) and has nothing to do with linux
  - #34441 clearly states `windows` yet it was put in the linux queue