### PR TITLE
[Linux] Fix crash when shutting down BLE Manager after platform shutdown

### DIFF
--- a/src/platform/Linux/bluez/BluezObjectManager.cpp
+++ b/src/platform/Linux/bluez/BluezObjectManager.cpp
@@ -62,6 +62,11 @@ CHIP_ERROR BluezObjectManager::Init()
 
 void BluezObjectManager::Shutdown()
 {
+    // If the D-Bus connection or the object manager are not initialized,
+    // there is nothing to shutdown. This check prevents unnecessary call
+    // to the GLibMatterContextInvokeSync function.
+    VerifyOrReturn(mConnection || mObjectManager);
+
     // Run endpoint cleanup on the CHIPoBluez thread. This is necessary because the
     // cleanup function releases the D-Bus manager client object, which handles D-Bus
     // signals. Otherwise, we will face race condition when the D-Bus signal is in


### PR DESCRIPTION
### Problem

It's not possible to call `PlatformMgrImpl().GLibMatterContextInvokeSync()` after platform was shut down. To prevent crash we should check if calling this function is necessary at all. Similar checks are in all other Shutdown() methods of BLE module.

### Testing

No crash when CHIP shutdown procedure is called twice.