### PR TITLE
[NXP][platform][common] Fix return status when removed a non-existing…

### DIFF
--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -144,6 +144,8 @@ Status NXPWiFiDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & outDeb
 {
     outDebugText.reduce_size(0);
     outNetworkIndex = 0;
+    VerifyOrReturnError(NetworkMatch(mStagingNetwork, networkId), Status::kNetworkIDNotFound);
+
     // Use empty ssid for representing invalid network
     mStagingNetwork.ssidLen = 0;
 


### PR DESCRIPTION
Return an error if the network ID does not match when trying to remove it

