### PR TITLE
setup: support installations with Python3.13

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -32,8 +32,6 @@ cbor2==5.4.6
     # via -r requirements.zephyr.txt
 certifi==2022.12.7
     # via requests
-cffi==1.15.1
-    # via cryptography
 charset-normalizer==3.0.1
     # via requests
 click==8.1.3

--- a/scripts/setup/requirements.all.txt
+++ b/scripts/setup/requirements.all.txt
@@ -43,6 +43,8 @@ mypy-protobuf==3.5.0
 protobuf==4.24.4
 types-protobuf==4.24.0.2
 
+cffi==1.15.0; python_version < "3.13"
+cffi==1.17.1; python_version >= "3.13"
 cryptography
 
 # python unit tests

--- a/scripts/tools/telink/requirements.txt
+++ b/scripts/tools/telink/requirements.txt
@@ -1,5 +1,6 @@
 cryptography==43.0.1
-cffi==1.15.0
+cffi==1.15.0; python_version < "3.13"
+cffi==1.17.1; python_version >= "3.13"
 future==0.18.3
 pycparser==2.21
 pypng==0.0.21


### PR DESCRIPTION
#### Problem
cffi v1.15.x is not compatible with Python3.13 and its support is added in v1.17.0 (https://github.com/python-cffi/cffi/issues/23).

#### Change overview
Conditionally install the cffi version for Python 3.13 and below versions.

#### Tests
successfully sourced bootstrap.sh with Python3.11 and Python3.13