### PR TITLE
[Silabs] Delete SDK files to reduce the amount of flash consummed in the docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-86 : [Tizen] Pass runner's path as QEMU argument
+87 : [Silabs] Delete SDK files to reduce the amount of flash consummed

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -18,21 +18,28 @@ RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6
     && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
     && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space
-    && rm -rf /tmp/simplicity_sdk/protocol/flex /tmp/simplicity_sdk/protocol/z-wave /tmp/simplicity_sdk/protocol/zigbee /tmp/simplicity_sdk/protocol/wisun \
+    && rm -rf /tmp/simplicity_sdk/protocol/flex /tmp/simplicity_sdk/protocol/z-wave /tmp/simplicity_sdk/protocol/zigbee /tmp/simplicity_sdk/protocol/wisun /tmp/simplicity_sdk/util/third_party/tensorflow_extra \
+    /tmp/simplicity_sdk/util/third_party/sqlite /tmp/simplicity_sdk/util/third_party/ot-br-posix /tmp/simplicity_sdk/util/third_party/tflite-micro /tmp/simplicity_sdk/util/third_party/tflite-fatfs /tmp/simplicity_sdk/util/third_party/unity_test_framework \
+    /tmp/simplicity_sdk/platform/radio/efr32_multiphy_configurator \
     && find /tmp/simplicity_sdk/protocol/bluetooth /tmp/simplicity_sdk/platform -name "*.a" -type f -delete \
     && find /tmp/simplicity_sdk/protocol/openthread -name "*efr32mg21*" -delete \
+    && find /tmp/simplicity_sdk \( -name "libsl_platform_ftd_efr32mg2*" -o -name "libsl_ot_stack_mtd_efr32mg2*" \) -type f -delete \
+    && find /tmp/simplicity_sdk/hardware/board/config -mindepth 1 -maxdepth 1 -type d ! \( -name '*brd4186c*' -o -name '*brd4187c*' -o -name '*brd4186a*' -o -name '*brd4187a*' -o -name '*brd2601b*' -o -name '*brd2703a*' -o -name '*brd2704a*' \
+    -o -name '*brd4316a*' -o -name '*brd4317a*' -o -name '*brd4318a*' -o -name '*brd4319a*' -o -name '*brd4116a*' -o -name '*brd4117a*' -o -name '*brd4118a*' -o -name '*brd2608a*' \) -exec rm -rf {} + \
+    && find /tmp/simplicity_sdk/platform/Device/SiliconLabs  -mindepth 1 -maxdepth 1 -type d ! \( -name 'EFR32MG24' -o -name 'EFR32MG26' -o -name 'MGM24' \) -exec rm -rf {} + \
+    && find /tmp/simplicity_sdk -name "*.slc*" -type f -delete \
     && : # last line
 
 # Clone WiSeConnect Wi-Fi and Bluetooth Software 2.10.3 (b6d6cb5)
 RUN git clone --depth=1 --single-branch --branch=2.10.3 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
     cd /tmp/wiseconnect-wifi-bt-sdk && \
-    rm -rf .git \
+    rm -rf .git examples \
     && : # last line
 
 # Clone WiSeConnect SDK v3.3.3 (a6390dd)
 RUN git clone --depth=1 --single-branch --branch=v3.3.3 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
-    rm -rf .git \
+    rm -rf .git examples components/device/stm32 \
     && : # last line
 
 # SLC-cli install


### PR DESCRIPTION
#### Description
After the last round of SDK updates, the EFR32 CI started failing on some PRs due to the docker image running out of size.
This PR deletes all major items from all SDK to reduces the amount of disk space used by the three silabs SDKs.

Simplicity SDK 2.3GB -> 769M
Wiseconnect 599M -> 65M
Wi-Fi SDK 412M ->39M

This should solve the docker image issues for while.