### PR TITLE
[Fabric-Admin] Use Meyers' Singleton pattern for DeviceManager

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -51,14 +51,14 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetRemoteBridgeNodeId(mBridgeNodeId);
+        DeviceManager::Instance().SetRemoteBridgeNodeId(mBridgeNodeId);
         ChipLogProgress(NotSpecified, "Successfully paired bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mBridgeNodeId));
 
-        DeviceMgr().UpdateLastUsedNodeId(mBridgeNodeId);
-        DeviceMgr().SubscribeRemoteFabricBridge();
+        DeviceManager::Instance().UpdateLastUsedNodeId(mBridgeNodeId);
+        DeviceManager::Instance().SubscribeRemoteFabricBridge();
 
-        if (DeviceMgr().IsLocalBridgeReady())
+        if (DeviceManager::Instance().IsLocalBridgeReady())
         {
             // After successful commissioning of the Commissionee, initiate Reverse Commissioning
             // via the Commissioner Control Cluster. However, we must first verify that the
@@ -66,7 +66,7 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
             //
             // Note: The Fabric-Admin MUST NOT send the RequestCommissioningApproval command
             // if the remote Fabric-Bridge lacks Fabric Synchronization support.
-            DeviceLayer::SystemLayer().ScheduleLambda([]() { DeviceMgr().ReadSupportedDeviceCategories(); });
+            DeviceLayer::SystemLayer().ScheduleLambda([]() { DeviceManager::Instance().ReadSupportedDeviceCategories(); });
         }
     }
     else
@@ -80,7 +80,7 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
 
 CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
 {
-    if (DeviceMgr().IsFabricSyncReady())
+    if (DeviceManager::Instance().IsFabricSyncReady())
     {
         // print to console
         fprintf(stderr, "Remote Fabric Bridge has already been configured.\n");
@@ -91,7 +91,8 @@ CHIP_ERROR FabricSyncAddBridgeCommand::RunCommand(NodeId remoteId)
 
     mBridgeNodeId = remoteId;
 
-    DeviceMgr().PairRemoteFabricBridge(remoteId, mSetupPINCode, reinterpret_cast<const char *>(mRemoteAddr.data()), mRemotePort);
+    DeviceManager::Instance().PairRemoteFabricBridge(remoteId, mSetupPINCode, reinterpret_cast<const char *>(mRemoteAddr.data()),
+                                                     mRemotePort);
 
     return CHIP_NO_ERROR;
 }
@@ -106,7 +107,7 @@ void FabricSyncRemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR 
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetRemoteBridgeNodeId(kUndefinedNodeId);
+        DeviceManager::Instance().SetRemoteBridgeNodeId(kUndefinedNodeId);
         ChipLogProgress(NotSpecified, "Successfully removed bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mBridgeNodeId));
     }
@@ -121,7 +122,7 @@ void FabricSyncRemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR 
 
 CHIP_ERROR FabricSyncRemoveBridgeCommand::RunCommand()
 {
-    NodeId bridgeNodeId = DeviceMgr().GetRemoteBridgeNodeId();
+    NodeId bridgeNodeId = DeviceManager::Instance().GetRemoteBridgeNodeId();
 
     if (bridgeNodeId == kUndefinedNodeId)
     {
@@ -133,7 +134,7 @@ CHIP_ERROR FabricSyncRemoveBridgeCommand::RunCommand()
     mBridgeNodeId = bridgeNodeId;
 
     PairingManager::Instance().SetPairingDelegate(this);
-    DeviceMgr().UnpairRemoteFabricBridge();
+    DeviceManager::Instance().UnpairRemoteFabricBridge();
 
     return CHIP_NO_ERROR;
 }
@@ -157,8 +158,8 @@ void FabricSyncAddLocalBridgeCommand::OnCommissioningComplete(NodeId deviceId, C
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetLocalBridgeNodeId(mLocalBridgeNodeId);
-        DeviceMgr().UpdateLastUsedNodeId(mLocalBridgeNodeId);
+        DeviceManager::Instance().SetLocalBridgeNodeId(mLocalBridgeNodeId);
+        DeviceManager::Instance().UpdateLastUsedNodeId(mLocalBridgeNodeId);
         ChipLogProgress(NotSpecified, "Successfully paired local bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mLocalBridgeNodeId));
     }
@@ -173,7 +174,7 @@ void FabricSyncAddLocalBridgeCommand::OnCommissioningComplete(NodeId deviceId, C
 
 CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
 {
-    if (DeviceMgr().IsLocalBridgeReady())
+    if (DeviceManager::Instance().IsLocalBridgeReady())
     {
         // print to console
         fprintf(stderr, "Local Fabric Bridge has already been configured.\n");
@@ -185,14 +186,14 @@ CHIP_ERROR FabricSyncAddLocalBridgeCommand::RunCommand(NodeId deviceId)
 
     if (mSetupPINCode.HasValue())
     {
-        DeviceMgr().SetLocalBridgeSetupPinCode(mSetupPINCode.Value());
+        DeviceManager::Instance().SetLocalBridgeSetupPinCode(mSetupPINCode.Value());
     }
     if (mLocalPort.HasValue())
     {
-        DeviceMgr().SetLocalBridgePort(mLocalPort.Value());
+        DeviceManager::Instance().SetLocalBridgePort(mLocalPort.Value());
     }
 
-    DeviceMgr().PairLocalFabricBridge(deviceId);
+    DeviceManager::Instance().PairLocalFabricBridge(deviceId);
 
     return CHIP_NO_ERROR;
 }
@@ -207,7 +208,7 @@ void FabricSyncRemoveLocalBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_E
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().SetLocalBridgeNodeId(kUndefinedNodeId);
+        DeviceManager::Instance().SetLocalBridgeNodeId(kUndefinedNodeId);
         ChipLogProgress(NotSpecified, "Successfully removed local bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mLocalBridgeNodeId));
     }
@@ -222,7 +223,7 @@ void FabricSyncRemoveLocalBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_E
 
 CHIP_ERROR FabricSyncRemoveLocalBridgeCommand::RunCommand()
 {
-    NodeId bridgeNodeId = DeviceMgr().GetLocalBridgeNodeId();
+    NodeId bridgeNodeId = DeviceManager::Instance().GetLocalBridgeNodeId();
 
     if (bridgeNodeId == kUndefinedNodeId)
     {
@@ -234,7 +235,7 @@ CHIP_ERROR FabricSyncRemoveLocalBridgeCommand::RunCommand()
     mLocalBridgeNodeId = bridgeNodeId;
 
     PairingManager::Instance().SetPairingDelegate(this);
-    DeviceMgr().UnpairLocalFabricBridge();
+    DeviceManager::Instance().UnpairLocalFabricBridge();
 
     return CHIP_NO_ERROR;
 }
@@ -250,14 +251,14 @@ void FabricSyncDeviceCommand::OnCommissioningWindowOpened(NodeId deviceId, CHIP_
         CHIP_ERROR error = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualCode);
         if (error == CHIP_NO_ERROR)
         {
-            NodeId nodeId = DeviceMgr().GetNextAvailableNodeId();
+            NodeId nodeId = DeviceManager::Instance().GetNextAvailableNodeId();
 
             PairingManager::Instance().SetPairingDelegate(this);
             mAssignedNodeId = nodeId;
 
             usleep(kCommissionPrepareTimeMs * 1000);
 
-            DeviceMgr().PairRemoteDevice(nodeId, payloadBuffer);
+            DeviceManager::Instance().PairRemoteDevice(nodeId, payloadBuffer);
         }
         else
         {
@@ -283,7 +284,7 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERRO
 
     if (err == CHIP_NO_ERROR)
     {
-        DeviceMgr().AddSyncedDevice(Device(mAssignedNodeId, mRemoteEndpointId));
+        DeviceManager::Instance().AddSyncedDevice(Device(mAssignedNodeId, mRemoteEndpointId));
     }
     else
     {
@@ -294,7 +295,7 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERRO
 
 CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteEndpointId)
 {
-    if (!DeviceMgr().IsFabricSyncReady())
+    if (!DeviceManager::Instance().IsFabricSyncReady())
     {
         // print to console
         fprintf(stderr, "Remote Fabric Bridge is not configured yet.\n");
@@ -303,7 +304,7 @@ CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteEndpointId)
 
     PairingManager::Instance().SetOpenCommissioningWindowDelegate(this);
 
-    DeviceMgr().OpenRemoteDeviceCommissioningWindow(remoteEndpointId);
+    DeviceManager::Instance().OpenRemoteDeviceCommissioningWindow(remoteEndpointId);
 
     return CHIP_NO_ERROR;
 }

--- a/examples/fabric-admin/commands/pairing/PairingCommand.cpp
+++ b/examples/fabric-admin/commands/pairing/PairingCommand.cpp
@@ -540,7 +540,7 @@ void PairingCommand::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
 
         app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(command->CurrentCommissioner().GetFabricIndex(), nodeId);
         ScopedNodeId scopedNodeId(nodeId, command->CurrentCommissioner().GetFabricIndex());
-        admin::DeviceMgr().RemoveSyncedDevice(scopedNodeId);
+        admin::DeviceManager::Instance().RemoveSyncedDevice(scopedNodeId);
     }
     else
     {

--- a/examples/fabric-admin/device_manager/BridgeSubscription.cpp
+++ b/examples/fabric-admin/device_manager/BridgeSubscription.cpp
@@ -80,7 +80,7 @@ void BridgeSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         return;
     }
 
-    DeviceMgr().HandleAttributeData(path, *data);
+    DeviceManager::Instance().HandleAttributeData(path, *data);
 }
 
 void BridgeSubscription::OnEventData(const app::EventHeader & eventHeader, TLV::TLVReader * data, const app::StatusIB * status)
@@ -101,7 +101,7 @@ void BridgeSubscription::OnEventData(const app::EventHeader & eventHeader, TLV::
         return;
     }
 
-    DeviceMgr().HandleEventData(eventHeader, *data);
+    DeviceManager::Instance().HandleEventData(eventHeader, *data);
 }
 
 void BridgeSubscription::OnError(CHIP_ERROR error)

--- a/examples/fabric-admin/device_manager/CommissionerControl.cpp
+++ b/examples/fabric-admin/device_manager/CommissionerControl.cpp
@@ -66,7 +66,7 @@ void CommissionerControl::OnResponse(app::CommandSender * client, const app::Con
 
     if (data != nullptr)
     {
-        DeviceMgr().HandleCommandResponse(path, *data);
+        DeviceManager::Instance().HandleCommandResponse(path, *data);
     }
 }
 

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -42,9 +42,6 @@ constexpr uint16_t kMaxDiscriminatorLength = 4095;
 
 } // namespace
 
-// Define the static member
-DeviceManager DeviceManager::sInstance;
-
 void DeviceManager::Init()
 {
     // TODO: (#34113) Init mLastUsedNodeId from chip config file

--- a/examples/fabric-admin/device_manager/DeviceManager.h
+++ b/examples/fabric-admin/device_manager/DeviceManager.h
@@ -55,6 +55,12 @@ class DeviceManager
 public:
     DeviceManager() = default;
 
+    static DeviceManager & Instance()
+    {
+        static DeviceManager instance;
+        return instance;
+    }
+
     void Init();
 
     chip::NodeId GetNextAvailableNodeId();
@@ -175,8 +181,6 @@ public:
     Device * FindDeviceByNode(chip::NodeId nodeId);
 
 private:
-    friend DeviceManager & DeviceMgr();
-
     void RequestCommissioningApproval();
 
     void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader & data);
@@ -211,20 +215,5 @@ private:
     CommissionerControl mCommissionerControl;
     FabricSyncGetter mFabricSyncGetter;
 };
-
-/**
- * Returns the public interface of the DeviceManager singleton object.
- *
- * Applications should use this to access features of the DeviceManager
- * object.
- */
-inline DeviceManager & DeviceMgr()
-{
-    if (!DeviceManager::sInstance.mInitialized)
-    {
-        DeviceManager::sInstance.Init();
-    }
-    return DeviceManager::sInstance;
-}
 
 } // namespace admin

--- a/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscriptionManager.cpp
@@ -34,12 +34,6 @@ using namespace ::chip::app;
 
 namespace admin {
 
-DeviceSubscriptionManager & DeviceSubscriptionManager::Instance()
-{
-    static DeviceSubscriptionManager instance;
-    return instance;
-}
-
 CHIP_ERROR DeviceSubscriptionManager::StartSubscription(Controller::DeviceController & controller, ScopedNodeId scopedNodeId)
 {
     assertChipStackLockedByCurrentThread();

--- a/examples/fabric-admin/device_manager/DeviceSubscriptionManager.h
+++ b/examples/fabric-admin/device_manager/DeviceSubscriptionManager.h
@@ -30,7 +30,11 @@ namespace admin {
 class DeviceSubscriptionManager
 {
 public:
-    static DeviceSubscriptionManager & Instance();
+    static DeviceSubscriptionManager & Instance()
+    {
+        static DeviceSubscriptionManager instance;
+        return instance;
+    }
 
     /// Usually called after we have added a synchronized device to fabric-bridge to monitor
     /// for any changes that need to be propagated to fabric-bridge.

--- a/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSynchronization.cpp
@@ -143,7 +143,7 @@ void DeviceSynchronizer::OnReportEnd()
 void DeviceSynchronizer::OnDone(app::ReadClient * apReadClient)
 {
 #if defined(PW_RPC_ENABLED)
-    if (mState == State::ReceivedResponse && !DeviceMgr().IsCurrentBridgeDevice(mNodeId))
+    if (mState == State::ReceivedResponse && !DeviceManager::Instance().IsCurrentBridgeDevice(mNodeId))
     {
         GetUniqueId();
         if (mState == State::GettingUid)
@@ -230,15 +230,15 @@ void DeviceSynchronizer::GetUniqueId()
     VerifyOrReturn(!mCurrentDeviceData.has_unique_id, ChipLogDetail(NotSpecified, "We already have UniqueId"));
 #endif
 
-    auto * device = DeviceMgr().FindDeviceByNode(mNodeId);
+    auto * device = DeviceManager::Instance().FindDeviceByNode(mNodeId);
     // If there is no associated remote Fabric Sync Aggregator there is no other place for us to try
     // getting the UniqueId from and can return leaving the state in ReceivedResponse.
     VerifyOrReturn(device, ChipLogDetail(NotSpecified, "No remote Fabric Sync Aggregator to get UniqueId from"));
 
     // Because device is not-null we expect IsFabricSyncReady to be true. IsFabricSyncReady indicates we have a
     // connection to the remote Fabric Sync Aggregator.
-    VerifyOrDie(DeviceMgr().IsFabricSyncReady());
-    auto remoteBridgeNodeId               = DeviceMgr().GetRemoteBridgeNodeId();
+    VerifyOrDie(DeviceManager::Instance().IsFabricSyncReady());
+    auto remoteBridgeNodeId               = DeviceManager::Instance().GetRemoteBridgeNodeId();
     EndpointId remoteEndpointIdOfInterest = device->GetEndpointId();
 
     ChipLogDetail(NotSpecified, "Attempting to get UniqueId from remote Fabric Sync Aggregator");

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -560,7 +560,7 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
         FabricIndex fabricIndex = self->CurrentCommissioner().GetFabricIndex();
         app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(fabricIndex, nodeId);
         ScopedNodeId scopedNodeId(nodeId, fabricIndex);
-        DeviceMgr().RemoveSyncedDevice(scopedNodeId);
+        DeviceManager::Instance().RemoveSyncedDevice(scopedNodeId);
     }
     else
     {

--- a/examples/fabric-admin/main.cpp
+++ b/examples/fabric-admin/main.cpp
@@ -32,7 +32,7 @@ using namespace chip;
 
 void ApplicationInit()
 {
-    admin::DeviceMgr().Init();
+    admin::DeviceManager::Instance().Init();
 }
 
 // ================================================================================

--- a/examples/fabric-admin/rpc/RpcServer.cpp
+++ b/examples/fabric-admin/rpc/RpcServer.cpp
@@ -112,9 +112,9 @@ public:
                         ChipLogValueX64(scopedNodeId.GetNodeId()), commissioningTimeoutSec, iterations, discriminator);
 
         // Open the device commissioning window using raw binary data for salt and verifier
-        DeviceMgr().OpenDeviceCommissioningWindow(scopedNodeId, iterations, commissioningTimeoutSec, discriminator,
-                                                  ByteSpan(request.salt.bytes, request.salt.size),
-                                                  ByteSpan(request.verifier.bytes, request.verifier.size));
+        DeviceManager::Instance().OpenDeviceCommissioningWindow(scopedNodeId, iterations, commissioningTimeoutSec, discriminator,
+                                                                ByteSpan(request.salt.bytes, request.salt.size),
+                                                                ByteSpan(request.verifier.bytes, request.verifier.size));
 
         response.success = true;
 
@@ -146,13 +146,13 @@ public:
 
         if (error == CHIP_NO_ERROR)
         {
-            NodeId nodeId = DeviceMgr().GetNextAvailableNodeId();
+            NodeId nodeId = DeviceManager::Instance().GetNextAvailableNodeId();
 
             // After responding with RequestCommissioningApproval to the node where the client initiated the
             // RequestCommissioningApproval, you need to wait for it to open a commissioning window on its bridge.
             usleep(kCommissionPrepareTimeMs * 1000);
 
-            DeviceMgr().PairRemoteDevice(nodeId, code.c_str());
+            DeviceManager::Instance().PairRemoteDevice(nodeId, code.c_str());
         }
         else
         {


### PR DESCRIPTION
Replace traditional pattern to declare singleton using 'friend' with Meyers' Singleton pattern using a static local variable within the Instance() function).

Memory for instance is allocated the first time the Instance() method is called. This is known as lazy initialization, meaning the object is only created when it is needed for the first time.
