### PR TITLE
Improve logging in setPersistedClusterData.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3799,7 +3799,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 - (void)setPersistedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData
 {
+    [self _doSetPersistedClusterData:clusterData];
+
+    // Log after we do the state update, so the log includes the data we just set.
     MTR_LOG("%@ setPersistedClusterData count: %lu", self, static_cast<unsigned long>(clusterData.count));
+}
+
+- (void)_doSetPersistedClusterData:(NSDictionary<MTRClusterPath *, MTRDeviceClusterData *> *)clusterData
+{
     if (!clusterData.count) {
         return;
     }


### PR DESCRIPTION
Before this change we would log setPersistedClusterData claiming we don't know our VID/PID/etc, though chances are the data being passed in exactly contains that information.

In the new setup, we update our state, then log.
