### PR TITLE
[1.4]  Fix cluster `Bridged Device Basic Information` in matter-devices.xml

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -204,7 +204,7 @@ limitations under the License.
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Bridged Device Basic" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Bridged Device Basic Information" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>REACHABLE</requireAttribute>
             </include>
             <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>


### PR DESCRIPTION
Fix cluster `Bridged Device Basic Information` in matter-devices.xml

Fixes https://github.com/project-chip/connectedhomeip/issues/36421