### PR TITLE
[darwin-framework-tool] Sending a command or issuing a write using the any cluster leaks

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -47,22 +47,8 @@ public:
 
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
-        chip::TLV::TLVWriter writer;
-        chip::TLV::TLVReader reader;
-
-        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
-        VerifyOrReturnError(mData != nullptr, CHIP_ERROR_NO_MEMORY);
-
-        writer.Init(mData, mDataMaxLen);
-
-        ReturnErrorOnFailure(mPayload.Encode(writer, chip::TLV::AnonymousTag()));
-        reader.Init(mData, writer.GetLengthWritten());
-        ReturnErrorOnFailure(reader.Next());
-
-        id commandFields = NSObjectFromCHIPTLV(&reader);
-        if (commandFields == nil) {
-            return CHIP_ERROR_INTERNAL;
-        }
+        id commandFields;
+        ReturnErrorOnFailure(GetCommandFields(&commandFields));
         return ClusterCommand::SendCommand(device, endpointId, mClusterId, mCommandId, commandFields);
     }
 
@@ -136,6 +122,35 @@ protected:
     NSError * _Nullable mError = nil;
 
 private:
+    CHIP_ERROR GetCommandFields(id _Nonnull * _Nonnull outCommandFields)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        chip::TLV::TLVWriter writer;
+        chip::TLV::TLVReader reader;
+
+        mData = static_cast<uint8_t *>(chip::Platform::MemoryCalloc(sizeof(uint8_t), mDataMaxLen));
+        VerifyOrExit(mData != nullptr, err = CHIP_ERROR_NO_MEMORY);
+
+        writer.Init(mData, mDataMaxLen);
+
+        err = mPayload.Encode(writer, chip::TLV::AnonymousTag());
+        SuccessOrExit(err);
+
+        reader.Init(mData, writer.GetLengthWritten());
+        err = reader.Next();
+        SuccessOrExit(err);
+
+        *outCommandFields = NSObjectFromCHIPTLV(&reader);
+        VerifyOrDo(nil != *outCommandFields, err = CHIP_ERROR_INTERNAL);
+
+    exit:
+        if (nullptr != mData) {
+            chip::Platform::MemoryFree(mData);
+            mData = nullptr;
+        }
+        return err;
+    }
+
     chip::ClusterId mClusterId;
     chip::CommandId mCommandId;
 


### PR DESCRIPTION
#### Problem

With `darwin-framework-tool` sending a command or a write via ` ClusterCommandBridge.h` or `WriteAttributeCommandBridge.h`  results into a leak. This is distracting and may hide other real leaks.