### PR TITLE
Incremental improvements to controller dependencies

### DIFF
--- a/examples/fabric-admin/device_manager/DeviceManager.cpp
+++ b/examples/fabric-admin/device_manager/DeviceManager.cpp
@@ -227,8 +227,9 @@ void DeviceManager::SubscribeRemoteFabricBridge()
 
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "Failed to subscribe to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+        ChipLogError(NotSpecified,
+                     "Failed to subscribe to the remote bridge (NodeId: " ChipLogFormatX64 "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 }
@@ -251,8 +252,9 @@ void DeviceManager::ReadSupportedDeviceCategories()
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to read SupportedDeviceCategories from the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to read SupportedDeviceCategories from the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
     }
 }
 
@@ -293,8 +295,9 @@ void DeviceManager::RequestCommissioningApproval()
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to request commissioning-approval to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to request commissioning-approval to the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 
@@ -417,8 +420,9 @@ void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t respo
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to send CommissionNode command to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to send CommissionNode command to the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 }

--- a/examples/fabric-sync/admin/DeviceManager.cpp
+++ b/examples/fabric-sync/admin/DeviceManager.cpp
@@ -296,8 +296,9 @@ void DeviceManager::SubscribeRemoteFabricBridge()
 
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "Failed to subscribe to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+        ChipLogError(NotSpecified,
+                     "Failed to subscribe to the remote bridge (NodeId: " ChipLogFormatX64 "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 }
@@ -320,8 +321,9 @@ void DeviceManager::ReadSupportedDeviceCategories()
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to read SupportedDeviceCategories from the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to read SupportedDeviceCategories from the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
     }
 }
 
@@ -362,8 +364,9 @@ void DeviceManager::RequestCommissioningApproval()
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to request commissioning-approval to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to request commissioning-approval to the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 
@@ -486,8 +489,9 @@ void DeviceManager::SendCommissionNodeRequest(uint64_t requestId, uint16_t respo
     if (error != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified,
-                     "Failed to send CommissionNode command to the remote bridge (NodeId: %lu). Error: %" CHIP_ERROR_FORMAT,
-                     mRemoteBridgeNodeId, error.Format());
+                     "Failed to send CommissionNode command to the remote bridge (NodeId: " ChipLogFormatX64
+                     "). Error: %" CHIP_ERROR_FORMAT,
+                     ChipLogValueX64(mRemoteBridgeNodeId), error.Format());
         return;
     }
 }

--- a/examples/fabric-sync/admin/DeviceSynchronization.cpp
+++ b/examples/fabric-sync/admin/DeviceSynchronization.cpp
@@ -262,7 +262,7 @@ void DeviceSynchronizer::GetUniqueId()
     }
     else
     {
-        ChipLogDetail(NotSpecified, "Failed to get UniqueId from remote Fabric Sync Aggregator")
+        ChipLogDetail(NotSpecified, "Failed to get UniqueId from remote Fabric Sync Aggregator");
     }
 }
 

--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -17,6 +17,7 @@
 
 #include "FabricAdmin.h"
 #include <AppMain.h>
+#include <CommissionerMain.h>
 #include <bridge/include/FabricBridge.h>
 #include <controller/CHIPDeviceControllerFactory.h>
 

--- a/examples/fabric-sync/main.cpp
+++ b/examples/fabric-sync/main.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <AppMain.h>
+#include <CommissionerMain.h>
 #include <admin/FabricAdmin.h>
 #include <admin/PairingManager.h>
 #include <bridge/include/Bridge.h>

--- a/examples/fabric-sync/shell/AddBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/AddBridgeCommand.cpp
@@ -85,8 +85,9 @@ CHIP_ERROR AddBridgeCommand::RunCommand()
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    ChipLogProgress(NotSpecified, "Running AddBridgeCommand with Node ID: %lu, PIN Code: %u, Address: %s, Port: %u", mBridgeNodeId,
-                    mSetupPINCode, mRemoteAddr, mRemotePort);
+    ChipLogProgress(NotSpecified,
+                    "Running AddBridgeCommand with Node ID: " ChipLogFormatX64 ", PIN Code: %u, Address: %s, Port: %u",
+                    ChipLogValueX64(mBridgeNodeId), mSetupPINCode, mRemoteAddr, mRemotePort);
 
     return admin::DeviceManager::Instance().PairRemoteFabricBridge(mBridgeNodeId, mSetupPINCode, mRemoteAddr, mRemotePort);
 }

--- a/examples/fabric-sync/shell/AddDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/AddDeviceCommand.cpp
@@ -71,8 +71,9 @@ CHIP_ERROR AddDeviceCommand::RunCommand()
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ChipLogProgress(NotSpecified, "Running AddDeviceCommand with Node ID: %lu, PIN Code: %u, Address: %s, Port: %u", mNodeId,
-                    mSetupPINCode, mRemoteAddr, mRemotePort);
+    ChipLogProgress(NotSpecified,
+                    "Running AddDeviceCommand with Node ID: " ChipLogFormatX64 ", PIN Code: %u, Address: %s, Port: %u",
+                    ChipLogValueX64(mNodeId), mSetupPINCode, mRemoteAddr, mRemotePort);
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 

--- a/examples/fabric-sync/shell/PairDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/PairDeviceCommand.cpp
@@ -69,7 +69,8 @@ CHIP_ERROR PairDeviceCommand::RunCommand()
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ChipLogProgress(NotSpecified, "Running PairDeviceCommand with Node ID: %lu, Code: %s", mNodeId, mPayload);
+    ChipLogProgress(NotSpecified, "Running PairDeviceCommand with Node ID: " ChipLogFormatX64 ", Code: %s",
+                    ChipLogValueX64(mNodeId), mPayload);
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 

--- a/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
@@ -61,7 +61,7 @@ CHIP_ERROR RemoveDeviceCommand::RunCommand()
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    ChipLogProgress(NotSpecified, "Running RemoveDeviceCommand with Node ID: %lu", mNodeId);
+    ChipLogProgress(NotSpecified, "Running RemoveDeviceCommand with Node ID: " ChipLogFormatX64, ChipLogValueX64(mNodeId));
 
     return admin::DeviceManager::Instance().UnpairRemoteDevice(mNodeId);
 }

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -33,8 +33,6 @@
 #include <lib/support/logging/CHIPLogging.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
-#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/ScopedBuffer.h>
@@ -51,10 +49,6 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 #include "CommissionerMain.h"
 #include <ControllerShellCommands.h>
-#include <controller/CHIPDeviceControllerFactory.h>
-#include <controller/ExampleOperationalCredentialsIssuer.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
-#include <platform/KeyValueStoreManager.h>
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
 #if defined(ENABLE_CHIP_SHELL)

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <app/server/Server.h>
-#include <controller/CHIPDeviceController.h>
 #include <controller/CommissionerDiscoveryController.h>
 #include <crypto/RawKeySessionKeystore.h>
 #include <lib/core/CHIPError.h>
@@ -88,23 +87,6 @@ public:
  * DefaultAppMainLoopImplementation will be used.
  */
 void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl = nullptr);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-
-using chip::PersistentStorageDelegate;
-using chip::Controller::DeviceCommissioner;
-using chip::Crypto::SessionKeystore;
-using chip::Transport::PeerAddress;
-
-CHIP_ERROR CommissionerPairOnNetwork(uint32_t pincode, uint16_t disc, PeerAddress address);
-CHIP_ERROR CommissionerPairUDC(uint32_t pincode, size_t index);
-
-DeviceCommissioner * GetDeviceCommissioner();
-CommissionerDiscoveryController * GetCommissionerDiscoveryController();
-SessionKeystore * GetSessionKeystore();
-PersistentStorageDelegate * GetPersistentStorageDelegate();
-
-#endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
 // For extra init calls, the function will be called right before running Matter main loop.
 void ApplicationInit();

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -96,8 +96,6 @@ source_set("app-main") {
     ":smco-test-event-trigger",
     ":water-heater-management-test-event-trigger",
     "${chip_root}/src/app/codegen-data-model-provider:instance-header",
-    "${chip_root}/src/controller:controller",
-    "${chip_root}/src/controller:gen_check_chip_controller_headers",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform/logging:default",
   ]
@@ -164,7 +162,6 @@ source_set("commissioner-main") {
 
   public_deps = [
     "${chip_root}/src/controller:controller",
-    "${chip_root}/src/controller:gen_check_chip_controller_headers",
     "${chip_root}/src/lib",
   ]
   deps = [ "${chip_root}/src/app/server" ]

--- a/examples/platform/linux/ControllerShellCommands.cpp
+++ b/examples/platform/linux/ControllerShellCommands.cpp
@@ -19,9 +19,9 @@
  * @file Contains shell commands for for performing discovery (eg. of commissionable nodes) related to commissioning.
  */
 
-#include <AppMain.h>
-#include <ControllerShellCommands.h>
-#include <inttypes.h>
+#include "ControllerShellCommands.h"
+#include "CommissionerMain.h"
+
 #include <lib/core/CHIPCore.h>
 #include <lib/shell/Commands.h>
 #include <lib/shell/Engine.h>
@@ -32,6 +32,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 #include <protocols/user_directed_commissioning/UserDirectedCommissioning.h>
+
+#include <inttypes.h>
 
 namespace chip {
 namespace Shell {

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -25,9 +25,7 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_ENABLE_READ_CLIENT
-class ReadClient;
-#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
+
 struct AttributePathParams
 {
     AttributePathParams() = default;

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -235,6 +235,10 @@ template("chip_data_model") {
       deps = []
     }
 
+    if (!defined(public_deps)) {
+      public_deps = []
+    }
+
     if (!defined(cflags)) {
       cflags = []
     }
@@ -269,9 +273,12 @@ template("chip_data_model") {
       } else if (cluster == "application-launcher-server") {
         sources += [
           "${_app_root}/app-platform/ContentApp.cpp",
+          "${_app_root}/app-platform/ContentApp.h",
           "${_app_root}/app-platform/ContentAppPlatform.cpp",
+          "${_app_root}/app-platform/ContentAppPlatform.h",
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",
         ]
+        deps += [ "${chip_root}/src/controller" ]
       } else if (cluster == "ota-requestor") {
         sources += [
           # TODO - align name of folder ?
@@ -288,6 +295,10 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/OTATestEventTriggerHandler.cpp",
           "${_app_root}/clusters/${cluster}/OTATestEventTriggerHandler.h",
         ]
+
+        # TODO: DefaultOTARequestor depends on controller, however the cluster server itself does not.
+        # Maybe DefaultOTARequestor and related code should have its own source set.
+        deps += [ "${chip_root}/src/controller:interactions" ]
       } else if (cluster == "bindings") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",
@@ -446,10 +457,6 @@ template("chip_data_model") {
       }
     }
 
-    if (!defined(public_deps)) {
-      public_deps = []
-    }
-
     public_deps += [
       ":${_data_model_name}_codegen",
       ":${_data_model_name}_zapgen",
@@ -459,12 +466,16 @@ template("chip_data_model") {
       "${chip_root}/src/app/common:attribute-type",
       "${chip_root}/src/app/common:cluster-objects",
       "${chip_root}/src/app/common:enums",
+      "${chip_root}/src/app/server",
       "${chip_root}/src/app/util:types",
       "${chip_root}/src/app/util/persistence",
-      "${chip_root}/src/controller",
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/support",
       "${chip_root}/src/protocols/secure_channel",
+
+      # TODO: Embedded example apps currently build with chip_build_controller = false, and so get a libCHIP without controller support,
+      # but nevertheless expect to have access to some of the "controller" code to implement bindings and related functionality.
+      "${chip_root}/src/controller:interactions",
     ]
     public_deps += codegen_data_model_PUBLIC_DEPS
 

--- a/src/app/clusters/content-app-observer/content-app-observer.cpp
+++ b/src/app/clusters/content-app-observer/content-app-observer.cpp
@@ -33,7 +33,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 using namespace chip;

--- a/src/app/clusters/content-control-server/content-control-server.cpp
+++ b/src/app/clusters/content-control-server/content-control-server.cpp
@@ -33,7 +33,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 using namespace chip;

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -29,7 +29,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 #include <list>

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -35,7 +35,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 using namespace chip;

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -37,7 +37,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 using namespace chip;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -36,7 +36,8 @@
 #include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-#include <app/app-platform/ContentAppPlatform.h>
+#include <app/app-platform/ContentAppPlatform.h> // nogncheck
+
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
 using namespace chip;

--- a/src/controller/BUILD.gn
+++ b/src/controller/BUILD.gn
@@ -24,30 +24,21 @@ source_set("nodatamodel") {
   public_deps = [ "${chip_root}/src/app" ]
 }
 
-CHIP_CONTROLLER_HEADERS = [ "ExampleOperationalCredentialsIssuer.h" ]
-CHIP_READ_CLIENT_HEADERS = [
-  "CommissioningWindowOpener.h",
-  "CurrentFabricRemover.h",
-]
-
-# This source set exists specifically to deny including them without dependencies
-# if "controller" sources do not contain them
-#
-# They are NOT intended to be used directly.
-#
-# The intent for this is to force gn to be aware that these files are known and
-# error out as `include not allowed due to missing dependency` even if
-# controller is built without these sources
-source_set("gen_check_chip_controller_headers") {
-  sources = CHIP_CONTROLLER_HEADERS
-}
-
-source_set("gen_check_chip_read_client_headers") {
-  sources = CHIP_READ_CLIENT_HEADERS
-}
-
 source_set("delegates") {
   sources = [ "OperationalCredentialsDelegate.h" ]
+}
+
+source_set("interactions") {
+  sources = [
+    "CHIPCluster.h",
+    "CommandSenderAllocator.h",
+    "InvokeInteraction.h",
+    "ReadInteraction.h",
+    "TypedCommandCallback.h",
+    "TypedReadCallback.h",
+    "WriteInteraction.h",
+  ]
+  public_deps = [ "${chip_root}/src/app" ]
 }
 
 static_library("controller") {
@@ -67,26 +58,23 @@ static_library("controller") {
     # dependencies
     "AbstractDnssdDiscoveryController.h",
     "AutoCommissioner.h",
-    "CHIPCluster.h",
     "CHIPCommissionableNodeController.h",
     "CHIPDeviceController.h",
     "CHIPDeviceControllerSystemState.h",
-    "CommandSenderAllocator.h",
     "CommissioneeDeviceProxy.h",
     "CommissioningDelegate.h",
+    "CommissioningWindowOpener.h",
     "CommissioningWindowParams.h",
+    "CurrentFabricRemover.h",
     "DeviceDiscoveryDelegate.h",
     "DevicePairingDelegate.h",
-    "InvokeInteraction.h",
-    "ReadInteraction.h",
+    "ExampleOperationalCredentialsIssuer.h",
     "SetUpCodePairer.h",
-    "TypedCommandCallback.h",
-    "TypedReadCallback.h",
-    "WriteInteraction.h",
   ]
 
+  deps = [ "${chip_root}/src/lib/address_resolve" ]
+
   if (chip_controller && chip_build_controller) {
-    sources += CHIP_CONTROLLER_HEADERS
     sources += [
       "AbstractDnssdDiscoveryController.cpp",
       "AutoCommissioner.cpp",
@@ -100,8 +88,11 @@ static_library("controller") {
       "ExampleOperationalCredentialsIssuer.cpp",
       "SetUpCodePairer.cpp",
     ]
+
+    # ExampleOperationalCredentialsIssuer uses TestGroupData
+    deps += [ "${chip_root}/src/lib/support:testing" ]
+
     if (chip_enable_read_client) {
-      sources += CHIP_READ_CLIENT_HEADERS
       sources += [
         "CHIPDeviceController.cpp",
         "CommissioningWindowOpener.cpp",
@@ -110,9 +101,8 @@ static_library("controller") {
     }
   }
 
-  cflags = [ "-Wconversion" ]
-
   public_deps = [
+    ":interactions",
     "${chip_root}/src/app",
     "${chip_root}/src/app/server",
     "${chip_root}/src/lib/core",
@@ -127,12 +117,7 @@ static_library("controller") {
     "${chip_root}/src/transport",
   ]
 
-  deps = [ "${chip_root}/src/lib/address_resolve" ]
-
-  if (chip_controller && chip_build_controller) {
-    # ExampleOperationalCredentialsIssuer uses TestGroupData
-    deps += [ "${chip_root}/src/lib/support:testing" ]
-  }
+  cflags = [ "-Wconversion" ]
 
   public_configs = [ "${chip_root}/src:includes" ]
 }

--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -26,9 +26,8 @@
 
 #pragma once
 
-#include "app/ConcreteCommandPath.h"
 #include <app/AppConfig.h>
-#include <app/DeviceProxy.h>
+#include <app/ConcreteCommandPath.h>
 #include <controller/InvokeInteraction.h>
 #include <controller/ReadInteraction.h>
 #include <controller/WriteInteraction.h>

--- a/src/controller/ExamplePersistentStorage.cpp
+++ b/src/controller/ExamplePersistentStorage.cpp
@@ -19,6 +19,7 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/IniEscaping.h>
+#include <protocols/secure_channel/PASESession.h>
 
 #include <fstream>
 #include <map>
@@ -30,7 +31,6 @@ using Section  = std::map<String, String>;
 using Sections = std::map<String, Section>;
 
 using namespace ::chip;
-using namespace ::chip::Controller;
 using namespace ::chip::IniEscaping;
 using namespace ::chip::Logging;
 

--- a/src/controller/ExamplePersistentStorage.h
+++ b/src/controller/ExamplePersistentStorage.h
@@ -18,10 +18,12 @@
 
 #pragma once
 
-#include <app/util/basic-types.h>
-#include <controller/CHIPDeviceController.h>
-#include <inipp/inipp.h>
+#include <lib/core/CASEAuthTag.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/NodeId.h>
 #include <lib/support/logging/CHIPLogging.h>
+
+#include <inipp/inipp.h>
 
 class PersistentStorage : public chip::PersistentStorageDelegate
 {

--- a/src/controller/ReadInteraction.h
+++ b/src/controller/ReadInteraction.h
@@ -21,6 +21,7 @@
 #include <app/AppConfig.h>
 #include <app/AttributePathParams.h>
 #include <app/InteractionModelEngine.h>
+#include <app/ReadClient.h>
 #include <app/ReadPrepareParams.h>
 #include <controller/TypedReadCallback.h>
 

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -42,5 +42,4 @@ chip_codegen("cluster-tlv-metadata") {
 
 chip_data_model("data_model") {
   zap_file = "controller-clusters.zap"
-  allow_circular_includes_from = [ "${chip_root}/src/controller" ]
 }


### PR DESCRIPTION
Have fewer this depend on CHIPDeviceController.

- Create a `controller:interactions` source set for the sub-set of interaction utilities used various cluster-adjacent code that doesn't depend on CHIPDeviceController.
- chip_data_model targets now only depend on this subset (and this can hopefully be removed in a follow-up in favor of having only those clusters that actually need it have this dependency)
- Also remove the `controller` dependency from Linux `app-main`. Disentangle `CommissionerMain.h` from `AppMain.h`.