### PR TITLE
Resolve CommissionerMain dependency issues

### DIFF
--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -28,6 +28,7 @@
 #include <crypto/CHIPCryptoPAL.h>
 #include <crypto/RawKeySessionKeystore.h>
 #include <lib/core/CHIPError.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -49,13 +50,12 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/KeyValueStoreManager.h>
 #include <platform/PlatformManager.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
-#include <controller/CHIPDeviceControllerFactory.h>
-#include <controller/ExampleOperationalCredentialsIssuer.h>
-#include <lib/core/CHIPPersistentStorageDelegate.h>
-#include <platform/KeyValueStoreManager.h>
+#include <controller/CHIPDeviceControllerFactory.h>         // nogncheck
+#include <controller/ExampleOperationalCredentialsIssuer.h> // nogncheck
 
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 #include "TraceHandlers.h"

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -16,10 +16,7 @@
  *    limitations under the License.
  */
 
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
-
-#include <string>
+#include "CommissionerMain.h"
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
@@ -48,9 +45,11 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/PlatformManager.h>
 #include <platform/TestOnlyCommissionableDataProvider.h>
 
 #include <controller/CHIPDeviceControllerFactory.h>
@@ -63,8 +62,7 @@
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 
 #include <signal.h>
-
-#include "CommissionerMain.h"
+#include <string>
 
 using namespace chip;
 using namespace chip::Credentials;
@@ -459,7 +457,7 @@ CommissionerDiscoveryController * GetCommissionerDiscoveryController()
     return &gCommissionerDiscoveryController;
 }
 
-SessionKeystore * GetSessionKeystore()
+Crypto::SessionKeystore * GetSessionKeystore()
 {
     return &gSessionKeystore;
 }

--- a/examples/platform/linux/CommissionerMain.h
+++ b/examples/platform/linux/CommissionerMain.h
@@ -18,20 +18,15 @@
 
 #pragma once
 
-#include <controller/CHIPDeviceController.h>
-#include <controller/CommissionerDiscoveryController.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <lib/core/CHIPError.h>
-#include <platform/CHIPDeviceLayer.h>
-#include <platform/PlatformManager.h>
-#include <transport/TransportMgr.h>
+#include <platform/CHIPDeviceConfig.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
-using chip::PersistentStorageDelegate;
-using chip::Controller::DeviceCommissioner;
-using chip::Crypto::SessionKeystore;
-using chip::Transport::PeerAddress;
+#include <controller/CHIPDeviceController.h> // nogncheck
+#include <controller/CommissionerDiscoveryController.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
 
 CHIP_ERROR CommissionerPairOnNetwork(uint32_t pincode, uint16_t disc, PeerAddress address);
 CHIP_ERROR CommissionerPairUDC(uint32_t pincode, size_t index);
@@ -39,9 +34,9 @@ CHIP_ERROR CommissionerPairUDC(uint32_t pincode, size_t index);
 CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, chip::FabricId fabricId = chip::kUndefinedFabricId);
 void ShutdownCommissioner();
 
-DeviceCommissioner * GetDeviceCommissioner();
+chip::Controller::DeviceCommissioner * GetDeviceCommissioner();
 CommissionerDiscoveryController * GetCommissionerDiscoveryController();
-SessionKeystore * GetSessionKeystore();
-PersistentStorageDelegate * GetPersistentStorageDelegate();
+chip::Crypto::SessionKeystore * GetSessionKeystore();
+chip::PersistentStorageDelegate * GetPersistentStorageDelegate();
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -305,10 +305,9 @@ chip_test_suite("tests") {
     test_sources += [ "TestClusterStateCache.cpp" ]
   }
 
-  # On NRF, Open IoT SDK and fake platforms we do not have a realtime clock available, so
-  # TestEventLogging.cpp would be testing the same thing as
-  # TestEventLoggingNoUTCTime, but it's not set up to deal with the timestamps
-  # being that low.
+  # On NRF, Open IoT SDK and fake platforms we do not have a realtime clock available,
+  # so TestEventLogging.cpp would be testing the same thing as TestEventLoggingNoUTCTime,
+  # but it's not set up to deal with the timestamps being that low.
   if (chip_device_platform != "nrfconnect" &&
       chip_device_platform != "openiotsdk" && chip_device_platform != "fake") {
     test_sources += [ "TestEventLogging.cpp" ]


### PR DESCRIPTION
Note that CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE=1 requires chip_build_controller=true at the GN level, otherwise `lib` does not pull in `controller`.

Example nrfconnect build failure: https://github.com/project-chip/connectedhomeip/actions/runs/11978465521/job/33398541849