### PR TITLE
[Fabric-Sync] Fix segment fault during fabric device sync

### DIFF
--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -44,8 +44,12 @@ CHIP_ERROR FabricAdmin::Init()
     auto engine = chip::app::InteractionModelEngine::GetInstance();
     VerifyOrReturnError(engine != nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnLogErrorOnFailure(IcdManager::Instance().Init(&sICDClientStorage, engine));
-    ReturnLogErrorOnFailure(sCheckInHandler.Init(Controller::DeviceControllerFactory::GetInstance().GetSystemState()->ExchangeMgr(),
-                                                 &sICDClientStorage, &IcdManager::Instance(), engine));
+
+    auto exchangeMgr = Controller::DeviceControllerFactory::GetInstance().GetSystemState()->ExchangeMgr();
+    VerifyOrReturnError(exchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnLogErrorOnFailure(sCheckInHandler.Init(exchangeMgr, &sICDClientStorage, &IcdManager::Instance(), engine));
+
+    ReturnLogErrorOnFailure(PairingManager::Instance().Init(GetDeviceCommissioner()));
 
     return CHIP_NO_ERROR;
 }

--- a/examples/fabric-sync/main.cpp
+++ b/examples/fabric-sync/main.cpp
@@ -87,6 +87,9 @@ void ApplicationInit()
 
     CHIP_ERROR err = bridge::BridgeInit(&admin::FabricAdmin::Instance());
     VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Fabric-Sync: Failed to initialize bridge, error: %s", ErrorStr(err));
+
+    err = admin::FabricAdmin::Instance().Init();
+    VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Fabric-Sync: Failed to initialize admin, error: %s", ErrorStr(err));
 }
 
 void ApplicationShutdown()
@@ -111,25 +114,6 @@ int main(int argc, char * argv[])
 #endif
 
     ChipLinuxAppMainLoop();
-
-    CHIP_ERROR err = admin::FabricAdmin::Instance().Init();
-
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(NotSpecified, "Failed to init FabricAdmin: %s ", ErrorStr(err));
-
-        // End the program with non zero error code to indicate a error.
-        return 1;
-    }
-
-    err = admin::PairingManager::Instance().Init(GetDeviceCommissioner());
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogProgress(NotSpecified, "Failed to init PairingManager: %s ", ErrorStr(err));
-
-        // End the program with non zero error code to indicate a error.
-        return 1;
-    }
 
     return 0;
 }


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/36635 resolved the random segmentation fault during FabricAdmin initialization. However, I am still encountering another segmentation fault when syncing a device between ecosystems.

The issue arises because I delayed the FabricAdmin initialization too much. It needs to be initialized after DeviceControllerSystemState is initialized, but before ChipLinuxAppMainLoop.

