### PR TITLE
[Silabs] Adds fix for support default value in refrigerator alarm cluster Refrigerator application 

### DIFF
--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.matter
@@ -1929,7 +1929,7 @@ endpoint 1 {
   server cluster RefrigeratorAlarm {
     ram      attribute mask default = 1;
     ram      attribute state default = 0;
-    ram      attribute supported default = 0;
+    ram      attribute supported default = 1;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-thread-app.zap
@@ -3453,7 +3453,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.matter
@@ -1837,7 +1837,7 @@ endpoint 1 {
   server cluster RefrigeratorAlarm {
     ram      attribute mask default = 1;
     ram      attribute state default = 0;
-    ram      attribute supported default = 0;
+    ram      attribute supported default = 1;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;

--- a/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
+++ b/examples/refrigerator-app/silabs/data_model/refrigerator-wifi-app.zap
@@ -3358,7 +3358,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
**Problem** Test case TC_REFALM-2.1 is getting failed because of the support attribute default value is 0 
**Solution** Updated the support attribute value to 1 in the zap configuration 
**Testing** Done on the 917 SoC
