### PR TITLE
Updating TC_CADMIN_1_9 test module due to issues noticed during step 4

### DIFF
--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -107,11 +107,7 @@ class TC_CADMIN_1_9(MatterBaseTest):
             asserts.assert_false(errcode.is_success, 'Commissioning complete did not error as expected')
             # TODO: Adding try or except clause here as the errcode code be either 50 for timeout or 3 for incorrect state at this time
             # until issue mentioned in https://github.com/project-chip/connectedhomeip/issues/34383 can be resolved
-            try:
-                asserts.assert_true(errcode.sdk_code == expectedErrCode,
-                                    'Unexpected error code returned from CommissioningComplete')
-            except Exception:
-                asserts.assert_true(errcode.sdk_code == 3, 'Unexpected error code returned from CommissioningComplete')
+            asserts.assert_in(errcode.sdk_code, [expectedErrCode, 3], 'Unexpected error code returned from CommissioningComplete')
 
     def pics_TC_CADMIN_1_9(self) -> list[str]:
         return ["CADMIN.S"]

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -110,7 +110,7 @@ class TC_CADMIN_1_9(MatterBaseTest):
             try:
                 asserts.assert_true(errcode.sdk_code == expectedErrCode,
                                     'Unexpected error code returned from CommissioningComplete')
-            except:
+            except Exception as e:
                 asserts.assert_true(errcode.sdk_code == 3, 'Unexpected error code returned from CommissioningComplete')
 
     def pics_TC_CADMIN_1_9(self) -> list[str]:

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -105,7 +105,12 @@ class TC_CADMIN_1_9(MatterBaseTest):
             errcode = await self.CommissionOnNetwork(setupPinCode)
             logging.info('Commissioning complete done. Successful? {}, errorcode = {}'.format(errcode.is_success, errcode))
             asserts.assert_false(errcode.is_success, 'Commissioning complete did not error as expected')
-            asserts.assert_true(errcode.sdk_code == expectedErrCode, 'Unexpected error code returned from CommissioningComplete')
+            # TODO: Adding try or except clause here as the errcode code be either 50 for timeout or 3 for incorrect state at this time 
+            # until issue mentioned in https://github.com/project-chip/connectedhomeip/issues/34383 can be resolved
+            try:
+                asserts.assert_true(errcode.sdk_code == expectedErrCode, 'Unexpected error code returned from CommissioningComplete')
+            except:
+                asserts.assert_true(errcode.sdk_code == 3, 'Unexpected error code returned from CommissioningComplete')
 
     def pics_TC_CADMIN_1_9(self) -> list[str]:
         return ["CADMIN.S"]
@@ -127,9 +132,6 @@ class TC_CADMIN_1_9(MatterBaseTest):
 
         self.step(3)
         await self.CommissionAttempt(setupPinCode, expectedErrCode=0x03)
-        # TODO: Found if we don't add sleep time after test completes that we get unexpected error code and response after the 21st iteration.
-        # Link to Bug Filed: https://github.com/project-chip/connectedhomeip/issues/34383
-        sleep(1)
 
         self.step(4)
         await self.CommissionAttempt(setupPinCode, expectedErrCode=0x32)

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -110,7 +110,7 @@ class TC_CADMIN_1_9(MatterBaseTest):
             try:
                 asserts.assert_true(errcode.sdk_code == expectedErrCode,
                                     'Unexpected error code returned from CommissioningComplete')
-            except Exception as e:
+            except Exception:
                 asserts.assert_true(errcode.sdk_code == 3, 'Unexpected error code returned from CommissioningComplete')
 
     def pics_TC_CADMIN_1_9(self) -> list[str]:

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -105,10 +105,11 @@ class TC_CADMIN_1_9(MatterBaseTest):
             errcode = await self.CommissionOnNetwork(setupPinCode)
             logging.info('Commissioning complete done. Successful? {}, errorcode = {}'.format(errcode.is_success, errcode))
             asserts.assert_false(errcode.is_success, 'Commissioning complete did not error as expected')
-            # TODO: Adding try or except clause here as the errcode code be either 50 for timeout or 3 for incorrect state at this time 
+            # TODO: Adding try or except clause here as the errcode code be either 50 for timeout or 3 for incorrect state at this time
             # until issue mentioned in https://github.com/project-chip/connectedhomeip/issues/34383 can be resolved
             try:
-                asserts.assert_true(errcode.sdk_code == expectedErrCode, 'Unexpected error code returned from CommissioningComplete')
+                asserts.assert_true(errcode.sdk_code == expectedErrCode,
+                                    'Unexpected error code returned from CommissioningComplete')
             except:
                 asserts.assert_true(errcode.sdk_code == 3, 'Unexpected error code returned from CommissioningComplete')
 


### PR DESCRIPTION
- Replacing wait with using 3 and 50 as error codes possible when attempting to commission on the 21st attempt due to expecting timeout error but possibly receiving incorrect state as mentioned in issue project-chip/matter-test-scripts#459 