### PR TITLE
[ICD] Shutdown icd client storage when destroying android controller

### DIFF
--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -542,5 +542,14 @@ CHIP_ERROR DefaultICDClientStorage::ProcessCheckInPayload(const ByteSpan & paylo
     iterator->Release();
     return CHIP_ERROR_NOT_FOUND;
 }
+
+void DefaultICDClientStorage::Shutdown()
+{
+    mICDClientInfoIterators.ReleaseAll();
+    mpClientInfoStore = nullptr;
+    mpKeyStore        = nullptr;
+    mFabricList.clear();
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -119,10 +119,10 @@ public:
 
     CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
                                      Protocols::SecureChannel::CounterType & counter) override;
-    
+
     /**
      * Shutdown DefaultICDClientStorage
-     * 
+     *
      */
     void Shutdown();
 

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -119,6 +119,12 @@ public:
 
     CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
                                      Protocols::SecureChannel::CounterType & counter) override;
+    
+    /**
+     * Shutdown DefaultICDClientStorage
+     * 
+     */
+    void Shutdown();
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     size_t GetFabricListSize() { return mFabricList.size(); }

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -121,7 +121,7 @@ public:
                                      Protocols::SecureChannel::CounterType & counter) override;
 
     /**
-     * Shutdown DefaultICDClientStorage
+     * Shut down DefaultICDClientStorage
      *
      */
     void Shutdown();

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -50,6 +50,7 @@ using namespace TLV;
 
 AndroidDeviceControllerWrapper::~AndroidDeviceControllerWrapper()
 {
+    getICDClientStorage()->Shutdown();
     mController->Shutdown();
 
     if (mKeypairBridge != nullptr)


### PR DESCRIPTION
Summary: In android controller , DefaultICDClientStorage has been handled as static instance, which is reused across multiple controllers, without this PR, it would crash when second controller reinitialize the ICDClientStorage

In order to resolve this issue, we need shutdown icd client storage when destroying android controller

fixes: https://github.com/project-chip/connectedhomeip/issues/36346
