### PR TITLE
Fix argument count handling in Command::InitArguments to prevent integer overflow

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -55,7 +55,7 @@ bool Command::InitArguments(int argc, char ** argv)
         {
             optionalArgsCount++;
         }
-	else if (argvExtraArgsCount == 0)
+        else if (argvExtraArgsCount == 0)
         {
             mandatoryArgsCount++;
         }

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -55,6 +55,10 @@ bool Command::InitArguments(int argc, char ** argv)
         {
             optionalArgsCount++;
         }
+	else if (argvExtraArgsCount == 0)
+        {
+            mandatoryArgsCount++;
+        }
         else
         {
             mandatoryArgsCount++;


### PR DESCRIPTION
### Description

- Running the `chip-tool` command with zero arguments results in an unsigned integer overflow due to attempting to decrement `argvExtraArgsCount` below zero in `Command::InitArguments`.

### Changes

- Added a condition to only decrement `argvExtraArgsCount` if it is non-zero. If it is zero, the code now correctly counts `mandatoryArgsCount` without modifying `argvExtraArgsCount`. This prevents overflow by ensuring safe handling when the number of arguments is less than expected.

### Reproducing

To reproduce this issue, attempt the following command:

```
$ ./chip-tool pairing onnetwork
```

Expected error message before the fix:

```
../../examples/chip-tool/commands/common/Command.cpp:61:31: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../examples/chip-tool/commands/common/Command.cpp:61:31 
[1730944494.021] [132704:132704] [TOO] InitArgs: Wrong arguments number: 0 instead of 2
```

