### PR TITLE
Ensure SYSTEM_STATS_INCREMENT only on successful memory allocation in SystemPacketBuffer.cpp

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -620,7 +620,6 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
     // checked to fit in a size_t.
     const size_t lBlockSize = static_cast<size_t>(sumOfSizes);
     lPacket                 = reinterpret_cast<PacketBuffer *>(chip::Platform::MemoryAlloc(lBlockSize));
-    SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
 
 #else
 #error "Unimplemented PacketBuffer storage case"
@@ -631,6 +630,8 @@ PacketBufferHandle PacketBufferHandle::New(size_t aAvailableSize, uint16_t aRese
         ChipLogError(chipSystemLayer, "PacketBuffer: pool EMPTY.");
         return PacketBufferHandle();
     }
+
+    SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs);
 
     lPacket->payload = lPacket->ReserveStart() + aReservedSize;
     lPacket->len = lPacket->tot_len = 0;


### PR DESCRIPTION
### Description

- Fixes an issue in `SystemPacketBuffer.cpp` where `SYSTEM_STATS_INCREMENT` is called even when memory allocation fails, leading to incorrect packet buffer statistics.

- Moved `SYSTEM_STATS_INCREMENT` to occur only after verifying that `MemoryAlloc` did not return `nullptr`, ensuring `kSystemLayer_NumPacketBufs` is incremented only when allocation is successful.

### Changes

- Adjusted the position of `SYSTEM_STATS_INCREMENT(chip::System::Stats::kSystemLayer_NumPacketBufs)` in `SystemPacketBuffer.cpp` to be called after `nullptr` validation.