### PR TITLE
[Silabs ]Fix some build conditions for apps with matter shell enabled

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -364,7 +364,7 @@ void USART_IRQHandler(void)
 {
 #ifdef ENABLE_CHIP_SHELL
     chip::NotifyShellProcess();
-#elif !defined(PW_RPC_ENABLED) && !defined(SL_WIFI)
+#elif !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     otSysEventSignalPending();
 #endif
 #ifdef SL_CATALOG_UARTDRV_EUSART_PRESENT

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -411,7 +411,7 @@ static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, ui
 
 #ifdef ENABLE_CHIP_SHELL
     chip::NotifyShellProcess();
-#elif !defined(PW_RPC_ENABLED)
+#elif !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI == 1
     otSysEventSignalPending();
 #endif
 }

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -411,7 +411,7 @@ static void UART_rx_callback(UARTDRV_Handle_t handle, Ecode_t transferStatus, ui
 
 #ifdef ENABLE_CHIP_SHELL
     chip::NotifyShellProcess();
-#elif !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI == 1
+#elif !defined(PW_RPC_ENABLED) && CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI
     otSysEventSignalPending();
 #endif
 }


### PR DESCRIPTION
Build issues for wifi apps with matter shell and thread apps with matter shell enabled but ot cli disabled.

Fix: Don't call `otSysEventSignalPending` if `CHIP_DEVICE_CONFIG_THREAD_ENABLE_CLI` is not enabled in the UART_rx_callback