### PR TITLE
Update zapxml python parsing to not log conformance as warnings on parsing

### DIFF
--- a/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
+++ b/scripts/py_matter_idl/matter_idl/data_model_xml/handlers/handlers.py
@@ -343,10 +343,7 @@ class AttributeHandler(BaseHandler):
             if "nullable" in attrs and attrs["nullable"] != "false":
                 self._attribute.definition.qualities |= FieldQuality.NULLABLE
             return BaseHandler(self.context, handled=HandledDepth.SINGLE_TAG)
-        elif name == "optionalConform":
-            self._attribute.definition.qualities |= FieldQuality.OPTIONAL
-            return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
-        elif name == "otherwiseConform":
+        elif name in {"optionalConform", "otherwiseConform"}:
             self._attribute.definition.qualities |= FieldQuality.OPTIONAL
             return BaseHandler(self.context, handled=HandledDepth.ENTIRE_TREE)
         elif name == "mandatoryConform":


### PR DESCRIPTION
Since we added conformance in zapXML our tests are very noisy like:

```
...
INFO    WARNING:root:TAG configurator::cluster::attribute::mandatoryConform was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml:71:25
INFO    WARNING:root:TAG configurator::cluster::attribute::optionalConform was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml:77:24
INFO    WARNING:root:TAG configurator::cluster::command::otherwiseConform::mandatoryConform::command was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml:99:34
INFO    WARNING:root:TAG configurator::cluster::command::otherwiseConform::mandatoryConform was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml:100:8
INFO    WARNING:root:TAG configurator::cluster::command::otherwiseConform::optionalConform was not handled/recognized at src/app/zap-templates/zcl/data-model/chip/operational-state-rvc-cluster.xml:101:26
...
```

This makes the parser skip the conformance tags alltogether since they are not part of matter IDL AST.