### PR TITLE
[NXP][platform][examples] Low power changes

### DIFF
--- a/examples/contact-sensor-app/nxp/common/AppTask.cpp
+++ b/examples/contact-sensor-app/nxp/common/AppTask.cpp
@@ -18,10 +18,6 @@
 
 #include "AppTask.h"
 
-#if CONFIG_LOW_POWER
-#include "PWR_Interface.h"
-#endif
-
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -35,18 +31,6 @@ void ContactSensorApp::AppTask::PreInitMatterStack()
 {
     ChipLogProgress(DeviceLayer, "Welcome to NXP Contact Sensor Demo App");
 }
-
-#if CONFIG_LOW_POWER
-void ContactSensorApp::AppTask::AppMatter_DisallowDeviceToSleep()
-{
-    PWR_DisallowDeviceToSleep();
-}
-
-void ContactSensorApp::AppTask::AppMatter_AllowDeviceToSleep()
-{
-    PWR_AllowDeviceToSleep();
-}
-#endif
 
 ContactSensorApp::AppTask & ContactSensorApp::AppTask::GetDefaultInstance()
 {

--- a/examples/contact-sensor-app/nxp/common/include/AppTask.h
+++ b/examples/contact-sensor-app/nxp/common/include/AppTask.h
@@ -34,10 +34,6 @@ public:
 
     // AppTaskFreeRTOS virtual methods
     void PreInitMatterStack() override;
-#if CONFIG_LOW_POWER
-    void AppMatter_DisallowDeviceToSleep() override;
-    void AppMatter_AllowDeviceToSleep() override;
-#endif
 
     // This returns an instance of this class.
     static AppTask & GetDefaultInstance();

--- a/examples/platform/nxp/common/app_task/include/AppTaskBase.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskBase.h
@@ -102,7 +102,7 @@ public:
      * This function can be overridden in order to implement a specific disallow mechanism.
      *
      */
-    virtual void AppMatter_DisallowDeviceToSleep(void) {}
+    virtual void AppMatter_DisallowDeviceToSleep(void);
 
     /**
      * \brief Allow entering low power mode.
@@ -110,7 +110,7 @@ public:
      * This function can be overridden in order to implement a specific allow mechanism.
      *
      */
-    virtual void AppMatter_AllowDeviceToSleep(void) {}
+    virtual void AppMatter_AllowDeviceToSleep(void);
 
     /**
      * \brief Print onboarding information.

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -74,8 +74,8 @@
 #endif
 
 #if CONFIG_LOW_POWER
-#include "PWR_Interface.h"
 #include "LowPower.h"
+#include "PWR_Interface.h"
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -74,6 +74,7 @@
 #endif
 
 #if CONFIG_LOW_POWER
+#include "PWR_Interface.h"
 #include "LowPower.h"
 #endif
 
@@ -429,6 +430,20 @@ void chip::NXP::App::AppTaskBase::FactoryResetHandler(void)
     /* Emit the ShutDown event before factory reset */
     chip::Server::GetInstance().GenerateShutDownEvent();
     chip::Server::GetInstance().ScheduleFactoryReset();
+}
+
+void chip::NXP::App::AppTaskBase::AppMatter_DisallowDeviceToSleep(void)
+{
+#if CONFIG_LOW_POWER
+    PWR_DisallowDeviceToSleep();
+#endif
+}
+
+void chip::NXP::App::AppTaskBase::AppMatter_AllowDeviceToSleep(void)
+{
+#if CONFIG_LOW_POWER
+    PWR_AllowDeviceToSleep();
+#endif
 }
 
 void chip::NXP::App::AppTaskBase::PrintOnboardingInfo()

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -1190,7 +1190,7 @@ void BLEManagerCommon::blekw_gap_connection_cb(deviceId_t deviceId, gapConnectio
 
     if (pConnectionEvent->eventType == gConnEvtConnected_c)
     {
-#if CHIP_DEVICE_K32W1
+#if NXP_DEVICE_K32W1_MCXW7X
 #if defined(nxp_use_low_power) && (nxp_use_low_power == 1)
         /* Disallow must be called here for K32W1, otherwise an assert will be reached.
          * Disclaimer: this is a workaround until a better cross platform solution is found. */


### PR DESCRIPTION
- [nxp][platform][common][ble] Change CHIP_DEVICE_K32W1 define to NXP_DEVICE_K32W1_MCXW7X

- [nxp][examples][common][contact-sensor-app] Remove low-power app callbacks

- [nxp][examples][common] Add low-power app callbacks default implementation
Add AppMatter_(Allow/Disallow)DeviceToSleep default implementation in AppTaskBase.
