### PR TITLE
Fix Chef MaxMeasuredValue of PressureMeasurement

### DIFF
--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -1845,7 +1845,7 @@ endpoint 1 {
   server cluster PressureMeasurement {
     ram      attribute measuredValue default = 0xA;
     ram      attribute minMeasuredValue default = 1;
-    ram      attribute maxMeasuredValue default = 0xfffe;
+    ram      attribute maxMeasuredValue default = 32767;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
@@ -2721,7 +2721,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0xfffe",
+              "defaultValue": "32767",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
The MaxMeasuredValue in Pressure Measurement cluster are incorrectly set to 0xFFFE (or -2) which is not compatible with the the spec (max 32767)