### PR TITLE
[darwin-framework-tool] Add an optional -use-mtr-device argument to read-by-id and write-by-id commands

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -45,6 +45,8 @@ public:
 
     ~ClusterCommand() {}
 
+    using ModelCommand::SendCommand;
+
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
         id commandFields;

--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.h
@@ -52,6 +52,10 @@ public:
     }
 
     virtual CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endPointId) = 0;
+    virtual CHIP_ERROR SendCommand(MTRDevice * _Nonnull device, chip::EndpointId endPointId) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+protected:
+    chip::Optional<bool> mUseMTRDevice;
 
 private:
     chip::NodeId mNodeId;

--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
@@ -26,10 +26,18 @@ using namespace ::chip;
 CHIP_ERROR ModelCommand::RunCommand()
 {
     ChipLogProgress(chipTool, "Sending command to node 0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
-    auto * device = BaseDeviceWithNodeId(mNodeId);
-    VerifyOrReturnError(device != nil, CHIP_ERROR_INCORRECT_STATE);
 
-    CHIP_ERROR err = SendCommand(device, mEndPointId);
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (mUseMTRDevice.ValueOr(false)) {
+        auto * device = DeviceWithNodeId(mNodeId);
+        VerifyOrReturnError(device != nil, CHIP_ERROR_INCORRECT_STATE);
+        err = SendCommand(device, mEndPointId);
+    } else {
+        auto * device = BaseDeviceWithNodeId(mNodeId);
+        VerifyOrReturnError(device != nil, CHIP_ERROR_INCORRECT_STATE);
+        err = SendCommand(device, mEndPointId);
+    }
 
     if (err != CHIP_NO_ERROR) {
         ChipLogError(chipTool, "Error: %s", chip::ErrorStr(err));

--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -28,7 +28,7 @@ public:
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        ModelCommand::AddArguments();
+        AddCommonByIdArguments();
     }
 
     ReadAttribute(chip::ClusterId clusterId)
@@ -37,7 +37,7 @@ public:
     {
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        ModelCommand::AddArguments();
+        AddCommonByIdArguments();
     }
 
     ReadAttribute(const char * _Nonnull attributeName)
@@ -83,7 +83,46 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    CHIP_ERROR SendCommand(MTRDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        MTRReadParams * params = [[MTRReadParams alloc] init];
+        if (mFabricFiltered.HasValue()) {
+            params.filterByFabric = mFabricFiltered.Value();
+        }
+
+        __auto_type * endpoint = @(endpointId);
+        __auto_type * cluster = @(mClusterId);
+        __auto_type * attribute = @(mAttributeId);
+        __auto_type values = [device readAttributeWithEndpointID:endpoint
+                                                       clusterID:cluster
+                                                     attributeID:attribute
+                                                          params:params];
+
+        NSError * error = nil;
+        if (nil == values) {
+            __auto_type * userInfo = @ { @"reason" : @"No value available." };
+            error = [NSError errorWithDomain:@"Error" code:0 userInfo:userInfo];
+            LogNSError("Error reading attribute", error);
+            RemoteDataModelLogger::LogAttributeErrorAsJSON(endpoint, cluster, attribute, error);
+        } else {
+            for (id item in values) {
+                NSLog(@"Response Item: %@", [item description]);
+            }
+            RemoteDataModelLogger::LogAttributeAsJSON(endpoint, cluster, attribute, values);
+        }
+
+        SetCommandExitStatus(error);
+        return CHIP_NO_ERROR;
+    }
+
 protected:
+    void AddCommonByIdArguments()
+    {
+        AddArgument("use-mtr-device", 0, 1, &mUseMTRDevice,
+            "Use MTRDevice instead of MTRBaseDevice to send this command. Default is false.");
+        ModelCommand::AddArguments();
+    }
+
     chip::Optional<bool> mFabricFiltered;
 
 private:

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -25,6 +25,8 @@
 #import "MTRError_Utils.h"
 #import <Matter/Matter.h>
 
+constexpr uint32_t kDefaultExpectedValueInterval = 60000;
+
 class WriteAttribute : public ModelCommand {
 public:
     WriteAttribute()
@@ -33,7 +35,7 @@ public:
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("attribute-value", &mAttributeValue);
-        AddArguments();
+        AddCommonByIdArguments();
     }
 
     WriteAttribute(chip::ClusterId clusterId)
@@ -42,14 +44,19 @@ public:
     {
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("attribute-value", &mAttributeValue);
-        AddArguments();
+        AddCommonByIdArguments();
     }
 
     ~WriteAttribute() {}
 
-    using ModelCommand::SendCommand;
-
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
+    {
+        id value;
+        ReturnErrorOnFailure(GetValue(&value));
+        return WriteAttribute::SendCommand(device, endpointId, mClusterId, mAttributeId, value);
+    }
+
+    CHIP_ERROR SendCommand(MTRDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
         id value;
         ReturnErrorOnFailure(GetValue(&value));
@@ -89,12 +96,42 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    CHIP_ERROR SendCommand(MTRDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+        chip::AttributeId attributeId, id _Nonnull value)
+    {
+        __auto_type * endpoint = @(endpointId);
+        __auto_type * cluster = @(mClusterId);
+        __auto_type * attribute = @(mAttributeId);
+        __auto_type * expectedValueInterval = @(mExpectedValueInterval.ValueOr(kDefaultExpectedValueInterval));
+        __auto_type * timedWriteTimeout = mTimedInteractionTimeoutMs.HasValue()
+            ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]
+            : nil;
+
+        [device writeAttributeWithEndpointID:endpoint
+                                   clusterID:cluster
+                                 attributeID:attribute
+                                       value:value
+                       expectedValueInterval:expectedValueInterval
+                           timedWriteTimeout:timedWriteTimeout];
+
+        SetCommandExitStatus(CHIP_NO_ERROR);
+        return CHIP_NO_ERROR;
+    }
+
 protected:
     WriteAttribute(const char * _Nonnull attributeName)
         : ModelCommand("write")
     {
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         // Subclasses are responsible for calling AddArguments.
+    }
+
+    void AddCommonByIdArguments()
+    {
+        AddArgument("use-mtr-device", 0, 1, &mUseMTRDevice,
+            "Use MTRDevice instead of MTRBaseDevice to send this command. Default is false.");
+        AddArgument("expectedValueInterval", 0, UINT32_MAX, &mExpectedValueInterval, "When the write is issued using an MTRDevice (via –use-mtr-device), specify the maximum interval (in milliseconds) during which reads of the attribute will return the expected value. The default is 60000 milliseconds (60 seconds).");
+        AddArguments();
     }
 
     void AddArguments()
@@ -106,6 +143,7 @@ protected:
     }
 
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
+    chip::Optional<uint32_t> mExpectedValueInterval;
     chip::Optional<uint32_t> mDataVersion;
 
 private:

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -47,6 +47,8 @@ public:
 
     ~WriteAttribute() {}
 
+    using ModelCommand::SendCommand;
+
     CHIP_ERROR SendCommand(MTRBaseDevice * _Nonnull device, chip::EndpointId endpointId) override
     {
         id value;

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -97,6 +97,10 @@ protected:
     // Will utilize an existing PASE connection if the device is being commissioned.
     MTRBaseDevice * BaseDeviceWithNodeId(chip::NodeId nodeId);
 
+    // Returns the MTRDevice for the specified node ID.
+    // Will utilize an existing PASE connection if the device is being commissioned.
+    MTRDevice * DeviceWithNodeId(chip::NodeId nodeId);
+
     // Will log the given string and given error (as progress if success, error
     // if failure).
     void LogNSError(const char * logString, NSError * error);

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -285,6 +285,17 @@ MTRBaseDevice * CHIPCommandBridge::BaseDeviceWithNodeId(chip::NodeId nodeId)
         ?: [MTRBaseDevice deviceWithNodeID:@(nodeId) controller:controller];
 }
 
+MTRDevice * CHIPCommandBridge::DeviceWithNodeId(chip::NodeId nodeId)
+{
+    __auto_type * controller = CurrentCommissioner();
+    VerifyOrReturnValue(nil != controller, nil);
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(nodeId) controller:controller];
+    VerifyOrReturnValue(nil != device, nil);
+
+    return device;
+}
+
 void CHIPCommandBridge::StopCommissioners()
 {
     for (auto & pair : mControllers) {


### PR DESCRIPTION
#### Problem

This PR adds an optional argument to the `read-by-id` and `write-by-id` commands, allowing the use of an `MTRDevice` instead of an `MTRBaseDevice`. The two classes have different behaviors, so this option is useful for testing and debugging by allowing commands to be sent through either class.