### PR TITLE
[darwin-framework-tool] Use per commissioner storage by default inste…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -42,7 +42,7 @@ public:
             "commissioner-name. Interactive mode will only set a single commissioner on the inital command. "
             "The commissioner node ID will be persisted until a different one is specified.");
         AddArgument("commissioner-shared-storage", 0, 1, &mCommissionerSharedStorage,
-            "Use a shared storage instance instead of individual storage for each commissioner. Default is true.");
+            "Use a shared storage instance instead of individual storage for each commissioner. Default is false.");
         AddArgument("paa-trust-store-path", &mPaaTrustStorePath,
             "Path to directory holding PAA certificate information.  Can be absolute or relative to the current working "
             "directory.");

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -139,7 +139,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
         productAttestationAuthorityCertificates = nil;
     }
 
-    sUseSharedStorage = mCommissionerSharedStorage.ValueOr(true);
+    sUseSharedStorage = mCommissionerSharedStorage.ValueOr(false);
     if (sUseSharedStorage) {
         return SetUpStackWithSharedStorage(productAttestationAuthorityCertificates);
     }

--- a/examples/darwin-framework-tool/commands/common/CertificateIssuer.mm
+++ b/examples/darwin-framework-tool/commands/common/CertificateIssuer.mm
@@ -21,6 +21,8 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
+constexpr const uint32_t kIssuerId = 12345678;
+
 @interface CertificateIssuer ()
 - (MTRCertificateDERBytes _Nullable)issueOperationalCertificateForNodeID:(NSNumber *)nodeID
                                                                 fabricID:(NSNumber *)fabricID
@@ -67,7 +69,7 @@
         return;
     }
 
-    __auto_type * rootCertificate = [MTRCertificates createRootCertificate:signingKey issuerID:nil fabricID:nil error:error];
+    __auto_type * rootCertificate = [MTRCertificates createRootCertificate:signingKey issuerID:@(kIssuerId) fabricID:nil error:error];
     if (nil == rootCertificate) {
         *error = [NSError errorWithDomain:@"Error" code:0 userInfo:@{ @"reason" : @"Error creating root certificate" }];
         return;


### PR DESCRIPTION
…ad of shared storage

#### Problem

This PR makes per-controller storage the default behavior for `darwin-framework-tool`.