### PR TITLE
Clean up and unify HSV command handlers of the color control

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1261,12 +1261,12 @@ EmberEventControl * ColorControlServer::configureHSVEventControl(EndpointId endp
 }
 
 /**
- * @brief executes move to saturation command
+ * @brief Executes move to saturation command
  *
- * @param endpoint target endpoint where to execute move
- * @param saturation target saturation
- * @param transitionTime transition time in 10th of seconds
- * @return Status::Success when successful,
+ * @param endpoint Target endpoint where to execute move
+ * @param saturation Target saturation
+ * @param transitionTime Transition time in 10th of seconds
+ * @return Status::Success When successful,
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
  */
 Status ColorControlServer::moveToSaturation(EndpointId endpoint, uint8_t saturation, uint16_t transitionTime)
@@ -1300,15 +1300,15 @@ Status ColorControlServer::moveToSaturation(EndpointId endpoint, uint8_t saturat
 }
 
 /**
- * @brief executes move to hue and saturatioan command
+ * @brief Executes move to hue and saturatioan command.
  *
- * @param[in] endpoint endpointId of the recipient Color control cluster
- * @param[in] hue target hue
- * @param[in] saturation target saturation
- * @param[in] transitionTime transition time in 10th of seconds
+ * @param[in] endpoint EndpointId of the recipient Color control cluster.
+ * @param[in] hue Target hue.
+ * @param[in] saturation Target saturation.
+ * @param[in] transitionTime Transition time in 10th of seconds.
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
- * was called by MoveHue command and rate is a uint8 value
- * @return Status::Success when successful,
+ * was called by MoveHue command and rate is a uint8 value.
+ * @return Status::Success When successful,
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state,
  */
 Status ColorControlServer::moveToHueAndSaturation(EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
@@ -1389,15 +1389,15 @@ Status ColorControlServer::moveToHueAndSaturation(EndpointId endpoint, uint16_t 
 }
 
 /**
- * @brief Executes move Hue Command
+ * @brief Executes move Hue Command.
  *
- * @param[in] endpoint endpointId of the recipient Color control cluster
+ * @param[in] endpoint EndpointId of the recipient Color control cluster.
  * @param[in] moveMode
  * @param[in] rate
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
- * was called by MoveHue command and rate is a uint8 value
+ * was called by MoveHue command and rate is a uint8 value.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when Rate is 0 or an unknown moveMode is provided
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
@@ -1485,16 +1485,16 @@ Status ColorControlServer::moveHueCommand(EndpointId endpoint, HueMoveMode moveM
 }
 
 /**
- * @brief Executes move to hue command
+ * @brief Executes move to hue command.
  *
- * @param[in] endpointId of the recipient Color control cluster
+ * @param[in] endpoint EndpointId of the recipient Color control cluster.
  * @param[in] hue
  * @param[in] moveDirection
  * @param[in] transitionTime
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
- * was called by MoveHue command and rate is a uint8 value
+ * was called by MoveHue command and rate is a uint8 value.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when Rate is 0 or an unknown moveDirection is provided
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
@@ -1604,15 +1604,15 @@ Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, D
 }
 
 /**
- * @brief executes move to hue and saturatioan command
- * @param[in] endpointId of the recipient Color control cluster
+ * @brief Executes move to hue and saturatioan command.
+ * @param[in] endpoint EndpointId of the recipient Color control cluster.
  * @param[in] hue
  * @param[in] saturation
  * @param[in] transitionTime
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
- * was called by MoveHue command and rate is a uint8 value
+ * was called by MoveHue command and rate is a uint8 value.
  * @return Status::Success when successful,
  *         Status::ConstraintError when the other parameters are outside their defined value range.
 
@@ -1636,7 +1636,7 @@ Status ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, ui
 }
 
 /**
- * @brief Executes step hue command
+ * @brief Executes step hue command.
  *
  * @param[in] endpoint
  * @param[in] stepMode
@@ -1645,7 +1645,7 @@ Status ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, ui
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
- * was called by MoveHue command and rate is a uint8 value
+ * was called by MoveHue command and rate is a uint8 value.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when StepSize is 0 or an unknown HueStepMode is provided
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state.
@@ -1724,9 +1724,9 @@ Status ColorControlServer::stepHueCommand(EndpointId endpoint, HueStepMode stepM
 }
 
 /**
- * @brief executes moveSaturation command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes moveSaturation command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when a rate of 0 for a non-stop move or an unknown SaturationMoveMode is provided
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
@@ -1785,9 +1785,9 @@ Status ColorControlServer::moveSaturationCommand(EndpointId endpoint, const Comm
 }
 
 /**
- * @brief executes move to saturation command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes move to saturation command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state (verified in
  * moveToSaturation function) Status::ConstraintError when a command parameters is outside its defined value range.
@@ -1808,9 +1808,9 @@ Status ColorControlServer::moveToSaturationCommand(EndpointId endpoint,
 }
 
 /**
- * @brief executes step saturation command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes step saturation command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when a step size of 0 or an unknown SaturationStepMode is provided
  *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
@@ -1859,12 +1859,12 @@ Status ColorControlServer::stepSaturationCommand(EndpointId endpoint, const Comm
 }
 
 /**
- * @brief executes ColorLoop command
- * @param endpoint endpointId of the recipient Color control cluster
- * @param commandData Struct containing the parameters of the command
+ * @brief Executes ColorLoop command.
+ * @param endpoint EndpointId of the recipient Color control cluster.
+ * @param commandData Struct containing the parameters of the command.
  * @return Status::Success when successful,
  *         Status::InvalidCommand when an unknown action or direction is provided
- *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state.
  */
 Status ColorControlServer::colorLoopCommand(EndpointId endpoint, const Commands::ColorLoopSet::DecodableType & commandData)
 {
@@ -1976,7 +1976,7 @@ Status ColorControlServer::colorLoopCommand(EndpointId endpoint, const Commands:
 }
 
 /**
- * @brief updates Hue and saturation after timer is finished
+ * @brief Updates Hue and saturation after timer is finished.
  *
  * @param endpoint
  */

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -307,8 +307,8 @@ public:
             {
             case EnhancedColorMode::kCurrentHueAndCurrentSaturation:
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-                ColorControlServer::Instance().moveToSaturation(static_cast<uint8_t>(colorSaturationTransitionState->finalValue),
-                                                                transitionTime10th, endpoint);
+                ColorControlServer::Instance().moveToSaturation(
+                    endpoint, static_cast<uint8_t>(colorSaturationTransitionState->finalValue), transitionTime10th);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
                 break;
             case EnhancedColorMode::kCurrentXAndCurrentY:
@@ -326,8 +326,8 @@ public:
             case EnhancedColorMode::kEnhancedCurrentHueAndCurrentSaturation:
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
                 ColorControlServer::Instance().moveToHueAndSaturation(
-                    colorHueTransitionState->finalEnhancedHue, static_cast<uint8_t>(colorSaturationTransitionState->finalValue),
-                    transitionTime10th, true, endpoint);
+                    endpoint, colorHueTransitionState->finalEnhancedHue,
+                    static_cast<uint8_t>(colorSaturationTransitionState->finalValue), transitionTime10th, true);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
                 break;
             default:
@@ -1263,13 +1263,13 @@ EmberEventControl * ColorControlServer::configureHSVEventControl(EndpointId endp
 /**
  * @brief executes move to saturation command
  *
+ * @param endpoint target endpoint where to execute move
  * @param saturation target saturation
  * @param transitionTime transition time in 10th of seconds
- * @param endpoint target endpoint where to execute move
- * @return Status::Success if successful,Status::UnsupportedEndpoint if the saturation transition state doesn't exist,
- * Status::ConstraintError if the saturation is above maximum
+ * @return Status::Success when successful,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
  */
-Status ColorControlServer::moveToSaturation(uint8_t saturation, uint16_t transitionTime, EndpointId endpoint)
+Status ColorControlServer::moveToSaturation(EndpointId endpoint, uint8_t saturation, uint16_t transitionTime)
 {
     Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
     VerifyOrReturnError(nullptr != colorSaturationTransitionState, Status::UnsupportedEndpoint);
@@ -1302,17 +1302,17 @@ Status ColorControlServer::moveToSaturation(uint8_t saturation, uint16_t transit
 /**
  * @brief executes move to hue and saturatioan command
  *
+ * @param[in] endpoint endpointId of the recipient Color control cluster
  * @param[in] hue target hue
  * @param[in] saturation target saturation
  * @param[in] transitionTime transition time in 10th of seconds
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
  * was called by MoveHue command and rate is a uint8 value
- * @param[in] endpoint
- * @return Status::Success if successful,Status::UnsupportedEndpoint if the saturation transition state doesn't exist,
- * Status::ConstraintError if the saturation is above maximum
+ * @return Status::Success when successful,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state,
  */
-Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturation, uint16_t transitionTime, bool isEnhanced,
-                                                  EndpointId endpoint)
+Status ColorControlServer::moveToHueAndSaturation(EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
+                                                  bool isEnhanced)
 {
     uint16_t currentHue = 0;
     uint16_t halfWay    = isEnhanced ? HALF_MAX_UINT16T : HALF_MAX_UINT8T;
@@ -1391,42 +1391,33 @@ Status ColorControlServer::moveToHueAndSaturation(uint16_t hue, uint8_t saturati
 /**
  * @brief Executes move Hue Command
  *
- * @param[in] endpoint
+ * @param[in] endpoint endpointId of the recipient Color control cluster
  * @param[in] moveMode
  * @param[in] rate
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
  * was called by MoveHue command and rate is a uint8 value
- * @return true Success
- * @return false Failed
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when Rate is 0 or an unknown moveMode is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
  */
-bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                        HueMoveMode moveMode, uint16_t rate, BitMask<OptionsBitmap> optionsMask,
-                                        BitMask<OptionsBitmap> optionsOverride, bool isEnhanced)
+Status ColorControlServer::moveHueCommand(EndpointId endpoint, HueMoveMode moveMode, uint16_t rate,
+                                          BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride,
+                                          bool isEnhanced)
 {
     MATTER_TRACE_SCOPE("moveHue", "ColorControl");
-    EndpointId endpoint = commandPath.mEndpointId;
-    Status status       = Status::Success;
-
-    uint16_t epIndex                                  = getEndpointIndex(endpoint);
-    ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
-
-    VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // check moveMode and rate before any operation is done on the transition states
     // rate value is ignored if the MoveMode is stop
-    if (moveMode == HueMoveMode::kUnknownEnumValue || (rate == 0 && moveMode != HueMoveMode::kStop))
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
+    VerifyOrReturnValue(moveMode != HueMoveMode::kUnknownEnumValue, Status::InvalidCommand);
+    VerifyOrReturnValue((rate != 0 || moveMode == HueMoveMode::kStop), Status::InvalidCommand);
 
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
+    uint16_t epIndex                                  = getEndpointIndex(endpoint);
+    ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
+    VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
+
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
@@ -1438,8 +1429,7 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
         // Per spec any saturation transition must also be cancelled.
         Color16uTransitionState * saturationState = getSaturationTransitionStateByIndex(epIndex);
         initSaturationTransitionState(endpoint, saturationState);
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
+        return Status::Success;
     }
 
     // Handle color mode transition, if necessary.
@@ -1491,50 +1481,42 @@ bool ColorControlServer::moveHueCommand(app::CommandHandler * commandObj, const 
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
-
-exit:
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
 /**
  * @brief Executes move to hue command
  *
- * @param[in] endpoint
+ * @param[in] endpointId of the recipient Color control cluster
  * @param[in] hue
- * @param[in] hueMoveMode
+ * @param[in] moveDirection
  * @param[in] transitionTime
  * @param[in] optionsMask
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
  * was called by MoveHue command and rate is a uint8 value
- * @return true Success
- * @return false Failed
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when Rate is 0 or an unknown moveDirection is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
+ *         Status::ConstraintError when the other parameters are outside their defined value range.
  */
-bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                          uint16_t hue, DirectionEnum moveDirection, uint16_t transitionTime,
-                                          BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride,
-                                          bool isEnhanced)
+Status ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, DirectionEnum moveDirection, uint16_t transitionTime,
+                                            BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride,
+                                            bool isEnhanced)
 {
     MATTER_TRACE_SCOPE("moveToHue", "ColorControl");
-    EndpointId endpoint = commandPath.mEndpointId;
+    VerifyOrReturnValue(moveDirection != DirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
-    Status status       = Status::Success;
-    uint16_t currentHue = 0;
-    DirectionEnum direction;
+    // Command Parameters constraint checks:
+    VerifyOrReturnValue((isEnhanced || hue <= MAX_HUE_VALUE), Status::ConstraintError);
 
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
+    VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
 
-    VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
-    // Standard Hue limit checking:  hue is 0..254.  Spec dictates we ignore
-    // this and report a constraint error.
-    if (!isEnhanced && (hue > MAX_HUE_VALUE))
-    {
-        commandObj->AddStatus(commandPath, Status::ConstraintError);
-        return true;
-    }
-
+    uint16_t currentHue = 0;
+    DirectionEnum direction;
     if (isEnhanced)
     {
         Attributes::EnhancedCurrentHue::Get(endpoint, &currentHue);
@@ -1543,7 +1525,6 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
     {
         uint8_t current8bitHue = 0;
         Attributes::CurrentHue::Get(endpoint, &current8bitHue);
-
         currentHue = static_cast<uint16_t>(current8bitHue);
     }
 
@@ -1577,16 +1558,9 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
         direction = moveDirection;
         break;
     case DirectionEnum::kUnknownEnumValue:
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
+        return Status::InvalidCommand;
         /* No default case, so if a new direction value gets added we will just fail
            to compile until we handle it correctly.  */
-    }
-
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
     }
 
     // New command.  Need to stop any active transitions.
@@ -1626,17 +1600,12 @@ bool ColorControlServer::moveToHueCommand(app::CommandHandler * commandObj, cons
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
-
-exit:
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
 /**
  * @brief executes move to hue and saturatioan command
- *
- * @param[in] commandObj
- * @param[in] commandPath
+ * @param[in] endpointId of the recipient Color control cluster
  * @param[in] hue
  * @param[in] saturation
  * @param[in] transitionTime
@@ -1644,35 +1613,26 @@ exit:
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
  * was called by MoveHue command and rate is a uint8 value
- * @return true Success
- * @return false Failed
+ * @return Status::Success when successful,
+ *         Status::ConstraintError when the other parameters are outside their defined value range.
+
  */
-bool ColorControlServer::moveToHueAndSaturationCommand(app::CommandHandler * commandObj,
-                                                       const app::ConcreteCommandPath & commandPath, uint16_t hue,
-                                                       uint8_t saturation, uint16_t transitionTime,
-                                                       BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride,
-                                                       bool isEnhanced)
+Status ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint16_t hue, uint8_t saturation,
+                                                         uint16_t transitionTime, BitMask<OptionsBitmap> optionsMask,
+                                                         BitMask<OptionsBitmap> optionsOverride, bool isEnhanced)
 {
     MATTER_TRACE_SCOPE("moveToHueAndSaturation", "ColorControl");
-    // limit checking:  hue and saturation are 0..254.  Spec dictates we ignore
-    // this and report a constraint error.
-    if ((!isEnhanced && hue > MAX_HUE_VALUE) || saturation > MAX_SATURATION_VALUE)
-    {
-        commandObj->AddStatus(commandPath, Status::ConstraintError);
-        return true;
-    }
+    // Command Parameters constraint checks:
+    VerifyOrReturnValue((isEnhanced || hue <= MAX_HUE_VALUE), Status::ConstraintError);
+    VerifyOrReturnValue(saturation <= MAX_SATURATION_VALUE, Status::ConstraintError);
 
-    if (!shouldExecuteIfOff(commandPath.mEndpointId, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
-    Status status = moveToHueAndSaturation(hue, saturation, transitionTime, isEnhanced, commandPath.mEndpointId);
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
+
+    Status status = moveToHueAndSaturation(endpoint, hue, saturation, transitionTime, isEnhanced);
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(commandPath.mEndpointId);
+    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return status;
 }
 
 /**
@@ -1686,33 +1646,23 @@ bool ColorControlServer::moveToHueAndSaturationCommand(app::CommandHandler * com
  * @param[in] optionsOverride
  * @param[in] isEnhanced If True, function was called by EnhancedMoveHue command and rate is a uint16 value. If False function
  * was called by MoveHue command and rate is a uint8 value
- * @return true Success
- * @return false Failed
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when StepSize is 0 or an unknown HueStepMode is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state.
  */
-bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                        HueStepMode stepMode, uint16_t stepSize, uint16_t transitionTime,
-                                        BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride, bool isEnhanced)
+Status ColorControlServer::stepHueCommand(EndpointId endpoint, HueStepMode stepMode, uint16_t stepSize, uint16_t transitionTime,
+                                          BitMask<OptionsBitmap> optionsMask, BitMask<OptionsBitmap> optionsOverride,
+                                          bool isEnhanced)
 {
     MATTER_TRACE_SCOPE("stepHue", "ColorControl");
-    EndpointId endpoint = commandPath.mEndpointId;
-
-    Status status = Status::Success;
+    // Confirm validity of the step mode and step size received
+    VerifyOrReturnValue(stepMode != HueStepMode::kUnknownEnumValue, Status::InvalidCommand);
+    VerifyOrReturnValue(stepSize != 0, Status::InvalidCommand);
 
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionState(endpoint);
-    VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
+    VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
 
-    // Confirm validity of the step mode and step size received
-    if (stepMode == HueStepMode::kUnknownEnumValue || stepSize == 0)
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
-
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
@@ -1770,55 +1720,45 @@ bool ColorControlServer::stepHueCommand(app::CommandHandler * commandObj, const 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
 
-exit:
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
-bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                               const Commands::MoveSaturation::DecodableType & commandData)
+/**
+ * @brief executes moveSaturation command
+ * @param endpoint endpointId of the recipient Color control cluster
+ * @param commandData Struct containing the parameters of the command
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when a rate of 0 for a non-stop move or an unknown SaturationMoveMode is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
+ */
+Status ColorControlServer::moveSaturationCommand(EndpointId endpoint, const Commands::MoveSaturation::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("moveSaturation", "ColorControl");
     auto & moveMode        = commandData.moveMode;
     auto & rate            = commandData.rate;
     auto & optionsMask     = commandData.optionsMask;
     auto & optionsOverride = commandData.optionsOverride;
-    EndpointId endpoint    = commandPath.mEndpointId;
-    Status status          = Status::Success;
-
-    uint16_t epIndex                                         = getEndpointIndex(endpoint);
-    Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
-    VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
 
     // check moveMode and rate before any operation is done on the transition states
     // rate value is ignored if the MoveMode is stop
-    if (moveMode == SaturationMoveMode::kUnknownEnumValue || (rate == 0 && moveMode != SaturationMoveMode::kStop))
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
+    VerifyOrReturnValue(moveMode != SaturationMoveMode::kUnknownEnumValue, Status::InvalidCommand);
+    VerifyOrReturnValue(rate != 0 || moveMode == SaturationMoveMode::kStop, Status::InvalidCommand);
 
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
+    uint16_t epIndex                                         = getEndpointIndex(endpoint);
+    Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionStateByIndex(epIndex);
+    VerifyOrReturnValue(colorSaturationTransitionState != nullptr, Status::UnsupportedEndpoint);
 
-    uint16_t transitionTime;
-
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
-
     // now, kick off the state machine.
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
-
     if (moveMode == SaturationMoveMode::kStop)
     {
         // Per spec any hue transition must also be cancelled.
         ColorHueTransitionState * hueState = getColorHueTransitionStateByIndex(epIndex);
         initHueTransitionState(endpoint, hueState, false /*isEnhancedHue don't care*/);
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
+        return Status::Success;
     }
 
     // Handle color mode transition, if necessary.
@@ -1833,8 +1773,7 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
         colorSaturationTransitionState->finalValue = MIN_SATURATION_VALUE;
     }
 
-    transitionTime = computeTransitionTimeFromStateAndRate(colorSaturationTransitionState, rate);
-
+    uint16_t transitionTime                        = computeTransitionTimeFromStateAndRate(colorSaturationTransitionState, rate);
     colorSaturationTransitionState->stepsRemaining = transitionTime;
     colorSaturationTransitionState->stepsTotal     = transitionTime;
     colorSaturationTransitionState->timeRemaining  = transitionTime;
@@ -1847,84 +1786,65 @@ bool ColorControlServer::moveSaturationCommand(app::CommandHandler * commandObj,
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), TRANSITION_UPDATE_TIME_MS.count());
-
-exit:
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
 /**
  * @brief executes move to saturation command
- *
- * @param commandObj
- * @param commandPath
- * @param commandData
- * @return true
- * @return false
+ * @param endpoint endpointId of the recipient Color control cluster
+ * @param commandData Struct containing the parameters of the command
+ * @return Status::Success when successful,
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state (verified in
+ * moveToSaturation function) Status::ConstraintError when a command parameters is outside its defined value range.
  */
-bool ColorControlServer::moveToSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                                 const Commands::MoveToSaturation::DecodableType & commandData)
+Status ColorControlServer::moveToSaturationCommand(EndpointId endpoint,
+                                                   const Commands::MoveToSaturation::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("moveToSaturation", "ColorControl");
-    // limit checking: saturation is 0..254.  Spec dictates we ignore
-    // this and report a malformed packet.
-    if (commandData.saturation > MAX_SATURATION_VALUE)
-    {
-        commandObj->AddStatus(commandPath, Status::ConstraintError);
-        return true;
-    }
+    // Command Parameters constraint checks:
+    VerifyOrReturnValue(commandData.saturation <= MAX_SATURATION_VALUE, Status::ConstraintError);
 
-    if (!shouldExecuteIfOff(commandPath.mEndpointId, commandData.optionsMask, commandData.optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
-    Status status = moveToSaturation(commandData.saturation, commandData.transitionTime, commandPath.mEndpointId);
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, commandData.optionsMask, commandData.optionsOverride), Status::Success);
+    Status status = moveToSaturation(endpoint, commandData.saturation, commandData.transitionTime);
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(commandPath.mEndpointId);
+    ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return status;
 }
 
-bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                               const Commands::StepSaturation::DecodableType & commandData)
+/**
+ * @brief executes step saturation command
+ * @param endpoint endpointId of the recipient Color control cluster
+ * @param commandData Struct containing the parameters of the command
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when a step size of 0 or an unknown SaturationStepMode is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a saturation transition state.
+ */
+Status ColorControlServer::stepSaturationCommand(EndpointId endpoint, const Commands::StepSaturation::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("stepSaturation", "ColorControl");
-    auto stepMode                          = commandData.stepMode;
-    uint8_t stepSize                       = commandData.stepSize;
-    uint8_t transitionTime                 = commandData.transitionTime;
-    BitMask<OptionsBitmap> optionsMask     = commandData.optionsMask;
-    BitMask<OptionsBitmap> optionsOverride = commandData.optionsOverride;
-    EndpointId endpoint                    = commandPath.mEndpointId;
-    Status status                          = Status::Success;
-    uint8_t currentSaturation              = 0;
-
-    Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
-    VerifyOrExit(colorSaturationTransitionState != nullptr, status = Status::UnsupportedEndpoint);
+    auto & stepMode        = commandData.stepMode;
+    auto & stepSize        = commandData.stepSize;
+    auto & transitionTime  = commandData.transitionTime;
+    auto & optionsMask     = commandData.optionsMask;
+    auto & optionsOverride = commandData.optionsOverride;
 
     // Confirm validity of the step mode and step size received
-    if (stepMode == SaturationStepMode::kUnknownEnumValue || stepSize == 0)
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
+    VerifyOrReturnValue(stepMode != SaturationStepMode::kUnknownEnumValue, Status::InvalidCommand);
+    VerifyOrReturnValue(stepSize != 0, Status::InvalidCommand);
 
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
+    Color16uTransitionState * colorSaturationTransitionState = getSaturationTransitionState(endpoint);
+    VerifyOrReturnValue(colorSaturationTransitionState != nullptr, Status::UnsupportedEndpoint);
+
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
     // New command.  Need to stop any active transitions.
     stopAllColorTransitions(endpoint);
-
     // Handle color mode transition, if necessary.
     handleModeSwitch(endpoint, EnhancedColorMode::kCurrentHueAndCurrentSaturation);
-
     // now, kick off the state machine.
     initSaturationTransitionState(endpoint, colorSaturationTransitionState);
-    currentSaturation = static_cast<uint8_t>(colorSaturationTransitionState->currentValue);
+    uint8_t currentSaturation = static_cast<uint8_t>(colorSaturationTransitionState->currentValue);
 
     if (stepMode == SaturationStepMode::kUp)
     {
@@ -1946,52 +1866,46 @@ bool ColorControlServer::stepSaturationCommand(app::CommandHandler * commandObj,
 
     // kick off the state machine:
     scheduleTimerCallbackMs(configureHSVEventControl(endpoint), transitionTime ? TRANSITION_UPDATE_TIME_MS.count() : 0);
-
-exit:
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
-bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                          const Commands::ColorLoopSet::DecodableType & commandData)
+/**
+ * @brief executes ColorLoop command
+ * @param endpoint endpointId of the recipient Color control cluster
+ * @param commandData Struct containing the parameters of the command
+ * @return Status::Success when successful,
+ *         Status::InvalidCommand when an unknown action or direction is provided
+ *         Status::UnsupportedEndpoint when the provided endpoint doesn't correspond with a hue transition state,
+ */
+Status ColorControlServer::colorLoopCommand(EndpointId endpoint, const Commands::ColorLoopSet::DecodableType & commandData)
 {
     MATTER_TRACE_SCOPE("colorLoop", "ColorControl");
-    auto updateFlags                       = commandData.updateFlags;
-    auto action                            = commandData.action;
-    auto direction                         = commandData.direction;
-    uint16_t time                          = commandData.time;
-    uint16_t startHue                      = commandData.startHue;
-    BitMask<OptionsBitmap> optionsMask     = commandData.optionsMask;
-    BitMask<OptionsBitmap> optionsOverride = commandData.optionsOverride;
-    EndpointId endpoint                    = commandPath.mEndpointId;
-    Status status                          = Status::Success;
-    uint8_t isColorLoopActive              = 0;
-    uint8_t deactiveColorLoop              = 0;
+    auto & updateFlags     = commandData.updateFlags;
+    auto & action          = commandData.action;
+    auto & direction       = commandData.direction;
+    auto & time            = commandData.time;
+    auto & startHue        = commandData.startHue;
+    auto & optionsMask     = commandData.optionsMask;
+    auto & optionsOverride = commandData.optionsOverride;
+
+    // Validate the action and direction parameters of the command
+    VerifyOrReturnValue(action != ColorLoopActionEnum::kUnknownEnumValue, Status::InvalidCommand);
+    VerifyOrReturnValue(direction != ColorLoopDirectionEnum::kUnknownEnumValue, Status::InvalidCommand);
 
     uint16_t epIndex                                  = getEndpointIndex(endpoint);
     ColorHueTransitionState * colorHueTransitionState = getColorHueTransitionStateByIndex(epIndex);
-    VerifyOrExit(colorHueTransitionState != nullptr, status = Status::UnsupportedEndpoint);
+    VerifyOrReturnValue(colorHueTransitionState != nullptr, Status::UnsupportedEndpoint);
 
-    // Validate the action and direction parameters of the command
-    if (action == ColorLoopActionEnum::kUnknownEnumValue || direction == ColorLoopDirectionEnum::kUnknownEnumValue)
-    {
-        commandObj->AddStatus(commandPath, Status::InvalidCommand);
-        return true;
-    }
+    VerifyOrReturnValue(shouldExecuteIfOff(endpoint, optionsMask, optionsOverride), Status::Success);
 
-    if (!shouldExecuteIfOff(endpoint, optionsMask, optionsOverride))
-    {
-        commandObj->AddStatus(commandPath, Status::Success);
-        return true;
-    }
-
+    uint8_t isColorLoopActive = 0;
     // In case of get failure, isColorLoopActive will remain at the init value 0 (not active)
     if (Attributes::ColorLoopActive::Get(endpoint, &isColorLoopActive) != Status::Success)
     {
         ChipLogError(Zcl, "Failed to retrieve ColorLoopActive value");
     }
 
-    deactiveColorLoop = updateFlags.Has(ColorLoopUpdateFlags::kUpdateAction) && (action == ColorLoopAction::kDeactivate);
+    uint8_t deactiveColorLoop = updateFlags.Has(ColorLoopUpdateFlags::kUpdateAction) && (action == ColorLoopAction::kDeactivate);
 
     if (updateFlags.Has(ColorLoopUpdateFlags::kUpdateDirection))
     {
@@ -2073,12 +1987,10 @@ bool ColorControlServer::colorLoopCommand(app::CommandHandler * commandObj, cons
         }
     }
 
-exit:
 #ifdef MATTER_DM_PLUGIN_SCENES_MANAGEMENT
     ScenesManagement::ScenesServer::Instance().MakeSceneInvalidForAllFabrics(endpoint);
 #endif // MATTER_DM_PLUGIN_SCENES_MANAGEMENT
-    commandObj->AddStatus(commandPath, status);
-    return true;
+    return Status::Success;
 }
 
 /**
@@ -3201,96 +3113,119 @@ Status ColorControlServer::SetQuietReportRemainingTime(EndpointId endpoint, uint
 bool emberAfColorControlClusterMoveHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::MoveHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveHueCommand(commandObj, commandPath, commandData.moveMode, commandData.rate,
-                                                         commandData.optionsMask, commandData.optionsOverride, false);
+    Status status = ColorControlServer::Instance().moveHueCommand(commandPath.mEndpointId, commandData.moveMode, commandData.rate,
+                                                                  commandData.optionsMask, commandData.optionsOverride, false);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterMoveSaturationCallback(app::CommandHandler * commandObj,
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const Commands::MoveSaturation::DecodableType & commandData)
 {
-
-    return ColorControlServer::Instance().moveSaturationCommand(commandObj, commandPath, commandData);
+    Status status = ColorControlServer::Instance().moveSaturationCommand(commandPath.mEndpointId, commandData);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterMoveToHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                  const Commands::MoveToHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueCommand(commandObj, commandPath, commandData.hue, commandData.direction,
-                                                           commandData.transitionTime, commandData.optionsMask,
-                                                           commandData.optionsOverride, false);
+    Status status = ColorControlServer::Instance().moveToHueCommand(commandPath.mEndpointId, commandData.hue, commandData.direction,
+                                                                    commandData.transitionTime, commandData.optionsMask,
+                                                                    commandData.optionsOverride, false);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterMoveToSaturationCallback(app::CommandHandler * commandObj,
                                                         const app::ConcreteCommandPath & commandPath,
                                                         const Commands::MoveToSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToSaturationCommand(commandObj, commandPath, commandData);
+    Status status = ColorControlServer::Instance().moveToSaturationCommand(commandPath.mEndpointId, commandData);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterMoveToHueAndSaturationCallback(app::CommandHandler * commandObj,
                                                               const app::ConcreteCommandPath & commandPath,
                                                               const Commands::MoveToHueAndSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueAndSaturationCommand(
-        commandObj, commandPath, commandData.hue, commandData.saturation, commandData.transitionTime, commandData.optionsMask,
+    Status status = ColorControlServer::Instance().moveToHueAndSaturationCommand(
+        commandPath.mEndpointId, commandData.hue, commandData.saturation, commandData.transitionTime, commandData.optionsMask,
         commandData.optionsOverride, false);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterStepHueCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                const Commands::StepHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepHueCommand(commandObj, commandPath, commandData.stepMode, commandData.stepSize,
-                                                         commandData.transitionTime, commandData.optionsMask,
-                                                         commandData.optionsOverride, false);
+    Status status = ColorControlServer::Instance().stepHueCommand(commandPath.mEndpointId, commandData.stepMode,
+                                                                  commandData.stepSize, commandData.transitionTime,
+                                                                  commandData.optionsMask, commandData.optionsOverride, false);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterStepSaturationCallback(app::CommandHandler * commandObj,
                                                       const app::ConcreteCommandPath & commandPath,
                                                       const Commands::StepSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepSaturationCommand(commandObj, commandPath, commandData);
+    Status status = ColorControlServer::Instance().stepSaturationCommand(commandPath.mEndpointId, commandData);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterEnhancedMoveHueCallback(app::CommandHandler * commandObj,
                                                        const app::ConcreteCommandPath & commandPath,
                                                        const Commands::EnhancedMoveHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveHueCommand(commandObj, commandPath, commandData.moveMode, commandData.rate,
-                                                         commandData.optionsMask, commandData.optionsOverride, true);
+    Status status = ColorControlServer::Instance().moveHueCommand(commandPath.mEndpointId, commandData.moveMode, commandData.rate,
+                                                                  commandData.optionsMask, commandData.optionsOverride, true);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterEnhancedMoveToHueCallback(app::CommandHandler * commandObj,
                                                          const app::ConcreteCommandPath & commandPath,
                                                          const Commands::EnhancedMoveToHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueCommand(commandObj, commandPath, commandData.enhancedHue, commandData.direction,
-                                                           commandData.transitionTime, commandData.optionsMask,
-                                                           commandData.optionsOverride, true);
+    Status status = ColorControlServer::Instance().moveToHueCommand(commandPath.mEndpointId, commandData.enhancedHue,
+                                                                    commandData.direction, commandData.transitionTime,
+                                                                    commandData.optionsMask, commandData.optionsOverride, true);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterEnhancedMoveToHueAndSaturationCallback(
     app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
     const Commands::EnhancedMoveToHueAndSaturation::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().moveToHueAndSaturationCommand(commandObj, commandPath, commandData.enhancedHue,
-                                                                        commandData.saturation, commandData.transitionTime,
-                                                                        commandData.optionsMask, commandData.optionsOverride, true);
+    Status status = ColorControlServer::Instance().moveToHueAndSaturationCommand(
+        commandPath.mEndpointId, commandData.enhancedHue, commandData.saturation, commandData.transitionTime,
+        commandData.optionsMask, commandData.optionsOverride, true);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterEnhancedStepHueCallback(app::CommandHandler * commandObj,
                                                        const app::ConcreteCommandPath & commandPath,
                                                        const Commands::EnhancedStepHue::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().stepHueCommand(commandObj, commandPath, commandData.stepMode, commandData.stepSize,
-                                                         commandData.transitionTime, commandData.optionsMask,
-                                                         commandData.optionsOverride, true);
+    Status status = ColorControlServer::Instance().stepHueCommand(commandPath.mEndpointId, commandData.stepMode,
+                                                                  commandData.stepSize, commandData.transitionTime,
+                                                                  commandData.optionsMask, commandData.optionsOverride, true);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 bool emberAfColorControlClusterColorLoopSetCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
                                                     const Commands::ColorLoopSet::DecodableType & commandData)
 {
-    return ColorControlServer::Instance().colorLoopCommand(commandObj, commandPath, commandData);
+    Status status = ColorControlServer::Instance().colorLoopCommand(commandPath.mEndpointId, commandData);
+    commandObj->AddStatus(commandPath, status);
+    return true;
 }
 
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -148,31 +148,38 @@ public:
                              chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    bool moveHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        MoveModeEnum moveMode, uint16_t rate,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveToHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath, uint16_t hue,
-                          DirectionEnum moveDirection, uint16_t transitionTime,
-                          chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                          chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveToHueAndSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                       uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                       chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                                       chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride,
-                                       bool isEnhanced);
-    bool stepHueCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                        StepModeEnum stepMode, uint16_t stepSize, uint16_t transitionTime,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
-                        chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
-    bool moveSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
-    bool moveToSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                 const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::DecodableType & commandData);
-    bool stepSaturationCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::ColorControl::Commands::StepSaturation::DecodableType & commandData);
-    bool colorLoopCommand(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                          const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::DecodableType & commandData);
+    // The Commands DecodableType to pass the command arguments are not used in the following HSV command handlers
+    // as they handle both standard and Enhanced HSV commands.
+    // The command arguments are decoupled in the command callback.
+    chip::Protocols::InteractionModel::Status
+    moveHueCommand(const chip::EndpointId endpoint, MoveModeEnum moveMode, uint16_t rate,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    moveToHueCommand(const chip::EndpointId endpoint, uint16_t hue, DirectionEnum moveDirection, uint16_t transitionTime,
+                     chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                     chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    moveToHueAndSaturationCommand(const chip::EndpointId endpoint, uint16_t hue, uint8_t saturation, uint16_t transitionTime,
+                                  chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                                  chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+    chip::Protocols::InteractionModel::Status
+    stepHueCommand(const chip::EndpointId endpoint, StepModeEnum stepMode, uint16_t stepSize, uint16_t transitionTime,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsMask,
+                   chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride, bool isEnhanced);
+
+    chip::Protocols::InteractionModel::Status
+    moveSaturationCommand(const chip::EndpointId endpoint,
+                          const chip::app::Clusters::ColorControl::Commands::MoveSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    moveToSaturationCommand(const chip::EndpointId endpoint,
+                            const chip::app::Clusters::ColorControl::Commands::MoveToSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    stepSaturationCommand(const chip::EndpointId endpoint,
+                          const chip::app::Clusters::ColorControl::Commands::StepSaturation::DecodableType & commandData);
+    chip::Protocols::InteractionModel::Status
+    colorLoopCommand(const chip::EndpointId endpoint,
+                     const chip::app::Clusters::ColorControl::Commands::ColorLoopSet::DecodableType & commandData);
     void updateHueSatCommand(chip::EndpointId endpoint);
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
@@ -231,10 +238,10 @@ private:
     uint16_t getEndpointIndex(chip::EndpointId);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    chip::Protocols::InteractionModel::Status moveToSaturation(uint8_t saturation, uint16_t transitionTime,
-                                                               chip::EndpointId endpoint);
-    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(uint16_t hue, uint8_t saturation, uint16_t transitionTime,
-                                                                     bool isEnhanced, chip::EndpointId endpoint);
+    chip::Protocols::InteractionModel::Status moveToSaturation(chip::EndpointId endpoint, uint8_t saturation,
+                                                               uint16_t transitionTime);
+    chip::Protocols::InteractionModel::Status moveToHueAndSaturation(chip::EndpointId endpoint, uint16_t hue, uint8_t saturation,
+                                                                     uint16_t transitionTime, bool isEnhanced);
     ColorHueTransitionState * getColorHueTransitionState(chip::EndpointId endpoint);
     Color16uTransitionState * getSaturationTransitionState(chip::EndpointId endpoint);
     ColorHueTransitionState * getColorHueTransitionStateByIndex(uint16_t index);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -148,7 +148,7 @@ public:
                              chip::BitMask<chip::app::Clusters::ColorControl::OptionsBitmap> optionsOverride);
 
 #ifdef MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
-    // The Commands DecodableType to pass the command arguments are not used in the following HSV command handlers
+    // The Command's DecodableType are not used to pass arguments in the following HSV handlers,
     // as they handle both standard and Enhanced HSV commands.
     // The command arguments are decoupled in the command callback.
     chip::Protocols::InteractionModel::Status


### PR DESCRIPTION
This PR is the 3rd of a few that splits https://github.com/project-chip/connectedhomeip/pull/36202 into smaller chunks for ease of review and to ensure that no regression slips through

- No behaviour change
- Clean up and unify the HSV command handlers of the color control.
- remove the goto mechanism and in favour of early return conditions (VerifyOrReturnValue)

sibling PRs #36376 #36377
