### PR TITLE
[Implementation] Adding get_endpoint functionality to matter_testing support module 

### DIFF
--- a/src/python_testing/TC_BOOLCFG_2_1.py
+++ b/src/python_testing/TC_BOOLCFG_2_1.py
@@ -72,7 +72,7 @@ class TC_BOOLCFG_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         all_alarm_mode_bitmap_bits = functools.reduce(
             ior, [b.value for b in Clusters.BooleanStateConfiguration.Bitmaps.AlarmModeBitmap])
         all_sensor_fault_bitmap_bits = functools.reduce(

--- a/src/python_testing/TC_BOOLCFG_3_1.py
+++ b/src/python_testing/TC_BOOLCFG_3_1.py
@@ -75,7 +75,7 @@ class TC_BOOLCFG_3_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_3_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.BooleanStateConfiguration.Attributes

--- a/src/python_testing/TC_BOOLCFG_4_1.py
+++ b/src/python_testing/TC_BOOLCFG_4_1.py
@@ -67,7 +67,7 @@ class TC_BOOLCFG_4_1(MatterBaseTest):
     @async_test_body
     async def test_TC_BOOLCFG_4_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.BooleanStateConfiguration.Attributes

--- a/src/python_testing/TC_BOOLCFG_4_2.py
+++ b/src/python_testing/TC_BOOLCFG_4_2.py
@@ -89,7 +89,7 @@ class TC_BOOLCFG_4_2(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_4_3.py
+++ b/src/python_testing/TC_BOOLCFG_4_3.py
@@ -101,7 +101,7 @@ class TC_BOOLCFG_4_3(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -93,7 +93,7 @@ class TC_BOOLCFG_4_4(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_5_1.py
+++ b/src/python_testing/TC_BOOLCFG_5_1.py
@@ -88,7 +88,7 @@ class TC_BOOLCFG_5_1(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -87,7 +87,7 @@ class TC_BOOLCFG_5_2(MatterBaseTest):
                             "the --hex-arg flag as PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:<key>, "
                             "e.g. --hex-arg PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY:000102030405060708090a0b0c0d0e0f")
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
         enableKey = self.matter_test_config.global_test_params['PIXIT.BOOLCFG.TEST_EVENT_TRIGGER_KEY']
 
         self.step(1)

--- a/src/python_testing/TC_CADMIN_1_11.py
+++ b/src/python_testing/TC_CADMIN_1_11.py
@@ -28,7 +28,7 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #     factory-reset: true
-#     quiet: false
+#     quiet: true
 # === END CI TEST ARGUMENTS ===
 
 

--- a/src/python_testing/TC_DEM_2_10.py
+++ b/src/python_testing/TC_DEM_2_10.py
@@ -162,7 +162,7 @@ class TC_DEM_2_10(MatterBaseTest, DEMTestBase):
         self.step("4")
         sub_handler = ClusterAttributeChangeAccumulator(Clusters.DeviceEnergyManagement)
         await sub_handler.start(self.default_controller, self.dut_node_id,
-                                self.matter_test_config.endpoint,
+                                self.get_endpoint(),
                                 min_interval_sec=0,
                                 max_interval_sec=10, keepSubscriptions=False)
 

--- a/src/python_testing/TC_DEM_2_2.py
+++ b/src/python_testing/TC_DEM_2_2.py
@@ -181,7 +181,7 @@ class TC_DEM_2_2(MatterBaseTest, DEMTestBase):
         events_callback = EventChangeCallback(Clusters.DeviceEnergyManagement)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint(default=1))
 
         self.step("4")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_DEM_2_4.py
+++ b/src/python_testing/TC_DEM_2_4.py
@@ -186,7 +186,7 @@ class TC_DEM_2_4(MatterBaseTest, DEMTestBase):
         events_callback = EventChangeCallback(Clusters.DeviceEnergyManagement)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("4")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_DGSW_2_1.py
+++ b/src/python_testing/TC_DGSW_2_1.py
@@ -74,7 +74,7 @@ class TC_DGSW_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_DGSW_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 0)
+        endpoint = self.get_endpoint(default=0)
 
         # STEP 1: Commission DUT (already done)
         self.step(1)

--- a/src/python_testing/TC_DRLK_2_13.py
+++ b/src/python_testing/TC_DRLK_2_13.py
@@ -368,7 +368,7 @@ class TC_DRLK_2_13(MatterBaseTest):
         self.groupIdentifier = bytes.fromhex("89d085fc302ca53e279bfcdecdf3c4ad")
         self.groupResolvingKey = bytes.fromhex("89d0859bfcdecdf3c4adfc302ca53e27")
         self.common_cluster_endpoint = 0
-        self.app_cluster_endpoint = self.matter_test_config.endpoint
+        self.app_cluster_endpoint = self.get_endpoint(default=1)
         self.alirouser = "AliroUser"
         self.alirocredentialissuerkey = bytes.fromhex(
             "047a4c882d753924cdf3779a3c84fec2debaa6f0b3084450878acc7ddcce7856ae57b1ebbe2561015103dd7474c2a183675378ec55f1e465ac3436bf3dd5ca54d4")

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -379,7 +379,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
         self.maxrfidcodelength = None
         self.minrfidcodelength = None
 
-        self.endpoint = self.user_params.get("endpoint", 1)
+        self.endpoint = self.get_endpoint(default=1)
         print("endpoint", self.endpoint)
 
         # Aliro Keys for setting Aliro configuration and credential

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -172,7 +172,7 @@ class TC_EEVSE_2_2(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -211,7 +211,7 @@ class TC_EEVSE_2_3(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -127,7 +127,7 @@ class TC_EEVSE_2_4(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -119,7 +119,7 @@ class TC_EEVSE_2_5(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("2")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_2_6.py
+++ b/src/python_testing/TC_EEVSE_2_6.py
@@ -149,7 +149,7 @@ class TC_EEVSE_2_6(MatterBaseTest, EEVSEBaseTestHelper):
         events_callback = EventChangeCallback(Clusters.EnergyEvse)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("4")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -59,7 +59,7 @@ class EEVSEBaseTestHelper:
 
     async def write_user_max_charge(self, endpoint: int = None, user_max_charge: int = 0):
         if endpoint is None:
-            endpoint = self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
         result = await self.default_controller.WriteAttribute(self.dut_node_id,
                                                               [(endpoint,
                                                                Clusters.EnergyEvse.Attributes.UserMaximumChargeCurrent(user_max_charge))])

--- a/src/python_testing/TC_EWATERHTR_2_2.py
+++ b/src/python_testing/TC_EWATERHTR_2_2.py
@@ -213,7 +213,7 @@ class TC_EWATERHTR_2_2(MatterBaseTest, EWATERHTRBase):
         events_callback = EventChangeCallback(Clusters.WaterHeaterManagement)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("3")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_EWATERHTR_2_3.py
+++ b/src/python_testing/TC_EWATERHTR_2_3.py
@@ -166,7 +166,7 @@ class TC_EWATERHTR_2_3(MatterBaseTest, EWATERHTRBase):
         events_callback = EventChangeCallback(Clusters.WaterHeaterManagement)
         await events_callback.start(self.default_controller,
                                     self.dut_node_id,
-                                    self.matter_test_config.endpoint)
+                                    self.get_endpoint())
 
         self.step("3")
         await self.check_test_event_triggers_enabled()

--- a/src/python_testing/TC_FAN_3_1.py
+++ b/src/python_testing/TC_FAN_3_1.py
@@ -73,7 +73,7 @@ class TC_FAN_3_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_FAN_3_1(self):
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.print_step(1, "Commissioning, already done")
 

--- a/src/python_testing/TC_FAN_3_2.py
+++ b/src/python_testing/TC_FAN_3_2.py
@@ -72,8 +72,7 @@ class TC_FAN_3_2(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F00 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
         self.print_step(1, "Commissioning, already done")
 
         self.print_step(2, "Read from the DUT the SpeedSetting attribute and store")

--- a/src/python_testing/TC_FAN_3_3.py
+++ b/src/python_testing/TC_FAN_3_3.py
@@ -94,7 +94,7 @@ class TC_FAN_3_3(MatterBaseTest):
             self.skip_all_remaining_steps(1)
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
 

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -95,7 +95,7 @@ class TC_FAN_3_4(MatterBaseTest):
             return
 
         endpoint = self.get_endpoint(default=1)
-        
+
         self.step(1)
 
         self.step(2)

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -94,8 +94,8 @@ class TC_FAN_3_4(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F03 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         self.step(1)
 
         self.step(2)

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -86,8 +86,8 @@ class TC_FAN_3_5(MatterBaseTest):
             logger.info("Test skipped because PICS FAN.S.F04 is not set")
             return
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         # Part 1
 
         self.print_step(1, "Commissioning, already done")

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -87,7 +87,7 @@ class TC_FAN_3_5(MatterBaseTest):
             return
 
         endpoint = self.get_endpoint(default=1)
-        
+
         # Part 1
 
         self.print_step(1, "Commissioning, already done")

--- a/src/python_testing/TC_LVL_2_3.py
+++ b/src/python_testing/TC_LVL_2_3.py
@@ -131,7 +131,7 @@ class TC_LVL_2_3(MatterBaseTest):
 
         self.step(6)
         sub_handler = ClusterAttributeChangeAccumulator(lvl)
-        await sub_handler.start(self.default_controller, self.dut_node_id, self.matter_test_config.endpoint)
+        await sub_handler.start(self.default_controller, self.dut_node_id, self.get_endpoint())
 
         self.step(7)
         cmd = lvl.Commands.MoveToLevelWithOnOff(level=max_level, transitionTime=100, optionsMask=0, optionsOverride=0)

--- a/src/python_testing/TC_MWOCTRL_2_1.py
+++ b/src/python_testing/TC_MWOCTRL_2_1.py
@@ -107,7 +107,7 @@ class TC_MWOCTRL_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_MWOCTRL_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.MicrowaveOvenControl.Attributes

--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -106,7 +106,7 @@ class TC_MWOCTRL_2_2(MatterBaseTest):
     @async_test_body
     async def test_TC_MWOCTRL_2_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.MicrowaveOvenControl.Attributes

--- a/src/python_testing/TC_MWOCTRL_2_4.py
+++ b/src/python_testing/TC_MWOCTRL_2_4.py
@@ -75,7 +75,7 @@ class TC_MWOCTRL_2_4(MatterBaseTest):
     @async_test_body
     async def test_TC_MWOCTRL_2_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.MicrowaveOvenControl.Attributes

--- a/src/python_testing/TC_MWOM_1_2.py
+++ b/src/python_testing/TC_MWOM_1_2.py
@@ -67,7 +67,7 @@ class TC_MWOM_1_2(MatterBaseTest):
     @async_test_body
     async def test_TC_MWOM_1_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         attributes = Clusters.MicrowaveOvenMode.Attributes
 

--- a/src/python_testing/TC_OCC_2_1.py
+++ b/src/python_testing/TC_OCC_2_1.py
@@ -83,7 +83,7 @@ class TC_OCC_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_OCC_2_1(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
         cluster = Clusters.Objects.OccupancySensing
         attributes = cluster.Attributes
 

--- a/src/python_testing/TC_OCC_2_2.py
+++ b/src/python_testing/TC_OCC_2_2.py
@@ -65,7 +65,7 @@ class TC_OCC_2_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_OCC_2_2(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
 
         self.step(1)  # Already done, immediately go to step 2
 

--- a/src/python_testing/TC_OCC_2_3.py
+++ b/src/python_testing/TC_OCC_2_3.py
@@ -46,7 +46,7 @@ from mobly import asserts
 class TC_OCC_2_3(MatterBaseTest):
     async def read_occ_attribute_expect_success(self, attribute):
         cluster = Clusters.Objects.OccupancySensing
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
         return await self.read_single_attribute_check_success(endpoint=endpoint_id, cluster=cluster, attribute=attribute)
 
     def desc_TC_OCC_2_3(self) -> str:

--- a/src/python_testing/TC_OCC_3_1.py
+++ b/src/python_testing/TC_OCC_3_1.py
@@ -55,13 +55,13 @@ class TC_OCC_3_1(MatterBaseTest):
 
     async def read_occ_attribute_expect_success(self, attribute):
         cluster = Clusters.Objects.OccupancySensing
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     async def write_hold_time(self, hold_time: Optional[Any]) -> Status:
         dev_ctrl = self.default_controller
         node_id = self.dut_node_id
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
 
         cluster = Clusters.OccupancySensing
         write_result = await dev_ctrl.WriteAttribute(node_id, [(endpoint, cluster.Attributes.HoldTime(hold_time))])
@@ -144,7 +144,7 @@ class TC_OCC_3_1(MatterBaseTest):
 
         self.step(4)
         # Setup Occupancy attribute subscription here
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
         node_id = self.dut_node_id
         dev_ctrl = self.default_controller
         attrib_listener = ClusterAttributeChangeAccumulator(cluster)

--- a/src/python_testing/TC_OCC_3_2.py
+++ b/src/python_testing/TC_OCC_3_2.py
@@ -56,7 +56,7 @@ class TC_OCC_3_2(MatterBaseTest):
 
     async def read_occ_attribute_expect_success(self, attribute):
         cluster = Clusters.Objects.OccupancySensing
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
         return await self.read_single_attribute_check_success(endpoint=endpoint_id, cluster=cluster, attribute=attribute)
 
     def desc_TC_OCC_3_2(self) -> str:
@@ -100,7 +100,7 @@ class TC_OCC_3_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_OCC_3_2(self):
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint()
         node_id = self.dut_node_id
         dev_ctrl = self.default_controller
 

--- a/src/python_testing/TC_OCC_3_2.py
+++ b/src/python_testing/TC_OCC_3_2.py
@@ -56,7 +56,7 @@ class TC_OCC_3_2(MatterBaseTest):
 
     async def read_occ_attribute_expect_success(self, attribute):
         cluster = Clusters.Objects.OccupancySensing
-        endpoint = self.get_endpoint()
+        endpoint_id = self.get_endpoint()
         return await self.read_single_attribute_check_success(endpoint=endpoint_id, cluster=cluster, attribute=attribute)
 
     def desc_TC_OCC_3_2(self) -> str:
@@ -100,7 +100,7 @@ class TC_OCC_3_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_OCC_3_2(self):
-        endpoint = self.get_endpoint()
+        endpoint_id = self.get_endpoint()
         node_id = self.dut_node_id
         dev_ctrl = self.default_controller
 

--- a/src/python_testing/TC_OPSTATE_2_1.py
+++ b/src/python_testing/TC_OPSTATE_2_1.py
@@ -60,7 +60,7 @@ class TC_OPSTATE_2_1(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_1(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
         await self.TEST_TC_OPSTATE_BASE_2_1(endpoint)
 
 

--- a/src/python_testing/TC_OPSTATE_2_2.py
+++ b/src/python_testing/TC_OPSTATE_2_2.py
@@ -62,7 +62,7 @@ class TC_OPSTATE_2_2(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_2(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_2(endpoint=endpoint)
 

--- a/src/python_testing/TC_OPSTATE_2_3.py
+++ b/src/python_testing/TC_OPSTATE_2_3.py
@@ -62,7 +62,7 @@ class TC_OPSTATE_2_3(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_3(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_3(endpoint=endpoint)
 

--- a/src/python_testing/TC_OPSTATE_2_4.py
+++ b/src/python_testing/TC_OPSTATE_2_4.py
@@ -62,7 +62,7 @@ class TC_OPSTATE_2_4(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_4(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_4(endpoint=endpoint)
 

--- a/src/python_testing/TC_OPSTATE_2_5.py
+++ b/src/python_testing/TC_OPSTATE_2_5.py
@@ -62,7 +62,7 @@ class TC_OPSTATE_2_5(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_5(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_5(endpoint=endpoint)
 

--- a/src/python_testing/TC_OPSTATE_2_6.py
+++ b/src/python_testing/TC_OPSTATE_2_6.py
@@ -62,8 +62,8 @@ class TC_OPSTATE_2_6(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OPSTATE_2_6(self):
-        endpoint = self.matter_test_config.endpoint
-
+        endpoint = self.get_endpoint(default=1)
+        
         await self.TEST_TC_OPSTATE_BASE_2_6(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_OPSTATE_2_6.py
+++ b/src/python_testing/TC_OPSTATE_2_6.py
@@ -63,7 +63,7 @@ class TC_OPSTATE_2_6(MatterBaseTest, TC_OPSTATE_BASE):
     @async_test_body
     async def test_TC_OPSTATE_2_6(self):
         endpoint = self.get_endpoint(default=1)
-        
+
         await self.TEST_TC_OPSTATE_BASE_2_6(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_OVENOPSTATE_2_1.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_1.py
@@ -61,7 +61,7 @@ class TC_OVENOPSTATE_2_1(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OVENOPSTATE_2_1(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
         await self.TEST_TC_OPSTATE_BASE_2_1(endpoint)
 
 

--- a/src/python_testing/TC_OVENOPSTATE_2_2.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_2.py
@@ -62,7 +62,7 @@ class TC_OVENOPSTATE_2_2(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OVENOPSTATE_2_2(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_2(endpoint=endpoint)
 

--- a/src/python_testing/TC_OVENOPSTATE_2_3.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_3.py
@@ -61,7 +61,7 @@ class TC_OVENOPSTATE_2_3(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OVENOPSTATE_2_3(self):
-        endpoint = self.matter_test_config.endpoint
+        endpoint = self.get_endpoint(default=1)
 
         await self.TEST_TC_OPSTATE_BASE_2_3(endpoint=endpoint)
 

--- a/src/python_testing/TC_OVENOPSTATE_2_4.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_4.py
@@ -61,8 +61,8 @@ class TC_OVENOPSTATE_2_4(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OVENOPSTATE_2_4(self):
-        endpoint = self.matter_test_config.endpoint
-
+        endpoint = self.get_endpoint(default=1)
+        
         await self.TEST_TC_OPSTATE_BASE_2_4(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_OVENOPSTATE_2_4.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_4.py
@@ -62,7 +62,7 @@ class TC_OVENOPSTATE_2_4(MatterBaseTest, TC_OPSTATE_BASE):
     @async_test_body
     async def test_TC_OVENOPSTATE_2_4(self):
         endpoint = self.get_endpoint(default=1)
-        
+
         await self.TEST_TC_OPSTATE_BASE_2_4(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_OVENOPSTATE_2_5.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_5.py
@@ -63,7 +63,7 @@ class TC_OVENOPSTATE_2_5(MatterBaseTest, TC_OPSTATE_BASE):
     @async_test_body
     async def test_TC_OVENOPSTATE_2_5(self):
         endpoint = self.get_endpoint(default=1)
-        
+
         await self.TEST_TC_OPSTATE_BASE_2_5(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_OVENOPSTATE_2_5.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_5.py
@@ -62,8 +62,8 @@ class TC_OVENOPSTATE_2_5(MatterBaseTest, TC_OPSTATE_BASE):
 
     @async_test_body
     async def test_TC_OVENOPSTATE_2_5(self):
-        endpoint = self.matter_test_config.endpoint
-
+        endpoint = self.get_endpoint(default=1)
+        
         await self.TEST_TC_OPSTATE_BASE_2_5(endpoint=endpoint)
 
 

--- a/src/python_testing/TC_PS_2_3.py
+++ b/src/python_testing/TC_PS_2_3.py
@@ -62,7 +62,7 @@ class TC_PS_2_3(MatterBaseTest):
         self.step(2)
         ps = Clusters.PowerSource
         sub_handler = ClusterAttributeChangeAccumulator(ps)
-        await sub_handler.start(self.default_controller, self.dut_node_id, self.matter_test_config.endpoint)
+        await sub_handler.start(self.default_controller, self.dut_node_id, self.get_endpoint())
 
         self.step(3)
         logging.info("This test will now wait for 30 seconds.")

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -52,7 +52,7 @@ class TC_PWRTL_2_1(MatterBaseTest):
         attributes = Clusters.PowerTopology.Attributes
 
         endpoint = self.get_endpoint(default=1)
-        
+
         powertop_attr_list = Clusters.Objects.PowerTopology.Attributes.AttributeList
         powertop_cluster = Clusters.Objects.PowerTopology
         attribute_list = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=powertop_cluster, attribute=powertop_attr_list)

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -51,8 +51,8 @@ class TC_PWRTL_2_1(MatterBaseTest):
 
         attributes = Clusters.PowerTopology.Attributes
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         powertop_attr_list = Clusters.Objects.PowerTopology.Attributes.AttributeList
         powertop_cluster = Clusters.Objects.PowerTopology
         attribute_list = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=powertop_cluster, attribute=powertop_attr_list)

--- a/src/python_testing/TC_RVCCLEANM_1_2.py
+++ b/src/python_testing/TC_RVCCLEANM_1_2.py
@@ -69,7 +69,7 @@ class TC_RVCCLEANM_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCCLEANM_1_2(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
 
         attributes = Clusters.RvcCleanMode.Attributes
 

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -88,7 +88,7 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
                             "PIXIT.RVCCLEANM.MODE_CHANGE_FAIL must be included on the command line in "
                             "the --int-arg flag as PIXIT.RVCCLEANM.MODE_CHANGE_FAIL:<mode id>")
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.mode_ok = self.matter_test_config.global_test_params['PIXIT.RVCCLEANM.MODE_CHANGE_OK']
         self.mode_fail = self.matter_test_config.global_test_params['PIXIT.RVCCLEANM.MODE_CHANGE_FAIL']
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -105,7 +105,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
     @async_test_body
     async def test_TC_RVCCLEANM_2_2(self):
         self.directmodech_bit_mask = Clusters.RvcCleanMode.Bitmaps.Feature.kDirectModeChange
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:
             app_pid = self.matter_test_config.app_pid

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -85,7 +85,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCOPSTATE_2_1(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -158,7 +158,7 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
     @async_test_body
     async def test_TC_RVCOPSTATE_2_3(self):
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -103,7 +103,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCOPSTATE_2_4(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -69,8 +69,8 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCRUNM_1_2(self):
-        self.endpoint = self.get_endpoint()     
-        
+        self.endpoint = self.get_endpoint()
+
         attributes = Clusters.RvcRunMode.Attributes
 
         self.print_step(1, "Commissioning, already done")

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -69,8 +69,8 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_RVCRUNM_1_2(self):
-        self.endpoint = self.matter_test_config.endpoint
-
+        self.endpoint = self.get_endpoint()     
+        
         attributes = Clusters.RvcRunMode.Attributes
 
         self.print_step(1, "Commissioning, already done")

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -83,7 +83,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
                             "PIXIT.RVCRUNM.MODE_CHANGE_FAIL must be included on the command line in "
                             "the --int-arg flag as PIXIT.RVCRUNM.MODE_CHANGE_FAIL:<mode id>")
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.mode_ok = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_CHANGE_OK']
         self.mode_fail = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_CHANGE_FAIL']
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -134,7 +134,7 @@ class TC_RVCRUNM_2_2(MatterBaseTest):
                          "PIXIT.RVCRUNM.MODE_B:<mode id>")
 
         self.directmodech_bit_mask = Clusters.RvcRunMode.Bitmaps.Feature.kDirectModeChange
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         self.mode_a = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_A']
         self.mode_b = self.matter_test_config.global_test_params['PIXIT.RVCRUNM.MODE_B']

--- a/src/python_testing/TC_SEAR_1_2.py
+++ b/src/python_testing/TC_SEAR_1_2.py
@@ -204,7 +204,7 @@ class TC_SEAR_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_2(self):
-        self.endpoint = self.get_endpoint(default=1)   
+        self.endpoint = self.get_endpoint(default=1)
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SEAR_1_2.py
+++ b/src/python_testing/TC_SEAR_1_2.py
@@ -204,7 +204,7 @@ class TC_SEAR_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_2(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint(default=1)   
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SEAR_1_3.py
+++ b/src/python_testing/TC_SEAR_1_3.py
@@ -88,7 +88,7 @@ class TC_SEAR_1_3(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_3(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SEAR_1_4.py
+++ b/src/python_testing/TC_SEAR_1_4.py
@@ -60,7 +60,7 @@ class TC_SEAR_1_4(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_4(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SEAR_1_5.py
+++ b/src/python_testing/TC_SEAR_1_5.py
@@ -102,7 +102,7 @@ class TC_SEAR_1_5(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_5(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SEAR_1_6.py
+++ b/src/python_testing/TC_SEAR_1_6.py
@@ -85,7 +85,7 @@ class TC_SEAR_1_6(MatterBaseTest):
 
     @async_test_body
     async def test_TC_SEAR_1_6(self):
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
         asserts.assert_false(self.endpoint is None, "--endpoint <endpoint> must be included on the command line in.")
         self.is_ci = self.check_pics("PICS_SDK_CI_ONLY")
         if self.is_ci:

--- a/src/python_testing/TC_SWTCH.py
+++ b/src/python_testing/TC_SWTCH.py
@@ -335,7 +335,7 @@ class TC_SwitchTests(MatterBaseTest):
     async def test_TC_SWTCH_2_2(self):
         post_prompt_settle_delay_seconds = 10.0
         cluster = Clusters.Switch
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
 
         # Step 1: Commissioning - already done
         self.step(1)
@@ -452,7 +452,7 @@ class TC_SwitchTests(MatterBaseTest):
         has_msl_feature = (feature_map & cluster.Bitmaps.Feature.kMomentarySwitchLongPress) != 0
         has_as_feature = (feature_map & cluster.Bitmaps.Feature.kActionSwitch) != 0
 
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
 
         self.step(2)
         event_listener = EventChangeCallback(cluster)
@@ -524,7 +524,7 @@ class TC_SwitchTests(MatterBaseTest):
         switch_pressed_position = self._default_pressed_position
         post_prompt_settle_delay_seconds = 10.0
 
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
         cluster = Clusters.Objects.Switch
 
         # Step 1: Commission DUT - already done
@@ -704,7 +704,7 @@ class TC_SwitchTests(MatterBaseTest):
         has_msr_feature = (feature_map & cluster.Bitmaps.Feature.kMomentarySwitchRelease)
         multi_press_max = await self.read_single_attribute_check_success(cluster, attribute=cluster.Attributes.MultiPressMax)
 
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
         pressed_position = self._default_pressed_position
 
         self.step(2)
@@ -882,7 +882,7 @@ class TC_SwitchTests(MatterBaseTest):
         has_msl_feature = (feature_map & cluster.Bitmaps.Feature.kMomentarySwitchLongPress)
         multi_press_max = await self.read_single_attribute_check_success(cluster, attribute=cluster.Attributes.MultiPressMax)
 
-        endpoint_id = self.matter_test_config.endpoint
+        endpoint_id = self.get_endpoint()
         pressed_position = self._default_pressed_position
 
         self.step(2)

--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -253,7 +253,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
 
     @ async_test_body
     async def test_TC_TSTAT_4_2(self):
-        endpoint = self.matter_test_config.endpoint if self.matter_test_config.endpoint is not None else 1
+        endpoint = self.get_endpoint() 
 
         self.step("1")
         # Commission DUT - already done

--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -253,7 +253,7 @@ class TC_TSTAT_4_2(MatterBaseTest):
 
     @ async_test_body
     async def test_TC_TSTAT_4_2(self):
-        endpoint = self.get_endpoint() 
+        endpoint = self.get_endpoint()
 
         self.step("1")
         # Commission DUT - already done

--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -74,8 +75,8 @@ class TC_VALCC_2_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_2_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -76,7 +76,7 @@ class TC_VALCC_2_1(MatterBaseTest):
     async def test_TC_VALCC_2_1(self):
 
         endpoint = self.get_endpoint(default=1)
-        
+
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -71,7 +71,7 @@ class TC_VALCC_3_1(MatterBaseTest):
     async def test_TC_VALCC_3_1(self):
 
         endpoint = self.get_endpoint(default=1)
-        
+
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -69,8 +70,8 @@ class TC_VALCC_3_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -73,7 +73,7 @@ class TC_VALCC_3_2(MatterBaseTest):
     async def test_TC_VALCC_3_2(self):
 
         endpoint = self.get_endpoint(default=1)
-        
+
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -71,8 +72,8 @@ class TC_VALCC_3_2(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
-
+        endpoint = self.get_endpoint(default=1)
+        
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes
 

--- a/src/python_testing/TC_VALCC_3_3.py
+++ b/src/python_testing/TC_VALCC_3_3.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -72,7 +73,7 @@ class TC_VALCC_3_3(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_3(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_3_4.py
+++ b/src/python_testing/TC_VALCC_3_4.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -67,7 +68,7 @@ class TC_VALCC_3_4(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_3_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_1.py
+++ b/src/python_testing/TC_VALCC_4_1.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -71,7 +72,7 @@ class TC_VALCC_4_1(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_1(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_2.py
+++ b/src/python_testing/TC_VALCC_4_2.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -74,7 +75,7 @@ class TC_VALCC_4_2(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -71,7 +72,7 @@ class TC_VALCC_4_3(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_3(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -80,7 +81,7 @@ class TC_VALCC_4_4(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_4(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -27,6 +27,7 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
@@ -71,7 +72,7 @@ class TC_VALCC_4_5(MatterBaseTest):
     @async_test_body
     async def test_TC_VALCC_4_5(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         self.step(1)
         attributes = Clusters.ValveConfigurationAndControl.Attributes

--- a/src/python_testing/TC_WHM_1_2.py
+++ b/src/python_testing/TC_WHM_1_2.py
@@ -71,7 +71,7 @@ class TC_WHM_1_2(MatterBaseTest):
     @async_test_body
     async def test_TC_WHM_1_2(self):
 
-        endpoint = self.user_params.get("endpoint", 1)
+        endpoint = self.get_endpoint(default=1)
 
         attributes = Clusters.WaterHeaterMode.Attributes
 

--- a/src/python_testing/TC_WHM_2_1.py
+++ b/src/python_testing/TC_WHM_2_1.py
@@ -93,7 +93,7 @@ class TC_WHM_2_1(MatterBaseTest):
         ModeManual = 1
         # ModeTimed  = 2
 
-        self.endpoint = self.matter_test_config.endpoint
+        self.endpoint = self.get_endpoint()
 
         attributes = Clusters.WaterHeaterMode.Attributes
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1087,6 +1087,9 @@ class MatterBaseTest(base_test.BaseTestClass):
     def dut_node_id(self) -> int:
         return self.matter_test_config.dut_node_ids[0]
 
+    def get_endpoint(self, default: Optional[int] = 0) -> int:
+        return self.matter_test_config.endpoint if self.matter_test_config.endpoint is not None else default
+
     def setup_class(self):
         super().setup_class()
 
@@ -1163,7 +1166,8 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            #endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.ReadAttribute(node_id, [(endpoint, attribute)], fabricFiltered=fabric_filtered)
         attr_ret = result[endpoint][cluster][attribute]
@@ -1195,7 +1199,8 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            #endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.ReadAttribute(node_id, [(endpoint, attribute)], fabricFiltered=fabric_filtered)
         attr_ret = result[endpoint][cluster][attribute]
@@ -1243,7 +1248,8 @@ class MatterBaseTest(base_test.BaseTestClass):
         if node_id is None:
             node_id = self.dut_node_id
         if endpoint is None:
-            endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            #endpoint = 0 if self.matter_test_config.endpoint is None else self.matter_test_config.endpoint
+            endpoint = self.get_endpoint()
 
         result = await dev_ctrl.SendCommand(nodeid=node_id, endpoint=endpoint, payload=cmd, timedRequestTimeoutMs=timedRequestTimeoutMs,
                                             payloadCapability=payloadCapability)
@@ -1836,7 +1842,8 @@ def convert_args_to_matter_config(args: argparse.Namespace) -> MatterTestConfig:
     config.pics = {} if args.PICS is None else read_pics_from_file(args.PICS)
     config.tests = [] if args.tests is None else args.tests
     config.timeout = args.timeout  # This can be none, we pull the default from the test if it's unspecified
-    config.endpoint = args.endpoint
+    #config.endpoint = args.endpoint
+    config.endpoint = args.endpoint  # This can be None, the get_endpoint function allows the tests to supply a default
     config.app_pid = 0 if args.app_pid is None else args.app_pid
 
     config.controller_node_id = args.controller_node_id


### PR DESCRIPTION
Incorporating new get_endpoint functionality in matter_testing support module as mentioned in issue #[416](https://github.com/project-chip/matter-test-scripts/issues/416):
- Added prior previous get_endpoint functionality Cecille created to matter_testing support module as mentioned in PR#[31928](https://github.com/project-chip/connectedhomeip/pull/31928)
- Updating test modules to use new get_endpoint functionality 