### PR TITLE
Darwin XPC:  allow `NSDate` typed objects in `internalProperties` dictionary

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -258,7 +258,8 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 
 - (BOOL)_internalState:(NSDictionary *)dictionary hasValidValuesForKeys:(const NSArray<NSString *> *)keys valueRequired:(BOOL)required
 {
-    // All the keys are NSNumber-valued.
+    // At one point, all keys were NSNumber valued; now there are also NSDates.
+    // TODO:  Create a mapping between keys and their expected types and use that in the type check below.
     for (NSString * key in keys) {
         id value = dictionary[key];
         if (!value) {
@@ -269,7 +270,7 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 
             continue;
         }
-        if (!MTR_SAFE_CAST(value, NSNumber)) {
+        if (!MTR_SAFE_CAST(value, NSNumber) && !MTR_SAFE_CAST(value, NSDate)) {
             MTR_LOG_ERROR("%@ device:internalStateUpdated: handed state with invalid value for \"%@\": %@", self, key, value);
             return NO;
         }


### PR DESCRIPTION
`internalProperties` dictionary now includes dates (like for `MostRecentReportTime`).

A more robust fix would also map keys to expected types rather than allowing numbers and dates for each key.
