### PR TITLE
[SILABS] removed unnecessary include

### DIFF
--- a/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
+++ b/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
@@ -26,7 +26,6 @@
 extern "C" {
 #endif
 #include <sparkfun_sgp40.h>
-#include <sparkfun_sgp40_i2c.h>
 }
 #include "sl_i2cspm_instances.h"
 #endif // USE_SPARKFUN_AIR_QUALITY_SENSOR


### PR DESCRIPTION
The latest update to drivers (third_party_hw_driver) has removed the file. Removing it from matter implementation as well. 
