### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-91 : [Ameba] Update matter timers and add more examples
+92 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=9ab2325bf76bc7bec92a3ff93fad80ec5d3eae7c
+ARG ZEPHYR_REVISION=d88a47760dd4c7e57dfcc83e7c5856a9cea88fc1
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=f762f1a1027284e63e338e6d83deeade62f355b0
+ARG ZEPHYR_REVISION=9ab2325bf76bc7bec92a3ff93fad80ec5d3eae7c
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- telink: b92: fix pwm fault pulse
- soc: riscv: telink_b9x: Add timer usage example
- telink: telink_tlx: create new SoC TL321x
- kconfig: update N22 binary revision

**Changes of N22 binary:**

- [refactor]:Sync with SDK-1.2.7
- Fix build issues with SCM-1.2.7
- Add ipc-nuttx app
- New Zephyr IPC data structure. Set IPC_ICMSG_W91_DEPRECATED_BUF to 'n' for Zephyr 2.7+

Testing
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully