### PR TITLE
[Fabric-Sync] Fix segment fault during fabric admin initialization

### DIFF
--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -35,15 +35,6 @@ FabricAdmin FabricAdmin::sInstance;
 app::DefaultICDClientStorage FabricAdmin::sICDClientStorage;
 app::CheckInHandler FabricAdmin::sCheckInHandler;
 
-FabricAdmin & FabricAdmin::Instance()
-{
-    if (!sInstance.mInitialized)
-    {
-        VerifyOrDie(sInstance.Init() == CHIP_NO_ERROR);
-    }
-    return sInstance;
-}
-
 CHIP_ERROR FabricAdmin::Init()
 {
     IcdManager::Instance().SetDelegate(&sInstance);
@@ -55,8 +46,6 @@ CHIP_ERROR FabricAdmin::Init()
     ReturnLogErrorOnFailure(IcdManager::Instance().Init(&sICDClientStorage, engine));
     ReturnLogErrorOnFailure(sCheckInHandler.Init(Controller::DeviceControllerFactory::GetInstance().GetSystemState()->ExchangeMgr(),
                                                  &sICDClientStorage, &IcdManager::Instance(), engine));
-
-    mInitialized = true;
 
     return CHIP_NO_ERROR;
 }

--- a/examples/fabric-sync/admin/FabricAdmin.h
+++ b/examples/fabric-sync/admin/FabricAdmin.h
@@ -45,8 +45,10 @@ struct ScopedNodeIdHasher
 class FabricAdmin final : public bridge::FabricAdminDelegate, public PairingDelegate, public IcdManager::Delegate
 {
 public:
-    static FabricAdmin & Instance();
+    static FabricAdmin & Instance() { return sInstance; }
     static chip::app::DefaultICDClientStorage & GetDefaultICDClientStorage() { return sICDClientStorage; }
+
+    CHIP_ERROR Init();
 
     CHIP_ERROR OpenCommissioningWindow(chip::Controller::CommissioningWindowVerifierParams params,
                                        chip::FabricIndex fabricIndex) override;
@@ -100,10 +102,7 @@ private:
     static chip::app::DefaultICDClientStorage sICDClientStorage;
     static chip::app::CheckInHandler sCheckInHandler;
 
-    bool mInitialized    = false;
     chip::NodeId mNodeId = chip::kUndefinedNodeId;
-
-    CHIP_ERROR Init();
 };
 
 } // namespace admin

--- a/examples/fabric-sync/main.cpp
+++ b/examples/fabric-sync/main.cpp
@@ -110,7 +110,19 @@ int main(int argc, char * argv[])
     Shell::RegisterCommands();
 #endif
 
-    CHIP_ERROR err = admin::PairingManager::Instance().Init(GetDeviceCommissioner());
+    ChipLinuxAppMainLoop();
+
+    CHIP_ERROR err = admin::FabricAdmin::Instance().Init();
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogProgress(NotSpecified, "Failed to init FabricAdmin: %s ", ErrorStr(err));
+
+        // End the program with non zero error code to indicate a error.
+        return 1;
+    }
+
+    err = admin::PairingManager::Instance().Init(GetDeviceCommissioner());
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(NotSpecified, "Failed to init PairingManager: %s ", ErrorStr(err));
@@ -118,8 +130,6 @@ int main(int argc, char * argv[])
         // End the program with non zero error code to indicate a error.
         return 1;
     }
-
-    ChipLinuxAppMainLoop();
 
     return 0;
 }


### PR DESCRIPTION
We have random cash when start fabric-sync app after adding IDC support.

Explicitly initialize admin::FabricAdmin after calling ChipLinuxAppMainLoop() and ensure that the correct ExchangeMgr is properly initialized in the DeviceControllerSystemState before we initialize admin::FabricAdmin

