### PR TITLE
[Fabric-Sync] use namespace to isolate admin and bridge

### DIFF
--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -26,6 +26,7 @@
 
 using namespace chip;
 
+namespace admin {
 // Define the static member
 DeviceManager DeviceManager::sInstance;
 
@@ -109,3 +110,5 @@ void DeviceManager::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
     ChipLogProgress(NotSpecified, "Synced device with NodeId:" ChipLogFormatX64 " has been removed.", ChipLogValueX64(deviceId));
 }
+
+} // namespace admin

--- a/examples/fabric-sync/admin/DeviceManager.h
+++ b/examples/fabric-sync/admin/DeviceManager.h
@@ -23,6 +23,8 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
 
+namespace admin {
+
 class DeviceManager : public PairingDelegate
 {
 public:
@@ -97,3 +99,5 @@ inline DeviceManager & DeviceMgr()
     }
     return DeviceManager::sInstance;
 }
+
+} // namespace admin

--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -29,6 +29,8 @@
 using namespace ::chip;
 using namespace ::chip::Controller;
 
+namespace admin {
+
 namespace {
 
 CHIP_ERROR GetPayload(const char * setUpCode, SetupPayload & payload)
@@ -451,7 +453,7 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
     if (err == CHIP_NO_ERROR)
     {
         // print to console
-        fprintf(stderr, "Device with Node ID: " ChipLogFormatX64 "has been successfully removed.\n", ChipLogValueX64(nodeId));
+        fprintf(stderr, "Device with Node ID: " ChipLogFormatX64 " has been successfully removed.\n", ChipLogValueX64(nodeId));
     }
     else
     {
@@ -548,3 +550,5 @@ CHIP_ERROR PairingManager::UnpairDevice(NodeId nodeId)
         }
     });
 }
+
+} // namespace admin

--- a/examples/fabric-sync/admin/PairingManager.h
+++ b/examples/fabric-sync/admin/PairingManager.h
@@ -24,6 +24,8 @@
 #include <controller/CurrentFabricRemover.h>
 #include <crypto/CHIPCryptoPAL.h>
 
+namespace admin {
+
 // Constants
 constexpr uint16_t kMaxManualCodeLength = 22;
 
@@ -201,3 +203,5 @@ private:
     chip::Platform::UniquePtr<chip::Controller::CurrentFabricRemover> mCurrentFabricRemover;
     chip::Callback::Callback<chip::Controller::OnCurrentFabricRemove> mCurrentFabricRemoveCallback;
 };
+
+} // namespace admin

--- a/examples/fabric-sync/bridge/include/BridgedAdministratorCommissioning.h
+++ b/examples/fabric-sync/bridge/include/BridgedAdministratorCommissioning.h
@@ -20,6 +20,8 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 
+namespace bridge {
+
 /**
  * @brief CADMIN cluster implementation for handling attribute interactions of bridged device endpoints.
  *
@@ -56,3 +58,5 @@ private:
     // to reflect this change.
     chip::app::AttributeAccessInterface * mOriginalAttributeInterface = nullptr;
 };
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/include/BridgedDevice.h
+++ b/examples/fabric-sync/bridge/include/BridgedDevice.h
@@ -23,6 +23,8 @@
 
 #include <string>
 
+namespace bridge {
+
 class BridgedDevice
 {
 public:
@@ -90,3 +92,5 @@ protected:
     BridgedAttributes mAttributes;
     AdminCommissioningAttributes mAdminCommissioningAttributes;
 };
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/include/BridgedDeviceBasicInformationImpl.h
+++ b/examples/fabric-sync/bridge/include/BridgedDeviceBasicInformationImpl.h
@@ -18,6 +18,8 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 
+namespace bridge {
+
 class BridgedDeviceBasicInformationImpl : public chip::app::AttributeAccessInterface
 {
 public:
@@ -30,3 +32,5 @@ public:
     CHIP_ERROR Read(const chip::app::ConcreteReadAttributePath & path, chip::app::AttributeValueEncoder & encoder) override;
     CHIP_ERROR Write(const chip::app::ConcreteDataAttributePath & path, chip::app::AttributeValueDecoder & decoder) override;
 };
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/include/BridgedDeviceManager.h
+++ b/examples/fabric-sync/bridge/include/BridgedDeviceManager.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+namespace bridge {
+
 class BridgedDeviceManager
 {
 public:
@@ -52,9 +54,9 @@ public:
      *
      * @param dev A pointer to the device to be added.
      * @param parentEndpointId The parent endpoint ID. Defaults to an invalid endpoint ID.
-     * @return int The index of the dynamic endpoint if successful, nullopt otherwise
+     * @return uint16_t The index of the dynamic endpoint if successful, nullopt otherwise
      */
-    std::optional<unsigned> AddDeviceEndpoint(std::unique_ptr<BridgedDevice> dev,
+    std::optional<uint16_t> AddDeviceEndpoint(std::unique_ptr<BridgedDevice> dev,
                                               chip::EndpointId parentEndpointId = chip::kInvalidEndpointId);
 
     /**
@@ -100,9 +102,9 @@ public:
      * found, it removes the dynamic endpoint.
      *
      * @param scopedNodeId The ScopedNodeId of the device to be removed.
-     * @return unsigned of the index of the removed dynamic endpoint if successful, nullopt otherwise.
+     * @return uint16_t of the index of the removed dynamic endpoint if successful, nullopt otherwise.
      */
-    std::optional<unsigned> RemoveDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId);
+    std::optional<uint16_t> RemoveDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId);
 
     /**
      * Finds the device with the given unique id (if any)
@@ -134,3 +136,5 @@ inline BridgedDeviceManager & BridgeDeviceMgr()
 {
     return BridgedDeviceManager::sInstance;
 }
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedAdministratorCommissioning.cpp
@@ -26,6 +26,8 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::AdministratorCommissioning;
 
+namespace bridge {
+
 CHIP_ERROR BridgedAdministratorCommissioning::Init()
 {
     // We expect initialization after emberAfInit(). This allows us to unregister the existing
@@ -79,3 +81,5 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
 
     return CHIP_NO_ERROR;
 }
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/src/BridgedDevice.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDevice.cpp
@@ -27,6 +27,8 @@
 using namespace chip;
 using namespace chip::app::Clusters::Actions;
 
+namespace bridge {
+
 BridgedDevice::BridgedDevice(ScopedNodeId scopedNodeId)
 {
     mReachable    = false;
@@ -116,3 +118,5 @@ void BridgedDevice::SetAdminCommissioningAttributes(const AdminCommissioningAttr
         }
     });
 }
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/src/BridgedDeviceBasicInformationImpl.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceBasicInformationImpl.cpp
@@ -29,6 +29,8 @@ using namespace ::chip;
 using namespace ::chip::app;
 using namespace ::chip::app::Clusters;
 
+namespace bridge {
+
 CHIP_ERROR BridgedDeviceBasicInformationImpl::Read(const ConcreteReadAttributePath & path, AttributeValueEncoder & encoder)
 {
     // Registration is done for the bridged device basic information only
@@ -105,3 +107,5 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Write(const ConcreteDataAttributeP
 
     return CHIP_ERROR_INVALID_ARGUMENT;
 }
+
+} // namespace bridge

--- a/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
@@ -45,6 +45,8 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
+namespace bridge {
+
 namespace {
 
 constexpr uint8_t kMaxRetries      = 10;
@@ -184,7 +186,7 @@ void BridgedDeviceManager::Init()
     mCurrentEndpointId = mFirstDynamicEndpointId;
 }
 
-std::optional<unsigned> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<BridgedDevice> dev,
+std::optional<uint16_t> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<BridgedDevice> dev,
                                                                 chip::EndpointId parentEndpointId)
 {
     EmberAfEndpointType * ep = dev->IsIcd() ? &sIcdBridgedNodeEndpoint : &sBridgedNodeEndpoint;
@@ -193,6 +195,8 @@ std::optional<unsigned> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<
 
     // TODO: this shares data version among different clusters, which seems incorrect
     const chip::Span<chip::DataVersion> & dataVersionStorage = Span<DataVersion>(sBridgedNodeDataVersions);
+
+    assertChipStackLockedByCurrentThread();
 
     if (dev->GetBridgedAttributes().uniqueId.empty())
     {
@@ -204,7 +208,7 @@ std::optional<unsigned> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<
         return std::nullopt;
     }
 
-    for (unsigned index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; index++)
+    for (uint16_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; index++)
     {
         if (mDevices[index])
         {
@@ -213,7 +217,6 @@ std::optional<unsigned> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<
 
         for (int retryCount = 0; retryCount < kMaxRetries; retryCount++)
         {
-            DeviceLayer::StackLock lock;
             dev->SetEndpointId(mCurrentEndpointId);
             dev->SetParentEndpointId(parentEndpointId);
             CHIP_ERROR err =
@@ -327,9 +330,9 @@ BridgedDevice * BridgedDeviceManager::GetDeviceByScopedNodeId(chip::ScopedNodeId
     return nullptr;
 }
 
-std::optional<unsigned> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId)
+std::optional<uint16_t> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId)
 {
-    for (unsigned index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
+    for (uint16_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
     {
         if (mDevices[index] && mDevices[index]->GetScopedNodeId() == scopedNodeId)
         {
@@ -343,3 +346,5 @@ std::optional<unsigned> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::S
     }
     return std::nullopt;
 }
+
+} // namespace bridge

--- a/examples/fabric-sync/main.cpp
+++ b/examples/fabric-sync/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char * argv[])
     Shell::RegisterCommands();
 #endif
 
-    CHIP_ERROR err = PairingManager::Instance().Init(GetDeviceCommissioner());
+    CHIP_ERROR err = admin::PairingManager::Instance().Init(GetDeviceCommissioner());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(NotSpecified, "Failed to init PairingManager: %s ", ErrorStr(err));

--- a/examples/fabric-sync/shell/AddBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/AddBridgeCommand.cpp
@@ -48,11 +48,12 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetRemoteBridgeNodeId(mBridgeNodeId);
+        admin::DeviceMgr().SetRemoteBridgeNodeId(mBridgeNodeId);
+
         ChipLogProgress(NotSpecified, "Successfully paired bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mBridgeNodeId));
 
-        DeviceMgr().UpdateLastUsedNodeId(mBridgeNodeId);
+        admin::DeviceMgr().UpdateLastUsedNodeId(mBridgeNodeId);
     }
     else
     {
@@ -65,16 +66,16 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR AddBridgeCommand::RunCommand()
 {
-    if (DeviceMgr().IsFabricSyncReady())
+    if (admin::DeviceMgr().IsFabricSyncReady())
     {
         // print to console
         fprintf(stderr, "Remote Fabric Bridge has already been configured.\n");
-        return CHIP_ERROR_BUSY;
+        return CHIP_NO_ERROR;
     }
 
-    PairingManager::Instance().SetCommissioningDelegate(this);
+    admin::PairingManager::Instance().SetCommissioningDelegate(this);
 
-    return DeviceMgr().PairRemoteFabricBridge(mBridgeNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
+    return admin::DeviceMgr().PairRemoteFabricBridge(mBridgeNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/AddBridgeCommand.h
+++ b/examples/fabric-sync/shell/AddBridgeCommand.h
@@ -23,7 +23,7 @@
 
 namespace commands {
 
-class AddBridgeCommand : public Command, public CommissioningDelegate
+class AddBridgeCommand : public Command, public admin::CommissioningDelegate
 {
 public:
     AddBridgeCommand(chip::NodeId nodeId, uint32_t setupPINCode, const char * remoteAddr, uint16_t remotePort);

--- a/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
@@ -35,9 +35,10 @@ void RemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetRemoteBridgeNodeId(kUndefinedNodeId);
-        ChipLogProgress(NotSpecified, "Successfully removed bridge device: NodeId: " ChipLogFormatX64,
-                        ChipLogValueX64(mBridgeNodeId));
+        admin::DeviceMgr().SetRemoteBridgeNodeId(kUndefinedNodeId);
+
+        // print to console
+        fprintf(stderr, "Successfully removed bridge device: NodeId: " ChipLogFormatX64 "\n", ChipLogValueX64(mBridgeNodeId));
     }
     else
     {
@@ -50,21 +51,20 @@ void RemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR RemoveBridgeCommand::RunCommand()
 {
-    NodeId bridgeNodeId = DeviceMgr().GetRemoteBridgeNodeId();
+    NodeId bridgeNodeId = admin::DeviceMgr().GetRemoteBridgeNodeId();
 
     if (bridgeNodeId == kUndefinedNodeId)
     {
         // print to console
         fprintf(stderr, "Remote Fabric Bridge is not configured yet, nothing to remove.\n");
-        return CHIP_ERROR_BUSY;
+        return CHIP_NO_ERROR;
     }
 
     mBridgeNodeId = bridgeNodeId;
 
-    PairingManager::Instance().SetPairingDelegate(this);
-    DeviceMgr().UnpairRemoteFabricBridge();
+    admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    return CHIP_NO_ERROR;
+    return admin::DeviceMgr().UnpairRemoteFabricBridge();
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/RemoveBridgeCommand.h
+++ b/examples/fabric-sync/shell/RemoveBridgeCommand.h
@@ -23,7 +23,7 @@
 
 namespace commands {
 
-class RemoveBridgeCommand : public Command, public PairingDelegate
+class RemoveBridgeCommand : public Command, public admin::PairingDelegate
 {
 public:
     void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;


### PR DESCRIPTION
To differentiate the fabric sync logic between fabric-admin and fabric-bridge, place the sync logic in fabric-admin within an 'admin' namespace and sync logic in fabric-bridge within an 'bridge' namespace

