### PR TITLE
Scenes-cluster: move non-template things into non-template functions to save flash

### DIFF
--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -54,6 +54,24 @@ namespace ScenesManagement {
 
 namespace {
 
+Protocols::InteractionModel::Status ResponseStatus(CHIP_ERROR err)
+{
+    if (CHIP_ERROR_NOT_FOUND == err)
+    {
+        return Protocols::InteractionModel::Status::NotFound;
+    }
+    if (CHIP_ERROR_NO_MEMORY == err)
+    {
+        return Protocols::InteractionModel::Status::ResourceExhausted;
+    }
+    if (CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) == err)
+    {
+        // TODO: Confirm if we need to add UnsupportedAttribute status as a return for Scene Commands
+        return Protocols::InteractionModel::Status::InvalidCommand;
+    }
+    return StatusIB(err).mStatus;
+}
+
 /// @brief Generate and add a response to a command handler context if err parameter is not CHIP_NO_ERROR
 /// @tparam ResponseType Type of response, depends on the command
 /// @param ctx Command Handler context where to add reponse
@@ -65,24 +83,7 @@ CHIP_ERROR AddResponseOnError(CommandHandlerInterface::HandlerContext & ctx, Res
 {
     if (CHIP_NO_ERROR != err)
     {
-        // TODO : Properly fix mapping between error types (issue https://github.com/project-chip/connectedhomeip/issues/26885)
-        if (CHIP_ERROR_NOT_FOUND == err)
-        {
-            resp.status = to_underlying(Protocols::InteractionModel::Status::NotFound);
-        }
-        else if (CHIP_ERROR_NO_MEMORY == err)
-        {
-            resp.status = to_underlying(Protocols::InteractionModel::Status::ResourceExhausted);
-        }
-        else if (CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute) == err)
-        {
-            // TODO: Confirm if we need to add UnsupportedAttribute status as a return for Scene Commands
-            resp.status = to_underlying(Protocols::InteractionModel::Status::InvalidCommand);
-        }
-        else
-        {
-            resp.status = to_underlying(StatusIB(err).mStatus);
-        }
+        resp.status = to_underlying(ResponseStatus(err));
         ctx.mCommandHandler.AddResponse(ctx.mRequestPath, resp);
     }
     return err;
@@ -100,20 +101,22 @@ CHIP_ERROR AddResponseOnError(CommandHandlerInterface::HandlerContext & ctx, Res
     return AddResponseOnError(ctx, resp, StatusIB(status).ToChipError());
 }
 
-template <typename ResponseType>
-CHIP_ERROR UpdateLastConfiguredBy(HandlerContext & ctx, ResponseType resp)
+Status SetLastConfiguredBy(HandlerContext & ctx)
 {
-    Access::SubjectDescriptor descriptor = ctx.mCommandHandler.GetSubjectDescriptor();
-    Status status                        = Status::Success;
+    const Access::SubjectDescriptor descriptor = ctx.mCommandHandler.GetSubjectDescriptor();
 
     if (AuthMode::kCase == descriptor.authMode)
     {
-        status = Attributes::LastConfiguredBy::Set(ctx.mRequestPath.mEndpointId, descriptor.subject);
+        return Attributes::LastConfiguredBy::Set(ctx.mRequestPath.mEndpointId, descriptor.subject);
     }
-    else
-    {
-        status = Attributes::LastConfiguredBy::SetNull(ctx.mRequestPath.mEndpointId);
-    }
+
+    return Attributes::LastConfiguredBy::SetNull(ctx.mRequestPath.mEndpointId);
+}
+
+template <typename ResponseType>
+CHIP_ERROR UpdateLastConfiguredBy(HandlerContext & ctx, ResponseType resp)
+{
+    Status status = SetLastConfiguredBy(ctx);
 
     // LastConfiguredBy is optional, so we don't want to fail the command if it fails to update
     VerifyOrReturnValue(!(Status::Success == status || Status::UnsupportedAttribute == status), CHIP_NO_ERROR);

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -99,6 +99,8 @@ CHIP_ERROR AddResponseOnError(CommandHandlerInterface::HandlerContext & ctx, Res
 template <typename ResponseType>
 CHIP_ERROR AddResponseOnError(CommandHandlerInterface::HandlerContext & ctx, ResponseType & resp, Status status)
 {
+    // TODO: this seems odd: we convert `status` to a CHIP_ERROR and then back to status. This seems
+    //       potentially lossy and not ideal.
     return AddResponseOnError(ctx, resp, StatusIB(status).ToChipError());
 }
 

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -56,6 +56,7 @@ namespace {
 
 Protocols::InteractionModel::Status ResponseStatus(CHIP_ERROR err)
 {
+    // TODO : Properly fix mapping between error types (issue https://github.com/project-chip/connectedhomeip/issues/26885)
     if (CHIP_ERROR_NOT_FOUND == err)
     {
         return Protocols::InteractionModel::Status::NotFound;


### PR DESCRIPTION
Scenes seems to use templates quite a bit so there is a code size multipler for template code. Switched code to use non-template functions for some parts that do not need to be templates.

This saves some flash