### PR TITLE
[ESP32] Added GetThreadMetrics Implementation to DiagnosticDataProvider

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -325,8 +325,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
     *threadMetricsOut = head;
 
     return CHIP_NO_ERROR;
-#endif
+#else
     return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetrics)

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -292,6 +292,55 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
     }
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadMetricsOut)
+{
+#ifdef CONFIG_FREERTOS_USE_TRACE_FACILITY
+    ThreadMetrics * head = nullptr;
+    uint32_t arraySize   = uxTaskGetNumberOfTasks();
+
+    Platform::ScopedMemoryBuffer<TaskStatus_t> taskStatusArray;
+    VerifyOrReturnError(taskStatusArray.Calloc(arraySize), CHIP_ERROR_NO_MEMORY);
+
+    uint32_t dummyRunTimeCounter;
+    arraySize = uxTaskGetSystemState(taskStatusArray.Get(), arraySize, &dummyRunTimeCounter);
+
+    for (uint32_t i = 0; i < arraySize; i++)
+    {
+        auto thread = static_cast<ThreadMetrics *>(Platform::MemoryCalloc(1, sizeof(ThreadMetrics)));
+        VerifyOrReturnError(thread, CHIP_ERROR_NO_MEMORY, ReleaseThreadMetrics(head));
+
+        Platform::CopyString(thread->NameBuf, taskStatusArray[i].pcTaskName);
+        thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+        thread->id = taskStatusArray[i].xTaskNumber;
+        thread->stackFreeMinimum.Emplace(taskStatusArray[i].usStackHighWaterMark);
+
+        // Todo: Calculate stack size and current free stack value and assign.
+        thread->stackFreeCurrent.ClearValue();
+        thread->stackSize.ClearValue();
+
+        thread->Next = head;
+        head         = thread;
+    }
+
+    *threadMetricsOut = head;
+
+    return CHIP_NO_ERROR;
+#endif
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetrics)
+{
+#ifdef CONFIG_FREERTOS_USE_TRACE_FACILITY
+    while (threadMetrics)
+    {
+        ThreadMetrics * del = threadMetrics;
+        threadMetrics       = threadMetrics->Next;
+        Platform::MemoryFree(del);
+    }
+#endif
+}
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -50,6 +50,8 @@ public:
 
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
+    CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
+    void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     CHIP_ERROR GetWiFiBssId(MutableByteSpan & BssId) override;


### PR DESCRIPTION
Problem:
The DiagnosticDataProvider for the ESP32 platform lacks an implementation of the GetThreadMetrics() method.

Change Overview:
Implemented the GetThreadMetrics() and ReleaseThreadMetrics() methods in DiagnosticDataProviderImpl.cpp and DiagnosticDataProviderImpl.h.

Testing:
Successfully read thread metrics using the Software Diagnostic Cluster in the lighting-app on ESP32-C3.

