### PR TITLE
Adding python code for generating data model xml .gni file

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -45,6 +45,5 @@ pw_python_package("chip-testing") {
   tests = [
     "chip/testing/test_metadata.py",
     "chip/testing/test_tasks.py",
-    "generate_data_model_xmls_gni.py",
   ]
 }

--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -45,5 +45,6 @@ pw_python_package("chip-testing") {
   tests = [
     "chip/testing/test_metadata.py",
     "chip/testing/test_tasks.py",
+    "generate_data_model_xmls_gni.py",
   ]
 }

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -21,6 +21,7 @@ so that methods requiring data model files work just by installing the python
 package without requiring a full chip SDK checkout.
 """
 import os
+
 import jinja2
 
 # Set chip_root to be dynamically based on the script's location

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -62,10 +62,6 @@ data_model_XMLS = [
 """
 
 # Function to find and collect all .xml and .json files
-#
-# Data model files that the module uses are currently all XML and JSON files.
-#    - XMLs are generally data definitions
-#    - json are currently only cluster_ids.json
 def get_data_model_file_names():
     file_list = []
     for directory in directories:
@@ -82,20 +78,28 @@ def get_data_model_file_names():
 # Main function to generate the data_model_xmls.gni file
 def generate_gni_file():
     # Step 1: Find all files and create the sorted file list
-    file_list = get_data_model_file_names()  # Fixed: Changed to get_data_model_file_names()
+    file_list = get_data_model_file_names()
 
     # Step 2: Render the template with the file list
     environment = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
     template = environment.from_string(GNI_TEMPLATE)
     output_content = template.render(file_list=file_list)
 
-    # Step 3: Write the rendered content to data_model_xmls.gni
-    output_file = "src/python_testing/matter_testing_infrastructure/data_model_xmls.gni"
-    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    # Step 3: Dynamically generate the output file path
+    # Get the script's directory (where this script is located)
+    script_dir = os.path.dirname(os.path.realpath(__file__))  # Directory of the current script
+    
+    # Step 4: Ensure we are in the correct `src/python_testing/` directory
+    base_dir = os.path.abspath(os.path.join(script_dir, "../.."))  # Go up two levels to src/python_testing/
+    output_dir = os.path.join(base_dir, "python_testing", "matter_testing_infrastructure")  # Now append `matter_testing_infrastructure`
+    output_file = os.path.join(output_dir, "data_model_xmls.gni")
+
+    # Step 5: Write the rendered content to the output file
+    os.makedirs(output_dir, exist_ok=True)  # Ensure the output directory exists
     with open(output_file, "wt") as f:
         f.write(output_content)
     print(f"{output_file} has been generated successfully.")
 
 # Run the function to generate the .gni file
-if __name__ == "__main__":  # Fixed: Changed = to ==
+if __name__ == "__main__":  # Fixed = to ==
     generate_gni_file()

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -62,6 +62,8 @@ data_model_XMLS = [
 """
 
 # Function to find and collect all .xml and .json files
+
+
 def get_data_model_file_names():
     file_list = []
     for directory in directories:
@@ -76,6 +78,8 @@ def get_data_model_file_names():
     return file_list
 
 # Main function to generate the data_model_xmls.gni file
+
+
 def generate_gni_file():
     # Step 1: Find all files and create the sorted file list
     file_list = get_data_model_file_names()
@@ -88,10 +92,11 @@ def generate_gni_file():
     # Step 3: Dynamically generate the output file path
     # Get the script's directory (where this script is located)
     script_dir = os.path.dirname(os.path.realpath(__file__))  # Directory of the current script
-    
+
     # Step 4: Ensure we are in the correct `src/python_testing/` directory
     base_dir = os.path.abspath(os.path.join(script_dir, "../.."))  # Go up two levels to src/python_testing/
-    output_dir = os.path.join(base_dir, "python_testing", "matter_testing_infrastructure")  # Now append `matter_testing_infrastructure`
+    # Now append `matter_testing_infrastructure`
+    output_dir = os.path.join(base_dir, "python_testing", "matter_testing_infrastructure")
     output_file = os.path.join(output_dir, "data_model_xmls.gni")
 
     # Step 5: Write the rendered content to the output file
@@ -99,6 +104,7 @@ def generate_gni_file():
     with open(output_file, "wt") as f:
         f.write(output_content)
     print(f"{output_file} has been generated successfully.")
+
 
 # Run the function to generate the .gni file
 if __name__ == "__main__":  # Fixed = to ==

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -89,4 +89,5 @@ def generate_gni_file():
     print(f"{output_file} has been generated successfully.")
 
 # Run the function to generate the .gni file
-generate_gni_file()
+if __name__ = "__main__":
+    generate_gni_file()

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -54,7 +54,11 @@ data_model_XMLS = [
 """
 
 # Function to find and collect all .xml and .json files
-def find_files():
+#
+# Data model files that the module uses are currently all XML and JSON files.
+#    - XMLs are generally data definitions
+#    - json are currently only cluster_ids.json
+def get_data_model_file_names():
     file_list = []
     for directory in directories:
         for root, _, files in os.walk(directory):

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Generates a gni file containing all data_model files (generally XML and JSON files) 
+that are typically used by matter_testing_infrastructure.
+
+These files are to be bundled with whl packages of the matter_testing_infrastructure
+so that methods requiring data model files work just by installing the python
+package without requiring a full chip SDK checkout.
+"""
 import os
 import jinja2
 

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -82,7 +82,7 @@ def get_data_model_file_names():
 # Main function to generate the data_model_xmls.gni file
 def generate_gni_file():
     # Step 1: Find all files and create the sorted file list
-    file_list = find_files()
+    file_list = get_data_model_file_names()  # Fixed: Changed to get_data_model_file_names()
 
     # Step 2: Render the template with the file list
     environment = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
@@ -97,5 +97,5 @@ def generate_gni_file():
     print(f"{output_file} has been generated successfully.")
 
 # Run the function to generate the .gni file
-if __name__ = "__main__":
+if __name__ == "__main__":  # Fixed: Changed = to ==
     generate_gni_file()

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -108,5 +108,5 @@ def generate_gni_file():
 
 
 # Run the function to generate the .gni file
-if __name__ == "__main__":  # Fixed = to ==
+if __name__ == "__main__":
     generate_gni_file()

--- a/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
+++ b/src/python_testing/matter_testing_infrastructure/generate_data_model_xmls_gni.py
@@ -28,7 +28,7 @@ directories = [
     os.path.join(chip_root, "data_model/master/device_types/"),
 ]
 
-# Template for generating the GNI file content
+# Template for generating the GNI file content with proper indentation
 GNI_TEMPLATE = """\
 # Copyright (c) 2024 Project CHIP Authors
 #
@@ -47,9 +47,9 @@ GNI_TEMPLATE = """\
 import("//build_overrides/chip.gni")
 
 data_model_XMLS = [
-{% for name in file_list -%}
-"{{ name }}",
-{% endfor -%}
+{% for name in file_list %}
+    "{{ name }}",
+{% endfor %}
 ]
 """
 
@@ -79,6 +79,7 @@ def generate_gni_file():
 
     # Step 3: Write the rendered content to data_model_xmls.gni
     output_file = "src/python_testing/matter_testing_infrastructure/data_model_xmls.gni"
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
     with open(output_file, "wt") as f:
         f.write(output_content)
     print(f"{output_file} has been generated successfully.")


### PR DESCRIPTION
Work for Issue #31317 

PR 21 - This script generates the data_model_xmls.gni file by dynamically identifying and listing files located in various data model directories. The chip_root directory path is automatically set relative to the script’s location, ensuring portability. The Jinja2 template is used to format the output, and the generated file is saved in src/python_testing/matter_testing_infrastructure/.

