### PR TITLE
Fix android CHIPTest linkage after #36297 .

### DIFF
--- a/examples/android/CHIPTest/BUILD.gn
+++ b/examples/android/CHIPTest/BUILD.gn
@@ -39,6 +39,7 @@ shared_library("jni") {
     "${chip_root}/src/platform/android:java",
     "${chip_root}/src/platform/android:logging",
     "${chip_root}/src/platform/tests:tests",
+    "${chip_root}/src/pw_backends/assert:assert.impl",
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/nlfaultinjection:nlfaultinjection",
   ]


### PR DESCRIPTION
Tested locally that `android-arm64-chip-test` builds.
