### PR TITLE
[Fabric-Sync] Fix failing to pair sync device

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -381,13 +381,14 @@ void DeviceManager::HandleAttributePartsListUpdate(TLV::TLVReader & data)
     for (const auto & endpoint : addedEndpoints)
     {
         // print to console
-        fprintf(stderr, "A new device is added on Endpoint: %u\n", endpoint);
+        fprintf(stderr, "A new endpoint %u is added on the remote bridge\n", endpoint);
     }
 
     // Process removed endpoints
     for (const auto & endpoint : removedEndpoints)
     {
-        ChipLogProgress(NotSpecified, "Endpoint removed: %u", endpoint);
+        // print to console
+        fprintf(stderr, "Endpoint %u removed from the remote bridge\n", endpoint);
 
         Device * device = FindDeviceByEndpoint(endpoint);
 

--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -381,14 +381,13 @@ void DeviceManager::HandleAttributePartsListUpdate(TLV::TLVReader & data)
     for (const auto & endpoint : addedEndpoints)
     {
         // print to console
-        fprintf(stderr, "A new endpoint %u is added on the remote bridge\n", endpoint);
+        fprintf(stderr, "A new device is added on Endpoint: %u\n", endpoint);
     }
 
     // Process removed endpoints
     for (const auto & endpoint : removedEndpoints)
     {
-        // print to console
-        fprintf(stderr, "Endpoint %u removed from the remote bridge\n", endpoint);
+        ChipLogProgress(NotSpecified, "Endpoint removed: %u", endpoint);
 
         Device * device = FindDeviceByEndpoint(endpoint);
 

--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -450,13 +450,14 @@ void DeviceManager::HandleAttributePartsListUpdate(TLV::TLVReader & data)
     for (const auto & endpoint : addedEndpoints)
     {
         // print to console
-        fprintf(stderr, "A new device is added on Endpoint: %u\n", endpoint);
+        fprintf(stderr, "A new endpoint %u is added on the remote bridge\n", endpoint);
     }
 
     // Process removed endpoints
     for (const auto & endpoint : removedEndpoints)
     {
-        ChipLogProgress(NotSpecified, "Endpoint removed: %u", endpoint);
+        // print to console
+        fprintf(stderr, "Endpoint %u removed from the remote bridge\n", endpoint);
 
         SyncedDevice * device = FindDeviceByEndpoint(endpoint);
 

--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -467,6 +467,11 @@ void PairingManager::OnCurrentFabricRemove(void * context, NodeId nodeId, CHIP_E
             self->mPairingDelegate->OnDeviceRemoved(nodeId, err);
             self->SetPairingDelegate(nullptr);
         }
+
+        FabricIndex fabricIndex = self->CurrentCommissioner().GetFabricIndex();
+        app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(fabricIndex, nodeId);
+        ScopedNodeId scopedNodeId(nodeId, fabricIndex);
+        DeviceManager::Instance().RemoveSyncedDevice(scopedNodeId);
     }
     else
     {

--- a/examples/fabric-sync/bridge/src/Bridge.cpp
+++ b/examples/fabric-sync/bridge/src/Bridge.cpp
@@ -192,6 +192,7 @@ void BridgedDeviceInformationCommandHandler::InvokeCommand(HandlerContext & hand
 
 BridgedAdministratorCommissioning gBridgedAdministratorCommissioning;
 BridgedDeviceBasicInformationImpl gBridgedDeviceBasicInformationAttributes;
+AdministratorCommissioningCommandHandler gAdministratorCommissioningCommandHandler;
 BridgedDeviceInformationCommandHandler gBridgedDeviceInformationCommandHandler;
 
 } // namespace
@@ -199,6 +200,7 @@ BridgedDeviceInformationCommandHandler gBridgedDeviceInformationCommandHandler;
 CHIP_ERROR BridgeInit(FabricAdminDelegate * delegate)
 {
     MatterEcosystemInformationPluginServerInitCallback();
+    CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gAdministratorCommissioningCommandHandler);
     CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gBridgedDeviceInformationCommandHandler);
     AttributeAccessInterfaceRegistry::Instance().Register(&gBridgedDeviceBasicInformationAttributes);
 


### PR DESCRIPTION
It looks I missed to logic to intercept the AdministratorCommissioning command, app sync-device always fail since the bridge does not forward the command to open the commission window of the device
