### PR TITLE
Remove the ToString from pigweed as googletest complains

### DIFF
--- a/src/app/codegen-data-model-provider/tests/TestEmberAttributeDataBuffer.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestEmberAttributeDataBuffer.cpp
@@ -164,24 +164,6 @@ const EmberAfAttributeMetadata * CreateFakeMeta(EmberAfAttributeType type, bool 
 }
 
 } // namespace
-//
-namespace pw {
-
-// Pretty format in case of errors
-template <>
-StatusWithSize ToString<EncodeResult>(const EncodeResult & result, pw::span<char> buffer)
-{
-    const std::optional<CHIP_ERROR> & value = result.Value();
-
-    if (!value.has_value())
-    {
-        return pw::string::Format(buffer, "SuccessResult");
-    }
-
-    return pw::string::Format(buffer, "FailureResult:CHIP_ERROR:<%" CHIP_ERROR_FORMAT ">", value->Format());
-}
-
-} // namespace pw
 
 // All the tests below assume buffer ordering in little endian format
 // Since currently all chip platforms in CI are little endian, we just kept tests


### PR DESCRIPTION
ToT gets:

```
INFO    ../../src/app/codegen-data-model-provider/tests/TestEmberAttributeDataBuffer.cpp:172:16: error: unused function 'ToString<(anonymous namespace)::EncodeResult>' [-Werror,-Wunused-function]
835
INFO    StatusWithSize ToString<EncodeResult>(const EncodeResult & result, pw::span<char> buffer)
836
INFO          
```

even though #36228 merged without any CI errors, it likely got a conflict with #36137

I believe this is due to using googletest backent which does not use ToString. In any case, as long as tests pass this tostring is not used, so to unblock master builds I removed the definition.