### PR TITLE
[Fabric-Bridge] Put fabric sync logic into namespace 'bridge'

### DIFF
--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedAdministratorCommissioning.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedAdministratorCommissioning.h
@@ -20,6 +20,8 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 
+namespace bridge {
+
 /**
  * @brief CADMIN cluster implementation for handling attribute interactions of bridged device endpoints.
  *
@@ -56,3 +58,5 @@ private:
     // to reflect this change.
     chip::app::AttributeAccessInterface * mOriginalAttributeInterface = nullptr;
 };
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDevice.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDevice.h
@@ -23,6 +23,8 @@
 
 #include <string>
 
+namespace bridge {
+
 class BridgedDevice
 {
 public:
@@ -90,3 +92,5 @@ protected:
     BridgedAttributes mAttributes;
     AdminCommissioningAttributes mAdminCommissioningAttributes;
 };
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceBasicInformationImpl.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceBasicInformationImpl.h
@@ -18,6 +18,8 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 
+namespace bridge {
+
 class BridgedDeviceBasicInformationImpl : public chip::app::AttributeAccessInterface
 {
 public:
@@ -30,3 +32,5 @@ public:
     CHIP_ERROR Read(const chip::app::ConcreteReadAttributePath & path, chip::app::AttributeValueEncoder & encoder) override;
     CHIP_ERROR Write(const chip::app::ConcreteDataAttributePath & path, chip::app::AttributeValueDecoder & decoder) override;
 };
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceManager.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceManager.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+namespace bridge {
+
 class BridgedDeviceManager
 {
 public:
@@ -134,3 +136,5 @@ inline BridgedDeviceManager & BridgeDeviceMgr()
 {
     return BridgedDeviceManager::sInstance;
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
@@ -26,6 +26,8 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AdministratorCommissioning;
 
+namespace bridge {
+
 CHIP_ERROR BridgedAdministratorCommissioning::Init()
 {
     // We expect initialization after emberAfInit(). This allows us to unregister the existing
@@ -79,3 +81,5 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
 
     return CHIP_NO_ERROR;
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDevice.cpp
@@ -27,6 +27,8 @@
 using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
+namespace bridge {
+
 BridgedDevice::BridgedDevice(ScopedNodeId scopedNodeId)
 {
     mReachable    = false;
@@ -116,3 +118,5 @@ void BridgedDevice::SetAdminCommissioningAttributes(const AdminCommissioningAttr
         }
     });
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceBasicInformationImpl.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceBasicInformationImpl.cpp
@@ -29,6 +29,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
+namespace bridge {
+
 CHIP_ERROR BridgedDeviceBasicInformationImpl::Read(const ConcreteReadAttributePath & path, AttributeValueEncoder & encoder)
 {
     // Registration is done for the bridged device basic information only
@@ -105,3 +107,5 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Write(const ConcreteDataAttributeP
 
     return CHIP_ERROR_INVALID_ARGUMENT;
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceManager.cpp
@@ -45,6 +45,8 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
+namespace bridge {
+
 namespace {
 
 constexpr uint8_t kMaxRetries      = 10;
@@ -343,3 +345,5 @@ std::optional<unsigned> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::S
     }
     return std::nullopt;
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/CommissionerControlDelegate.cpp
+++ b/examples/fabric-bridge-app/linux/CommissionerControlDelegate.cpp
@@ -186,13 +186,13 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissionNode(const Commissioning
     VerifyOrReturnError(mNextStep == Step::kStartCommissionNode, CHIP_ERROR_INCORRECT_STATE);
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
-    err = CommissionNode(Controller::CommissioningWindowPasscodeParams()
-                             .SetSetupPIN(kSetupPinCode)
-                             .SetTimeout(params.commissioningTimeout)
-                             .SetDiscriminator(params.discriminator)
-                             .SetIteration(params.iterations)
-                             .SetSalt(params.salt),
-                         mVendorId, mProductId);
+    err = bridge::CommissionNode(Controller::CommissioningWindowPasscodeParams()
+                                     .SetSetupPIN(kSetupPinCode)
+                                     .SetTimeout(params.commissioningTimeout)
+                                     .SetDiscriminator(params.discriminator)
+                                     .SetIteration(params.iterations)
+                                     .SetSalt(params.salt),
+                                 mVendorId, mProductId);
 #else
     ChipLogProgress(NotSpecified, "Failed to reverse commission bridge: PW_RPC_FABRIC_BRIDGE_SERVICE not defined");
     err = CHIP_ERROR_NOT_IMPLEMENTED;
@@ -208,6 +208,8 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissionNode(const Commissioning
 } // namespace Clusters
 } // namespace app
 } // namespace chip
+
+namespace bridge {
 
 CHIP_ERROR CommissionerControlInit()
 {
@@ -262,3 +264,5 @@ CHIP_ERROR CommissionerControlShutdown()
 
     return CHIP_NO_ERROR;
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/RpcClient.cpp
+++ b/examples/fabric-bridge-app/linux/RpcClient.cpp
@@ -35,6 +35,8 @@
 
 using namespace chip;
 
+namespace bridge {
+
 namespace {
 
 // Constants
@@ -205,3 +207,5 @@ CHIP_ERROR KeepActive(chip::ScopedNodeId scopedNodeId, uint32_t stayActiveDurati
 
     return WaitForResponse(call);
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -37,6 +37,8 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 
+namespace bridge {
+
 namespace {
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
@@ -256,3 +258,5 @@ void InitRpcServer(uint16_t rpcServerPort)
     std::thread rpc_service(RunRpcService);
     rpc_service.detach();
 }
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
+++ b/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
@@ -89,5 +89,9 @@ private:
 } // namespace app
 } // namespace chip
 
+namespace bridge {
+
 CHIP_ERROR CommissionerControlInit();
 CHIP_ERROR CommissionerControlShutdown();
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/include/RpcClient.h
+++ b/examples/fabric-bridge-app/linux/include/RpcClient.h
@@ -22,6 +22,8 @@
 #include <lib/core/ScopedNodeId.h>
 #include <platform/CHIPDeviceLayer.h>
 
+namespace bridge {
+
 /**
  * Sets the RPC server port to which the RPC client will connect.
  *
@@ -70,3 +72,5 @@ CHIP_ERROR
 CommissionNode(chip::Controller::CommissioningWindowPasscodeParams params, chip::VendorId vendorId, uint16_t productId);
 
 CHIP_ERROR KeepActive(chip::ScopedNodeId scopedNodeId, uint32_t stayActiveDurationMs, uint32_t timeoutMs);
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/include/RpcServer.h
+++ b/examples/fabric-bridge-app/linux/include/RpcServer.h
@@ -18,4 +18,8 @@
 
 #pragma once
 
+namespace bridge {
+
 void InitRpcServer(uint16_t rpcServerPort);
+
+} // namespace bridge

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -98,7 +98,7 @@ ArgParser::OptionSet sProgramCustomOptions = { HandleCustomOption, sProgramCusto
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
 void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
 {
-    if (StartRpcClient() == CHIP_NO_ERROR)
+    if (bridge::StartRpcClient() == CHIP_NO_ERROR)
     {
         ChipLogProgress(NotSpecified, "Connected to Fabric-Admin");
     }
@@ -109,6 +109,10 @@ void AttemptRpcClientConnect(System::Layer * systemLayer, void * appState)
     }
 }
 #endif // defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
+
+} // namespace
+
+namespace bridge {
 
 class AdministratorCommissioningCommandHandler : public CommandHandlerInterface
 {
@@ -241,27 +245,27 @@ BridgedDeviceBasicInformationImpl gBridgedDeviceBasicInformationAttributes;
 AdministratorCommissioningCommandHandler gAdministratorCommissioningCommandHandler;
 BridgedDeviceInformationCommandHandler gBridgedDeviceInformationCommandHandler;
 
-} // namespace
+} // namespace bridge
 
 void ApplicationInit()
 {
     ChipLogDetail(NotSpecified, "Fabric-Bridge: ApplicationInit()");
 
     MatterEcosystemInformationPluginServerInitCallback();
-    CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gAdministratorCommissioningCommandHandler);
-    CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gBridgedDeviceInformationCommandHandler);
-    AttributeAccessInterfaceRegistry::Instance().Register(&gBridgedDeviceBasicInformationAttributes);
+    CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&bridge::gAdministratorCommissioningCommandHandler);
+    CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&bridge::gBridgedDeviceInformationCommandHandler);
+    AttributeAccessInterfaceRegistry::Instance().Register(&bridge::gBridgedDeviceBasicInformationAttributes);
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
-    SetRpcRemoteServerPort(gFabricAdminServerPort);
-    InitRpcServer(gLocalServerPort);
+    bridge::SetRpcRemoteServerPort(gFabricAdminServerPort);
+    bridge::InitRpcServer(gLocalServerPort);
     AttemptRpcClientConnect(&DeviceLayer::SystemLayer(), nullptr);
 #endif
 
-    BridgeDeviceMgr().Init();
-    VerifyOrDie(gBridgedAdministratorCommissioning.Init() == CHIP_NO_ERROR);
+    bridge::BridgeDeviceMgr().Init();
+    VerifyOrDie(bridge::gBridgedAdministratorCommissioning.Init() == CHIP_NO_ERROR);
 
-    VerifyOrDieWithMsg(CommissionerControlInit() == CHIP_NO_ERROR, NotSpecified,
+    VerifyOrDieWithMsg(bridge::CommissionerControlInit() == CHIP_NO_ERROR, NotSpecified,
                        "Failed to initialize Commissioner Control Server");
 }
 
@@ -269,7 +273,7 @@ void ApplicationShutdown()
 {
     ChipLogDetail(NotSpecified, "Fabric-Bridge: ApplicationShutdown()");
 
-    if (CommissionerControlShutdown() != CHIP_NO_ERROR)
+    if (bridge::CommissionerControlShutdown() != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "Failed to shutdown Commissioner Control Server");
     }


### PR DESCRIPTION
To differentiate the fabric sync logic between fabric-admin and fabric-bridge, place the sync logic in fabric-admin within an 'admin' namespace and sync logic in fabric-bridge within an 'bridge' namespace

