### PR TITLE
[darwin-framework-tool][interactive] Add Ctrl+Z as a shortcut key to …

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -128,6 +128,8 @@ protected:
 
     void RestartCommissioners();
 
+    void SuspendOrResumeCommissioners();
+
 private:
     CHIP_ERROR InitializeCommissioner(
         std::string key, chip::FabricId fabricId, const chip::Credentials::AttestationTrustStore * trustStore);

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -358,6 +358,16 @@ void CHIPCommandBridge::ShutdownCommissioner()
     [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
 }
 
+void CHIPCommandBridge::SuspendOrResumeCommissioners()
+{
+    for (auto & pair : mControllers) {
+        __auto_type * commissioner = pair.second;
+        if (commissioner.running) {
+            commissioner.suspended ? [commissioner resume] : [commissioner suspend];
+        }
+    }
+}
+
 CHIP_ERROR CHIPCommandBridge::StartWaiting(chip::System::Clock::Timeout duration)
 {
     auto waitingUntil = std::chrono::system_clock::now() + std::chrono::duration_cast<std::chrono::seconds>(duration);

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -30,9 +30,10 @@
 constexpr char kInteractiveModeInstruction[] = "╔══════════════════════════════════════════════════════════════════╗\n"
                                                "║                        Interactive Mode                          ║\n"
                                                "╠══════════════════════════════════════════════════════════════════╣\n"
-                                               "║ Stop and restart stack: [Ctrl+_] & [Ctrl+^ ]                     ║\n"
-                                               "║ Trigger exit(0)       : [Ctrl+@]                                 ║\n"
-                                               "║ Quit Interactive      : 'quit()' or `quit`                       ║\n"
+                                               "║ Stop and restart stack    : [Ctrl+_] & [Ctrl+^ ]                 ║\n"
+                                               "║ Suspend/Resume controllers: [Ctrl+Z]                             ║\n"
+                                               "║ Trigger exit(0)           : [Ctrl+@]                             ║\n"
+                                               "║ Quit Interactive          : 'quit()' or `quit`                   ║\n"
                                                "╚══════════════════════════════════════════════════════════════════╝\n";
 constexpr char kInteractiveModePrompt[] = ">>> ";
 constexpr char kInteractiveModeHistoryFilePath[] = "/tmp/darwin_framework_tool_history";
@@ -70,6 +71,22 @@ public:
     CHIP_ERROR RunCommand() override
     {
         StopCommissioners();
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
+};
+
+class SuspendOrResumeCommand : public CHIPCommandBridge {
+public:
+    SuspendOrResumeCommand()
+        : CHIPCommandBridge("suspend")
+    {
+    }
+
+    CHIP_ERROR RunCommand() override
+    {
+        SuspendOrResumeCommissioners();
         return CHIP_NO_ERROR;
     }
 
@@ -312,6 +329,13 @@ el_status_t StopFunction()
     return CSstay;
 }
 
+el_status_t SuspendOrResumeFunction()
+{
+    SuspendOrResumeCommand cmd;
+    cmd.RunCommand();
+    return CSstay;
+}
+
 el_status_t ExitFunction()
 {
     exit(0);
@@ -333,6 +357,7 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     el_bind_key(CTL('^'), RestartFunction);
     el_bind_key(CTL('_'), StopFunction);
     el_bind_key(CTL('@'), ExitFunction);
+    el_bind_key(CTL('Z'), SuspendOrResumeFunction);
 
     char * command = nullptr;
     int status;


### PR DESCRIPTION
…suspend or resume the running controllers

#### Problem

This PR introduces a new shortcut, ‘Ctrl+Z’, to suspend or resume the controllers in interactive mode.