### PR TITLE
Add pigweed.json to root and opt out to cli analytics

### DIFF
--- a/pigweed.json
+++ b/pigweed.json
@@ -1,0 +1,7 @@
+{
+    "pw": {
+        "pw_cli_analytics": {
+            "enabled": false
+	}
+    }
+}

--- a/pigweed.json
+++ b/pigweed.json
@@ -2,6 +2,6 @@
     "pw": {
         "pw_cli_analytics": {
             "enabled": false
-	}
+        }
     }
 }


### PR DESCRIPTION
While anyone that has bootstrapped has a user config that has already opted in. This project level setting will override the user setting.

Tests:
* CI Passes
* bootstrapped then ran `pw cli-analytics` to confirm we are opted out from cli analytic
