### PR TITLE
[Fabric-Admin] Put fabric sync logic into namespace 'admin'

### DIFF
--- a/examples/fabric-admin/commands/common/CHIPCommand.cpp
+++ b/examples/fabric-admin/commands/common/CHIPCommand.cpp
@@ -182,7 +182,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     mCredIssuerCmds->SetCredentialIssuerOption(CredentialIssuerCommands::CredentialIssuerOptions::kAllowTestCdSigningKey,
                                                allowTestCdSigningKey);
 
-    ReturnLogErrorOnFailure(PairingManager::Instance().Init(&CurrentCommissioner(), mCredIssuerCmds));
+    ReturnLogErrorOnFailure(admin::PairingManager::Instance().Init(&CurrentCommissioner(), mCredIssuerCmds));
 
     return CHIP_NO_ERROR;
 }

--- a/examples/fabric-admin/commands/fabric-sync/Commands.h
+++ b/examples/fabric-admin/commands/fabric-sync/Commands.h
@@ -26,11 +26,11 @@ void registerCommandsFabricSync(Commands & commands, CredentialIssuerCommands * 
     const char * clusterName = "FabricSync";
 
     commands_list clusterCommands = {
-        make_unique<FabricSyncAddBridgeCommand>(credsIssuerConfig),
-        make_unique<FabricSyncRemoveBridgeCommand>(credsIssuerConfig),
-        make_unique<FabricSyncAddLocalBridgeCommand>(credsIssuerConfig),
-        make_unique<FabricSyncRemoveLocalBridgeCommand>(credsIssuerConfig),
-        make_unique<FabricSyncDeviceCommand>(credsIssuerConfig),
+        make_unique<admin::FabricSyncAddBridgeCommand>(credsIssuerConfig),
+        make_unique<admin::FabricSyncRemoveBridgeCommand>(credsIssuerConfig),
+        make_unique<admin::FabricSyncAddLocalBridgeCommand>(credsIssuerConfig),
+        make_unique<admin::FabricSyncRemoveLocalBridgeCommand>(credsIssuerConfig),
+        make_unique<admin::FabricSyncDeviceCommand>(credsIssuerConfig),
     };
 
     commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for fabric synchronization.");

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -30,6 +30,8 @@
 
 using namespace ::chip;
 
+namespace admin {
+
 void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 {
     if (mBridgeNodeId != deviceId)
@@ -305,3 +307,5 @@ CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteId)
 
     return CHIP_NO_ERROR;
 }
+
+} // namespace admin

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -21,6 +21,8 @@
 #include <commands/common/CHIPCommand.h>
 #include <device_manager/PairingManager.h>
 
+namespace admin {
+
 // Constants
 constexpr uint32_t kCommissionPrepareTimeMs = 500;
 
@@ -136,3 +138,5 @@ private:
 
     CHIP_ERROR RunCommand(chip::EndpointId remoteId);
 };
+
+} // namespace admin

--- a/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
+++ b/examples/fabric-admin/commands/interactive/InteractiveCommands.cpp
@@ -117,7 +117,7 @@ void ENFORCE_FORMAT(3, 0) LoggingCallback(const char * module, uint8_t category,
 #if defined(PW_RPC_ENABLED)
 void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
 {
-    if (StartRpcClient() == CHIP_NO_ERROR)
+    if (admin::StartRpcClient() == CHIP_NO_ERROR)
     {
         // print to console
         fprintf(stderr, "Connected to Fabric-Bridge\n");
@@ -199,8 +199,8 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     }
 
 #if defined(PW_RPC_ENABLED)
-    SetRpcRemoteServerPort(mFabricBridgeServerPort.Value());
-    InitRpcServer(mLocalServerPort.Value());
+    admin::SetRpcRemoteServerPort(mFabricBridgeServerPort.Value());
+    admin::InitRpcServer(mLocalServerPort.Value());
     ChipLogProgress(NotSpecified, "PW_RPC initialized.");
     DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredConnect, 0);
 #endif

--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -405,7 +405,7 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
         fprintf(stderr, "New device with Node ID: 0x%lx has been successfully added.\n", nodeId);
         // CurrentCommissioner() has a lifetime that is the entire life of the application itself
         // so it is safe to provide to StartDeviceSynchronization.
-        DeviceSynchronizer::Instance().StartDeviceSynchronization(&CurrentCommissioner(), mNodeId, mDeviceIsICD);
+        admin::DeviceSynchronizer::Instance().StartDeviceSynchronization(&CurrentCommissioner(), mNodeId, mDeviceIsICD);
     }
     else
     {
@@ -542,7 +542,7 @@ void PairingCommand::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
 #if defined(PW_RPC_ENABLED)
         app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(command->CurrentCommissioner().GetFabricIndex(), nodeId);
         ScopedNodeId scopedNodeId(nodeId, command->CurrentCommissioner().GetFabricIndex());
-        RemoveSynchronizedDevice(scopedNodeId);
+        admin::RemoveSynchronizedDevice(scopedNodeId);
 #endif
     }
     else

--- a/examples/fabric-admin/device_manager/BridgeSubscription.cpp
+++ b/examples/fabric-admin/device_manager/BridgeSubscription.cpp
@@ -17,11 +17,13 @@
  */
 
 #include "BridgeSubscription.h"
-#include <device_manager/DeviceManager.h>
+#include "DeviceManager.h"
 
 using namespace ::chip;
 using namespace ::chip::app;
 using chip::app::ReadClient;
+
+namespace admin {
 
 namespace {
 
@@ -157,3 +159,5 @@ void BridgeSubscription::OnDeviceConnectionFailure(const ScopedNodeId & peerId, 
     ChipLogError(NotSpecified, "BridgeSubscription failed to connect to " ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
     OnDone(nullptr);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/BridgeSubscription.h
+++ b/examples/fabric-admin/device_manager/BridgeSubscription.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <optional>
 
+namespace admin {
+
 /**
  * @brief Class used to subscribe to attributes and events from the remote bridged device.
  *
@@ -75,3 +77,5 @@ private:
     chip::EndpointId mEndpointId;
     bool subscriptionStarted = false;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/CommissionerControl.cpp
+++ b/examples/fabric-admin/device_manager/CommissionerControl.cpp
@@ -1,7 +1,9 @@
 #include "CommissionerControl.h"
-#include <device_manager/DeviceManager.h>
+#include "DeviceManager.h"
 
 using namespace ::chip;
+
+namespace admin {
 
 void CommissionerControl::Init(Controller::DeviceCommissioner & commissioner, NodeId nodeId, EndpointId endpointId)
 {
@@ -102,6 +104,9 @@ void CommissionerControl::OnDone(app::CommandSender * client)
 
 CHIP_ERROR CommissionerControl::SendCommandForType(CommandType commandType, DeviceProxy * device)
 {
+    ChipLogProgress(AppServer, "Sending command with Endpoint ID: %d, Command Type: %d", mEndpointId,
+                    static_cast<int>(commandType));
+
     switch (commandType)
     {
     case CommandType::kRequestCommissioningApproval:
@@ -139,3 +144,5 @@ void CommissionerControl::OnDeviceConnectionFailureFn(void * context, const Scop
     VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     self->OnDone(nullptr);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/CommissionerControl.h
+++ b/examples/fabric-admin/device_manager/CommissionerControl.h
@@ -21,6 +21,8 @@
 #include <app/CommandSender.h>
 #include <controller/CHIPDeviceController.h>
 
+namespace admin {
+
 /**
  * @class CommissionerControl
  * @brief This class handles sending CHIP commands related to commissioning, including sending
@@ -123,3 +125,5 @@ private:
     chip::app::Clusters::CommissionerControl::Commands::RequestCommissioningApproval::Type mRequestCommissioningApproval;
     chip::app::Clusters::CommissionerControl::Commands::CommissionNode::Type mCommissionNode;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -27,6 +27,8 @@
 
 using namespace chip;
 
+namespace admin {
+
 namespace {
 
 constexpr EndpointId kAggregatorEndpointId = 1;
@@ -465,3 +467,5 @@ void DeviceManager::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
     RemoveSyncedDevice(deviceId);
     ChipLogProgress(NotSpecified, "Synced device with NodeId:" ChipLogFormatX64 " has been removed.", ChipLogValueX64(deviceId));
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -26,6 +26,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <set>
 
+namespace admin {
+
 constexpr uint32_t kDefaultSetupPinCode    = 20202021;
 constexpr uint16_t kDefaultLocalBridgePort = 5540;
 constexpr uint16_t kResponseTimeoutSeconds = 30;
@@ -226,3 +228,5 @@ inline DeviceManager & DeviceMgr()
     }
     return DeviceManager::sInstance;
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSubscription.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.cpp
@@ -33,6 +33,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using chip::app::ReadClient;
 
+namespace admin {
+
 namespace {
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
@@ -281,3 +283,5 @@ void DeviceSubscription::StopSubscription()
     MoveToState(State::AwaitingDestruction);
     mOnDoneCallback(mScopedNodeId);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSubscription.h
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.h
@@ -20,13 +20,14 @@
 #include <app/ReadClient.h>
 #include <controller/CHIPDeviceController.h>
 #include <lib/core/DataModelTypes.h>
-
 #include <memory>
 
 #if defined(PW_RPC_ENABLED)
 #include "fabric_bridge_service/fabric_bridge_service.pb.h"
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
 #endif
+
+namespace admin {
 
 class DeviceSubscriptionManager;
 
@@ -95,3 +96,5 @@ private:
     bool mChangeDetected = false;
     State mState         = State::Idle;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
@@ -32,6 +32,8 @@
 using namespace ::chip;
 using namespace ::chip::app;
 
+namespace admin {
+
 DeviceSubscriptionManager & DeviceSubscriptionManager::Instance()
 {
     static DeviceSubscriptionManager instance;
@@ -78,3 +80,5 @@ void DeviceSubscriptionManager::DeviceSubscriptionTerminated(ScopedNodeId scoped
     VerifyOrDie(it != mDeviceSubscriptionMap.end());
     mDeviceSubscriptionMap.erase(scopedNodeId);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSubscriptionManager.h
+++ b/examples/fabric-admin/device_manager/DeviceSubscriptionManager.h
@@ -25,6 +25,8 @@
 
 #include <memory>
 
+namespace admin {
+
 class DeviceSubscriptionManager
 {
 public:
@@ -52,3 +54,5 @@ private:
 
     std::unordered_map<chip::ScopedNodeId, std::unique_ptr<DeviceSubscription>, ScopedNodeIdHasher> mDeviceSubscriptionMap;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
@@ -35,6 +35,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using chip::app::ReadClient;
 
+namespace admin {
+
 namespace {
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
@@ -324,3 +326,5 @@ const char * DeviceSynchronizer::GetStateStr() const
     }
     return "N/A";
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSynchronization.h
+++ b/examples/fabric-admin/device_manager/DeviceSynchronization.h
@@ -22,13 +22,14 @@
 #include <app/ReadClient.h>
 #include <controller/CHIPDeviceController.h>
 #include <lib/core/DataModelTypes.h>
-
 #include <memory>
 
 #if defined(PW_RPC_ENABLED)
 #include "fabric_bridge_service/fabric_bridge_service.pb.h"
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
 #endif
+
+namespace admin {
 
 /// Ensures that device data is synchronized to the remote fabric bridge.
 ///
@@ -100,3 +101,5 @@ private:
 #endif
     UniqueIdGetter mUniqueIdGetter;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/FabricSyncGetter.cpp
+++ b/examples/fabric-admin/device_manager/FabricSyncGetter.cpp
@@ -22,6 +22,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using chip::app::ReadClient;
 
+namespace admin {
+
 namespace {
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
@@ -119,3 +121,5 @@ void FabricSyncGetter::OnDeviceConnectionFailure(const ScopedNodeId & peerId, CH
 
     OnDone(nullptr);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/FabricSyncGetter.h
+++ b/examples/fabric-admin/device_manager/FabricSyncGetter.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <optional>
 
+namespace admin {
+
 /**
  * @brief Class used to get FabricSynchronization from SupportedDeviceCategories attribute of Commissioner Control Cluster.
  *
@@ -73,3 +75,5 @@ private:
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -35,6 +35,8 @@
 using namespace ::chip;
 using namespace ::chip::Controller;
 
+namespace admin {
+
 namespace {
 
 CHIP_ERROR GetPayload(const char * setUpCode, SetupPayload & payload)
@@ -655,3 +657,5 @@ CHIP_ERROR PairingManager::UnpairDevice(NodeId nodeId)
         }
     });
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/PairingManager.h
+++ b/examples/fabric-admin/device_manager/PairingManager.h
@@ -25,6 +25,8 @@
 #include <controller/CurrentFabricRemover.h>
 #include <crypto/CHIPCryptoPAL.h>
 
+namespace admin {
+
 // Constants
 constexpr uint16_t kMaxManualCodeLength = 22;
 
@@ -214,3 +216,5 @@ private:
     chip::Platform::UniquePtr<chip::Controller::CurrentFabricRemover> mCurrentFabricRemover;
     chip::Callback::Callback<chip::Controller::OnCurrentFabricRemove> mCurrentFabricRemoveCallback;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/UniqueIdGetter.cpp
+++ b/examples/fabric-admin/device_manager/UniqueIdGetter.cpp
@@ -22,6 +22,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using chip::app::ReadClient;
 
+namespace admin {
+
 namespace {
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
@@ -139,3 +141,5 @@ void UniqueIdGetter::OnDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP
 
     OnDone(nullptr);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/device_manager/UniqueIdGetter.h
+++ b/examples/fabric-admin/device_manager/UniqueIdGetter.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <optional>
 
+namespace admin {
+
 /**
  * @brief Class used to get UniqueID from Bridged Device Basic Information Cluster
  *
@@ -73,3 +75,5 @@ private:
     char mUniqueId[33];
     chip::EndpointId mEndpointId;
 };
+
+} // namespace admin

--- a/examples/fabric-admin/main.cpp
+++ b/examples/fabric-admin/main.cpp
@@ -32,7 +32,7 @@ using namespace chip;
 
 void ApplicationInit()
 {
-    DeviceMgr().Init();
+    admin::DeviceMgr().Init();
 }
 
 // ================================================================================

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -28,6 +28,8 @@
 
 using namespace chip;
 
+namespace admin {
+
 namespace {
 
 // Constants
@@ -227,3 +229,5 @@ CHIP_ERROR DeviceReachableChanged(const chip_rpc_ReachabilityChanged & data)
 
     return WaitForResponse(call);
 }
+
+} // namespace admin

--- a/examples/fabric-admin/rpc/RpcClient.h
+++ b/examples/fabric-admin/rpc/RpcClient.h
@@ -23,6 +23,8 @@
 
 #include "fabric_bridge_service/fabric_bridge_service.rpc.pb.h"
 
+namespace admin {
+
 /**
  * @brief Sets the RPC server port to which the RPC client will connect.
  *
@@ -99,3 +101,5 @@ CHIP_ERROR AdminCommissioningAttributeChanged(const chip_rpc_AdministratorCommis
  * - CHIP_ERROR_INTERNAL: An internal error occurred while activating the RPC call.
  */
 CHIP_ERROR DeviceReachableChanged(const chip_rpc_ReachabilityChanged & data);
+
+} // namespace admin

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -38,6 +38,8 @@
 
 using namespace ::chip;
 
+namespace admin {
+
 namespace {
 
 #if defined(PW_RPC_FABRIC_ADMIN_SERVICE) && PW_RPC_FABRIC_ADMIN_SERVICE
@@ -254,3 +256,5 @@ void InitRpcServer(uint16_t rpcServerPort)
     std::thread rpc_service(RunRpcService);
     rpc_service.detach();
 }
+
+} // namespace admin

--- a/examples/fabric-admin/rpc/RpcServer.h
+++ b/examples/fabric-admin/rpc/RpcServer.h
@@ -18,4 +18,8 @@
 
 #pragma once
 
+namespace admin {
+
 void InitRpcServer(uint16_t rpcServerPort);
+
+} // namespace admin


### PR DESCRIPTION
To differentiate the fabric sync logic between fabric-admin and fabric-bridge, place the sync logic in fabric-admin within an 'admin' namespace and  sync logic in fabric-bridge within an 'bridge' namespace
