### PR TITLE
Update pigweed to latest master

### DIFF
--- a/examples/all-clusters-app/nxp/common/main/main.cpp
+++ b/examples/all-clusters-app/nxp/common/main/main.cpp
@@ -32,7 +32,7 @@ uint8_t __attribute__((section(".heap"))) ucHeap[configTOTAL_HEAP_SIZE];
 
 using namespace ::chip::DeviceLayer;
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     TaskHandle_t taskHandle;
 

--- a/examples/contact-sensor-app/nxp/common/main.cpp
+++ b/examples/contact-sensor-app/nxp/common/main.cpp
@@ -30,7 +30,7 @@ extern "C" void main_task(void const * argument)
     chip::NXP::App::GetAppTask().Start();
 }
 #else
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     chip::DeviceLayer::PlatformMgrImpl().HardwareInit();
     chip::NXP::App::GetAppTask().Start();

--- a/examples/laundry-washer-app/nxp/common/main/main.cpp
+++ b/examples/laundry-washer-app/nxp/common/main/main.cpp
@@ -32,7 +32,7 @@ uint8_t __attribute__((section(".heap"))) ucHeap[configTOTAL_HEAP_SIZE];
 
 using namespace ::chip::DeviceLayer;
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     TaskHandle_t taskHandle;
 

--- a/examples/light-switch-app/genio/src/main.cpp
+++ b/examples/light-switch-app/genio/src/main.cpp
@@ -251,7 +251,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/lighting-app-data-mode-no-unique-id/linux/main.cpp
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/main.cpp
@@ -95,7 +95,7 @@ void ApplicationShutdown()
     }
 }
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     if (ChipLinuxAppInit(argc, argv) != 0)
     {

--- a/examples/lighting-app/genio/src/main.cpp
+++ b/examples/lighting-app/genio/src/main.cpp
@@ -251,7 +251,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -95,7 +95,7 @@ void ApplicationShutdown()
     }
 }
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     if (ChipLinuxAppInit(argc, argv) != 0)
     {

--- a/examples/lighting-app/linux/main.cpp
+++ b/examples/lighting-app/linux/main.cpp
@@ -95,6 +95,13 @@ void ApplicationShutdown()
     }
 }
 
+#ifdef __NuttX__
+// NuttX requires the main function to be defined with C-linkage. However, marking
+// the main as extern "C" is not strictly conformant with the C++ standard. Since
+// clang >= 20 such code triggers -Wmain warning.
+extern "C" {
+#endif
+
 int main(int argc, char * argv[])
 {
     if (ChipLinuxAppInit(argc, argv) != 0)
@@ -124,3 +131,7 @@ int main(int argc, char * argv[])
 
     return 0;
 }
+
+#ifdef __NuttX__
+}
+#endif

--- a/examples/lighting-app/nxp/common/main.cpp
+++ b/examples/lighting-app/nxp/common/main.cpp
@@ -30,7 +30,7 @@ extern "C" void main_task(void const * argument)
     chip::NXP::App::GetAppTask().Start();
 }
 #else
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     chip::DeviceLayer::PlatformMgrImpl().HardwareInit();
     chip::NXP::App::GetAppTask().Start();

--- a/examples/lock-app/genio/src/main.cpp
+++ b/examples/lock-app/genio/src/main.cpp
@@ -251,7 +251,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/lock-app/nxp/common/main/main.cpp
+++ b/examples/lock-app/nxp/common/main/main.cpp
@@ -39,7 +39,7 @@ extern "C" void main_task(void const * argument)
     chip::NXP::App::GetAppTask().Start();
 }
 #else
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     chip::DeviceLayer::PlatformMgrImpl().HardwareInit();
     chip::NXP::App::GetAppTask().Start();

--- a/examples/ota-requestor-app/genio/src/main.cpp
+++ b/examples/ota-requestor-app/genio/src/main.cpp
@@ -281,7 +281,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/platform/openiotsdk/app/openiotsdk_startup_gcc.cpp
+++ b/examples/platform/openiotsdk/app/openiotsdk_startup_gcc.cpp
@@ -57,7 +57,7 @@ alignas(8) static uint8_t malloc_mutex_obj[80];
 
 // C runtime import: constructor initialization and main
 extern "C" void __libc_init_array(void);
-extern "C" int main(void);
+int main(void);
 
 // IOT SDK serial declarations
 #define STDIN_FILENO 0

--- a/examples/shell/genio/src/main.cpp
+++ b/examples/shell/genio/src/main.cpp
@@ -161,7 +161,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/thermostat/genio/src/main.cpp
+++ b/examples/thermostat/genio/src/main.cpp
@@ -251,7 +251,7 @@ void vStartTask(void * pvParameters)
  * Main Function
  ****************************************************************************/
 
-extern "C" int main(void)
+int main(void)
 {
     mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
 

--- a/examples/thermostat/nxp/common/main/main.cpp
+++ b/examples/thermostat/nxp/common/main/main.cpp
@@ -32,7 +32,7 @@ uint8_t __attribute__((section(".heap"))) ucHeap[configTOTAL_HEAP_SIZE];
 
 using namespace ::chip::DeviceLayer;
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     TaskHandle_t taskHandle;
 

--- a/scripts/BUILD.gn
+++ b/scripts/BUILD.gn
@@ -20,8 +20,8 @@ import("$dir_pw_build/python_dist.gni")
 
 # This target creates a single Python package and wheel for yamltests. It will
 # merge all Python dependencies Matter. The output is located in:
-#   out/obj/matter_yamltests_distribution/  <- source files here
-#   out/obj/matter_yamltests_distribution._build_wheel/matter_yamltests-0.0.1-py3-none-any.whl
+#   out/obj/scripts/matter_yamltests_distribution/  <- source files here
+#   out/obj/scripts/matter_yamltests_distribution._build_wheel/matter_yamltests-0.0.1-py3-none-any.whl
 pw_python_distribution("matter_yamltests_distribution") {
   packages = [ "${chip_root}/scripts/py_matter_yamltests:matter_yamltests" ]
   generate_setup_cfg = {

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -175,22 +175,6 @@ tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode
 
 gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_crypto=\"boringssl\""
 
-function ninja_target() {
-    # Print the ninja target required to build a gn label.
-    local GN_LABEL="$1"
-    local NINJA_TARGET="$(gn ls "$OUTPUT_ROOT" --as=output "$GN_LABEL")"
-    echo "$NINJA_TARGET"
-}
-
-function wheel_output_dir() {
-    # Print the wheel output directory for a pw_python_package or
-    # pw_python_distribution. The label must end in "._build_wheel".
-    local GN_LABEL="$1"
-    local NINJA_TARGET="$(ninja_target "$GN_LABEL")"
-    local WHEEL_DIR="$OUTPUT_ROOT"/"$(dirname "$NINJA_TARGET")/$(basename -s .stamp "$NINJA_TARGET")"
-    echo "$WHEEL_DIR"
-}
-
 # Compile Python wheels
 ninja -C "$OUTPUT_ROOT" python_wheels
 
@@ -199,6 +183,11 @@ WHEEL=("$OUTPUT_ROOT"/controller/python/chip*.whl)
 
 # Add the matter_testing_infrastructure wheel
 WHEEL+=("$OUTPUT_ROOT"/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl)
+
+if [ "$install_pytest_requirements" = "yes" ]; then
+    # Add the matter_yamltests_distribution wheel
+    WHEEL+=("$OUTPUT_ROOT"/obj/scripts/matter_yamltests_distribution._build_wheel/matter_yamltests-*.whl)
+fi
 
 if [ -n "$extra_packages" ]; then
     WHEEL+=("$extra_packages")
@@ -221,14 +210,7 @@ if [ -n "$install_virtual_env" ]; then
     "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade "${WHEEL[@]}"
 
     if [ "$install_pytest_requirements" = "yes" ]; then
-        YAMLTESTS_GN_LABEL="//scripts:matter_yamltests_distribution._build_wheel"
-        # Add wheels from pw_python_package or pw_python_distribution templates.
-        YAMLTEST_WHEEL=(
-            "$(ls -tr "$(wheel_output_dir "$YAMLTESTS_GN_LABEL")"/*.whl | head -n 1)"
-        )
-
         echo_blue "Installing python test dependencies ..."
-        "$ENVIRONMENT_ROOT"/bin/pip install --upgrade "${YAMLTEST_WHEEL[@]}"
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/tests/requirements.txt"
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/src/python_testing/requirements.txt"
     fi

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -606,84 +606,82 @@
         /* Endpoint: 0, Cluster: Unit Localization (server) */                                                                     \
         { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x2 }, /* TemperatureUnit */                                                  \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: On/Off (server) */                                                                            \
-            { (uint16_t) 0xFF, (uint16_t) 0x0, (uint16_t) 0x2 }, /* StartUpOnOff */                                                \
+        /* Endpoint: 1, Cluster: On/Off (server) */                                                                                \
+        { (uint16_t) 0xFF, (uint16_t) 0x0, (uint16_t) 0x2 }, /* StartUpOnOff */                                                    \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 },   /* Options */                                                    \
-            { (uint16_t) 0x32, (uint16_t) 0x1, (uint16_t) 0xFF }, /* DefaultMoveRate */                                            \
+        /* Endpoint: 1, Cluster: Level Control (server) */                                                                         \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 },   /* Options */                                                        \
+        { (uint16_t) 0x32, (uint16_t) 0x1, (uint16_t) 0xFF }, /* DefaultMoveRate */                                                \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Laundry Washer Controls (server) */                                                           \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1F }, /* SpinSpeedCurrent */                                            \
+        /* Endpoint: 1, Cluster: Laundry Washer Controls (server) */                                                               \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1F }, /* SpinSpeedCurrent */                                                \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Smoke CO Alarm (server) */                                                                    \
-            { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x2 }, /* SmokeSensitivityLevel */                                        \
+        /* Endpoint: 1, Cluster: Smoke CO Alarm (server) */                                                                        \
+        { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x2 }, /* SmokeSensitivityLevel */                                            \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Valve Configuration and Control (server) */                                                   \
-            { (uint16_t) 0x64, (uint16_t) 0x1, (uint16_t) 0x64 }, /* DefaultOpenLevel */                                           \
+        /* Endpoint: 1, Cluster: Valve Configuration and Control (server) */                                                       \
+        { (uint16_t) 0x64, (uint16_t) 0x1, (uint16_t) 0x64 }, /* DefaultOpenLevel */                                               \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Energy EVSE (server) */                                                                       \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFFFE }, /* ApproximateEVEfficiency */                                   \
+        /* Endpoint: 1, Cluster: Energy EVSE (server) */                                                                           \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFFFE }, /* ApproximateEVEfficiency */                                       \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Window Covering (server) */                                                                   \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xF }, /* Mode */                                                         \
+        /* Endpoint: 1, Cluster: Window Covering (server) */                                                                       \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xF }, /* Mode */                                                             \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                    \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 }, /* OperationMode */                                                \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x7 }, /* ControlMode */                                                  \
+        /* Endpoint: 1, Cluster: Pump Configuration and Control (server) */                                                        \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 }, /* OperationMode */                                                    \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x7 }, /* ControlMode */                                                      \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Thermostat (server) */                                                                        \
-            { (uint16_t) 0xA28, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedCoolingSetpoint */                             \
-            { (uint16_t) 0x7D0, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedHeatingSetpoint */                             \
-            { (uint16_t) 0x2BC, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinHeatSetpointLimit */                                \
-            { (uint16_t) 0xBB8, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxHeatSetpointLimit */                                \
-            { (uint16_t) 0x640, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinCoolSetpointLimit */                                \
-            { (uint16_t) 0xC80, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxCoolSetpointLimit */                                \
-            { (uint16_t) 0x19, (uint16_t) 0x0, (uint16_t) 0x7F },        /* MinSetpointDeadBand */                                 \
-            { (uint16_t) 0x4, (uint16_t) 0x0, (uint16_t) 0x5 },          /* ControlSequenceOfOperation */                          \
-            { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x9 },          /* SystemMode */                                          \
+        /* Endpoint: 1, Cluster: Thermostat (server) */                                                                            \
+        { (uint16_t) 0xA28, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedCoolingSetpoint */                                 \
+        { (uint16_t) 0x7D0, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* OccupiedHeatingSetpoint */                                 \
+        { (uint16_t) 0x2BC, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinHeatSetpointLimit */                                    \
+        { (uint16_t) 0xBB8, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxHeatSetpointLimit */                                    \
+        { (uint16_t) 0x640, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MinCoolSetpointLimit */                                    \
+        { (uint16_t) 0xC80, (uint16_t) -0x6AB3, (uint16_t) 0x7FFF }, /* MaxCoolSetpointLimit */                                    \
+        { (uint16_t) 0x19, (uint16_t) 0x0, (uint16_t) 0x7F },        /* MinSetpointDeadBand */                                     \
+        { (uint16_t) 0x4, (uint16_t) 0x0, (uint16_t) 0x5 },          /* ControlSequenceOfOperation */                              \
+        { (uint16_t) 0x1, (uint16_t) 0x0, (uint16_t) 0x9 },          /* SystemMode */                                              \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Fan Control (server) */                                                                       \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x6 },  /* FanMode */                                                     \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x64 }, /* PercentSetting */                                              \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x64 }, /* SpeedSetting */                                                \
+        /* Endpoint: 1, Cluster: Fan Control (server) */                                                                           \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x6 },  /* FanMode */                                                         \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x64 }, /* PercentSetting */                                                  \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x64 }, /* SpeedSetting */                                                    \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Thermostat User Interface Configuration (server) */                                           \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 }, /* TemperatureDisplayMode */                                       \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x5 }, /* KeypadLockout */                                                \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 }, /* ScheduleProgrammingVisibility */                                \
+        /* Endpoint: 1, Cluster: Thermostat User Interface Configuration (server) */                                               \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 }, /* TemperatureDisplayMode */                                           \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x5 }, /* KeypadLockout */                                                    \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 }, /* ScheduleProgrammingVisibility */                                    \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Color Control (server) */                                                                     \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* WhitePointX */                                              \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* WhitePointY */                                              \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointRX */                                             \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointRY */                                             \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointGX */                                             \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointGY */                                             \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointBX */                                             \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointBY */                                             \
-            { (uint16_t) 0xFA, (uint16_t) 0x0, (uint16_t) 0xFEFF }, /* StartUpColorTemperatureMireds */                            \
+        /* Endpoint: 1, Cluster: Color Control (server) */                                                                         \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* WhitePointX */                                                  \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* WhitePointY */                                                  \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointRX */                                                 \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointRY */                                                 \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointGX */                                                 \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointGY */                                                 \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointBX */                                                 \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF },  /* ColorPointBY */                                                 \
+        { (uint16_t) 0xFA, (uint16_t) 0x0, (uint16_t) 0xFEFF }, /* StartUpColorTemperatureMireds */                                \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Ballast Configuration (server) */                                                             \
-            { (uint16_t) 0x1, (uint16_t) 0x1, (uint16_t) 0xFE },     /* MinLevel */                                                \
-            { (uint16_t) 0xFE, (uint16_t) 0x1, (uint16_t) 0xFE },    /* MaxLevel */                                                \
-            { (uint16_t) 0xFF, (uint16_t) 0x64, (uint16_t) 0xFFFF }, /* BallastFactorAdjustment */                                 \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 },      /* LampAlarmMode */                                           \
+        /* Endpoint: 1, Cluster: Ballast Configuration (server) */                                                                 \
+        { (uint16_t) 0x1, (uint16_t) 0x1, (uint16_t) 0xFE },     /* MinLevel */                                                    \
+        { (uint16_t) 0xFE, (uint16_t) 0x1, (uint16_t) 0xFE },    /* MaxLevel */                                                    \
+        { (uint16_t) 0xFF, (uint16_t) 0x64, (uint16_t) 0xFFFF }, /* BallastFactorAdjustment */                                     \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 },      /* LampAlarmMode */                                               \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Unit Testing (server) */                                                                      \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* range_restricted_int8u */                                  \
-            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* range_restricted_int8s */                                  \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* range_restricted_int16u */                                 \
-            { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* range_restricted_int16s */                                 \
-            { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* nullable_range_restricted_int8u */                         \
-            { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* nullable_range_restricted_int8s */                         \
-            { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* nullable_range_restricted_int16u */                        \
-            { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* nullable_range_restricted_int16s */                        \
+        /* Endpoint: 1, Cluster: Unit Testing (server) */                                                                          \
+        { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* range_restricted_int8u */                                      \
+        { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* range_restricted_int8s */                                      \
+        { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* range_restricted_int16u */                                     \
+        { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* range_restricted_int16s */                                     \
+        { (uint16_t) 0x46, (uint16_t) 0x14, (uint16_t) 0x64 },   /* nullable_range_restricted_int8u */                             \
+        { (uint16_t) -0x14, (uint16_t) -0x28, (uint16_t) 0x32 }, /* nullable_range_restricted_int8s */                             \
+        { (uint16_t) 0xC8, (uint16_t) 0x64, (uint16_t) 0x3E8 },  /* nullable_range_restricted_int16u */                            \
+        { (uint16_t) -0x64, (uint16_t) -0x96, (uint16_t) 0xC8 }, /* nullable_range_restricted_int16s */                            \
                                                                                                                                    \
         /* Endpoint: 2, Cluster: On/Off (server) */                                                                                \
-        {                                                                                                                          \
-            (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x2                                                                         \
-        } /* StartUpOnOff */                                                                                                       \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x2 } /* StartUpOnOff */                                                      \
     }
 
 // This is an array of EmberAfAttributeMetadata structures.
@@ -4394,12 +4392,8 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                                         \
-    {                                                                                                                              \
-        { 0x00000011, 1 }, { 0x00000016, 1 }, { 0x00000100, 1 }, { 0x00000011, 1 }, { 0x00000100, 1 }, { 0x00000011, 1 },          \
-        {                                                                                                                          \
-            0x00000019, 1                                                                                                          \
-        }                                                                                                                          \
-    }
+    { { 0x00000011, 1 }, { 0x00000016, 1 }, { 0x00000100, 1 }, { 0x00000011, 1 },                                                  \
+      { 0x00000100, 1 }, { 0x00000011, 1 }, { 0x00000019, 1 } }
 
 // Array of device type offsets
 #define FIXED_DEVICE_TYPE_OFFSETS { 0, 2, 4, 6 }

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
@@ -118,14 +118,12 @@
         /* Endpoint: 1, Cluster: On/Off (server) */                                                                                \
         { (uint16_t) 0xFF, (uint16_t) 0x0, (uint16_t) 0x2 }, /* StartUpOnOff */                                                    \
                                                                                                                                    \
-            /* Endpoint: 1, Cluster: Level Control (server) */                                                                     \
-            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 },   /* Options */                                                    \
-            { (uint16_t) 0x32, (uint16_t) 0x1, (uint16_t) 0xFF }, /* DefaultMoveRate */                                            \
+        /* Endpoint: 1, Cluster: Level Control (server) */                                                                         \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x3 },   /* Options */                                                        \
+        { (uint16_t) 0x32, (uint16_t) 0x1, (uint16_t) 0xFF }, /* DefaultMoveRate */                                                \
                                                                                                                                    \
         /* Endpoint: 1, Cluster: Color Control (server) */                                                                         \
-        {                                                                                                                          \
-            (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF                                                                      \
-        } /* StartUpColorTemperatureMireds */                                                                                      \
+        { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xFEFF } /* StartUpColorTemperatureMireds */                                  \
     }
 
 // This is an array of EmberAfAttributeMetadata structures.
@@ -1233,13 +1231,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 #define FIXED_PROFILE_IDS { 0x0103, 0x0103 }
 
 // Array of device types
-#define FIXED_DEVICE_TYPES                                                                                                         \
-    {                                                                                                                              \
-        { 0x00000016, 1 },                                                                                                         \
-        {                                                                                                                          \
-            0x00000101, 1                                                                                                          \
-        }                                                                                                                          \
-    }
+#define FIXED_DEVICE_TYPES { { 0x00000016, 1 }, { 0x00000101, 1 } }
 
 // Array of device type offsets
 #define FIXED_DEVICE_TYPE_OFFSETS { 0, 1 }

--- a/src/lib/address_resolve/tool.cpp
+++ b/src/lib/address_resolve/tool.cpp
@@ -147,7 +147,7 @@ extern "C" void StopSignalHandler(int signal)
 
 } // namespace
 
-extern "C" int main(int argc, const char ** argv)
+int main(int argc, const char ** argv)
 {
     Platform::MemoryInit();
 

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -29,7 +29,7 @@ using namespace ::chip::DeviceLayer;
 
 LOG_MODULE_REGISTER(runner, CONFIG_MATTER_LOG_LEVEL);
 
-extern "C" int main(void)
+int main(void)
 {
     VerifyOrDie(settings_subsys_init() == 0);
 

--- a/src/tools/chip-cert/chip-cert.cpp
+++ b/src/tools/chip-cert/chip-cert.cpp
@@ -85,7 +85,7 @@ bool PrintVersion()
 
 } // namespace
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     bool res = false;
 

--- a/src/tools/spake2p/spake2p.cpp
+++ b/src/tools/spake2p/spake2p.cpp
@@ -62,7 +62,7 @@ bool PrintVersion()
 
 } // namespace
 
-extern "C" int main(int argc, char * argv[])
+int main(int argc, char * argv[])
 {
     bool res = false;
 

--- a/third_party/pigweed/update.sh
+++ b/third_party/pigweed/update.sh
@@ -3,8 +3,8 @@
 
 # Update the submodule.
 cd "$(dirname "${BASH_SOURCE[0]}")/repo"
-git fetch origin master
-git checkout origin/master
+git fetch origin main
+git checkout origin/main
 
 # Copy the CIPD manifest but change the Python line so we don't use CIPD
 # Python on Linux.


### PR DESCRIPTION
### Changes

- Updated pigweed to latest main
- Removed `extern "C"` from C++ main functions as this triggers clang warning: `warning: 'main' should not be 'extern "C"' [-Wmain]`
- Workaround for NuttX which reuses lighting app main.cpp main function

### Testing

CI will verify