### PR TITLE
FIX TC_EEVSE_2_3 test fail when run in EST timezone

### DIFF
--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -194,8 +194,11 @@ class TC_EEVSE_2_3(MatterBaseTest, EEVSEBaseTestHelper):
             f"{int(minutes_past_midnight/60)}:{int(minutes_past_midnight%60)}"
             f" Expected target_time = {target_time}")
 
-        target_time_delta = target_time - \
-            datetime(2000, 1, 1, 0, 0, 0, 0).astimezone(timezone.utc)
+
+        matter_base_time = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+        target_time_delta = target_time - matter_base_time
+
         expected_target_time_epoch_s = int(target_time_delta.total_seconds())
         return expected_target_time_epoch_s
 

--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -194,7 +194,6 @@ class TC_EEVSE_2_3(MatterBaseTest, EEVSEBaseTestHelper):
             f"{int(minutes_past_midnight/60)}:{int(minutes_past_midnight%60)}"
             f" Expected target_time = {target_time}")
 
-
         matter_base_time = datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
 
         target_time_delta = target_time - matter_base_time


### PR DESCRIPTION
Fixes #35623 

- Ensure calculation of target_time_delta in compute_expected_target_time_as_epoch_s is done fully in UTC

I've run the fix in the following time zones:
* US/Alaska
* Pacific/Auckland
* Europe/London

All tests pass under Linux.
Without the fix, it fails in Alaska and Auckland so I think the fix is good to go.
