### PR TITLE
[Telink] Add support for groups multicast control

### DIFF
--- a/config/telink/chip-module/Kconfig.defaults
+++ b/config/telink/chip-module/Kconfig.defaults
@@ -83,7 +83,12 @@ config COMMON_LIBC_MALLOC_ARENA_SIZE
     default 12288
 
 config NET_IPV6_MLD
-    default n
+    default n if PM
+    default y
+
+config NET_IF_MCAST_IPV6_ADDR_COUNT
+    default 8 if PM
+    default 15
 
 # Network buffers
 config NET_PKT_RX_COUNT
@@ -271,6 +276,10 @@ config OPENTHREAD_MANUAL_START
 config OPENTHREAD_DEFAULT_TX_POWER
     default 3 if PM
     default 9
+
+config OPENTHREAD_IP6_MAX_EXT_MCAST_ADDRS
+    default 2 if PM
+    default 8
 
 endif # NET_L2_OPENTHREAD
 

--- a/examples/lighting-app/telink/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/telink/include/CHIPProjectConfig.h
@@ -35,3 +35,9 @@
 //  Until this is improved in OpenThread we need to increase the retransmission
 //  interval to survive the stall.
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (1000_ms32)
+
+// ========== Multicast groups Configuration Overrides =========
+#undef CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC
+#define CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC 2
+
+#define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_SUBJECTS_PER_ENTRY (4 * CHIP_CONFIG_MAX_GROUP_ENDPOINTS_PER_FABRIC)


### PR DESCRIPTION
Add support for up to 8 groups for lighting-app.
Tested on Telink B9x, W91 platform. 
Increased Thread multicast configs for ble-thread plarforms 
