### PR TITLE
Allow to easy install CHIP wheels in current virtual env

### DIFF
--- a/.github/workflows/examples-openiotsdk.yaml
+++ b/.github/workflows/examples-openiotsdk.yaml
@@ -58,7 +58,7 @@ jobs:
 
             - name: Build and install Python controller
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install-virtual-env out/venv'
                   scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.openiotsdk.txt'
 
             - name: Build shell example

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -86,7 +86,7 @@ jobs:
                    matter.onboardingpayload.QRCodeTest
             - name: Build Java Matter Controller and all clusters app
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install-virtual-env out/venv'
                   scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.build.txt'
                   scripts/run_in_python_env.sh out/venv 'pip install colorama'
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -215,7 +215,7 @@ jobs:
                     "
             - name: Build Apps
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install-virtual-env out/venv'
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
@@ -484,7 +484,7 @@ jobs:
               #       This may result in invalid errors, however for most purposes of our testing, we are unlikely to
               #       hit such cases so we remain very strict on testing here.
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install-virtual-env out/venv'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test \
@@ -588,7 +588,7 @@ jobs:
 
             - name: Build Python REPL and example apps
               run: |
-                  scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
+                  scripts/run_in_build_env.sh './scripts/build_python.sh --install-virtual-env out/venv'
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target darwin-x64-all-clusters-${BUILD_VARIANT}-test \

--- a/docs/development_controllers/chip-repl/matter-repl.md
+++ b/docs/development_controllers/chip-repl/matter-repl.md
@@ -54,7 +54,7 @@ choices.
    the -z argument that points to the directory of pre-generated code:
 
     ```
-    scripts/build_python.sh -m platform -i out/python_env -z "/some/pregen/dir"
+    scripts/build_python.sh -m platform -e out/python_env -z "/some/pregen/dir"
     ```
 
     > Note: To get more details about available build configurations, run the

--- a/docs/development_controllers/chip-repl/python_chip_controller_building.md
+++ b/docs/development_controllers/chip-repl/python_chip_controller_building.md
@@ -77,7 +77,7 @@ To build and run the Python CHIP controller:
 5. Build and install the Python CHIP controller:
 
     ```
-    scripts/build_python.sh -m platform -i out/python_env
+    scripts/build_python.sh -m platform -e out/python_env
     source out/python_env/bin/activate
     ```
 

--- a/docs/platforms/openiotsdk/openiotsdk_examples.md
+++ b/docs/platforms/openiotsdk/openiotsdk_examples.md
@@ -272,7 +272,7 @@ following command from the CLI:
 
 ```
 ${MATTER_ROOT}/scripts/run_in_build_env.sh \
-    './scripts/build_python.sh --install_virtual_env out/venv'
+    './scripts/build_python.sh --install-virtual-env out/venv'
 
 source out/venv/bin/activate
 ```

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -594,7 +594,7 @@ Next build the python wheels and create / activate a venv (called `pyenv` here,
 but any name may be used)
 
 ```
-./scripts/build_python.sh -i out/python_env
+./scripts/build_python.sh --install-virtual-env out/python_env
 source pyenv/bin/activate
 ```
 

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -333,8 +333,8 @@ subsequent setups as it is faster.
 Next build the python wheels and create a venv (called `py` here, but any name
 may be used)
 
-```
-./scripts/build_python.sh -i out/python_env
+```shell
+./scripts/build_python.sh --install-virtual-env out/python_env
 source py/bin/activate
 ```
 

--- a/examples/energy-management-app/linux/README.md
+++ b/examples/energy-management-app/linux/README.md
@@ -245,7 +245,7 @@ data (e.g. fabric info).
 ### Building chip-repl:
 
 ```bash
-    $ ./build_python.sh -i <path_to_out_folder>
+    $ ./build_python.sh --install-virtual-env <path_to_out_folder>
 ```
 
 ### Activating python virtual env

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -248,7 +248,7 @@ RUN case ${TARGETPLATFORM} in \
     *) ;; \
     esac
 
-RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true -i out/python_env
+RUN source scripts/activate.sh && scripts/build_python.sh -m platform -d true -e out/python_env
 
 # Stage 3: Copy relevant cert bins to a minimal image to reduce size.
 FROM ubuntu:24.04

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -35,7 +35,7 @@ echo_bold_white() {
 }
 
 check_one_of() {
-    local value=$1
+    local value="$1"
     shift
     for v in "$@"; do
         if [ "$value" = "$v" ]; then

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -150,7 +150,7 @@ def _do_build_python():
     """
     logging.info("Building python packages in out/venv ...")
     subprocess.run(
-        ["./scripts/build_python.sh", "--install_virtual_env", "out/venv"], check=True
+        ["./scripts/build_python.sh", "--install-virtual-env", "out/venv"], check=True
     )
 
 

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -31,7 +31,7 @@
 # files, then add the extra dependencies. From the root:
 #
 # . scripts/activate.sh
-# ./scripts/build_python.sh -i out/python_env
+# ./scripts/build_python.sh --install-virtual-env out/python_env
 # source out/python_env/bin/activate
 # pip install opencv-python requests click_option_group
 # python src/python_testing/post_certification_tests/production_device_checks.py

--- a/src/tools/PICS-generator/README.md
+++ b/src/tools/PICS-generator/README.md
@@ -21,7 +21,7 @@ This tool uses the python environment used by the python_testing efforts, which
 can be built using the below command.
 
 ```
-scripts/build_python.sh -m platform -i out/python_env
+scripts/build_python.sh -m platform -e out/python_env
 ```
 
 Once the python environment is build it can be activated using this command:

--- a/src/tools/device-graph/README.md
+++ b/src/tools/device-graph/README.md
@@ -9,7 +9,7 @@ can be built using the below command. Notice that graphviz is required as an
 extra package in order for the tool to generate the graph file.
 
 ```
-scripts/build_python.sh -m platform -i out/python_env --extra_packages graphviz
+scripts/build_python.sh -m platform -e out/python_env --extra-packages graphviz
 ```
 
 Once the python environment is build it can be activated using this command:


### PR DESCRIPTION
### Problem

It's not easy to build and install all CHIP packages in the current python virtual environment. Current use case:
```sh
./scripts/build_python.sh
# find all wheels generated in the output directory (where is the output, though)
# uninstall them, and install again...
```

In order to simplify that, the `build_python.sh` now provides option to automatically install all generated packages without the need of creating new virtual env (which is time costly since new env is re-created by default), i.e.:
```sh
source ./scripts/activate.sh
./scripts/build_python.sh -i
# do some modifications in the code
./scripts/build_python.sh -i
# ... repeat ...
```

### Changes

- added `-i`/`--install-wheels` option to install generated packages
- renamed `-i`/`--create_virtual_env` to  `-e`/`--create-virtual-env` (the `-e` better align with "environment", though, this change breaks backward compatibility)
- renamed some long options to use "-" instead of "_"

### Testing

CI will verify