### PR TITLE
[Crypto] Replace OpenSSL-specific flag with public API to check SHA256 digest initialization

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -901,6 +901,13 @@ public:
     CHIP_ERROR Begin();
 
     /**
+     * @brief check if the digest computation has been initialized.
+     *
+     * @return True if the context is correctly initialized; otherwise, false.
+     */
+    bool IsInitialized();
+
+    /**
      * @brief Add some data to the digest computation, updating internal state.
      *
      * @param[in] data The span of bytes to include in the digest update process.
@@ -942,9 +949,6 @@ public:
 
 private:
     HashSHA256OpaqueContext mContext;
-#if CHIP_CRYPTO_BORINGSSL || CHIP_CRYPTO_OPENSSL
-    bool mInitialized = false;
-#endif
 };
 
 class HKDF_sha


### PR DESCRIPTION
This is a follow_up to #36386 based on a post-merge comment.

- an OpenSSL-specific `mInitialized` flag was added to HASH_SHA256 to check if digest computation was initialized, which isn't used for other Crypto Backends. 
- It also added platform-specific `#ifdefs` to the a platform-agnostic header.

- Fix: replace by a Public API `IsInitialized`, with its implementation for OpenSSL/BoringSSL

