### PR TITLE
[Fabric-Admin] Fix failing to cleanup bridge after bridge is removed

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
     if (DeviceMgr().IsFabricSyncReady())
     {
         // print to console
-        fprintf(stderr, "Remote Fabric Bridge has already been configured.");
+        fprintf(stderr, "Remote Fabric Bridge has already been configured.\n");
         return CHIP_NO_ERROR;
     }
 
@@ -126,7 +126,7 @@ CHIP_ERROR FabricSyncRemoveBridgeCommand::RunCommand()
     if (bridgeNodeId == kUndefinedNodeId)
     {
         // print to console
-        fprintf(stderr, "Remote Fabric Bridge is not configured yet, nothing to remove.");
+        fprintf(stderr, "Remote Fabric Bridge is not configured yet, nothing to remove.\n");
         return CHIP_NO_ERROR;
     }
 
@@ -176,7 +176,7 @@ CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
     if (DeviceMgr().IsLocalBridgeReady())
     {
         // print to console
-        fprintf(stderr, "Local Fabric Bridge has already been configured.");
+        fprintf(stderr, "Local Fabric Bridge has already been configured.\n");
         return CHIP_NO_ERROR;
     }
 
@@ -227,7 +227,7 @@ CHIP_ERROR FabricSyncRemoveLocalBridgeCommand::RunCommand()
     if (bridgeNodeId == kUndefinedNodeId)
     {
         // print to console
-        fprintf(stderr, "Local Fabric Bridge is not configured yet, nothing to remove.");
+        fprintf(stderr, "Local Fabric Bridge is not configured yet, nothing to remove.\n");
         return CHIP_NO_ERROR;
     }
 
@@ -292,18 +292,18 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERRO
     }
 }
 
-CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteId)
+CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteEndpointId)
 {
     if (!DeviceMgr().IsFabricSyncReady())
     {
         // print to console
-        fprintf(stderr, "Remote Fabric Bridge is not configured yet.");
+        fprintf(stderr, "Remote Fabric Bridge is not configured yet.\n");
         return CHIP_NO_ERROR;
     }
 
     PairingManager::Instance().SetOpenCommissioningWindowDelegate(this);
 
-    DeviceMgr().OpenRemoteDeviceCommissioningWindow(remoteId);
+    DeviceMgr().OpenRemoteDeviceCommissioningWindow(remoteEndpointId);
 
     return CHIP_NO_ERROR;
 }

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -124,8 +124,8 @@ public:
         AddArgument("endpointid", 0, UINT16_MAX, &mRemoteEndpointId);
     }
 
-    void OnCommissioningWindowOpened(NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload) override;
-    void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err) override;
+    void OnCommissioningWindowOpened(chip::NodeId deviceId, CHIP_ERROR status, chip::SetupPayload payload) override;
+    void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) override;
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override { return RunCommand(mRemoteEndpointId); }
@@ -136,7 +136,7 @@ private:
     chip::EndpointId mRemoteEndpointId = chip::kInvalidEndpointId;
     chip::NodeId mAssignedNodeId       = chip::kUndefinedNodeId;
 
-    CHIP_ERROR RunCommand(chip::EndpointId remoteId);
+    CHIP_ERROR RunCommand(chip::EndpointId remoteEndpointId);
 };
 
 } // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -71,7 +71,11 @@ void DeviceManager::UpdateLastUsedNodeId(NodeId nodeId)
 void DeviceManager::SetRemoteBridgeNodeId(chip::NodeId nodeId)
 {
     mRemoteBridgeNodeId = nodeId;
-    mCommissionerControl.Init(PairingManager::Instance().CurrentCommissioner(), mRemoteBridgeNodeId, kAggregatorEndpointId);
+
+    if (mRemoteBridgeNodeId != kUndefinedNodeId)
+    {
+        mCommissionerControl.Init(PairingManager::Instance().CurrentCommissioner(), mRemoteBridgeNodeId, kAggregatorEndpointId);
+    }
 }
 
 void DeviceManager::AddSyncedDevice(const Device & device)

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -550,7 +550,12 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
     if (err == CHIP_NO_ERROR)
     {
         // print to console
-        fprintf(stderr, "Device with Node ID: " ChipLogFormatX64 "has been successfully removed.\n", ChipLogValueX64(nodeId));
+        fprintf(stderr, "Device with Node ID: " ChipLogFormatX64 " has been successfully removed.\n", ChipLogValueX64(nodeId));
+
+        if (self->mPairingDelegate)
+        {
+            self->mPairingDelegate->OnDeviceRemoved(nodeId, err);
+        }
 
 #if defined(PW_RPC_ENABLED)
         FabricIndex fabricIndex = self->CurrentCommissioner().GetFabricIndex();

--- a/examples/fabric-admin/rpc/RpcClient.cpp
+++ b/examples/fabric-admin/rpc/RpcClient.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR WaitForResponse(CallType & call)
     }
     else
     {
-        fprintf(stderr, "RPC Response timed out!");
+        fprintf(stderr, "RPC Response timed out!\n");
         return CHIP_ERROR_TIMEOUT;
     }
 }


### PR DESCRIPTION
After the local or remote bridge is successfully removed, the OnDeviceRemoved callback is not called in FabricSyncRemoveBridgeCommand

