### PR TITLE
Adds SubscriptionInfoProvider API to check if a given fabric has at least 1 subscription

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -128,7 +128,8 @@ bool MayHaveAccessibleEventPath(DataModel::Provider * aProvider, const EventPath
 class AutoReleaseSubscriptionInfoIterator
 {
 public:
-    AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) : mIterator(iterator){};
+    AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) :
+        mIterator(iterator) {};
     ~AutoReleaseSubscriptionInfoIterator() { mIterator->Release(); }
 
     SubscriptionResumptionStorage::SubscriptionInfoIterator * operator->() const { return mIterator; }
@@ -471,10 +472,11 @@ bool InteractionModelEngine::FabricHasAtLeastOneActiveSubscription(FabricIndex a
         Access::SubjectDescriptor subject = handler->GetSubjectDescriptor();
         VerifyOrReturnValue(subject.fabricIndex == aFabricIndex, Loop::Continue);
 
-        if (subject.authMode == Access::AuthMode::kCase)
+        if ((subject.authMode == Access::AuthMode::kCase) && handler->IsActiveSubscription())
         {
-            hasActiveSubscription = handler->IsActiveSubscription();
-            VerifyOrReturnValue(!hasActiveSubscription, Loop::Break);
+            // On first subscription found for fabric, we can immediately stop checking.
+            hasActiveSubscription = true;
+            return Loop::Break;
         }
 
         return Loop::Continue;

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -128,8 +128,7 @@ bool MayHaveAccessibleEventPath(DataModel::Provider * aProvider, const EventPath
 class AutoReleaseSubscriptionInfoIterator
 {
 public:
-    AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) :
-        mIterator(iterator) {};
+    AutoReleaseSubscriptionInfoIterator(SubscriptionResumptionStorage::SubscriptionInfoIterator * iterator) : mIterator(iterator){};
     ~AutoReleaseSubscriptionInfoIterator() { mIterator->Release(); }
 
     SubscriptionResumptionStorage::SubscriptionInfoIterator * operator->() const { return mIterator; }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -315,6 +315,8 @@ public:
 
     bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID) override;
 
+    bool FabricHasAtLeastOneActiveSubscription(FabricIndex aFabricIndex) override;
+
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
     /**
      * @brief Function decrements the number of subscriptions to resume counter - mNumOfSubscriptionsToResume.

--- a/src/app/SubscriptionsInfoProvider.h
+++ b/src/app/SubscriptionsInfoProvider.h
@@ -68,7 +68,7 @@ public:
      * @param aFabricIndex fabric index for which we want to validate is has at least one active subscription
      *
      * @return true fabric has at least one active subscription
-     * @return false fabric doesn't have any active subscription or failed to validate
+     *         false fabric doesn't have any active subscription or failed to validate
      */
     virtual bool FabricHasAtLeastOneActiveSubscription(FabricIndex aFabricIndex) = 0;
 };

--- a/src/app/SubscriptionsInfoProvider.h
+++ b/src/app/SubscriptionsInfoProvider.h
@@ -35,7 +35,7 @@ namespace app {
 class SubscriptionsInfoProvider
 {
 public:
-    virtual ~SubscriptionsInfoProvider() {};
+    virtual ~SubscriptionsInfoProvider(){};
 
     /**
      * @brief Check if a given subject (CAT or operational NodeId) has at least 1 active subscription.

--- a/src/app/SubscriptionsInfoProvider.h
+++ b/src/app/SubscriptionsInfoProvider.h
@@ -35,7 +35,7 @@ namespace app {
 class SubscriptionsInfoProvider
 {
 public:
-    virtual ~SubscriptionsInfoProvider(){};
+    virtual ~SubscriptionsInfoProvider() {};
 
     /**
      * @brief Check if a given subject (CAT or operational NodeId) has at least 1 active subscription.
@@ -61,6 +61,16 @@ public:
      *         false subject doesn't have any persisted subscription with the device
      */
     virtual bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subjectID) = 0;
+
+    /**
+     * @brief Check if a given fabric has at least 1 active subscription.
+     *
+     * @param aFabricIndex fabric index for which we want to validate is has at least one active subscription
+     *
+     * @return true fabric has at least one active subscription
+     * @return false fabric doesn't have any active subscription or failed to validate
+     */
+    virtual bool FabricHasAtLeastOneActiveSubscription(FabricIndex aFabricIndex) = 0;
 };
 
 } // namespace app

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -115,7 +115,7 @@ class TestSubscriptionsInfoProvider : public SubscriptionsInfoProvider
 {
 public:
     TestSubscriptionsInfoProvider() = default;
-    ~TestSubscriptionsInfoProvider() {};
+    ~TestSubscriptionsInfoProvider(){};
 
     void SetHasActiveSubscription(bool value) { mHasActiveSubscription = value; };
     void SetHasPersistedSubscription(bool value) { mHasPersistedSubscription = value; };

--- a/src/app/icd/server/tests/TestICDManager.cpp
+++ b/src/app/icd/server/tests/TestICDManager.cpp
@@ -115,13 +115,14 @@ class TestSubscriptionsInfoProvider : public SubscriptionsInfoProvider
 {
 public:
     TestSubscriptionsInfoProvider() = default;
-    ~TestSubscriptionsInfoProvider(){};
+    ~TestSubscriptionsInfoProvider() {};
 
     void SetHasActiveSubscription(bool value) { mHasActiveSubscription = value; };
     void SetHasPersistedSubscription(bool value) { mHasPersistedSubscription = value; };
 
     bool SubjectHasActiveSubscription(FabricIndex aFabricIndex, NodeId subject) { return mHasActiveSubscription; };
     bool SubjectHasPersistedSubscription(FabricIndex aFabricIndex, NodeId subject) { return mHasPersistedSubscription; };
+    bool FabricHasAtLeastOneActiveSubscription(FabricIndex aFabricIndex) { return false; };
 
 private:
     bool mHasActiveSubscription    = false;

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -68,6 +68,8 @@ public:
     void TestSubjectHasActiveSubscriptionSubWithCAT();
     void TestSubscriptionResumptionTimer();
     void TestDecrementNumSubscriptionsToResume();
+    void TestFabricHasAtLeastOneActiveSubscription();
+    void TestFabricHasAtLeastOneActiveSubscriptionWithMixedStates();
     static int GetAttributePathListLength(SingleLinkedListNode<AttributePathParams> * apattributePathParamsList);
 };
 
@@ -380,11 +382,6 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestSubjectHasActiveSubscription
         engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx1, ReadHandler::InteractionType::Subscribe,
                                                   reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
 
-    // Create and setup readHandler 2
-    ReadHandler * readHandler2 =
-        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
-                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
-
     // Verify that Bob still doesn't have an active subscription
     EXPECT_FALSE(engine->SubjectHasActiveSubscription(bobFabricIndex, bobNodeId));
 
@@ -396,6 +393,11 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestSubjectHasActiveSubscription
 
     // Verify that Alice still doesn't have an active subscription
     EXPECT_FALSE(engine->SubjectHasActiveSubscription(aliceFabricIndex, aliceNodeId));
+
+    // Create and setup readHandler 2
+    ReadHandler * readHandler2 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
 
     // Set readHandler2 to active
     readHandler2->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, true);
@@ -719,6 +721,125 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestDecrementNumSubscriptionsToR
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP && CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 }
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
+
+TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestFabricHasAtLeastOneActiveSubscription)
+{
+    NullReadHandlerCallback nullCallback;
+    InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+
+    FabricIndex fabricIndex1 = 1;
+    FabricIndex fabricIndex2 = 2;
+
+    // Create ExchangeContexts
+    Messaging::ExchangeContext * exchangeCtx1 = NewExchangeToBob(nullptr, false);
+    ASSERT_TRUE(exchangeCtx1);
+
+    Messaging::ExchangeContext * exchangeCtx2 = NewExchangeToAlice(nullptr, false);
+    ASSERT_TRUE(exchangeCtx2);
+
+    // InteractionModelEngine init
+    EXPECT_EQ(CHIP_NO_ERROR, engine->Init(&GetExchangeManager(), &GetFabricTable(), reporting::GetDefaultReportScheduler()));
+
+    // Verify that both fabrics have no active subscriptions
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex1));
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex2));
+
+    // Create and setup readHandler 1
+    ReadHandler * readHandler1 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx1, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
+
+    // Verify that fabric 1 still doesn't have an active subscription
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex1));
+
+    // Set readHandler1 to active
+    readHandler1->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, true);
+
+    // Verify that fabric 1 has an active subscription
+    EXPECT_TRUE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex1));
+
+    // Verify that fabric 2 still doesn't have an active subscription
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex2));
+
+    // Create and setup readHandler 2
+    ReadHandler * readHandler2 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
+
+    // Set readHandler2 to active
+    readHandler2->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, true);
+
+    // Verify that fabric 2 has an active subscription
+    EXPECT_TRUE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex2));
+
+    // Clean up read handlers
+    engine->GetReadHandlerPool().ReleaseAll();
+
+    // Verify that both fabrics have no active subscriptions
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex1));
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex2));
+}
+
+TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestFabricHasAtLeastOneActiveSubscriptionWithMixedStates)
+{
+    NullReadHandlerCallback nullCallback;
+    InteractionModelEngine * engine = InteractionModelEngine::GetInstance();
+
+    FabricIndex fabricIndex = 1;
+
+    // Create ExchangeContexts
+    Messaging::ExchangeContext * exchangeCtx1 = NewExchangeToBob(nullptr, false);
+    ASSERT_TRUE(exchangeCtx1);
+
+    Messaging::ExchangeContext * exchangeCtx2 = NewExchangeToBob(nullptr, false);
+    ASSERT_TRUE(exchangeCtx2);
+
+    // InteractionModelEngine init
+    EXPECT_EQ(CHIP_NO_ERROR, engine->Init(&GetExchangeManager(), &GetFabricTable(), reporting::GetDefaultReportScheduler()));
+
+    // Verify that the fabric has no active subscriptions
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Create and setup readHandler 1
+    ReadHandler * readHandler1 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx1, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
+
+    // Verify that the fabric still doesn't have an active subscription
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Set readHandler1 to active
+    readHandler1->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, true);
+
+    // Verify that the fabric has an active subscription
+    EXPECT_TRUE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Create and setup readHandler 2
+    ReadHandler * readHandler2 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
+
+    // Verify that the fabric still has an active subscription
+    EXPECT_TRUE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Set readHandler2 to inactive
+    readHandler2->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, false);
+
+    // Verify that the fabric still has an active subscription
+    EXPECT_TRUE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Set readHandler1 to inactive
+    readHandler1->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, false);
+
+    // Verify that the fabric doesn't have an active subscription
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+
+    // Clean up read handlers
+    engine->GetReadHandlerPool().ReleaseAll();
+
+    // Verify that the fabric has no active subscriptions
+    EXPECT_FALSE(engine->FabricHasAtLeastOneActiveSubscription(fabricIndex));
+}
 
 } // namespace app
 } // namespace chip

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -382,6 +382,11 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestSubjectHasActiveSubscription
         engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx1, ReadHandler::InteractionType::Subscribe,
                                                   reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
 
+    // Create and setup readHandler 2
+    ReadHandler * readHandler2 =
+        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
+                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
+
     // Verify that Bob still doesn't have an active subscription
     EXPECT_FALSE(engine->SubjectHasActiveSubscription(bobFabricIndex, bobNodeId));
 
@@ -393,11 +398,6 @@ TEST_F_FROM_FIXTURE(TestInteractionModelEngine, TestSubjectHasActiveSubscription
 
     // Verify that Alice still doesn't have an active subscription
     EXPECT_FALSE(engine->SubjectHasActiveSubscription(aliceFabricIndex, aliceNodeId));
-
-    // Create and setup readHandler 2
-    ReadHandler * readHandler2 =
-        engine->GetReadHandlerPool().CreateObject(nullCallback, exchangeCtx2, ReadHandler::InteractionType::Subscribe,
-                                                  reporting::GetDefaultReportScheduler(), CodegenDataModelProviderInstance());
 
     // Set readHandler2 to active
     readHandler2->SetStateFlag(ReadHandler::ReadHandlerFlags::ActiveSubscription, true);


### PR DESCRIPTION
#### Description
PR adds an API  that validates that a given fabric has at least on active subscription.
This can be used in application level logic to help decision talking around that state of a given fabric.

#### Note to reviewers
The change to the examples linux build.gn was to fix a Nordic Zephyr CI which was complaining about unresolved dependencies.

#### Tests
Added unit tests that validate the multi fabric and the single fabric cases
