### PR TITLE
[Silabs] Refactor Wifi eventing structure to be align with C++ standards

### DIFF
--- a/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
+++ b/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
@@ -424,8 +424,7 @@ sl_status_t JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_wifi_connect failed: 0x%lx", static_cast<uint32_t>(status));
     VerifyOrReturnError((wfx_rsi.join_retries <= MAX_JOIN_RETRIES_COUNT), status);
 
-    WifiStateFlags flagsToClear = WifiStateFlags(WifiState::kStationConnecting, WifiState::kStationConnected);
-    wfx_rsi.dev_state.Clear(flagsToClear);
+    wfx_rsi.dev_state.Clear(WifiState::kStationConnecting).Clear(WifiState::kStationConnected);
 
     ChipLogProgress(DeviceLayer, "Connection retry attempt %d", wfx_rsi.join_retries);
     wfx_retry_connection(++wfx_rsi.join_retries);
@@ -735,9 +734,10 @@ void ProcessEvent(WifiEvent event)
         ChipLogDetail(DeviceLayer, "WifiEvent::kStationDisconnect");
         // TODO: This event is not being posted anywhere, seems to be a dead code or we are missing something
 
-        WifiStateFlags flagsToClear = WifiStateFlags(WifiState::kStationReady, WifiState::kStationConnecting,
-                                                     WifiState::kStationConnected, WifiState::kStationDhcpDone);
-        wfx_rsi.dev_state.Clear(flagsToClear);
+        wfx_rsi.dev_state.Clear(WifiState::kStationReady)
+                .Clear(WifiState::kStationConnecting)
+                .Clear(WifiState::kStationConnected)
+                .Clear(WifiState::kStationDhcpDone);
 
         /* TODO: Implement disconnect notify */
         ResetDHCPNotificationFlags();
@@ -922,7 +922,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     ChipLogDetail(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
                   wfx_rsi.ip4_addr[3]);
     /* Notify the Connectivity Manager - via the app */
-    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone, WifiState::kStationReady);
+    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone).Set(WifiState::kStationReady);
     wfx_ip_changed_notify(IP_STATUS_SUCCESS);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */

--- a/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
+++ b/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
@@ -735,9 +735,9 @@ void ProcessEvent(WifiEvent event)
         // TODO: This event is not being posted anywhere, seems to be a dead code or we are missing something
 
         wfx_rsi.dev_state.Clear(WifiState::kStationReady)
-                .Clear(WifiState::kStationConnecting)
-                .Clear(WifiState::kStationConnected)
-                .Clear(WifiState::kStationDhcpDone);
+            .Clear(WifiState::kStationConnecting)
+            .Clear(WifiState::kStationConnected)
+            .Clear(WifiState::kStationDhcpDone);
 
         /* TODO: Implement disconnect notify */
         ResetDHCPNotificationFlags();

--- a/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
+++ b/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
@@ -61,6 +61,7 @@ extern "C" {
 #include <lib/support/logging/CHIPLogging.h>
 
 #define WFX_QUEUE_SIZE 10
+#define WFX_RSI_BUF_SZ (1024 * 10)
 
 static osThreadId_t sDrvThread;
 constexpr uint32_t kDrvTaskSize = 1792;

--- a/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
+++ b/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
@@ -320,8 +320,7 @@ static void wfx_rsi_join_fail_cb(uint16_t status, uint8_t * buf, uint32_t len)
     ChipLogError(DeviceLayer, "wfx_rsi_join_fail_cb: status: %d", status);
     wfx_rsi.join_retries += 1;
 
-    WifiStateFlags flagsToClear = WifiStateFlags(WifiState::kStationConnecting, WifiState::kStationConnected);
-    wfx_rsi.dev_state.Clear(flagsToClear);
+    wfx_rsi.dev_state.Clear(WifiState::kStationConnecting).Clear(WifiState::kStationConnected);
 
     WifiEvent event = WifiEvent::kStationStartJoin;
     sl_matter_wifi_post_event(event);

--- a/examples/platform/silabs/efr32/rs911x/hal/efx_spi.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/efx_spi.c
@@ -41,7 +41,6 @@
 #include "sl_status.h"
 #include "spidrv.h"
 
-#include "WifiInterfaceAbstraction.h"
 #include "silabs_utils.h"
 #include "spi_multiplex.h"
 #include "wfx_host_events.h"

--- a/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_interrupt.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_interrupt.c
@@ -35,7 +35,6 @@
 #include "event_groups.h"
 #include "task.h"
 
-#include "WifiInterfaceAbstraction.h"
 #include "wfx_host_events.h"
 
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)

--- a/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_ioports.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_ioports.c
@@ -35,7 +35,6 @@
 #include "event_groups.h"
 #include "task.h"
 
-#include "WifiInterfaceAbstraction.h"
 #include "wfx_host_events.h"
 
 #include "rsi_board_configuration.h"

--- a/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_timer.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_timer.c
@@ -39,7 +39,6 @@ extern void xPortSysTickHandler(void);
 /* RSI Driver include file */
 #include "rsi_driver.h"
 /* RSI WLAN Config include file */
-#include "WifiInterfaceAbstraction.h"
 #include "rsi_bootup_config.h"
 #include "rsi_common_apis.h"
 #include "rsi_data_types.h"

--- a/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_timer.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/rsi_hal_mcu_timer.c
@@ -51,6 +51,8 @@ extern void xPortSysTickHandler(void);
 #include "rsi_wlan_apis.h"
 #include "rsi_wlan_config.h"
 
+#define WFX_RSI_NUM_TIMERS (2) /* Number of RSI timers to alloc	*/
+
 #ifndef _use_the_rsi_defined_functions
 
 StaticTimer_t sRsiTimerBuffer;

--- a/examples/platform/silabs/efr32/rs911x/hal/sl_si91x_ncp_utility.c
+++ b/examples/platform/silabs/efr32/rs911x/hal/sl_si91x_ncp_utility.c
@@ -44,7 +44,6 @@
 #include "sl_device_init_hfxo.h"
 #include "sl_status.h"
 
-#include "WifiInterfaceAbstraction.h"
 #include "silabs_utils.h"
 #include "sl_si91x_ncp_utility.h"
 #include "wfx_host_events.h"

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -34,6 +34,8 @@
 using namespace chip;
 using namespace chip::DeviceLayer;
 
+using WifiStateFlags = chip::BitFlags<WifiState>;
+
 namespace {
 
 constexpr uint8_t kWlanMinRetryIntervalsInSec = 1;
@@ -88,8 +90,8 @@ void RetryConnectionTimerHandler(void * arg)
  ***********************************************************************/
 sl_status_t wfx_wifi_start(void)
 {
-    VerifyOrReturnError(!(wfx_rsi.dev_state & WifiState::kStationStarted), SL_STATUS_OK);
-    wfx_rsi.dev_state |= WifiState::kStationStarted;
+    VerifyOrReturnError(!(wfx_rsi.dev_state.Has(WifiState::kStationStarted)), SL_STATUS_OK);
+    wfx_rsi.dev_state.Set(WifiState::kStationStarted);
 
     // Creating a Wi-Fi driver thread
     sWlanThread = osThreadNew(sl_matter_wifi_task, NULL, &kWlanTaskAttr);
@@ -201,9 +203,9 @@ sl_status_t wfx_connect_to_ap(void)
     VerifyOrReturnError(wfx_rsi.sec.ssid_length, SL_STATUS_INVALID_CREDENTIALS);
     VerifyOrReturnError(wfx_rsi.sec.ssid_length <= WFX_MAX_SSID_LENGTH, SL_STATUS_HAS_OVERFLOWED);
     ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.sec.ssid);
-    WfxEvent_t event;
-    event.eventType = WifiEvent::kStationStartJoin;
-    sl_matter_wifi_post_event(&event);
+
+    WifiEvent event = WifiEvent::kStationStartJoin;
+    sl_matter_wifi_post_event(event);
     return SL_STATUS_OK;
 }
 
@@ -401,9 +403,8 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
     chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
 
-    WfxEvent_t event;
-    event.eventType = WifiEvent::kScan;
-    sl_matter_wifi_post_event(&event);
+    WifiEvent event = WifiEvent::kScan;
+    sl_matter_wifi_post_event(event);
 
     return true;
 }

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -88,8 +88,8 @@ void RetryConnectionTimerHandler(void * arg)
  ***********************************************************************/
 sl_status_t wfx_wifi_start(void)
 {
-    VerifyOrReturnError(!(wfx_rsi.dev_state & WFX_RSI_ST_STARTED), SL_STATUS_OK);
-    wfx_rsi.dev_state |= WFX_RSI_ST_STARTED;
+    VerifyOrReturnError(!(wfx_rsi.dev_state & WifiState::kStationStarted), SL_STATUS_OK);
+    wfx_rsi.dev_state |= WifiState::kStationStarted;
 
     // Creating a Wi-Fi driver thread
     sWlanThread = osThreadNew(sl_matter_wifi_task, NULL, &kWlanTaskAttr);
@@ -109,7 +109,7 @@ sl_status_t wfx_wifi_start(void)
  ***********************************************************************/
 void wfx_enable_sta_mode(void)
 {
-    wfx_rsi.dev_state |= WFX_RSI_ST_STA_MODE;
+    wfx_rsi.dev_state.Set(WifiState::kStationMode);
 }
 
 /*********************************************************************
@@ -121,9 +121,7 @@ void wfx_enable_sta_mode(void)
  ***********************************************************************/
 bool wfx_is_sta_mode_enabled(void)
 {
-    bool mode;
-    mode = !!(wfx_rsi.dev_state & WFX_RSI_ST_STA_MODE);
-    return mode;
+    return wfx_rsi.dev_state.Has(WifiState::kStationMode);
 }
 
 /*********************************************************************
@@ -157,7 +155,7 @@ void wfx_set_wifi_provision(wfx_wifi_provision_t * cfg)
 {
     VerifyOrReturn(cfg != nullptr);
     wfx_rsi.sec = *cfg;
-    wfx_rsi.dev_state |= WFX_RSI_ST_STA_PROVISIONED;
+    wfx_rsi.dev_state.Set(WifiState::kStationProvisioned);
 }
 
 /*********************************************************************
@@ -171,7 +169,7 @@ void wfx_set_wifi_provision(wfx_wifi_provision_t * cfg)
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig)
 {
     VerifyOrReturnError(wifiConfig != nullptr, false);
-    VerifyOrReturnError(wfx_rsi.dev_state & WFX_RSI_ST_STA_PROVISIONED, false);
+    VerifyOrReturnError(wfx_rsi.dev_state.Has(WifiState::kStationProvisioned), false);
     *wifiConfig = wfx_rsi.sec;
     return true;
 }
@@ -186,7 +184,7 @@ bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig)
 void wfx_clear_wifi_provision(void)
 {
     memset(&wfx_rsi.sec, 0, sizeof(wfx_rsi.sec));
-    wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_PROVISIONED;
+    wfx_rsi.dev_state.Clear(WifiState::kStationProvisioned);
     ChipLogProgress(DeviceLayer, "Clear WiFi Provision");
 }
 
@@ -199,12 +197,12 @@ void wfx_clear_wifi_provision(void)
  ****************************************************************************/
 sl_status_t wfx_connect_to_ap(void)
 {
-    VerifyOrReturnError(wfx_rsi.dev_state & WFX_RSI_ST_STA_PROVISIONED, SL_STATUS_INVALID_CONFIGURATION);
+    VerifyOrReturnError(wfx_rsi.dev_state.Has(WifiState::kStationProvisioned), SL_STATUS_INVALID_CONFIGURATION);
     VerifyOrReturnError(wfx_rsi.sec.ssid_length, SL_STATUS_INVALID_CREDENTIALS);
     VerifyOrReturnError(wfx_rsi.sec.ssid_length <= WFX_MAX_SSID_LENGTH, SL_STATUS_HAS_OVERFLOWED);
     ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.sec.ssid);
     WfxEvent_t event;
-    event.eventType = WFX_EVT_STA_START_JOIN;
+    event.eventType = WifiEvent::kStationStartJoin;
     sl_matter_wifi_post_event(&event);
     return SL_STATUS_OK;
 }
@@ -266,8 +264,7 @@ void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)
  ***********************************************************************/
 bool wfx_is_sta_connected(void)
 {
-    bool status = (wfx_rsi.dev_state & WFX_RSI_ST_STA_CONNECTED) > 0;
-    return status;
+    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
 /*********************************************************************
@@ -280,7 +277,7 @@ bool wfx_is_sta_connected(void)
  ***********************************************************************/
 wifi_mode_t wfx_get_wifi_mode(void)
 {
-    if (wfx_rsi.dev_state & WFX_RSI_ST_DEV_READY)
+    if (wfx_rsi.dev_state.Has(WifiState::kStationInit))
         return WIFI_MODE_STA;
     return WIFI_MODE_NULL;
 }
@@ -297,7 +294,7 @@ sl_status_t sl_matter_wifi_disconnect(void)
 {
     sl_status_t status;
     status = sl_wifi_platform_disconnect();
-    wfx_rsi.dev_state &= ~WFX_RSI_ST_STA_CONNECTED;
+    wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
     return status;
 }
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
@@ -312,7 +309,7 @@ sl_status_t sl_matter_wifi_disconnect(void)
 bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
 {
     VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
-    return ((wfx_rsi.dev_state & WFX_RSI_ST_STA_DHCP_DONE) > 0);
+    return wfx_rsi.dev_state.Has(WifiState::kStationDhcpDone);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
@@ -327,8 +324,8 @@ bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
 bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
 {
     VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
-    // TODO: WFX_RSI_ST_STA_CONNECTED does not guarantee SLAAC IPv6 LLA, maybe use a different FLAG
-    return ((wfx_rsi.dev_state & WFX_RSI_ST_STA_CONNECTED) > 0);
+    // TODO: WifiState::kStationConnected does not guarantee SLAAC IPv6 LLA, maybe use a different FLAG
+    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
 /*********************************************************************
@@ -341,7 +338,7 @@ bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
  ***********************************************************************/
 bool wfx_hw_ready(void)
 {
-    return (wfx_rsi.dev_state & WFX_RSI_ST_DEV_READY) ? true : false;
+    return wfx_rsi.dev_state.Has(WifiState::kStationInit);
 }
 
 /*********************************************************************
@@ -405,7 +402,7 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
 
     WfxEvent_t event;
-    event.eventType = WFX_EVT_SCAN;
+    event.eventType = WifiEvent::kScan;
     sl_matter_wifi_post_event(&event);
 
     return true;
@@ -486,7 +483,7 @@ void wfx_connected_notify(int32_t status, sl_wfx_mac_address_t * ap)
  *    notification of disconnection
  * @param[in] status:
  * @return None
- ********************************************************************************************/
+ *************************************************************************************/
 void wfx_disconnected_notify(int32_t status)
 {
     sl_wfx_disconnect_ind_t evt;
@@ -504,7 +501,7 @@ void wfx_disconnected_notify(int32_t status)
  *      notification of ipv6
  * @param[in]  got_ip:
  * @return None
- ********************************************************************************************/
+ *************************************************************************************/
 void wfx_ipv6_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
@@ -521,7 +518,7 @@ void wfx_ipv6_notify(int got_ip)
  *      notification of ip change
  * @param[in]  got_ip:
  * @return None
- ********************************************************************************************/
+ *************************************************************************************/
 void wfx_ip_changed_notify(int got_ip)
 {
     sl_wfx_generic_message_t eventData;
@@ -540,7 +537,7 @@ void wfx_ip_changed_notify(int got_ip)
  *      with AP continously after a certain time interval.
  * @param[in]  retryAttempt
  * @return None
- ********************************************************************************************/
+ *************************************************************************************/
 void wfx_retry_connection(uint16_t retryAttempt)
 {
     // During commissioning, we retry to join the network MAX_JOIN_RETRIES_COUNT

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -18,6 +18,7 @@
 
 #include <app/icd/server/ICDServerConfig.h>
 #include <cmsis_os2.h>
+#include <lib/support/BitFlags.h>
 #include <sl_cmsis_os2_common.h>
 #include <wfx_host_events.h>
 
@@ -27,44 +28,44 @@
 
 #define WFX_RSI_DHCP_POLL_INTERVAL (250) /* Poll interval in ms for DHCP		*/
 
-
-typedef enum
+enum class WifiEvent : uint8_t
 {
-    WFX_EVT_STA_CONN,
-    WFX_EVT_STA_DISCONN,
-    WFX_EVT_AP_START,
-    WFX_EVT_AP_STOP,
-    WFX_EVT_SCAN, /* This is used as scan result and start */
-    WFX_EVT_STA_START_JOIN,
-    WFX_EVT_STA_DO_DHCP,
-    WFX_EVT_STA_DHCP_DONE,
-    WFX_EVT_DHCP_POLL
-} WfxEventType_e;
+    kStationConnect    = 0,
+    kStationDisconnect = 1,
+    kAPStart           = 2,
+    kAPStop            = 3,
+    kScan              = 4, /* This is used as scan result and start */
+    kStationStartJoin  = 5,
+    kStationDoDhcp     = 6,
+    kStationDhcpDone   = 7,
+    kStationDhcpPoll   = 8
+};
 
-typedef enum
+enum class WifiState : uint16_t
 {
-    WFX_RSI_ST_DEV_READY       = (1 << 0),
-    WFX_RSI_ST_AP_READY        = (1 << 1),
-    WFX_RSI_ST_STA_PROVISIONED = (1 << 2),
-    WFX_RSI_ST_STA_CONNECTING  = (1 << 3),
-    WFX_RSI_ST_STA_CONNECTED   = (1 << 4),
-    WFX_RSI_ST_STA_DHCP_DONE   = (1 << 6), /* Requested to do DHCP after conn	*/
-    WFX_RSI_ST_STA_MODE        = (1 << 7), /* Enable Station Mode			*/
-    WFX_RSI_ST_AP_MODE         = (1 << 8), /* Enable AP Mode			*/
-    WFX_RSI_ST_STA_READY       = (WFX_RSI_ST_STA_CONNECTED | WFX_RSI_ST_STA_DHCP_DONE),
-    WFX_RSI_ST_STARTED         = (1 << 9),  /* RSI task started			*/
-    WFX_RSI_ST_SCANSTARTED     = (1 << 10), /* Scan Started				*/
-} WfxStateType_e;
+    kStationInit        = (1 << 0),
+    kAPReady            = (1 << 1),
+    kStationProvisioned = (1 << 2),
+    kStationConnecting  = (1 << 3),
+    kStationConnected   = (1 << 4),
+    kStationDhcpDone    = (1 << 6), /* Requested to do DHCP after conn	*/
+    kStationMode        = (1 << 7), /* Enable Station Mode			*/
+    kAPMode             = (1 << 8), /* Enable AP Mode			*/
+    kStationReady       = (kStationConnected | kStationDhcpDone),
+    kStationStarted     = (1 << 9),  /* RSI task started			*/
+    kScanStarted        = (1 << 10), /* Scan Started					*/
+};
+using WifiStateFlags = chip::BitFlags<WifiState>;
 
 typedef struct WfxEvent_s
 {
-    WfxEventType_e eventType;
+    WifiEvent eventType;
     void * eventData; // event data TODO: confirm needed
 } WfxEvent_t;
 
 typedef struct wfx_rsi_s
 {
-    uint16_t dev_state;
+    WifiStateFlags dev_state;
     uint16_t ap_chan; /* The chan our STA is using	*/
     wfx_wifi_provision_t sec;
 #ifdef SL_WFX_CONFIG_SCAN

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -25,10 +25,8 @@
  * Interface to RSI Sapis
  */
 
-#define WFX_RSI_WLAN_TASK_SZ (1024 + 512 + 256) /* Stack for the WLAN task	 	*/ // TODO: For rs9116
-#define WFX_RSI_BUF_SZ (1024 * 10)
 #define WFX_RSI_DHCP_POLL_INTERVAL (250) /* Poll interval in ms for DHCP		*/
-#define WFX_RSI_NUM_TIMERS (2)           /* Number of RSI timers to alloc	*/
+
 
 typedef enum
 {

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -57,12 +57,6 @@ enum class WifiState : uint16_t
 };
 using WifiStateFlags = chip::BitFlags<WifiState>;
 
-typedef struct WfxEvent_s
-{
-    WifiEvent eventType;
-    void * eventData; // event data TODO: confirm needed
-} WfxEvent_t;
-
 typedef struct wfx_rsi_s
 {
     WifiStateFlags dev_state;
@@ -120,7 +114,6 @@ int32_t wfx_rsi_power_save();
 /**
  * @brief Posts an event to the Wi-Fi task
  *
- * @param[in] event Event to process. Must be valid ptr
+ * @param[in] event Event to process.
  */
-// TODO: Can't be a const & since the ncp builds are still using c files
-void sl_matter_wifi_post_event(WfxEvent_t * event);
+void sl_matter_wifi_post_event(WifiEvent event);


### PR DESCRIPTION
#### Description
PR refactors the Wi-Fi event data structure and usage.
- Moves the enum to be inline with Matter and C++ standards
- Instead of using direct bit operation; move towards the Bitflag wrapper class
- Simplify the event data structure since we don't need to pass any extra information

The PR has no functionnal changes.

#### Tests
Commissioning and CI