### PR TITLE
[Darwin] API to list all network commissioning features supported by an MTRDevice

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -18,6 +18,7 @@
 #import <Foundation/Foundation.h>
 #import <Matter/MTRAttributeValueWaiter.h>
 #import <Matter/MTRBaseDevice.h>
+#import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -124,11 +125,8 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 /**
  * Network commissioning features supported by the device.
- *
- * The value if not nil, represents the options available in MTRNetworkCommissioningFeature type.
- *
  */
-@property (nonatomic, readonly, nullable, copy) NSNumber * networkCommissioningFeatures MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly) MTRNetworkCommissioningFeature networkCommissioningFeatures MTR_NEWLY_AVAILABLE;
 
 /**
  * Set the delegate to receive asynchronous callbacks about the device.

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -123,6 +123,14 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (nonatomic, readonly, nullable, copy) NSNumber * productID MTR_NEWLY_AVAILABLE;
 
 /**
+ * Network commissioning features supported by the device.
+ *
+ * The value if not nil, represents the options available in MTRNetworkCommissioningFeature type.
+ *
+ */
+@property (nonatomic, readonly, nullable, copy) NSNumber * networkCommissioningFeature MTR_NEWLY_AVAILABLE;
+
+/**
  * Set the delegate to receive asynchronous callbacks about the device.
  *
  * The delegate will be called on the provided queue, for attribute reports, event reports, and device state changes.

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -17,8 +17,8 @@
 
 #import <Foundation/Foundation.h>
 #import <Matter/MTRAttributeValueWaiter.h>
-#import <Matter/MTRBaseDevice.h>
 #import <Matter/MTRBaseClusters.h>
+#import <Matter/MTRBaseDevice.h>
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -128,7 +128,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The value if not nil, represents the options available in MTRNetworkCommissioningFeature type.
  *
  */
-@property (nonatomic, readonly, nullable, copy) NSNumber * networkCommissioningFeature MTR_NEWLY_AVAILABLE;
+@property (nonatomic, readonly, nullable, copy) NSNumber * networkCommissioningFeatures MTR_NEWLY_AVAILABLE;
 
 /**
  * Set the delegate to receive asynchronous callbacks about the device.

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -514,7 +514,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     return [_pid copy];
 }
 
-- (nullable NSNumber *)networkCommissioningFeature
+- (nullable NSNumber *)networkCommissioningFeatures
 {
     std::lock_guard lock(_descriptionLock);
     return [_allNetworkFeatures copy];

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -514,6 +514,12 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     return [_pid copy];
 }
 
+- (nullable NSNumber *)networkCommissioningFeature
+{
+    std::lock_guard lock(_descriptionLock);
+    return [_allNetworkFeatures copy];
+}
+
 - (void)_notifyDelegateOfPrivateInternalPropertiesChanges
 {
     os_unfair_lock_assert_owner(&self->_lock);

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -514,10 +514,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     return [_pid copy];
 }
 
-- (nullable NSNumber *)networkCommissioningFeatures
+- (MTRNetworkCommissioningFeature)networkCommissioningFeatures
 {
     std::lock_guard lock(_descriptionLock);
-    return [_allNetworkFeatures copy];
+    return [_allNetworkFeatures unsignedIntValue];
 }
 
 - (void)_notifyDelegateOfPrivateInternalPropertiesChanges

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -141,7 +141,7 @@
     return [[self._internalState objectForKey:kMTRDeviceInternalPropertyKeyProductID] copy];
 }
 
-- (nullable NSNumber *)networkCommissioningFeature
+- (nullable NSNumber *)networkCommissioningFeatures
 {
     return [[self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures] copy];
 }

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -141,6 +141,11 @@
     return [[self._internalState objectForKey:kMTRDeviceInternalPropertyKeyProductID] copy];
 }
 
+- (nullable NSNumber *)networkCommissioningFeature
+{
+    return [[self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures] copy];
+}
+
 #pragma mark - Client Callbacks (MTRDeviceDelegate)
 
 // required methods for MTRDeviceDelegates

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -141,9 +141,9 @@
     return [[self._internalState objectForKey:kMTRDeviceInternalPropertyKeyProductID] copy];
 }
 
-- (nullable NSNumber *)networkCommissioningFeatures
+- (MTRNetworkCommissioningFeature)networkCommissioningFeatures
 {
-    return [[self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures] copy];
+    return [[self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures] unsignedIntValue];
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)


### PR DESCRIPTION
- Expose the network commissioning feature bitset as API to know what transports are supported by the device.
