### PR TITLE
[Cherry-pick][ICD] Shutdown icd client storage when destroying android controller …

### DIFF
--- a/src/app/icd/client/DefaultICDClientStorage.cpp
+++ b/src/app/icd/client/DefaultICDClientStorage.cpp
@@ -542,5 +542,14 @@ CHIP_ERROR DefaultICDClientStorage::ProcessCheckInPayload(const ByteSpan & paylo
     iterator->Release();
     return CHIP_ERROR_NOT_FOUND;
 }
+
+void DefaultICDClientStorage::Shutdown()
+{
+    mICDClientInfoIterators.ReleaseAll();
+    mpClientInfoStore = nullptr;
+    mpKeyStore        = nullptr;
+    mFabricList.clear();
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/icd/client/DefaultICDClientStorage.h
+++ b/src/app/icd/client/DefaultICDClientStorage.h
@@ -120,6 +120,12 @@ public:
     CHIP_ERROR ProcessCheckInPayload(const ByteSpan & payload, ICDClientInfo & clientInfo,
                                      Protocols::SecureChannel::CounterType & counter) override;
 
+    /**
+     * Shut down DefaultICDClientStorage
+     *
+     */
+    void Shutdown();
+
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     size_t GetFabricListSize() { return mFabricList.size(); }
 

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -52,6 +52,7 @@ using namespace TLV;
 
 AndroidDeviceControllerWrapper::~AndroidDeviceControllerWrapper()
 {
+    getICDClientStorage()->Shutdown();
     mController->Shutdown();
 
 #ifndef JAVA_MATTER_CONTROLLER_TEST


### PR DESCRIPTION
* Shutdown DefautICDClientStorage when destorying Android controller
* This is 1.4 cherrypick for ICD, merged PR https://github.com/project-chip/connectedhomeip/pull/36348

