### PR TITLE
fan_control_server: Fix circular callback issue

### DIFF
--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -85,6 +85,10 @@ namespace {
 // Indicates if the write operation is from the cluster server itself
 bool gWriteFromClusterLogic = false;
 
+// Avoid circular callback calls when adjusting SpeedSetting and PercentSetting together.
+bool gSpeedWriteInProgress   = false;
+bool gPercentWriteInProgress = false;
+
 Status SetFanModeToOff(EndpointId endpointId)
 {
     FanModeEnum currentFanMode;
@@ -185,6 +189,10 @@ MatterFanControlClusterServerPreAttributeChangedCallback(const ConcreteAttribute
         break;
     }
     case SpeedSetting::Id: {
+        if (gSpeedWriteInProgress)
+        {
+            return Status::WriteIgnored;
+        }
         if (SupportsMultiSpeed(attributePath.mEndpointId))
         {
             // Check if the SpeedSetting is null.
@@ -224,6 +232,10 @@ MatterFanControlClusterServerPreAttributeChangedCallback(const ConcreteAttribute
         break;
     }
     case PercentSetting::Id: {
+        if (gPercentWriteInProgress)
+        {
+            return Status::WriteIgnored;
+        }
         // Check if the PercentSetting is null.
         if (NumericAttributeTraits<Percent>::IsNullValue(*value))
         {
@@ -360,80 +372,70 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
     }
     case PercentSetting::Id: {
         DataModel::Nullable<Percent> percentSetting;
+        uint8_t speedMax;
         Status status = PercentSetting::Get(attributePath.mEndpointId, percentSetting);
         VerifyOrReturn(Status::Success == status && !percentSetting.IsNull());
 
+        status = SpeedMax::Get(attributePath.mEndpointId, &speedMax);
+        VerifyOrReturn(Status::Success == status,
+                       ChipLogError(Zcl, "Failed to get SpeedMax with error: 0x%02x", to_underlying(status)));
+
+        // Avoid circular callback calls
+        gPercentWriteInProgress = true;
         // If PercentSetting is set to 0, the server SHALL set the FanMode attribute value to Off.
         if (percentSetting.Value() == 0)
         {
             status = SetFanModeToOff(attributePath.mEndpointId);
-            VerifyOrReturn(Status::Success == status,
-                           ChipLogError(Zcl, "Failed to set FanMode to off with error: 0x%02x", to_underlying(status)));
+            VerifyOrDo(status == Status::Success,
+                       ChipLogError(Zcl, "Failed to set FanMode to off with error: 0x%02x", to_underlying(status)));
         }
 
         if (SupportsMultiSpeed(attributePath.mEndpointId))
         {
             // Adjust SpeedSetting from a percent value change for PercentSetting
             // speed = ceil( SpeedMax * (percent * 0.01) )
-            uint8_t speedMax;
-            status = SpeedMax::Get(attributePath.mEndpointId, &speedMax);
-            VerifyOrReturn(Status::Success == status,
-                           ChipLogError(Zcl, "Failed to get SpeedMax with error: 0x%02x", to_underlying(status)));
-
-            DataModel::Nullable<uint8_t> currentSpeedSetting;
-            status = SpeedSetting::Get(attributePath.mEndpointId, currentSpeedSetting);
-            VerifyOrReturn(Status::Success == status,
-                           ChipLogError(Zcl, "Failed to get SpeedSetting with error: 0x%02x", to_underlying(status)));
-
             uint16_t percent = percentSetting.Value();
             // Plus 99 then integer divide by 100 instead of multiplying 0.01 to avoid floating point precision error
             uint8_t speedSetting = static_cast<uint8_t>((speedMax * percent + 99) / 100);
 
-            if (currentSpeedSetting.IsNull() || speedSetting != currentSpeedSetting.Value())
-            {
-                status = SpeedSetting::Set(attributePath.mEndpointId, speedSetting);
-                VerifyOrReturn(Status::Success == status,
-                               ChipLogError(Zcl, "Failed to set SpeedSetting with error: 0x%02x", to_underlying(status)));
-            }
+            status = SpeedSetting::Set(attributePath.mEndpointId, speedSetting);
+            VerifyOrDo(Status::Success == status,
+                       ChipLogError(Zcl, "Failed to set SpeedSetting with error: 0x%02x", to_underlying(status)));
         }
+        gPercentWriteInProgress = false;
         break;
     }
     case SpeedSetting::Id: {
         if (SupportsMultiSpeed(attributePath.mEndpointId))
         {
             DataModel::Nullable<uint8_t> speedSetting;
+            uint8_t speedMax;
             Status status = SpeedSetting::Get(attributePath.mEndpointId, speedSetting);
             VerifyOrReturn(Status::Success == status && !speedSetting.IsNull());
 
-            // If SpeedSetting is set to 0, the server SHALL set the FanMode attribute value to Off.
-            if (speedSetting.Value() == 0)
-            {
-                status = SetFanModeToOff(attributePath.mEndpointId);
-                VerifyOrReturn(Status::Success == status,
-                               ChipLogError(Zcl, "Failed to set FanMode to off with error: 0x%02x", to_underlying(status)));
-            }
-
-            // Adjust PercentSetting from a speed value change for SpeedSetting
-            // percent = floor( speed/SpeedMax * 100 )
-            uint8_t speedMax;
             status = SpeedMax::Get(attributePath.mEndpointId, &speedMax);
             VerifyOrReturn(Status::Success == status,
                            ChipLogError(Zcl, "Failed to get SpeedMax with error: 0x%02x", to_underlying(status)));
 
-            DataModel::Nullable<Percent> currentPercentSetting;
-            status = PercentSetting::Get(attributePath.mEndpointId, currentPercentSetting);
-            VerifyOrReturn(Status::Success == status,
-                           ChipLogError(Zcl, "Failed to get PercentSetting with error: 0x%02x", to_underlying(status)));
+            // Avoid circular callback calls
+            gSpeedWriteInProgress = true;
+            // If SpeedSetting is set to 0, the server SHALL set the FanMode attribute value to Off.
+            if (speedSetting.Value() == 0)
+            {
+                status = SetFanModeToOff(attributePath.mEndpointId);
+                VerifyOrDo(Status::Success == status,
+                           ChipLogError(Zcl, "Failed to set FanMode to off with error: 0x%02x", to_underlying(status)));
+            }
 
+            // Adjust PercentSetting from a speed value change for SpeedSetting
+            // percent = floor( speed/SpeedMax * 100 )
             float speed            = speedSetting.Value();
             Percent percentSetting = static_cast<Percent>(speed / speedMax * 100);
 
-            if (currentPercentSetting.IsNull() || percentSetting != currentPercentSetting.Value())
-            {
-                status = PercentSetting::Set(attributePath.mEndpointId, percentSetting);
-                VerifyOrReturn(Status::Success == status,
-                               ChipLogError(Zcl, "Failed to set PercentSetting with error: 0x%02x", to_underlying(status)));
-            }
+            status = PercentSetting::Set(attributePath.mEndpointId, percentSetting);
+            VerifyOrDo(Status::Success == status,
+                       ChipLogError(Zcl, "Failed to set PercentSetting with error: 0x%02x", to_underlying(status)));
+            gSpeedWriteInProgress = false;
         }
         break;
     }


### PR DESCRIPTION
This PR fixes a circular callback bug in fan control server using flags when updating SpeedSetting and PercentSetting.

Before this change, a PercentSetting write to 25% would end up circling back to 30% as shown:

```
[MatterTest] 11-12 19:16:40.792 INFO @@@ WRITE PercentSetting to 25
[MatterTest] 11-12 19:16:40.801 INFO @@@ ATTRIB: EP1/FanControl/SpeedSetting: 3
[MatterTest] 11-12 19:16:40.802 INFO @@@ ATTRIB: EP1/FanControl/SpeedCurrent: 3
[MatterTest] 11-12 19:16:40.802 INFO @@@ ATTRIB: EP1/FanControl/PercentSetting: 30
[MatterTest] 11-12 19:16:40.802 INFO @@@ ATTRIB: EP1/FanControl/PercentCurrent: 30
```

Now it behaves as expected:
```
[MatterTest] 11-13 18:54:27.961 INFO @@@ WRITE PercentSetting to 25
[MatterTest] 11-13 18:54:27.970 INFO @@@ ATTRIB: EP1/FanControl/SpeedSetting: 3
[MatterTest] 11-13 18:54:27.970 INFO @@@ ATTRIB: EP1/FanControl/SpeedCurrent: 3
[MatterTest] 11-13 18:54:27.970 INFO @@@ ATTRIB: EP1/FanControl/PercentSetting: 25
[MatterTest] 11-13 18:54:27.971 INFO @@@ ATTRIB: EP1/FanControl/PercentCurrent: 25
```

