### PR TITLE
[v1.4] ESP32: fix typo to include correct Span.h in secure cert data provider (#36589)

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -21,8 +21,8 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <lib/support/span.h>
 #include <platform/ESP32/ESP32SecureCertDataProvider.h>
 
 namespace chip {


### PR DESCRIPTION
cherry-picking #36589  on v1.4-branch