### PR TITLE
Fix crash in NamedPipeCommands.cpp caused by stack-buffer-underflow

### DIFF
--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -82,11 +82,14 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
         }
 
         ssize_t readBytes      = read(fd, readbuf, kChipEventCmdBufSize);
-        readbuf[readBytes - 1] = '\0';
-        ChipLogProgress(NotSpecified, "Received payload: \"%s\"", readbuf);
+        if (readBytes > 0)
+        {
+            readbuf[readBytes - 1] = '\0';
+            ChipLogProgress(NotSpecified, "Received payload: \"%s\"", readbuf);
 
-        // Process the received command request from event fifo
-        self->mDelegate->OnEventCommandReceived(readbuf);
+            // Process the received command request from event fifo
+            self->mDelegate->OnEventCommandReceived(readbuf);
+        }
 
         close(fd);
     }

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -81,7 +81,7 @@ void * NamedPipeCommands::EventCommandListenerTask(void * arg)
             break;
         }
 
-        ssize_t readBytes      = read(fd, readbuf, kChipEventCmdBufSize);
+        ssize_t readBytes = read(fd, readbuf, kChipEventCmdBufSize);
         if (readBytes > 0)
         {
             readbuf[readBytes - 1] = '\0';


### PR DESCRIPTION
### Description

- Running the `chip-all-clusters-app` example can result in a stack-buffer-underflow error when handling named pipes in `NamedPipeCommands.cpp`. The underflow occurs at `NamedPipeCommands.cpp:85` by writing to `readbuf[readBytes - 1]` without checking if `readBytes` is zero. This leads to accessing memory out of bounds and can potentially crash the application.

### Changes

- Added a condition to verify `readBytes` is greater than zero before writing to `readbuf[readBytes - 1]`. This prevents stack-buffer-underflow by ensuring the code only accesses valid indices within `readbuf`.

### Reproducing

To reproduce:

```bash
$ '' > /tmp/chip_all_clusters_fifo_12142 
```

Expected error message before the fix:

```bash
../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/platform/linux/NamedPipeCommands.cpp:85:9: runtime error: index -1 out of bounds for type 'char[256]'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../examples/all-clusters-app/linux/third_party/connectedhomeip/examples/platform/linux/NamedPipeCommands.cpp:85:9 
=================================================================
==12142==ERROR: AddressSanitizer: stack-buffer-underflow on address 0x7d0ff8f0901f at pc 0x6217ac4c01cf bp 0x7d0ff9fffad0 sp 0x7d0ff9fffac8
WRITE of size 1 at 0x7d0ff8f0901f thread T2
    #0 0x6217ac4c01ce  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x13171ce) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #1 0x6217ac2aee1c  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1105e1c) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #2 0x6217ac214016  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x106b016) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #3 0x6217ac2a87cf  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x10ff7cf) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #4 0x6217ac2abe06  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1102e06) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #5 0x6217ac2ace68  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1103e68) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)

Address 0x7d0ff8f0901f is located in stack of thread T2 at offset 31 in frame
    #0 0x6217ac4bfb87  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1316b87) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
  
  This frame has 1 object(s):
    [32, 288) 'readbuf' (line 71) <== Memory access at offset 31 underflows this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
Thread T2 created by T0 here:
    #0 0x6217ac2897b1  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x10e07b1) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #1 0x6217ac4bf152  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1316152) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #2 0x6217ac47a9f0  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x12d19f0) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #3 0x6217ac488e89  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x12dfe89) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #4 0x6217ac2dd243  (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x1134243) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda)
    #5 0x7d0ffea29d8f  (/lib/x86_64-linux-gnu/libc.so.6+0x29d8f) (BuildId: 490fef8403240c91833978d494d39e537409b92e)

SUMMARY: AddressSanitizer: stack-buffer-underflow (/home/beom/Desktop/connectedhomeip/out/linux-x64-all-clusters-asan-ubsan-clang/chip-all-clusters-app+0x13171ce) (BuildId: bad9472b693d466f1f24620bf834cbc228a1cfda) 
Shadow bytes around the buggy address:
  0x7d0ff8f08d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f08e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f08e80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f08f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f08f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x7d0ff8f09000: f1 f1 f1[f1]00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f09080: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f09100: 00 00 00 00 f3 f3 f3 f3 f3 f3 f3 f3 00 00 00 00
  0x7d0ff8f09180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f09200: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d0ff8f09280: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==12142==ABORTING
```