### PR TITLE
XML updates for ServiceArea related namespaces

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
@@ -80,64 +80,62 @@ limitations under the License.
     <item value="0x25" name="Garden Door"/>
     <item value="0x26" name="Guest Bathroom"/>
     <item value="0x27" name="Guest Bedroom"/>
-    <item value="0x28" name="Guest Restroom"/>
-    <item value="0x29" name="Guest Room"/>
-    <item value="0x2A" name="Gym"/>
-    <item value="0x2B" name="Hallway"/>
-    <item value="0x2C" name="Hearth Room"/>
-    <item value="0x2D" name="Kids Room"/>
-    <item value="0x2E" name="Kids Bedroom"/>
-    <item value="0x2F" name="Kitchen"/>
+    <item value="0x28" name="Guest Room"/>
+    <item value="0x29" name="Gym"/>
+    <item value="0x2A" name="Hallway"/>
+    <item value="0x2B" name="Hearth Room"/>
+    <item value="0x2C" name="Kids Room"/>
+    <item value="0x2D" name="Kids Bedroom"/>
+    <item value="0x2E" name="Kitchen"/>
+    <item value="0x2F" name="Laundry Room"/>
 
-    <item value="0x30" name="Larder"/>
-    <item value="0x31" name="Laundry Room"/>
-    <item value="0x32" name="Lawn"/>
-    <item value="0x33" name="Library"/>
-    <item value="0x34" name="Living Room"/>
-    <item value="0x35" name="Lounge"/>
-    <item value="0x36" name="Media/TV Room"/>
-    <item value="0x37" name="Mud Room"/>
-    <item value="0x38" name="Music Room"/>
-    <item value="0x39" name="Nursery"/>
-    <item value="0x3A" name="Office"/>
-    <item value="0x3B" name="Outdoor Kitchen"/>
-    <item value="0x3C" name="Outside"/>
-    <item value="0x3D" name="Pantry"/>
-    <item value="0x3E" name="Parking Lot"/>
-    <item value="0x3F" name="Parlor"/>
+    <item value="0x30" name="Lawn"/>
+    <item value="0x31" name="Library"/>
+    <item value="0x32" name="Living Room"/>
+    <item value="0x33" name="Lounge"/>
+    <item value="0x34" name="Media/TV Room"/>
+    <item value="0x35" name="Mud Room"/>
+    <item value="0x36" name="Music Room"/>
+    <item value="0x37" name="Nursery"/>
+    <item value="0x38" name="Office"/>
+    <item value="0x39" name="Outdoor Kitchen"/>
+    <item value="0x3A" name="Outside"/>
+    <item value="0x3B" name="Pantry"/>
+    <item value="0x3C" name="Parking Lot"/>
+    <item value="0x3D" name="Parlor"/>
+    <item value="0x3E" name="Patio"/>
+    <item value="0x3F" name="Play Room"/>
 
-    <item value="0x40" name="Patio"/>
-    <item value="0x41" name="Play Room"/>
-    <item value="0x42" name="Pool Room"/>
-    <item value="0x43" name="Porch"/>
-    <item value="0x44" name="Primary Bathroom"/>
-    <item value="0x45" name="Primary Bedroom"/>
-    <item value="0x46" name="Ramp"/>
-    <item value="0x47" name="Reception Room"/>
-    <item value="0x48" name="Recreation Room"/>
-    <item value="0x49" name="Restroom"/>
-    <item value="0x4A" name="Roof"/>
-    <item value="0x4B" name="Sauna"/>
-    <item value="0x4C" name="Scullery"/>
-    <item value="0x4D" name="Sewing Room"/>
-    <item value="0x4E" name="Shed"/>
-    <item value="0x4F" name="Side Door"/>
+    <item value="0x40" name="Pool Room"/>
+    <item value="0x41" name="Porch"/>
+    <item value="0x42" name="Primary Bathroom"/>
+    <item value="0x43" name="Primary Bedroom"/>
+    <item value="0x44" name="Ramp"/>
+    <item value="0x45" name="Reception Room"/>
+    <item value="0x46" name="Recreation Room"/>
+    <item value="0x47" name="Roof"/>
+    <item value="0x48" name="Sauna"/>
+    <item value="0x49" name="Scullery"/>
+    <item value="0x4A" name="Sewing Room"/>
+    <item value="0x4B" name="Shed"/>
+    <item value="0x4C" name="Side Door"/>
+    <item value="0x4D" name="Side Yard"/>
+    <item value="0x4E" name="Sitting Room"/>
+    <item value="0x4F" name="Snug"/>
 
-    <item value="0x50" name="Side Yard"/>
-    <item value="0x51" name="Sitting Room"/>
-    <item value="0x52" name="Snug"/>
-    <item value="0x53" name="Spa"/>
-    <item value="0x54" name="Staircase"/>
-    <item value="0x55" name="Steam Room"/>
-    <item value="0x56" name="Storage Room"/>
-    <item value="0x57" name="Studio"/>
-    <item value="0x58" name="Study"/>
-    <item value="0x59" name="Sun Room"/>
-    <item value="0x5A" name="Swimming Pool"/>
-    <item value="0x5B" name="Terrace"/>
-    <item value="0x5C" name="Utility Room"/>
-    <item value="0x5D" name="Ward"/>
-    <item value="0x5E" name="Workshop"/>
+    <item value="0x50" name="Spa"/>
+    <item value="0x51" name="Staircase"/>
+    <item value="0x52" name="Steam Room"/>
+    <item value="0x53" name="Storage Room"/>
+    <item value="0x54" name="Studio"/>
+    <item value="0x55" name="Study"/>
+    <item value="0x56" name="Sun Room"/>
+    <item value="0x57" name="Swimming Pool"/>
+    <item value="0x58" name="Terrace"/>
+    <item value="0x59" name="Toilet"/>
+    <item value="0x5A" name="Utility Room"/>
+    <item value="0x5B" name="Ward"/>
+    <item value="0x5C" name="Workshop"/>
   </enum>
 
   <enum name="LandmarkTag" type="enum8">

--- a/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
@@ -17,6 +17,12 @@ limitations under the License.
 
 
 <configurator>
+  <enum name="LocationTag" type="enum8">
+    <item value="0x00" name="Indoor"/>
+    <item value="0x01" name="Outdoor"/>
+    <item value="0x02" name="Inside"/>
+    <item value="0x03" name="Outside"/>
+  </enum>
   <enum name="PositionTag" type="enum8">
     <item value="0x00" name="Left"/>
     <item value="0x01" name="Right"/>

--- a/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/semantic-tag-namespace-enums.xml
@@ -201,33 +201,4 @@ limitations under the License.
     <item value="0x32" name="Wine Cooler"/>
   </enum>
 
-  <enum name="FloorSurfaceTag" type="enum8">
-    <item value="0x00" name="Carpet"/>
-    <item value="0x01" name="Ceramic"/>
-    <item value="0x02" name="Concrete"/>
-    <item value="0x03" name="Cork"/>
-    <item value="0x04" name="Deep Carpet"/>
-    <item value="0x05" name="Dirt"/>
-    <item value="0x06" name="Engineered Wood"/>
-    <item value="0x07" name="Glass"/>
-    <item value="0x08" name="Grass"/>
-    <item value="0x09" name="Hardwood"/>
-    <item value="0x0A" name="Laminate"/>
-    <item value="0x0B" name="Linoleum"/>
-    <item value="0x0C" name="Mat"/>
-    <item value="0x0D" name="Metal"/>
-    <item value="0x0E" name="Plastic"/>
-    <item value="0x0F" name="Polished Concrete"/>
-    
-    <item value="0x10" name="Rubber"/>
-    <item value="0x11" name="Rug"/>
-    <item value="0x12" name="Sand"/>
-    <item value="0x13" name="Stone"/>
-    <item value="0x14" name="Tatami"/>
-    <item value="0x15" name="Terrazzo"/>
-    <item value="0x16" name="Tile"/>
-    <item value="0x17" name="Vinyl"/>
-  </enum>
-
-
 </configurator>


### PR DESCRIPTION
- **regen common area namespace tags**
  - tried to preserve newlines every 0x10 items - unclear if this is globally desired.  if it is, maybe we should add that to `alchemy`.
  - note that this changes the values of all items 0x28 and above. 
- **generate common location namespace tags XML**
  - was not present yet
- **remove FloorSurfaceTag** 
  - removed in [spec issue 10135](https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10135)

fixes #36584

**TODO**
- [x] determine spec-SDK reconcilliation direction