### PR TITLE
[Silabs] Drop BLE connection on endpoint close

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -343,7 +343,7 @@ CHIP_ERROR BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const C
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
-    // Nothing to do
+    CloseConnection(conId);
 }
 
 CHIP_ERROR BLEManagerImpl::MapBLEError(int bleErr)


### PR DESCRIPTION
Problem
When a BLE endpoint is closed on the peripheral side, the associated connection is not automatically closed.

Change overview
Implement connection closing for Silabs platform.

Testing
Tested on Silabs EFR32 examples with chip-tool.