### PR TITLE
Revert "Add new API so it's possible to not leak a key (#36299)"

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
@@ -22,7 +22,7 @@
 @interface CHIPToolKeypair : NSObject <MTRKeypair>
 - (BOOL)initialize;
 - (NSData *)signMessageECDSA_RAW:(NSData *)message;
-- (SecKeyRef)copyPublicKey;
+- (SecKeyRef)publicKey;
 - (CHIP_ERROR)Serialize:(chip::Crypto::P256SerializedKeypair &)output;
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input;
 - (CHIP_ERROR)createOrLoadKeys:(id)storage;

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,7 +65,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
-- (SecKeyRef)copyPublicKey
+- (SecKeyRef)publicKey
 {
     if (_mPublicKey == nil) {
         chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
@@ -79,13 +79,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         };
         _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
     }
-
-    if (_mPublicKey) {
-        CFRetain(_mPublicKey);
-        return _mPublicKey;
-    }
-
-    return NULL;
+    return _mPublicKey;
 }
 
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -152,24 +152,7 @@ using namespace chip::Credentials;
 + (BOOL)keypair:(id<MTRKeypair>)keypair matchesCertificate:(NSData *)certificate
 {
     P256PublicKey keypairPubKey;
-    SecKeyRef publicKey = NULL;
-
-    if ([keypair respondsToSelector:@selector(copyPublicKey)]) {
-        publicKey = [keypair copyPublicKey];
-    } else {
-        publicKey = [keypair publicKey];
-        if (publicKey) {
-            CFRetain(publicKey);
-        }
-    }
-
-    CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &keypairPubKey);
-
-    if (publicKey != NULL) {
-        CFRelease(publicKey);
-        publicKey = NULL;
-    }
-
+    CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(keypair.publicKey, &keypairPubKey);
     if (err != CHIP_NO_ERROR) {
         MTR_LOG_ERROR("Can't extract public key from keypair: %s", ErrorStr(err));
         return NO;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -819,24 +819,7 @@ MTR_DIRECT_MEMBERS
     } else {
         // No root certificate means the nocSigner is using the root keys, because
         // consumers must provide a root certificate whenever an ICA is used.
-        SecKeyRef publicKey = NULL;
-
-        if ([params.nocSigner respondsToSelector:@selector(copyPublicKey)]) {
-            publicKey = [params.nocSigner copyPublicKey];
-        } else {
-            publicKey = [params.nocSigner publicKey];
-            if (publicKey) {
-                CFRetain(publicKey);
-            }
-        }
-
-        CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &pubKey);
-
-        if (publicKey != NULL) {
-            CFRelease(publicKey);
-            publicKey = NULL;
-        }
-
+        CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(params.nocSigner.publicKey, &pubKey);
         if (err != CHIP_NO_ERROR) {
             MTR_LOG_ERROR("Can't extract public key from MTRKeypair: %s", ErrorStr(err));
             return NO;

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -16,7 +16,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Matter/Matter.h>
 #import <Security/Security.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,19 +31,13 @@ NS_ASSUME_NONNULL_BEGIN
  * framework APIs.
  */
 @protocol MTRKeypair <NSObject>
+@required
+/**
+ * @brief Return public key for the keypair.
+ */
+- (SecKeyRef)publicKey;
 
 @optional
-/**
- * @brief Returns a copy of the public key for the keypair.
- */
-- (SecKeyRef)copyPublicKey MTR_NEWLY_AVAILABLE;
-
-/**
- * @brief Returns public key for the keypair without adding a reference. DEPRECATED - please use copyPublicKey, otherwise this will leak.
- */
-
-- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.1, 18.3), macos(13.0, 15.3), watchos(9.1, 11.3), tvos(16.1, 18.3));
-
 /**
  * @brief A function to sign a message using ECDSA
  *

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -127,13 +127,9 @@
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
 
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
-
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediatePublicKey
+                                                              intermediatePublicKey:intermediateKeys.publicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                               error:nil];
@@ -159,16 +155,13 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * startDate = [MTRCertificateTests startDateWithTimeIntervalSinceNow:300];
     __auto_type * validityPeriod = [[NSDateInterval alloc] initWithStartDate:startDate duration:400];
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediatePublicKey
+                                                              intermediatePublicKey:intermediateKeys.publicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -199,16 +192,13 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * startDate = [MTRCertificateTests startDateWithTimeIntervalSinceNow:300];
     __auto_type * validityPeriod = [[NSDateInterval alloc] initWithStartDate:startDate endDate:[NSDate distantFuture]];
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediatePublicKey
+                                                              intermediatePublicKey:intermediateKeys.publicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -239,9 +229,6 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -251,7 +238,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalPublicKey
+                                                             operationalPublicKey:operationalKeys.publicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -278,9 +265,6 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -293,7 +277,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalPublicKey
+                                                             operationalPublicKey:operationalKeys.publicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -325,9 +309,6 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -340,7 +321,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalPublicKey
+                                                             operationalPublicKey:operationalKeys.publicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -372,13 +353,10 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediatePublicKey
+                                                              intermediatePublicKey:intermediateKeys.publicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                               error:nil];
@@ -386,13 +364,10 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                                signingCertificate:intermediateCert
-                                                             operationalPublicKey:operationalPublicKey
+                                                             operationalPublicKey:operationalKeys.publicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -419,9 +394,6 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * longCats = [[NSMutableSet alloc] initWithCapacity:4];
     [longCats addObject:@0x00010001];
@@ -443,7 +415,7 @@
     // Check basic case works
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalPublicKey
+                                                             operationalPublicKey:operationalKeys.publicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -453,7 +425,7 @@
     // CATs too long
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:longCats
@@ -463,7 +435,7 @@
     // Multiple CATs with the same identifier but different versions
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithSameIdentifier
@@ -473,7 +445,7 @@
     // CAT with invalid version
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithInvalidVersion
@@ -483,7 +455,7 @@
     // Signing key mismatch
     operationalCert = [MTRCertificates createOperationalCertificate:operationalKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -493,7 +465,7 @@
     // Invalid fabric id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@0
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -503,7 +475,7 @@
     // Undefined node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@0
                                               caseAuthenticatedTags:nil
@@ -513,7 +485,7 @@
     // Non-operational node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalPublicKey
+                                               operationalPublicKey:operationalKeys.publicKey
                                                            fabricID:@1
                                                              nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
                                               caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -259,13 +259,10 @@ static BOOL sNeedsStackShutdown = YES;
 
     __auto_type * controllerOperationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(controllerOperationalKeys);
-    __auto_type * controllerPublicKey = controllerOperationalKeys.copyPublicKey;
-    XCTAssert(controllerPublicKey != NULL);
-    CFAutorelease(controllerPublicKey);
 
     __auto_type * controllerOperationalCert =
         [certificateIssuer issueOperationalCertificateForNode:@(kControllerId)
-                                         operationalPublicKey:controllerPublicKey];
+                                         operationalPublicKey:controllerOperationalKeys.publicKey];
     XCTAssertNotNil(controllerOperationalCert);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:certificateIssuer.rootKey.ipk

--- a/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
@@ -164,13 +164,10 @@ static const DNSServiceFlags kBrowseFlags = 0;
     __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:@(1) fabricID:nil error:error];
     XCTAssertNil(*error);
     XCTAssertNotNil(root);
-    __auto_type * publicKey = operationalKeys.copyPublicKey;
-    XCTAssert(publicKey != NULL);
-    CFAutorelease(publicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:publicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -620,13 +620,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -863,12 +860,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -927,13 +922,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -994,13 +986,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys1 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys1);
-    __auto_type * intermediate1PublicKey = [intermediateKeys1 copyPublicKey];
-    XCTAssert(intermediate1PublicKey != NULL);
-    CFAutorelease(intermediate1PublicKey);
 
     __auto_type * intermediate1 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:intermediate1PublicKey
+                                                           intermediatePublicKey:intermediateKeys1.publicKey
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -1008,13 +997,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys2 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys2);
-    __auto_type * intermediate2PublicKey = [intermediateKeys2 copyPublicKey];
-    XCTAssert(intermediate2PublicKey != NULL);
-    CFAutorelease(intermediate2PublicKey);
 
     __auto_type * intermediate2 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:intermediate2PublicKey
+                                                           intermediatePublicKey:intermediateKeys2.publicKey
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -1075,13 +1061,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1121,13 +1104,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1135,13 +1115,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:operationalPublicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1202,13 +1179,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalPublicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1255,13 +1229,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalPublicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1302,13 +1273,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:@111
                                                                           error:nil];
@@ -1316,13 +1284,10 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:operationalPublicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
@@ -157,13 +157,10 @@ static uint16_t kTestVendorId2 = 0xFFF2u;
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
-    XCTAssert(intermediatePublicKey != NULL);
-    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediatePublicKey
+                                                          intermediatePublicKey:intermediateKeys.publicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -403,13 +403,9 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     XCTAssertNil(*error);
     XCTAssertNotNil(root);
 
-    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
-    XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
-
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalPublicKey
+                                                         operationalPublicKey:operationalKeys.publicKey
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:caseAuthenticatedTags

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
@@ -31,12 +31,6 @@
     return (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation([self publicKey], nil);
 }
 
-- (SecKeyRef)copyPublicKey
-{
-    CFRetain(_publicKey);
-    return _publicKey;
-}
-
 - (instancetype)init
 {
     if (!(self = [super init])) {


### PR DESCRIPTION
This reverts commit 08024d2ddb5f330384411d55bc44e2ee9bbcad8d because it's failing CI as committed.
