### PR TITLE
[Fabric-Admin] Fix failing to cleanup the synced device after it is removed

### DIFF
--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -23,6 +23,7 @@
 #include <commands/interactive/InteractiveCommands.h>
 #include <controller/ExampleOperationalCredentialsIssuer.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <device_manager/DeviceManager.h>
 #include <device_manager/DeviceSynchronization.h>
 #include <lib/core/CHIPSafeCasts.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -32,10 +33,6 @@
 #include <setup_payload/QRCodeSetupPayloadParser.h>
 
 #include <string>
-
-#if defined(PW_RPC_ENABLED)
-#include <rpc/RpcClient.h>
-#endif
 
 using namespace ::chip;
 using namespace ::chip::Controller;
@@ -534,16 +531,16 @@ void PairingCommand::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
     PairingCommand * command = reinterpret_cast<PairingCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(NotSpecified, "OnCurrentFabricRemove: context is null"));
 
+    ChipLogProgress(NotSpecified, "PairingCommand::OnCurrentFabricRemove");
+
     if (err == CHIP_NO_ERROR)
     {
         // print to console
         fprintf(stderr, "Device with Node ID: 0x%lx has been successfully removed.\n", nodeId);
 
-#if defined(PW_RPC_ENABLED)
         app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(command->CurrentCommissioner().GetFabricIndex(), nodeId);
         ScopedNodeId scopedNodeId(nodeId, command->CurrentCommissioner().GetFabricIndex());
-        admin::RemoveSynchronizedDevice(scopedNodeId);
-#endif
+        admin::DeviceMgr().RemoveSyncedDevice(scopedNodeId);
     }
     else
     {

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -25,6 +25,10 @@
 #include <cstdio>
 #include <string>
 
+#if defined(PW_RPC_ENABLED)
+#include <rpc/RpcClient.h>
+#endif
+
 using namespace chip;
 
 namespace admin {
@@ -109,8 +113,13 @@ Device * DeviceManager::FindDeviceByNode(NodeId nodeId)
     return nullptr;
 }
 
-void DeviceManager::RemoveSyncedDevice(NodeId nodeId)
+void DeviceManager::RemoveSyncedDevice(chip::ScopedNodeId scopedNodeId)
 {
+#if defined(PW_RPC_ENABLED)
+    RemoveSynchronizedDevice(scopedNodeId);
+#endif
+
+    NodeId nodeId   = scopedNodeId.GetNodeId();
     Device * device = FindDeviceByNode(nodeId);
     if (device == nullptr)
     {
@@ -259,6 +268,10 @@ void DeviceManager::HandleReadSupportedDeviceCategories(TLV::TLVReader & data)
         ChipLogProgress(NotSpecified, "Remote Fabric-Bridge supports Fabric Synchronization, start reverse commissioning.");
         RequestCommissioningApproval();
     }
+    else
+    {
+        ChipLogProgress(NotSpecified, "Remote Fabric-Bridge does not support Fabric Synchronization.");
+    }
 }
 
 void DeviceManager::RequestCommissioningApproval()
@@ -406,6 +419,8 @@ void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t respo
 
 void DeviceManager::HandleReverseOpenCommissioningWindow(TLV::TLVReader & data)
 {
+    ChipLogProgress(NotSpecified, "Handle ReverseOpenCommissioningWindow command.");
+
     app::Clusters::CommissionerControl::Commands::ReverseOpenCommissioningWindow::DecodableType value;
     CHIP_ERROR error = app::DataModel::Decode(data, value);
 
@@ -457,19 +472,6 @@ void DeviceManager::HandleCommandResponse(const app::ConcreteCommandPath & path,
     {
         HandleReverseOpenCommissioningWindow(data);
     }
-}
-
-void DeviceManager::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
-{
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Failed to remove synced device:(" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
-                     ChipLogValueX64(deviceId), err.Format());
-        return;
-    }
-
-    RemoveSyncedDevice(deviceId);
-    ChipLogProgress(NotSpecified, "Synced device with NodeId:" ChipLogFormatX64 " has been removed.", ChipLogValueX64(deviceId));
 }
 
 } // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -50,7 +50,7 @@ private:
     chip::EndpointId mEndpointId;
 };
 
-class DeviceManager : public PairingDelegate
+class DeviceManager
 {
 public:
     DeviceManager() = default;
@@ -77,7 +77,7 @@ public:
 
     void AddSyncedDevice(const Device & device);
 
-    void RemoveSyncedDevice(chip::NodeId nodeId);
+    void RemoveSyncedDevice(chip::ScopedNodeId scopedNodeId);
 
     /**
      * @brief Determines whether a given nodeId corresponds to the "current bridge device," either local or remote.
@@ -176,8 +176,6 @@ public:
 
 private:
     friend DeviceManager & DeviceMgr();
-
-    void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;
 
     void RequestCommissioningApproval();
 

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -23,14 +23,11 @@
 #include <sys/types.h>
 
 #include <commands/common/CHIPCommand.h>
+#include <device_manager/DeviceManager.h>
 #include <device_manager/DeviceSynchronization.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <setup_payload/ManualSetupPayloadParser.h>
 #include <setup_payload/QRCodeSetupPayloadParser.h>
-
-#if defined(PW_RPC_ENABLED)
-#include <rpc/RpcClient.h>
-#endif
 
 using namespace ::chip;
 using namespace ::chip::Controller;
@@ -547,6 +544,8 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
     PairingManager * self = reinterpret_cast<PairingManager *>(context);
     VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnCurrentFabricRemove: context is null"));
 
+    ChipLogProgress(NotSpecified, "PairingManager::OnCurrentFabricRemove");
+
     if (err == CHIP_NO_ERROR)
     {
         // print to console
@@ -558,12 +557,10 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
             self->SetPairingDelegate(nullptr);
         }
 
-#if defined(PW_RPC_ENABLED)
         FabricIndex fabricIndex = self->CurrentCommissioner().GetFabricIndex();
         app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(fabricIndex, nodeId);
         ScopedNodeId scopedNodeId(nodeId, fabricIndex);
-        RemoveSynchronizedDevice(scopedNodeId);
-#endif
+        DeviceMgr().RemoveSyncedDevice(scopedNodeId);
     }
     else
     {

--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -143,16 +143,4 @@ CHIP_ERROR DeviceManager::UnpairRemoteDevice(NodeId nodeId)
     return CHIP_NO_ERROR;
 }
 
-void DeviceManager::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
-{
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "Failed to remove synced device:(" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
-                     ChipLogValueX64(deviceId), err.Format());
-        return;
-    }
-
-    ChipLogProgress(NotSpecified, "Synced device with NodeId:" ChipLogFormatX64 " has been removed.", ChipLogValueX64(deviceId));
-}
-
 } // namespace admin

--- a/examples/fabric-sync/admin/DeviceManager.h
+++ b/examples/fabric-sync/admin/DeviceManager.h
@@ -25,7 +25,7 @@
 
 namespace admin {
 
-class DeviceManager : public PairingDelegate
+class DeviceManager
 {
 public:
     DeviceManager() = default;
@@ -118,8 +118,6 @@ public:
 
 private:
     friend DeviceManager & DeviceMgr();
-
-    void OnDeviceRemoved(chip::NodeId deviceId, CHIP_ERROR err) override;
 
     static DeviceManager sInstance;
 

--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -450,6 +450,8 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
     PairingManager * self = reinterpret_cast<PairingManager *>(context);
     VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnCurrentFabricRemove: context is null"));
 
+    ChipLogProgress(NotSpecified, "PairingManager::OnCurrentFabricRemove");
+
     if (err == CHIP_NO_ERROR)
     {
         // print to console


### PR DESCRIPTION
This regression was introduced during the API-based command refactor. The DeviceManager is not registered as a delegate of the PairingManager, so it does not receive the OnDeviceRemoved callback when a synced device is removed.

