### PR TITLE
Attempt to fix cirque by replacing OTBR agent startup string that we look for.

### DIFF
--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -143,7 +143,7 @@ class CHIPVirtualHome:
         for device_id in devices:
             # Wait for otbr-agent and CHIP server start
             self.assertTrue(self.wait_for_device_output(
-                device_id, "Thread Border Router started on AIL", 10))
+                device_id, "Thread interface: wpan0", 10))
             self.assertTrue(self.wait_for_device_output(
                 device_id, "[SVR] Server Listening...", 15))
             # Clear default Thread network commissioning data


### PR DESCRIPTION
This is after https://github.com/openthread/ot-br-posix/pull/2574 removed the log line we were looking for.

