### PR TITLE
Add skip_bytes functionality to OTA Provider and BDX downloader class

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -124,16 +124,24 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
 
         break;
     }
-    case TransferSession::OutputEventType::kQueryReceived: {
+    case TransferSession::OutputEventType::kQueryReceived:
+    case TransferSession::OutputEventType::kQueryWithSkipReceived: {
         TransferSession::BlockData blockData;
         uint16_t blockSize   = mTransfer.GetTransferBlockSize();
         uint16_t bytesToRead = blockSize;
+        uint64_t bytesToSkip = 0;
+
+        if (event.EventType == TransferSession::OutputEventType::kQueryWithSkipReceived)
+        {
+            bytesToSkip = event.bytesToSkip.BytesToSkip;
+        }
+        uint64_t seekOffset = mNumBytesSent + bytesToSkip;
 
         // TODO: This should be a utility function in TransferSession
-        if (mTransfer.GetTransferLength() > 0 && mNumBytesSent + blockSize > mTransfer.GetTransferLength())
+        if ((mTransfer.GetTransferLength() > 0) && ((seekOffset + blockSize) > mTransfer.GetTransferLength()))
         {
             // cast should be safe because of condition above
-            bytesToRead = static_cast<uint16_t>(mTransfer.GetTransferLength() - mNumBytesSent);
+            bytesToRead = static_cast<uint16_t>(mTransfer.GetTransferLength() - seekOffset);
         }
 
         chip::System::PacketBufferHandle blockBuf = chip::System::PacketBufferHandle::New(bytesToRead);
@@ -152,7 +160,13 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
             return;
         }
 
-        otaFile.seekg(mNumBytesSent);
+        if (seekOffset > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max()))
+        {
+            ChipLogError(BDX, "Seek offset too large");
+            mTransfer.AbortTransfer(StatusCode::kLengthTooLarge);
+            return;
+        }
+        otaFile.seekg(static_cast<std::streamoff>(seekOffset));
         otaFile.read(reinterpret_cast<char *>(blockBuf->Start()), bytesToRead);
         if (!(otaFile.good() || otaFile.eof()))
         {
@@ -164,8 +178,8 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         blockData.Data   = blockBuf->Start();
         blockData.Length = static_cast<size_t>(otaFile.gcount());
         blockData.IsEof  = (blockData.Length < blockSize) ||
-            (mNumBytesSent + static_cast<uint64_t>(blockData.Length) == mTransfer.GetTransferLength() || (otaFile.peek() == EOF));
-        mNumBytesSent = static_cast<uint32_t>(mNumBytesSent + blockData.Length);
+            (seekOffset + static_cast<uint64_t>(blockData.Length) == mTransfer.GetTransferLength() || (otaFile.peek() == EOF));
+        mNumBytesSent = static_cast<uint32_t>(seekOffset + blockData.Length);
         otaFile.close();
 
         err = mTransfer.PrepareBlock(blockData);

--- a/src/app/clusters/ota-requestor/BDXDownloader.cpp
+++ b/src/app/clusters/ota-requestor/BDXDownloader.cpp
@@ -159,6 +159,15 @@ CHIP_ERROR BDXDownloader::FetchNextData()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR BDXDownloader::SkipData(uint32_t numBytes)
+{
+    VerifyOrReturnError(mState == State::kInProgress, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(mBdxTransfer.PrepareBlockQueryWithSkip(numBytes));
+    PollTransferSession();
+
+    return CHIP_NO_ERROR;
+}
+
 void BDXDownloader::OnDownloadTimeout()
 {
     Reset();

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -73,7 +73,7 @@ public:
     // instead.
     void EndDownload(CHIP_ERROR reason = CHIP_NO_ERROR) override;
     CHIP_ERROR FetchNextData() override;
-    // TODO: override SkipData
+    CHIP_ERROR SkipData(uint32_t numBytes) override;
 
     System::Clock::Timeout GetTimeout();
     // If True, there's been a timeout in the transfer as measured by no download progress after 'mTimeout' seconds.


### PR DESCRIPTION
Implementation to extend BDX class with the capability to skip bytes during OTA download - functionality is provisioned for, but not yet implemented. This PR fixes that.

