### PR TITLE
[ESP32] Backport the latest esp-insights version change to the v1.4-branch

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -18,18 +18,10 @@ dependencies:
             - if: "idf_version >=4.4"
 
     espressif/esp_insights:
-        version: "1.0.1"
+        version: "1.2.2"
         require: public
         # There is an issue with IDF-Component-Manager when ESP Insights is included.
         # Issue: https://github.com/project-chip/connectedhomeip/issues/29125
-        rules:
-            - if: "idf_version >=5.0"
-            - if: "target != esp32h2"
-
-    # This matches the dependency of esp_insights
-    espressif/esp_diag_data_store:
-        version: "1.0.1"
-        require: public
         rules:
             - if: "idf_version >=5.0"
             - if: "target != esp32h2"


### PR DESCRIPTION
**Change Overview**
-  Backport https://github.com/project-chip/connectedhomeip/pull/36078 to v1.4-branch.