### PR TITLE
[VSCode] Add Debugging targets for pw_fuzzer FuzzTests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,25 @@
             "args": [],
             "cwd": "${workspaceFolder}"
         },
+
+        {
+            "name": "Run pw FuzzTest (Linux x64) UnitTest Mode",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/${input:outPWFuzzTestLinux}",
+            "cwd": "${workspaceFolder}"
+        },
+
+        {
+            "name": "Run pw FuzzTest (Linux x64) Continuous Fuzzing Mode",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/${input:outPWFuzzTestLinux}",
+            "args": ["-fuzz=${input:fuzzTestName}"],
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": ""
+        },
+
         {
             "name": "QRCode Tests",
             "type": "cppdbg",
@@ -526,6 +545,24 @@
             "args": {
                 "command": "find ${workspaceFolder}/out/linux-x64-*/tests -type f -executable |sort |sed 's$${workspaceFolder}/out/$$'",
                 "description": "Select the test to run"
+            }
+        },
+        {
+            "type": "command",
+            "id": "outPWFuzzTestLinux",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "find ${workspaceFolder}/out/linux-x64-*/chip_pw_fuzztest/tests -type f -executable |sort |sed 's$${workspaceFolder}/out/$$'",
+                "description": "Select the FuzzTest to run"
+            }
+        },
+        {
+            "id": "fuzzTestName",
+            "type": "command",
+            "command": "shellCommand.execute",
+            "args": {
+                "command": "./out/${input:outPWFuzzTestLinux} --list_fuzz_tests | grep 'Fuzz test:' | awk -F ': ' '{print $2}'",
+                "description": "Select the specific FuzzTest to fuzz continuously"
             }
         },
         {


### PR DESCRIPTION
Two  Debugging targets are added:
1. Unit Test Mode: which executes all FuzzTests in a single binary for a few seconds.
2. Continuous Fuzzing Mode: A specific binary is chosen, then we can execute a specific FuzzTest; execution will only stop once a crash occurs, or if user explicitly Interrupts it, Screenshot:

![image](https://github.com/user-attachments/assets/ecd95b65-ccfd-4570-8607-e8bd91101858)




