### PR TITLE
[Matter.framework] Remove the MTRDeviceController_Concrete::invalidat…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -179,12 +179,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)invalidateCASESessionForNode:(NSNumber *)nodeID;
 
 /**
- * Invalidate the CASE session establishment for the specified node ID.
- * Must not be called on the Matter event queue.
- */
-- (void)invalidateCASESessionEstablishmentForNode:(NSNumber *)nodeID;
-
-/**
  * Download log of the desired type from the device.
  */
 - (void)downloadLogFromNodeWithID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1619,17 +1619,6 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     [self syncRunOnWorkQueue:block error:nil];
 }
 
-- (void)invalidateCASESessionEstablishmentForNode:(NSNumber *)nodeID;
-{
-    auto block = ^{
-        auto caseSessionMgr = self->_cppCommissioner->CASESessionMgr();
-        VerifyOrDie(caseSessionMgr != nullptr);
-        caseSessionMgr->ReleaseSession(self->_cppCommissioner->GetPeerScopedId(nodeID.unsignedLongLongValue));
-    };
-
-    [self syncRunOnWorkQueue:block error:nil];
-}
-
 - (void)operationalInstanceAdded:(NSNumber *)nodeID
 {
     // Don't use deviceForNodeID here, because we don't want to create the

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -901,9 +901,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     } else if (_internalDeviceState == MTRInternalDeviceStateSubscribing && nodeLikelyReachable) {
         // If we have reason to suspect that the node is now reachable and we haven’t established a
         // CASE session yet, let’s consider it to be stalled and invalidate the pairing session.
-        dispatch_async(self.queue, ^{
-            [[self _concreteController] invalidateCASESessionEstablishmentForNode:self->_nodeID];
-        });
+        [[self _concreteController] asyncGetCommissionerOnMatterQueue:^(Controller::DeviceCommissioner * commissioner) {
+            auto caseSessionMgr = commissioner->CASESessionMgr();
+            VerifyOrDie(caseSessionMgr != nullptr);
+            caseSessionMgr->ReleaseSession(commissioner->GetPeerScopedId(self->_nodeID.unsignedLongLongValue));
+        } errorHandler:nil /* not much we can do */];
     }
 }
 


### PR DESCRIPTION
…eCASESessionEstablishmentForNode API and move the code inside MTRDevice_Concrete instead

#### Problem

This is a followup to answer https://github.com/project-chip/connectedhomeip/pull/36298#discussion_r1823248707