### PR TITLE
Move the controllerDataStore property to MTRDeviceController_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -18,6 +18,7 @@
 #import "MTRCertificates.h"
 #import "MTRConversion.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
+#import "MTRDeviceController_Concrete.h"
 #import "MTRDeviceController_Internal.h"
 #import "MTRLogging_Internal.h"
 #import "MTRP256KeypairBridge.h"
@@ -596,7 +597,7 @@ constexpr NSUInteger kDefaultConcurrentSubscriptionPoolSize = 300;
     return self;
 }
 
-- (instancetype)initForNewController:(MTRDeviceController *)controller
+- (instancetype)initForNewController:(MTRDeviceController_Concrete *)controller
                          fabricTable:(chip::FabricTable *)fabricTable
                             keystore:(chip::Crypto::OperationalKeystore *)keystore
                 advertiseOperational:(BOOL)advertiseOperational

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -26,6 +26,9 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 
+// MTRDeviceController_Concrete.h imports this header, so we can't import it.
+@class MTRDeviceController_Concrete;
+
 namespace chip {
 class FabricTable;
 
@@ -157,7 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Initialize for controller bringup with per-controller storage.
  */
-- (instancetype)initForNewController:(MTRDeviceController *)controller
+- (instancetype)initForNewController:(MTRDeviceController_Concrete *)controller
                          fabricTable:(chip::FabricTable *)fabricTable
                             keystore:(chip::Crypto::OperationalKeystore *)keystore
                 advertiseOperational:(BOOL)advertiseOperational

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -28,6 +28,7 @@
 
 #import "MTRAsyncWorkQueue.h"
 #import "MTRDeviceConnectionBridge.h"
+#import "MTRDeviceControllerDataStore.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 
 #include <credentials/FabricTable.h>
@@ -232,6 +233,11 @@ NS_ASSUME_NONNULL_BEGIN
  * subscription at the same time.
  */
 @property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDeviceController *> * concurrentSubscriptionPool;
+
+/**
+ * The per-controller data store this controller was initialized with, if any.
+ */
+@property (nonatomic, readonly, nullable) MTRDeviceControllerDataStore * controllerDataStore;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -30,7 +30,6 @@
 #import "MTRBaseDevice.h"
 #import "MTRDeviceClusterData.h"
 #import "MTRDeviceController.h"
-#import "MTRDeviceControllerDataStore.h"
 #import "MTRDeviceControllerDelegate.h"
 #import "MTRDeviceStorageBehaviorConfiguration.h"
 
@@ -64,11 +63,6 @@ NS_ASSUME_NONNULL_BEGIN
  * running, else nil.
  */
 @property (nonatomic, readonly, nullable) NSNumber * compressedFabricID;
-
-/**
- * The per-controller data store this controller was initialized with, if any.
- */
-@property (nonatomic, readonly, nullable) MTRDeviceControllerDataStore * controllerDataStore;
 
 /**
  * OTA delegate and its queue, if this controller supports OTA.  Either both


### PR DESCRIPTION
Non-concrete controllers are not initialized with a datastore.
