### PR TITLE
[nxp][platform][mcxw71_k32w1] Relocate key storage default option to example apps args

### DIFF
--- a/examples/contact-sensor-app/nxp/k32w1/args.gni
+++ b/examples/contact-sensor-app/nxp/k32w1/args.gni
@@ -42,3 +42,5 @@ chip_openthread_ftd = false
 nxp_enable_ot_cli = false
 
 chip_with_diag_logs_demo = true
+
+nxp_nvm_component = "nvs"

--- a/examples/contact-sensor-app/nxp/mcxw71/args.gni
+++ b/examples/contact-sensor-app/nxp/mcxw71/args.gni
@@ -40,3 +40,5 @@ chip_openthread_ftd = false
 nxp_enable_ot_cli = false
 
 chip_with_diag_logs_demo = true
+
+nxp_nvm_component = "nvs"

--- a/examples/lighting-app/nxp/k32w1/args.gni
+++ b/examples/lighting-app/nxp/k32w1/args.gni
@@ -35,5 +35,7 @@ chip_system_config_provide_statistics = false
 chip_system_config_use_open_thread_inet_endpoints = true
 chip_with_lwip = false
 
+nxp_nvm_component = "nvs"
+
 nxp_use_smu2_static = true
 nxp_use_smu2_dynamic = true

--- a/examples/lighting-app/nxp/mcxw71/args.gni
+++ b/examples/lighting-app/nxp/mcxw71/args.gni
@@ -35,5 +35,7 @@ chip_system_config_provide_statistics = false
 chip_system_config_use_open_thread_inet_endpoints = true
 chip_with_lwip = false
 
+nxp_nvm_component = "nvs"
+
 nxp_use_smu2_static = true
 nxp_use_smu2_dynamic = true

--- a/src/platform/nxp/mcxw71_k32w1/args.gni
+++ b/src/platform/nxp/mcxw71_k32w1/args.gni
@@ -21,7 +21,6 @@ openthread_root =
 nxp_platform = "mcxw71_k32w1"
 nxp_sdk_name = "mcxw71_k32w1_sdk"
 nxp_device_layer = "nxp/${nxp_platform}"
-nxp_nvm_component = "nvs"
 nxp_use_lwip = false
 
 # ARM architecture flags will be set based on NXP board.


### PR DESCRIPTION
The GN args file for the MCXW71/K32W1 platforms defines a default for the "_nxp_nvm_component_" option which prevents the users from selecting a different option in the command line. The default value for this build option is already defined by the

third_party/nxp/nxp_matter_support/gn_build/nxp_sdk.gni

GN arguments file. If one would want to override the default, this has to be done in the scope of the application so that the user can also override the build option from the command line.
