### PR TITLE
[darwin-framework-tool] [darwin-framework-tool] Add an optional parameter to the storage view command to only show the entries for a given commissioner

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -30,6 +30,7 @@
 inline constexpr char kIdentityAlpha[] = "alpha";
 inline constexpr char kIdentityBeta[] = "beta";
 inline constexpr char kIdentityGamma[] = "gamma";
+inline constexpr char kControllerIdPrefix[] = "8DCADB14-AF1F-45D0-B084-00000000000";
 
 class CHIPCommandBridge : public Command {
 public:
@@ -68,6 +69,8 @@ public:
     }
 
     static OTAProviderDelegate * mOTADelegate;
+
+    static NSNumber * GetCommissionerFabricId(const char * identity);
 
 protected:
     // Will be called in a setting in which it's safe to touch the CHIP

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -154,10 +154,10 @@ CHIP_ERROR CHIPCommandBridge::SetUpStackWithPerControllerStorage(NSArray<NSData 
     constexpr const char * identities[] = { kIdentityAlpha, kIdentityBeta, kIdentityGamma };
     std::string commissionerName = mCommissionerName.HasValue() ? mCommissionerName.Value() : kIdentityAlpha;
     for (size_t i = 0; i < ArraySize(identities); ++i) {
-        __auto_type * uuidString = [NSString stringWithFormat:@"%@%@", @"8DCADB14-AF1F-45D0-B084-00000000000", @(i)];
+        __auto_type * fabricId = GetCommissionerFabricId(identities[i]);
+        __auto_type * uuidString = [NSString stringWithFormat:@"%@%@", @(kControllerIdPrefix), fabricId];
         __auto_type * controllerId = [[NSUUID alloc] initWithUUIDString:uuidString];
         __auto_type * vendorId = @(mCommissionerVendorId.ValueOr(chip::VendorId::TestVendor1));
-        __auto_type * fabricId = @(i + 1);
         __auto_type * nodeId = @(chip::kTestControllerNodeId);
 
         if (commissionerName.compare(identities[i]) == 0 && mCommissionerNodeId.HasValue()) {
@@ -218,7 +218,7 @@ CHIP_ERROR CHIPCommandBridge::SetUpStackWithSharedStorage(NSArray<NSData *> * pr
     constexpr const char * identities[] = { kIdentityAlpha, kIdentityBeta, kIdentityGamma };
     std::string commissionerName = mCommissionerName.HasValue() ? mCommissionerName.Value() : kIdentityAlpha;
     for (size_t i = 0; i < ArraySize(identities); ++i) {
-        __auto_type * fabricId = @(i + 1);
+        __auto_type * fabricId = GetCommissionerFabricId(identities[i]);
         __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:certificateIssuer.ipk
                                                                             fabricID:fabricId
                                                                            nocSigner:certificateIssuer.signingKey];
@@ -264,14 +264,19 @@ MTRDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mCurrent
 
 NSNumber * CHIPCommandBridge::CurrentCommissionerFabricId()
 {
-    if (mCurrentIdentity.compare(kIdentityAlpha) == 0) {
+    return GetCommissionerFabricId(mCurrentIdentity.c_str());
+}
+
+NSNumber * CHIPCommandBridge::GetCommissionerFabricId(const char * identity)
+{
+    if (strcmp(identity, kIdentityAlpha) == 0) {
         return @(1);
-    } else if (mCurrentIdentity.compare(kIdentityBeta) == 0) {
+    } else if (strcmp(identity, kIdentityBeta) == 0) {
         return @(2);
-    } else if (mCurrentIdentity.compare(kIdentityGamma) == 0) {
+    } else if (strcmp(identity, kIdentityGamma) == 0) {
         return @(3);
     } else {
-        ChipLogError(chipTool, "Unknown commissioner name: %s. Supported names are [%s, %s, %s]", mCurrentIdentity.c_str(), kIdentityAlpha,
+        ChipLogError(chipTool, "Unknown commissioner name: %s. Supported names are [%s, %s, %s]", identity, kIdentityAlpha,
             kIdentityBeta, kIdentityGamma);
         chipDie();
     }

--- a/examples/darwin-framework-tool/commands/common/ControllerStorage.h
+++ b/examples/darwin-framework-tool/commands/common/ControllerStorage.h
@@ -44,6 +44,7 @@ extern NSString * const kDarwinFrameworkToolControllerDomain;
 
 - (NSData *)valueForKey:(NSString *)key;
 - (void)storeValue:(NSData *)value forKey:key;
+- (void)print;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/examples/darwin-framework-tool/commands/common/ControllerStorage.mm
+++ b/examples/darwin-framework-tool/commands/common/ControllerStorage.mm
@@ -143,6 +143,20 @@ NSString * const kDarwinFrameworkToolControllerDomain = @"com.apple.darwin-frame
     self.storage[controllerKey] = value;
 }
 
+- (void)print
+{
+    NSLog(@"%@ (%@)", kDarwinFrameworkToolControllerDomain, _keyScopingPrefix);
+    for (NSString * controllerKey in self.storage) {
+        if (![self _isControllerScopedKey:controllerKey]) {
+            continue;
+        }
+
+        __auto_type * key = [self _controllerScopedKeyToKey:controllerKey];
+        __auto_type * data = self.storage[controllerKey];
+        NSLog(@" * %@: %@", key, data);
+    }
+}
+
 - (NSString *)_keyToControllerScopedKey:(NSString *)key
 {
     return [NSString stringWithFormat:@"%@%@", _keyScopingPrefix, key];

--- a/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.h
+++ b/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.h
@@ -33,7 +33,15 @@ public:
 class StorageViewAll : public Command
 {
 public:
-    StorageViewAll() : Command("view-all") {}
+    StorageViewAll() : Command("view")
+    {
+        AddArgument("commissioner-name", &mCommissionerName,
+                    "If specified, only the keys associated with the given commissioner will be displayed. Valid options are: "
+                    "‘alpha’, ‘beta’, ‘gamma’.");
+    }
 
     CHIP_ERROR Run() override;
+
+private:
+    chip::Optional<char *> mCommissionerName;
 };

--- a/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.mm
+++ b/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.mm
@@ -49,11 +49,22 @@ CHIP_ERROR StorageClearAll::Run()
 
 CHIP_ERROR StorageViewAll::Run()
 {
-    __auto_type * domains = GetDomains();
-    for (NSString * domain in domains) {
-        __auto_type * storage = [[PreferencesStorage alloc] initWithDomain:domain];
-        [storage print];
+    if (!mCommissionerName.HasValue()) {
+        __auto_type * domains = GetDomains();
+        for (NSString * domain in domains) {
+            __auto_type * storage = [[PreferencesStorage alloc] initWithDomain:domain];
+            [storage print];
+        }
+
+        return CHIP_NO_ERROR;
     }
+
+    const char * commissionerName = mCommissionerName.Value();
+    __auto_type * fabricId = CHIPCommandBridge::GetCommissionerFabricId(commissionerName);
+    __auto_type * uuidString = [NSString stringWithFormat:@"%@%@", @(kControllerIdPrefix), fabricId];
+    __auto_type * controllerId = [[NSUUID alloc] initWithUUIDString:uuidString];
+    __auto_type * storage = [[ControllerStorage alloc] initWithControllerID:controllerId];
+    [storage print];
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Problem

This PR adds an option to filter by controller (`identity [alpha, beta, gamma]`) when inspecting the contents of per-controller storage, making it easier to navigate. It also improves consistency in the use of `fabricId` alongside `controllerId`.
