### PR TITLE
Add APIs to access default SessionKeystore & PersistentStorageDelegate

### DIFF
--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -459,12 +459,12 @@ CommissionerDiscoveryController * GetCommissionerDiscoveryController()
 
 SessionKeystore * GetSessionKeystore()
 {
-    return &gSessionKeystore; 
+    return &gSessionKeystore;
 }
 
 PersistentStorageDelegate * GetPersistentStorageDelegate()
 {
-    return &gServerStorage;  
+    return &gServerStorage;
 }
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -457,4 +457,14 @@ CommissionerDiscoveryController * GetCommissionerDiscoveryController()
     return &gCommissionerDiscoveryController;
 }
 
+SessionKeystore * GetSessionKeystore()
+{
+    return &gSessionKeystore; 
+}
+
+PersistentStorageDelegate * GetPersistentStorageDelegate()
+{
+    return &gServerStorage;  
+}
+
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE

--- a/examples/platform/linux/CommissionerMain.h
+++ b/examples/platform/linux/CommissionerMain.h
@@ -28,7 +28,9 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
+using chip::PersistentStorageDelegate;
 using chip::Controller::DeviceCommissioner;
+using chip::Crypto::SessionKeystore;
 using chip::Transport::PeerAddress;
 
 CHIP_ERROR CommissionerPairOnNetwork(uint32_t pincode, uint16_t disc, PeerAddress address);
@@ -39,5 +41,7 @@ void ShutdownCommissioner();
 
 DeviceCommissioner * GetDeviceCommissioner();
 CommissionerDiscoveryController * GetCommissionerDiscoveryController();
+SessionKeystore * GetSessionKeystore();
+PersistentStorageDelegate * GetPersistentStorageDelegate();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE


### PR DESCRIPTION
The fabric-sync example app utilizes the default DeviceCommissioner from examples/platform/linux and it needs to access the default SessionKeystore and PersistentStorageDelegate to support its ICD implementation.

