### PR TITLE
Add contraint checks on Color contol arguments value ranges

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -474,10 +474,6 @@ Status ColorControlServer::stopMoveStepCommand(EndpointId endpoint, const Comman
 {
     Status status = Status::Success;
 
-    // Command parameters constraint checks:
-    VerifyOrReturnValue(commandData.optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsOverride <= kMaxOptionValue, Status::ConstraintError);
-
     // StopMoveStep command has no effect on an active color loop.
     // Fetch if it is supported and active.
     uint8_t isColorLoopActive = 0;
@@ -1421,10 +1417,6 @@ Status ColorControlServer::moveHueCommand(EndpointId endpoint, HueMoveMode moveM
     VerifyOrReturnValue(moveMode != HueMoveMode::kUnknownEnumValue, Status::InvalidCommand);
     VerifyOrReturnValue((rate != 0 || moveMode == HueMoveMode::kStop), Status::InvalidCommand);
 
-    // Command Parameters constraint checks:
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
-
     uint16_t epIndex                                  = getEndpointIndex(endpoint);
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
     VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
@@ -1523,8 +1515,6 @@ Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, D
     // Command Parameters constraint checks:
     VerifyOrReturnValue((isEnhanced || hue <= MAX_HUE_VALUE), Status::ConstraintError);
     VerifyOrReturnValue(transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
     VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
@@ -1642,8 +1632,6 @@ Status ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, ui
     VerifyOrReturnValue((isEnhanced || hue <= MAX_HUE_VALUE), Status::ConstraintError);
     VerifyOrReturnValue(saturation <= MAX_SATURATION_VALUE, Status::ConstraintError);
     VerifyOrReturnValue(transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
@@ -1688,8 +1676,6 @@ Status ColorControlServer::stepHueCommand(EndpointId endpoint, HueStepMode stepM
     {
         VerifyOrReturnValue(transitionTime <= UINT8_MAX, Status::ConstraintError);
     }
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
     VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
@@ -1777,10 +1763,6 @@ Status ColorControlServer::moveSaturationCommand(EndpointId endpoint, const Comm
     VerifyOrReturnValue(moveMode != SaturationMoveMode::kUnknownEnumValue, Status::InvalidCommand);
     VerifyOrReturnValue(rate != 0 || moveMode == SaturationMoveMode::kStop, Status::InvalidCommand);
 
-    // Command Parameters constraint checks
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
-
     uint16_t epIndex                                         = getEndpointIndex(endpoint);
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
     VerifyOrReturnValue(colorSaturationTransitionState != nullptr, Status::UnsupportedEndpoint);
@@ -1841,8 +1823,6 @@ Status ColorControlServer::moveToSaturationCommand(EndpointId endpoint,
     // Command Parameters constraint checks:
     VerifyOrReturnValue(commandData.saturation <= MAX_SATURATION_VALUE, Status::ConstraintError);
     VerifyOrReturnValue(commandData.transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
     Status status = moveToSaturation(endpoint, commandData.saturation, commandData.transitionTime);
@@ -1875,8 +1855,6 @@ Status ColorControlServer::stepSaturationCommand(EndpointId endpoint, const Comm
     VerifyOrReturnValue(stepSize != 0, Status::InvalidCommand);
     // Command Parameters constraint checks:
     VerifyOrReturnValue(transitionTime <= UINT8_MAX, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
     VerifyOrReturnValue(colorSaturationTransitionState != nullptr, Status::UnsupportedEndpoint);
@@ -1943,8 +1921,6 @@ Status ColorControlServer::colorLoopCommand(EndpointId endpoint, const Commands:
     VerifyOrReturnValue(direction != ColorLoopDirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
     VerifyOrReturnValue(updateFlags <= maxUpdateFlagsValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     uint16_t epIndex                                  = getEndpointIndex(endpoint);
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
@@ -2282,8 +2258,6 @@ Status ColorControlServer::moveToColorCommand(EndpointId endpoint, const Command
 {
     // Command Parameters constraint checks:
     VerifyOrReturnValue(commandData.transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
 
@@ -2309,9 +2283,6 @@ Status ColorControlServer::moveColorCommand(EndpointId endpoint, const Commands:
     auto & rateY           = commandData.rateY;
     auto & optionsMask     = commandData.optionsMask;
     auto & optionsOverride = commandData.optionsOverride;
-
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
@@ -2407,8 +2378,6 @@ Status ColorControlServer::stepColorCommand(EndpointId endpoint, const Commands:
 
     // Command Parameters constraint checks:
     VerifyOrReturnValue(transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     uint16_t epIndex                                = getEndpointIndex(endpoint);
     Color16uTransitionState * colorXTransitionState = getXTransitionStateByIndex(epIndex);
@@ -2757,10 +2726,6 @@ Status ColorControlServer::moveColorTempCommand(EndpointId endpoint,
     VerifyOrReturnValue(moveMode != HueMoveMode::kUnknownEnumValue, Status::InvalidCommand);
     VerifyOrReturnValue((rate != 0 || moveMode == HueMoveMode::kStop), Status::InvalidCommand);
 
-    // Command Parameters constraint checks:
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
-
     Color16uTransitionState * colorTempTransitionState = getTempTransitionState(endpoint);
     VerifyOrReturnValue(colorTempTransitionState != nullptr, Status::UnsupportedEndpoint);
 
@@ -2853,8 +2818,6 @@ Status ColorControlServer::moveToColorTempCommand(EndpointId endpoint,
 {
     // Command Parameters constraint checks:
     VerifyOrReturnValue(commandData.transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(commandData.optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
 
@@ -2891,8 +2854,6 @@ Status ColorControlServer::stepColorTempCommand(EndpointId endpoint,
 
     // Command Parameters constraint checks:
     VerifyOrReturnValue(transitionTime <= kMaxtransitionTime, Status::ConstraintError);
-    VerifyOrReturnValue(optionsMask <= kMaxOptionValue, Status::ConstraintError);
-    VerifyOrReturnValue(optionsOverride <= kMaxOptionValue, Status::ConstraintError);
 
     Color16uTransitionState * colorTempTransitionState = getTempTransitionState(endpoint);
     VerifyOrReturnValue(colorTempTransitionState != nullptr, Status::UnsupportedEndpoint);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -239,9 +239,10 @@ private:
     uint16_t getEndpointIndex(chip::EndpointId);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    chip::Protocols::InteractionModel::Status moveToSaturation(chip::EndpointId endpoint, uint8_t saturation, uint16_t transitionTime);
-    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(chip::EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                                     bool isEnhanced);
+    chip::Protocols::InteractionModel::Status moveToSaturation(chip::EndpointId endpoint, uint8_t saturation,
+                                                               uint16_t transitionTime);
+    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(chip::EndpointId endpoint, uint16_t hue, uint8_t saturation,
+                                                                     uint16_t transitionTime, bool isEnhanced);
     ColorHueTransitionState * getColorHueTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getSaturationTransitionState(chip::EndpointId endpoint);
     ColorHueTransitionState * getColorHueTransitionStateByIndex(uint16_t index);
@@ -262,7 +263,8 @@ private:
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
-    chip::Protocols::InteractionModel::Status moveToColor(chip::EndpointId endpoint, uint16_t colorX, uint16_t colorY, uint16_t transitionTime);
+    chip::Protocols::InteractionModel::Status moveToColor(chip::EndpointId endpoint, uint16_t colorX, uint16_t colorY,
+                                                          uint16_t transitionTime);
     Color16uTransitionState * getXTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getYTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getXTransitionStateByIndex(uint16_t index);
@@ -289,8 +291,6 @@ private:
     static_assert(kColorControlClusterServerMaxEndpointCount <= kEmberInvalidEndpointIndex, "ColorControl endpoint count error");
 
     static constexpr uint16_t kMaxtransitionTime = 65534; // Max value as defined by the spec.
-    static constexpr chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> kMaxOptionValue =
-        chip::app::Clusters::ColorControl::OptionsBitmap::kExecuteIfOff; // add any new bitmap field to this value!
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
     ColorHueTransitionState colorHueTransitionStates[kColorControlClusterServerMaxEndpointCount];

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -143,57 +143,65 @@ public:
 
     bool HasFeature(chip::EndpointId endpoint, Feature feature);
     chip::Protocols::InteractionModel::Status stopAllColorTransitions(chip::EndpointId endpoint);
-    bool stopMoveStepCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                             chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                             chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride);
+    chip::Protocols::InteractionModel::Status
+    stopMoveStepCommand(const chip::EndpointId endpoint,
+                        const chip::app::Clusters::ColorControl::Commands::StopMoveStep::DecodableType & commandData);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    bool moveHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        MoveModeEnum moveMode, uint16_t rate,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveToHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath, uint16_t hue,
-                          DirectionEnum moveDirection, uint16_t transitionTime,
-                          chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                          chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveToHueAndSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                       uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                       chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                                       chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride,
-                                       bool isEnhanced);
-    bool stepHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        StepModeEnum stepMode, uint16_t stepSize, uint16_t transitionTime,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
-    bool moveToSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                 const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::DecodableType & commandData);
-    bool stepSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::ColorControl::Commands::StepSaturation::DecodableType & commandData);
-    bool colorLoopCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                          const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveHueCommand(const chip::EndpointId endpoint, MoveModeEnum moveMode, uint16_t rate,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    moveToHueCommand(const chip::EndpointId endpoint, uint16_t hue, DirectionEnum moveDirection, uint16_t transitionTime,
+                     chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                     chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    moveToHueAndSaturationCommand(const chip::EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
+                                  chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                                  chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    stepHueCommand(const chip::EndpointId endpoint, StepModeEnum stepMode, uint16_t stepSize, uint16_t transitionTime,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    moveSaturationCommand(const chip::EndpointId endpoint,
+                          const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveToSaturationCommand(const chip::EndpointId endpoint,
+                            const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    stepSaturationCommand(const chip::EndpointId endpoint,
+                          const chip::app::Clusters::ColorControl::Commands::StepSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    colorLoopCommand(const chip::EndpointId endpoint,
+                     const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::DecodableType & commandData);
     void updateHueSatCommand(chip::EndpointId endpoint);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
-    bool moveToColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                            const chip::app::Clusters::ColorControl::Commands::MoveToColor::DecodableType & commandData);
-    bool moveColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                          const chip::app::Clusters::ColorControl::Commands::MoveColor::DecodableType & commandData);
-    bool stepColorCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                          const chip::app::Clusters::ColorControl::Commands::StepColor::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveToColorCommand(const chip::EndpointId endpoint,
+                       const chip::app::Clusters::ColorControl::Commands::MoveToColor::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveColorCommand(const chip::EndpointId endpoint,
+                     const chip::app::Clusters::ColorControl::Commands::MoveColor::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    stepColorCommand(const chip::EndpointId endpoint,
+                     const chip::app::Clusters::ColorControl::Commands::StepColor::DecodableType & commandData);
     void updateXYCommand(chip::EndpointId endpoint);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
-    bool moveColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::DecodableType & commandData);
-    bool
-    moveToColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+    chip::Protocols::InteractionModel::Status
+    moveColorTempCommand(const chip::EndpointId endpoint,
+                         const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveToColorTempCommand(const chip::EndpointId endpoint,
                            const chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::DecodableType & commandData);
-    bool stepColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    stepColorTempCommand(const chip::EndpointId endpoint,
+                         const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::DecodableType & commandData);
     void levelControlColorTempChangeCommand(chip::EndpointId endpoint);
     void startUpColorTempCommand(chip::EndpointId endpoint);
     void updateTempCommand(chip::EndpointId endpoint);
@@ -231,10 +239,9 @@ private:
     uint16_t getEndpointIndex(chip::EndpointId);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    chip::Protocols::InteractionModel::Status moveToSaturation(uint8_t saturation, uint16_t transitionTime,
-                                                               chip::EndpointId endpoint);
-    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                                     bool isEnhanced, chip::EndpointId endpoint);
+    chip::Protocols::InteractionModel::Status moveToSaturation(chip::EndpointId endpoint, uint8_t saturation, uint16_t transitionTime);
+    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(chip::EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
+                                                                     bool isEnhanced);
     ColorHueTransitionState * getColorHueTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getSaturationTransitionState(chip::EndpointId endpoint);
     ColorHueTransitionState * getColorHueTransitionStateByIndex(uint16_t index);
@@ -255,8 +262,7 @@ private:
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
-    chip::Protocols::InteractionModel::Status moveToColor(uint16_t colorX, uint16_t colorY, uint16_t transitionTime,
-                                                          chip::EndpointId endpoint);
+    chip::Protocols::InteractionModel::Status moveToColor(chip::EndpointId endpoint, uint16_t colorX, uint16_t colorY, uint16_t transitionTime);
     Color16uTransitionState * getXTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getYTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getXTransitionStateByIndex(uint16_t index);
@@ -281,6 +287,10 @@ private:
     static constexpr size_t kColorControlClusterServerMaxEndpointCount =
         MATTER_DM_COLOR_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
     static_assert(kColorControlClusterServerMaxEndpointCount <= kEmberInvalidEndpointIndex, "ColorControl endpoint count error");
+
+    static constexpr uint16_t kMaxtransitionTime = 65534; // Max value as defined by the spec.
+    static constexpr chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> kMaxOptionValue =
+        chip::app::Clusters::ColorControl::OptionsBitmap::kExecuteIfOff; // add any new bitmap field to this value!
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
     ColorHueTransitionState colorHueTransitionStates[kColorControlClusterServerMaxEndpointCount];


### PR DESCRIPTION
fixes #34721

This PR adds some constraint checks on some Color control command arguments, most notably the TransitionTime.

It also rework the command handlers to :
- Clean up and unify all command handlers of the color control. There were multiple implementation schemes  across handlers 
- remove the goto mechanism and in favour of early return conditions (`VerifyOrReturnValue`)

I verified that there is no regression by running all automated TC-CC tests.