### PR TITLE
[ESP32] Updated the esp-insights to latest version to fix build failures on v1.3-branch.

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -18,7 +18,7 @@ dependencies:
             - if: "idf_version >=4.4"
 
     espressif/esp_insights:
-        version: "1.0.1"
+        version: "1.2.2"
         require: public
         # There is an issue with IDF-Component-Manager when ESP Insights is included.
         # Issue: https://github.com/project-chip/connectedhomeip/issues/29125


### PR DESCRIPTION
**Problem**
- Build failures same as  #36031 were observed on v1.3-branch due to insights component versions.

**Change Overview**
- Updated esp-insights to latest  v1.2.2 version with component dependencies versions pinned.

**Testing**
- Tested the lighting-app esp32 and all-clusters-app esp32 for build failures before and after the changes.
