### PR TITLE
OpenDeviceCommissioningWindow verifies fabric index is what we expect

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -124,11 +124,12 @@ void DeviceManager::OpenDeviceCommissioningWindow(ScopedNodeId scopedNodeId, uin
     // the controller for. Currently no implementation need this functionality, but should they need it they will hit
     // the verify or die below and it will be the responsiblity of whoever requires that functionality to implement.
     VerifyOrDie(PairingManager::Instance().CurrentCommissioner().GetFabricIndex() == scopedNodeId.GetFabricIndex());
-    ChipLogProgress(NotSpecified, "Opening commissioning window for Node ID: " ChipLogFormatX64, ChipLogValueX64(scopedNodeId.GetNodeId()));
+    ChipLogProgress(NotSpecified, "Opening commissioning window for Node ID: " ChipLogFormatX64,
+                    ChipLogValueX64(scopedNodeId.GetNodeId()));
 
     // Open the commissioning window of a device within its own fabric.
-    CHIP_ERROR err = PairingManager::Instance().OpenCommissioningWindow(scopedNodeId.GetNodeId(), kRootEndpointId, commissioningTimeoutSec,
-                                                                        iterations, discriminator, salt, verifier);
+    CHIP_ERROR err = PairingManager::Instance().OpenCommissioningWindow(
+        scopedNodeId.GetNodeId(), kRootEndpointId, commissioningTimeoutSec, iterations, discriminator, salt, verifier);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to open commissioning window: %s", ErrorStr(err));

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -117,13 +117,17 @@ void DeviceManager::RemoveSyncedDevice(NodeId nodeId)
                     ChipLogValueX64(device->GetNodeId()), device->GetEndpointId());
 }
 
-void DeviceManager::OpenDeviceCommissioningWindow(NodeId nodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
+void DeviceManager::OpenDeviceCommissioningWindow(ScopedNodeId scopedNodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
                                                   uint16_t discriminator, const ByteSpan & salt, const ByteSpan & verifier)
 {
-    ChipLogProgress(NotSpecified, "Opening commissioning window for Node ID: " ChipLogFormatX64, ChipLogValueX64(nodeId));
+    // PairingManager isn't currently capable of OpenCommissioningWindow on a device of a fabric that it doesn't have
+    // the controller for. Currently no implementation need this functionality, but should they need it they will hit
+    // the verify or die below and it will be the responsiblity of whoever requires that functionality to implement.
+    VerifyOrDie(PairingManager::Instance().CurrentCommissioner().GetFabricIndex() == scopedNodeId.GetFabricIndex());
+    ChipLogProgress(NotSpecified, "Opening commissioning window for Node ID: " ChipLogFormatX64, ChipLogValueX64(scopedNodeId.GetNodeId()));
 
     // Open the commissioning window of a device within its own fabric.
-    CHIP_ERROR err = PairingManager::Instance().OpenCommissioningWindow(nodeId, kRootEndpointId, commissioningTimeoutSec,
+    CHIP_ERROR err = PairingManager::Instance().OpenCommissioningWindow(scopedNodeId.GetNodeId(), kRootEndpointId, commissioningTimeoutSec,
                                                                         iterations, discriminator, salt, verifier);
     if (err != CHIP_NO_ERROR)
     {
@@ -412,7 +416,8 @@ void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader & data)
     ChipLogProgress(NotSpecified, "  PAKEPasscodeVerifier size: %lu", value.PAKEPasscodeVerifier.size());
     ChipLogProgress(NotSpecified, "  salt size: %lu", value.salt.size());
 
-    OpenDeviceCommissioningWindow(mLocalBridgeNodeId, value.iterations, value.commissioningTimeout, value.discriminator,
+    ScopedNodeId scopedNodeId(mLocalBridgeNodeId, PairingManager::Instance().CurrentCommissioner().GetFabricIndex());
+    OpenDeviceCommissioningWindow(scopedNodeId, value.iterations, value.commissioningTimeout, value.discriminator,
                                   ByteSpan(value.salt.data(), value.salt.size()),
                                   ByteSpan(value.PAKEPasscodeVerifier.data(), value.PAKEPasscodeVerifier.size()));
 }

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -91,7 +91,7 @@ public:
      *
      * This function initiates the process to open the commissioning window for a device identified by the given node ID.
      *
-     * @param nodeId               The ID of the node that should open the commissioning window.
+     * @param scopedNodeId         The scoped node ID of the device that should open the commissioning window.
      * @param iterations           The number of PBKDF (Password-Based Key Derivation Function) iterations to use
      *                             for deriving the PAKE (Password Authenticated Key Exchange) verifier.
      * @param commissioningTimeoutSec The time in seconds before the commissioning window closes. This value determines
@@ -102,7 +102,7 @@ public:
      * @param verifier             The PAKE verifier used to authenticate the commissioning process.
      *
      */
-    void OpenDeviceCommissioningWindow(chip::NodeId nodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
+    void OpenDeviceCommissioningWindow(chip::ScopedNodeId scopedNodeId, uint32_t iterations, uint16_t commissioningTimeoutSec,
                                        uint16_t discriminator, const chip::ByteSpan & salt, const chip::ByteSpan & verifier);
 
     /**

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -105,8 +105,9 @@ public:
 
         // Log the request details for debugging
         ChipLogProgress(NotSpecified,
-                        "Received OpenCommissioningWindow request: NodeId " ChipLogFormatX64 ", Timeout: %u, Iterations: %u, Discriminator: %u",
-                            ChipLogValueX64(scopedNodeId.GetNodeId()), commissioningTimeoutSec, iterations, discriminator);
+                        "Received OpenCommissioningWindow request: NodeId " ChipLogFormatX64
+                        ", Timeout: %u, Iterations: %u, Discriminator: %u",
+                        ChipLogValueX64(scopedNodeId.GetNodeId()), commissioningTimeoutSec, iterations, discriminator);
 
         // Open the device commissioning window using raw binary data for salt and verifier
         DeviceMgr().OpenDeviceCommissioningWindow(scopedNodeId, iterations, commissioningTimeoutSec, discriminator,

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -98,20 +98,18 @@ public:
                                        chip_rpc_OperationStatus & response) override
     {
         VerifyOrReturnValue(request.has_id, pw::Status::InvalidArgument());
-        // TODO(#35875): OpenDeviceCommissioningWindow uses the same controller every time and doesn't currently accept
-        // FabricIndex. For now we are dropping fabric index from the scoped node id.
-        NodeId nodeId                    = request.id.node_id;
+        ScopedNodeId scopedNodeId(request.id.node_id, request.id.fabric_index);
         uint32_t iterations              = request.iterations;
         uint16_t discriminator           = request.discriminator;
         uint16_t commissioningTimeoutSec = static_cast<uint16_t>(request.commissioning_timeout);
 
         // Log the request details for debugging
         ChipLogProgress(NotSpecified,
-                        "Received OpenCommissioningWindow request: NodeId 0x%lx, Timeout: %u, Iterations: %u, Discriminator: %u",
-                        static_cast<unsigned long>(nodeId), commissioningTimeoutSec, iterations, discriminator);
+                        "Received OpenCommissioningWindow request: NodeId " ChipLogFormatX64 ", Timeout: %u, Iterations: %u, Discriminator: %u",
+                            ChipLogValueX64(scopedNodeId.GetNodeId()), commissioningTimeoutSec, iterations, discriminator);
 
         // Open the device commissioning window using raw binary data for salt and verifier
-        DeviceMgr().OpenDeviceCommissioningWindow(nodeId, iterations, commissioningTimeoutSec, discriminator,
+        DeviceMgr().OpenDeviceCommissioningWindow(scopedNodeId, iterations, commissioningTimeoutSec, discriminator,
                                                   ByteSpan(request.salt.bytes, request.salt.size),
                                                   ByteSpan(request.verifier.bytes, request.verifier.size));
 


### PR DESCRIPTION
With today's implementation of fabric-admin we are not capable of selecting which controller is used by the PairingManager when  calling `OpenCommissioningWindow`. For that reason we only validate the assumption that the controller fabric index matches the ScopedNodeId we are intending to open up a commissioning window on. Should the functionality be needed to select some other controller that is left to implementer needing that functionality to identify and implement a solution

Fixes: https://github.com/project-chip/connectedhomeip/issues/35875
