### PR TITLE
[Darwin][Ble] Keep scanning while connecting to a device until didCon…

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -447,6 +447,7 @@ namespace DeviceLayer {
     MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredServices);
     [peripheral setDelegate:self];
     [peripheral discoverServices:nil];
+    [self stopScanning];
 }
 
 // End CBCentralManagerDelegate
@@ -734,7 +735,7 @@ namespace DeviceLayer {
         MATTER_LOG_METRIC_BEGIN(kMetricBLEDiscoveredMatchingPeripheral);
         ChipLogProgress(Ble, "Connecting to cached device: %p", peripheral);
         [self connect:peripheral];
-        [self stopScanning];
+        // The cached peripheral might be obsolete, so continue scanning until didConnectPeripheral is triggered.
     } else {
         [self setupTimer:kScanningWithDiscriminatorTimeoutInSeconds];
     }


### PR DESCRIPTION
…nectPeripheral fires

#### Problem

When commissioning a device over BLE, the `src/platform/Darwin` implementation uses a caching mechanism. 
If the BLE device is turned off and back on, the cached peripheral may become obsolete. 

This PR ensures scanning continues until `didConnectPeripheral` is triggered. If a new peripheral 
with a matching discriminator is discovered during this time, the implementation will attempt to connect to it.