### PR TITLE
improve naming and description of parameters in CHIPCryptoPAL functions

### DIFF
--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -330,16 +330,16 @@ CHIP_ERROR Spake2p::BeginVerifier(const uint8_t * my_identity, size_t my_identit
 }
 
 CHIP_ERROR Spake2p::BeginProver(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
-                                size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
-                                size_t w1in_len)
+                                size_t peer_identity_len, const uint8_t * w0sin, size_t w0sin_len, const uint8_t * w1sin,
+                                size_t w1sin_len)
 {
     VerifyOrReturnError(state == CHIP_SPAKE2P_STATE::INIT, CHIP_ERROR_INTERNAL);
 
     ReturnErrorOnFailure(InternalHash(my_identity, my_identity_len));
     ReturnErrorOnFailure(InternalHash(peer_identity, peer_identity_len));
     ReturnErrorOnFailure(WriteMN());
-    ReturnErrorOnFailure(FELoad(w0in, w0in_len, w0));
-    ReturnErrorOnFailure(FELoad(w1in, w1in_len, w1));
+    ReturnErrorOnFailure(FELoad(w0sin, w0sin_len, w0));
+    ReturnErrorOnFailure(FELoad(w1sin, w1sin_len, w1));
 
     state = CHIP_SPAKE2P_STATE::STARTED;
     role  = CHIP_SPAKE2P_ROLE::PROVER;

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1163,16 +1163,16 @@ public:
      * @param my_identity_len   The prover identity length.
      * @param peer_identity     The peer identity. May be NULL if identities are not established.
      * @param peer_identity_len The peer identity length.
-     * @param w0in              The input w0 (an output from the PBKDF).
-     * @param w0in_len          The input w0 length.
-     * @param w1in              The input w1 (an output from the PBKDF).
-     * @param w1in_len          The input w1 length.
+     * @param w0sin             The input w0s (an output from the PBKDF).
+     * @param w0sin_len         The input w0s length.
+     * @param w1sin             The input w1s (an output from the PBKDF).
+     * @param w1sin_len         The input w1s length.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     virtual CHIP_ERROR BeginProver(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
-                                   size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
-                                   size_t w1in_len);
+                                   size_t peer_identity_len, const uint8_t * w0sin, size_t w0sin_len, const uint8_t * w1sin,
+                                   size_t w1sin_len);
 
     /**
      * @brief Compute the first round of the protocol.
@@ -1347,26 +1347,26 @@ public:
     /*
      *   @synopsis Compute w0sin mod p
      *
-     *   @param w0out       Output field element (modulo p)
+     *   @param w0out       Output field element w0
      *   @param w0_len      Output field element length
-     *   @param w1sin       Input field element
-     *   @param w1sin_len   Input field element length
+     *   @param w0sin       Input field element
+     *   @param w0sin_len   Input field element length
      *
      *   @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     virtual CHIP_ERROR ComputeW0(uint8_t * w0out, size_t * w0_len, const uint8_t * w0sin, size_t w0sin_len) = 0;
 
     /*
-     *   @synopsis Compute w1in*G
+     *   @synopsis Compute w1in*G where w1in is w1sin mod p
      *
      *   @param Lout        Output point in 0x04 || X || Y format.
      *   @param L_len       Output point length
-     *   @param w1in        Input field element
-     *   @param w1in_len    Input field element size
+     *   @param w1sin       Input field element
+     *   @param w1sin_len   Input field element size
      *
      *   @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
-    virtual CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len) = 0;
+    virtual CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len) = 0;
 
     void * M;
     void * N;
@@ -1521,7 +1521,7 @@ public:
     CHIP_ERROR PointIsValid(void * R) override;
 
     CHIP_ERROR ComputeW0(uint8_t * w0out, size_t * w0_len, const uint8_t * w0sin, size_t w0sin_len) override;
-    CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len) override;
+    CHIP_ERROR ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len) override;
 
 protected:
     CHIP_ERROR InitImpl() override;
@@ -1561,12 +1561,12 @@ public:
     CHIP_ERROR Generate(uint32_t pbkdf2IterCount, const ByteSpan & salt, uint32_t setupPin);
 
     /**
-     * @brief Compute the initiator values (w0, w1) used for PAKE input.
+     * @brief Compute the initiator values (w0s, w1s) used for PAKE input.
      *
      * @param pbkdf2IterCount Iteration count for PBKDF2 function
      * @param salt            Salt to be used for Spake2+ operation
      * @param setupPin        Provided setup PIN (passcode)
-     * @param ws              The output pair (w0, w1) stored sequentially
+     * @param ws              The output pair (w0s, w1s) stored sequentially
      * @param ws_len          The output length
      *
      * @return CHIP_ERROR     The result from running PBKDF2

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1608,7 +1608,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error      = CHIP_ERROR_INTERNAL;
     int error_openssl     = 0;
@@ -1623,8 +1623,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     Lout_point = EC_POINT_new(context->curve);
     VerifyOrExit(Lout_point != nullptr, error = CHIP_ERROR_INTERNAL);
 
-    VerifyOrExit(CanCastTo<boringssl_size_t_openssl_int>(w1in_len), error = CHIP_ERROR_INTERNAL);
-    BN_bin2bn(Uint8::to_const_uchar(w1in), static_cast<boringssl_size_t_openssl_int>(w1in_len), w1_bn);
+    VerifyOrExit(CanCastTo<boringssl_size_t_openssl_int>(w1sin_len), error = CHIP_ERROR_INTERNAL);
+    BN_bin2bn(Uint8::to_const_uchar(w1sin), static_cast<boringssl_size_t_openssl_int>(w1sin_len), w1_bn);
     error_openssl = BN_mod(w1_bn, w1_bn, (BIGNUM *) order, context->bn_ctx);
     VerifyOrExit(error_openssl == 1, error = CHIP_ERROR_INTERNAL);
 

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -1042,7 +1042,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -1058,7 +1058,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1in), w1in_len);
+    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1sin), w1sin_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &curve.N);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1092,7 +1092,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -1108,7 +1108,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1in), w1in_len);
+    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1sin), w1sin_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &curve.N);

--- a/src/crypto/PSASpake2p.cpp
+++ b/src/crypto/PSASpake2p.cpp
@@ -94,11 +94,11 @@ CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
 
 CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_identity, size_t my_identity_len,
                                                          const uint8_t * peer_identity, size_t peer_identity_len,
-                                                         const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
-                                                         size_t w1in_len)
+                                                         const uint8_t * w0sin, size_t w0sin_len, const uint8_t * w1sin,
+                                                         size_t w1sin_len)
 {
-    VerifyOrReturnError(w0in_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(w1in_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w0sin_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w1sin_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
 
     uint8_t password[kSpake2p_WS_Length * 2];
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -107,13 +107,13 @@ CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     psa_pake_cs_set_algorithm(&cp, PSA_ALG_SPAKE2P_MATTER);
     psa_pake_cs_set_primitive(&cp, PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC, PSA_ECC_FAMILY_SECP_R1, 256));
 
-    memcpy(password + 0, w0in, w0in_len);
-    memcpy(password + w0in_len, w1in, w1in_len);
+    memcpy(password + 0, w0sin, w0sin_len);
+    memcpy(password + w0sin_len, w1sin, w1sin_len);
     psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
     psa_set_key_algorithm(&attributes, PSA_ALG_SPAKE2P_MATTER);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_SPAKE2P_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
 
-    psa_status_t status = psa_import_key(&attributes, password, w0in_len + w1in_len, &mKey);
+    psa_status_t status = psa_import_key(&attributes, password, w0sin_len + w1sin_len, &mKey);
 
     psa_reset_key_attributes(&attributes);
     VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);

--- a/src/crypto/PSASpake2p.h
+++ b/src/crypto/PSASpake2p.h
@@ -89,15 +89,16 @@ public:
      * @param my_identity_len   The prover identity length.
      * @param peer_identity     The peer identity. May be NULL if identities are not established.
      * @param peer_identity_len The peer identity length.
-     * @param w0in              The input w0 (an output from the PBKDF).
-     * @param w0in_len          The input w0 length.
-     * @param w1in              The input w1 (an output from the PBKDF).
-     * @param w1in_len          The input w1 length.
+     * @param w0sin             The input w0s (an output from the PBKDF).
+     * @param w0sin_len         The input w0s length.
+     * @param w1sin             The input w1s (an output from the PBKDF).
+     * @param w1sin_len         The input w1s length.
      *
      * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
      **/
     CHIP_ERROR BeginProver(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
-                           size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in, size_t w1in_len);
+                           size_t peer_identity_len, const uint8_t * w0sin, size_t w0sin_len, const uint8_t * w1sin,
+                           size_t w1sin_len);
 
     /**
      * @brief Compute the first round of the protocol.

--- a/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
+++ b/src/platform/Infineon/crypto/trustm/CHIPCryptoPALHost.cpp
@@ -838,7 +838,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -854,7 +854,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1in), w1in_len);
+    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1sin), w1sin_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &curve.N);

--- a/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/nxp/common/crypto/CHIPCryptoPALTinyCrypt.cpp
@@ -1051,7 +1051,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -1061,7 +1061,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     uECC_word_t w1_bn[NUM_ECC_WORDS];
     uECC_word_t L_tmp[2 * NUM_ECC_WORDS];
 
-    uECC_vli_bytesToNative(tmp, w1in, NUM_ECC_BYTES);
+    uECC_vli_bytesToNative(tmp, w1sin, NUM_ECC_BYTES);
 
     uECC_vli_mmod(w1_bn, tmp, curve_n);
 

--- a/src/platform/nxp/common/crypto/CHIPCryptoPalS200.cpp
+++ b/src/platform/nxp/common/crypto/CHIPCryptoPalS200.cpp
@@ -1138,13 +1138,13 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     secEcp256Status_t result;
     ecp256Point_t gen_point;
     uint32_t W1[SEC_ECP256_COORDINATE_WLEN];
 
-    result = ECP256_ModularReductionN(W1, w1in, w1in_len);
+    result = ECP256_ModularReductionN(W1, w1sin, w1sin_len);
     VerifyOrReturnError(result == gSecEcp256Success_c, CHIP_ERROR_INTERNAL);
 
     result = ECP256_GeneratePublicKey((uint8_t *) &gen_point, (uint8_t *) &W1, NULL);

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHost.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHost.cpp
@@ -712,7 +712,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -728,7 +728,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = mbedtls_ecp_group_load(&curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1in), w1in_len);
+    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1sin), w1sin_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &curve.N);

--- a/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
+++ b/src/platform/nxp/crypto/se05x/CHIPCryptoPALHsm_se05x_spake2p.cpp
@@ -283,8 +283,8 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_id
 #if ENABLE_SE05X_SPAKE_PROVER
 CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_identity, size_t my_identity_len,
                                                          const uint8_t * peer_identity, size_t peer_identity_len,
-                                                         const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
-                                                         size_t w1in_len)
+                                                         const uint8_t * w0sin, size_t w0sin_len, const uint8_t * w1sin,
+                                                         size_t w1sin_len)
 {
     smStatus_t smstatus  = SM_NOT_OK;
     uint8_t w0in_mod[32] = {
@@ -296,8 +296,8 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
     };
     size_t w1in_mod_len = 32;
 
-    VerifyOrReturnError(w0in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(w1in != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w0sin != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w1sin != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     if (my_identity_len > 0)
     {
         VerifyOrReturnError(my_identity != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -311,9 +311,9 @@ CHIP_ERROR Spake2pHSM_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_iden
 
     ChipLogProgress(Crypto, "SE05x: HSM - BeginProver");
 
-    ReturnErrorOnFailure(FELoad(w0in, w0in_len, w0));
+    ReturnErrorOnFailure(FELoad(w0sin, w0sin_len, w0));
     ReturnErrorOnFailure(FEWrite(w0, w0in_mod, w0in_mod_len));
-    ReturnErrorOnFailure(FELoad(w1in, w1in_len, w1));
+    ReturnErrorOnFailure(FELoad(w1sin, w1sin_len, w1));
     ReturnErrorOnFailure(FEWrite(w1, w1in_mod, w1in_mod_len));
     ReturnErrorOnFailure(create_init_crypto_obj(chip::Crypto::CHIP_SPAKE2P_ROLE::PROVER, &hsm_pake_context));
 

--- a/src/platform/nxp/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
+++ b/src/platform/nxp/k32w0/crypto/CHIPCryptoPALNXPUltrafastP256.cpp
@@ -1017,7 +1017,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
 
@@ -1026,7 +1026,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     uint32_t W1[SEC_ECP256_COORDINATE_WLEN];
     do
     {
-        result = ECP256_ModularReductionN(W1, w1in, w1in_len);
+        result = ECP256_ModularReductionN(W1, w1sin, w1sin_len);
         if (result != gSecEcp256Success_c)
             break;
         ecp256Point_t gen_point;

--- a/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/platform/silabs/SiWx917/CHIPCryptoPALTinyCrypt.cpp
@@ -1070,7 +1070,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = 0;
@@ -1080,7 +1080,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     uECC_word_t w1_bn[NUM_ECC_WORDS];
     uECC_word_t L_tmp[2 * NUM_ECC_WORDS];
 
-    uECC_vli_bytesToNative(tmp, w1in, NUM_ECC_BYTES);
+    uECC_vli_bytesToNative(tmp, w1sin, NUM_ECC_BYTES);
 
     uECC_vli_mmod(w1_bn, tmp, curve_n);
 

--- a/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/silabs/efr32/CHIPCryptoPALPsaEfr32.cpp
@@ -1406,7 +1406,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointCofactorMul(void * R)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1in, size_t w1in_len)
+CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_len, const uint8_t * w1sin, size_t w1sin_len)
 {
     CHIP_ERROR error          = CHIP_NO_ERROR;
     int result                = 0;
@@ -1418,7 +1418,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     mbedtls_mpi_init(&w1_bn);
     mbedtls_ecp_point_init(&Ltemp);
 
-    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1in), w1in_len);
+    result = mbedtls_mpi_read_binary(&w1_bn, Uint8::to_const_uchar(w1sin), w1sin_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
     result = mbedtls_mpi_mod_mpi(&w1_bn, &w1_bn, &context->curve.N);


### PR DESCRIPTION
There seems to be inaccurate naming of crypto primitives. Are these correct observations?
 - w0s and w1s are not exactly identical to w0 and w1
 - w0s and w0 are used , in at least 1 instance, interchangeably and I am not sure if this is correct but the tests seem to pass.
    - e.g. in TestChipCryptoPAL.cpp in test TestSPAKE2P_RFC, both `BeginProver()` and `BeginVerifier()` use the same w0. But according to the description of these functions they should use w0s w0 respectively. (This could just be my limited knowledge in the topic)