### PR TITLE
[Darwin] add API to get public key without leaks (with fixes)

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -172,10 +172,18 @@ CHIP_ERROR CHIPCommandBridge::SetUpStackWithPerControllerStorage(NSArray<NSData 
 
         NSError * error;
         __auto_type * operationalKeypair = [certificateIssuer issueOperationalKeypairWithControllerStorage:controllerStorage error:&error];
+        SecKeyRef publicKey = [operationalKeypair copyPublicKey];
+
         __auto_type * operational = [certificateIssuer issueOperationalCertificateForNodeID:nodeId
                                                                                    fabricID:fabricId
-                                                                                  publicKey:operationalKeypair.publicKey
+                                                                                  publicKey:publicKey
                                                                                       error:&error];
+
+        if (publicKey != NULL) {
+            CFAutorelease(publicKey);
+        }
+
+
         VerifyOrReturnError(nil == error, MTRErrorToCHIPErrorCode(error), ChipLogError(chipTool, "Can not issue an operational certificate: %@", error));
 
         __auto_type * controllerStorageQueue = dispatch_queue_create("com.chip.storage", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -183,7 +183,6 @@ CHIP_ERROR CHIPCommandBridge::SetUpStackWithPerControllerStorage(NSArray<NSData 
             CFAutorelease(publicKey);
         }
 
-
         VerifyOrReturnError(nil == error, MTRErrorToCHIPErrorCode(error), ChipLogError(chipTool, "Can not issue an operational certificate: %@", error));
 
         __auto_type * controllerStorageQueue = dispatch_queue_create("com.chip.storage", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
@@ -22,7 +22,7 @@
 @interface CHIPToolKeypair : NSObject <MTRKeypair>
 - (BOOL)initialize;
 - (NSData *)signMessageECDSA_RAW:(NSData *)message;
-- (SecKeyRef)publicKey;
+- (SecKeyRef)copyPublicKey;
 - (CHIP_ERROR)Serialize:(chip::Crypto::P256SerializedKeypair &)output;
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input;
 - (CHIP_ERROR)createOrLoadKeys:(id)storage;

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
@@ -22,6 +22,7 @@
 @interface CHIPToolKeypair : NSObject <MTRKeypair>
 - (BOOL)initialize;
 - (NSData *)signMessageECDSA_RAW:(NSData *)message;
+- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.1, 18.3), macos(13.0, 15.3), watchos(9.1, 11.3), tvos(16.1, 18.3));
 - (SecKeyRef)copyPublicKey;
 - (CHIP_ERROR)Serialize:(chip::Crypto::P256SerializedKeypair &)output;
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input;

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.h
@@ -22,7 +22,6 @@
 @interface CHIPToolKeypair : NSObject <MTRKeypair>
 - (BOOL)initialize;
 - (NSData *)signMessageECDSA_RAW:(NSData *)message;
-- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.1, 18.3), macos(13.0, 15.3), watchos(9.1, 11.3), tvos(16.1, 18.3));
 - (SecKeyRef)copyPublicKey;
 - (CHIP_ERROR)Serialize:(chip::Crypto::P256SerializedKeypair &)output;
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input;

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -58,7 +58,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
 {
     chip::Crypto::P256ECDSASignature signature;
     NSData * out_signature;
-    CHIP_ERROR signing_error = _mKeyPair.ECDSA_sign_msg((const uint8_t *) [message bytes], (size_t)[message length], signature);
+    CHIP_ERROR signing_error = _mKeyPair.ECDSA_sign_msg((const uint8_t *) [message bytes], (size_t) [message length], signature);
     if (signing_error != CHIP_NO_ERROR)
         return nil;
     out_signature = [NSData dataWithBytes:signature.Bytes() length:signature.Length()];
@@ -80,8 +80,9 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
     }
 
-    if (_mPublicKey)
+    if (_mPublicKey) {
         return CFRetain(_mPublicKey);
+    }
 
     return NULL;
 }

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,9 +65,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
-// TODO:  dedupe shared parts of below once this passes tests
-- (SecKeyRef)publicKey
-{
+- (void)_populatePublicKeyIfNecessary {
     if (_mPublicKey == nil) {
         chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
         NSData * publicKeyNSData = [NSData dataWithBytes:publicKey.Bytes() length:publicKey.Length()];
@@ -80,24 +78,18 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         };
         _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
     }
+}
+
+- (SecKeyRef)publicKey
+{
+    [self _populatePublicKeyIfNecessary];
 
     return _mPublicKey;
 }
 
 - (SecKeyRef)copyPublicKey
 {
-    if (_mPublicKey == nil) {
-        chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
-        NSData * publicKeyNSData = [NSData dataWithBytes:publicKey.Bytes() length:publicKey.Length()];
-        NSDictionary * attributes = @{
-            (__bridge NSString *) kSecAttrKeyClass : (__bridge NSString *) kSecAttrKeyClassPublic,
-            (NSString *) kSecAttrKeyType : (NSString *) kSecAttrKeyTypeECSECPrimeRandom,
-            (NSString *) kSecAttrKeySizeInBits : @Public_KeySize,
-            (NSString *) kSecAttrLabel : kCHIPToolKeychainLabel,
-            (NSString *) kSecAttrApplicationTag : @CHIPPlugin_CAKeyTag,
-        };
-        _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
-    }
+    [self _populatePublicKeyIfNecessary];
 
     if (_mPublicKey) {
         CFRetain(_mPublicKey);

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,7 +65,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
-- (SecKeyRef)publicKey
+- (SecKeyRef)copyPublicKey
 {
     if (_mPublicKey == nil) {
         chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
@@ -79,7 +79,11 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         };
         _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
     }
-    return _mPublicKey;
+
+    if (_mPublicKey)
+        return CFRetain(_mPublicKey);
+
+    return NULL;
 }
 
 - (CHIP_ERROR)Deserialize:(chip::Crypto::P256SerializedKeypair &)input

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,6 +65,25 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
+// TODO:  dedupe shared parts of below once this passes tests
+- (SecKeyRef)publicKey
+{
+    if (_mPublicKey == nil) {
+        chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
+        NSData * publicKeyNSData = [NSData dataWithBytes:publicKey.Bytes() length:publicKey.Length()];
+        NSDictionary * attributes = @{
+            (__bridge NSString *) kSecAttrKeyClass : (__bridge NSString *) kSecAttrKeyClassPublic,
+            (NSString *) kSecAttrKeyType : (NSString *) kSecAttrKeyTypeECSECPrimeRandom,
+            (NSString *) kSecAttrKeySizeInBits : @Public_KeySize,
+            (NSString *) kSecAttrLabel : kCHIPToolKeychainLabel,
+            (NSString *) kSecAttrApplicationTag : @CHIPPlugin_CAKeyTag,
+        };
+        _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
+    }
+
+    return _mPublicKey;
+}
+
 - (SecKeyRef)copyPublicKey
 {
     if (_mPublicKey == nil) {

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,7 +65,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
-- (void)_populatePublicKeyIfNecessary
+- (SecKeyRef)copyPublicKey
 {
     if (_mPublicKey == nil) {
         chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
@@ -79,18 +79,6 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         };
         _mPublicKey = SecKeyCreateWithData((__bridge CFDataRef) publicKeyNSData, (__bridge CFDictionaryRef) attributes, nullptr);
     }
-}
-
-- (SecKeyRef)publicKey
-{
-    [self _populatePublicKeyIfNecessary];
-
-    return _mPublicKey;
-}
-
-- (SecKeyRef)copyPublicKey
-{
-    [self _populatePublicKeyIfNecessary];
 
     if (_mPublicKey) {
         CFRetain(_mPublicKey);

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -58,7 +58,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
 {
     chip::Crypto::P256ECDSASignature signature;
     NSData * out_signature;
-    CHIP_ERROR signing_error = _mKeyPair.ECDSA_sign_msg((const uint8_t *) [message bytes], (size_t) [message length], signature);
+    CHIP_ERROR signing_error = _mKeyPair.ECDSA_sign_msg((const uint8_t *) [message bytes], (size_t)[message length], signature);
     if (signing_error != CHIP_NO_ERROR)
         return nil;
     out_signature = [NSData dataWithBytes:signature.Bytes() length:signature.Length()];

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -81,7 +81,8 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     }
 
     if (_mPublicKey) {
-        return CFRetain(_mPublicKey);
+        CFRetain(_mPublicKey);
+        return _mPublicKey;
     }
 
     return NULL;

--- a/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPToolKeypair.mm
@@ -65,7 +65,8 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     return out_signature;
 }
 
-- (void)_populatePublicKeyIfNecessary {
+- (void)_populatePublicKeyIfNecessary
+{
     if (_mPublicKey == nil) {
         chip::Crypto::P256PublicKey publicKey = _mKeyPair.Pubkey();
         NSData * publicKeyNSData = [NSData dataWithBytes:publicKey.Bytes() length:publicKey.Length()];

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -152,7 +152,23 @@ using namespace chip::Credentials;
 + (BOOL)keypair:(id<MTRKeypair>)keypair matchesCertificate:(NSData *)certificate
 {
     P256PublicKey keypairPubKey;
-    CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(keypair.publicKey, &keypairPubKey);
+    SecKeyRef publicKey = NULL;
+
+    if ([keypair respondsToSelector:@selector(copyPublicKey)]) {
+        publicKey = [keypair copyPublicKey];
+    } else {
+        publicKey = [keypair publicKey];
+        if (publicKey)
+            CFRetain(publicKey);
+    }
+
+    CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &keypairPubKey);
+
+    if (publicKey != NULL) {
+        CFRelease(publicKey);
+        publicKey = NULL;
+    }
+
     if (err != CHIP_NO_ERROR) {
         MTR_LOG_ERROR("Can't extract public key from keypair: %s", ErrorStr(err));
         return NO;

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -158,8 +158,9 @@ using namespace chip::Credentials;
         publicKey = [keypair copyPublicKey];
     } else {
         publicKey = [keypair publicKey];
-        if (publicKey)
+        if (publicKey) {
             CFRetain(publicKey);
+        }
     }
 
     CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &keypairPubKey);

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -819,7 +819,23 @@ MTR_DIRECT_MEMBERS
     } else {
         // No root certificate means the nocSigner is using the root keys, because
         // consumers must provide a root certificate whenever an ICA is used.
-        CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(params.nocSigner.publicKey, &pubKey);
+        SecKeyRef publicKey = NULL;
+
+        if ([params.nocSigner respondsToSelector:@selector(copyPublicKey)]) {
+            publicKey = [params.nocSigner copyPublicKey];
+        } else {
+            publicKey = [params.nocSigner publicKey];
+            if (publicKey)
+                CFRetain(publicKey);
+        }
+
+        CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &pubKey);
+
+        if (publicKey != NULL) {
+            CFRelease(publicKey);
+            publicKey = NULL;
+        }
+
         if (err != CHIP_NO_ERROR) {
             MTR_LOG_ERROR("Can't extract public key from MTRKeypair: %s", ErrorStr(err));
             return NO;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -825,8 +825,9 @@ MTR_DIRECT_MEMBERS
             publicKey = [params.nocSigner copyPublicKey];
         } else {
             publicKey = [params.nocSigner publicKey];
-            if (publicKey)
+            if (publicKey) {
                 CFRetain(publicKey);
+            }
         }
 
         CHIP_ERROR err = MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(publicKey, &pubKey);

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -17,6 +17,7 @@
 
 #import <Foundation/Foundation.h>
 #import <Security/Security.h>
+#import <Matter/Matter.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,19 +32,19 @@ NS_ASSUME_NONNULL_BEGIN
  * framework APIs.
  */
 @protocol MTRKeypair <NSObject>
-@required
-/**
- * @brief Return a copy of the public key for the keypair.
- */
-@property (nonatomic, readonly, copy) SecKeyRef copyPublicKey MTR_NEWLY_AVAILABLE;
-
-/**
- * @brief Return public key for the keypair. DEPRECATED
- */
-
-@property (nonatomic, readonly, copy) SecKeyRef publicKey MTR_DEPRECATED("Please implement copyPublicKey", ios(16.4, 17.2), macos(13.3, 14.2), watchos(9.4, 10.2), tvos(16.4, 17.2));
 
 @optional
+/**
+ * @brief Returns a copy of the public key for the keypair.
+ */
+- (SecKeyRef)copyPublicKey MTR_NEWLY_AVAILABLE;
+
+/**
+ * @brief Returns public key for the keypair. DEPRECATED - please use copyPublicKey, otherwise this will leak
+ */
+
+- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.4, 17.2), macos(13.3, 14.2), watchos(9.4, 10.2), tvos(16.4, 17.2));
+
 /**
  * @brief A function to sign a message using ECDSA
  *

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -33,9 +33,15 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MTRKeypair <NSObject>
 @required
 /**
- * @brief Return public key for the keypair.
+ * @brief Return a copy of the public key for the keypair.
  */
-- (SecKeyRef)publicKey;
+@property (nonatomic, readonly, copy) SecKeyRef copyPublicKey MTR_NEWLY_AVAILABLE;
+
+/**
+ * @brief Return public key for the keypair. DEPRECATED
+ */
+
+@property (nonatomic, readonly, copy) SecKeyRef publicKey MTR_DEPRECATED("Please implement copyPublicKey", ios(16.4, 17.2), macos(13.3, 14.2), watchos(9.4, 10.2), tvos(16.4, 17.2));
 
 @optional
 /**

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -16,8 +16,8 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <Security/Security.h>
 #import <Matter/Matter.h>
+#import <Security/Security.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Returns public key for the keypair without adding a reference. DEPRECATED - please use copyPublicKey, otherwise this will leak.
  */
 
-- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.4, 18.3), macos(13.3, 15.3), watchos(9.4, 11.3), tvos(16.4, 18.3));
+- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.1, 18.3), macos(13.0, 15.3), watchos(9.1, 11.3), tvos(16.1, 18.3));
 
 /**
  * @brief A function to sign a message using ECDSA

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Returns public key for the keypair. DEPRECATED - please use copyPublicKey, otherwise this will leak
  */
 
-- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.4, 17.2), macos(13.3, 14.2), watchos(9.4, 10.2), tvos(16.4, 17.2));
+- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.4, 18.3), macos(13.3, 15.3), watchos(9.4, 11.3), tvos(16.4, 18.3));
 
 /**
  * @brief A function to sign a message using ECDSA

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -42,8 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Returns public key for the keypair without adding a reference. DEPRECATED - please use copyPublicKey, otherwise this will leak.
  */
-
-- (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.1, 18.3), macos(13.0, 15.3), watchos(9.1, 11.3), tvos(16.1, 18.3));
+- (SecKeyRef)publicKey MTR_NEWLY_DEPRECATED("Please implement copyPublicKey, this will leak otherwise");
 
 /**
  * @brief A function to sign a message using ECDSA

--- a/src/darwin/Framework/CHIP/MTRKeypair.h
+++ b/src/darwin/Framework/CHIP/MTRKeypair.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (SecKeyRef)copyPublicKey MTR_NEWLY_AVAILABLE;
 
 /**
- * @brief Returns public key for the keypair. DEPRECATED - please use copyPublicKey, otherwise this will leak
+ * @brief Returns public key for the keypair without adding a reference. DEPRECATED - please use copyPublicKey, otherwise this will leak.
  */
 
 - (SecKeyRef)publicKey MTR_DEPRECATED("Please implement copyPublicKey, this will leak otherwise", ios(16.4, 18.3), macos(13.3, 15.3), watchos(9.4, 11.3), tvos(16.4, 18.3));

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -135,7 +135,10 @@ CHIP_ERROR MTRP256KeypairBridge::ECDH_derive_secret(
 CHIP_ERROR MTRP256KeypairBridge::setPubkey()
 {
     if ([mKeypair respondsToSelector:@selector(copyPublicKey)]) {
-        return MatterPubKeyFromSecKeyRef([mKeypair copyPublicKey], &mPubkey);
+        SecKeyRef publicKey = [mKeypair copyPublicKey];
+        auto copyResult = MatterPubKeyFromSecKeyRef(publicKey, &mPubkey);
+        CFRelease(publicKey);
+        return copyResult;
     } else {
         return MatterPubKeyFromSecKeyRef([mKeypair publicKey], &mPubkey);
     }

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -132,7 +132,14 @@ CHIP_ERROR MTRP256KeypairBridge::ECDH_derive_secret(
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
-CHIP_ERROR MTRP256KeypairBridge::setPubkey() { return MatterPubKeyFromSecKeyRef([mKeypair publicKey], &mPubkey); }
+CHIP_ERROR MTRP256KeypairBridge::setPubkey()
+{
+    if ([mKeypair respondsToSelector:@selector(copyPublicKey)]) {
+        return MatterPubKeyFromSecKeyRef([mKeypair copyPublicKey], &mPubkey);
+    } else {
+        return MatterPubKeyFromSecKeyRef([mKeypair publicKey], &mPubkey);
+    }
+}
 
 CHIP_ERROR MTRP256KeypairBridge::MatterPubKeyFromSecKeyRef(SecKeyRef pubkeyRef, P256PublicKey * matterPubKey)
 {

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -535,6 +535,7 @@
     SecKeyRef originalKeyRef;
     if ([testKeys respondsToSelector:@selector(copyPublicKey)]) {
         originalKeyRef = [testKeys copyPublicKey];
+        CFAutorelease(originalKeyRef);
     } else {
         originalKeyRef = [testKeys publicKey];
     }

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -126,10 +126,8 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    // TODO:  there are several places in our tests where we call `copyPublicKey` on objects without first
-    // seeing if it's implemented by the receiver.  (the `MTRKeypair` protocol says both `publicKey` and
-    // `copyPublicKey` are optional.)
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
     XCTAssert(intermediatePublicKey != NULL);
     CFAutorelease(intermediatePublicKey);
 

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -535,7 +535,9 @@
     SecKeyRef originalKeyRef;
     if ([testKeys respondsToSelector:@selector(copyPublicKey)]) {
         originalKeyRef = [testKeys copyPublicKey];
-        CFAutorelease(originalKeyRef);
+        if (originalKeyRef != NULL) {
+            CFAutorelease(originalKeyRef);
+        }
     } else {
         originalKeyRef = [testKeys publicKey];
     }

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -131,11 +131,11 @@
     CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
-                                                                rootCertificate:rootCert
-                                                          intermediatePublicKey:intermediatePublicKey
-                                                                       issuerID:nil
-                                                                       fabricID:nil
-                                                                          error:nil];
+                                                                    rootCertificate:rootCert
+                                                              intermediatePublicKey:intermediatePublicKey
+                                                                           issuerID:nil
+                                                                           fabricID:nil
+                                                                              error:nil];
     XCTAssertNotNil(intermediateCert);
 
     // Test round-trip through TLV format.

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -532,7 +532,13 @@
     __auto_type * publicKey = [MTRCertificates publicKeyFromCSR:csr error:nil];
     XCTAssertNotNil(publicKey);
 
-    SecKeyRef originalKeyRef = [testKeys publicKey];
+    SecKeyRef originalKeyRef;
+    if ([testKeys respondsToSelector:@selector(copyPublicKey)]) {
+        originalKeyRef = [testKeys copyPublicKey];
+    } else {
+        originalKeyRef = [testKeys publicKey];
+    }
+
     XCTAssertTrue(originalKeyRef != NULL);
 
     NSData * originalPublicKey = (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation(originalKeyRef, nil);

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -129,7 +129,7 @@
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                               error:nil];
@@ -161,7 +161,7 @@
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -198,7 +198,7 @@
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -238,7 +238,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalKeys.publicKey
+                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -277,7 +277,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalKeys.publicKey
+                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -321,7 +321,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalKeys.publicKey
+                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -356,7 +356,7 @@
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:intermediateKeys.publicKey
+                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                               error:nil];
@@ -367,7 +367,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                                signingCertificate:intermediateCert
-                                                             operationalPublicKey:operationalKeys.publicKey
+                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -415,7 +415,7 @@
     // Check basic case works
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:operationalKeys.publicKey
+                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -425,7 +425,7 @@
     // CATs too long
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:longCats
@@ -435,7 +435,7 @@
     // Multiple CATs with the same identifier but different versions
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithSameIdentifier
@@ -445,7 +445,7 @@
     // CAT with invalid version
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithInvalidVersion
@@ -455,7 +455,7 @@
     // Signing key mismatch
     operationalCert = [MTRCertificates createOperationalCertificate:operationalKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -465,7 +465,7 @@
     // Invalid fabric id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@0
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -475,7 +475,7 @@
     // Undefined node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@0
                                               caseAuthenticatedTags:nil
@@ -485,7 +485,7 @@
     // Non-operational node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:operationalKeys.publicKey
+                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                            fabricID:@1
                                                              nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
                                               caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -126,13 +126,16 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
-                                                                    rootCertificate:rootCert
-                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
-                                                                           issuerID:nil
-                                                                           fabricID:nil
-                                                                              error:nil];
+                                                                rootCertificate:rootCert
+                                                          intermediatePublicKey:intermediatePublicKey
+                                                                       issuerID:nil
+                                                                       fabricID:nil
+                                                                          error:nil];
     XCTAssertNotNil(intermediateCert);
 
     // Test round-trip through TLV format.
@@ -155,13 +158,16 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * startDate = [MTRCertificateTests startDateWithTimeIntervalSinceNow:300];
     __auto_type * validityPeriod = [[NSDateInterval alloc] initWithStartDate:startDate duration:400];
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                              intermediatePublicKey:intermediatePublicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -192,13 +198,16 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * startDate = [MTRCertificateTests startDateWithTimeIntervalSinceNow:300];
     __auto_type * validityPeriod = [[NSDateInterval alloc] initWithStartDate:startDate endDate:[NSDate distantFuture]];
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                              intermediatePublicKey:intermediatePublicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                      validityPeriod:validityPeriod
@@ -229,6 +238,9 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -238,7 +250,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                             operationalPublicKey:operationalPublicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -265,6 +277,9 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -277,7 +292,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                             operationalPublicKey:operationalPublicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -309,6 +324,9 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * cats = [[NSMutableSet alloc] initWithCapacity:3];
     // High bits are identifier, low bits are version.
@@ -321,7 +339,7 @@
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                             operationalPublicKey:operationalPublicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:cats
@@ -353,10 +371,13 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediateCert = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                     rootCertificate:rootCert
-                                                              intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                              intermediatePublicKey:intermediatePublicKey
                                                                            issuerID:nil
                                                                            fabricID:nil
                                                                               error:nil];
@@ -364,10 +385,13 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                                signingCertificate:intermediateCert
-                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                             operationalPublicKey:operationalPublicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -394,6 +418,9 @@
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * longCats = [[NSMutableSet alloc] initWithCapacity:4];
     [longCats addObject:@0x00010001];
@@ -415,7 +442,7 @@
     // Check basic case works
     __auto_type * operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                                signingCertificate:rootCert
-                                                             operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                             operationalPublicKey:operationalPublicKey
                                                                          fabricID:@1
                                                                            nodeID:@1
                                                             caseAuthenticatedTags:nil
@@ -425,7 +452,7 @@
     // CATs too long
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:longCats
@@ -435,7 +462,7 @@
     // Multiple CATs with the same identifier but different versions
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithSameIdentifier
@@ -445,7 +472,7 @@
     // CAT with invalid version
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:catsWithInvalidVersion
@@ -455,7 +482,7 @@
     // Signing key mismatch
     operationalCert = [MTRCertificates createOperationalCertificate:operationalKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -465,7 +492,7 @@
     // Invalid fabric id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@0
                                                              nodeID:@1
                                               caseAuthenticatedTags:nil
@@ -475,7 +502,7 @@
     // Undefined node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@0
                                               caseAuthenticatedTags:nil
@@ -485,7 +512,7 @@
     // Non-operational node id
     operationalCert = [MTRCertificates createOperationalCertificate:rootKeys
                                                  signingCertificate:rootCert
-                                               operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                               operationalPublicKey:operationalPublicKey
                                                            fabricID:@1
                                                              nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
                                               caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -126,6 +126,9 @@
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    // TODO:  there are several places in our tests where we call `copyPublicKey` on objects without first
+    // seeing if it's implemented by the receiver.  (the `MTRKeypair` protocol says both `publicKey` and
+    // `copyPublicKey` are optional.)
     __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
     XCTAssert(intermediatePublicKey != NULL);
     CFAutorelease(intermediatePublicKey);

--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -259,10 +259,13 @@ static BOOL sNeedsStackShutdown = YES;
 
     __auto_type * controllerOperationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(controllerOperationalKeys);
+    __auto_type * controllerPublicKey = controllerOperationalKeys.copyPublicKey;
+    XCTAssert(controllerPublicKey != NULL);
+    CFAutorelease(controllerPublicKey);
 
     __auto_type * controllerOperationalCert =
         [certificateIssuer issueOperationalCertificateForNode:@(kControllerId)
-                                         operationalPublicKey:[controllerOperationalKeys.copyPublicKey autorelease]];
+                                         operationalPublicKey:controllerPublicKey];
     XCTAssertNotNil(controllerOperationalCert);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:certificateIssuer.rootKey.ipk

--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -262,7 +262,7 @@ static BOOL sNeedsStackShutdown = YES;
 
     __auto_type * controllerOperationalCert =
         [certificateIssuer issueOperationalCertificateForNode:@(kControllerId)
-                                         operationalPublicKey:controllerOperationalKeys.publicKey];
+                                         operationalPublicKey:[controllerOperationalKeys.copyPublicKey autorelease]];
     XCTAssertNotNil(controllerOperationalCert);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:certificateIssuer.rootKey.ipk

--- a/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
@@ -164,10 +164,13 @@ static const DNSServiceFlags kBrowseFlags = 0;
     __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:@(1) fabricID:nil error:error];
     XCTAssertNil(*error);
     XCTAssertNotNil(root);
+    __auto_type * publicKey = operationalKeys.copyPublicKey;
+    XCTAssert(publicKey != NULL);
+    CFAutorelease(publicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:publicKey
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerAdvertisingTests.m
@@ -167,7 +167,7 @@ static const DNSServiceFlags kBrowseFlags = 0;
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -620,10 +620,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -860,10 +863,12 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -922,10 +927,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -986,10 +994,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys1 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys1);
+    __auto_type * intermediate1PublicKey = [intermediateKeys1 copyPublicKey];
+    XCTAssert(intermediate1PublicKey != NULL);
+    CFAutorelease(intermediate1PublicKey);
 
     __auto_type * intermediate1 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:[intermediateKeys1.copyPublicKey autorelease]
+                                                           intermediatePublicKey:intermediate1PublicKey
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -997,10 +1008,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys2 = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys2);
+    __auto_type * intermediate2PublicKey = [intermediateKeys2 copyPublicKey];
+    XCTAssert(intermediate2PublicKey != NULL);
+    CFAutorelease(intermediate2PublicKey);
 
     __auto_type * intermediate2 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:[intermediateKeys2.copyPublicKey autorelease]
+                                                           intermediatePublicKey:intermediate2PublicKey
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -1061,10 +1075,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1104,10 +1121,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1115,10 +1135,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:operationalPublicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1179,10 +1202,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:operationalPublicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1229,10 +1255,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:operationalPublicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1273,10 +1302,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:@111
                                                                           error:nil];
@@ -1284,10 +1316,13 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:operationalPublicKey
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -620,7 +620,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
-    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    __auto_type * intermediatePublicKey = [intermediateKeys copyPublicKey];
     XCTAssert(intermediatePublicKey != NULL);
     CFAutorelease(intermediatePublicKey);
 

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -623,7 +623,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -863,7 +863,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -925,7 +925,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -989,7 +989,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate1 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:intermediateKeys1.publicKey
+                                                           intermediatePublicKey:[intermediateKeys1.copyPublicKey autorelease]
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -1000,7 +1000,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate2 = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                  rootCertificate:root
-                                                           intermediatePublicKey:intermediateKeys2.publicKey
+                                                           intermediatePublicKey:[intermediateKeys2.copyPublicKey autorelease]
                                                                         issuerID:nil
                                                                         fabricID:nil
                                                                            error:nil];
@@ -1064,7 +1064,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1107,7 +1107,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];
@@ -1118,7 +1118,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1182,7 +1182,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1232,7 +1232,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil
@@ -1276,7 +1276,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:@111
                                                                           error:nil];
@@ -1287,7 +1287,7 @@ static void CheckStoredOpcertCats(id<MTRStorage> storage, uint8_t fabricIndex, N
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:intermediateKeys
                                                            signingCertificate:intermediate
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:@123
                                                                        nodeID:@456
                                                         caseAuthenticatedTags:nil

--- a/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
@@ -160,7 +160,7 @@ static uint16_t kTestVendorId2 = 0xFFF2u;
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:intermediateKeys.publicKey
+                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];

--- a/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRFabricInfoTests.m
@@ -157,10 +157,13 @@ static uint16_t kTestVendorId2 = 0xFFF2u;
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(intermediateKeys);
+    __auto_type * intermediatePublicKey = intermediateKeys.copyPublicKey;
+    XCTAssert(intermediatePublicKey != NULL);
+    CFAutorelease(intermediatePublicKey);
 
     __auto_type * intermediate = [MTRCertificates createIntermediateCertificate:rootKeys
                                                                 rootCertificate:root
-                                                          intermediatePublicKey:[intermediateKeys.copyPublicKey autorelease]
+                                                          intermediatePublicKey:intermediatePublicKey
                                                                        issuerID:nil
                                                                        fabricID:nil
                                                                           error:nil];

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -405,7 +405,6 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
     __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
     XCTAssert(operationalPublicKey != NULL);
-    CFAutorelease(operationalPublicKey);
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
@@ -414,6 +413,8 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:caseAuthenticatedTags
                                                                         error:error];
+    CFRelease(operationalPublicKey);
+
     XCTAssertNil(*error);
     XCTAssertNotNil(operational);
 

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -405,7 +405,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:operationalKeys.publicKey
+                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:caseAuthenticatedTags

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -403,9 +403,13 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     XCTAssertNil(*error);
     XCTAssertNotNil(root);
 
+    __auto_type * operationalPublicKey = [operationalKeys copyPublicKey];
+    XCTAssert(operationalPublicKey != NULL);
+    CFAutorelease(operationalPublicKey);
+
     __auto_type * operational = [MTRCertificates createOperationalCertificate:rootKeys
                                                            signingCertificate:root
-                                                         operationalPublicKey:[operationalKeys.copyPublicKey autorelease]
+                                                         operationalPublicKey:operationalPublicKey
                                                                      fabricID:fabricID
                                                                        nodeID:nodeID
                                                         caseAuthenticatedTags:caseAuthenticatedTags

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
@@ -31,9 +31,8 @@
     return (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation([self publicKey], nil);
 }
 
-- (SecKeyRef)copyPublicKey {
-    // because this varies significantly from the actual implementations,
-    // it's probably not a great idea to rely on this for memory leak behavior information.
+- (SecKeyRef)copyPublicKey
+{
     CFRetain(_publicKey);
     return _publicKey;
 }

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestKeys.m
@@ -31,6 +31,13 @@
     return (__bridge_transfer NSData *) SecKeyCopyExternalRepresentation([self publicKey], nil);
 }
 
+- (SecKeyRef)copyPublicKey {
+    // because this varies significantly from the actual implementations,
+    // it's probably not a great idea to rely on this for memory leak behavior information.
+    CFRetain(_publicKey);
+    return _publicKey;
+}
+
 - (instancetype)init
 {
     if (!(self = [super init])) {


### PR DESCRIPTION
reverted because mergify landed it with failing checks...?

- **Initial checkin**
- **Fixing review feedback**
- **Adding braces**
- **Restyled by clang-format**
- **Fixing build**
- **Restyled by clang-format**
- **Fixing annotations**
- **Update src/darwin/Framework/CHIP/MTRKeypair.h**
- **separate statements involving _mPublicKey to make compiler happy**
- **use `CFAutorelease` on CoreFoundation typed public key copies**
- **fix indent**
- **implement `copyPublicKey` for `MTRTestKeys`; add TODO note about optional method calls**
- **remove comment**
- **consistent formatting for `copyPublicKey` calls**
- **reformat `copyPublicKey` in `MTRTestKeys`**
- **Update src/darwin/Framework/CHIP/MTRKeypair.h**
