### PR TITLE
chef-fan-control: Remove unnecessary circular callback checks

### DIFF
--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -26,6 +26,7 @@
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <map>
 
 #include <functional>
 
@@ -35,6 +36,7 @@ using namespace chip::app::DataModel;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::FanControl;
 using namespace chip::app::Clusters::FanControl::Attributes;
+using namespace std;
 using Protocols::InteractionModel::Status;
 
 namespace {
@@ -207,11 +209,6 @@ FanControl::FanModeEnum ChefFanControlManager::SpeedToFanMode(uint8_t speed)
 
 void ChefFanControlManager::SetPercentCurrent(uint8_t aNewPercentCurrent)
 {
-    if (aNewPercentCurrent == mPercentCurrent)
-    {
-        return;
-    }
-
     ChipLogDetail(NotSpecified, "ChefFanControlManager::SetPercentCurrent: %d", aNewPercentCurrent);
     mPercentCurrent = aNewPercentCurrent;
     Status status   = FanControl::Attributes::PercentCurrent::Set(mEndpoint, mPercentCurrent);
@@ -224,12 +221,6 @@ void ChefFanControlManager::SetPercentCurrent(uint8_t aNewPercentCurrent)
 
 void ChefFanControlManager::SetSpeedCurrent(uint8_t aNewSpeedCurrent)
 {
-    if (aNewSpeedCurrent == mSpeedCurrent)
-    {
-        return;
-    }
-
-    ChipLogDetail(NotSpecified, "ChefFanControlManager::SetSpeedCurrent: %d", aNewSpeedCurrent);
     mSpeedCurrent = aNewSpeedCurrent;
     Status status = FanControl::Attributes::SpeedCurrent::Set(mEndpoint, aNewSpeedCurrent);
     if (status != Status::Success)
@@ -245,11 +236,8 @@ void ChefFanControlManager::FanModeWriteCallback(FanControl::FanModeEnum aNewFan
     switch (aNewFanMode)
     {
     case FanControl::FanModeEnum::kOff: {
-        if (mSpeedCurrent != 0)
-        {
-            DataModel::Nullable<uint8_t> speedSetting(0);
-            SetSpeedSetting(speedSetting);
-        }
+        DataModel::Nullable<uint8_t> speedSetting(0);
+        SetSpeedSetting(speedSetting);
         break;
     }
     case FanControl::FanModeEnum::kLow: {
@@ -291,20 +279,11 @@ void ChefFanControlManager::FanModeWriteCallback(FanControl::FanModeEnum aNewFan
 
 void ChefFanControlManager::SetSpeedSetting(DataModel::Nullable<uint8_t> aNewSpeedSetting)
 {
-    if (aNewSpeedSetting.IsNull())
+    Status status = FanControl::Attributes::SpeedSetting::Set(mEndpoint, aNewSpeedSetting);
+    if (status != Status::Success)
     {
-        ChipLogError(NotSpecified, "ChefFanControlManager::SetSpeedSetting: null value is invalid");
-        return;
-    }
-
-    if (aNewSpeedSetting.Value() != mSpeedCurrent)
-    {
-        Status status = FanControl::Attributes::SpeedSetting::Set(mEndpoint, aNewSpeedSetting);
-        if (status != Status::Success)
-        {
-            ChipLogError(NotSpecified, "ChefFanControlManager::SetSpeedSetting: failed to set SpeedSetting attribute: %d",
-                         to_underlying(status));
-        }
+        ChipLogError(NotSpecified, "ChefFanControlManager::SetSpeedSetting: failed to set SpeedSetting attribute: %d",
+                     to_underlying(status));
     }
 }
 

--- a/examples/chef/common/chef-fan-control-manager.cpp
+++ b/examples/chef/common/chef-fan-control-manager.cpp
@@ -26,7 +26,6 @@
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <map>
 
 #include <functional>
 
@@ -36,7 +35,6 @@ using namespace chip::app::DataModel;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::FanControl;
 using namespace chip::app::Clusters::FanControl::Attributes;
-using namespace std;
 using Protocols::InteractionModel::Status;
 
 namespace {


### PR DESCRIPTION
With the recent circular callback bugfixes implemented in the cluster code in [36515](https://github.com/project-chip/connectedhomeip/pull/36515) and [36489](https://github.com/project-chip/connectedhomeip/pull/36489), we can now safely remove unnecessary checks that prevented the circular callbacks on the app side.
