### PR TITLE
Remove Active flag when the readhandler is going to be destroyed

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -55,8 +55,7 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer, DataModel::Provider * apDataModel) :
-    mAttributePathExpandIterator(apDataModel, nullptr),
-    mExchangeCtx(*this), mManagementCallback(apCallback)
+    mAttributePathExpandIterator(apDataModel, nullptr), mExchangeCtx(*this), mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 
@@ -152,6 +151,7 @@ ReadHandler::~ReadHandler()
     auto * appCallback = mManagementCallback.GetAppCallback();
     if (mFlags.Has(ReadHandlerFlags::ActiveSubscription) && appCallback)
     {
+        mFlags.Clear(ReadHandlerFlags::ActiveSubscription);
         appCallback->OnSubscriptionTerminated(*this);
     }
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -55,7 +55,8 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer, DataModel::Provider * apDataModel) :
-    mAttributePathExpandIterator(apDataModel, nullptr), mExchangeCtx(*this), mManagementCallback(apCallback)
+    mAttributePathExpandIterator(apDataModel, nullptr),
+    mExchangeCtx(*this), mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 


### PR DESCRIPTION
Description
When the OnSubscriptionTerminated callback is called, the readhandler that is being destroyed is still marked as active even if the destructor has been called.

Due to this, if we want to check the state of the different subscription for the fabric, the readhandler that is being destroyed skews the results since it is marked as active. This renders the SubscriptionInfoProvider pointless since any check has risk of returning a false positive.

PR removes the ActiveSubscription flag before calling the OnSubscriptionTerminated to avoid having false positives when checking for active subscriptions on the fabric afterwards. This also prevents the OnSubscriptionTerminated to be called twice if for some reason the destructor is called twice we shouldn't happen.

Tests
CI

