### PR TITLE
[Fabric-Sync] Use Meyers' Singleton pattern for BridgedDeviceManager and DeviceManager

### DIFF
--- a/examples/fabric-sync/admin/BridgeSubscription.cpp
+++ b/examples/fabric-sync/admin/BridgeSubscription.cpp
@@ -80,7 +80,7 @@ void BridgeSubscription::OnAttributeData(const ConcreteDataAttributePath & path,
         return;
     }
 
-    DeviceMgr().HandleAttributeData(path, *data);
+    DeviceManager::Instance().HandleAttributeData(path, *data);
 }
 
 void BridgeSubscription::OnEventData(const app::EventHeader & eventHeader, TLV::TLVReader * data, const app::StatusIB * status)
@@ -101,7 +101,7 @@ void BridgeSubscription::OnEventData(const app::EventHeader & eventHeader, TLV::
         return;
     }
 
-    DeviceMgr().HandleEventData(eventHeader, *data);
+    DeviceManager::Instance().HandleEventData(eventHeader, *data);
 }
 
 void BridgeSubscription::OnError(CHIP_ERROR error)

--- a/examples/fabric-sync/admin/CommissionerControl.cpp
+++ b/examples/fabric-sync/admin/CommissionerControl.cpp
@@ -84,7 +84,7 @@ void CommissionerControl::OnResponse(app::CommandSender * client, const app::Con
 
     if (data != nullptr)
     {
-        DeviceMgr().HandleCommandResponse(path, *data);
+        DeviceManager::Instance().HandleCommandResponse(path, *data);
     }
 }
 

--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -36,9 +36,6 @@ constexpr EndpointId kAggregatorEndpointId = 1;
 
 } // namespace
 
-// Define the static member
-DeviceManager DeviceManager::sInstance;
-
 LinuxCommissionableDataProvider sCommissionableDataProvider;
 
 void DeviceManager::Init()

--- a/examples/fabric-sync/admin/DeviceManager.h
+++ b/examples/fabric-sync/admin/DeviceManager.h
@@ -54,6 +54,12 @@ class DeviceManager
 public:
     DeviceManager() = default;
 
+    static DeviceManager & Instance()
+    {
+        static DeviceManager instance;
+        return instance;
+    }
+
     void Init();
 
     chip::NodeId GetNextAvailableNodeId();
@@ -170,8 +176,6 @@ public:
     SyncedDevice * FindDeviceByNode(chip::NodeId nodeId);
 
 private:
-    friend DeviceManager & DeviceMgr();
-
     void RequestCommissioningApproval();
 
     void HandleReadSupportedDeviceCategories(chip::TLV::TLVReader & data);
@@ -183,8 +187,6 @@ private:
     void SendCommissionNodeRequest(uint64_t requestId, uint16_t responseTimeoutSeconds);
 
     void HandleReverseOpenCommissioningWindow(chip::TLV::TLVReader & data);
-
-    static DeviceManager sInstance;
 
     chip::NodeId mLastUsedNodeId = 0;
 
@@ -200,20 +202,5 @@ private:
     CommissionerControl mCommissionerControl;
     FabricSyncGetter mFabricSyncGetter;
 };
-
-/**
- * Returns the public interface of the DeviceManager singleton object.
- *
- * Applications should use this to access features of the DeviceManager
- * object.
- */
-inline DeviceManager & DeviceMgr()
-{
-    if (!DeviceManager::sInstance.mInitialized)
-    {
-        DeviceManager::sInstance.Init();
-    }
-    return DeviceManager::sInstance;
-}
 
 } // namespace admin

--- a/examples/fabric-sync/admin/DeviceSynchronization.cpp
+++ b/examples/fabric-sync/admin/DeviceSynchronization.cpp
@@ -148,7 +148,7 @@ void DeviceSynchronizer::OnDone(app::ReadClient * apReadClient)
 {
     ChipLogProgress(NotSpecified, "Synchronization complete for NodeId:" ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
-    if (mState == State::ReceivedResponse && !DeviceMgr().IsCurrentBridgeDevice(mNodeId))
+    if (mState == State::ReceivedResponse && !DeviceManager::Instance().IsCurrentBridgeDevice(mNodeId))
     {
         GetUniqueId();
         if (mState == State::GettingUid)
@@ -229,15 +229,15 @@ void DeviceSynchronizer::GetUniqueId()
     // If we have a UniqueId we can return leaving state in ReceivedResponse.
     VerifyOrReturn(!mCurrentDeviceData.uniqueId.has_value(), ChipLogDetail(NotSpecified, "We already have UniqueId"));
 
-    auto * device = DeviceMgr().FindDeviceByNode(mNodeId);
+    auto * device = DeviceManager::Instance().FindDeviceByNode(mNodeId);
     // If there is no associated remote Fabric Sync Aggregator there is no other place for us to try
     // getting the UniqueId from and can return leaving the state in ReceivedResponse.
     VerifyOrReturn(device, ChipLogDetail(NotSpecified, "No remote Fabric Sync Aggregator to get UniqueId from"));
 
     // Because device is not-null we expect IsFabricSyncReady to be true. IsFabricSyncReady indicates we have a
     // connection to the remote Fabric Sync Aggregator.
-    VerifyOrDie(DeviceMgr().IsFabricSyncReady());
-    auto remoteBridgeNodeId               = DeviceMgr().GetRemoteBridgeNodeId();
+    VerifyOrDie(DeviceManager::Instance().IsFabricSyncReady());
+    auto remoteBridgeNodeId               = DeviceManager::Instance().GetRemoteBridgeNodeId();
     EndpointId remoteEndpointIdOfInterest = device->GetEndpointId();
 
     ChipLogDetail(NotSpecified, "Attempting to get UniqueId from remote Fabric Sync Aggregator");

--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -65,13 +65,13 @@ FabricAdmin::CommissionRemoteBridge(Controller::CommissioningWindowPasscodeParam
 
     if (err == CHIP_NO_ERROR)
     {
-        NodeId nodeId = DeviceMgr().GetNextAvailableNodeId();
+        NodeId nodeId = DeviceManager::Instance().GetNextAvailableNodeId();
 
         // After responding with RequestCommissioningApproval to the node where the client initiated the
         // RequestCommissioningApproval, you need to wait for it to open a commissioning window on its bridge.
         usleep(kCommissionPrepareTimeMs * 1000);
 
-        DeviceMgr().PairRemoteDevice(nodeId, code.c_str());
+        DeviceManager::Instance().PairRemoteDevice(nodeId, code.c_str());
     }
     else
     {

--- a/examples/fabric-sync/bridge/include/BridgedDeviceManager.h
+++ b/examples/fabric-sync/bridge/include/BridgedDeviceManager.h
@@ -30,6 +30,12 @@ class BridgedDeviceManager
 public:
     BridgedDeviceManager() = default;
 
+    static BridgedDeviceManager & Instance()
+    {
+        static BridgedDeviceManager instance;
+        return instance;
+    }
+
     /**
      * @brief Initializes the BridgedDeviceManager.
      *
@@ -111,29 +117,14 @@ public:
     BridgedDevice * GetDeviceByUniqueId(const std::string & id);
 
 private:
-    friend BridgedDeviceManager & BridgeDeviceMgr();
-
     /**
      * Creates a new unique ID that is not used by any other mDevice
      */
     std::string GenerateUniqueId();
 
-    static BridgedDeviceManager sInstance;
-
     chip::EndpointId mCurrentEndpointId;
     chip::EndpointId mFirstDynamicEndpointId;
     std::unique_ptr<BridgedDevice> mDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT + 1];
 };
-
-/**
- * Returns the public interface of the BridgedDeviceManager singleton object.
- *
- * Applications should use this to access features of the BridgedDeviceManager
- * object.
- */
-inline BridgedDeviceManager & BridgeDeviceMgr()
-{
-    return BridgedDeviceManager::sInstance;
-}
 
 } // namespace bridge

--- a/examples/fabric-sync/bridge/src/Bridge.cpp
+++ b/examples/fabric-sync/bridge/src/Bridge.cpp
@@ -81,7 +81,7 @@ void BridgedDeviceInformationCommandHandler::InvokeCommand(HandlerContext & hand
         return;
     }
 
-    BridgedDevice * device = BridgeDeviceMgr().GetDevice(endpointId);
+    BridgedDevice * device = BridgedDeviceManager::Instance().GetDevice(endpointId);
     if (device == nullptr || !device->IsIcd())
     {
         handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, Status::Failure);
@@ -125,7 +125,7 @@ CHIP_ERROR BridgeInit(FabricAdminDelegate * delegate)
     CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gBridgedDeviceInformationCommandHandler);
     AttributeAccessInterfaceRegistry::Instance().Register(&gBridgedDeviceBasicInformationAttributes);
 
-    BridgeDeviceMgr().Init();
+    BridgedDeviceManager::Instance().Init();
     FabricBridge::Instance().SetDelegate(delegate);
     ReturnErrorOnFailure(gBridgedAdministratorCommissioning.Init());
     ReturnErrorOnFailure(CommissionerControlInit(delegate));

--- a/examples/fabric-sync/bridge/src/BridgedAdministratorCommissioning.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedAdministratorCommissioning.cpp
@@ -45,7 +45,7 @@ CHIP_ERROR BridgedAdministratorCommissioning::Read(const ConcreteReadAttributePa
 {
     VerifyOrDie(aPath.mClusterId == Clusters::AdministratorCommissioning::Id);
     EndpointId endpointId  = aPath.mEndpointId;
-    BridgedDevice * device = BridgeDeviceMgr().GetDevice(endpointId);
+    BridgedDevice * device = BridgedDeviceManager::Instance().GetDevice(endpointId);
 
     if (!device)
     {

--- a/examples/fabric-sync/bridge/src/BridgedDeviceBasicInformationImpl.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceBasicInformationImpl.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Read(const ConcreteReadAttributePa
     // Registration is done for the bridged device basic information only
     VerifyOrDie(path.mClusterId == app::Clusters::BridgedDeviceBasicInformation::Id);
 
-    BridgedDevice * dev = BridgeDeviceMgr().GetDevice(path.mEndpointId);
+    BridgedDevice * dev = BridgedDeviceManager::Instance().GetDevice(path.mEndpointId);
     VerifyOrReturnError(dev != nullptr, CHIP_ERROR_NOT_FOUND);
 
     switch (path.mAttributeId)
@@ -93,7 +93,7 @@ CHIP_ERROR BridgedDeviceBasicInformationImpl::Write(const ConcreteDataAttributeP
 {
     VerifyOrDie(path.mClusterId == app::Clusters::BridgedDeviceBasicInformation::Id);
 
-    BridgedDevice * dev = BridgeDeviceMgr().GetDevice(path.mEndpointId);
+    BridgedDevice * dev = BridgedDeviceManager::Instance().GetDevice(path.mEndpointId);
     VerifyOrReturnError(dev != nullptr, CHIP_ERROR_NOT_FOUND);
 
     if (!dev->IsReachable())

--- a/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
@@ -175,9 +175,6 @@ const EmberAfDeviceType sBridgedDeviceTypes[] = { { DEVICE_TYPE_BRIDGED_NODE, DE
 
 } // namespace
 
-// Define the static member
-BridgedDeviceManager BridgedDeviceManager::sInstance;
-
 void BridgedDeviceManager::Init()
 {
     mFirstDynamicEndpointId = static_cast<chip::EndpointId>(

--- a/examples/fabric-sync/bridge/src/FabricBridge.cpp
+++ b/examples/fabric-sync/bridge/src/FabricBridge.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR FabricBridge::AddSynchronizedDevice(const SynchronizedDevice & data)
     device->SetIcd(data.isIcd.value_or(false));
 
     // Add the device to the bridge manager with a parent endpoint
-    auto result = BridgeDeviceMgr().AddDeviceEndpoint(std::move(device), /* parentEndpointId= */ 1);
+    auto result = BridgedDeviceManager::Instance().AddDeviceEndpoint(std::move(device), /* parentEndpointId= */ 1);
     if (!result.has_value())
     {
         ChipLogError(NotSpecified, "Failed to add device with Id=[%d:0x" ChipLogFormatX64 "]", data.id.GetFabricIndex(),
@@ -112,7 +112,7 @@ CHIP_ERROR FabricBridge::AddSynchronizedDevice(const SynchronizedDevice & data)
     }
 
     // Retrieve and verify the added device by ScopedNodeId
-    BridgedDevice * addedDevice = BridgeDeviceMgr().GetDeviceByScopedNodeId(data.id);
+    BridgedDevice * addedDevice = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(data.id);
     VerifyOrDie(addedDevice);
 
     ChipLogProgress(NotSpecified, "Added device with Id=[%d:0x" ChipLogFormatX64 "]", data.id.GetFabricIndex(),
@@ -137,7 +137,7 @@ CHIP_ERROR FabricBridge::RemoveSynchronizedDevice(ScopedNodeId scopedNodeId)
     ChipLogProgress(NotSpecified, "Received RemoveSynchronizedDevice: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto removedIdx = BridgeDeviceMgr().RemoveDeviceByScopedNodeId(scopedNodeId);
+    auto removedIdx = BridgedDeviceManager::Instance().RemoveDeviceByScopedNodeId(scopedNodeId);
     if (!removedIdx.has_value())
     {
         ChipLogError(NotSpecified, "Failed to remove device with Id=[%d:0x" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
@@ -153,7 +153,7 @@ CHIP_ERROR FabricBridge::ActiveChanged(ScopedNodeId scopedNodeId, uint32_t promi
     ChipLogProgress(NotSpecified, "Received ActiveChanged: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",
@@ -170,7 +170,7 @@ CHIP_ERROR FabricBridge::AdminCommissioningAttributeChanged(const AdministratorC
     ChipLogProgress(NotSpecified, "Received CADMIN attribute change: Id=[%d:" ChipLogFormatX64 "]", data.id.GetFabricIndex(),
                     ChipLogValueX64(data.id.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(data.id);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(data.id);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",
@@ -207,7 +207,7 @@ CHIP_ERROR FabricBridge::DeviceReachableChanged(ScopedNodeId scopedNodeId, bool 
     ChipLogProgress(NotSpecified, "Received device reachable changed: Id=[%d:" ChipLogFormatX64 "]", scopedNodeId.GetFabricIndex(),
                     ChipLogValueX64(scopedNodeId.GetNodeId()));
 
-    auto * device = BridgeDeviceMgr().GetDeviceByScopedNodeId(scopedNodeId);
+    auto * device = BridgedDeviceManager::Instance().GetDeviceByScopedNodeId(scopedNodeId);
     if (device == nullptr)
     {
         ChipLogError(NotSpecified, "Could not find bridged device associated with Id=[%d:0x" ChipLogFormatX64 "]",

--- a/examples/fabric-sync/shell/AddBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/AddBridgeCommand.cpp
@@ -48,13 +48,13 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
     if (err == CHIP_NO_ERROR)
     {
-        admin::DeviceMgr().SetRemoteBridgeNodeId(mBridgeNodeId);
+        admin::DeviceManager::Instance().SetRemoteBridgeNodeId(mBridgeNodeId);
 
         ChipLogProgress(NotSpecified, "Successfully paired bridge device: NodeId: " ChipLogFormatX64,
                         ChipLogValueX64(mBridgeNodeId));
 
-        admin::DeviceMgr().UpdateLastUsedNodeId(mBridgeNodeId);
-        admin::DeviceMgr().SubscribeRemoteFabricBridge();
+        admin::DeviceManager::Instance().UpdateLastUsedNodeId(mBridgeNodeId);
+        admin::DeviceManager::Instance().SubscribeRemoteFabricBridge();
 
         // After successful commissioning of the Commissionee, initiate Reverse Commissioning
         // via the Commissioner Control Cluster. However, we must first verify that the
@@ -62,7 +62,7 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
         //
         // Note: The Fabric-Admin MUST NOT send the RequestCommissioningApproval command
         // if the remote Fabric-Bridge lacks Fabric Synchronization support.
-        DeviceLayer::SystemLayer().ScheduleLambda([]() { admin::DeviceMgr().ReadSupportedDeviceCategories(); });
+        DeviceLayer::SystemLayer().ScheduleLambda([]() { admin::DeviceManager::Instance().ReadSupportedDeviceCategories(); });
     }
     else
     {
@@ -75,7 +75,7 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR AddBridgeCommand::RunCommand()
 {
-    if (admin::DeviceMgr().IsFabricSyncReady())
+    if (admin::DeviceManager::Instance().IsFabricSyncReady())
     {
         // print to console
         fprintf(stderr, "Remote Fabric Bridge has already been configured.\n");
@@ -87,7 +87,7 @@ CHIP_ERROR AddBridgeCommand::RunCommand()
     ChipLogProgress(NotSpecified, "Running AddBridgeCommand with Node ID: %lu, PIN Code: %u, Address: %s, Port: %u", mBridgeNodeId,
                     mSetupPINCode, mRemoteAddr, mRemotePort);
 
-    return admin::DeviceMgr().PairRemoteFabricBridge(mBridgeNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
+    return admin::DeviceManager::Instance().PairRemoteFabricBridge(mBridgeNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/AddDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/AddDeviceCommand.cpp
@@ -51,7 +51,7 @@ void AddDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
     {
         ChipLogProgress(NotSpecified, "Successfully paired device: NodeId: " ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
-        admin::DeviceMgr().UpdateLastUsedNodeId(mNodeId);
+        admin::DeviceManager::Instance().UpdateLastUsedNodeId(mNodeId);
     }
     else
     {
@@ -64,7 +64,7 @@ void AddDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR AddDeviceCommand::RunCommand()
 {
-    if (admin::DeviceMgr().IsCurrentBridgeDevice(mNodeId))
+    if (admin::DeviceManager::Instance().IsCurrentBridgeDevice(mNodeId))
     {
         // print to console
         fprintf(stderr, "The specified node ID has been reserved by the Fabric Bridge.\n");
@@ -76,7 +76,7 @@ CHIP_ERROR AddDeviceCommand::RunCommand()
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    return admin::DeviceMgr().PairRemoteDevice(mNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
+    return admin::DeviceManager::Instance().PairRemoteDevice(mNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
@@ -35,7 +35,7 @@ void RemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
     if (err == CHIP_NO_ERROR)
     {
-        admin::DeviceMgr().SetRemoteBridgeNodeId(kUndefinedNodeId);
+        admin::DeviceManager::Instance().SetRemoteBridgeNodeId(kUndefinedNodeId);
 
         // print to console
         fprintf(stderr, "Successfully removed bridge device: NodeId: " ChipLogFormatX64 "\n", ChipLogValueX64(mBridgeNodeId));
@@ -51,7 +51,7 @@ void RemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR RemoveBridgeCommand::RunCommand()
 {
-    NodeId bridgeNodeId = admin::DeviceMgr().GetRemoteBridgeNodeId();
+    NodeId bridgeNodeId = admin::DeviceManager::Instance().GetRemoteBridgeNodeId();
 
     if (bridgeNodeId == kUndefinedNodeId)
     {
@@ -66,7 +66,7 @@ CHIP_ERROR RemoveBridgeCommand::RunCommand()
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    return admin::DeviceMgr().UnpairRemoteFabricBridge();
+    return admin::DeviceManager::Instance().UnpairRemoteFabricBridge();
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
@@ -52,7 +52,7 @@ void RemoveDeviceCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
 
 CHIP_ERROR RemoveDeviceCommand::RunCommand()
 {
-    if (admin::DeviceMgr().IsCurrentBridgeDevice(mNodeId))
+    if (admin::DeviceManager::Instance().IsCurrentBridgeDevice(mNodeId))
     {
         // print to console
         fprintf(stderr, "The specified node ID has been reserved by the Fabric Bridge.\n");
@@ -63,7 +63,7 @@ CHIP_ERROR RemoveDeviceCommand::RunCommand()
 
     ChipLogProgress(NotSpecified, "Running RemoveDeviceCommand with Node ID: %lu", mNodeId);
 
-    return admin::DeviceMgr().UnpairRemoteDevice(mNodeId);
+    return admin::DeviceManager::Instance().UnpairRemoteDevice(mNodeId);
 }
 
 } // namespace commands


### PR DESCRIPTION
Replace traditional pattern to declare singleton using 'friend' with Meyers' Singleton pattern using a static local variable within the Instance() function).

Memory for instance is allocated the first time the Instance() method is called. This is known as lazy initialization, meaning the object is only created when it is needed for the first time.
