### PR TITLE
Remove "run on work queue" bits from non-concrete controllers.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -554,40 +554,6 @@ using namespace chip::Tracing::DarwinFramework;
     errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
 }
 
-- (void)syncRunOnWorkQueue:(SyncWorkQueueBlock)block error:(NSError * __autoreleasing *)error
-{
-    VerifyOrDie(!chip::DeviceLayer::PlatformMgrImpl().IsWorkQueueCurrentQueue());
-    VerifyOrReturn([self checkIsRunning:error]);
-
-    dispatch_sync(_chipWorkQueue, ^{
-        VerifyOrReturn([self checkIsRunning:error]);
-        block();
-    });
-}
-
-- (id)syncRunOnWorkQueueWithReturnValue:(SyncWorkQueueBlockWithReturnValue)block error:(NSError * __autoreleasing *)error
-{
-    __block id rv = nil;
-    auto adapter = ^{
-        rv = block();
-    };
-
-    [self syncRunOnWorkQueue:adapter error:error];
-
-    return rv;
-}
-
-- (BOOL)syncRunOnWorkQueueWithBoolReturnValue:(SyncWorkQueueBlockWithBoolReturnValue)block error:(NSError * __autoreleasing *)error
-{
-    __block BOOL success = NO;
-    auto adapter = ^{
-        success = block();
-    };
-    [self syncRunOnWorkQueue:adapter error:error];
-
-    return success;
-}
-
 - (chip::FabricIndex)fabricIndex
 {
     return _storedFabricIndex;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -68,8 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, assign) os_unfair_lock_t deviceMapLock;
 
 @property (readwrite, nonatomic) NSUUID * uniqueIdentifier;
-
-// queue used to serialize all work performed by the MTRDeviceController
 // (moved here so subclasses can initialize differently)
 
 - (instancetype)initForSubclasses:(BOOL)startSuspended;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -71,7 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 // queue used to serialize all work performed by the MTRDeviceController
 // (moved here so subclasses can initialize differently)
-@property (readwrite, retain) dispatch_queue_t chipWorkQueue;
 
 - (instancetype)initForSubclasses:(BOOL)startSuspended;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -37,6 +37,7 @@
 @property (nonnull, atomic, readwrite, retain) MTRXPCDeviceControllerParameters * xpcParameters;
 @property (atomic, readwrite, assign) NSTimeInterval xpcRetryTimeInterval;
 @property (atomic, readwrite, assign) BOOL xpcConnectedOrConnecting;
+@property (nonatomic, readonly, retain) dispatch_queue_t workQueue;
 
 @end
 
@@ -194,7 +195,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_COMMAND(updateControllerConfiguration
         self.xpcRetryTimeInterval = 0.5;
         mtr_weakify(self);
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (self.xpcRetryTimeInterval * NSEC_PER_SEC)), self.chipWorkQueue, ^{
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (self.xpcRetryTimeInterval * NSEC_PER_SEC)), self.workQueue, ^{
             mtr_strongify(self);
             [self _xpcConnectionRetry];
         });
@@ -214,7 +215,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_COMMAND(updateControllerConfiguration
             self.xpcRetryTimeInterval = MIN(60.0, self.xpcRetryTimeInterval);
             mtr_weakify(self);
 
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.xpcRetryTimeInterval * NSEC_PER_SEC)), self.chipWorkQueue, ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.xpcRetryTimeInterval * NSEC_PER_SEC)), self.workQueue, ^{
                 mtr_strongify(self);
                 [self _xpcConnectionRetry];
             });
@@ -302,7 +303,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_COMMAND(updateControllerConfiguration
 
         self.uniqueIdentifier = UUID;
         self.xpcParameters = xpcParameters;
-        self.chipWorkQueue = dispatch_queue_create("MTRDeviceController_XPC_queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        _workQueue = dispatch_queue_create("MTRDeviceController_XPC_queue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         if (![self _setupXPCConnection]) {
             return nil;


### PR DESCRIPTION
There is no "work queue" in the sense of the Matter queue involved unless we have a concrete controller.

* syncRunOnWorkQueueWithReturnValue was unused on MTRDeviceController, so can just be removed.

* syncRunOnWorkQueueWithBoolReturnValue was unused on MTRDeviceController, so can just be removed.

* After that syncRunOnWorkQueue becomes unused and can be removed.

* At this point chipWorkQueue is not used on the base class and can be moved into the subclasses as needed.
