### PR TITLE
Add the current provider to AttributeAccessInterface

### DIFF
--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -18,11 +18,11 @@
 
 #pragma once
 
-#include <app/data-model-provider/ProviderChangeListener.h>
 #include <app/AttributeReportBuilder.h>
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>
 #include <app/data-model-provider/Provider.h>
+#include <app/data-model-provider/ProviderChangeListener.h>
 #include <lib/core/CHIPError.h>
 
 /**

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "data-model-provider/ProviderChangeListener.h"
+#include <app/data-model-provider/ProviderChangeListener.h>
 #include <app/AttributeReportBuilder.h>
 #include <app/AttributeValueDecoder.h>
 #include <app/AttributeValueEncoder.h>

--- a/src/app/AttributeAccessInterface.h
+++ b/src/app/AttributeAccessInterface.h
@@ -78,7 +78,7 @@ public:
      * Note that the `attributeChangeListener` is also invalidated, however that is not passed in as
      * the provider is considered sufficiently unique.
      */
-    virtual void DetachProvider(DataModel::Provider * provider);
+    virtual void DetachProvider(DataModel::Provider * provider) {}
 
     /**
      * Callback for reading attributes.

--- a/src/app/AttributeAccessInterfaceRegistry.h
+++ b/src/app/AttributeAccessInterfaceRegistry.h
@@ -18,12 +18,61 @@
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceCache.h>
 
+#include <cstddef>
+#include <iterator>
+
 namespace chip {
 namespace app {
 
 class AttributeAccessInterfaceRegistry
 {
 public:
+    class Iterator
+    {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = AttributeAccessInterface;
+        using pointer           = value_type *;
+        using reference         = value_type &;
+
+        explicit Iterator(AttributeAccessInterface * value) : mValue(value) {}
+        Iterator(Iterator &&)                  = default;
+        Iterator(const Iterator &)             = default;
+        Iterator & operator=(const Iterator &) = default;
+        Iterator & operator=(Iterator &&)      = default;
+
+        reference operator*() const { return *mValue; }
+        pointer operator->() const { return mValue; }
+
+        Iterator & operator++()
+        {
+            if (mValue != nullptr)
+            {
+                mValue = mValue->GetNext();
+            }
+            return *this;
+        }
+
+        Iterator operator++(int)
+        {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const Iterator & a, const Iterator & b) { return a.mValue == b.mValue; }
+        friend bool operator!=(const Iterator & a, const Iterator & b) { return a.mValue != b.mValue; }
+
+    private:
+        AttributeAccessInterface * mValue;
+    };
+
+    /// Iterator is for single for loop iterations (do not store it as Register/Unregister may
+    /// change registry content)
+    Iterator begin() { return Iterator(mAttributeAccessOverrides); }
+    Iterator end() { return Iterator(nullptr); }
+
     /**
      * Register an attribute access override.  It will remain registered until the
      * endpoint it's registered for is disabled (or until shutdown if it's

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -315,10 +315,6 @@ static_library("attribute-access") {
     "AttributeAccessInterfaceCache.h",
     "AttributeAccessInterfaceRegistry.cpp",
     "AttributeAccessInterfaceRegistry.h",
-    "AttributeEncodeState.h",
-    "AttributeValueDecoder.h",
-    "AttributeValueEncoder.cpp",
-    "AttributeValueEncoder.h",
   ]
 
   deps = [

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -291,11 +291,11 @@ source_set("events") {
 static_library("attribute-value-encode-decode") {
   sources = [
     "AttributeEncodeState.h",
+    "AttributeReportBuilder.cpp",
+    "AttributeReportBuilder.h",
     "AttributeValueDecoder.h",
     "AttributeValueEncoder.cpp",
     "AttributeValueEncoder.h",
-    "AttributeReportBuilder.cpp",
-    "AttributeReportBuilder.h",
   ]
 
   deps = [

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -288,6 +288,27 @@ source_set("events") {
   ]
 }
 
+static_library("attribute-value-encode-decode") {
+  sources = [
+    "AttributeEncodeState.h",
+    "AttributeValueDecoder.h",
+    "AttributeValueEncoder.cpp",
+    "AttributeValueEncoder.h",
+    "AttributeReportBuilder.cpp",
+    "AttributeReportBuilder.h",
+  ]
+
+  deps = [
+    ":paths",
+    "${chip_root}/src/access:types",
+    "${chip_root}/src/app/MessageDef",
+    "${chip_root}/src/app/data-model",
+    "${chip_root}/src/app/util:af-types",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+  ]
+}
+
 static_library("attribute-access") {
   sources = [
     "AttributeAccessInterface.h",
@@ -295,8 +316,6 @@ static_library("attribute-access") {
     "AttributeAccessInterfaceRegistry.cpp",
     "AttributeAccessInterfaceRegistry.h",
     "AttributeEncodeState.h",
-    "AttributeReportBuilder.cpp",
-    "AttributeReportBuilder.h",
     "AttributeValueDecoder.h",
     "AttributeValueEncoder.cpp",
     "AttributeValueEncoder.h",
@@ -312,6 +331,8 @@ static_library("attribute-access") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]
+
+  public_deps = [ ":attribute-value-encode-decode" ]
 }
 
 source_set("required-privileges") {

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -307,6 +307,7 @@ static_library("attribute-access") {
     "${chip_root}/src/access:types",
     "${chip_root}/src/app/MessageDef",
     "${chip_root}/src/app/data-model",
+    "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/util:af-types",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -811,7 +811,8 @@ void CodegenDataModelProvider::IncrementClustersVersionForEndpoint(EndpointId en
 
         // double check this path is valid (wildcard endpoints would try to expand all endpoint IDs)
         // we do not rely here that emberAfDataVersionStorage would return null (e.g. our tests do not return null)
-        if (FindServerCluster(clusterPath) == nullptr) {
+        if (FindServerCluster(clusterPath) == nullptr)
+        {
             return;
         }
 

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -807,8 +807,16 @@ void CodegenDataModelProvider::IncrementClustersVersionForEndpoint(EndpointId en
 
     if (clusterIdMayBeWildcard != kInvalidClusterId)
     {
+        const ConcreteClusterPath clusterPath(endpointId, clusterIdMayBeWildcard);
+
+        // double check this path is valid (wildcard endpoints would try to expand all endpoint IDs)
+        // we do not rely here that emberAfDataVersionStorage would return null (e.g. our tests do not return null)
+        if (FindServerCluster(clusterPath) == nullptr) {
+            return;
+        }
+
         // exact cluster ID, not a wildcard
-        DataVersion * versionPtr = emberAfDataVersionStorage(ConcreteClusterPath(endpointId, clusterIdMayBeWildcard));
+        DataVersion * versionPtr = emberAfDataVersionStorage(clusterPath);
         if (versionPtr != nullptr)
         {
             (*versionPtr)++;

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -805,9 +805,9 @@ CHIP_ERROR CodegenDataModelProvider::Startup(DataModel::InteractionModelContext 
 void CodegenDataModelProvider::IncrementClustersVersionForEndpoint(EndpointId endpointId, ClusterId clusterIdMayBeWildcard)
 {
 
-    if (clusterIdMayBeWildcard == kInvalidClusterId)
+    if (clusterIdMayBeWildcard != kInvalidClusterId)
     {
-        // wildcard
+        // exact cluster ID, not a wildcard
         DataVersion * versionPtr = emberAfDataVersionStorage(ConcreteClusterPath(endpointId, clusterIdMayBeWildcard));
         if (versionPtr != nullptr)
         {

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
@@ -180,9 +180,11 @@ public:
     void MarkDirty(const AttributePathParams & path) override;
 
 private:
+    // Flag tracking initialization for the purposes of attaching/deteaching to AttributeAccessInterface
+    // entries.
+    bool mInitialized = false;
     // Iteration is often done in a tight loop going through all values.
     // To avoid N^2 iterations, cache a hint of where something is positioned
-    bool mInitialized                 = false;
     uint16_t mEndpointIterationHint   = 0;
     unsigned mClusterIterationHint    = 0;
     unsigned mAttributeIterationHint  = 0;

--- a/src/app/codegen-data-model-provider/model.gni
+++ b/src/app/codegen-data-model-provider/model.gni
@@ -37,6 +37,7 @@ codegen_data_model_SOURCES = [
 ]
 
 codegen_data_model_PUBLIC_DEPS = [
+  "${chip_root}/src/app:attribute-access",
   "${chip_root}/src/app/common:attribute-type",
   "${chip_root}/src/app/data-model-provider",
   "${chip_root}/src/app/codegen-data-model-provider:instance-header",

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -2650,9 +2650,8 @@ TEST(TestCodegenModelViaMocks, TestMarkDirty)
         model.ChangeListener().DirtyList().clear();
         model.MarkDirty(kPath);
 
-        // exactly one cluster increased
-        // we do not validate cluster versions here, so versions increase
-        EXPECT_EQ(startVersion + 1, chip::Test::GetVersion());
+        // Cluster is not valid, so no version change
+        EXPECT_EQ(startVersion, chip::Test::GetVersion());
 
         // mark dirty does go through
         EXPECT_EQ(model.ChangeListener().DirtyList().size(), 1u);
@@ -2697,6 +2696,51 @@ TEST(TestCodegenModelViaMocks, TestMarkDirty)
         // Each cluster should call the increase once
         constexpr unsigned kNumTotalClusters = 9; // see gTestNodeConfig
         EXPECT_EQ(startVersion + kNumTotalClusters, chip::Test::GetVersion());
+
+        EXPECT_EQ(model.ChangeListener().DirtyList().size(), 1u);
+        EXPECT_EQ(model.ChangeListener().DirtyList()[0], kPath);
+    }
+
+    // Mark a specific cluster on all endpoints
+    {
+        const DataVersion startVersion = chip::Test::GetVersion();
+        const AttributePathParams kPath(kInvalidEndpointId, MockClusterId(1));
+        model.ChangeListener().DirtyList().clear();
+        model.MarkDirty(kPath);
+
+        // Each cluster should call the increase once
+        constexpr unsigned kNumClusterId1 = 3; // Appears on al endpoints
+        EXPECT_EQ(startVersion + kNumClusterId1, chip::Test::GetVersion());
+
+        EXPECT_EQ(model.ChangeListener().DirtyList().size(), 1u);
+        EXPECT_EQ(model.ChangeListener().DirtyList()[0], kPath);
+    }
+
+    // Mark a specific cluster on all endpoints
+    {
+        const DataVersion startVersion = chip::Test::GetVersion();
+        const AttributePathParams kPath(kInvalidEndpointId, MockClusterId(3));
+        model.ChangeListener().DirtyList().clear();
+        model.MarkDirty(kPath);
+
+        // Each cluster should call the increase once
+        constexpr unsigned kNumClusterId3 = 2; // Appears mock endpoints 2 and 3
+        EXPECT_EQ(startVersion + kNumClusterId3, chip::Test::GetVersion());
+
+        EXPECT_EQ(model.ChangeListener().DirtyList().size(), 1u);
+        EXPECT_EQ(model.ChangeListener().DirtyList()[0], kPath);
+    }
+
+    // Mark a specific cluster on all endpoints
+    {
+        const DataVersion startVersion = chip::Test::GetVersion();
+        const AttributePathParams kPath(kInvalidEndpointId, MockClusterId(4));
+        model.ChangeListener().DirtyList().clear();
+        model.MarkDirty(kPath);
+
+        // Each cluster should call the increase once
+        constexpr unsigned kNumClusterId4 = 1; // Appears mock endpoints 3 only
+        EXPECT_EQ(startVersion + kNumClusterId4, chip::Test::GetVersion());
 
         EXPECT_EQ(model.ChangeListener().DirtyList().size(), 1u);
         EXPECT_EQ(model.ChangeListener().DirtyList()[0], kPath);

--- a/src/app/data-model-provider/BUILD.gn
+++ b/src/app/data-model-provider/BUILD.gn
@@ -30,7 +30,7 @@ source_set("data-model-provider") {
 
   public_deps = [
     "${chip_root}/src/access:types",
-    "${chip_root}/src/app:attribute-access",
+    "${chip_root}/src/app:attribute-value-encode-decode",
     "${chip_root}/src/app:command-handler-interface",
     "${chip_root}/src/app:events",
     "${chip_root}/src/app:paths",

--- a/src/app/data-model-provider/Context.h
+++ b/src/app/data-model-provider/Context.h
@@ -34,6 +34,13 @@ struct InteractionModelContext
     EventsGenerator * eventsGenerator;
     ProviderChangeListener * dataModelChangeListener;
     ActionContext * actionContext;
+
+    void Reset()
+    {
+        eventsGenerator         = nullptr;
+        dataModelChangeListener = nullptr;
+        actionContext           = nullptr;
+    }
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -53,7 +53,12 @@ public:
         mContext = context;
         return CHIP_NO_ERROR;
     }
-    virtual CHIP_ERROR Shutdown() = 0;
+
+    virtual CHIP_ERROR Shutdown()
+    {
+        mContext.Reset();
+        return CHIP_NO_ERROR;
+    }
 
     // During the transition phase, we expect a large subset of code to require access to
     // event emitting, path marking and other operations

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -160,6 +160,7 @@ source_set("ecosystem-information-test-srcs") {
     "${chip_root}/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h",
   ]
   public_deps = [
+    "${chip_root}/src/app:attribute-access",
     "${chip_root}/src/app:interaction-model",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/lib/core",


### PR DESCRIPTION
This is currently done on Startup of the DataModel::Provider.

We do not yet have a set ordering for Startup, so we may have to iterate among `register attribute access interface` and usage of DataModel::Provider startup. However for now the basics should be there for addressing #36381 