### PR TITLE
Updated spec_parsing.py to now use the data model directory from python package

### DIFF
--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -276,9 +276,6 @@ class TestSpecParsingSupport(MatterBaseTest):
 
         asserts.assert_count_equal(string_override_check.keys(), self.spec_xml_clusters.keys(), "Mismatched cluster generation")
 
-        with asserts.assert_raises(SpecParsingException):
-            build_xml_clusters("baddir")
-
     def test_spec_parsing_access(self):
         strs = [None, 'view', 'operate', 'manage', 'admin']
         for read in strs:

--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -21,7 +21,7 @@ import chip.clusters as Clusters
 import jinja2
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.matter_testing import MatterBaseTest, ProblemNotice, default_matter_test_main
-from chip.testing.spec_parsing import (ClusterParser, DataModelLevel, PrebuiltDataModelDirectory, SpecParsingException, XmlCluster,
+from chip.testing.spec_parsing import (ClusterParser, DataModelLevel, PrebuiltDataModelDirectory, XmlCluster,
                                        add_cluster_data_from_xml, build_xml_clusters, check_clusters_for_unknown_commands,
                                        combine_derived_clusters_with_base, get_data_model_directory)
 from mobly import asserts

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -825,15 +825,22 @@ def build_xml_device_types(data_model_directory: typing.Union[PrebuiltDataModelD
     top = get_data_model_directory(data_model_directory, DataModelLevel.kDeviceType)
     device_types: dict[int, XmlDeviceType] = {}
     problems = []
+
+    found_xmls = 0
+
     for file in top.iterdir():
         if not file.name.endswith('.xml'):
             continue
         logging.info('Parsing file %r / %s', top, file.name)
+        found_xmls += 1
         with file.open('r', encoding="utf8") as xml:
             root = ElementTree.parse(xml).getroot()
             tmp_device_types, tmp_problems = parse_single_device_type(root)
             problems = problems + tmp_problems
             device_types.update(tmp_device_types)
+
+    if found_xmls < 1:
+        logging.warning("No XML files found in the specified device type directory: %r", top)
 
     if -1 not in device_types.keys():
         raise ConformanceException("Base device type not found in device type xml data")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -539,7 +539,7 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
     """
     data_model_root = _get_data_model_root()
 
-    # Build path based on the version and data model level
+    # If it's a prebuilt directory, build the path based on the version and data model level
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
         version_map = {
             PrebuiltDataModelDirectory.k1_3: '1.3',
@@ -558,8 +558,15 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
 
 
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, str] = PrebuiltDataModelDirectory.k1_4) -> tuple[dict[int, XmlCluster], list[ProblemNotice]]:
-    # Get the data model directory path inside the package
-    dir = get_data_model_directory(data_model_directory, 'clusters')
+    """
+    Build XML clusters from the specified data model directory.
+    This function supports both pre-built locations (via `PrebuiltDataModelDirectory`) and full paths (strings).
+    """
+    # If a pre-built directory is provided, resolve the full path
+    if isinstance(data_model_directory, PrebuiltDataModelDirectory):
+        data_model_directory = get_data_model_directory(data_model_directory, 'clusters')
+
+    dir = pathlib.Path(data_model_directory)
 
     clusters: dict[int, XmlCluster] = {}
     pure_base_clusters: dict[str, XmlCluster] = {}
@@ -583,6 +590,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
                 add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)
             except Exception as e:
                 logging.error(f"Error parsing XML file {xml}: {e}")
+
 
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -524,7 +524,7 @@ class PrebuiltDataModelDirectory(Enum):
         raise KeyError("Invalid enum: %r" % self)
 
 
-class DataModelLevel(str, Enum):
+class DataModelLevel(Enum):
     kCluster = auto()
     kDeviceType = auto()
 
@@ -578,7 +578,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
             continue
 
         logging.info('Parsing file %s', f.name)
-
         with f.open("r", encoding="utf8") as file:
             root = ElementTree.parse(file).getroot()
             add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -16,10 +16,10 @@
 #
 
 import glob
-import logging
-import os
 import importlib
 import importlib.resources
+import logging
+import os
 import typing
 import xml.etree.ElementTree as ElementTree
 from copy import deepcopy

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -591,7 +591,6 @@ def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[
             # Open the resource file using pkg_resources and parse it
             with pkg_resources.open_text(pkg_resources.files(pkg_resources.import_module('chip.testing')).joinpath('data_model').joinpath(data_model_directory), xml) as file:
                 tree = ElementTree.parse(file)
-                root = tree.getroot()
         except Exception as e:
             logging.error(f"Error parsing XML file {xml}: {e}")
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -525,7 +525,7 @@ def _get_data_model_root() -> pathlib.Path:
     package_dir = pkg_resources.files('chip.testing')
 
     # Construct the path to the 'data_model' directory inside the package
-    data_model_root = package_dir / 'data_model'
+    data_model_root = pathlib.Path(package_dir) / 'data_model'
 
     # Check if the 'data_model' directory exists
     if not data_model_root.exists():
@@ -569,15 +569,10 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
         data_model_directory = get_data_model_directory(data_model_directory, 'clusters')
 
     # Use importlib.resources to access the data model root directory
-    data_model_root = _get_data_model_root()  # Get the correct path
+    data_model_root = _get_data_model_root()
 
-    # We can now use pkg_resources to list XML files inside the data_model directory
-    xml_files = []
-
-    # Recursively find all XML files in the 'data_model' directory
-    for xml in pkg_resources.contents(data_model_root):
-        if xml.endswith('.xml'):
-            xml_files.append(pathlib.Path(xml))  # Create Path objects for XML files
+    # List all .xml files in the directory using pathlib
+    xml_files = [file for file in data_model_root.iterdir() if file.suffix == '.xml']
 
     if not xml_files:
         raise SpecParsingException(f'No XML files found in the specified package directory {data_model_root}')

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -563,7 +563,7 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
 
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, str] = PrebuiltDataModelDirectory.k1_4) -> tuple[dict[int, XmlCluster], list[ProblemNotice]]:
     # Get the data model directory path inside the package
-    dir = get_data_model_directory(data_model_directory, 'kCluster')
+    dir = get_data_model_directory(data_model_directory, 'clusters')
 
     clusters: dict[int, XmlCluster] = {}
     pure_base_clusters: dict[str, XmlCluster] = {}

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -541,7 +541,9 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
     """
     Get the directory of the data model for a specific version and level from the installed package.
 
-    If `data_model_directory` is given as a PATH, it is returned directly WITHOUT using the data_model level at all.
+
+    `data_model_directory` given as a path MUST be of type Traversable (often `pathlib.Path(somepathstring)`).
+    If `data_model_directory` is given as a Traversable, it is returned directly WITHOUT using the data_model_level at all.
     """
     # If it's a prebuilt directory, build the path based on the version and data model level
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
@@ -554,9 +556,10 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable] = PrebuiltDataModelDirectory.k1_4) -> typing.Tuple[dict[int, dict], list]:
     """
     Build XML clusters from the specified data model directory.
-    This function supports both pre-built locations and full paths
+    This function supports both pre-built locations and full paths.
 
-    if data_model_directory is a Travesable, it is assumed to already contain `clusters` (i.e. be a directory
+    `data_model_directory`` given as a path MUST be of type Traversable (often `pathlib.Path(somepathstring)`).
+    If data_model_directory is a Travesable, it is assumed to already contain `clusters` (i.e. be a directory
     with all XML files in it)
     """
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -539,19 +539,6 @@ class DataModelLevel(str, Enum):
         raise KeyError("Invalid enum: %r" % self)
 
 
-def _get_data_model_root() -> pathlib.PosixPath:
-    """Attempts to find the 'data_model' directory inside the 'chip.testing' package."""
-    # Access the 'chip.testing' package directly via importlib and pkg_resources
-    package = pkg_resources.files(importlib.import_module('chip.testing'))  # Corrected: using importlib
-    try:
-        # We assume the 'data_model' directory is inside the package itself
-        data_model_root = package / 'data_model'
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}")
-
-    return data_model_root
-
-
 def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable], data_model_level: DataModelLevel) -> Traversable:
     """
     Get the directory of the data model for a specific version and level from the installed package.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -523,7 +523,7 @@ class DataModelLevel(str, Enum):
 def _get_data_model_root() -> pathlib.Path:
     """Attempts to find the 'data_model' directory inside the 'chip.testing' package."""
     # Access the 'chip.testing' package using importlib.resources
-    package_dir = pkg_resources.files(chip.testing)
+    package_dir = pkg_resources.files('chip.testing')
 
     # Construct the path to the 'data_model' directory inside the package
     data_model_root = package_dir / 'data_model'

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -557,7 +557,7 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
 
     else:
         # If it's a custom directory, return it directly
-        return pathlib.PosixPath(data_model_directory)     
+        return pathlib.PosixPath(data_model_directory)
 
 
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, str] = PrebuiltDataModelDirectory.k1_4) -> tuple[dict[int, XmlCluster], list[ProblemNotice]]:
@@ -598,7 +598,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
                 root = tree.getroot()
                 add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)
             except Exception as e:
-                logging.error(f"Error parsing XML file {xml}: {e}")                
+                logging.error(f"Error parsing XML file {xml}: {e}")
 
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -16,8 +16,8 @@
 #
 
 import glob
-import logging
 import importlib.resources as pkg_resources
+import logging
 import pathlib
 import typing
 import xml.etree.ElementTree as ElementTree

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -15,7 +15,6 @@
 #    limitations under the License.
 #
 
-import glob
 import importlib
 import importlib.resources as pkg_resources
 import logging

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -27,7 +27,6 @@ from enum import Enum, auto
 from typing import Callable, Optional, Union
 
 import chip.clusters as Clusters
-import chip.testing
 import chip.testing.conformance as conformance_support
 from chip.testing.conformance import (OPTIONAL_CONFORM, TOP_LEVEL_CONFORMANCE_TAGS, ConformanceDecision, ConformanceException,
                                       ConformanceParseParameters, feature, is_disallowed, mandatory, optional, or_operation,

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -572,15 +572,26 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
     problems: list[ProblemNotice] = []
 
     logging.info("Reading XML clusters from %r", top)
+
+    found_xmls = 0
     for f in top.iterdir():
         if not f.name.endswith('.xml'):
             logging.info("Ignoring non-XML file %s", f.name)
             continue
 
         logging.info('Parsing file %s', f.name)
+        found_xmls += 1
         with f.open("r", encoding="utf8") as file:
             root = ElementTree.parse(file).getroot()
             add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)
+
+    # For now we assume even a single XML means the directory was probaly OK
+    # we may increase this later as most our data model directories are larger
+    #
+    # Intent here is to make user aware of typos in paths instead of silently having
+    # empty parsing
+    if found_xmls < 1:
+        raise SpecParsingException(f'No data model files found in specified directory {top:r}')
 
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -553,7 +553,7 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
 
         return data_model_root / version / data_model_level
     else:
-        # If it's a custom directory, return it directly
+        # If it's a custom directory, returns directly
         return pathlib.Path(data_model_directory)
 
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -17,7 +17,6 @@
 
 import glob
 import importlib
-from importlib.abc import Traversable
 import importlib.resources as pkg_resources
 import logging
 import pathlib
@@ -26,6 +25,7 @@ import xml.etree.ElementTree as ElementTree
 from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum, auto
+from importlib.abc import Traversable
 from typing import Callable, Optional, Union
 
 import chip.clusters as Clusters

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -591,7 +591,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
             except Exception as e:
                 logging.error(f"Error parsing XML file {xml}: {e}")
 
-
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.
     # Descriptor - TagList feature - this feature is mandated when the duplicate condition holds for the endpoint. It is tested in DESC-2.2

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -742,7 +742,7 @@ def combine_derived_clusters_with_base(xml_clusters: dict[int, XmlCluster], pure
             xml_clusters[id] = new
 
 
-def parse_single_device_type(root: ElementTree.Element) -> tuple[list[ProblemNotice], dict[int, XmlDeviceType]]:
+def parse_single_device_type(root: ElementTree.Element) -> tuple[dict[int, XmlDeviceType], list[ProblemNotice]]:
     problems: list[ProblemNotice] = []
     device_types: dict[int, XmlDeviceType] = {}
     device = root.iter('deviceType')
@@ -823,7 +823,7 @@ def build_xml_device_types(data_model_directory: typing.Union[PrebuiltDataModelD
             continue
         logging.info('Parsing file %r / %s', top, file.name)
         with file.open('r', encoding="utf8") as xml:
-            root = ElementTree.parse(xml)
+            root = ElementTree.parse(xml).getroot()
             tmp_device_types, tmp_problems = parse_single_device_type(root)
             problems = problems + tmp_problems
             device_types.update(tmp_device_types)

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -528,7 +528,7 @@ def _get_data_model_root() -> pathlib.PosixPath:
         data_model_root = package / 'data_model'
     except FileNotFoundError:
         raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}")
-    
+
     return data_model_root
 
 
@@ -568,18 +568,19 @@ def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[
     # Convert the resolved directory path into a resource path using pkg_resources
     dir = pathlib.Path(data_model_directory)
 
-    clusters = {} 
+    clusters = {}
     pure_base_clusters = {}
     ids_by_name = {}
     problems = []
 
     # Use pkg_resources to list all XML files in the data model directory
     try:
-        xml_files = [f for f in pkg_resources.contents(pkg_resources.files(pkg_resources.import_module('chip.testing')).joinpath('data_model').joinpath(data_model_directory)).splitlines() if f.endswith('.xml')]
+        xml_files = [f for f in pkg_resources.contents(pkg_resources.files(pkg_resources.import_module(
+            'chip.testing')).joinpath('data_model').joinpath(data_model_directory)).splitlines() if f.endswith('.xml')]
     except Exception as e:
         logging.error(f"Error accessing XML files in {data_model_directory}: {e}")
         return clusters, problems
-    
+
     if not xml_files:
         raise FileNotFoundError(f'No XML files found in the specified package directory {dir}')
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -16,8 +16,8 @@
 #
 
 import glob
-import pathlib
 import logging
+import pathlib
 import typing
 import xml.etree.ElementTree as ElementTree
 from copy import deepcopy
@@ -25,8 +25,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable, Optional, Union
 
-import chip.testing
 import chip.clusters as Clusters
+import chip.testing
 import chip.testing.conformance as conformance_support
 from chip.testing.conformance import (OPTIONAL_CONFORM, TOP_LEVEL_CONFORMANCE_TAGS, ConformanceDecision, ConformanceException,
                                       ConformanceParseParameters, feature, is_disallowed, mandatory, optional, or_operation,

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -580,11 +580,8 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
 
         logging.info('Parsing file %s', f.name)
 
-        # Open the resource file using importlib.resources and parse it
         with f.open("r", encoding="utf8") as file:
-            # Directly parse the XML file without assigning it to 'tree'
-            tree = ElementTree.parse(file)  # Parse the file to process it
-            root = tree.getroot()
+            root = ElementTree.parse(file).getroot()
             add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)
 
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -19,7 +19,6 @@ import glob
 import importlib
 import importlib.resources as pkg_resources
 import logging
-import pathlib
 import typing
 import xml.etree.ElementTree as ElementTree
 from copy import deepcopy

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -532,6 +532,7 @@ def _get_data_model_root() -> pathlib.PosixPath:
 
     return data_model_root
 
+
 def get_data_model_directory(data_model_directory: Union[str, pathlib.Path], data_model_level: str) -> pathlib.PosixPath:
     """
     Get the directory of the data model for a specific version and level from the installed package.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -584,7 +584,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
             except Exception as e:
                 logging.error(f"Error parsing XML file {xml}: {e}")
 
-
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.
     # Descriptor - TagList feature - this feature is mandated when the duplicate condition holds for the endpoint. It is tested in DESC-2.2

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -16,6 +16,7 @@
 #
 
 import glob
+import importlib
 import importlib.resources as pkg_resources
 import logging
 import pathlib
@@ -519,19 +520,6 @@ class DataModelLevel(str, Enum):
     kDeviceType = 'device_types'
 
 
-def _get_data_model_root() -> pathlib.PosixPath:
-    """Attempts to find the 'data_model' directory inside the 'chip.testing' package."""
-    # Access the 'chip.testing' package directly via pkg_resources
-    package = pkg_resources.files(pkg_resources.import_module('chip.testing'))  # Corrected: Removed importlib
-    try:
-        # We assume the 'data_model' directory is inside the package itself
-        data_model_root = package / 'data_model'
-    except FileNotFoundError:
-        raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}")
-
-    return data_model_root
-
-
 def get_data_model_directory(data_model_directory: Union[str], data_model_level: str) -> pathlib.PosixPath:
     """
     Get the directory of the data model for a specific version and level from the installed package.
@@ -552,11 +540,11 @@ def get_data_model_directory(data_model_directory: Union[str], data_model_level:
 
         return data_model_root / version / data_model_level
     else:
-        # If it's a custom directory, returns directly
+        # If it's a custom directory, return directly
         return pathlib.Path(data_model_directory)
 
 
-def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[int, dict], list]:
+def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> typing.Tuple[dict[int, dict], list]:
     """
     Build XML clusters from the specified data model directory.
     This function supports both pre-built locations (via `str` directory names) and full paths (strings).
@@ -575,7 +563,7 @@ def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[
 
     # Use pkg_resources to list all XML files in the data model directory
     try:
-        xml_files = [f for f in pkg_resources.contents(pkg_resources.files(pkg_resources.import_module(
+        xml_files = [f for f in pkg_resources.contents(pkg_resources.files(importlib.import_module(
             'chip.testing')).joinpath('data_model').joinpath(data_model_directory)).splitlines() if f.endswith('.xml')]
     except Exception as e:
         logging.error(f"Error accessing XML files in {data_model_directory}: {e}")
@@ -589,7 +577,7 @@ def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[
         try:
             # Open the resource file using pkg_resources and parse it
             with pkg_resources.open_text(
-                pkg_resources.files(pkg_resources.import_module('chip.testing'))
+                pkg_resources.files(importlib.import_module('chip.testing'))
                 .joinpath('data_model')
                 .joinpath(data_model_directory), xml
             ) as file:

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -524,24 +524,25 @@ def _get_data_model_root() -> pathlib.PosixPath:
     try:
         # Locate the directory where the 'chip.testing' module is located
         package_dir = pathlib.Path(chip.testing.__file__).parent
-        
+
         # Construct the path to the 'data_model' directory (assuming this structure)
         data_model_root = package_dir / 'data_model'
-        
+
         if not data_model_root.exists():
             raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}.")
-        
+
         return data_model_root
 
     except Exception as e:
         raise FileNotFoundError(f"Failed to find the data model root: {e}")
+
 
 def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirectory, str], data_model_level: str) -> pathlib.PosixPath:
     """
     Get the directory of the data model for a specific version and level from the installed package.
     """
     data_model_root = _get_data_model_root()
-    
+
     # Build path based on the version and data model level
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
         version_map = {
@@ -549,15 +550,16 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
             PrebuiltDataModelDirectory.k1_4: '1.4',
             PrebuiltDataModelDirectory.kMaster: 'master',
         }
-        
+
         version = version_map.get(data_model_directory)
         if not version:
             raise ValueError(f"Unsupported data model directory: {data_model_directory}")
-        
+
         return data_model_root / version / data_model_level
     else:
         # If it's a custom directory, return it directly
         return pathlib.Path(data_model_directory)
+
 
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, str] = PrebuiltDataModelDirectory.k1_4) -> tuple[dict[int, XmlCluster], list[ProblemNotice]]:
     # Get the data model directory path inside the package

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -545,7 +545,8 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
     """
     # If it's a prebuilt directory, build the path based on the version and data model level
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
-        top = pkg_resources.files(importlib.import_module('chip.testing')).joinpath('data_model').joinpath(data_model_directory.dirname)
+        top = pkg_resources.files(importlib.import_module('chip.testing')).joinpath(
+            'data_model').joinpath(data_model_directory.dirname)
     else:
         top = data_model_directory
 
@@ -562,7 +563,8 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
     """
 
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
-        top = pkg_resources.files(importlib.import_module("chip.testing")).joinpath('data_model').joinpath(data_model_directory.dirname).joinpath(DataModelLevel.kCluster.dirname)
+        top = pkg_resources.files(importlib.import_module("chip.testing")).joinpath(
+            'data_model').joinpath(data_model_directory.dirname).joinpath(DataModelLevel.kCluster.dirname)
     else:
         top = data_model_directory
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -595,7 +595,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
     # Actions cluster - all commands - these need to be listed in the ActionsList attribute to be supported.
     #                                  We do not currently have a test for this. Please see https://github.com/CHIP-Specifications/chip-test-plans/issues/3646.
 
-    # Define remove_problem function to modify the problems list
     def remove_problem(location: typing.Union[CommandPathLocation, FeaturePathLocation]):
         nonlocal problems
         problems = [p for p in problems if p.location != location]
@@ -620,11 +619,25 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
     # see 3.2.8. Defined Primaries Information Attribute Set, affects Primary<#>X/Y/Intensity attributes.
     cc_id = Clusters.ColorControl.id
     cc_attr = Clusters.ColorControl.Attributes
-    affected_attributes = [cc_attr.Primary1X, cc_attr.Primary1Y, cc_attr.Primary1Intensity, cc_attr.Primary2X,
-                           cc_attr.Primary2Y, cc_attr.Primary2Intensity, cc_attr.Primary3X, cc_attr.Primary3Y,
-                           cc_attr.Primary3Intensity, cc_attr.Primary4X, cc_attr.Primary4Y, cc_attr.Primary4Intensity,
-                           cc_attr.Primary5X, cc_attr.Primary5Y, cc_attr.Primary5Intensity, cc_attr.Primary6X,
-                           cc_attr.Primary6Y, cc_attr.Primary6Intensity]
+    affected_attributes = [cc_attr.Primary1X,
+                           cc_attr.Primary1Y,
+                           cc_attr.Primary1Intensity,
+                           cc_attr.Primary2X,
+                           cc_attr.Primary2Y,
+                           cc_attr.Primary2Intensity,
+                           cc_attr.Primary3X,
+                           cc_attr.Primary3Y,
+                           cc_attr.Primary3Intensity,
+                           cc_attr.Primary4X,
+                           cc_attr.Primary4Y,
+                           cc_attr.Primary4Intensity,
+                           cc_attr.Primary5X,
+                           cc_attr.Primary5Y,
+                           cc_attr.Primary5Intensity,
+                           cc_attr.Primary6X,
+                           cc_attr.Primary6Y,
+                           cc_attr.Primary6Intensity,
+                           ]
     for a in affected_attributes:
         clusters[cc_id].attributes[a.attribute_id].conformance = optional()
 
@@ -654,7 +667,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
         presents_id = clusters[Clusters.Thermostat.id].attribute_map[presets_name]
         schedules_id = clusters[Clusters.Thermostat.id].attribute_map[schedules_name]
         conformance = or_operation([conformance_support.attribute(presents_id, presets_name),
-                                    conformance_support.attribute(schedules_id, schedules_name)])
+                                   conformance_support.attribute(schedules_id, schedules_name)])
         clusters[Clusters.Thermostat.id].accepted_commands[atomic_request_cmd_id] = XmlCommand(
             id=atomic_request_cmd_id, name=atomic_request_name, conformance=conformance)
         clusters[Clusters.Thermostat.id].generated_commands[atomic_response_cmd_id] = XmlCommand(

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -570,7 +570,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
         data_model_directory = get_data_model_directory(data_model_directory, 'clusters')
 
     # Use importlib.resources to access the data model root directory
-    data_model_root = pkg_resources.files(chip.testing) / 'data_model'
+    data_model_root = _get_data_model_root()  # Get the correct path
 
     # We can now use pkg_resources to list XML files inside the data_model directory
     xml_files = []

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -815,16 +815,18 @@ def parse_single_device_type(root: ElementTree.Element) -> tuple[list[ProblemNot
 
 
 def build_xml_device_types(data_model_directory: typing.Union[PrebuiltDataModelDirectory, Traversable] = PrebuiltDataModelDirectory.k1_4) -> tuple[dict[int, XmlDeviceType], list[ProblemNotice]]:
-    dir = get_data_model_directory(data_model_directory, DataModelLevel.kDeviceType)
+    top = get_data_model_directory(data_model_directory, DataModelLevel.kDeviceType)
     device_types: dict[int, XmlDeviceType] = {}
     problems = []
-    for xml in glob.glob(f"{dir}/*.xml"):
-        logging.info(f'Parsing file {xml}')
-        tree = ElementTree.parse(f'{xml}')
-        root = tree.getroot()
-        tmp_device_types, tmp_problems = parse_single_device_type(root)
-        problems = problems + tmp_problems
-        device_types.update(tmp_device_types)
+    for file in top.iterdir():
+        if not file.name.endswith('.xml'):
+            continue
+        logging.info('Parsing file %r / %s', top, file.name)
+        with file.open('r', encoding="utf8") as xml:
+            root = ElementTree.parse(xml)
+            tmp_device_types, tmp_problems = parse_single_device_type(root)
+            problems = problems + tmp_problems
+            device_types.update(tmp_device_types)
 
     if -1 not in device_types.keys():
         raise ConformanceException("Base device type not found in device type xml data")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -520,6 +520,19 @@ class DataModelLevel(str, Enum):
     kDeviceType = 'device_types'
 
 
+def _get_data_model_root() -> pathlib.PosixPath:
+    """Attempts to find the 'data_model' directory inside the 'chip.testing' package."""
+    # Access the 'chip.testing' package directly via importlib and pkg_resources
+    package = pkg_resources.files(importlib.import_module('chip.testing'))  # Corrected: using importlib
+    try:
+        # We assume the 'data_model' directory is inside the package itself
+        data_model_root = package / 'data_model'
+    except FileNotFoundError:
+        raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}")
+
+    return data_model_root
+
+
 def get_data_model_directory(data_model_directory: Union[str], data_model_level: str) -> pathlib.PosixPath:
     """
     Get the directory of the data model for a specific version and level from the installed package.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -526,18 +526,18 @@ def _get_data_model_root() -> str:
         # Use importlib.resources to get the directory contents
         package = importlib.import_module('chip_testing')
         data_model_path = None
-        
+
         # This lists all resources under the package, filtering for the 'data_model' directory
         for resource in importlib.resources.contents(package):
             if resource.endswith('data_model'):
                 data_model_path = resource
                 break
-        
+
         if not data_model_path:
             raise FileNotFoundError("Data model directory not found in the package.")
-        
+
         return data_model_path
-    
+
     except Exception as e:
         raise FileNotFoundError(f"Failed to find the data model root: {e}")
 
@@ -573,7 +573,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
         # Use importlib.resources to list all files in the data model directory within the package
         package = importlib.import_module(package_name)
         xml_files = [f for f in importlib.resources.contents(package) if f.endswith('.xml') and f.startswith(dir)]
-        
+
         if not xml_files:
             raise SpecParsingException(f'No XML files found in the specified package directory {dir}')
 
@@ -605,7 +605,7 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
     mask = clusters[descriptor_id].feature_map[code]
     clusters[descriptor_id].features[mask].conformance = optional()
     remove_problem(FeaturePathLocation(endpoint_id=0, cluster_id=descriptor_id, feature_code=code))
-    
+
     action_id = Clusters.Actions.id
     for c in Clusters.ClusterObjects.ALL_ACCEPTED_COMMANDS[action_id]:
         clusters[action_id].accepted_commands[c].conformance = optional()

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -521,20 +521,16 @@ class DataModelLevel(str, Enum):
 
 def _get_data_model_root() -> pathlib.PosixPath:
     """Attempts to find the 'data_model' directory inside the 'chip.testing' package."""
-    try:
-        # Locate the directory where the 'chip.testing' module is located
-        package_dir = pathlib.Path(chip.testing.__file__).parent
+    # Locate the directory where the 'chip.testing' module is located
+    package_dir = pathlib.Path(chip.testing.__file__).parent
 
-        # Construct the path to the 'data_model' directory (assuming this structure)
-        data_model_root = package_dir / 'data_model'
+    # Construct the path to the 'data_model' directory (assuming this structure)
+    data_model_root = package_dir / 'data_model'
 
-        if not data_model_root.exists():
-            raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}.")
+    if not data_model_root.exists():
+        raise FileNotFoundError(f"Data model directory not found in the package at {data_model_root}.")
 
-        return data_model_root
-
-    except Exception as e:
-        raise FileNotFoundError(f"Failed to find the data model root: {e}")
+    return data_model_root
 
 
 def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirectory, str], data_model_level: str) -> pathlib.PosixPath:
@@ -570,24 +566,24 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, s
     ids_by_name: dict[str, int] = {}
     problems: list[ProblemNotice] = []
 
-    try:
-        # Use pathlib.Path to list all XML files in the data model directory
-        xml_files = [f for f in dir.glob('**/*.xml')]  # Recursively find all .xml files
+    # Use pathlib.Path to list all XML files in the data model directory
+    xml_files = [f for f in dir.glob('**/*.xml')]  # Recursively find all .xml files
 
-        if not xml_files:
-            raise SpecParsingException(f'No XML files found in the specified package directory {dir}')
+    if not xml_files:
+        raise SpecParsingException(f'No XML files found in the specified package directory {dir}')
 
-        # Parse each XML file found inside the package
-        for xml in xml_files:
-            logging.info(f'Parsing file {xml}')
-            # Open and parse each XML file from the directory
-            with xml.open('r') as file:
+    # Parse each XML file found inside the package
+    for xml in xml_files:
+        logging.info(f'Parsing file {xml}')
+        # Open and parse each XML file from the directory
+        with xml.open('r') as file:
+            try:
                 tree = ElementTree.parse(file)
                 root = tree.getroot()
                 add_cluster_data_from_xml(root, clusters, pure_base_clusters, ids_by_name, problems)
+            except Exception as e:
+                logging.error(f"Error parsing XML file {xml}: {e}")
 
-    except Exception as e:
-        raise SpecParsingException(f"Error reading XML files from the package: {e}")
 
     # There are a few clusters where the conformance columns are listed as desc. These clusters need specific, targeted tests
     # to properly assess conformance. Here, we list them as Optional to allow these for the general test. Targeted tests are described below.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -552,18 +552,19 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
     return top.joinpath(data_model_level.dirname)
 
 
-def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, pathlib.Path] = PrebuiltDataModelDirectory.k1_4) -> typing.Tuple[dict[int, dict], list]:
+def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable] = PrebuiltDataModelDirectory.k1_4) -> typing.Tuple[dict[int, dict], list]:
     """
     Build XML clusters from the specified data model directory.
     This function supports both pre-built locations and full paths
+
+    if data_model_directory is a Travesable, it is assumed to already contain `clusters` (i.e. be a directory
+    with all XML files in it)
     """
 
     if isinstance(data_model_directory, PrebuiltDataModelDirectory):
-        top = pkg_resources.files(importlib.import_module("chip.testing")).joinpath('data_model').joinpath(data_model_directory.dirname)
+        top = pkg_resources.files(importlib.import_module("chip.testing")).joinpath('data_model').joinpath(data_model_directory.dirname).joinpath(DataModelLevel.kCluster.dirname)
     else:
         top = data_model_directory
-
-    top = top.joinpath(DataModelLevel.kCluster.dirname)
 
     clusters: dict[int, XmlCluster] = {}
     pure_base_clusters: dict[str, XmlCluster] = {}

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -584,13 +584,17 @@ def build_xml_clusters(data_model_directory: Union[str] = 'k1_4') -> tuple[dict[
     if not xml_files:
         raise FileNotFoundError(f'No XML files found in the specified package directory {dir}')
 
-    # Parse each XML file found inside the package
     for xml in xml_files:
         logging.info(f'Parsing file {xml}')
         try:
             # Open the resource file using pkg_resources and parse it
-            with pkg_resources.open_text(pkg_resources.files(pkg_resources.import_module('chip.testing')).joinpath('data_model').joinpath(data_model_directory), xml) as file:
-                tree = ElementTree.parse(file)
+            with pkg_resources.open_text(
+                pkg_resources.files(pkg_resources.import_module('chip.testing'))
+                .joinpath('data_model')
+                .joinpath(data_model_directory), xml
+            ) as file:
+                # Directly parse the XML file without assigning it to 'tree'
+                ElementTree.parse(file)  # Parse the file to process it
         except Exception as e:
             logging.error(f"Error parsing XML file {xml}: {e}")
 


### PR DESCRIPTION
Work for Issue #31317 

PR 23 - Updated `spec_parsing.py` to dynamically reference the data model directory from the python package `chip_testing` ensuring consistent and flexible path handling

