### PR TITLE
Add a largeMessage property support to Commands based on the quality setting in xml.

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -241,6 +241,8 @@ DataModel::CommandEntry CommandEntryFrom(const ConcreteClusterPath & clusterPath
     entry.info.flags.Set(DataModel::CommandQualityFlags::kFabricScoped,
                          CommandIsFabricScoped(clusterPath.mClusterId, clusterCommandId));
 
+    entry.info.flags.Set(DataModel::CommandQualityFlags::kLargeMessage,
+                         CommandHasLargePayload(clusterPath.mClusterId, clusterCommandId));
     return entry;
 }
 

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -83,10 +83,12 @@ struct AttributeEntry
     static const AttributeEntry kInvalid;
 };
 
+// Bitmask values for different Command qualities.
 enum class CommandQualityFlags : uint32_t
 {
     kFabricScoped = 0x0001,
     kTimed        = 0x0002, // `T` quality on commands
+    kLargeMessage = 0x0004, // `L` quality on commands
 };
 
 struct CommandInfo

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -261,5 +261,21 @@ bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
+bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand)
+{
+    {{#zcl_clusters}}
+      {{#zcl_commands}}
+          {{#if isLargeMessage}}
+          if ((aCluster == Clusters::{{asUpperCamelCase parent.name}}::Id) &&
+		       (aCommand == Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Id))
+		  {
+              return true;
+		  }
+          {{/if}}
+      {{/zcl_commands}}
+    {{/zcl_clusters}}
+	return false;
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -228,6 +228,7 @@ public:
 
 bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand);
 bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand);
+bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip

--- a/src/app/zap-templates/zcl/data-model/chip/camera-av-stream-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/camera-av-stream-management-cluster.xml
@@ -380,6 +380,7 @@ Git: 0.9-fall2024-411-g9835b5cd7
 
     <command code="0x0B" source="client" name="CaptureSnapshot" optional="true">
       <description>This command SHALL return a Snapshot from the camera.</description>
+      <quality largeMessage="true"/>
       <access op="invoke" privilege="manage"/>
       <arg id="0" name="SnapshotStreamID" type="int16u"/>
       <arg id="1" name="RequestedResolution" type="VideoResolutionStruct"/>
@@ -387,6 +388,7 @@ Git: 0.9-fall2024-411-g9835b5cd7
 
     <command code="0x0C" source="server" name="CaptureSnapshotResponse" optional="true" disableDefaultResponse="true">
       <description>This command SHALL be sent by the device in response to the CaptureSnapshot command, carrying the requested snapshot.</description>
+      <quality largeMessage="true"/>
       <arg id="0" name="Data" type="octet_string"/>
       <arg id="1" name="ImageCodec" type="ImageCodecEnum" min="0x00" max="0x00"/>
       <arg id="2" name="Resolution" type="VideoResolutionStruct"/>

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -35101,5 +35101,20 @@ bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
+bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand)
+{
+    if ((aCluster == Clusters::CameraAvStreamManagement::Id) &&
+        (aCommand == Clusters::CameraAvStreamManagement::Commands::CaptureSnapshot::Id))
+    {
+        return true;
+    }
+    if ((aCluster == Clusters::CameraAvStreamManagement::Id) &&
+        (aCommand == Clusters::CameraAvStreamManagement::Commands::CaptureSnapshotResponse::Id))
+    {
+        return true;
+    }
+    return false;
+}
+
 } // namespace app
 } // namespace chip

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -47768,6 +47768,7 @@ public:
 
 bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand);
 bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand);
+bool CommandHasLargePayload(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
* Define a constant bool property in Commands via the corresponding zap template.
* Set the largeMessage=true for the 'CaptureSnapshot' command in AVStreamMgmt cluster xml.

