### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-89 : [Silabs] Leave Simplicity SDK components for SLC generation CI
+90 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=3ed7686a9378de6be1368c912f9a42f998bbfb18
+ARG ZEPHYR_REVISION=f762f1a1027284e63e338e6d83deeade62f355b0
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- drivers: W91 ADC driver
- west.yml: Update HAL Telink
- soc: riscv: telink_w91: Optimize telink_w91_post_build file
- soc: riscv: telink_b9x: Add mcuboot LZMA image decompression


**Changes of N22 binary:**

None

Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully