### PR TITLE
Refactor kReadCommissioningInfo step in DeviceCommissioner

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -359,8 +359,6 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
             // Per the spec, we restart from after adding the NOC.
             return GetNextCommissioningStage(CommissioningStage::kSendNOC, lastErr);
         }
-        return CommissioningStage::kReadCommissioningInfo2;
-    case CommissioningStage::kReadCommissioningInfo2:
         return CommissioningStage::kArmFailsafe;
     case CommissioningStage::kArmFailsafe:
         return CommissioningStage::kConfigRegulatory;
@@ -764,9 +762,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
         ChipLogProgress(Controller, "Successfully finished commissioning step '%s'", StageToString(report.stageCompleted));
         switch (report.stageCompleted)
         {
-        case CommissioningStage::kReadCommissioningInfo:
-            break;
-        case CommissioningStage::kReadCommissioningInfo2: {
+        case CommissioningStage::kReadCommissioningInfo: {
             mDeviceCommissioningInfo = report.Get<ReadCommissioningInfo>();
 
             if (!mParams.GetFailsafeTimerSeconds().HasValue() && mDeviceCommissioningInfo.general.recommendedFailsafe > 0)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2211,7 +2211,13 @@ void DeviceCommissioner::OnDone(app::ReadClient * readClient)
 }
 
 namespace {
-// Helper for grouping attribute paths into read interactions
+// Helper for grouping attribute paths into read interactions in ContinueReadingCommissioningInfo()
+// below. The logic generates a sequence of calls to AddAttributePath(), stopping when the capacity
+// of the builder is exceeded. When creating subsequent read requests, the same sequence of calls
+// is generated again, but the builder will skip however many attributes were already read in
+// previous requests. This makes it easy to have logic that conditionally reads attributes, without
+// needing to write manual code to work out where subsequent reads need to resume -- the logic that
+// decides which attributes to read simply needs to be repeatable / deterministic.
 class ReadInteractionBuilder
 {
     static constexpr auto kCapacity = InteractionModelEngine::kMinSupportedPathsPerReadRequest;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -82,11 +82,11 @@
 #include <time.h>
 
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::Inet;
 using namespace chip::System;
 using namespace chip::Transport;
 using namespace chip::Credentials;
-using namespace chip::app::Clusters;
 using namespace chip::Crypto;
 using namespace chip::Tracing;
 
@@ -2332,24 +2332,28 @@ void DeviceCommissioner::ContinueReadingCommissioningInfo(const CommissioningPar
     SendCommissioningReadRequest(mDeviceBeingCommissioned, timeout, builder.paths(), builder.size());
 }
 
+namespace {
+void AccumulateErrors(CHIP_ERROR & acc, CHIP_ERROR err)
+{
+    if (acc == CHIP_NO_ERROR && err != CHIP_NO_ERROR)
+    {
+        acc = err;
+    }
+}
+} // namespace
+
 void DeviceCommissioner::FinishReadingCommissioningInfo()
 {
+    // We want to parse as much information as possible, even if we eventually end
+    // up returning an error (e.g. because some mandatory information was missing).
     CHIP_ERROR err = CHIP_NO_ERROR;
     ReadCommissioningInfo info;
-
-    err = ParseCommissioningInfo1(info);
-    if (err == CHIP_NO_ERROR)
-    {
-        err = ParseCommissioningInfo2(info);
-    }
-
-    // Move ownership of mAttributeCache to the stack, but don't release it until this function returns.
-    // This way we don't have to make a copy while parsing commissioning info, and it won't
-    // affect future commissioning steps.
-    //
-    // The stack reference needs to survive until CommissioningStageComplete and OnReadCommissioningInfo
-    // return.
-    auto attributeCache = std::move(mAttributeCache);
+    AccumulateErrors(err, ParseGeneralCommissioningInfo(info));
+    AccumulateErrors(err, ParseBasicInformation(info));
+    AccumulateErrors(err, ParseNetworkCommissioningInfo(info));
+    AccumulateErrors(err, ParseTimeSyncInfo(info));
+    AccumulateErrors(err, ParseFabrics(info));
+    AccumulateErrors(err, ParseICDInfo(info));
 
     if (mPairingDelegate != nullptr && err == CHIP_NO_ERROR)
     {
@@ -2359,188 +2363,201 @@ void DeviceCommissioner::FinishReadingCommissioningInfo()
     CommissioningDelegate::CommissioningReport report;
     report.Set<ReadCommissioningInfo>(info);
     CommissioningStageComplete(err, report);
+
+    // Only release the attribute cache once `info` is no longer needed.
+    mAttributeCache.reset();
 }
 
-CHIP_ERROR DeviceCommissioner::ParseCommissioningInfo1(ReadCommissioningInfo & info)
+CHIP_ERROR DeviceCommissioner::ParseGeneralCommissioningInfo(ReadCommissioningInfo & info)
 {
-    CHIP_ERROR err;
+    using namespace GeneralCommissioning::Attributes;
     CHIP_ERROR return_err = CHIP_NO_ERROR;
+    CHIP_ERROR err;
 
-    // Try to parse as much as we can here before returning, even if attributes
-    // are missing or cannot be decoded.
+    BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
+    err = mAttributeCache->Get<BasicCommissioningInfo::TypeInfo>(kRootEndpointId, basicInfo);
+    if (err == CHIP_NO_ERROR)
     {
-        using namespace chip::app::Clusters::GeneralCommissioning;
-        using namespace chip::app::Clusters::GeneralCommissioning::Attributes;
-
-        BasicCommissioningInfo::TypeInfo::DecodableType basicInfo;
-        err = mAttributeCache->Get<BasicCommissioningInfo::TypeInfo>(kRootEndpointId, basicInfo);
-        if (err == CHIP_NO_ERROR)
-        {
-            info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
-        }
-        else
-        {
-            ChipLogError(Controller, "Failed to read BasicCommissioningInfo: %" CHIP_ERROR_FORMAT, err.Format());
-            return_err = err;
-        }
-
-        err = mAttributeCache->Get<RegulatoryConfig::TypeInfo>(kRootEndpointId, info.general.currentRegulatoryLocation);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Controller, "Failed to read RegulatoryConfig: %" CHIP_ERROR_FORMAT, err.Format());
-            return_err = err;
-        }
-
-        err = mAttributeCache->Get<LocationCapability::TypeInfo>(kRootEndpointId, info.general.locationCapability);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Controller, "Failed to read LocationCapability: %" CHIP_ERROR_FORMAT, err.Format());
-            return_err = err;
-        }
-
-        err = mAttributeCache->Get<Breadcrumb::TypeInfo>(kRootEndpointId, info.general.breadcrumb);
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(Controller, "Failed to read Breadcrumb: %" CHIP_ERROR_FORMAT, err.Format());
-            return_err = err;
-        }
+        info.general.recommendedFailsafe = basicInfo.failSafeExpiryLengthSeconds;
+    }
+    else
+    {
+        ChipLogError(Controller, "Failed to read BasicCommissioningInfo: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
     }
 
+    err = mAttributeCache->Get<RegulatoryConfig::TypeInfo>(kRootEndpointId, info.general.currentRegulatoryLocation);
+    if (err != CHIP_NO_ERROR)
     {
-        using namespace chip::app::Clusters::BasicInformation;
-        using namespace chip::app::Clusters::BasicInformation::Attributes;
-
-        err        = mAttributeCache->Get<VendorID::TypeInfo>(kRootEndpointId, info.basic.vendorId);
-        return_err = err == CHIP_NO_ERROR ? return_err : err;
-
-        err        = mAttributeCache->Get<ProductID::TypeInfo>(kRootEndpointId, info.basic.productId);
-        return_err = err == CHIP_NO_ERROR ? return_err : err;
+        ChipLogError(Controller, "Failed to read RegulatoryConfig: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
     }
-    // Try to parse as much as we can here before returning, even if this is an error.
-    return_err = err == CHIP_NO_ERROR ? return_err : err;
 
-    // Set the network cluster endpoints first so we can match up the connection
-    // times.  Note that here we don't know what endpoints the network
-    // commissioning clusters might be on.
-    err = mAttributeCache->ForEachAttribute(
-        app::Clusters::NetworkCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
-            using namespace chip::app::Clusters;
-            using namespace chip::app::Clusters::NetworkCommissioning::Attributes;
-            if (path.mAttributeId != FeatureMap::Id)
-            {
-                return CHIP_NO_ERROR;
-            }
-            TLV::TLVReader reader;
-            if (this->mAttributeCache->Get(path, reader) == CHIP_NO_ERROR)
-            {
-                BitFlags<NetworkCommissioning::Feature> features;
-                if (app::DataModel::Decode(reader, features) == CHIP_NO_ERROR)
-                {
-                    if (features.Has(NetworkCommissioning::Feature::kWiFiNetworkInterface))
-                    {
-                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has WiFi. endpointid = %u",
-                                        path.mEndpointId);
-                        info.network.wifi.endpoint = path.mEndpointId;
-                    }
-                    else if (features.Has(NetworkCommissioning::Feature::kThreadNetworkInterface))
-                    {
-                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Thread. endpointid = %u",
-                                        path.mEndpointId);
-                        info.network.thread.endpoint = path.mEndpointId;
-                    }
-                    else if (features.Has(NetworkCommissioning::Feature::kEthernetNetworkInterface))
-                    {
-                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Ethernet. endpointid = %u",
-                                        path.mEndpointId);
-                        info.network.eth.endpoint = path.mEndpointId;
-                    }
-                    else
-                    {
-                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: no features.");
-                        // TODO: Gross workaround for the empty feature map on all clusters. Remove.
-                        if (info.network.thread.endpoint == kInvalidEndpointId)
-                        {
-                            info.network.thread.endpoint = path.mEndpointId;
-                        }
-                        if (info.network.wifi.endpoint == kInvalidEndpointId)
-                        {
-                            info.network.wifi.endpoint = path.mEndpointId;
-                        }
-                    }
-                }
-            }
-            return CHIP_NO_ERROR;
-        });
-    return_err = err == CHIP_NO_ERROR ? return_err : err;
-
-    err = mAttributeCache->ForEachAttribute(
-        app::Clusters::NetworkCommissioning::Id, [this, &info](const app::ConcreteAttributePath & path) {
-            using namespace chip::app::Clusters::NetworkCommissioning::Attributes;
-            if (path.mAttributeId != ConnectMaxTimeSeconds::Id)
-            {
-                return CHIP_NO_ERROR;
-            }
-            ConnectMaxTimeSeconds::TypeInfo::DecodableArgType time;
-            ReturnErrorOnFailure(this->mAttributeCache->Get<ConnectMaxTimeSeconds::TypeInfo>(path, time));
-            if (path.mEndpointId == info.network.wifi.endpoint)
-            {
-                info.network.wifi.minConnectionTime = time;
-            }
-            else if (path.mEndpointId == info.network.thread.endpoint)
-            {
-                info.network.thread.minConnectionTime = time;
-            }
-            else if (path.mEndpointId == info.network.eth.endpoint)
-            {
-                info.network.eth.minConnectionTime = time;
-            }
-            return CHIP_NO_ERROR;
-        });
-    return_err = err == CHIP_NO_ERROR ? return_err : err;
-
-    ParseTimeSyncInfo(info);
-
-    if (return_err != CHIP_NO_ERROR)
+    err = mAttributeCache->Get<LocationCapability::TypeInfo>(kRootEndpointId, info.general.locationCapability);
+    if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Error parsing commissioning information");
+        ChipLogError(Controller, "Failed to read LocationCapability: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
+    }
+
+    err = mAttributeCache->Get<Breadcrumb::TypeInfo>(kRootEndpointId, info.general.breadcrumb);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to read Breadcrumb: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
+    }
+
+    err = mAttributeCache->Get<SupportsConcurrentConnection::TypeInfo>(kRootEndpointId, info.supportsConcurrentConnection);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Ignoring failure to read SupportsConcurrentConnection: %" CHIP_ERROR_FORMAT, err.Format());
+        info.supportsConcurrentConnection = true; // default to true (concurrent), not a fatal error
     }
 
     return return_err;
 }
 
-void DeviceCommissioner::ParseTimeSyncInfo(ReadCommissioningInfo & info)
+CHIP_ERROR DeviceCommissioner::ParseBasicInformation(ReadCommissioningInfo & info)
 {
-    using namespace app::Clusters;
-
+    using namespace BasicInformation::Attributes;
+    CHIP_ERROR return_err = CHIP_NO_ERROR;
     CHIP_ERROR err;
+
+    err = mAttributeCache->Get<VendorID::TypeInfo>(kRootEndpointId, info.basic.vendorId);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to read VendorID: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
+    }
+
+    err = mAttributeCache->Get<ProductID::TypeInfo>(kRootEndpointId, info.basic.productId);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to read ProductID: %" CHIP_ERROR_FORMAT, err.Format());
+        return_err = err;
+    }
+
+    return return_err;
+}
+
+CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningInfo & info)
+{
+    using namespace NetworkCommissioning::Attributes;
+    CHIP_ERROR return_err = CHIP_NO_ERROR;
+    CHIP_ERROR err;
+
+    // Set the network cluster endpoints first so we can match up the connection
+    // times. Note that here we don't know what endpoints the network
+    // commissioning clusters might be on.
+    err = mAttributeCache->ForEachAttribute(NetworkCommissioning::Id, [this, &info](const ConcreteAttributePath & path) {
+        if (path.mAttributeId != FeatureMap::Id)
+        {
+            return CHIP_NO_ERROR;
+        }
+        TLV::TLVReader reader;
+        if (this->mAttributeCache->Get(path, reader) == CHIP_NO_ERROR)
+        {
+            BitFlags<NetworkCommissioning::Feature> features;
+            if (app::DataModel::Decode(reader, features) == CHIP_NO_ERROR)
+            {
+                if (features.Has(NetworkCommissioning::Feature::kWiFiNetworkInterface))
+                {
+                    ChipLogProgress(Controller, "----- NetworkCommissioning Features: has WiFi. endpointid = %u", path.mEndpointId);
+                    info.network.wifi.endpoint = path.mEndpointId;
+                }
+                else if (features.Has(NetworkCommissioning::Feature::kThreadNetworkInterface))
+                {
+                    ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Thread. endpointid = %u",
+                                    path.mEndpointId);
+                    info.network.thread.endpoint = path.mEndpointId;
+                }
+                else if (features.Has(NetworkCommissioning::Feature::kEthernetNetworkInterface))
+                {
+                    ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Ethernet. endpointid = %u",
+                                    path.mEndpointId);
+                    info.network.eth.endpoint = path.mEndpointId;
+                }
+                else
+                {
+                    ChipLogProgress(Controller, "----- NetworkCommissioning Features: no features.");
+                    // TODO: Gross workaround for the empty feature map on all clusters. Remove.
+                    if (info.network.thread.endpoint == kInvalidEndpointId)
+                    {
+                        info.network.thread.endpoint = path.mEndpointId;
+                    }
+                    if (info.network.wifi.endpoint == kInvalidEndpointId)
+                    {
+                        info.network.wifi.endpoint = path.mEndpointId;
+                    }
+                }
+            }
+        }
+        return CHIP_NO_ERROR;
+    });
+    AccumulateErrors(return_err, err);
+
+    err = mAttributeCache->ForEachAttribute(Clusters::NetworkCommissioning::Id, [this, &info](const ConcreteAttributePath & path) {
+        if (path.mAttributeId != ConnectMaxTimeSeconds::Id)
+        {
+            return CHIP_NO_ERROR;
+        }
+        ConnectMaxTimeSeconds::TypeInfo::DecodableArgType time;
+        ReturnErrorOnFailure(this->mAttributeCache->Get<ConnectMaxTimeSeconds::TypeInfo>(path, time));
+        if (path.mEndpointId == info.network.wifi.endpoint)
+        {
+            info.network.wifi.minConnectionTime = time;
+        }
+        else if (path.mEndpointId == info.network.thread.endpoint)
+        {
+            info.network.thread.minConnectionTime = time;
+        }
+        else if (path.mEndpointId == info.network.eth.endpoint)
+        {
+            info.network.eth.minConnectionTime = time;
+        }
+        return CHIP_NO_ERROR;
+    });
+    AccumulateErrors(return_err, err);
+
+    if (return_err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to parsing Network Commissioning information: %" CHIP_ERROR_FORMAT, return_err.Format());
+    }
+
+    return return_err;
+}
+
+CHIP_ERROR DeviceCommissioner::ParseTimeSyncInfo(ReadCommissioningInfo & info)
+{
+    using namespace TimeSynchronization::Attributes;
+    CHIP_ERROR err;
+
     // If we fail to get the feature map, there's no viable time cluster, don't set anything.
-    TimeSynchronization::Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
-    err = mAttributeCache->Get<TimeSynchronization::Attributes::FeatureMap::TypeInfo>(kRootEndpointId, featureMap);
+    BitFlags<TimeSynchronization::Feature> featureMap;
+    err = mAttributeCache->Get<FeatureMap::TypeInfo>(kRootEndpointId, *featureMap.RawStorage());
     if (err != CHIP_NO_ERROR)
     {
         info.requiresUTC               = false;
         info.requiresTimeZone          = false;
         info.requiresDefaultNTP        = false;
         info.requiresTrustedTimeSource = false;
-        return;
+        return CHIP_NO_ERROR;
     }
     info.requiresUTC               = true;
-    info.requiresTimeZone          = featureMap & chip::to_underlying(TimeSynchronization::Feature::kTimeZone);
-    info.requiresDefaultNTP        = featureMap & chip::to_underlying(TimeSynchronization::Feature::kNTPClient);
-    info.requiresTrustedTimeSource = featureMap & chip::to_underlying(TimeSynchronization::Feature::kTimeSyncClient);
+    info.requiresTimeZone          = featureMap.Has(TimeSynchronization::Feature::kTimeZone);
+    info.requiresDefaultNTP        = featureMap.Has(TimeSynchronization::Feature::kNTPClient);
+    info.requiresTrustedTimeSource = featureMap.Has(TimeSynchronization::Feature::kTimeSyncClient);
 
     if (info.requiresTimeZone)
     {
-        err = mAttributeCache->Get<TimeSynchronization::Attributes::TimeZoneListMaxSize::TypeInfo>(kRootEndpointId,
-                                                                                                   info.maxTimeZoneSize);
+        err = mAttributeCache->Get<TimeZoneListMaxSize::TypeInfo>(kRootEndpointId, info.maxTimeZoneSize);
         if (err != CHIP_NO_ERROR)
         {
             // This information should be available, let's do our best with what we have, but we can't set
             // the time zone without this information
             info.requiresTimeZone = false;
         }
-        err =
-            mAttributeCache->Get<TimeSynchronization::Attributes::DSTOffsetListMaxSize::TypeInfo>(kRootEndpointId, info.maxDSTSize);
+        err = mAttributeCache->Get<DSTOffsetListMaxSize::TypeInfo>(kRootEndpointId, info.maxDSTSize);
         if (err != CHIP_NO_ERROR)
         {
             info.requiresTimeZone = false;
@@ -2548,8 +2565,8 @@ void DeviceCommissioner::ParseTimeSyncInfo(ReadCommissioningInfo & info)
     }
     if (info.requiresDefaultNTP)
     {
-        TimeSynchronization::Attributes::DefaultNTP::TypeInfo::DecodableType defaultNTP;
-        err = mAttributeCache->Get<TimeSynchronization::Attributes::DefaultNTP::TypeInfo>(kRootEndpointId, defaultNTP);
+        DefaultNTP::TypeInfo::DecodableType defaultNTP;
+        err = mAttributeCache->Get<DefaultNTP::TypeInfo>(kRootEndpointId, defaultNTP);
         if (err == CHIP_NO_ERROR && (!defaultNTP.IsNull()) && (defaultNTP.Value().size() != 0))
         {
             info.requiresDefaultNTP = false;
@@ -2557,49 +2574,26 @@ void DeviceCommissioner::ParseTimeSyncInfo(ReadCommissioningInfo & info)
     }
     if (info.requiresTrustedTimeSource)
     {
-        TimeSynchronization::Attributes::TrustedTimeSource::TypeInfo::DecodableType trustedTimeSource;
-        err =
-            mAttributeCache->Get<TimeSynchronization::Attributes::TrustedTimeSource::TypeInfo>(kRootEndpointId, trustedTimeSource);
-
+        TrustedTimeSource::TypeInfo::DecodableType trustedTimeSource;
+        err = mAttributeCache->Get<TrustedTimeSource::TypeInfo>(kRootEndpointId, trustedTimeSource);
         if (err == CHIP_NO_ERROR && !trustedTimeSource.IsNull())
         {
             info.requiresTrustedTimeSource = false;
         }
     }
-}
 
-CHIP_ERROR DeviceCommissioner::ParseCommissioningInfo2(ReadCommissioningInfo & info)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    using namespace chip::app::Clusters::GeneralCommissioning::Attributes;
-
-    if (mAttributeCache->Get<SupportsConcurrentConnection::TypeInfo>(kRootEndpointId, info.supportsConcurrentConnection) !=
-        CHIP_NO_ERROR)
-    {
-        // May not be present so don't return the error code, non fatal, default concurrent
-        ChipLogError(Controller, "Failed to read SupportsConcurrentConnection: %" CHIP_ERROR_FORMAT, err.Format());
-        info.supportsConcurrentConnection = true;
-    }
-
-    err = ParseFabrics(info);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        err = ParseICDInfo(info);
-    }
-
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceCommissioner::ParseFabrics(ReadCommissioningInfo & info)
 {
+    using namespace OperationalCredentials::Attributes;
     CHIP_ERROR err;
     CHIP_ERROR return_err = CHIP_NO_ERROR;
 
     // We might not have requested a Fabrics attribute at all, so not having a
     // value for it is not an error.
-    err = mAttributeCache->ForEachAttribute(OperationalCredentials::Id, [this, &info](const app::ConcreteAttributePath & path) {
+    err = mAttributeCache->ForEachAttribute(OperationalCredentials::Id, [this, &info](const ConcreteAttributePath & path) {
         using namespace chip::app::Clusters::OperationalCredentials::Attributes;
         // this code is checking if the device is already on the commissioner's fabric.
         // if a matching fabric is found, then remember the nodeId so that the commissioner
@@ -2664,18 +2658,19 @@ CHIP_ERROR DeviceCommissioner::ParseFabrics(ReadCommissioningInfo & info)
 
 CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
 {
-    using chip::app::Clusters::IcdManagement::UserActiveModeTriggerBitmap;
-
+    using namespace IcdManagement::Attributes;
     CHIP_ERROR err;
-    IcdManagement::Attributes::FeatureMap::TypeInfo::DecodableType featureMap;
+
     bool hasUserActiveModeTrigger = false;
     bool isICD                    = false;
-    err = mAttributeCache->Get<IcdManagement::Attributes::FeatureMap::TypeInfo>(kRootEndpointId, featureMap);
+
+    BitFlags<IcdManagement::Feature> featureMap;
+    err = mAttributeCache->Get<FeatureMap::TypeInfo>(kRootEndpointId, *featureMap.RawStorage());
     if (err == CHIP_NO_ERROR)
     {
-        info.icd.isLIT                  = !!(featureMap & to_underlying(IcdManagement::Feature::kLongIdleTimeSupport));
-        info.icd.checkInProtocolSupport = !!(featureMap & to_underlying(IcdManagement::Feature::kCheckInProtocolSupport));
-        hasUserActiveModeTrigger        = !!(featureMap & to_underlying(IcdManagement::Feature::kUserActiveModeTrigger));
+        info.icd.isLIT                  = featureMap.Has(IcdManagement::Feature::kLongIdleTimeSupport);
+        info.icd.checkInProtocolSupport = featureMap.Has(IcdManagement::Feature::kCheckInProtocolSupport);
+        hasUserActiveModeTrigger        = featureMap.Has(IcdManagement::Feature::kUserActiveModeTrigger);
         isICD                           = true;
     }
     else if (err == CHIP_ERROR_KEY_NOT_FOUND)
@@ -2687,8 +2682,7 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
     else if (err == CHIP_ERROR_IM_STATUS_CODE_RECEIVED)
     {
         app::StatusIB statusIB;
-        err = mAttributeCache->GetStatus(
-            app::ConcreteAttributePath(kRootEndpointId, IcdManagement::Id, IcdManagement::Attributes::FeatureMap::Id), statusIB);
+        err = mAttributeCache->GetStatus(app::ConcreteAttributePath(kRootEndpointId, IcdManagement::Id, FeatureMap::Id), statusIB);
         if (err == CHIP_NO_ERROR)
         {
             if (statusIB.mStatus == Protocols::InteractionModel::Status::UnsupportedCluster)
@@ -2712,14 +2706,14 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
         // Intentionally ignore errors since they are not mandatory.
         bool activeModeTriggerInstructionRequired = false;
 
-        err = mAttributeCache->Get<IcdManagement::Attributes::UserActiveModeTriggerHint::TypeInfo>(
-            kRootEndpointId, info.icd.userActiveModeTriggerHint);
+        err = mAttributeCache->Get<UserActiveModeTriggerHint::TypeInfo>(kRootEndpointId, info.icd.userActiveModeTriggerHint);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "IcdManagement.UserActiveModeTriggerHint expected, but failed to read.");
             return err;
         }
 
+        using IcdManagement::UserActiveModeTriggerBitmap;
         activeModeTriggerInstructionRequired = info.icd.userActiveModeTriggerHint.HasAny(
             UserActiveModeTriggerBitmap::kCustomInstruction, UserActiveModeTriggerBitmap::kActuateSensorSeconds,
             UserActiveModeTriggerBitmap::kActuateSensorTimes, UserActiveModeTriggerBitmap::kActuateSensorLightsBlink,
@@ -2730,8 +2724,8 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
 
         if (activeModeTriggerInstructionRequired)
         {
-            err = mAttributeCache->Get<IcdManagement::Attributes::UserActiveModeTriggerInstruction::TypeInfo>(
-                kRootEndpointId, info.icd.userActiveModeTriggerInstruction);
+            err = mAttributeCache->Get<UserActiveModeTriggerInstruction::TypeInfo>(kRootEndpointId,
+                                                                                   info.icd.userActiveModeTriggerInstruction);
             if (err != CHIP_NO_ERROR)
             {
                 ChipLogError(Controller,
@@ -2750,14 +2744,14 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
         return CHIP_NO_ERROR;
     }
 
-    err = mAttributeCache->Get<IcdManagement::Attributes::IdleModeDuration::TypeInfo>(kRootEndpointId, info.icd.idleModeDuration);
+    err = mAttributeCache->Get<IdleModeDuration::TypeInfo>(kRootEndpointId, info.icd.idleModeDuration);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "IcdManagement.IdleModeDuration expected, but failed to read: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
-    err =
-        mAttributeCache->Get<IcdManagement::Attributes::ActiveModeDuration::TypeInfo>(kRootEndpointId, info.icd.activeModeDuration);
+
+    err = mAttributeCache->Get<ActiveModeDuration::TypeInfo>(kRootEndpointId, info.icd.activeModeDuration);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "IcdManagement.ActiveModeDuration expected, but failed to read: %" CHIP_ERROR_FORMAT,
@@ -2765,8 +2759,7 @@ CHIP_ERROR DeviceCommissioner::ParseICDInfo(ReadCommissioningInfo & info)
         return err;
     }
 
-    err = mAttributeCache->Get<IcdManagement::Attributes::ActiveModeThreshold::TypeInfo>(kRootEndpointId,
-                                                                                         info.icd.activeModeThreshold);
+    err = mAttributeCache->Get<ActiveModeThreshold::TypeInfo>(kRootEndpointId, info.icd.activeModeThreshold);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "IcdManagement.ActiveModeThreshold expected, but failed to read: %" CHIP_ERROR_FORMAT,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2259,7 +2259,7 @@ void DeviceCommissioner::ContinueReadingCommissioningInfo(const CommissioningPar
 {
     VerifyOrDie(mCommissioningStage == CommissioningStage::kReadCommissioningInfo);
 
-    // mReadCommissioningInfoProgress starts at 0 and counts the number of attributes we have read.
+    // mReadCommissioningInfoProgress starts at 0 and counts the number of paths we have read.
     // A marker value is used to indicate that there are no further attributes to read.
     static constexpr auto kReadProgressNoFurtherAttributes = std::numeric_limits<decltype(mReadCommissioningInfoProgress)>::max();
     if (mReadCommissioningInfoProgress == kReadProgressNoFurtherAttributes)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2232,8 +2232,17 @@ public:
     template <typename... Ts>
     bool AddAttributePath(Ts &&... args)
     {
-        VerifyOrReturnValue(mSkip == 0, true, mSkip--);
-        VerifyOrReturnValue(mCount < kCapacity, false, mCount = kCapacity + 1);
+        if (mSkip > 0)
+        {
+            mSkip--;
+            return true;
+        }
+        if (mCount >= kCapacity)
+        {
+            // capacity exceeded
+            mCount = kCapacity + 1;
+            return false;
+        }
         mPaths[mCount++] = app::AttributePathParams(std::forward<Ts>(args)...);
         return true;
     }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2484,19 +2484,6 @@ CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningIn
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Ethernet. endpointid = %u", path.mEndpointId);
                 info.network.eth.endpoint = path.mEndpointId;
             }
-            else
-            {
-                ChipLogProgress(Controller, "NetworkCommissioning Features: no features.");
-                // TODO: Gross workaround for the empty feature map on all clusters. Remove.
-                if (info.network.thread.endpoint == kInvalidEndpointId)
-                {
-                    info.network.thread.endpoint = path.mEndpointId;
-                }
-                if (info.network.wifi.endpoint == kInvalidEndpointId)
-                {
-                    info.network.wifi.endpoint = path.mEndpointId;
-                }
-            }
         }
         return CHIP_NO_ERROR;
     });

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2259,6 +2259,7 @@ void DeviceCommissioner::ContinueReadingCommissioningInfo(const CommissioningPar
 {
     VerifyOrDie(mCommissioningStage == CommissioningStage::kReadCommissioningInfo);
 
+    // mReadCommissioningInfoProgress starts at 0 and counts the number of attributes we have read.
     // A marker value is used to indicate that there are no further attributes to read.
     static constexpr auto kReadProgressNoFurtherAttributes = std::numeric_limits<decltype(mReadCommissioningInfoProgress)>::max();
     if (mReadCommissioningInfoProgress == kReadProgressNoFurtherAttributes)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -1054,14 +1054,12 @@ private:
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     void ContinueReadingCommissioningInfo(const CommissioningParameters & params);
     void FinishReadingCommissioningInfo();
-    // Parsing attributes read in kReadCommissioningInfo stage.
-    CHIP_ERROR ParseCommissioningInfo1(ReadCommissioningInfo & info);
-    CHIP_ERROR ParseCommissioningInfo2(ReadCommissioningInfo & info);
-    // Called by ParseCommissioningInfo2
+    CHIP_ERROR ParseGeneralCommissioningInfo(ReadCommissioningInfo & info);
+    CHIP_ERROR ParseBasicInformation(ReadCommissioningInfo & info);
+    CHIP_ERROR ParseNetworkCommissioningInfo(ReadCommissioningInfo & info);
     CHIP_ERROR ParseFabrics(ReadCommissioningInfo & info);
     CHIP_ERROR ParseICDInfo(ReadCommissioningInfo & info);
-    // Called by ParseCommissioningInfo
-    void ParseTimeSyncInfo(ReadCommissioningInfo & info);
+    CHIP_ERROR ParseTimeSyncInfo(ReadCommissioningInfo & info);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
     static CHIP_ERROR

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -839,7 +839,7 @@ private:
     CommissioneeDeviceProxy * mDeviceInPASEEstablishment = nullptr;
 
     CommissioningStage mCommissioningStage = CommissioningStage::kSecurePairing;
-    uint8_t mReadCommissioningInfoProgress = 0;
+    uint8_t mReadCommissioningInfoProgress = 0; // see ContinueReadingCommissioningInfo()
 
     bool mRunCommissioningAfterConnection = false;
     Internal::InvokeCancelFn mInvokeCancelFn;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -839,7 +839,9 @@ private:
     CommissioneeDeviceProxy * mDeviceInPASEEstablishment = nullptr;
 
     CommissioningStage mCommissioningStage = CommissioningStage::kSecurePairing;
-    bool mRunCommissioningAfterConnection  = false;
+    uint8_t mReadCommissioningInfoProgress = 0;
+
+    bool mRunCommissioningAfterConnection = false;
     Internal::InvokeCancelFn mInvokeCancelFn;
     Internal::WriteCancelFn mWriteCancelFn;
 
@@ -1050,10 +1052,10 @@ private:
     void CancelCASECallbacks();
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-    void ParseCommissioningInfo();
+    void ContinueReadingCommissioningInfo(const CommissioningParameters & params);
+    void FinishReadingCommissioningInfo();
     // Parsing attributes read in kReadCommissioningInfo stage.
     CHIP_ERROR ParseCommissioningInfo1(ReadCommissioningInfo & info);
-    // Parsing attributes read in kReadCommissioningInfo2 stage.
     CHIP_ERROR ParseCommissioningInfo2(ReadCommissioningInfo & info);
     // Called by ParseCommissioningInfo2
     CHIP_ERROR ParseFabrics(ReadCommissioningInfo & info);

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -34,9 +34,6 @@ const char * StageToString(CommissioningStage stage)
     case kReadCommissioningInfo:
         return "ReadCommissioningInfo";
 
-    case kReadCommissioningInfo2:
-        return "ReadCommissioningInfo2";
-
     case kArmFailsafe:
         return "ArmFailSafe";
 
@@ -163,9 +160,6 @@ const char * MetricKeyForCommissioningStage(CommissioningStage stage)
 
     case kReadCommissioningInfo:
         return "core_commissioning_stage_read_commissioning_info";
-
-    case kReadCommissioningInfo2:
-        return "core_commissioning_stage_read_commissioning_info2";
 
     case kArmFailsafe:
         return "core_commissioning_stage_arm_failsafe";

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -690,7 +690,7 @@ struct OperationalNodeFoundData
 struct NetworkClusterInfo
 {
     EndpointId endpoint = kInvalidEndpointId;
-    app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType minConnectionTime;
+    app::Clusters::NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::TypeInfo::DecodableType minConnectionTime = 0;
 };
 struct NetworkClusters
 {

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -36,8 +36,7 @@ enum CommissioningStage : uint8_t
 {
     kError,
     kSecurePairing,              ///< Establish a PASE session with the device
-    kReadCommissioningInfo,      ///< Query General Commissioning Attributes, Network Features and Time Synchronization Cluster
-    kReadCommissioningInfo2,     ///< Query SupportsConcurrentConnection, ICD state, check for matching fabric
+    kReadCommissioningInfo,      ///< Query Attributes relevant to commissioning (can perform multiple read interactions)
     kArmFailsafe,                ///< Send ArmFailSafe (0x30:0) command to the device
     kConfigRegulatory,           ///< Send SetRegulatoryConfig (0x30:2) command to the device
     kConfigureUTCTime,           ///< SetUTCTime if the DUT has a time cluster
@@ -55,7 +54,7 @@ enum CommissioningStage : uint8_t
     kSendTrustedRootCert,        ///< Send AddTrustedRootCertificate (0x3E:11) command to the device
     kSendNOC,                    ///< Send AddNOC (0x3E:6) command to the device
     kConfigureTrustedTimeSource, ///< Configure a trusted time source if one is required and available (must be done after SendNOC)
-    kICDGetRegistrationInfo,     ///< Waiting for the higher layer to provide ICD registraion informations.
+    kICDGetRegistrationInfo,     ///< Waiting for the higher layer to provide ICD registration informations.
     kICDRegistration,            ///< Register for ICD management
     kWiFiNetworkSetup,           ///< Send AddOrUpdateWiFiNetwork (0x31:2) command to the device
     kThreadNetworkSetup,         ///< Send AddOrUpdateThreadNetwork (0x31:3) command to the device
@@ -163,7 +162,7 @@ public:
     }
 
     // Value to determine whether the node supports Concurrent Connections as read from the GeneralCommissioning cluster.
-    // In the AutoCommissioner, this is automatically set from from the kReadCommissioningInfo2 stage.
+    // In the AutoCommissioner, this is automatically set from from the kReadCommissioningInfo stage.
     Optional<bool> GetSupportsConcurrentConnection() const { return mSupportsConcurrentConnection; }
 
     // The country code to be used for the node, if set.
@@ -788,8 +787,7 @@ class CommissioningDelegate
 public:
     virtual ~CommissioningDelegate(){};
     /* CommissioningReport is returned after each commissioning step is completed. The reports for each step are:
-     * kReadCommissioningInfo: Reported together with ReadCommissioningInfo2
-     * kReadCommissioningInfo2: ReadCommissioningInfo
+     * kReadCommissioningInfo: ReadCommissioningInfo
      * kArmFailsafe: CommissioningErrorInfo if there is an error
      * kConfigRegulatory: CommissioningErrorInfo if there is an error
      * kConfigureUTCTime: None

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -162,7 +162,7 @@ public:
                 mCompletionError = err;
             }
         }
-        if (report.stageCompleted == chip::Controller::CommissioningStage::kReadCommissioningInfo2)
+        if (report.stageCompleted == chip::Controller::CommissioningStage::kReadCommissioningInfo)
         {
             mReadCommissioningInfo = report.Get<chip::Controller::ReadCommissioningInfo>();
         }

--- a/src/controller/python/test/test_scripts/commissioning_failure_test.py
+++ b/src/controller/python/test/test_scripts/commissioning_failure_test.py
@@ -97,7 +97,8 @@ async def main():
 
     # TODO: Start at stage 2 once handling for arming failsafe on pase is done.
     if options.report:
-        for testFailureStage in range(3, 21):
+        # [kArmFailsafe, kConfigureTrustedTimeSource] (inclusive). TODO: https://github.com/project-chip/connectedhomeip/issues/36629
+        for testFailureStage in range(3, 20):
             FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
                                               setuppin=20202021,
                                               nodeid=1),
@@ -106,7 +107,8 @@ async def main():
                       "Commissioning failure tests failed for simulated report failure on stage {}".format(testFailureStage))
 
     else:
-        for testFailureStage in range(3, 21):
+        # [kArmFailsafe, kConfigureTrustedTimeSource] (inclusive). TODO: https://github.com/project-chip/connectedhomeip/issues/36629
+        for testFailureStage in range(3, 20):
             FailIfNot(await test.TestPaseOnly(ip=options.deviceAddress1,
                                               setuppin=20202021,
                                               nodeid=1),

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
@@ -61,7 +61,7 @@ static const uint16_t kBasePort = 5542 - kMinDiscriminator;
         @"--passcode",
         [NSString stringWithFormat:@"%llu", passcode.unsignedLongLongValue],
         @"--KVS",
-        [NSString stringWithFormat:@"/tmp/chip-%@-kvs%u", name, uniqueIndex],
+        [NSString stringWithFormat:@"/tmp/xctest-%d-chip-%@-kvs%u", getpid(), name, uniqueIndex],
         @"--product-id",
         [NSString stringWithFormat:@"%u", parsedPayload.productID.unsignedShortValue],
     ];

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -50,14 +50,15 @@ from chip.testing.matter_testing import MatterBaseTest, async_test_body, default
 from mobly import asserts
 
 # Commissioning stage numbers - we should find a better way to match these to the C++ code
-kArmFailsafe = 4
-kConfigRegulatory = 5
-kSendPAICertificateRequest = 10
-kSendDACCertificateRequest = 11
-kSendAttestationRequest = 12
-kSendOpCertSigningRequest = 15
-kSendTrustedRootCert = 18
-kSendNOC = 19
+# TODO: https://github.com/project-chip/connectedhomeip/issues/36629
+kArmFailsafe = 3
+kConfigRegulatory = 4
+kSendPAICertificateRequest = 9
+kSendDACCertificateRequest = 10
+kSendAttestationRequest = 11
+kSendOpCertSigningRequest = 14
+kSendTrustedRootCert = 17
+kSendNOC = 18
 
 
 class TC_CGEN_2_4(MatterBaseTest):


### PR DESCRIPTION
This PR refactors the kReadCommissioningInfo DeviceCommissioner step in preparation for adding the ability to read additional data. Having a fixed split of the attributes to be read into two steps in inflexible and makes it hard to optimize the reads that are performed.

Specifically this change
- Rolls kReadCommissioningInfo2 stage into kReadCommissioningInfo and tracks progress internally instead
- Groups attributes being read and parsing methods by cluster (where this wasn't already done)
- Makes the parsing code more consistent and simplifies some logic.

If desired this PR can be reviewed commit by commit; builds and tests were green after each commit.