### PR TITLE
Fix cert tests for rev 0 tv clusters

### DIFF
--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -106,6 +106,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::VendorName::Id, CHAR_STR
                               0), /* ApplicationVersion */
     DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::AllowedVendorList::Id, ARRAY, kDescriptorAttributeArraySize,
                               0), /* AllowedVendorList */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::Application::Id, STRUCT, 1, 0),                  /* Application */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                 /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Keypad Input cluster attributes
@@ -117,12 +119,14 @@ DECLARE_DYNAMIC_ATTRIBUTE(KeypadInput::Attributes::FeatureMap::Id, BITMAP32, 4, 
 // NOTE: Does not make sense for content app to be able to set the AP feature flag
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(applicationLauncherAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CatalogList::Id, ARRAY, kDescriptorAttributeArraySize,
-                          0),                                                                 /* catalog list */
-    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CurrentApp::Id, STRUCT, 1, 0), /* current app */
+                          0),                                                                   /* catalog list */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CurrentApp::Id, STRUCT, 1, 0),   /* current app */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Account Login cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(accountLoginAttrs)
+    DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Content Launcher cluster attributes
@@ -150,6 +154,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(MediaPlayback::Attributes::CurrentState::Id, ENUM8, 1,
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(targetNavigatorAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::TargetList::Id, ARRAY, kDescriptorAttributeArraySize, 0), /* target list */
     DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::CurrentTarget::Id, INT8U, 1, 0), /* current target */
+    DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Channel cluster attributes

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -348,6 +348,8 @@ DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::VendorName::Id, CHAR_STR
                               0), /* ApplicationVersion */
     DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::AllowedVendorList::Id, ARRAY, kDescriptorAttributeArraySize,
                               0), /* AllowedVendorList */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::Application::Id, STRUCT, 1, 0),                  /* Application */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationBasic::Attributes::FeatureMap::Id, BITMAP32, 4, 0),                 /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Keypad Input cluster attributes
@@ -359,12 +361,14 @@ DECLARE_DYNAMIC_ATTRIBUTE(KeypadInput::Attributes::FeatureMap::Id, BITMAP32, 4, 
 // NOTE: Does not make sense for content app to be able to set the AP feature flag
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(applicationLauncherAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CatalogList::Id, ARRAY, kDescriptorAttributeArraySize,
-                          0),                                                                 /* catalog list */
-    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CurrentApp::Id, STRUCT, 1, 0), /* current app */
+                          0),                                                                   /* catalog list */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::CurrentApp::Id, STRUCT, 1, 0),   /* current app */
+    DECLARE_DYNAMIC_ATTRIBUTE(ApplicationLauncher::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Account Login cluster attributes
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(accountLoginAttrs)
+    DECLARE_DYNAMIC_ATTRIBUTE(AccountLogin::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Content Launcher cluster attributes
@@ -392,6 +396,7 @@ DECLARE_DYNAMIC_ATTRIBUTE(MediaPlayback::Attributes::CurrentState::Id, ENUM8, 1,
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(targetNavigatorAttrs)
 DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::TargetList::Id, ARRAY, kDescriptorAttributeArraySize, 0), /* target list */
     DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::CurrentTarget::Id, INT8U, 1, 0), /* current target */
+    DECLARE_DYNAMIC_ATTRIBUTE(TargetNavigator::Attributes::FeatureMap::Id, BITMAP32, 4, 0), /* FeatureMap */
     DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
 
 // Declare Channel cluster attributes

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -142,6 +142,11 @@ CHIP_ERROR AccountLoginAttrAccess::Read(const app::ConcreteReadAttributePath & a
     {
     case app::Clusters::AccountLogin::Attributes::ClusterRevision::Id:
         return ReadRevisionAttribute(endpoint, aEncoder, delegate);
+    case app::Clusters::AccountLogin::Attributes::FeatureMap::Id: {
+            uint32_t featureMap = 0;
+            return aEncoder.Encode(featureMap);
+
+    }
     default:
         break;
     }

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -188,6 +188,15 @@ CHIP_ERROR ApplicationBasicAttrAccess::Read(const app::ConcreteReadAttributePath
         return ReadApplicationVersionAttribute(aEncoder, delegate);
     case chip::app::Clusters::ApplicationBasic::Attributes::AllowedVendorList::Id:
         return ReadAllowedVendorListAttribute(aEncoder, delegate);
+    case chip::app::Clusters::ApplicationBasic::Attributes::FeatureMap::Id: {
+            uint32_t featureMap = 0;
+            return aEncoder.Encode(featureMap);
+
+    }
+    case chip::app::Clusters::ApplicationBasic::Attributes::ClusterRevision::Id: {
+            uint16_t clusterRevision = 0;
+            return aEncoder.Encode(clusterRevision);
+    }
     default: {
         break;
     }

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -201,6 +201,15 @@ CHIP_ERROR ApplicationLauncherAttrAccess::Read(const app::ConcreteReadAttributeP
 
         return ReadCurrentAppAttribute(aEncoder, delegate);
     }
+    case chip::app::Clusters::ApplicationLauncher::Attributes::FeatureMap::Id: {
+            uint32_t featureMap = 0;
+            return aEncoder.Encode(featureMap);
+
+    }
+    case chip::app::Clusters::ApplicationLauncher::Attributes::ClusterRevision::Id: {
+            uint16_t clusterRevision = 0;
+            return aEncoder.Encode(clusterRevision);
+    }
     default: {
         break;
     }

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -150,6 +150,10 @@ CHIP_ERROR KeypadInputAttrAccess::Read(const app::ConcreteReadAttributePath & aP
     case app::Clusters::KeypadInput::Attributes::FeatureMap::Id: {
         return ReadFeatureFlagAttribute(endpoint, aEncoder, delegate);
     }
+    case app::Clusters::KeypadInput::Attributes::ClusterRevision::Id: {
+            uint16_t clusterRevision = 0;
+            return aEncoder.Encode(clusterRevision);
+    }
 
     default: {
         break;

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -159,6 +159,11 @@ CHIP_ERROR TargetNavigatorAttrAccess::Read(const app::ConcreteReadAttributePath 
     }
     case app::Clusters::TargetNavigator::Attributes::ClusterRevision::Id:
         return ReadRevisionAttribute(endpoint, aEncoder, delegate);
+    case app::Clusters::TargetNavigator::Attributes::FeatureMap::Id: {
+            uint32_t featureMap = 0;
+            return aEncoder.Encode(featureMap);
+
+    }
     default:
         break;
     }


### PR DESCRIPTION
Matter 1.0 did not require all clusters to have a feature-map or cluster-revision attribute. This fix adds them.
Fixes #36141 (https://github.com/project-chip/connectedhomeip/issues/36141)