### PR TITLE
[hotfix][darwin-framework-tool] Add missing OTA delegate for per cont…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -185,6 +185,10 @@ CHIP_ERROR CHIPCommandBridge::SetUpStackWithPerControllerStorage(NSArray<NSData 
                                                                                          intermediateCertificate:nil
                                                                                                  rootCertificate:certificateIssuer.rootCertificate];
         [params setOperationalCertificateIssuer:certificateIssuer queue:controllerStorageQueue];
+
+        __auto_type * otaDelegateQueue = dispatch_queue_create("com.chip.ota", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        [params setOTAProviderDelegate:mOTADelegate queue:otaDelegateQueue];
+
         params.productAttestationAuthorityCertificates = productAttestationAuthorityCertificates;
 
         __auto_type * controller = [[MTRDeviceController alloc] initWithParameters:params error:&error];


### PR DESCRIPTION
…roller storage

#### Problem

PR #36194 was merged despite CI failures (see https://github.com/project-chip/connectedhomeip/actions/runs/11550232815/job/32144785745).
This was unexpected and has caused the ToT to break.

This PR adds the missing delegate required to resolve the CI failure.