### PR TITLE
Add controller dependency in for linux platform examples to fix CI

### DIFF
--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -96,6 +96,7 @@ source_set("app-main") {
     ":smco-test-event-trigger",
     ":water-heater-management-test-event-trigger",
     "${chip_root}/src/app/codegen-data-model-provider:instance-header",
+    "${chip_root}/src/controller:controller",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform/logging:default",
   ]


### PR DESCRIPTION
ToT is broken for nrfconnect due to some controller related dependency.

broken job - https://github.com/project-chip/connectedhomeip/actions/runs/11980797407/job/33405801839

Likely a regression from #36567