### PR TITLE
Implement Operational State Cluster PhaseList attribute

### DIFF
--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -110,8 +110,7 @@ private:
         GenericOperationalState(to_underlying(OperationalStateEnum::kPaused)),
         GenericOperationalState(to_underlying(OperationalStateEnum::kError)),
     };
-    // const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
-    const CharSpan opPhaseList[] = { "pre-soak"_span, "rinse"_span, "spin"_span };
+    const CharSpan opPhaseList[3] = { "pre-soak"_span, "rinse"_span, "spin"_span };
 
 public:
     const uint32_t kExampleCountDown = 30;

--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -118,6 +118,7 @@ public:
     OperationalStateDelegate()
     {
         GenericOperationalStateDelegateImpl::mOperationalStateList = Span<const GenericOperationalState>(opStateList);
+        GenericOperationalStateDelegateImpl::mOperationalPhaseList = Span<const CharSpan>(opPhaseList);
     }
 
     /**

--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -110,7 +110,8 @@ private:
         GenericOperationalState(to_underlying(OperationalStateEnum::kPaused)),
         GenericOperationalState(to_underlying(OperationalStateEnum::kError)),
     };
-    const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
+    //const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
+    const CharSpan opPhaseList[] = { "pre-soak"_span, "rinse"_span, "spin"_span };
 
 public:
     const uint32_t kExampleCountDown = 30;

--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -110,7 +110,7 @@ private:
         GenericOperationalState(to_underlying(OperationalStateEnum::kPaused)),
         GenericOperationalState(to_underlying(OperationalStateEnum::kError)),
     };
-    const char* opPhaseList[3] = { "pre-soak", "rinse", "spin" };
+    const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
 
 public:
     const uint32_t kExampleCountDown = 30;

--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -110,6 +110,7 @@ private:
         GenericOperationalState(to_underlying(OperationalStateEnum::kPaused)),
         GenericOperationalState(to_underlying(OperationalStateEnum::kError)),
     };
+    const char* opPhaseList[3] = { "pre-soak", "rinse", "spin" };
 
 public:
     const uint32_t kExampleCountDown = 30;

--- a/examples/chef/common/chef-operational-state-delegate-impl.h
+++ b/examples/chef/common/chef-operational-state-delegate-impl.h
@@ -110,7 +110,7 @@ private:
         GenericOperationalState(to_underlying(OperationalStateEnum::kPaused)),
         GenericOperationalState(to_underlying(OperationalStateEnum::kError)),
     };
-    //const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
+    // const char * opPhaseList[3] = { "pre-soak", "rinse", "spin" };
     const CharSpan opPhaseList[] = { "pre-soak"_span, "rinse"_span, "spin"_span };
 
 public:


### PR DESCRIPTION
Implement Laundry Washer `Operational State` Cluster `PhaseList` attribute
Fixes:
- #36349

> 1.14.5.1. PhaseList Attribute
> 
> This attribute SHALL indicate a list of names of different phases that the device can go through for the selected function or mode. The list may not be in sequence order. For example in a washing machine this could include items such as "pre-soak", "rinse", and "spin". These phases are manufacturer specific and may change when a different function or mode is selected.
> A null value indicates that the device does not present phases during its operation. When this attribute’s value is null, the CurrentPhase attribute SHALL also be set to null.

**Testing**

```
cd ~/connectedhomeip/
./examples/chef/chef.py -t linux -d rootnode_laundrywasher_fb10d238c8 -b -P "Laundry washer"
./examples/chef/linux/out/rootnode_laundrywasher_fb10d238c8
```