### PR TITLE
[Fabric-Bridge] Use Meyers' Singleton pattern for BridgedDeviceManager

### DIFF
--- a/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceManager.h
+++ b/examples/fabric-bridge-app/fabric-bridge-common/include/BridgedDeviceManager.h
@@ -31,6 +31,12 @@ class BridgedDeviceManager
 public:
     BridgedDeviceManager() = default;
 
+    static BridgedDeviceManager & Instance()
+    {
+        static BridgedDeviceManager instance;
+        return instance;
+    }
+
     /**
      * @brief Initializes the BridgedDeviceManager.
      *
@@ -112,8 +118,6 @@ public:
     BridgedDevice * GetDeviceByUniqueId(const std::string & id);
 
 private:
-    friend BridgedDeviceManager & BridgeDeviceMgr();
-
     /**
      * Creates a new unique ID that is not used by any other mDevice
      */
@@ -125,16 +129,5 @@ private:
     chip::EndpointId mFirstDynamicEndpointId;
     std::unique_ptr<BridgedDevice> mDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT + 1];
 };
-
-/**
- * Returns the public interface of the BridgedDeviceManager singleton object.
- *
- * Applications should use this to access features of the BridgedDeviceManager
- * object.
- */
-inline BridgedDeviceManager & BridgeDeviceMgr()
-{
-    return BridgedDeviceManager::sInstance;
-}
 
 } // namespace bridge

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedAdministratorCommissioning.cpp
@@ -45,7 +45,7 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
 {
     VerifyOrDie(aPath.mClusterId == Clusters::AdministratorCommissioning::Id);
     EndpointId endpointId  = aPath.mEndpointId;
-    BridgedDevice * device = BridgeDeviceMgr().GetDevice(endpointId);
+    BridgedDevice * device = BridgedDeviceManager::Instance().GetDevice(endpointId);
 
     if (!device)
     {

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceBasicInformationImpl.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceBasicInformationImpl.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Read(const ConcreteReadAttributePa
     // Registration is done for the bridged device basic information only
     VerifyOrDie(path.mClusterId == app::Clusters::BridgedDeviceBasicInformation::Id);
 
-    BridgedDevice * dev = BridgeDeviceMgr().GetDevice(path.mEndpointId);
+    BridgedDevice * dev = BridgedDeviceManager::Instance().GetDevice(path.mEndpointId);
     VerifyOrReturnError(dev != nullptr, CHIP_ERROR_NOT_FOUND);
 
     switch (path.mAttributeId)
@@ -93,7 +93,7 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Write(const ConcreteDataAttributeP
 {
     VerifyOrDie(path.mClusterId == app::Clusters::BridgedDeviceBasicInformation::Id);
 
-    BridgedDevice * dev = BridgeDeviceMgr().GetDevice(path.mEndpointId);
+    BridgedDevice * dev = BridgedDeviceManager::Instance().GetDevice(path.mEndpointId);
     VerifyOrReturnError(dev != nullptr, CHIP_ERROR_NOT_FOUND);
 
     if (!dev->IsReachable())

--- a/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-bridge-app/fabric-bridge-common/src/BridgedDeviceManager.cpp
@@ -176,9 +176,6 @@ const EmberAfDeviceType sBridgedDeviceTypes[] = { { DEVICE_TYPE_BRIDGED_NODE, DE
 
 } // namespace
 
-// Define the static member
-BridgedDeviceManager BridgedDeviceManager::sInstance;
-
 void BridgedDeviceManager::Init()
 {
     mFirstDynamicEndpointId = static_cast<chip::EndpointId>(

--- a/examples/fabric-bridge-app/linux/RpcServer.cpp
+++ b/examples/fabric-bridge-app/linux/RpcServer.cpp
@@ -118,7 +118,7 @@ pw::Status FabricBridge::AddSynchronizedDevice(const chip_rpc_SynchronizedDevice
     device->SetBridgedAttributes(attributes);
     device->SetIcd(request.has_is_icd && request.is_icd);
 
-    auto result = BridgeDeviceMgr().AddDeviceEndpoint(std::move(device), 1 /* parentEndpointId */);
+    auto result = BridgedDeviceManager::Instance().AddDeviceEndpoint(std::move(device), 1 /* parentEndpointId */);
     if (!result.has_value())
     {
         ChipLogError(NotSpecified, "Failed to add device with Id=[%d:0x" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
@@ -126,7 +126,7 @@ pw::Status FabricBridge::AddSynchronizedDevice(const chip_rpc_SynchronizedDevice
         return pw::Status::Unknown();
     }
 
-    BridgedDevice * addedDevice = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    BridgedDevice * addedDevice = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     VerifyOrDie(addedDevice);
 
     CHIP_ERROR err = EcosystemInformation::EcosystemInformationServer::Instance().AddEcosystemInformationClusterToEndpoint(
@@ -143,7 +143,7 @@ pw::Status FabricBridge::RemoveSynchronizedDevice(const chip_rpc_SynchronizedDev
     ChipLogProgress(NotSpecified, "Received RemoveSynchronizedDevice: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto removed_idx = BridgeDeviceMgr().RemoveDeviceByScopedNodeId(scopedNodeId);
+    auto removed_idx = BridgedDeviceManager::Instance().RemoveDeviceByScopedNodeId(scopedNodeId);
     if (!removed_idx.has_value())
     {
         ChipLogError(NotSpecified, "Failed to remove device with Id=[%d:0x" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
@@ -161,7 +161,7 @@ pw::Status FabricBridge::ActiveChanged(const chip_rpc_KeepActiveChanged & reques
     ChipLogProgress(NotSpecified, "Received ActiveChanged: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",
@@ -181,7 +181,7 @@ pw::Status FabricBridge::AdminCommissioningAttributeChanged(const chip_rpc_Admin
     ChipLogProgress(NotSpecified, "Received CADMIN attribute change: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",
@@ -220,7 +220,7 @@ pw::Status FabricBridge::DeviceReachableChanged(const chip_rpc_ReachabilityChang
     ChipLogProgress(NotSpecified, "Received device reachable changed: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",

--- a/examples/fabric-bridge-app/linux/main.cpp
+++ b/examples/fabric-bridge-app/linux/main.cpp
@@ -151,7 +151,7 @@ void AdministratorCommissioningCommandHandler::InvokeCommand(HandlerContext & ha
     Status status = Status::Failure;
 
 #if defined(PW_RPC_FABRIC_BRIDGE_SERVICE) && PW_RPC_FABRIC_BRIDGE_SERVICE
-    BridgedDevice * device = BridgeDeviceMgr().GetDevice(endpointId);
+    BridgedDevice * device = BridgedDeviceManager::Instance().GetDevice(endpointId);
 
     // TODO: issues:#33784, need to make OpenCommissioningWindow synchronous
     if (device != nullptr &&
@@ -214,7 +214,7 @@ void BridgedDeviceInformationCommandHandler::InvokeCommand(HandlerContext & hand
         return;
     }
 
-    BridgedDevice * device = BridgeDeviceMgr().GetDevice(endpointId);
+    BridgedDevice * device = BridgedDeviceManager::Instance().GetDevice(endpointId);
     if (device == nullptr || !device->IsIcd())
     {
         handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::Failure);
@@ -262,7 +262,7 @@ void ApplicationInit()
     AttemptRpcClientConnect(&DeviceLayer::SystemLayer(), nullptr);
 #endif
 
-    bridge::BridgeDeviceMgr().Init();
+    bridge::BridgedDeviceManager::Instance().Init();
     VerifyOrDie(bridge::gBridgedAdministratorCommissioning.Init() == CHIP_NO_ERROR);
 
     VerifyOrDieWithMsg(bridge::CommissionerControlInit() == CHIP_NO_ERROR, NotSpecified,


### PR DESCRIPTION
Replace traditional pattern to declare singleton using 'friend' with Meyers' Singleton pattern using a static local variable within the Instance() function).

Memory for instance is allocated the first time the Instance() method is called. This is known as lazy initialization, meaning the object is only created when it is needed for the first time.

