### PR TITLE
Handle ACL and readability in `reporting/Engine.cpp`

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -201,7 +201,10 @@ static_library("interaction-model") {
     "reporting/reporting.h",
   ]
 
-  deps = [ "${chip_root}/src/app:events" ]
+  deps = [
+    "${chip_root}/src/app:events",
+    "${chip_root}/src/app:global-attributes",
+  ]
 
   # Temporary dependency: codegen data provider instance should be provided
   # by the application

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1321,20 +1321,6 @@ TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceAcceptedCommands)
     EXPECT_FALSE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 33)).has_value());
 }
 
-TEST(TestCodegenModelViaMocks, EmberAttributeReadAclDeny)
-{
-    UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
-    ScopedMockAccessControl accessControl;
-
-    ReadOperation testRequest(kMockEndpoint1, MockClusterId(1), MockAttributeId(10));
-    testRequest.SetSubjectDescriptor(kDenySubjectDescriptor);
-
-    std::unique_ptr<AttributeValueEncoder> encoder = testRequest.StartEncoding();
-
-    ASSERT_EQ(model.ReadAttribute(testRequest.GetRequest(), *encoder), Status::UnsupportedAccess);
-}
-
 TEST(TestCodegenModelViaMocks, ReadForInvalidGlobalAttributePath)
 {
     UseMockNodeConfig config(gTestNodeConfig);
@@ -1390,24 +1376,6 @@ TEST(TestCodegenModelViaMocks, EmberAttributeInvalidRead)
 
         ASSERT_EQ(model.ReadAttribute(testRequest.GetRequest(), *encoder), Status::UnsupportedEndpoint);
     }
-}
-
-TEST(TestCodegenModelViaMocks, EmberAttributePathExpansionAccessDeniedRead)
-{
-    UseMockNodeConfig config(gTestNodeConfig);
-    CodegenDataModelProviderWithContext model;
-    ScopedMockAccessControl accessControl;
-
-    ReadOperation testRequest(kMockEndpoint1, MockClusterId(1), MockAttributeId(10));
-    testRequest.SetSubjectDescriptor(kDenySubjectDescriptor);
-    testRequest.SetPathExpanded(true);
-
-    std::unique_ptr<AttributeValueEncoder> encoder = testRequest.StartEncoding();
-
-    // For expanded paths, access control failures succeed without encoding anything
-    // This is temporary until ACL checks are moved inside the IM/ReportEngine
-    ASSERT_EQ(model.ReadAttribute(testRequest.GetRequest(), *encoder), CHIP_NO_ERROR);
-    ASSERT_FALSE(encoder->TriedEncode());
 }
 
 TEST(TestCodegenModelViaMocks, AccessInterfaceUnsupportedRead)

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -61,14 +61,7 @@ public:
 
     /// TEMPORARY/TRANSITIONAL requirement for transitioning from ember-specific code
     ///   ReadAttribute is REQUIRED to perform:
-    ///     - ACL validation (see notes on OperationFlags::kInternal)
     ///     - Validation of readability/writability (also controlled by OperationFlags::kInternal)
-    ///     - use request.path.mExpanded to skip encoding replies for data according
-    ///       to 8.4.3.2 of the spec:
-    ///         > If the path indicates attribute data that is not readable, then the path SHALL
-    ///           be discarded.
-    ///         > Else if reading from the attribute in the path requires a privilege that is not
-    ///           granted to access the cluster in the path, then the path SHALL be discarded.
     ///
     /// Return value notes:
     ///   ActionReturnStatus::IsOutOfSpaceEncodingResponse

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -60,8 +60,7 @@ public:
     virtual InteractionModelContext CurrentContext() const { return mContext; }
 
     /// TEMPORARY/TRANSITIONAL requirement for transitioning from ember-specific code
-    ///   ReadAttribute is REQUIRED to perform:
-    ///     - Validation of readability/writability (also controlled by OperationFlags::kInternal)
+    ///   ReadAttribute is REQUIRED to respond to GlobalAttribute read requests
     ///
     /// Return value notes:
     ///   ActionReturnStatus::IsOutOfSpaceEncodingResponse

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -115,7 +115,7 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
         //           - "write-only" attributes should return UNSUPPORTED_READ (this is done here)
         if (info.has_value() && !info->readPrivilege.has_value())
         {
-            return CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
+            return CHIP_IM_GLOBAL_STATUS(UnsupportedRead);
         }
 
         return std::nullopt;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -99,7 +99,7 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
             return std::nullopt;
         }
 
-        // We want to return "success" (i.e. nulopt) IF AND ONLY IF attribute exists and is readable (has read privilege).
+        // We want to return "success" (i.e. nulopt) IF AND ONLY IF the attribute exists and is readable (has read privilege).
         // Since the Access control check above may have passed with kView, we do another check here:
         //    - Attribute exists (info has value)
         //    - Attribute is readable (readProvilege has value) and not "write only"

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -78,7 +78,7 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
 
     std::optional<DataModel::AttributeInfo> info = dataModel->GetAttributeInfo(path);
 
-    // If the attribute exists, we know if it is readable (readPrivilege has value)
+    // If the attribute exists, we know whether it is readable (readPrivilege has value)
     // and what the required access privilege is. However for attributes missing from the metatada
     // (e.g. global attributes) or completely missing attributes we do not actually know of a required
     // privilege and default to kView (this is correct for global attributes and a reasonable check

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -103,16 +103,16 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
         // Since the Access control check above may have passed with kView, we do another check here:
         //    - Attribute exists (info has value)
         //    - Attribute is readable (readProvilege has value) and not "write only"
-        // If the above aret not true, we will return UnsupportedRead (spec 8.4.3.2: "Else if the path indicates attribute
+        // If the attribute exists and is not readable, we will return UnsupportedRead (spec 8.4.3.2: "Else if the path indicates attribute
         // data that is not readable, an AttributeStatusIB SHALL be generated with the UNSUPPORTED_READ Status Code.")
         //
         // TODO:: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/9024 requires interleaved ordering that
         //        is NOT implemented here. Spec requires:
         //           - check cluster access check (done here as kView at least)
         //           - unsupported endpoint/cluster/attribute check (NOT done here) when the attribute is missing.
-        //             this SOUND be done here when info does not have a value. This was not done as a first pass to
+        //             this SHOULD be done here when info does not have a value. This was not done as a first pass to
         //             minimize amount of delta in the initial PR.
-        //           - "write-only" attributes should retuirn UNSUPPORTED_READ (this is done heere)
+        //           - "write-only" attributes should return UNSUPPORTED_READ (this is done here)
         VerifyOrReturnError(!info.has_value() || info->readPrivilege.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
 
         return std::nullopt;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -1197,6 +1197,6 @@ void Engine::MarkDirty(const AttributePathParams & path)
 
 // TODO: MatterReportingAttributeChangeCallback should just live in libCHIP, It does not depend on any
 // app-specific generated bits.
-void __attribute__((weak)) MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                                  chip::AttributeId attributeId)
+void __attribute__((weak))
+MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {}

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -113,7 +113,10 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
         //             this SHOULD be done here when info does not have a value. This was not done as a first pass to
         //             minimize amount of delta in the initial PR.
         //           - "write-only" attributes should return UNSUPPORTED_READ (this is done here)
-        VerifyOrReturnError(!info.has_value() || info->readPrivilege.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
+        if (info.has_value() && !info->readPrivilege.has_value())
+        {
+            return CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
+        }
 
         return std::nullopt;
     }

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -1185,6 +1185,6 @@ void Engine::MarkDirty(const AttributePathParams & path)
 
 // TODO: MatterReportingAttributeChangeCallback should just live in libCHIP, It does not depend on any
 // app-specific generated bits.
-void __attribute__((weak)) MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId,
-                                                                  chip::AttributeId attributeId)
+void __attribute__((weak))
+MatterReportingAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {}

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -20,6 +20,7 @@
 #include <access/Privilege.h>
 #include <app/AppConfig.h>
 #include <app/ConcreteEventPath.h>
+#include <app/GlobalAttributes.h>
 #include <app/InteractionModelEngine.h>
 #include <app/RequiredPrivilege.h>
 #include <app/data-model-provider/ActionReturnStatus.h>
@@ -83,8 +84,13 @@ std::optional<CHIP_ERROR> ValidateReadACL(DataModel::Provider * dataModel, const
     if (err == CHIP_NO_ERROR)
     {
         // success, but only if this is actually a valid path
-        VerifyOrReturnError(info.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute));
-        VerifyOrReturnError(info->readPrivilege.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
+        // Global attributes have no metadata, so allow them through as long as `kView` access is available.
+        if (!IsSupportedGlobalAttributeNotInMetadata(path.mAttributeId))
+        {
+            VerifyOrReturnError(info.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute));
+            VerifyOrReturnError(info->readPrivilege.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedRead));
+        }
+
         return std::nullopt;
     }
     VerifyOrReturnError((err == CHIP_ERROR_ACCESS_DENIED) || (err == CHIP_ERROR_ACCESS_RESTRICTED_BY_ARL), err);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -60,8 +60,13 @@ Status EventPathValid(DataModel::Provider * model, const ConcreteEventPath & eve
 }
 
 /// Returns the status of ACL validation.
-///   if the status is set, the status is FINAL (i.e. permanent failure OR success due to path expansion logic.)
-///   if the status is not set, the processing can continue
+///   If the return value has a status set, that means the ACL check failed,
+///   the read must not be performed, and the returned status (which may
+///   be success, when dealing with non-concrete paths) should be used
+///   as the status for the read.
+///
+///   If the returned value is std::nullopt, that means the ACL check passed and the 
+///   read should proceed.
 std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataModel, const SubjectDescriptor & subjectDescriptor,
                                                    const ConcreteReadAttributePath & path)
 {

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -65,7 +65,7 @@ Status EventPathValid(DataModel::Provider * model, const ConcreteEventPath & eve
 ///   be success, when dealing with non-concrete paths) should be used
 ///   as the status for the read.
 ///
-///   If the returned value is std::nullopt, that means the ACL check passed and the 
+///   If the returned value is std::nullopt, that means the ACL check passed and the
 ///   read should proceed.
 std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataModel, const SubjectDescriptor & subjectDescriptor,
                                                    const ConcreteReadAttributePath & path)
@@ -103,8 +103,8 @@ std::optional<CHIP_ERROR> ValidateReadAttributeACL(DataModel::Provider * dataMod
         // Since the Access control check above may have passed with kView, we do another check here:
         //    - Attribute exists (info has value)
         //    - Attribute is readable (readProvilege has value) and not "write only"
-        // If the attribute exists and is not readable, we will return UnsupportedRead (spec 8.4.3.2: "Else if the path indicates attribute
-        // data that is not readable, an AttributeStatusIB SHALL be generated with the UNSUPPORTED_READ Status Code.")
+        // If the attribute exists and is not readable, we will return UnsupportedRead (spec 8.4.3.2: "Else if the path indicates
+        // attribute data that is not readable, an AttributeStatusIB SHALL be generated with the UNSUPPORTED_READ Status Code.")
         //
         // TODO:: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/9024 requires interleaved ordering that
         //        is NOT implemented here. Spec requires:

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -128,7 +128,7 @@ public:
         //       nonsense, however adding actual paths into the mock config changes existing
         //       test behaviour.
         //
-        // These specific paths were obtrained by grepping logs for what fake attributes we
+        // These specific paths were obtained by grepping logs for what fake attributes we
         // attempt to get info for within this test.
         const ConcreteAttributePath kFakePaths[] = {
             ConcreteAttributePath(kTestEndpointId, MockClusterId(2), 1),

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4687,8 +4687,8 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
 
     readParam.mAttributePathParamsListSize = 0;
     readClient                             = std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                                                               app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                                               app::ReadClient::InteractionType::Subscribe);
+                                                   app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                                   app::ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -125,7 +125,11 @@ public:
         }
 
         // TODO: figure out why these are special and fix up the test. This mock seems
-        //       nonsense
+        //       nonsense, however adding actual paths into the mock config changes existing
+        //       test behaviour.
+        //
+        // These specific paths were obtrained by grepping logs for what fake attributes we
+        // attempt to get info for within this test.
         const ConcreteAttributePath kFakePaths[] = {
             ConcreteAttributePath(kTestEndpointId, MockClusterId(2), 1),
             ConcreteAttributePath(kTestEndpointId, MockClusterId(5), MockAttributeId(1)),
@@ -163,7 +167,7 @@ protected:
         // Register app callback, so we can test it as well to ensure we get the right
         // number of SubscriptionEstablishment/Termination callbacks.
         InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
-        mOldProvider = InteractionModelEngine::GetInstance()->SetDataModelProvider(&CustomDataModel::Instance());
+        mOldProvider = InteractionModelEngine::GetInstance()->SetDataModelProvider(&gReadDataModel);
         chip::Test::SetMockNodeConfig(TestMockNodeConfig());
     }
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -144,7 +144,7 @@ public:
                              path.mAttributeId);
                 DataModel::AttributeInfo info;
 
-                // Pretendint it is readable - allow ALL reads!!!
+                // Pretending these attributes exist and are generaly readable.
                 info.readPrivilege = Access::Privilege::kView;
 
                 return info;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -20,16 +20,15 @@
 #include <pw_unit_test/framework.h>
 
 #include "DataModelFixtures.h"
-#include "access/Privilege.h"
-#include "app/data-model-provider/MetadataTypes.h"
-#include "lib/support/logging/TextOnlyLogging.h"
 
+#include <access/Privilege.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/ClusterStateCache.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/ConcreteEventPath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
+#include <app/data-model-provider/MetadataTypes.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/mock/Constants.h>
 #include <app/util/mock/Functions.h>
@@ -37,6 +36,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/core/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <lib/support/logging/TextOnlyLogging.h>
 #include <messaging/tests/MessagingContext.h>
 #include <protocols/interaction_model/Constants.h>
 #include <system/SystemClock.h>
@@ -4687,8 +4687,8 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
 
     readParam.mAttributePathParamsListSize = 0;
     readClient                             = std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                                   app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                   app::ReadClient::InteractionType::Subscribe);
+                                                                               app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                                                               app::ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();


### PR DESCRIPTION
This is part of #36484: move the ACL validation out of `DataModel::Provider::ReadAttribute` and have this handled by the interaction model reporting engine based on the metadata passed in by the provider.