### PR TITLE
[darwin-framework-tool] Enable leak checking by default if built for …

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -45,7 +45,7 @@ declare_args() {
   generate_compilation_database = false
 
   # Enable automatic leak checks before the application exits
-  enable_leak_checking = false
+  enable_leak_checking = !is_asan && target_os == "mac"
 }
 
 sdk = "macosx"


### PR DESCRIPTION
…mac with ASan disabled

#### Problem

Building `darwin-framework-tool` on macOS with leak checking enabled by default would make it easier to catch memory leaks. Not everyone knows about the build flags, so having this as the default could help others spot leaks I might have missed.
