### PR TITLE
remove unused CHIP_CONFIG_MAX_BINDINGS

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -37,16 +37,6 @@ menu "CHIP Core"
                 exchange (conversation) with a peer, e.g. a cloud service, a mobile application, or
                 another device.
 
-        config MAX_BINDINGS
-            int "Max Bindings"
-            range 0 65535
-            default 8
-            help
-                The maximum number of simultaneously active CHIP Binding objects.
-
-                A Binding object is used to configure how the local device communicates with
-                a remote entity, be it a cloud service, a mobile application, or another device.
-
         config MAX_FABRICS
             int "Max Fabrics"
             range 5 255

--- a/examples/all-clusters-app/nxp/mw320/include/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/nxp/mw320/include/CHIPProjectConfig.h
@@ -144,15 +144,6 @@
 #define CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE 0
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/all-clusters-app/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/all-clusters-app/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/all-clusters-app/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
+++ b/examples/all-clusters-app/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
@@ -169,15 +169,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/laundry-washer-app/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
+++ b/examples/laundry-washer-app/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/laundry-washer-app/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
+++ b/examples/laundry-washer-app/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/laundry-washer-app/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
+++ b/examples/laundry-washer-app/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
@@ -169,15 +169,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/thermostat/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
+++ b/examples/thermostat/nxp/rt/rt1060/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/thermostat/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
+++ b/examples/thermostat/nxp/rt/rt1170/include/config/CHIPProjectConfig.h
@@ -168,15 +168,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.

--- a/examples/thermostat/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
+++ b/examples/thermostat/nxp/rt/rw61x/include/config/CHIPProjectConfig.h
@@ -169,15 +169,6 @@
 // #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 1
 
 /**
- * CHIP_CONFIG_MAX_BINDINGS
- *
- * Maximum number of simultaneously active bindings per ChipExchangeManager
- * 1 (Time Sync) + 2 (Two 1-way subscriptions) + 1 (Software Update) = 4
- * in the worst case. Keeping another 4 as buffer.
- */
-#define CHIP_CONFIG_MAX_BINDINGS 6
-
-/**
  * CHIP_CONFIG_EVENT_LOGGING_WDM_OFFLOAD
  *
  * Select the ability to offload event logs to any interested subscribers using WDM.


### PR DESCRIPTION
`git grep CHIP_CONFIG_MAX_BINDINGS` and `git grep MAX_BINDINGS` do not come up with any consumer of these config.