### PR TITLE
Install chip-testing package in the final docker image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -40,6 +40,7 @@ RUN set -x \
     clang \
     clang-format \
     clang-tidy \
+    cmake \
     curl \
     flex \
     gcc \
@@ -91,30 +92,6 @@ RUN set -x \
     zlib1g-dev \
     && git lfs install \
     && : # last line
-
-# Cmake (Mbed OS requires >=3.19.0-rc3 version which is not available in Ubuntu 20.04 repository)
-RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") \
-    set -x \
-    && (cd /tmp \
-    && wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh \
-    && sh cmake-3.19.3-Linux-x86_64.sh --exclude-subdir --prefix=/usr/local \
-    && rm -rf cmake-3.19.3-Linux-x86_64.sh) \
-    && exec bash \
-    ;; \
-    "linux/arm64") \
-    set -x \
-    && (cd /tmp \
-    && wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-aarch64.sh \
-    && sh cmake-3.19.3-Linux-aarch64.sh --exclude-subdir --prefix=/usr/local \
-    && rm -rf cmake-3.19.3-Linux-aarch64.sh) \
-    && exec bash \
-    ;; \
-    *) \
-    test -n "$TARGETPLATFORM" \
-    echo "Unsupported platform ${TARGETPLATFORM}" \
-    ;; \
-    esac
 
 # Python 3 and PIP
 RUN set -x \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -296,4 +296,6 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 # PIP requires MASON package compilation, which seems to require a JDK
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
-RUN pip install --break-system-packages --no-cache-dir python_lib/controller/python/chip*.whl
+RUN pip install --break-system-packages --no-cache-dir \
+    python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
+    python_lib/controller/python/chip*.whl

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -43,9 +43,10 @@ RUN set -x \
     cmake \
     curl \
     flex \
-    gcc \
     g++ \
+    gcc \
     git \
+    git-lfs \
     gperf \
     iproute2 \
     jq \
@@ -55,11 +56,12 @@ RUN set -x \
     libcairo2-dev \
     libdbus-1-dev \
     libdbus-glib-1-dev \
+    libdmalloc-dev \
     libgif-dev \
+    libgirepository1.0-dev \
     libglib2.0-dev \
     libical-dev \
     libjpeg-dev \
-    libdmalloc-dev \
     libmbedtls-dev \
     libncurses5-dev \
     libncursesw5-dev \
@@ -84,12 +86,12 @@ RUN set -x \
     python3-venv \
     rsync \
     shellcheck \
+    software-properties-common \
     strace \
     systemd \
     udev \
     unzip \
     wget \
-    git-lfs \
     zlib1g-dev \
     && git lfs install \
     && : # last line

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -80,6 +80,7 @@ RUN set -x \
     pkg-config \
     python3 \
     python3-dev \
+    python3-pip \
     python3-venv \
     rsync \
     shellcheck \
@@ -93,18 +94,9 @@ RUN set -x \
     && git lfs install \
     && : # last line
 
-# Python 3 and PIP
 RUN set -x \
-    && DEBIAN_FRONTEND=noninteractive  apt-get install -y \
-    libgirepository1.0-dev \
-    software-properties-common \
-    && add-apt-repository universe \
-    && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3 get-pip.py --break-system-packages \
-    && : # last line
-
-RUN set -x \
-    && pip3 install attrs coloredlogs PyGithub pygit future portpicker mobly click cxxfilt ghapi pandas tabulate --break-system-packages \
+    && pip3 install --break-system-packages \
+    attrs coloredlogs PyGithub pygit future portpicker mobly click cxxfilt ghapi pandas tabulate \
     && : # last line
 
 # build and install gn


### PR DESCRIPTION
### Problem

The chip-testing is not installed which prevents test scripts to run properly.

Fixes https://github.com/project-chip/certification-tool/issues/473

### Changes

- Install chip-testing with PIP
- Install `pip` and `cmake` via APT

### Testing

```
docker run -it --rm --name cert chip-cert-bins:latest /bin/bash
root@736688122ffc:~# python3
Python 3.12.3 (main, Sep 11 2024, 14:17:37) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import chip.testing.tasks
>>> 
```