### PR TITLE
Clean up and unify ColorTemp command handlers of the color control

### DIFF
--- a/examples/lighting-app/tizen/src/DBusInterface.cpp
+++ b/examples/lighting-app/tizen/src/DBusInterface.cpp
@@ -203,7 +203,8 @@ gboolean DBusInterface::OnColorTemperatureChanged(LightAppColorControl * colorCo
     data.colorTemperatureMireds = light_app_color_control_get_color_temperature_mireds(colorControl);
 
     chip::DeviceLayer::StackLock lock;
-    ColorControlServer::Instance().moveToColorTempCommand(&handler, path, data);
+    auto status = ColorControlServer::Instance().moveToColorTempCommand(self->mEndpointId, data);
+    handler.AddStatus(path, status);
 
     return G_DBUS_METHOD_INVOCATION_HANDLED;
 }

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2563,12 +2563,12 @@ ColorControlServer::Color16uTransitionState * ColorControlServer::getTempTransit
 }
 
 /**
- * @brief executes move to color temp logic
+ * @brief Executes move to color temp logic.
  *
  * @param aEndpoint
  * @param colorTemperature
  * @param transitionTime
- * @return Status::Success if successful, Status::UnsupportedEndpoint if the endpoint doesn't support color temperature
+ * @return Status::Success if successful, Status::UnsupportedEndpoint if the endpoint doesn't support color temperature.
  */
 Status ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorTemperature, uint16_t transitionTime)
 {
@@ -2764,12 +2764,12 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
 }
 
 /**
- * @brief executes move color temp command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes move color temp command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when a rate of 0 for a non-stop move or an unknown HueMoveMode is provided
- *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a color temp transition state,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a color temp transition state.
  */
 Status ColorControlServer::moveColorTempCommand(EndpointId endpoint,
                                                 const Commands::MoveColorTemperature::DecodableType & commandData)
@@ -2861,9 +2861,9 @@ Status ColorControlServer::moveColorTempCommand(EndpointId endpoint,
 }
 
 /**
- * @brief executes move to color temp command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes move to color temp command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a color XY transition state (verified in
  * moveToColorTemp function).
@@ -2881,12 +2881,12 @@ Status ColorControlServer::moveToColorTempCommand(EndpointId endpoint,
 }
 
 /**
- * @brief executes step color temp command
- * @param endpoint endpointId of the recipient Color control cluster
+ * @brief Executes step color temp command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
  * @param commandData Struct containing the parameters of the command
  * @return Status::Success when successful,
  *         Status::InvalidCommand when stepSize is 0 or an unknown stepMode is provided
- *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a color temp transition state,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a color temp transition state.
  */
 Status ColorControlServer::stepColorTempCommand(EndpointId endpoint,
                                                 const Commands::StepColorTemperature::DecodableType & commandData)

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -2774,12 +2774,12 @@ void ColorControlServer::updateTempCommand(EndpointId endpoint)
 Status ColorControlServer::moveColorTempCommand(EndpointId endpoint,
                                                 const Commands::MoveColorTemperature::DecodableType & commandData)
 {
-    auto moveMode                = commandData.moveMode;
-    auto rate                    = commandData.rate;
-    auto colorTemperatureMinimum = commandData.colorTemperatureMinimumMireds;
-    auto colorTemperatureMaximum = commandData.colorTemperatureMaximumMireds;
-    auto optionsMask             = commandData.optionsMask;
-    auto optionsOverride         = commandData.optionsOverride;
+    HueMoveMode moveMode                   = commandData.moveMode;
+    uint16_t rate                          = commandData.rate;
+    uint16_t colorTemperatureMinimum       = commandData.colorTemperatureMinimumMireds;
+    uint16_t colorTemperatureMaximum       = commandData.colorTemperatureMaximumMireds;
+    BitMask<OptionsBitmap> optionsMask     = commandData.optionsMask;
+    BitMask<OptionsBitmap> optionsOverride = commandData.optionsOverride;
 
     // check moveMode and rate before any operation is done on the transition states
     // rate value is ignored if the MoveMode is stop
@@ -2896,13 +2896,13 @@ Status ColorControlServer::moveToColorTempCommand(EndpointId endpoint,
 Status ColorControlServer::stepColorTempCommand(EndpointId endpoint,
                                                 const Commands::StepColorTemperature::DecodableType & commandData)
 {
-    auto stepMode                = commandData.stepMode;
-    auto stepSize                = commandData.stepSize;
-    auto transitionTime          = commandData.transitionTime;
-    auto colorTemperatureMinimum = commandData.colorTemperatureMinimumMireds;
-    auto colorTemperatureMaximum = commandData.colorTemperatureMaximumMireds;
-    auto optionsMask             = commandData.optionsMask;
-    auto optionsOverride         = commandData.optionsOverride;
+    HueStepMode stepMode                   = commandData.stepMode;
+    uint16_t stepSize                      = commandData.stepSize;
+    uint16_t transitionTime                = commandData.transitionTime;
+    uint16_t colorTemperatureMinimum       = commandData.colorTemperatureMinimumMireds;
+    uint16_t colorTemperatureMaximum       = commandData.colorTemperatureMaximumMireds;
+    BitMask<OptionsBitmap> optionsMask     = commandData.optionsMask;
+    BitMask<OptionsBitmap> optionsOverride = commandData.optionsOverride;
 
     // Confirm validity of the step mode and step size received
     VerifyOrReturnValue(stepMode != HueStepMode::kUnknownEnumValue, Status::InvalidCommand);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -187,13 +187,15 @@ public:
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_XY
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_TEMP
-    bool moveColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::DecodableType & commandData);
-    bool
-    moveToColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+    chip::Protocols::InteractionModel::Status
+    moveColorTempCommand(const chip::EndpointId endpoint,
+                         const chip::app::Clusters::ColorControl::Commands::MoveColorTemperature::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveToColorTempCommand(const chip::EndpointId endpoint,
                            const chip::app::Clusters::ColorControl::Commands::MoveToColorTemperature::DecodableType & commandData);
-    bool stepColorTempCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    stepColorTempCommand(const chip::EndpointId endpoint,
+                         const chip::app::Clusters::ColorControl::Commands::StepColorTemperature::DecodableType & commandData);
     void levelControlColorTempChangeCommand(chip::EndpointId endpoint);
     void startUpColorTempCommand(chip::EndpointId endpoint);
     void updateTempCommand(chip::EndpointId endpoint);


### PR DESCRIPTION
This PR is the 2nd of a few that splits #36202 into smaller chunks for ease of review and to ensure that no regression slips through

- No behaviour change
- Clean up and unify the Colortemp command handlers of the color control.
- remove the goto mechanism and in favour of early return conditions (VerifyOrReturnValue)


sibling PR #36376 #36378