### PR TITLE
[SILABS] use VerifyOrDie instead of assert()

### DIFF
--- a/examples/platform/silabs/MatterShell.cpp
+++ b/examples/platform/silabs/MatterShell.cpp
@@ -114,7 +114,7 @@ void cmdSilabsInit()
 void startShellTask()
 {
     int status = chip::Shell::Engine::Root().Init();
-    assert(status == 0);
+    VerifyOrDie(status == 0);
 
     // For now also register commands from shell_common (shell app).
     // TODO move at least OTCLI to default commands in lib/shell/commands


### PR DESCRIPTION
When NDEBUG is enabled the assert is ignored status becomes an unused variable, throwing warnings/errors depending on linker settings. 

Use VerifyOrDie instead of assert in this case.

Testing:
built, flashed and made sure shell still works