### PR TITLE
Stop main event loop when shell prompt exits

### DIFF
--- a/examples/fabric-sync/shell/ShellCommands.cpp
+++ b/examples/fabric-sync/shell/ShellCommands.cpp
@@ -140,7 +140,6 @@ void RegisterCommands()
 
     // Register the root `device` command with the top-level shell.
     Engine::Root().RegisterCommands(&sDeviceComand, 1);
-    return;
 }
 
 } // namespace Shell

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -694,14 +694,15 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     Server::GetInstance().Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    // Commissioner shutdown call shuts down entire stack, including the platform manager.
     ShutdownCommissioner();
+#else
+    DeviceLayer::PlatformMgr().Shutdown();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
 #if ENABLE_TRACING
     tracing_setup.StopTracing();
 #endif
-
-    DeviceLayer::PlatformMgr().Shutdown();
 
     Cleanup();
 }

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -298,6 +298,19 @@ void EventHandler(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
     }
 }
 
+void StopMainEventLoop()
+{
+    if (gMainLoopImplementation != nullptr)
+    {
+        gMainLoopImplementation->SignalSafeStopMainLoop();
+    }
+    else
+    {
+        Server::GetInstance().GenerateShutDownEvent();
+        PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
+    }
+}
+
 void Cleanup()
 {
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
@@ -314,17 +327,9 @@ void Cleanup()
 // We should stop using signals for those faults, and move to a different notification
 // means, like a pipe. (see issue #19114)
 #if !defined(ENABLE_CHIP_SHELL)
-void StopSignalHandler(int signal)
+void StopSignalHandler(int /* signal */)
 {
-    if (gMainLoopImplementation != nullptr)
-    {
-        gMainLoopImplementation->SignalSafeStopMainLoop();
-    }
-    else
-    {
-        Server::GetInstance().GenerateShutDownEvent();
-        PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().StopEventLoopTask(); });
-    }
+    StopMainEventLoop();
 }
 #endif // !defined(ENABLE_CHIP_SHELL)
 
@@ -527,7 +532,10 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();
-    std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
+    std::thread shellThread([]() {
+        Engine::Root().RunMainLoop();
+        StopMainEventLoop();
+    });
     Shell::RegisterCommissioneeCommands();
 #endif
     initParams.operationalServicePort        = CHIP_PORT;

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -201,7 +201,7 @@ public:
     //
     // The stack will shut down when all references are released.
     //
-    // NB: The system state is owned by the factory; Relase() will not free it
+    // NB: The system state is owned by the factory; Release() will not free it
     // but will free its members (Shutdown()).
     //
     // Returns true if the system state was shut down in response to this call.

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -274,9 +274,13 @@ void PlatformManagerImpl::_Shutdown()
     Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
 
 #if CHIP_DEVICE_CONFIG_WITH_GLIB_MAIN_LOOP
-    g_main_loop_quit(mGLibMainLoop);
-    g_thread_join(mGLibMainLoopThread);
-    g_main_loop_unref(mGLibMainLoop);
+    if (mGLibMainLoop != nullptr)
+    {
+        g_main_loop_quit(mGLibMainLoop);
+        g_thread_join(mGLibMainLoopThread);
+        g_main_loop_unref(mGLibMainLoop);
+        mGLibMainLoop = nullptr;
+    }
 #endif
 }
 


### PR DESCRIPTION
### Problem

The `fabric-sync` application does not exit when Ctrl-D is pressed. Instead, it terminates the shell, but the event loop still runs.

### Changes 

- stop main event loop when shell exists
- add check for double free when `PlatformManagerImpl::_Shutdown()` is called twice (that happens due to registerd onexit handler by the shell code)

### Testing

Tested locally that `fabric-sync` terminates cleanly on Ctrl-D (it still aborts on `exit`, but for that there's going to be a follow-up PR)

CI will verify potential breaks.

