### PR TITLE
[Telink] build version info log prints

### DIFF
--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -155,6 +155,10 @@ set_property(GLOBAL APPEND PROPERTY ZEPHYR_INTERFACE_LIBS chip)
 
 include(${TELINK_COMMON}/common.cmake)
 
+if (CONFIG_CHIP_APP_LOG_LEVEL GREATER_EQUAL 4)
+    include(${TELINK_COMMON}/build_info.cmake)
+endif()
+
 # ==============================================================================
 # Define 'process_binaries' target for collecting final binary to flash
 # ==============================================================================

--- a/examples/platform/telink/build_info.cmake
+++ b/examples/platform/telink/build_info.cmake
@@ -1,0 +1,148 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+# Matter git info
+execute_process(
+    COMMAND git rev-parse HEAD
+    OUTPUT_VARIABLE MATTER_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git diff --quiet
+    RESULT_VARIABLE MATTER_LOCAL_STATUS
+)
+
+if(MATTER_LOCAL_STATUS)
+  set(MATTER_LOCAL_STATUS "-dirty")
+else()
+  set(MATTER_LOCAL_STATUS "")
+endif()
+
+execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE MATTER_BRANCH_NAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND python3 -c "from datetime import datetime; print(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))"
+    OUTPUT_VARIABLE BUILD_TIMESTAMP
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git show -s --format=%cd --date=format:%Y-%m-%d
+    OUTPUT_VARIABLE MATTER_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git remote get-url origin
+    OUTPUT_VARIABLE MATTER_REMOTE_URL
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Zephyr git info
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE} rev-parse HEAD
+    OUTPUT_VARIABLE ZEPHYR_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE} rev-parse --abbrev-ref HEAD
+    OUTPUT_VARIABLE ZEPHYR_BRANCH_NAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE} show -s --format=%cd --date=format:%Y-%m-%d HEAD
+    OUTPUT_VARIABLE ZEPHYR_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND bash -c "git -C ${ZEPHYR_BASE} remote get-url \$(git -C ${ZEPHYR_BASE} remote | head -n 1)"
+    OUTPUT_VARIABLE ZEPHYR_REMOTE_URL
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE} diff --quiet
+    RESULT_VARIABLE ZEPHYR_LOCAL_STATUS
+)
+
+if(ZEPHYR_LOCAL_STATUS)
+    set(ZEPHYR_LOCAL_STATUS "-dirty")
+else()
+    set(ZEPHYR_LOCAL_STATUS "")
+endif()
+
+# Telink HAL info
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE}/../modules/hal/telink rev-parse HEAD
+    OUTPUT_VARIABLE TELINK_HAL_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE}/../modules/hal/telink diff --quiet
+    RESULT_VARIABLE HAL_LOCAL_STATUS
+)
+
+if(TELINK_HAL_LOCAL_STATUS)
+    set(TELINK_HAL_LOCAL_STATUS "-dirty")
+else()
+    set(TELINK_HAL_LOCAL_STATUS "")
+endif()
+
+execute_process(
+    COMMAND git -C ${ZEPHYR_BASE}/../modules/hal/telink show -s --format=%cd --date=format:%Y-%m-%d
+    OUTPUT_VARIABLE TELINK_HAL_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+target_compile_definitions(app PRIVATE
+  MATTER_COMMIT_HASH="${MATTER_COMMIT_HASH}"
+  MATTER_BRANCH="${MATTER_BRANCH_NAME}"
+  BUILD_TIMESTAMP="${BUILD_TIMESTAMP}"
+  MATTER_COMMIT_DATE="${MATTER_COMMIT_DATE}"
+  MATTER_REMOTE_URL="${MATTER_REMOTE_URL}"
+  MATTER_LOCAL_STATUS="${MATTER_LOCAL_STATUS}"
+
+  ZEPHYR_COMMIT_HASH="${ZEPHYR_COMMIT_HASH}"
+  ZEPHYR_BRANCH="${ZEPHYR_BRANCH_NAME}"
+  ZEPHYR_COMMIT_DATE="${ZEPHYR_COMMIT_DATE}"
+  ZEPHYR_REMOTE_URL="${ZEPHYR_REMOTE_URL}"
+  ZEPHYR_LOCAL_STATUS="${ZEPHYR_LOCAL_STATUS}"
+
+  TELINK_HAL_COMMIT_HASH="${TELINK_HAL_COMMIT_HASH}"
+  TELINK_HAL_LOCAL_STATUS="${TELINK_HAL_LOCAL_STATUS}"
+  TELINK_HAL_COMMIT_DATE="${TELINK_HAL_COMMIT_DATE}"
+)
+
+message(STATUS "Matter revision:")
+message(STATUS "      board: ${CONFIG_BOARD}")
+message(STATUS "      branch: ${MATTER_BRANCH_NAME} ${MATTER_COMMIT_HASH} ${MATTER_COMMIT_DATE}")
+message(STATUS "      remote: ${MATTER_REMOTE_URL}")
+message(STATUS "      build timestamp: ${BUILD_TIMESTAMP}")
+
+message(STATUS "Zephyr revision:")
+message(STATUS "      branch: ${ZEPHYR_BRANCH_NAME} ${ZEPHYR_COMMIT_HASH} ${ZEPHYR_COMMIT_DATE}")
+message(STATUS "      remote: ${ZEPHYR_REMOTE_URL}")
+
+message(STATUS "HAL revision:")
+message(STATUS "      commit: ${TELINK_HAL_COMMIT_HASH} ${TELINK_HAL_COMMIT_DATE}")

--- a/examples/platform/telink/common/include/AppTaskCommon.h
+++ b/examples/platform/telink/common/include/AppTaskCommon.h
@@ -84,6 +84,7 @@ public:
 
 protected:
     CHIP_ERROR InitCommonParts(void);
+    void PrintFirmwareInfo(void);
 
     void DispatchEvent(AppEvent * event);
     void GetEvent(AppEvent * aEvent);

--- a/examples/platform/telink/common/src/AppTaskCommon.cpp
+++ b/examples/platform/telink/common/src/AppTaskCommon.cpp
@@ -240,11 +240,28 @@ CHIP_ERROR AppTaskCommon::StartApp(void)
         DispatchEvent(&event);
     }
 }
+void AppTaskCommon::PrintFirmwareInfo(void)
+{
+    LOG_INF("SW Version: %u, %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
 
+#if CONFIG_CHIP_APP_LOG_LEVEL > 3
+    LOG_DBG("Matter revision: ");
+    LOG_DBG("\t board: %s", CONFIG_BOARD);
+    LOG_DBG("\t branch: %s %.8s%s %s", MATTER_BRANCH, MATTER_COMMIT_HASH, MATTER_LOCAL_STATUS, MATTER_COMMIT_DATE);
+    LOG_DBG("\t remote: %s", MATTER_REMOTE_URL);
+    LOG_DBG("\t build timestamp: %s", BUILD_TIMESTAMP);
+
+    LOG_DBG("Zephyr revision: ");
+    LOG_DBG("\t branch: %s %.8s%s %s", ZEPHYR_BRANCH, ZEPHYR_COMMIT_HASH, ZEPHYR_LOCAL_STATUS, ZEPHYR_COMMIT_DATE);
+    LOG_DBG("\t remote: %s", ZEPHYR_REMOTE_URL);
+    LOG_DBG("\t HAL commit: %.8s%s %s", TELINK_HAL_COMMIT_HASH, TELINK_HAL_LOCAL_STATUS, TELINK_HAL_COMMIT_DATE);
+#endif
+}
 CHIP_ERROR AppTaskCommon::InitCommonParts(void)
 {
     CHIP_ERROR err;
-    LOG_INF("SW Version: %u, %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+
+    PrintFirmwareInfo();
 
     InitLeds();
     UpdateStatusLED();


### PR DESCRIPTION
Added prints of git info for Matter, Zephyr and HAL repos for all Telink apps.
This detailed info in the logs is made for more clear version handling across the teams.

Device will have it printed in the COM port like this:

> I: SW Version: 1, prerelease
I: Matter revision: 
I:       board: tlsr9518adk80d
I:       branch: master 7e0634cf-dirty 2024-10-30
I:       remote: https://github.com/project-chip/connectedhomeip.git
I:       build timestamp: 2024-11-05 17:44:24
I: Zephyr revision: 
I:       branch: develop 6392406e 2024-10-04
I:       remote: git@github.com:telink-semi/zephyr.git
I:       HAL commit: e5a21d1f 2024-09-23

Note: `build timestamp` displays the time when the binary was created.
`dirty` means some local changes are present.

And during build there're similar format logs from Cmake:

> Loading Zephyr default modules (Zephyr base (cached)).
-- Matter revision:
--       board: tlsr9518adk80d
--       branch: build-version-info 9de0af072280e0aed80a2858c0ce578f1189c235 2024-11-05
--       remote: https://github.com/project-chip/connectedhomeip.git
--       build timestamp: 2024-11-05 18:40:19
-- Zephyr revision:
--       branch: develop 6392406e414697b3064a1193ea37fde9bdc7966a 2024-10-04
--       remote: git@github.com:telink-semi/zephyr.git
-- HAL revision:
--       commit: e5a21d1fb577c339ca149db91a67764e00338c61 2024-09-23
-- Configuring done (3.3s)