### PR TITLE
[scripts] Add core.symlinks=true to submodules init

### DIFF
--- a/scripts/checkout_submodules.py
+++ b/scripts/checkout_submodules.py
@@ -113,7 +113,8 @@ def checkout_modules(modules: list, shallow: bool, force: bool, recursive: bool,
     names = ', '.join([module.name for module in modules])
     logging.info(f'Checking out: {names}')
 
-    cmd = ['git', '-C', CHIP_ROOT, 'submodule', '--quiet', 'update', '--init']
+    cmd = ['git', '-c', 'core.symlinks=true', '-C', CHIP_ROOT]
+    cmd += ['submodule', '--quiet', 'update', '--init']
     cmd += ['--depth', '1'] if shallow else []
     cmd += ['--force'] if force else []
     cmd += ['--recursive'] if recursive else []


### PR DESCRIPTION
On Windows, symlinks in submodules are detected as simple text files. Adding this option to the git submodule command correctly detects the symlinks.
