### PR TITLE
[Fabric-Sync] Implement pair-device command

### DIFF
--- a/examples/fabric-sync/shell/BUILD.gn
+++ b/examples/fabric-sync/shell/BUILD.gn
@@ -33,6 +33,8 @@ source_set("shell") {
     "AddDeviceCommand.h",
     "CommandRegistry.cpp",
     "CommandRegistry.h",
+    "PairDeviceCommand.cpp",
+    "PairDeviceCommand.h",
     "RemoveBridgeCommand.cpp",
     "RemoveBridgeCommand.h",
     "RemoveDeviceCommand.cpp",

--- a/examples/fabric-sync/shell/PairDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/PairDeviceCommand.cpp
@@ -1,0 +1,79 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "PairDeviceCommand.h"
+
+#include <admin/DeviceManager.h>
+#include <lib/shell/streamer.h>
+
+using namespace ::chip;
+
+namespace commands {
+
+PairDeviceCommand::PairDeviceCommand(chip::NodeId nodeId, const char * payload) : mNodeId(nodeId), mPayload(payload) {}
+
+void PairDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
+{
+    if (mNodeId != deviceId)
+    {
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(NotSpecified,
+                         "Failed to pair non-specified device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                         ChipLogValueX64(deviceId), err.Format());
+        }
+        else
+        {
+            ChipLogProgress(NotSpecified, "Commissioning complete for non-specified device: NodeId: " ChipLogFormatX64,
+                            ChipLogValueX64(deviceId));
+        }
+        return;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        ChipLogProgress(NotSpecified, "Successfully paired device: NodeId: " ChipLogFormatX64, ChipLogValueX64(mNodeId));
+
+        admin::DeviceManager::Instance().UpdateLastUsedNodeId(mNodeId);
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Failed to pair device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(deviceId), err.Format());
+    }
+
+    CommandRegistry::Instance().ResetActiveCommand();
+}
+
+CHIP_ERROR PairDeviceCommand::RunCommand()
+{
+    if (admin::DeviceManager::Instance().IsCurrentBridgeDevice(mNodeId))
+    {
+        // print to console
+        fprintf(stderr, "The specified node ID has been reserved by the Fabric Bridge.\n");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    ChipLogProgress(NotSpecified, "Running PairDeviceCommand with Node ID: %lu, Code: %s", mNodeId, mPayload);
+
+    admin::PairingManager::Instance().SetPairingDelegate(this);
+
+    return admin::PairingManager::Instance().PairDeviceWithCode(mNodeId, mPayload);
+}
+
+} // namespace commands

--- a/examples/fabric-sync/shell/PairDeviceCommand.h
+++ b/examples/fabric-sync/shell/PairDeviceCommand.h
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (c) 2024 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include <CommandRegistry.h>
+#include <admin/PairingManager.h>
+
+namespace commands {
+
+class PairDeviceCommand : public Command, public admin::PairingDelegate
+{
+public:
+    PairDeviceCommand(chip::NodeId nodeId, const char * payload);
+    void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) override;
+    CHIP_ERROR RunCommand() override;
+
+private:
+    chip::NodeId mNodeId;
+    const char * mPayload;
+};
+
+} // namespace commands

--- a/examples/fabric-sync/shell/ShellCommands.cpp
+++ b/examples/fabric-sync/shell/ShellCommands.cpp
@@ -17,6 +17,7 @@
 #include "ShellCommands.h"
 #include "AddBridgeCommand.h"
 #include "AddDeviceCommand.h"
+#include "PairDeviceCommand.h"
 #include "RemoveBridgeCommand.h"
 #include "RemoveDeviceCommand.h"
 
@@ -45,6 +46,7 @@ static CHIP_ERROR PrintAllCommands()
     streamer_printf(sout,
                     "  add-device       Pair a device to local fabric. Usage: app add-device node-id setup-pin-code "
                     "device-remote-ip device-remote-port\r\n");
+    streamer_printf(sout, "  pair-device       Pair a device to local fabric. Usage: app pair-device node-id code\r\n");
     streamer_printf(sout, "  remove-device    Remove a device from the local fabric. Usage: app remove-device node-id\r\n");
     streamer_printf(sout, "  sync-device      Sync a device from other ecosystem. Usage: app sync-device endpointid\r\n");
     streamer_printf(sout, "\r\n");
@@ -144,6 +146,36 @@ static CHIP_ERROR HandleAddDeviceCommand(int argc, char ** argv)
     return result;
 }
 
+static CHIP_ERROR HandlePairDeviceCommand(int argc, char ** argv)
+{
+    if (argc != 3)
+    {
+        fprintf(stderr, "Invalid arguments. Usage: app pair-device node-id code\n");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Check if there is already an active command
+    if (commands::CommandRegistry::Instance().IsCommandActive())
+    {
+        fprintf(stderr, "Another command is currently active. Please wait until it completes.\n");
+        return CHIP_ERROR_BUSY;
+    }
+
+    // Parse arguments
+    chip::NodeId nodeId    = static_cast<chip::NodeId>(strtoull(argv[1], nullptr, 10));
+    const char * setUpCode = argv[2];
+
+    auto command = std::make_unique<commands::PairDeviceCommand>(nodeId, setUpCode);
+
+    CHIP_ERROR result = command->RunCommand();
+    if (result == CHIP_NO_ERROR)
+    {
+        commands::CommandRegistry::Instance().SetActiveCommand(std::move(command));
+    }
+
+    return result;
+}
+
 static CHIP_ERROR HandleRemoveDeviceCommand(int argc, char ** argv)
 {
     if (argc != 2)
@@ -196,6 +228,10 @@ static CHIP_ERROR AppPlatformHandler(int argc, char ** argv)
     else if (strcmp(argv[0], "add-device") == 0)
     {
         return HandleAddDeviceCommand(argc, argv);
+    }
+    else if (strcmp(argv[0], "pair-device") == 0)
+    {
+        return HandlePairDeviceCommand(argc, argv);
     }
     else if (strcmp(argv[0], "remove-device") == 0)
     {

--- a/examples/fabric-sync/shell/ShellCommands.cpp
+++ b/examples/fabric-sync/shell/ShellCommands.cpp
@@ -46,7 +46,7 @@ static CHIP_ERROR PrintAllCommands()
     streamer_printf(sout,
                     "  add-device       Pair a device to local fabric. Usage: app add-device node-id setup-pin-code "
                     "device-remote-ip device-remote-port\r\n");
-    streamer_printf(sout, "  pair-device       Pair a device to local fabric. Usage: app pair-device node-id code\r\n");
+    streamer_printf(sout, "  pair-device      Pair a device to local fabric. Usage: app pair-device node-id code\r\n");
     streamer_printf(sout, "  remove-device    Remove a device from the local fabric. Usage: app remove-device node-id\r\n");
     streamer_printf(sout, "  sync-device      Sync a device from other ecosystem. Usage: app sync-device endpointid\r\n");
     streamer_printf(sout, "\r\n");


### PR DESCRIPTION
We don't have 'pairing onnetwork' command in fabric-sync since it is not inherited from chip-tool, basically we need to implement all commands we need to do fabric-sync.

This command allow to pair a simulated matter device started on the same machine, then we don't need to use a separate matter device to test fabric-sync, just like what we did in the cert test. 

```
./out/linux-x64-all-clusters-no-ble/chip-all-clusters-app --discriminator 3843 --passcode 20202023 --secured-device-port 5543 --KVS /tmp/chip_all-cluster-kvs

Add device on user prompt:
> app pair-device 3 34970312335
```