### PR TITLE
[Silabs]Split UniqueId and PersistentUniqueId

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -403,14 +403,14 @@ CHIP_ERROR Storage::GetManufacturingDate(uint8_t * value, size_t max, size_t & s
     return SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_ManufacturingDate, (char *) value, max, size);
 }
 
-CHIP_ERROR Storage::SetUniqueId(const uint8_t * value, size_t size)
+CHIP_ERROR Storage::SetPersistentUniqueId(const uint8_t * value, size_t size)
 {
-    return SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_UniqueId, value, size);
+    return SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_PersistentUniqueId, value, size);
 }
 
-CHIP_ERROR Storage::GetUniqueId(uint8_t * value, size_t max, size_t & size)
+CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & size)
 {
-    return SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_UniqueId, value, max, size);
+    return SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_PersistentUniqueId, value, max, size);
 }
 
 //

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -470,14 +470,14 @@ CHIP_ERROR Storage::GetManufacturingDate(uint8_t * value, size_t max, size_t & s
     return Flash::Get(Parameters::ID::kManufacturingDate, value, max, size);
 }
 
-CHIP_ERROR Storage::SetUniqueId(const uint8_t * value, size_t size)
+CHIP_ERROR Storage::SetPersistentUniqueId(const uint8_t * value, size_t size)
 {
-    return Flash::Set(Parameters::ID::kUniqueId, value, size);
+    return Flash::Set(Parameters::ID::kPersistentUniqueId, value, size);
 }
 
-CHIP_ERROR Storage::GetUniqueId(uint8_t * value, size_t max, size_t & size)
+CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & size)
 {
-    return Flash::Get(Parameters::ID::kUniqueId, value, max, size);
+    return Flash::Get(Parameters::ID::kPersistentUniqueId, value, max, size);
 }
 
 //

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -120,42 +120,46 @@ public:
     static constexpr Key kConfigKey_hostname               = SilabsConfigKey(kMatterFactory_KeyBase, 0x15);
     static constexpr Key kConfigKey_clientid               = SilabsConfigKey(kMatterFactory_KeyBase, 0x16);
     static constexpr Key kConfigKey_Test_Event_Trigger_Key = SilabsConfigKey(kMatterFactory_KeyBase, 0x17);
-    static constexpr Key kConfigKey_UniqueId               = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
-    static constexpr Key kConfigKey_Creds_KeyId            = SilabsConfigKey(kMatterFactory_KeyBase, 0x20);
-    static constexpr Key kConfigKey_Creds_Base_Addr        = SilabsConfigKey(kMatterFactory_KeyBase, 0x21);
-    static constexpr Key kConfigKey_Creds_DAC_Offset       = SilabsConfigKey(kMatterFactory_KeyBase, 0x22);
-    static constexpr Key kConfigKey_Creds_DAC_Size         = SilabsConfigKey(kMatterFactory_KeyBase, 0x23);
-    static constexpr Key kConfigKey_Creds_PAI_Offset       = SilabsConfigKey(kMatterFactory_KeyBase, 0x24);
-    static constexpr Key kConfigKey_Creds_PAI_Size         = SilabsConfigKey(kMatterFactory_KeyBase, 0x25);
-    static constexpr Key kConfigKey_Creds_CD_Offset        = SilabsConfigKey(kMatterFactory_KeyBase, 0x26);
-    static constexpr Key kConfigKey_Creds_CD_Size          = SilabsConfigKey(kMatterFactory_KeyBase, 0x27);
-    static constexpr Key kConfigKey_Provision_Request      = SilabsConfigKey(kMatterFactory_KeyBase, 0x28);
-    static constexpr Key kConfigKey_Provision_Version      = SilabsConfigKey(kMatterFactory_KeyBase, 0x29);
-
-    static constexpr Key kOtaTlvEncryption_KeyId = SilabsConfigKey(kMatterFactory_KeyBase, 0x30);
+    // kConfigKey_PersistentUniqueId is the inputkey in the generating of the Rotating Device ID
+    // SHALL NOT be the same as the UniqueID attribute exposed in the Basic Information cluster.
+    static constexpr Key kConfigKey_PersistentUniqueId = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);
+    static constexpr Key kConfigKey_Creds_KeyId        = SilabsConfigKey(kMatterFactory_KeyBase, 0x20);
+    static constexpr Key kConfigKey_Creds_Base_Addr    = SilabsConfigKey(kMatterFactory_KeyBase, 0x21);
+    static constexpr Key kConfigKey_Creds_DAC_Offset   = SilabsConfigKey(kMatterFactory_KeyBase, 0x22);
+    static constexpr Key kConfigKey_Creds_DAC_Size     = SilabsConfigKey(kMatterFactory_KeyBase, 0x23);
+    static constexpr Key kConfigKey_Creds_PAI_Offset   = SilabsConfigKey(kMatterFactory_KeyBase, 0x24);
+    static constexpr Key kConfigKey_Creds_PAI_Size     = SilabsConfigKey(kMatterFactory_KeyBase, 0x25);
+    static constexpr Key kConfigKey_Creds_CD_Offset    = SilabsConfigKey(kMatterFactory_KeyBase, 0x26);
+    static constexpr Key kConfigKey_Creds_CD_Size      = SilabsConfigKey(kMatterFactory_KeyBase, 0x27);
+    static constexpr Key kConfigKey_Provision_Request  = SilabsConfigKey(kMatterFactory_KeyBase, 0x28);
+    static constexpr Key kConfigKey_Provision_Version  = SilabsConfigKey(kMatterFactory_KeyBase, 0x29);
+    static constexpr Key kOtaTlvEncryption_KeyId       = SilabsConfigKey(kMatterFactory_KeyBase, 0x30);
 
     // Matter Config Keys
-    static constexpr Key kConfigKey_ServiceConfig         = SilabsConfigKey(kMatterConfig_KeyBase, 0x01);
-    static constexpr Key kConfigKey_PairedAccountId       = SilabsConfigKey(kMatterConfig_KeyBase, 0x02);
-    static constexpr Key kConfigKey_ServiceId             = SilabsConfigKey(kMatterConfig_KeyBase, 0x03);
-    static constexpr Key kConfigKey_LastUsedEpochKeyId    = SilabsConfigKey(kMatterConfig_KeyBase, 0x05);
-    static constexpr Key kConfigKey_FailSafeArmed         = SilabsConfigKey(kMatterConfig_KeyBase, 0x06);
-    static constexpr Key kConfigKey_GroupKey              = SilabsConfigKey(kMatterConfig_KeyBase, 0x07);
-    static constexpr Key kConfigKey_HardwareVersion       = SilabsConfigKey(kMatterConfig_KeyBase, 0x08);
-    static constexpr Key kConfigKey_RegulatoryLocation    = SilabsConfigKey(kMatterConfig_KeyBase, 0x09);
-    static constexpr Key kConfigKey_CountryCode           = SilabsConfigKey(kMatterConfig_KeyBase, 0x0A);
-    static constexpr Key kConfigKey_WiFiSSID              = SilabsConfigKey(kMatterConfig_KeyBase, 0x0C);
-    static constexpr Key kConfigKey_WiFiPSK               = SilabsConfigKey(kMatterConfig_KeyBase, 0x0D);
-    static constexpr Key kConfigKey_WiFiSEC               = SilabsConfigKey(kMatterConfig_KeyBase, 0x0E);
-    static constexpr Key kConfigKey_GroupKeyBase          = SilabsConfigKey(kMatterConfig_KeyBase, 0x0F);
-    static constexpr Key kConfigKey_LockUser              = SilabsConfigKey(kMatterConfig_KeyBase, 0x10);
-    static constexpr Key kConfigKey_Credential            = SilabsConfigKey(kMatterConfig_KeyBase, 0x11);
-    static constexpr Key kConfigKey_LockUserName          = SilabsConfigKey(kMatterConfig_KeyBase, 0x12);
-    static constexpr Key kConfigKey_CredentialData        = SilabsConfigKey(kMatterConfig_KeyBase, 0x13);
-    static constexpr Key kConfigKey_UserCredentials       = SilabsConfigKey(kMatterConfig_KeyBase, 0x14);
-    static constexpr Key kConfigKey_WeekDaySchedules      = SilabsConfigKey(kMatterConfig_KeyBase, 0x15);
-    static constexpr Key kConfigKey_YearDaySchedules      = SilabsConfigKey(kMatterConfig_KeyBase, 0x16);
-    static constexpr Key kConfigKey_HolidaySchedules      = SilabsConfigKey(kMatterConfig_KeyBase, 0x17);
+    static constexpr Key kConfigKey_ServiceConfig      = SilabsConfigKey(kMatterConfig_KeyBase, 0x01);
+    static constexpr Key kConfigKey_PairedAccountId    = SilabsConfigKey(kMatterConfig_KeyBase, 0x02);
+    static constexpr Key kConfigKey_ServiceId          = SilabsConfigKey(kMatterConfig_KeyBase, 0x03);
+    static constexpr Key kConfigKey_LastUsedEpochKeyId = SilabsConfigKey(kMatterConfig_KeyBase, 0x05);
+    static constexpr Key kConfigKey_FailSafeArmed      = SilabsConfigKey(kMatterConfig_KeyBase, 0x06);
+    static constexpr Key kConfigKey_GroupKey           = SilabsConfigKey(kMatterConfig_KeyBase, 0x07);
+    static constexpr Key kConfigKey_HardwareVersion    = SilabsConfigKey(kMatterConfig_KeyBase, 0x08);
+    static constexpr Key kConfigKey_RegulatoryLocation = SilabsConfigKey(kMatterConfig_KeyBase, 0x09);
+    static constexpr Key kConfigKey_CountryCode        = SilabsConfigKey(kMatterConfig_KeyBase, 0x0A);
+    static constexpr Key kConfigKey_WiFiSSID           = SilabsConfigKey(kMatterConfig_KeyBase, 0x0C);
+    static constexpr Key kConfigKey_WiFiPSK            = SilabsConfigKey(kMatterConfig_KeyBase, 0x0D);
+    static constexpr Key kConfigKey_WiFiSEC            = SilabsConfigKey(kMatterConfig_KeyBase, 0x0E);
+    static constexpr Key kConfigKey_GroupKeyBase       = SilabsConfigKey(kMatterConfig_KeyBase, 0x0F);
+    static constexpr Key kConfigKey_LockUser           = SilabsConfigKey(kMatterConfig_KeyBase, 0x10);
+    static constexpr Key kConfigKey_Credential         = SilabsConfigKey(kMatterConfig_KeyBase, 0x11);
+    static constexpr Key kConfigKey_LockUserName       = SilabsConfigKey(kMatterConfig_KeyBase, 0x12);
+    static constexpr Key kConfigKey_CredentialData     = SilabsConfigKey(kMatterConfig_KeyBase, 0x13);
+    static constexpr Key kConfigKey_UserCredentials    = SilabsConfigKey(kMatterConfig_KeyBase, 0x14);
+    static constexpr Key kConfigKey_WeekDaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x15);
+    static constexpr Key kConfigKey_YearDaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x16);
+    static constexpr Key kConfigKey_HolidaySchedules   = SilabsConfigKey(kMatterConfig_KeyBase, 0x17);
+    // UniqueId exposed in the Basic Information cluster. It is cleared on factoryreset
+    // We will generate a random ID, if none was previously provided.
+    static constexpr Key kConfigKey_UniqueId              = SilabsConfigKey(kMatterConfig_KeyBase, 0x18);
     static constexpr Key kConfigKey_OpKeyMap              = SilabsConfigKey(kMatterConfig_KeyBase, 0x20);
     static constexpr Key kConfigKey_BootCount             = SilabsConfigKey(kMatterConfig_KeyBase, 0x21);
     static constexpr Key kConfigKey_TotalOperationalHours = SilabsConfigKey(kMatterConfig_KeyBase, 0x22);

--- a/src/platform/silabs/provision/ProvisionStorage.h
+++ b/src/platform/silabs/provision/ProvisionStorage.h
@@ -62,18 +62,18 @@ enum ID : uint16_t
     kCertToolPath  = 0x0137,
     kPylinkLib     = 0x0138,
     // Instance Info,
-    kSerialNumber      = 0x0141,
-    kVendorId          = 0x0142,
-    kVendorName        = 0x0143,
-    kProductId         = 0x0144,
-    kProductName       = 0x0145,
-    kProductLabel      = 0x0146,
-    kProductUrl        = 0x0147,
-    kPartNumber        = 0x0148,
-    kHwVersion         = 0x0151,
-    kHwVersionStr      = 0x0152,
-    kManufacturingDate = 0x0153,
-    kUniqueId          = 0x0154,
+    kSerialNumber       = 0x0141,
+    kVendorId           = 0x0142,
+    kVendorName         = 0x0143,
+    kProductId          = 0x0144,
+    kProductName        = 0x0145,
+    kProductLabel       = 0x0146,
+    kProductUrl         = 0x0147,
+    kPartNumber         = 0x0148,
+    kHwVersion          = 0x0151,
+    kHwVersionStr       = 0x0152,
+    kManufacturingDate  = 0x0153,
+    kPersistentUniqueId = 0x0154,
     // Commissionable Data,
     kDiscriminator     = 0x0161,
     kSpake2pPasscode   = 0x0162,
@@ -143,7 +143,7 @@ struct Storage : public GenericStorage,
     static constexpr size_t kPartNumberLengthMax         = 32;
     static constexpr size_t kHardwareVersionStrLengthMax = 32;
     static constexpr size_t kManufacturingDateLengthMax  = 11; // yyyy-mm-dd + \0
-    static constexpr size_t kUniqueIdLengthMax           = 16;
+    static constexpr size_t kPersistentUniqueIdMaxLength = 16;
     static constexpr size_t kSpake2pVerifierB64LengthMax = BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_VerifierSerialized_Length) + 1;
     static constexpr size_t kSpake2pSaltB64LengthMax     = BASE64_ENCODED_LEN(chip::Crypto::kSpake2p_Max_PBKDF_Salt_Length) + 1;
     static constexpr size_t kFirmwareInfoSizeMax         = 32;
@@ -259,8 +259,10 @@ private:
     CHIP_ERROR SetHardwareVersionString(const char * value, size_t len);
     CHIP_ERROR SetManufacturingDate(const char * value, size_t len);
     CHIP_ERROR GetManufacturingDate(uint8_t * value, size_t max, size_t & size);
-    CHIP_ERROR SetUniqueId(const uint8_t * value, size_t size);
-    CHIP_ERROR GetUniqueId(uint8_t * value, size_t max, size_t & size);
+    // PersistentUniqueId is used to generate the RotatingUniqueId
+    // This PersistentUniqueId SHALL NOT be the same as the UniqueID attribute exposed in the Basic Information cluster.
+    CHIP_ERROR SetPersistentUniqueId(const uint8_t * value, size_t size);
+    CHIP_ERROR GetPersistentUniqueId(uint8_t * value, size_t max, size_t & size);
     // CommissionableDataProvider
     CHIP_ERROR SetSetupDiscriminator(uint16_t value);
     CHIP_ERROR SetSpake2pIterationCount(uint32_t value);


### PR DESCRIPTION
We mistakenly used the same Unique ID for the rotation Device ID and the UniqueID attribute from the basic information cluster. But they shall not be the same.

Our previously provisioned UniqueID remains untouched but it is now renamed PersitentUniqueID to make it clear it is not the same as the UniqueId Attribute as presented in spec. This PersitentUniqueId, once provision for example, at manufacturing time, stays on the device unaltered.

The UniqueID attribute from the basicInformation value is now stored in our NVM3 config section. It is erased on factory reset. After a factory reset, at init, we generate a random unique id. A user can store a New UniqueID at runtime if he decides to with StoreUniqueId()
This code already exists so the only change in this PR on this topic is having the kConfigKey_UniqueId in the NVM3 config section which is erased on factory reset

