### PR TITLE
[NXP][third_party] Fixed memory leak in BR mDNS code

### DIFF
--- a/src/platform/nxp/common/DnssdImpl.cpp
+++ b/src/platform/nxp/common/DnssdImpl.cpp
@@ -99,7 +99,7 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chi
                            chip::Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context,
                            intptr_t * browseIdentifier)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected()) //|| ESP32Utils::HasIPv6LinkLocalAddress(ESP32Utils::kDefaultEthernetNetifKey))
+    if (ConnectivityMgr().IsWiFiStationConnected())
     {
         ReturnErrorOnFailure(NxpChipDnssdBrowse(type, protocol, addressType, interface, callback, context, browseIdentifier));
     }
@@ -119,7 +119,7 @@ CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier)
 CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                             void * context)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected()) //|| ESP32Utils::HasIPv6LinkLocalAddress(ESP32Utils::kDefaultEthernetNetifKey))
+    if (ConnectivityMgr().IsWiFiStationConnected())
     {
         ReturnErrorOnFailure(NxpChipDnssdResolve(service, interface, callback, context));
     }

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -28,6 +28,8 @@
 #include <openthread/mdns.h>
 #include <openthread/srp_server.h>
 
+#include <DnssdImplBr.h>
+
 using namespace ::chip::DeviceLayer;
 using namespace chip::DeviceLayer::Internal;
 
@@ -363,6 +365,11 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
     if (type == nullptr || callback == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
+    if(mBrowseContext != nullptr)
+    {
+        NxpChipDnssdStopBrowse(reinterpret_cast<intptr_t>(mBrowseContext));
+    }
+
     mBrowseContext = Platform::New<mDnsQueryCtx>(context, callback);
     VerifyOrReturnError(mBrowseContext != nullptr, CHIP_ERROR_NO_MEMORY);
 
@@ -412,7 +419,8 @@ CHIP_ERROR NxpChipDnssdStopBrowse(intptr_t browseIdentifier)
     // that has been freed in DispatchBrowseEmpty.
     if ((true == bBrowseInProgress) && (browseContext))
     {
-        browseContext->error = MapOpenThreadError(otMdnsStopBrowser(thrInstancePtr, &browseContext->mBrowseInfo));
+        error = otMdnsStopBrowser(thrInstancePtr, &browseContext->mBrowseInfo);
+        browseContext->error = MapOpenThreadError(error);
 
         // browse context will be freed in DispatchBrowseEmpty
         DispatchBrowseEmpty(reinterpret_cast<intptr_t>(browseContext));
@@ -429,6 +437,13 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
         return CHIP_ERROR_INVALID_ARGUMENT;
 
     otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
+
+    if(mResolveContext != nullptr)
+    {
+        // In case there is an ongoing query and NxpChipDnssdResolveNoLongerNeeded has not been called yet
+        // free the allocated context and do a proper cleanup of the previous transaction
+        NxpChipDnssdResolveNoLongerNeeded(mResolveContext->mMdnsService.mName);
+    }
 
     mResolveContext = Platform::New<mDnsQueryCtx>(context, callback);
     VerifyOrReturnError(mResolveContext != nullptr, CHIP_ERROR_NO_MEMORY);
@@ -450,12 +465,16 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
         mResolveContext->mSrvInfo.mServiceInstance = mResolveContext->mMdnsService.mName;
         mResolveContext->mSrvInfo.mServiceType     = mResolveContext->mServiceType;
 
-        return MapOpenThreadError(otMdnsStartSrvResolver(thrInstancePtr, &mResolveContext->mSrvInfo));
+        error = MapOpenThreadError(otMdnsStartSrvResolver(thrInstancePtr, &mResolveContext->mSrvInfo));
     }
-    else
+
+    if (error != CHIP_NO_ERROR)
     {
-        return error;
+        Platform::Delete<mDnsQueryCtx>(mResolveContext);
+        mResolveContext = nullptr;
     }
+
+    return error;
 }
 void NxpChipDnssdResolveNoLongerNeeded(const char * instanceName)
 {

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -365,7 +365,7 @@ CHIP_ERROR NxpChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, 
     if (type == nullptr || callback == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    if(mBrowseContext != nullptr)
+    if (mBrowseContext != nullptr)
     {
         NxpChipDnssdStopBrowse(reinterpret_cast<intptr_t>(mBrowseContext));
     }
@@ -419,7 +419,7 @@ CHIP_ERROR NxpChipDnssdStopBrowse(intptr_t browseIdentifier)
     // that has been freed in DispatchBrowseEmpty.
     if ((true == bBrowseInProgress) && (browseContext))
     {
-        error = otMdnsStopBrowser(thrInstancePtr, &browseContext->mBrowseInfo);
+        error                = otMdnsStopBrowser(thrInstancePtr, &browseContext->mBrowseInfo);
         browseContext->error = MapOpenThreadError(error);
 
         // browse context will be freed in DispatchBrowseEmpty
@@ -438,7 +438,7 @@ CHIP_ERROR NxpChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId in
 
     otInstance * thrInstancePtr = ThreadStackMgrImpl().OTInstance();
 
-    if(mResolveContext != nullptr)
+    if (mResolveContext != nullptr)
     {
         // In case there is an ongoing query and NxpChipDnssdResolveNoLongerNeeded has not been called yet
         // free the allocated context and do a proper cleanup of the previous transaction


### PR DESCRIPTION
This commit fixes potential memory leaks that could happen if multiple resolve of browse operations are done without calling the appropriate stop function to clean up the allocated resources. If using the Matter CLI this issue is not possible as the CLI always stops the previous operation but other processes calling the resolve/browse API might not follow this flow.

Also fixed the return value of the StopBrowse function.
