### PR TITLE
[Fabric-Admin] Merge CommissioningDelegate and PairingDelegate

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -87,7 +87,7 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
         return CHIP_NO_ERROR;
     }
 
-    PairingManager::Instance().SetCommissioningDelegate(this);
+    PairingManager::Instance().SetPairingDelegate(this);
 
     mBridgeNodeId = remoteId;
 
@@ -180,7 +180,7 @@ CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
         return CHIP_NO_ERROR;
     }
 
-    PairingManager::Instance().SetCommissioningDelegate(this);
+    PairingManager::Instance().SetPairingDelegate(this);
     mLocalBridgeNodeId = deviceId;
 
     if (mSetupPINCode.HasValue())
@@ -252,7 +252,7 @@ void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_
         {
             NodeId nodeId = DeviceMgr().GetNextAvailableNodeId();
 
-            PairingManager::Instance().SetCommissioningDelegate(this);
+            PairingManager::Instance().SetPairingDelegate(this);
             mAssignedNodeId = nodeId;
 
             usleep(kCommissionPrepareTimeMs * 1000);

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.h
@@ -26,7 +26,7 @@ namespace admin {
 // Constants
 constexpr uint32_t kCommissionPrepareTimeMs = 500;
 
-class FabricSyncAddBridgeCommand : public CHIPCommand, public CommissioningDelegate
+class FabricSyncAddBridgeCommand : public CHIPCommand, public PairingDelegate
 {
 public:
     FabricSyncAddBridgeCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("add-bridge", credIssuerCommands)
@@ -71,7 +71,7 @@ private:
     chip::NodeId mBridgeNodeId;
 };
 
-class FabricSyncAddLocalBridgeCommand : public CHIPCommand, public CommissioningDelegate
+class FabricSyncAddLocalBridgeCommand : public CHIPCommand, public PairingDelegate
 {
 public:
     FabricSyncAddLocalBridgeCommand(CredentialIssuerCommands * credIssuerCommands) :
@@ -116,7 +116,7 @@ private:
     chip::NodeId mLocalBridgeNodeId;
 };
 
-class FabricSyncDeviceCommand : public CHIPCommand, public CommissioningWindowDelegate, public CommissioningDelegate
+class FabricSyncDeviceCommand : public CHIPCommand, public CommissioningWindowDelegate, public PairingDelegate
 {
 public:
     FabricSyncDeviceCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("sync-device", credIssuerCommands)

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -312,10 +312,10 @@ void PairingManager::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
         ChipLogProgress(NotSpecified, "Device commissioning Failure: %s", ErrorStr(err));
     }
 
-    if (mCommissioningDelegate)
+    if (mPairingDelegate)
     {
-        mCommissioningDelegate->OnCommissioningComplete(nodeId, err);
-        SetCommissioningDelegate(nullptr);
+        mPairingDelegate->OnCommissioningComplete(nodeId, err);
+        SetPairingDelegate(nullptr);
     }
 }
 
@@ -555,6 +555,7 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
         if (self->mPairingDelegate)
         {
             self->mPairingDelegate->OnDeviceRemoved(nodeId, err);
+            self->SetPairingDelegate(nullptr);
         }
 
 #if defined(PW_RPC_ENABLED)

--- a/examples/fabric-admin/device_manager/PairingManager.h
+++ b/examples/fabric-admin/device_manager/PairingManager.h
@@ -37,18 +37,12 @@ public:
     virtual ~CommissioningWindowDelegate()                                                                      = default;
 };
 
-class CommissioningDelegate
-{
-public:
-    virtual void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) = 0;
-    virtual ~CommissioningDelegate()                                            = default;
-};
-
 class PairingDelegate
 {
 public:
-    virtual void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) = 0;
-    virtual ~PairingDelegate()                                          = default;
+    virtual void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) {}
+    virtual void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) {}
+    virtual ~PairingDelegate() = default;
 };
 
 /**
@@ -85,7 +79,6 @@ public:
     CHIP_ERROR Init(chip::Controller::DeviceCommissioner * commissioner, CredentialIssuerCommands * credIssuerCmds);
 
     void SetOpenCommissioningWindowDelegate(CommissioningWindowDelegate * delegate) { mCommissioningWindowDelegate = delegate; }
-    void SetCommissioningDelegate(CommissioningDelegate * delegate) { mCommissioningDelegate = delegate; }
     void SetPairingDelegate(PairingDelegate * delegate) { mPairingDelegate = delegate; }
     PairingDelegate * GetPairingDelegate() { return mPairingDelegate; }
 
@@ -181,7 +174,6 @@ private:
     CredentialIssuerCommands * mCredIssuerCmds           = nullptr;
 
     CommissioningWindowDelegate * mCommissioningWindowDelegate = nullptr;
-    CommissioningDelegate * mCommissioningDelegate             = nullptr;
     PairingDelegate * mPairingDelegate                         = nullptr;
 
     chip::NodeId mNodeId = chip::kUndefinedNodeId;


### PR DESCRIPTION
After refactoring to use PairingManager for all pairing activities, separate delegate functions for device pairing and unpairing will no longer be necessary. We should merge CommissioningDelegate into PairingDelegate to streamline these operations.

