### PR TITLE
[Linux] Revert passcode argument parsing from oct/hex to just dec

### DIFF
--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -477,7 +477,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
     }
 
     case kDeviceOption_Passcode:
-        LinuxDeviceOptions::GetInstance().payload.setUpPINCode = static_cast<uint32_t>(strtoul(aValue, nullptr, 0));
+        LinuxDeviceOptions::GetInstance().payload.setUpPINCode = static_cast<uint32_t>(atoi(aValue));
         break;
 
     case kDeviceOption_Spake2pSaltBase64: {


### PR DESCRIPTION
In PR https://github.com/project-chip/connectedhomeip/pull/34172 command argument parsing was changed to support HEX format for specific flags. Unfortunately the implementation uses `strtoul` which has the side effect of also interpreting base 8 (octal) integers.

When passing a passcode using the `--passcode` flag that contains a zero prefix, such as `06118492`, due to the above PR, it will interpret the passcode as an octal integer instead of decimal which causes unintended conversion and a different passcode as expected.

The same bug is present with other flags, however those I initially didn't change since it is less likely that a zero prefixed argument will be provided.

I doubt anyone will use the passcode in HEX format for the command line argument.