### PR TITLE
Add some additional `dataModelProvider` settings on server init

### DIFF
--- a/examples/common/tracing/BUILD.gn
+++ b/examples/common/tracing/BUILD.gn
@@ -79,7 +79,6 @@ source_set("trace_handlers") {
 source_set("trace_handlers_decoder") {
   sources = [
     "TraceDecoder.cpp",
-    "TraceHandlers.cpp",
     "decoder/TraceDecoderProtocols.cpp",
     "decoder/bdx/Decoder.cpp",
     "decoder/echo/Decoder.cpp",
@@ -94,6 +93,7 @@ source_set("trace_handlers_decoder") {
   public_configs = [ ":default_config" ]
 
   deps = [
+    ":trace_handlers",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/core:types",
   ]

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -29,6 +29,7 @@
 #include <app/TestEventTriggerDelegate.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/ota-requestor/OTATestEventTriggerHandler.h>
+#include <app/codegen-data-model-provider/Instance.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -262,6 +263,7 @@ CHIP_ERROR AppTask::Init()
     initParams.operationalKeystore = &sPSAOperationalKeystore;
 #endif
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.dataModelProvider        = CodegenDataModelProviderInstance();
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
     AppFabricTableDelegate::Init();

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -37,6 +37,7 @@
 #include <app/clusters/general-diagnostics-server/general-diagnostics-server.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/on-off-server/on-off-server.h>
+#include <app/codegen-data-model-provider/Instance.h>
 
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
@@ -273,6 +274,7 @@ void AppTask::InitServer(intptr_t arg)
     VerifyOrDie(sTestEventTriggerDelegate.Init(ByteSpan(sTestEventTriggerEnableKey)) == CHIP_NO_ERROR);
     VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sFaultTestEventTriggerHandler) == CHIP_NO_ERROR);
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.dataModelProvider        = CodegenDataModelProviderInstance();
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
 
     chip::Server::GetInstance().Init(initParams);

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -24,6 +24,7 @@
 #include <DeviceInfoProviderImpl.h>
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/codegen-data-model-provider/Instance.h>
 #include <app/server/Server.h>
 #include <app/util/endpoint-config-api.h>
 
@@ -78,7 +79,8 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     static AmebaObserver sAmebaObserver;
-    initParams.appDelegate = &sAmebaObserver;
+    initParams.dataModelProvider = CodegenDataModelProviderInstance();
+    initParams.appDelegate       = &sAmebaObserver;
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -74,8 +74,6 @@ source_set("app-main") {
     "AppMain.h",
     "CommissionableInit.cpp",
     "CommissionableInit.h",
-    "CommissionerMain.cpp",
-    "CommissionerMain.h",
     "LinuxCommissionableDataProvider.cpp",
     "LinuxCommissionableDataProvider.h",
     "NamedPipeCommands.cpp",
@@ -100,6 +98,7 @@ source_set("app-main") {
     "${chip_root}/src/platform/logging:default",
   ]
   deps = [
+    ":commissioner-main",
     ":ota-test-event-trigger",
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/app/server",

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -88,6 +88,7 @@ source_set("app-main") {
 
   public_deps = [
     ":boolean-state-configuration-test-event-trigger",
+    ":commissioner-main",
     ":device-energy-management-test-event-trigger",
     ":energy-evse-test-event-trigger",
     ":energy-reporting-test-event-trigger",
@@ -98,7 +99,6 @@ source_set("app-main") {
     "${chip_root}/src/platform/logging:default",
   ]
   deps = [
-    ":commissioner-main",
     ":ota-test-event-trigger",
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/app/server",


### PR DESCRIPTION
It seems in #36558 I have missed some sample applications. Added them back. 
Tested compiling and running nrfconnect light example.

also fixes dependencies to get `nrf-native-posix-64-tests` to compile