### PR TITLE
ESP32: Fix building chip_gn for cmake v3.31.x and onwards

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -389,7 +389,6 @@ externalproject_add(
     BUILD_COMMAND           ninja "esp32"
     INSTALL_COMMAND         ""
     BUILD_BYPRODUCTS        ${chip_libraries}
-    WORKING_DIRECTORY       ${CMAKE_CURRENT_LIST_DIR}
     DEPENDS                 args_gn
     BUILD_ALWAYS            1
 )


### PR DESCRIPTION
remove the WORKING_DIRECTORY from chip_gn target

For cmake v3.31.x, custom command generated for chip_gn-build in build.ninja concats the `$WORKING_DIRECTORY` and `$BUILD_DIR` paths and it mess up the `chip_gn` step when building example.
```
COMMAND = cd "/Users/account/esp-matter/connectedhomeip/connectedhomeip/config/esp32/components/chip;/Users/account/esp-matter/examples/light/build/esp-idf/chip" && ninja esp32
```

For cmake version prior to v3.31, it does not prepend the `$WORKING_DIRECTORY` path.
```
COMMAND = cd /Users/account/esp-matter/examples/light/build/esp-idf/chip && ninja esp32
```
This could be becuase of https://github.com/Kitware/CMake/commit/f5f80305ef69dd33fbedd31ef1d2cfd3d2bc15b4 which started using WORKING_DIRECTORY.

related issue - https://github.com/espressif/esp-matter/issues/1157

#### Tests
- build, flash, commissioning on few cmake version: 3.22, 3.24, 3.30, 3.31