### PR TITLE
[Fabric-Bridge] Update Readme.txt to exclude incorrect path info

### DIFF
--- a/examples/fabric-bridge-app/linux/README.md
+++ b/examples/fabric-bridge-app/linux/README.md
@@ -130,13 +130,6 @@ defined:
     scp ./fabric-bridge-app ubuntu@xxx.xxx.xxx.xxx:/home/ubuntu
     ```
 
--   To delete generated executable, libraries and object files use:
-
-    ```sh
-    cd ~/connectedhomeip/examples/fabric-bridge-app/linux
-    rm -rf out/
-    ```
-
 ## Running the Complete Example on Ubuntu
 
 -   Building


### PR DESCRIPTION
The output directory in readme is no more valid if we build with 

`./scripts/build/build_examples.py --target linux-x64-fabric-bridge-rpc-no-ble build`

