### PR TITLE
Make Hash_SHA256_stream::IsInitialized() protected

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -901,13 +901,6 @@ public:
     CHIP_ERROR Begin();
 
     /**
-     * @brief check if the digest computation has been initialized.
-     *
-     * @return True if the context is correctly initialized; otherwise, false.
-     */
-    bool IsInitialized();
-
-    /**
      * @brief Add some data to the digest computation, updating internal state.
      *
      * @param[in] data The span of bytes to include in the digest update process.
@@ -948,6 +941,9 @@ public:
     void Clear();
 
 private:
+    // Check if the digest computation has been initialized; implement this if your backend needs it.
+    bool IsInitialized();
+
     HashSHA256OpaqueContext mContext;
 };
 


### PR DESCRIPTION
This is a follow-up to the post-merge comment:  https://github.com/project-chip/connectedhomeip/pull/36608#discussion_r1854488325

-  `Hash_SHA256_stream::IsInitialized()` should have been `protected` instead of `public`, since it is not destined for API consumers; it is only destined for usage within `Hash_SHA256_stream` objects. It is also only implemented for a single back-end; the OpenSSL/BoringSSL Backend.