### PR TITLE
[Silabs][WiFi] Wifi scan fixes and additional advertising fix

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -123,7 +123,7 @@ jobs:
             "./scripts/build/build_examples.py \
                 --enable-flashbundle \
                 --target efr32-brd4187c-lock-wifi-siwx917 \
-                --target efr32-brd4187c-light-wifi-rs9116 \
+                --target efr32-brd4187c-light-wifi-rs9116-additional-data-advertising \
                 --target efr32-brd4187c-lock-wifi-wf200 \
                 build \
                 --copy-artifacts-to out/artifacts \

--- a/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
+++ b/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
@@ -327,7 +327,6 @@ sl_status_t InitiateScan()
     // TODO: this changes will be reverted back after the Silabs WiFi SDK team fix the scan API
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 
-    ssid.length = wfx_rsi.sec.ssid_length;
     ssid.length = std::min<size_t>(wfx_rsi.sec.ssid_length, sizeof(ssid.value) - 1);
     chip::Platform::CopyString((char *) &ssid.value[0], ssid.length + 1, wfx_rsi.sec.ssid); // +1 for null termination
     sl_wifi_set_scan_callback(ScanCallback, NULL);

--- a/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
+++ b/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
@@ -609,7 +609,8 @@ sl_status_t show_scan_results(sl_wifi_scan_result_t * scan_result)
         cur_scan_result.ssid_length = strnlen((char *) scan_result->scan_info[idx].ssid,
                                               std::min<size_t>(sizeof(scan_result->scan_info[idx].ssid), WFX_MAX_SSID_LENGTH));
         // cur_scan_result.ssid is of size WFX_MAX_SSID_LENGTH+1, we are safe with the cur_scan_result.ssid_length calculated above
-        chip::Platform::CopyString(cur_scan_result.ssid, cur_scan_result.ssid_length + 1, (char *) scan_result->scan_info[idx].ssid); // +1 for null termination
+        chip::Platform::CopyString(cur_scan_result.ssid, cur_scan_result.ssid_length + 1,
+                                   (char *) scan_result->scan_info[idx].ssid); // +1 for null termination
 
         // if user has provided ssid, then check if the current scan result ssid matches the user provided ssid
         if (wfx_rsi.scan_ssid != nullptr &&

--- a/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
+++ b/examples/platform/silabs/SiWx917/SiWxWifiInterface.cpp
@@ -328,7 +328,7 @@ sl_status_t InitiateScan()
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 
     ssid.length = wfx_rsi.sec.ssid_length;
-    ssid.length = std::min<size_t>(wfx_rsi.sec.ssid_length, sizeof(ssid_arg.value) - 1);
+    ssid.length = std::min<size_t>(wfx_rsi.sec.ssid_length, sizeof(ssid.value) - 1);
     chip::Platform::CopyString((char *) &ssid.value[0], ssid.length + 1, wfx_rsi.sec.ssid); // +1 for null termination
     sl_wifi_set_scan_callback(ScanCallback, NULL);
 

--- a/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
+++ b/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
@@ -755,7 +755,8 @@ void ProcessEvent(WfxEvent_t inEvent)
             ap.ssid_length =
                 strnlen(reinterpret_cast<char *>(scan->ssid), std::min<size_t>(sizeof(scan->ssid), WFX_MAX_SSID_LENGTH));
             // ap.ssid is of size WFX_MAX_SSID_LENGTH+1, we are safe with the ap.ssid_length calculated above
-            chip::Platform::CopyString(ap.ssid, ap.ssid_length + 1, reinterpret_cast<char *>(scan->ssid)); // +1 for null termination
+            chip::Platform::CopyString(ap.ssid, ap.ssid_length + 1,
+                                       reinterpret_cast<char *>(scan->ssid)); // +1 for null termination
 
             // check if the scanned ssid is the one we are looking for
             if (wfx_rsi.scan_ssid_length != 0 && strncmp(wfx_rsi.scan_ssid, ap.ssid, WFX_MAX_SSID_LENGTH) != CMP_SUCCESS)

--- a/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
+++ b/examples/platform/silabs/efr32/rs911x/Rsi91xWifiInterface.cpp
@@ -754,7 +754,8 @@ void ProcessEvent(WfxEvent_t inEvent)
             memset(&ap, 0, sizeof(ap));
             ap.ssid_length =
                 strnlen(reinterpret_cast<char *>(scan->ssid), std::min<size_t>(sizeof(scan->ssid), WFX_MAX_SSID_LENGTH));
-            chip::Platform::CopyString(ap.ssid, ap.ssid_length, reinterpret_cast<char *>(scan->ssid));
+            // ap.ssid is of size WFX_MAX_SSID_LENGTH+1, we are safe with the ap.ssid_length calculated above
+            chip::Platform::CopyString(ap.ssid, ap.ssid_length + 1, reinterpret_cast<char *>(scan->ssid)); // +1 for null termination
 
             // check if the scanned ssid is the one we are looking for
             if (wfx_rsi.scan_ssid_length != 0 && strncmp(wfx_rsi.scan_ssid, ap.ssid, WFX_MAX_SSID_LENGTH) != CMP_SUCCESS)

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -399,7 +399,8 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     wfx_rsi.scan_cb = callback;
 
     // if SSID is provided to scan only that SSID
-    if(ssid) {
+    if (ssid)
+    {
         wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
         wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length + 1));
         VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);

--- a/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/examples/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -395,14 +395,16 @@ int32_t wfx_reset_counts(void)
 bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
 {
     // check if already in progress
-    VerifyOrReturnError(wfx_rsi.scan_cb != nullptr, false);
+    VerifyOrReturnError(wfx_rsi.scan_cb == nullptr, false);
     wfx_rsi.scan_cb = callback;
 
-    VerifyOrReturnError(ssid != nullptr, false);
-    wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
-    wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
-    VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
-    chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
+    // if SSID is provided to scan only that SSID
+    if(ssid) {
+        wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
+        wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length + 1));
+        VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
+        chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length + 1, ssid);
+    }
 
     WfxEvent_t event;
     event.eventType = WFX_EVT_SCAN;

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -81,7 +81,7 @@ public:
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
-    static void HandleC3ReadRequest(SilabsBleWrapper::sl_wfx_msg_t * rsi_ble_read_req);
+    static void HandleC3ReadRequest(const SilabsBleWrapper::sl_wfx_msg_t & rsi_ble_read_req);
 #else
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
     static void HandleC3ReadRequest(volatile sl_bt_msg_t * evt);


### PR DESCRIPTION
WiFi scan was broken due to the refactor and failing with the ecosystem commissioning and normal scan commands. 
Additional advertising build was also failing due to incorrect signature of the API. 

Fixing the scan to copy the correct ssid and fixing the additional advertising API. Enabling the additional advertising for one of the NCP so the build failure can be captured in the CI

Tested locally