### PR TITLE
[Matter.framework] Invalidate the CASE session if something calls Tri…

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -188,6 +188,12 @@ Optional<SessionHandle> CASESessionManager::FindExistingSession(const ScopedNode
         peerId, MakeOptional(Transport::SecureSession::Type::kCASE), transportPayloadCapability);
 }
 
+void CASESessionManager::ReleaseSession(const ScopedNodeId & peerId)
+{
+    auto * session = mConfig.sessionSetupPool->FindSessionSetup(peerId, false);
+    ReleaseSession(session);
+}
+
 void CASESessionManager::ReleaseSession(OperationalSessionSetup * session)
 {
     if (session != nullptr)

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -142,6 +142,7 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                 TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
 
+    void ReleaseSession(const ScopedNodeId & peerId);
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 
     void ReleaseAllSessions();

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -204,6 +204,16 @@ public:
         return nullptr;
     }
 
+    CASESessionManager * CASESessionMgr()
+    {
+        if (mSystemState)
+        {
+            return mSystemState->CASESessionMgr();
+        }
+
+        return nullptr;
+    }
+
     Messaging::ExchangeManager * ExchangeMgr()
     {
         if (mSystemState != nullptr)

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -179,6 +179,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)invalidateCASESessionForNode:(NSNumber *)nodeID;
 
 /**
+ * Invalidate the CASE session establishment for the specified node ID.
+ * Must not be called on the Matter event queue.
+ */
+- (void)invalidateCASESessionEstablishmentForNode:(NSNumber *)nodeID;
+
+/**
  * Download log of the desired type from the device.
  */
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1619,6 +1619,17 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     [self syncRunOnWorkQueue:block error:nil];
 }
 
+- (void)invalidateCASESessionEstablishmentForNode:(NSNumber *)nodeID;
+{
+    auto block = ^{
+        auto caseSessionMgr = self->_cppCommissioner->CASESessionMgr();
+        VerifyOrDie(caseSessionMgr != nullptr);
+        caseSessionMgr->ReleaseSession(self->_cppCommissioner->GetPeerScopedId(nodeID.unsignedLongLongValue));
+    };
+
+    [self syncRunOnWorkQueue:block error:nil];
+}
+
 - (void)operationalInstanceAdded:(NSNumber *)nodeID
 {
     // Don't use deviceForNodeID here, because we don't want to create the

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -898,6 +898,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
             subscriptionCallback->ResetResubscriptionBackoff();
         }
         readClientToResubscribe->TriggerResubscribeIfScheduled(reason.UTF8String);
+    } else if (_internalDeviceState == MTRInternalDeviceStateSubscribing && nodeLikelyReachable) {
+        // If we have reason to suspect that the node is now reachable and we haven’t established a
+        // CASE session yet, let’s consider it to be stalled and invalidate the pairing session.
+        dispatch_async(self.queue, ^{
+            [[self _concreteController] invalidateCASESessionEstablishmentForNode:self->_nodeID];
+        });
     }
 }
 


### PR DESCRIPTION
…ggerResubscriptionWithReason and it has not been established yet

#### Problem

When setting up the initial subscription and it appears to be stuck, let’s cancel the session establishment. This will cause the session to fail, and the error will be caught by the following GitHub repository: https://github.com/project-chip/connectedhomeip/blob/7df767603817b737bd2d173d30da9751492bca39/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm#L2456
