### PR TITLE
Add unit test for deleting CommandSender when response is pending

### DIFF
--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1573,8 +1573,9 @@ TEST_F(TestCommandInteraction, CommandSenderDeletedWhenResponseIsPending)
     EXPECT_EQ(GetNumActiveCommandResponderObjects(), 1u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 2u);
 
-    // One very important note worthy things to mentions is that this is NOT deleted
-    // in one of the callbacks. This is deleted when no message is being processed.
+    // This is NOT deleting CommandSender in one of the callbacks, so we are not violating
+    // the API contract. CommandSender is deleted when no message is being processed which
+    // is a time that deleting CommandSender is considered safe.
     Platform::Delete(commandSender);
 
     // Decrease CommandHandler refcount and send response

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1558,7 +1558,7 @@ TEST_F(TestCommandInteraction, CommandSenderDeletedWhenResponseIsPending)
 {
 
     mockCommandSenderDelegate.ResetCounter();
-    app::CommandSender* commandSender = Platform::New<app::CommandSender>(&mockCommandSenderDelegate, &GetExchangeManager());
+    app::CommandSender * commandSender = Platform::New<app::CommandSender>(&mockCommandSenderDelegate, &GetExchangeManager());
 
     AddInvokeRequestData(commandSender);
     asyncCommand = true;


### PR DESCRIPTION
The CommandSender Callback APIs mention that the callback implementation should not delete the CommandSender object. This requirement is still upheld with what we are unit testing here. If CommandSender is deleted by application code while a command response is pending, the CommandSender does clean up the ExchangeDelegate and ExchangeContext appropriately. We are adding a unit test to ensure that expectation is upheld.