### PR TITLE
Add LWIP IPv6 zone index in chip::Inet::IPAddress

### DIFF
--- a/src/inet/IPAddress.cpp
+++ b/src/inet/IPAddress.cpp
@@ -59,6 +59,9 @@ IPAddress::IPAddress(const ip6_addr_t & ipv6Addr)
 {
     static_assert(sizeof(ipv6Addr.addr) == sizeof(Addr), "ip6_addr_t size mismatch");
     memcpy(Addr, &ipv6Addr.addr, sizeof(ipv6Addr.addr));
+#if LWIP_IPV6_SCOPES
+    Zone = ipv6Addr.zone;
+#endif
 }
 
 #if INET_CONFIG_ENABLE_IPV4 || LWIP_IPV4
@@ -193,6 +196,9 @@ ip6_addr_t IPAddress::ToIPv6() const
     ip6_addr_t ipAddr = {};
     static_assert(sizeof(ipAddr.addr) == sizeof(Addr), "ip6_addr_t size mismatch");
     memcpy(&ipAddr.addr, Addr, sizeof(ipAddr.addr));
+#if LWIP_IPV6_SCOPES
+    ipAddr.zone = Zone;
+#endif
     return ipAddr;
 }
 

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -201,6 +201,9 @@ public:
      *  address in network byte order.
      */
     uint32_t Addr[4];
+#if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_IPV6_SCOPES
+    uint8_t Zone;
+#endif
 
     /**
      * @brief   Test whether address is IPv6 compatible.

--- a/src/inet/IPAddress.h
+++ b/src/inet/IPAddress.h
@@ -202,7 +202,7 @@ public:
      */
     uint32_t Addr[4];
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && LWIP_IPV6_SCOPES
-    uint8_t Zone;
+    uint8_t Zone = IP6_NO_ZONE;
 #endif
 
     /**


### PR DESCRIPTION
If using LWIP without any patches and with LWIP_IPV6_SCOPES=1, outbound connections cannot be routed to the correct interface, because zone index is missing in chip::Inet::IPAddress.

This is a simple fix to keep the ip6_addr_t zone in IPAddress if needed.