### PR TITLE
[Fabric-Sync] Set remote bridge after reverse pair the bridge device

### DIFF
--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -72,11 +72,7 @@ void DeviceManager::UpdateLastUsedNodeId(NodeId nodeId)
 void DeviceManager::SetRemoteBridgeNodeId(chip::NodeId nodeId)
 {
     mRemoteBridgeNodeId = nodeId;
-
-    if (mRemoteBridgeNodeId != kUndefinedNodeId)
-    {
-        mCommissionerControl.Init(PairingManager::Instance().CurrentCommissioner(), mRemoteBridgeNodeId, kAggregatorEndpointId);
-    }
+    ChipLogProgress(NotSpecified, "Set remote bridge NodeId:" ChipLogFormatX64, ChipLogValueX64(mRemoteBridgeNodeId));
 }
 
 void DeviceManager::AddSyncedDevice(const SyncedDevice & device)
@@ -129,6 +125,18 @@ void DeviceManager::RemoveSyncedDevice(chip::ScopedNodeId scopedNodeId)
     mSyncedDevices.erase(*device);
     ChipLogProgress(NotSpecified, "Removed synced device: NodeId:" ChipLogFormatX64 ", EndpointId %u",
                     ChipLogValueX64(device->GetNodeId()), device->GetEndpointId());
+}
+
+void DeviceManager::InitCommissionerControl()
+{
+    if (mRemoteBridgeNodeId != kUndefinedNodeId)
+    {
+        mCommissionerControl.Init(PairingManager::Instance().CurrentCommissioner(), mRemoteBridgeNodeId, kAggregatorEndpointId);
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Failed to initialize the Commissioner Control delegate");
+    }
 }
 
 void DeviceManager::OpenLocalBridgeCommissioningWindow(uint32_t iterations, uint16_t commissioningTimeoutSec,

--- a/examples/fabric-sync/admin/DeviceManager.h
+++ b/examples/fabric-sync/admin/DeviceManager.h
@@ -77,6 +77,11 @@ public:
     void RemoveSyncedDevice(chip::ScopedNodeId scopedNodeId);
 
     /**
+     * @brief Initializes the CommissionerControl for fabric sync setup process.
+     */
+    void InitCommissionerControl();
+
+    /**
      * @brief Determines whether a given nodeId corresponds to the remote bridge device.
      *
      * @param nodeId            The ID of the node being checked.

--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -86,15 +86,14 @@ FabricAdmin::CommissionRemoteBridge(Controller::CommissioningWindowPasscodeParam
 
     if (err == CHIP_NO_ERROR)
     {
-        NodeId nodeId = DeviceManager::Instance().GetNextAvailableNodeId();
-        mNodeId       = nodeId;
+        mNodeId = DeviceManager::Instance().GetNextAvailableNodeId();
 
         // After responding with RequestCommissioningApproval to the node where the client initiated the
         // RequestCommissioningApproval, you need to wait for it to open a commissioning window on its bridge.
         usleep(kCommissionPrepareTimeMs * 1000);
 
         PairingManager::Instance().SetPairingDelegate(this);
-        DeviceManager::Instance().PairRemoteDevice(nodeId, code.c_str());
+        DeviceManager::Instance().PairRemoteDevice(mNodeId, code.c_str());
     }
     else
     {

--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -87,11 +87,13 @@ FabricAdmin::CommissionRemoteBridge(Controller::CommissioningWindowPasscodeParam
     if (err == CHIP_NO_ERROR)
     {
         NodeId nodeId = DeviceManager::Instance().GetNextAvailableNodeId();
+        mNodeId       = nodeId;
 
         // After responding with RequestCommissioningApproval to the node where the client initiated the
         // RequestCommissioningApproval, you need to wait for it to open a commissioning window on its bridge.
         usleep(kCommissionPrepareTimeMs * 1000);
 
+        PairingManager::Instance().SetPairingDelegate(this);
         DeviceManager::Instance().PairRemoteDevice(nodeId, code.c_str());
     }
     else
@@ -113,6 +115,28 @@ CHIP_ERROR FabricAdmin::KeepActive(ScopedNodeId scopedNodeId, uint32_t stayActiv
 
     DeviceLayer::PlatformMgr().ScheduleWork(KeepActiveWork, reinterpret_cast<intptr_t>(data));
     return CHIP_NO_ERROR;
+}
+
+void FabricAdmin::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
+{
+    if (mNodeId != deviceId)
+    {
+        ChipLogError(NotSpecified, "Tried to pair a non-bridge device (0x:" ChipLogFormatX64 ") with result: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(deviceId), err.Format());
+        return;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        DeviceManager::Instance().SetRemoteBridgeNodeId(deviceId);
+    }
+    else
+    {
+        ChipLogError(NotSpecified, "Failed to pair bridge device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(deviceId), err.Format());
+    }
+
+    mNodeId = kUndefinedNodeId;
 }
 
 void FabricAdmin::ScheduleSendingKeepActiveOnCheckIn(ScopedNodeId scopedNodeId, uint32_t stayActiveDurationMs, uint32_t timeoutMs)

--- a/examples/fabric-sync/admin/FabricAdmin.h
+++ b/examples/fabric-sync/admin/FabricAdmin.h
@@ -37,7 +37,7 @@ struct ScopedNodeIdHasher
     }
 };
 
-class FabricAdmin final : public bridge::FabricAdminDelegate
+class FabricAdmin final : public bridge::FabricAdminDelegate, public PairingDelegate
 {
 public:
     static FabricAdmin & Instance();
@@ -50,6 +50,8 @@ public:
                            uint16_t productId) override;
 
     CHIP_ERROR KeepActive(chip::ScopedNodeId scopedNodeId, uint32_t stayActiveDurationMs, uint32_t timeoutMs) override;
+
+    void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) override;
 
     void ScheduleSendingKeepActiveOnCheckIn(chip::ScopedNodeId scopedNodeId, uint32_t stayActiveDurationMs, uint32_t timeoutMs);
 
@@ -88,7 +90,8 @@ private:
 
     static FabricAdmin sInstance;
 
-    bool mInitialized = false;
+    bool mInitialized    = false;
+    chip::NodeId mNodeId = chip::kUndefinedNodeId;
 
     void Init() { mInitialized = true; }
 };

--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -281,6 +281,12 @@ void PairingManager::OnPairingDeleted(CHIP_ERROR err)
 
 void PairingManager::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
 {
+    if (mPairingDelegate)
+    {
+        mPairingDelegate->OnCommissioningComplete(nodeId, err);
+        SetPairingDelegate(nullptr);
+    }
+
     if (err == CHIP_NO_ERROR)
     {
         // print to console
@@ -293,12 +299,6 @@ void PairingManager::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
     else
     {
         ChipLogProgress(NotSpecified, "Device commissioning Failure: %s", ErrorStr(err));
-    }
-
-    if (mPairingDelegate)
-    {
-        mPairingDelegate->OnCommissioningComplete(nodeId, err);
-        SetPairingDelegate(nullptr);
     }
 }
 

--- a/examples/fabric-sync/shell/AddBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/AddBridgeCommand.cpp
@@ -55,6 +55,7 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 
         admin::DeviceManager::Instance().UpdateLastUsedNodeId(mBridgeNodeId);
         admin::DeviceManager::Instance().SubscribeRemoteFabricBridge();
+        admin::DeviceManager::Instance().InitCommissionerControl();
 
         // After successful commissioning of the Commissionee, initiate Reverse Commissioning
         // via the Commissioner Control Cluster. However, we must first verify that the


### PR DESCRIPTION
After complete fabric sync setup process from E1 to E2, we not only need to setup the remote fabric bridge in E1, but also need to setup the remote bridge in E2. Otherwise, we can only sync device from E2 to E1, not the other direction.

This is the fix ported from https://github.com/project-chip/connectedhomeip/pull/36451
