### PR TITLE
TC_WHM_2_1: Fix incorrect --aplication argument

### DIFF
--- a/src/python_testing/TC_WHM_2_1.py
+++ b/src/python_testing/TC_WHM_2_1.py
@@ -26,7 +26,7 @@
 #       --discriminator 1234
 #       --KVS kvs1
 #       --trace-to json:${TRACE_APP}.json
-#       --application evse
+#       --application water-heater
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network


### PR DESCRIPTION
It should be `water-heater` instead of `evse`.

The reason this test doesn't fail in ToT is that the current `energy-management` example app instantiates "too many clusters" for either app. For example, even when the app/argument selected is `evse` it still initializes the some of the `water-heater` functionality, which is enough to make that test pass.

Meanwhile, in https://github.com/project-chip/connectedhomeip/pull/36201 I hit this test failure in CI because I split that app to initialize only what's required for each app.