### PR TITLE
matter-devices.xml: remove EXTS as a required attribute for AccessControl

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -40,7 +40,6 @@ limitations under the License.
         <clusters lockOthers="true">
             <include cluster="Access Control" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>ACL</requireAttribute>
-                <requireAttribute>EXTENSION</requireAttribute>
             </include>
             <include cluster="Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>DATA_MODEL_REVISION</requireAttribute>


### PR DESCRIPTION
This PR removes the EXTENSION attribute as a requirement for the AccessControl cluster on the root node as it goes against the spec: https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/device_types/RootNodeDeviceType.adoc#element-requirements