### PR TITLE
Move fabricIndex property to MTRDeviceController_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -94,7 +94,6 @@ using namespace chip::Tracing::DarwinFramework;
 @implementation MTRDeviceController {
     os_unfair_lock _underlyingDeviceMapLock;
 
-    std::atomic<chip::FabricIndex> _storedFabricIndex;
     std::atomic<std::optional<uint64_t>> _storedCompressedFabricID;
 
     // For now, we just ensure that access to _suspended is atomic, but don't
@@ -501,11 +500,6 @@ using namespace chip::Tracing::DarwinFramework;
     // TODO: Figure out how to get callsites to have an MTRDeviceController_Concrete.
     MTR_ABSTRACT_METHOD();
     errorHandler([MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
-}
-
-- (chip::FabricIndex)fabricIndex
-{
-    return _storedFabricIndex;
 }
 
 - (nullable NSNumber *)compressedFabricID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -221,6 +221,11 @@ NS_ASSUME_NONNULL_BEGIN
                             queue:(dispatch_queue_t)queue
                        completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
+/**
+ * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.
+ */
+@property (readonly) chip::FabricIndex fabricIndex;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -25,9 +25,6 @@
 #import "MTRDeviceConnectionBridge.h" // For MTRInternalDeviceConnectionCallback
 #import "MTRDeviceController.h"
 
-#include <lib/core/CHIPError.h>
-#include <lib/core/DataModelTypes.h>
-
 #import <os/lock.h>
 
 #import "MTRBaseDevice.h"
@@ -37,11 +34,8 @@
 #import "MTRDeviceControllerDelegate.h"
 #import "MTRDeviceStorageBehaviorConfiguration.h"
 
-#import <Matter/MTRP256KeypairBridge.h>
-
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceControllerStorageDelegate.h>
-#import <Matter/MTRDiagnosticLogsType.h>
 #import <Matter/MTROTAProviderDelegate.h>
 
 @class MTRDeviceControllerParameters;
@@ -51,14 +45,6 @@
 @protocol MTRDevicePairingDelegate;
 @protocol MTRDeviceControllerDelegate;
 @class MTRDevice_Concrete;
-
-namespace chip {
-class FabricTable;
-
-namespace Controller {
-    class DeviceCommissioner;
-}
-} // namespace chip
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -73,11 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initForSubclasses:(BOOL)startSuspended;
 
 #pragma mark - MTRDeviceControllerFactory methods
-
-/**
- * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.
- */
-@property (readonly) chip::FabricIndex fabricIndex;
 
 /**
  * Will return the compressed fabric id of the fabric if the controller is

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -20,6 +20,7 @@
 #import "MTRDeviceController_Internal.h"
 #import "MTRDevice_XPC.h"
 #import "MTRDevice_XPC_Internal.h"
+#import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "MTRXPCClientProtocol.h"
 #import "MTRXPCServerProtocol.h"

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -17,6 +17,8 @@
 
 #import <Matter/MTROTAProviderDelegate.h>
 
+#import "MTRDeviceController_Concrete.h"
+
 #include <app/clusters/ota-provider/ota-provider-delegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,7 +37,7 @@ public:
 
     // ControllerShuttingDown must be called on the Matter work queue, since it
     // touches Matter objects.
-    void ControllerShuttingDown(MTRDeviceController * controller);
+    void ControllerShuttingDown(MTRDeviceController_Concrete * controller);
 
     void HandleQueryImage(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -112,7 +112,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    void ControllerShuttingDown(MTRDeviceController * controller)
+    void ControllerShuttingDown(MTRDeviceController_Concrete * controller)
     {
         assertChipStackLockedByCurrentThread();
 
@@ -506,7 +506,7 @@ CHIP_ERROR MTROTAProviderDelegateBridge::Init(System::Layer * systemLayer, Messa
 
 void MTROTAProviderDelegateBridge::Shutdown() { gOtaSender->Shutdown(); }
 
-void MTROTAProviderDelegateBridge::ControllerShuttingDown(MTRDeviceController * controller)
+void MTROTAProviderDelegateBridge::ControllerShuttingDown(MTRDeviceController_Concrete * controller)
 {
     gOtaSender->ControllerShuttingDown(controller);
 }

--- a/src/darwin/Framework/CHIP/MTRSessionResumptionStorageBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRSessionResumptionStorageBridge.mm
@@ -18,6 +18,7 @@
 
 #import "MTRConversion.h"
 #import "MTRDeviceControllerFactory_Internal.h"
+#import "MTRDeviceController_Concrete.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "NSDataSpanConversion.h"
@@ -58,7 +59,7 @@ CHIP_ERROR MTRSessionResumptionStorageBridge::FindByResumptionId(ConstResumption
     auto * resumptionIDData = AsData(resumptionId);
 
     auto * controllerList = [mFactory getRunningControllers];
-    for (MTRDeviceController * controller in controllerList) {
+    for (MTRDeviceController_Concrete * controller in controllerList) {
         FabricIndex fabricIndex = controller.fabricIndex;
         if (!IsValidFabricIndex(fabricIndex)) {
             // This controller is not sufficiently "running"; it does not have a


### PR DESCRIPTION
This doesn't really make sense for non-concrete controllers.

Also removes some unnecessary declarations and includes from MTRDeviceController_Internal.
