### PR TITLE
ESP32: fix typo to include correct Span.h in secure cert data provider

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -22,7 +22,7 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <lib/support/span.h>
+#include <lib/support/Span.h>
 #include <platform/ESP32/ESP32SecureCertDataProvider.h>
 
 namespace chip {

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -21,8 +21,8 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
 #include <platform/ESP32/ESP32SecureCertDataProvider.h>
 
 namespace chip {


### PR DESCRIPTION
use the correct header file i.e `Span.h` and not `span.h`