### PR TITLE
feat: Add ForceResubscribe method to ReadClient for immediate subscription recovery

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -930,6 +930,25 @@ CHIP_ERROR ReadClient::ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsRea
     return err;
 }
 
+CHIP_ERROR ReadClient::ForceResubscribe()
+{
+    if (IsSubscriptionActive())
+    {
+        CancelLivenessCheckTimer();
+        OnLivenessTimeoutCallback(nullptr, this);
+        return CHIP_NO_ERROR;
+    }
+    else if (IsIdle())
+    {
+        TriggerResubscribeIfScheduled("ForceResubscribe called");
+        return CHIP_NO_ERROR;
+    }
+    else
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+}
+
 void ReadClient::OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout)
 {
     mLivenessTimeoutOverride = aLivenessTimeout;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -503,6 +503,18 @@ public:
      */
     Optional<System::Clock::Timeout> GetSubscriptionTimeout();
 
+    /**
+     * Force the ReadClient to resubscribe immediately.
+     *
+     * This method can be called even when the subscription is active.
+     * It will simulate a liveness timeout to trigger the resubscription
+     * process according to the resubscription policy.
+     *
+     * @retval #CHIP_NO_ERROR On success.
+     * @retval #CHIP_ERROR_INCORRECT_STATE If the ReadClient is not in a state where resubscription is applicable.
+     */
+    CHIP_ERROR ForceResubscribe();
+
 private:
     friend class TestReadInteraction;
     friend class InteractionModelEngine;


### PR DESCRIPTION
**Pull Request Description:**

This pull request introduces a new public method ForceResubscribe to the ReadClient class, enabling clients to force an immediate resubscription even when the subscription is active.

**Purpose and Necessity:**

This change is necessary to restore the synchronization of subscriptions immediately when an external event indicates that the device has come back online, and we need to re-establish subscriptions without delay. For example, if the application receives information that the device has reconnected to the network, it can use ForceResubscribe to promptly resubscribe to the necessary attributes or events.

**Current Limitations:**

Previously, forcing an immediate resubscription was cumbersome and required a workaround:

1. Calling OverrideLivenessTimeout(1) to set a very short liveness timeout.
2. Then calling OverrideLivenessTimeout(0) to reset the timeout to its original value.
3. If the liveness timeout had already expired, manually invoking TriggerResubscribeIfScheduled.

This approach is not straightforward and can introduce unnecessary complexity and potential errors in the application logic.

**Solution Provided by This Change:**

The new ForceResubscribe method simplifies this process by directly triggering the resubscription logic according to the resubscription policy:

- **When the subscription is active:**
  - It simulates a liveness timeout by canceling any existing liveness timers and invoking the liveness timeout callback immediately.
  - This triggers the resubscription logic as if the subscription had naturally timed out, following the defined resubscription policy.
  
- **When the client is idle but has a resubscription scheduled:**
  - It triggers any scheduled resubscription immediately without waiting for the timer.
  
- **Improves Responsiveness:**
  - Allows applications to respond promptly to external events (e.g., device reconnection) by restoring subscriptions without unnecessary delays.
