### PR TITLE
Remove unused checkIsRunning on MTRDeviceController.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -57,9 +57,6 @@
 
 #import <os/lock.h>
 
-// TODO: These strings and their consumers in this file should probably go away,
-// since none of them really apply to all controllers.
-static NSString * const kErrorNotRunning = @"Controller is not running. Call startup first.";
 static NSString * const kErrorSpake2pVerifierGenerationFailed = @"PASE verifier generation failed";
 static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifier serialization failed";
 
@@ -471,25 +468,6 @@ using namespace chip::Tracing::DarwinFramework;
     }
 
     return YES;
-}
-
-- (BOOL)checkIsRunning
-{
-    return [self checkIsRunning:nil];
-}
-
-- (BOOL)checkIsRunning:(NSError * __autoreleasing *)error
-{
-    if ([self isRunning]) {
-        return YES;
-    }
-
-    MTR_LOG_ERROR("%@: %@ Error: %s", NSStringFromClass(self.class), self, [kErrorNotRunning UTF8String]);
-    if (error) {
-        *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
-    }
-
-    return NO;
 }
 
 - (void)asyncDispatchToMatterQueue:(dispatch_block_t)block errorHandler:(nullable MTRDeviceErrorHandler)errorHandler


### PR DESCRIPTION
Only MTRDeviceController_Concrete needs to do checkIsRunning at this point, and it implements that itself.
