### PR TITLE
Deliver SIGINT to the shell thread to interrupt read()

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -684,11 +684,12 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
     ApplicationInit();
 
-    struct sigaction sa = {};
-    sa.sa_handler       = StopSignalHandler;
-    sa.sa_flags         = SA_RESETHAND;
-    sigaction(SIGINT, &sa, nullptr);
-    sigaction(SIGTERM, &sa, nullptr);
+#if !defined(ENABLE_CHIP_SHELL)
+    // NOLINTBEGIN(bugprone-signal-handler)
+    signal(SIGINT, StopSignalHandler);
+    signal(SIGTERM, StopSignalHandler);
+    // NOLINTEND(bugprone-signal-handler)
+#endif // !defined(ENABLE_CHIP_SHELL)
 
     if (impl != nullptr)
     {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -684,12 +684,10 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
     ApplicationInit();
 
-#if !defined(ENABLE_CHIP_SHELL)
     // NOLINTBEGIN(bugprone-signal-handler)
     signal(SIGINT, StopSignalHandler);
     signal(SIGTERM, StopSignalHandler);
     // NOLINTEND(bugprone-signal-handler)
-#endif // !defined(ENABLE_CHIP_SHELL)
 
     if (impl != nullptr)
     {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -318,18 +318,13 @@ void Cleanup()
     // TODO(16968): Lifecycle management of storage-using components like GroupDataProvider, etc
 }
 
-// TODO(#20664) REPL test will fail if signal SIGINT is not caught, temporarily keep following logic.
-
-// when the shell is enabled, don't intercept signals since it prevents the user from
-// using expected commands like CTRL-C to quit the application. (see issue #17845)
-// We should stop using signals for those faults, and move to a different notification
-// means, like a pipe. (see issue #19114)
-#if !defined(ENABLE_CHIP_SHELL)
 void StopSignalHandler(int /* signal */)
 {
+#if defined(ENABLE_CHIP_SHELL)
+    Engine::Root().StopMainLoop();
+#endif
     StopMainEventLoop();
 }
-#endif // !defined(ENABLE_CHIP_SHELL)
 
 } // namespace
 
@@ -407,6 +402,18 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
         err = DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(LinuxDeviceOptions::GetInstance().KVS);
     }
     SuccessOrExit(err);
+#endif
+
+#if defined(ENABLE_CHIP_SHELL)
+    /* Block SIGINT and SIGTERM. Other threads created by the main thread
+     * will inherit the signal mask. Then we can explicitly unblock signals
+     * in the shell thread to handle them, so the read(stdin) call can be
+     * interrupted by a signal. */
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGINT);
+    sigaddset(&set, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &set, NULL);
 #endif
 
     err = DeviceLayer::PlatformMgr().InitChipStack();
@@ -532,6 +539,13 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();
     std::thread shellThread([]() {
+        sigset_t set;
+        sigemptyset(&set);
+        sigaddset(&set, SIGINT);
+        sigaddset(&set, SIGTERM);
+        // Unblock SIGINT and SIGTERM, so that the shell thread can handle
+        // them - we need read() call to be interrupted.
+        pthread_sigmask(SIG_UNBLOCK, &set, NULL);
         Engine::Root().RunMainLoop();
         StopMainEventLoop();
     });
@@ -670,12 +684,11 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
 
     ApplicationInit();
 
-#if !defined(ENABLE_CHIP_SHELL)
-    // NOLINTBEGIN(bugprone-signal-handler)
-    signal(SIGINT, StopSignalHandler);
-    signal(SIGTERM, StopSignalHandler);
-    // NOLINTEND(bugprone-signal-handler)
-#endif // !defined(ENABLE_CHIP_SHELL)
+    struct sigaction sa = {};
+    sa.sa_handler       = StopSignalHandler;
+    sa.sa_flags         = SA_RESETHAND;
+    sigaction(SIGINT, &sa, nullptr);
+    sigaction(SIGTERM, &sa, nullptr);
 
     if (impl != nullptr)
     {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -694,9 +694,9 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     signal(SIGTERM, StopSignalHandler);
     // NOLINTEND(bugprone-signal-handler)
 #else
-    struct sigaction sa = {};
-    sa.sa_handler       = StopSignalHandler;
-    sa.sa_flags         = SA_RESETHAND;
+    struct sigaction sa                        = {};
+    sa.sa_handler                              = StopSignalHandler;
+    sa.sa_flags                                = SA_RESETHAND;
     sigaction(SIGINT, &sa, nullptr);
     sigaction(SIGTERM, &sa, nullptr);
 #endif

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -16,6 +16,8 @@
  *    limitations under the License.
  */
 
+#include <signal.h>
+
 #include "commands/clusters/SubscriptionsCommands.h"
 #include "commands/common/Commands.h"
 #include "commands/example/ExampleCredentialIssuerCommands.h"
@@ -105,17 +107,56 @@ CHIP_ERROR ProcessClusterCommand(int argc, char ** argv)
     return CHIP_NO_ERROR;
 }
 
+void StopMainEventLoop()
+{
+    Server::GetInstance().GenerateShutDownEvent();
+    DeviceLayer::SystemLayer().ScheduleLambda([]() { DeviceLayer::PlatformMgr().StopEventLoopTask(); });
+}
+
+void StopSignalHandler(int /* signal */)
+{
+#if defined(ENABLE_CHIP_SHELL)
+    Engine::Root().StopMainLoop();
+#endif
+    StopMainEventLoop();
+}
+
 int main(int argc, char * argv[])
 {
-    ChipLogProgress(AppServer, "chip_casting_simplified = 0"); // this file is built/run only if chip_casting_simplified = 0
+    // This file is built/run only if chip_casting_simplified = 0
+    ChipLogProgress(AppServer, "chip_casting_simplified = 0");
+
+#if defined(ENABLE_CHIP_SHELL)
+    /* Block SIGINT and SIGTERM. Other threads created by the main thread
+     * will inherit the signal mask. Then we can explicitly unblock signals
+     * in the shell thread to handle them, so the read(stdin) call can be
+     * interrupted by a signal. */
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGINT);
+    sigaddset(&set, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &set, nullptr);
+#endif
+
     VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
     VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
 
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();
-    std::thread shellThread([]() { Engine::Root().RunMainLoop(); });
     Shell::RegisterCastingCommands();
+    std::thread shellThread([]() {
+        sigset_t set_;
+        sigemptyset(&set_);
+        sigaddset(&set_, SIGINT);
+        sigaddset(&set_, SIGTERM);
+        // Unblock SIGINT and SIGTERM, so that the shell thread can handle
+        // them - we need read() call to be interrupted.
+        pthread_sigmask(SIG_UNBLOCK, &set_, nullptr);
+        Engine::Root().RunMainLoop();
+        StopMainEventLoop();
+    });
 #endif
+
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init(CHIP_CONFIG_KVS_PATH);
@@ -172,11 +213,25 @@ int main(int argc, char * argv[])
         ProcessClusterCommand(argc, argv);
     }
 
+    {
+        struct sigaction sa = {};
+        sa.sa_handler       = StopSignalHandler;
+        sa.sa_flags         = SA_RESETHAND;
+        sigaction(SIGINT, &sa, nullptr);
+        sigaction(SIGTERM, &sa, nullptr);
+    }
+
     DeviceLayer::PlatformMgr().RunEventLoop();
+
 exit:
+
 #if defined(ENABLE_CHIP_SHELL)
     shellThread.join();
 #endif
+
+    chip::Server::GetInstance().Shutdown();
+    chip::DeviceLayer::PlatformMgr().Shutdown();
+
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "Failed to run TV Casting App: %s", ErrorStr(err));

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -32,7 +32,7 @@ from linux.tv_casting_test_sequences import START_APP, STOP_APP
 """
 This script can be used to validate the casting experience between the Linux tv-casting-app and the Linux tv-app.
 
-It runs a series of test sequences that check for expected output lines from the tv-casting-app and the tv-app in 
+It runs a series of test sequences that check for expected output lines from the tv-casting-app and the tv-app in
 a deterministic order. If these lines are not found, it indicates an issue with the casting experience.
 """
 
@@ -92,24 +92,14 @@ def stop_app(test_sequence_name: str, app_name: str, app: ProcessOutputCapture):
             None,
         )
 
-    if app_exit_code >= 0:
+    if app_exit_code != 0:
         raise TestStepException(
             f"{test_sequence_name}: {app_name} exited with unexpected exit code {app_exit_code}.",
             test_sequence_name,
             None,
         )
 
-    signal_number = -app_exit_code
-    if signal_number != signal.SIGTERM.value:
-        raise TestStepException(
-            f"{test_sequence_name}: {app_name} stopped by signal {signal_number} instead of {signal.SIGTERM.value} (SIGTERM).",
-            test_sequence_name,
-            None,
-        )
-
-    logging.info(
-        f"{test_sequence_name}: {app_name} stopped by {signal_number} (SIGTERM) signal."
-    )
+    logging.info(f"{test_sequence_name}: {app_name} stopped.")
 
 
 def parse_output_msg_in_subprocess(

--- a/scripts/tests/run_tv_casting_test.py
+++ b/scripts/tests/run_tv_casting_test.py
@@ -17,7 +17,6 @@
 import glob
 import logging
 import os
-import signal
 import sys
 import tempfile
 import time

--- a/src/lib/shell/Engine.h
+++ b/src/lib/shell/Engine.h
@@ -120,6 +120,13 @@ public:
     void RunMainLoop();
 
     /**
+     * Stop the shell mainloop on the next iteration.
+     *
+     * @note This method can be called from a signal handler to stop the main loop.
+     */
+    void StopMainLoop() { mRunning = false; }
+
+    /**
      * Initialize the Shell::Engine.
      *
      * Activates the linked streamer, registers default commands, and sets up exit handlers.
@@ -130,6 +137,7 @@ public:
 
 private:
     static void ProcessShellLineTask(intptr_t context);
+    bool mRunning = true;
 };
 
 } // namespace Shell

--- a/src/lib/shell/MainLoopAmeba.cpp
+++ b/src/lib/shell/MainLoopAmeba.cpp
@@ -135,7 +135,7 @@ namespace Shell {
 void Engine::RunMainLoop()
 {
     char line[CHIP_SHELL_MAX_LINE_SIZE];
-    while (true)
+    while (mRunning)
     {
         memset(line, 0, CHIP_SHELL_MAX_LINE_SIZE);
         if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) > 0u)

--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -15,13 +15,15 @@
  *    limitations under the License.
  */
 
-#include "streamer.h"
+#include <ctype.h>
+#include <errno.h>
+#include <string.h>
+
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#include <ctype.h>
-#include <string.h>
+#include "streamer.h"
 
 using chip::FormatCHIPError;
 using chip::Platform::MemoryAlloc;
@@ -46,10 +48,17 @@ size_t ReadLine(char * buffer, size_t max)
             break;
         }
 
-        if (streamer_read(streamer_get(), buffer + line_sz, 1) != 1)
+        auto ret = streamer_read(streamer_get(), buffer + line_sz, 1);
+        if (ret == -1 && errno == EINTR)
         {
-            continue;
+            streamer_printf(streamer_get(), "^C\r\n");
+            // In case of EINTR (Ctrl-C) reset the buffer and start over.
+            buffer[line_sz = 0] = '\0';
+            break;
         }
+
+        if (ret != 1)
+            continue;
 
         // Process character we just read.
         switch (buffer[line_sz])
@@ -188,7 +197,7 @@ void Engine::RunMainLoop()
 {
     streamer_printf(streamer_get(), CHIP_SHELL_PROMPT);
 
-    while (true)
+    while (mRunning)
     {
         char * line = static_cast<char *>(Platform::MemoryAlloc(CHIP_SHELL_MAX_LINE_SIZE));
         if (ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE) == 0u)

--- a/src/lib/shell/MainLoopESP32.cpp
+++ b/src/lib/shell/MainLoopESP32.cpp
@@ -70,7 +70,7 @@ namespace Shell {
 
 void Engine::RunMainLoop()
 {
-    while (true)
+    while (mRunning)
     {
         const char * prompt = LOG_COLOR_I "> " LOG_RESET_COLOR;
         char * line         = linenoise(prompt);

--- a/src/lib/shell/MainLoopMW320.cpp
+++ b/src/lib/shell/MainLoopMW320.cpp
@@ -273,7 +273,7 @@ void Engine::RunMainLoop()
     Engine::Root().RegisterDefaultCommands();
     RegisterMetaCommands();
 
-    while (true)
+    while (mRunning)
     {
         streamer_printf(streamer_get(), CHIP_SHELL_PROMPT);
 

--- a/src/lib/shell/MainLoopSilabs.cpp
+++ b/src/lib/shell/MainLoopSilabs.cpp
@@ -218,7 +218,7 @@ void Engine::RunMainLoop()
 {
     streamer_printf(streamer_get(), kShellPrompt);
 
-    while (true)
+    while (mRunning)
     {
         char * line = static_cast<char *>(Platform::MemoryAlloc(CHIP_SHELL_MAX_LINE_SIZE));
         ReadLine(line, CHIP_SHELL_MAX_LINE_SIZE);


### PR DESCRIPTION
### Problem

In case when shell is enabled in the application, the SIGINT/SIGTERM handlers are not registered. This prevents the application to exit cleanly, in particular to exit with 0 return code. Such behavior prevents applications with shell enabled to be used in CI testing (non-zero return code indicates some error, which triggers CI failure).

### Changes

- register SIGINT/SIGTERM handler even if app is built with shell
- make sure that the SIGTERM and SIGINT are delivered to shell thread, so we can interrupt read()

### Testing

Locally verified that fabric-sync app (built with shell) can be terminated cleanly with Ctrl-C.
CI will verify potential breaks.