### PR TITLE
Deduplicate repeated code in DeviceTypeResolver

### DIFF
--- a/src/access/BUILD.gn
+++ b/src/access/BUILD.gn
@@ -80,9 +80,7 @@ static_library("access") {
 }
 
 source_set("provider-impl") {
-  sources = [
-    "ProviderDeviceTypeResolver.h"
-  ]
+  sources = [ "ProviderDeviceTypeResolver.h" ]
 
   public_deps = [
     ":access",

--- a/src/access/BUILD.gn
+++ b/src/access/BUILD.gn
@@ -78,3 +78,14 @@ static_library("access") {
     ]
   }
 }
+
+source_set("provider-impl") {
+  sources = [
+    "ProviderDeviceTypeResolver.h"
+  ]
+
+  public_deps = [
+    ":access",
+    "${chip_root}/src/app/data-model-provider",
+  ]
+}

--- a/src/access/ProviderDeviceTypeResolver.h
+++ b/src/access/ProviderDeviceTypeResolver.h
@@ -25,7 +25,7 @@ namespace Access {
 class DynamicProviderDeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
 {
 public:
-    using ModelGetter = app::DataModel::Provider *(*)();
+    using ModelGetter = app::DataModel::Provider * (*) ();
 
     DynamicProviderDeviceTypeResolver(ModelGetter model) : mModelGetter(model) {}
 

--- a/src/access/ProviderDeviceTypeResolver.h
+++ b/src/access/ProviderDeviceTypeResolver.h
@@ -1,0 +1,50 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <access/AccessControl.h>
+#include <app/data-model-provider/Provider.h>
+
+namespace chip {
+namespace Access {
+
+/// A device type resolver where the DataModel::Provider is fetched dynamically (may change over time)
+class DynamicProviderDeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
+{
+public:
+    using ModelGetter = app::DataModel::Provider *(*)();
+
+    DynamicProviderDeviceTypeResolver(ModelGetter model) : mModelGetter(model) {}
+
+    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
+    {
+        app::DataModel::Provider * model = mModelGetter();
+        for (auto type = model->FirstDeviceType(endpoint); type.has_value(); type = model->NextDeviceType(endpoint, *type))
+        {
+            if (type->deviceTypeId == deviceType)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+private:
+    ModelGetter mModelGetter;
+};
+
+} // namespace Access
+} // namespace chip

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -267,6 +267,7 @@ static_library("interaction-model") {
     public_deps += [
       ":global-attributes",
       "${chip_root}/src/access",
+      "${chip_root}/src/access:provider-impl",
       "${chip_root}/src/app/common:attribute-type",
     ]
 

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -18,6 +18,7 @@
 
 #include <access/AccessControl.h>
 #include <access/Privilege.h>
+#include <access/ProviderDeviceTypeResolver.h>
 #include <access/RequestPath.h>
 #include <access/SubjectDescriptor.h>
 #include <app-common/zap-generated/ids/Clusters.h>
@@ -34,22 +35,13 @@ namespace {
 // DynamicDispatch.cpp.
 constexpr EndpointId kSupportedEndpoint = 0;
 
-class DeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver
+class DeviceTypeResolver : public chip::Access::DynamicProviderDeviceTypeResolver
 {
 public:
-    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override
-    {
-        chip::app::DataModel::Provider * model = chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
-
-        for (auto type = model->FirstDeviceType(endpoint); type.has_value(); type = model->NextDeviceType(endpoint, *type))
-        {
-            if (type->deviceTypeId == deviceType)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
+    DeviceTypeResolver() :
+        chip::Access::DynamicProviderDeviceTypeResolver(
+            [] { return chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider(); })
+    {}
 };
 
 // TODO: Make the policy more configurable by consumers.

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -52,6 +52,8 @@ static_library("server") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/access",
+    "${chip_root}/src/access:provider-impl",
     "${chip_root}/src/app",
     "${chip_root}/src/app:test-event-trigger",
     "${chip_root}/src/app/icd/server:icd-server-config",

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -17,8 +17,8 @@
 
 #include <app/server/Server.h>
 
-#include <access/examples/ExampleAccessControlDelegate.h>
 #include <access/ProviderDeviceTypeResolver.h>
+#include <access/examples/ExampleAccessControlDelegate.h>
 
 #include <app/AppConfig.h>
 #include <app/EventManagement.h>

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -18,6 +18,7 @@
 #include <app/server/Server.h>
 
 #include <access/examples/ExampleAccessControlDelegate.h>
+#include <access/ProviderDeviceTypeResolver.h>
 
 #include <app/AppConfig.h>
 #include <app/EventManagement.h>
@@ -82,23 +83,9 @@ using chip::Transport::TcpListenParameters;
 
 namespace {
 
-class DeviceTypeResolver : public chip::Access::AccessControl::DeviceTypeResolver
-{
-public:
-    bool IsDeviceTypeOnEndpoint(chip::DeviceTypeId deviceType, chip::EndpointId endpoint) override
-    {
-        chip::app::DataModel::Provider * model = chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
-
-        for (auto type = model->FirstDeviceType(endpoint); type.has_value(); type = model->NextDeviceType(endpoint, *type))
-        {
-            if (type->deviceTypeId == deviceType)
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-} sDeviceTypeResolver;
+chip::Access::DynamicProviderDeviceTypeResolver sDeviceTypeResolver([] {
+    return chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
+});
 
 } // namespace
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAccessControl.mm
@@ -26,6 +26,7 @@
 
 #include <access/AccessControl.h>
 #include <access/Privilege.h>
+#include <access/ProviderDeviceTypeResolver.h>
 #include <access/RequestPath.h>
 #include <access/SubjectDescriptor.h>
 #include <app/InteractionModelEngine.h>
@@ -42,18 +43,12 @@ using namespace chip::Access;
 
 namespace {
 
-class DeviceTypeResolver : public Access::AccessControl::DeviceTypeResolver {
+class DeviceTypeResolver : public chip::Access::DynamicProviderDeviceTypeResolver {
 public:
-    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override
+    DeviceTypeResolver()
+        : chip::Access::DynamicProviderDeviceTypeResolver(
+              [] { return chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider(); })
     {
-        app::DataModel::Provider * model = app::InteractionModelEngine::GetInstance()->GetDataModelProvider();
-
-        for (auto type = model->FirstDeviceType(endpoint); type.has_value(); type = model->NextDeviceType(endpoint, *type)) {
-            if (type->deviceTypeId == deviceType) {
-                return true;
-            }
-        }
-        return false;
     }
 };
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerAccessControl.mm
@@ -47,7 +47,7 @@ class DeviceTypeResolver : public chip::Access::DynamicProviderDeviceTypeResolve
 public:
     DeviceTypeResolver()
         : chip::Access::DynamicProviderDeviceTypeResolver(
-              [] { return chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider(); })
+            [] { return chip::app::InteractionModelEngine::GetInstance()->GetDataModelProvider(); })
     {
     }
 };


### PR DESCRIPTION
This completes an item in #36327 by not repeating code for IsDeviceTypeOnEndpoint.

Since we still use globals and IME in theory can get its provider changed, my implementation uses a callback to get the current provider. At some point we should probably switch to have a fixed provider since the application knows exactly what provider to use.