### PR TITLE
[darwin-framework-tool][interactive] Add Ctrl+G as a shortcut key to …

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -130,6 +130,8 @@ protected:
 
     void SuspendOrResumeCommissioners();
 
+    MTRDevice * GetLastUsedDevice();
+
 private:
     CHIP_ERROR InitializeCommissioner(
         std::string key, chip::FabricId fabricId, const chip::Credentials::AttestationTrustStore * trustStore);

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -35,6 +35,7 @@
 #include <string>
 
 static CHIPToolPersistentStorageDelegate * storage = nil;
+static MTRDevice * sLastUsedDevice = nil;
 static DeviceDelegate * sDeviceDelegate = nil;
 static dispatch_queue_t sDeviceDelegateDispatchQueue = nil;
 std::set<CHIPCommandBridge *> CHIPCommandBridge::sDeferredCleanups;
@@ -312,6 +313,7 @@ MTRDevice * CHIPCommandBridge::DeviceWithNodeId(chip::NodeId nodeId)
     }
     [device addDelegate:sDeviceDelegate queue:sDeviceDelegateDispatchQueue];
 
+    sLastUsedDevice = device;
     return device;
 }
 
@@ -366,6 +368,11 @@ void CHIPCommandBridge::SuspendOrResumeCommissioners()
             commissioner.suspended ? [commissioner resume] : [commissioner suspend];
         }
     }
+}
+
+MTRDevice * CHIPCommandBridge::GetLastUsedDevice()
+{
+    return sLastUsedDevice;
 }
 
 CHIP_ERROR CHIPCommandBridge::StartWaiting(chip::System::Clock::Timeout duration)

--- a/examples/darwin-framework-tool/commands/configuration/SetUpDeviceCommand.h
+++ b/examples/darwin-framework-tool/commands/configuration/SetUpDeviceCommand.h
@@ -50,6 +50,9 @@ protected:
         __auto_type queue = dispatch_queue_create("com.chip.devicedelegate", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         [device addDelegate:delegate queue:queue];
 
+        // Make sure the device is registered as the latest MTRDevice.
+        DeviceWithNodeId(mNodeId);
+
         mDelegate = delegate;
         SetCommandExitStatus(CHIP_NO_ERROR);
         return CHIP_NO_ERROR;


### PR DESCRIPTION
…trigger a resubscription to the last used MTRDevice

#### Problem

This PR adds a shortcut to trigger resubscription in interactive mode (`Ctrl+G`).