### PR TITLE
Support a `name` attribute for XML tags for attributes in zapxml

### DIFF
--- a/scripts/py_matter_idl/matter_idl/test_zapxml.py
+++ b/scripts/py_matter_idl/matter_idl/test_zapxml.py
@@ -360,6 +360,33 @@ class TestXmlParser(unittest.TestCase):
         )
         self.assertEqual(idl, Idl(global_structs=[struct]))
 
+    def testNameAttribute(self):
+        idl = XmlToIdl('''<?xml version="1.0"?>
+            <configurator>
+              <cluster>
+                  <name>TestCluster</name>
+                  <code>20</code>
+
+                  <attribute side="server" code="0x0002" name="SubjectsPerAccessControlEntry" define="SUBJECTS_PER_ACCESS_CONTROL_ENTRY" type="int16u" min="4" default="4">
+                     <mandatoryConform/>
+                   </attribute>
+              </cluster>
+            </configurator>
+        ''')
+        self.assertEqual(idl,
+                         Idl(clusters=[
+                             Cluster(name='TestCluster', code=20,
+                                     attributes=[
+                                         Attribute(
+                                             definition=Field(
+                                                 data_type=DataType(name='int16u', min_value=4),
+                                                 code=2,
+                                                 name='SubjectsPerAccessControlEntry',
+                                             ),
+                                             qualities=AttributeQuality.READABLE,
+                                             readacl=AccessPrivilege.VIEW,
+                                             writeacl=AccessPrivilege.OPERATE)])]))
+
     def testStruct(self):
         idl = XmlToIdl('''<?xml version="1.0"?>
             <configurator>

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/parsing.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/parsing.py
@@ -81,10 +81,12 @@ def AttrsToAttribute(attrs) -> Attribute:
     if 'max' in attrs:
         data_type.max_value = ParseInt(attrs['max'], data_type)
 
+    name = attrs['name'] if 'name' in attrs else ''
+
     field = Field(
         data_type=data_type,
         code=ParseInt(attrs['code']),
-        name='',
+        name=name,
         is_list=(attrs['type'].lower() == 'array')
     )
 


### PR DESCRIPTION
This is an upcoming change in zap, support it in zapxml