### PR TITLE
[IM] Handle internal fatal error in BufferReadCallback

### DIFF
--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -44,7 +44,7 @@ public:
 
 private:
     /*
-     * Generates the reconsistuted TLV array from the stored individual list elements
+     * Generates the reconstituted TLV array from the stored individual list elements
      */
     CHIP_ERROR GenerateListTLV(TLV::ScopedBufferTLVReader & reader);
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -231,7 +231,7 @@ void ReadClient::Close(CHIP_ERROR aError, bool allowResubscription)
     }
 
     mExchange.Release();
-
+    mpCallback.ClearFatalReportError();
     mpCallback.OnDone(this);
 }
 
@@ -805,6 +805,7 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
             ReturnErrorOnFailure(errorStatus.DecodeStatusIB(statusIB));
             NoteReportingData();
             mpCallback.OnAttributeData(attributePath, nullptr, statusIB);
+            ReturnErrorOnFailure(mpCallback.GetLastFatalReportError());
         }
         else if (CHIP_END_OF_TLV == err)
         {
@@ -861,6 +862,7 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
 
             NoteReportingData();
             mpCallback.OnAttributeData(attributePath, &dataReader, statusIB);
+            ReturnErrorOnFailure(mpCallback.GetLastFatalReportError());
         }
     }
 
@@ -868,7 +870,6 @@ CHIP_ERROR ReadClient::ProcessAttributeReportIBs(TLV::TLVReader & aAttributeRepo
     {
         err = CHIP_NO_ERROR;
     }
-
     return err;
 }
 
@@ -905,6 +906,7 @@ CHIP_ERROR ReadClient::ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsRea
 
             NoteReportingData();
             mpCallback.OnEventData(header, &dataReader, nullptr);
+            ReturnErrorOnFailure(mpCallback.GetLastFatalReportError());
         }
         else if (err == CHIP_END_OF_TLV)
         {
@@ -919,6 +921,7 @@ CHIP_ERROR ReadClient::ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsRea
 
             NoteReportingData();
             mpCallback.OnEventData(header, nullptr, &statusIB);
+            ReturnErrorOnFailure(mpCallback.GetLastFatalReportError());
         }
     }
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -202,6 +202,8 @@ public:
          * This object MUST continue to exist after this call is completed. The application shall wait until it
          * receives an OnDone call to destroy the object.
          *
+         * This callback is expected to be called inside the ReadClient.
+         *
          * @param[in] aError       A system error code that conveys the overall error code.
          */
         virtual void OnError(CHIP_ERROR aError) {}
@@ -284,6 +286,25 @@ public:
          * things like min/max intervals based on the session parameters).
          */
         virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
+
+        /*
+         * Get the last internal fatal error in callback
+         */
+        CHIP_ERROR GetLastFatalReportError() const { return mLastFatalReportError; }
+
+    protected:
+        /*
+         * Set the fatal report fatal error in report which would lead to ReadClient::Close()
+         */
+        void SetFatalReportError(CHIP_ERROR aError) { mLastFatalReportError = aError; }
+
+        /*
+         * Clear the fatal report fatal error
+         */
+        void ClearFatalReportError() { mLastFatalReportError = CHIP_NO_ERROR; }
+
+    private:
+        CHIP_ERROR mLastFatalReportError = CHIP_NO_ERROR;
     };
 
     enum class InteractionType : uint8_t


### PR DESCRIPTION
Revive https://github.com/project-chip/connectedhomeip/pull/30965

Issue: If onError has been called from BufferedReadCallback when processing multiple attrbitues, potentially onError or onAttribute or onEvent could be called again from ReadClient, as a result, the behavior in application could be unexpected, crash is possible. note: the errors in BufferredReadCallback are treated as fatal ones.

Solution: In order to resolve the above issue, we add mDataBufferingError to store internal error in BufferredReadCallback, we call a new introduced GetLastError callback in readClient after each onAttribute and onEvent, if any fatal error happens, we propagate the error to Close in ReadClient, for any new callback class that inherits ReadClient::Callback, if there is a fatal error, ReadClient can get aware of this error from GetLastError.
