### PR TITLE
[v1.4] OpenThread: ClearAllSrpHostAndServices should be guarded with CHIP_DE…

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -189,6 +189,7 @@ void GenericThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * c
         status = Status::kUnknownError;
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     if (status == Status::kSuccess && ThreadStackMgrImpl().IsThreadAttached())
     {
         Thread::OperationalDataset currentDataset;
@@ -206,6 +207,7 @@ void GenericThreadDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * c
             status = Status::kUnknownError;
         }
     }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
     if (status == Status::kSuccess &&
         DeviceLayer::ThreadStackMgrImpl().AttachToThreadNetwork(mStagingNetwork, callback) != CHIP_NO_ERROR)


### PR DESCRIPTION
…VICE_CONFIG_ENABLE_THREAD_SRP_CLIENT (#36284)

The code block added in #35065 should be guarded, if the thread stack manager is not pulled in then this function is not available and breaks the compilation.

---
Cherry-picking #36284 on v1.4-branch