### PR TITLE
[Fabric-Sync]: Convert ember-driven functions to interface functions

### DIFF
--- a/examples/fabric-bridge-app/linux/CommissionerControlDelegate.cpp
+++ b/examples/fabric-bridge-app/linux/CommissionerControlDelegate.cpp
@@ -116,7 +116,7 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissioningApprovalRequest(const
         mLabel.ClearValue();
     }
 
-    CHIP_ERROR err = CommissionerControlServer::Instance().GenerateCommissioningRequestResultEvent(kAggregatorEndpointId, result);
+    CHIP_ERROR err = mCommissionerControlServer.GenerateCommissioningRequestResultEvent(kAggregatorEndpointId, result);
 
     if (err == CHIP_NO_ERROR)
     {
@@ -228,7 +228,7 @@ CHIP_ERROR CommissionerControlInit()
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    err = Clusters::CommissionerControl::CommissionerControlServer::Instance().Init(*sCommissionerControlDelegate);
+    err = sCommissionerControlDelegate->GetCommissionerControlServer().Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "Initialization failed on Commissioner Control Delegate.");
@@ -242,7 +242,7 @@ CHIP_ERROR CommissionerControlInit()
     supportedDeviceCategories.SetField(Clusters::CommissionerControl::SupportedDeviceCategoryBitmap::kFabricSynchronization, 1);
 
     Protocols::InteractionModel::Status status =
-        Clusters::CommissionerControl::CommissionerControlServer::Instance().SetSupportedDeviceCategoriesValue(
+        sCommissionerControlDelegate->GetCommissionerControlServer().SetSupportedDeviceCategoriesValue(
             Clusters::CommissionerControl::kAggregatorEndpointId, supportedDeviceCategories);
 
     if (status != Protocols::InteractionModel::Status::Success)

--- a/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
+++ b/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
@@ -31,6 +31,8 @@ inline constexpr EndpointId kAggregatorEndpointId = 1;
 class CommissionerControlDelegate : public Delegate
 {
 public:
+    CommissionerControlDelegate() : mCommissionerControlServer(this, kAggregatorEndpointId, CommissionerControl::Id) {}
+
     CHIP_ERROR HandleCommissioningApprovalRequest(const CommissioningApprovalRequest & request) override;
     // TODO(#35627) clientNodeId should move towards ScopedNodeId.
     CHIP_ERROR ValidateCommissionNodeCommand(NodeId clientNodeId, uint64_t requestId) override;
@@ -38,6 +40,8 @@ public:
     CHIP_ERROR HandleCommissionNode(const CommissioningWindowParams & params) override;
 
     ~CommissionerControlDelegate() = default;
+
+    CommissionerControlServer & GetCommissionerControlServer() { return mCommissionerControlServer; }
 
 private:
     enum class Step : uint8_t
@@ -82,6 +86,8 @@ private:
     ByteSpan mPBKDFSalt;
     Crypto::Spake2pVerifierSerialized mPAKEPasscodeVerifierBuffer;
     ByteSpan mPAKEPasscodeVerifier;
+
+    CommissionerControlServer mCommissionerControlServer;
 };
 
 } // namespace CommissionerControl

--- a/examples/fabric-sync/bridge/include/CommissionerControlDelegate.h
+++ b/examples/fabric-sync/bridge/include/CommissionerControlDelegate.h
@@ -32,7 +32,9 @@ inline constexpr EndpointId kAggregatorEndpointId = 1;
 class CommissionerControlDelegate : public Delegate
 {
 public:
-    CommissionerControlDelegate(bridge::FabricAdminDelegate * fabricAdmin) : mFabricAdmin(fabricAdmin) {}
+    CommissionerControlDelegate(bridge::FabricAdminDelegate * fabricAdmin) :
+        mFabricAdmin(fabricAdmin), mCommissionerControlServer(this, kAggregatorEndpointId, CommissionerControl::Id)
+    {}
 
     CHIP_ERROR HandleCommissioningApprovalRequest(const CommissioningApprovalRequest & request) override;
     // TODO(#35627) clientNodeId should move towards ScopedNodeId.
@@ -41,6 +43,8 @@ public:
     CHIP_ERROR HandleCommissionNode(const CommissioningWindowParams & params) override;
 
     ~CommissionerControlDelegate() = default;
+
+    CommissionerControlServer & GetCommissionerControlServer() { return mCommissionerControlServer; }
 
 private:
     enum class Step : uint8_t
@@ -87,6 +91,7 @@ private:
     ByteSpan mPAKEPasscodeVerifier;
 
     bridge::FabricAdminDelegate * mFabricAdmin;
+    CommissionerControlServer mCommissionerControlServer;
 };
 
 } // namespace CommissionerControl

--- a/examples/fabric-sync/bridge/src/CommissionerControlDelegate.cpp
+++ b/examples/fabric-sync/bridge/src/CommissionerControlDelegate.cpp
@@ -114,7 +114,7 @@ CHIP_ERROR CommissionerControlDelegate::HandleCommissioningApprovalRequest(const
         mLabel.ClearValue();
     }
 
-    CHIP_ERROR err = CommissionerControlServer::Instance().GenerateCommissioningRequestResultEvent(kAggregatorEndpointId, result);
+    CHIP_ERROR err = mCommissionerControlServer.GenerateCommissioningRequestResultEvent(kAggregatorEndpointId, result);
 
     if (err == CHIP_NO_ERROR)
     {
@@ -227,7 +227,7 @@ CHIP_ERROR CommissionerControlInit(bridge::FabricAdminDelegate * fabricAdmin)
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    err = Clusters::CommissionerControl::CommissionerControlServer::Instance().Init(*sCommissionerControlDelegate);
+    err = sCommissionerControlDelegate->GetCommissionerControlServer().Init();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "Initialization failed on Commissioner Control Delegate.");
@@ -241,7 +241,7 @@ CHIP_ERROR CommissionerControlInit(bridge::FabricAdminDelegate * fabricAdmin)
     supportedDeviceCategories.SetField(Clusters::CommissionerControl::SupportedDeviceCategoryBitmap::kFabricSynchronization, 1);
 
     Protocols::InteractionModel::Status status =
-        Clusters::CommissionerControl::CommissionerControlServer::Instance().SetSupportedDeviceCategoriesValue(
+        sCommissionerControlDelegate->GetCommissionerControlServer().SetSupportedDeviceCategoriesValue(
             Clusters::CommissionerControl::kAggregatorEndpointId, supportedDeviceCategories);
 
     if (status != Protocols::InteractionModel::Status::Success)

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.h
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.h
@@ -138,8 +138,6 @@ public:
                                                        const Events::CommissioningRequestResult::Type & result);
 
 private:
-    Delegate * mDelegate = nullptr;
-
     /**
      * @brief Inherited from CommandHandlerInterface
      */
@@ -161,6 +159,8 @@ private:
      * If the operational state is in 'Error', returns the Interaction Model status code of INVALID_IN_STATE.
      */
     void HandleCommissionNode(HandlerContext & ctx, const Commands::CommissionNode::DecodableType & req);
+
+    Delegate * mDelegate = nullptr;
 };
 
 } // namespace CommissionerControl

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.h
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/CommandHandlerInterface.h>
 
 namespace chip {
 namespace app {
@@ -100,14 +101,27 @@ public:
     virtual ~Delegate() = default;
 };
 
-class CommissionerControlServer
+class CommissionerControlServer : public CommandHandlerInterface
 {
 public:
-    static CommissionerControlServer & Instance();
+    /**
+     * @brief Creates a Commissioner Control cluster instance. The Init() function needs to be called for this instance
+     * to be registered and called by the interaction model at the appropriate times.
+     * @param delegate A pointer to the delegate to be used by this server.
+     * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
+     * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
+     * @param clusterId The ID of the Microwave Oven Control cluster to be instantiated.
+     */
+    CommissionerControlServer(Delegate * delegate, EndpointId endpointId, ClusterId clusterId);
 
-    CHIP_ERROR Init(Delegate & delegate);
+    ~CommissionerControlServer() override;
 
-    Delegate * GetDelegate() { return mDelegate; }
+    /**
+     * @brief Initialise the Commissioner Control server instance.
+     * This function must be called after defining an CommissionerControlServer class object.
+     * @return Returns an error if the CommandHandler registration fails, else returns CHIP_NO_ERROR.
+     */
+    CHIP_ERROR Init();
 
     Protocols::InteractionModel::Status
     GetSupportedDeviceCategoriesValue(EndpointId endpoint,
@@ -124,12 +138,29 @@ public:
                                                        const Events::CommissioningRequestResult::Type & result);
 
 private:
-    CommissionerControlServer()  = default;
-    ~CommissionerControlServer() = default;
-
-    static CommissionerControlServer sInstance;
-
     Delegate * mDelegate = nullptr;
+
+    /**
+     * @brief Inherited from CommandHandlerInterface
+     */
+    void InvokeCommand(HandlerContext & ctx) override;
+
+    /**
+     * @brief Handle Command: SetCookingParameters.
+     * @param ctx Returns the Interaction Model status code which was user determined in the business logic.
+     * If the input value is invalid, returns the Interaction Model status code of INVALID_COMMAND.
+     * If the operational state is not in 'Stopped', returns the Interaction Model status code of INVALID_IN_STATE.
+     */
+    void HandleRequestCommissioningApproval(HandlerContext & ctx,
+                                            const Commands::RequestCommissioningApproval::DecodableType & req);
+
+    /**
+     * @brief Handle Command: AddMoreTime.
+     * @param ctx Returns the Interaction Model status code which was user determined in the business logic.
+     * If the cook time value is out of range, returns the Interaction Model status code of CONSTRAINT_ERROR.
+     * If the operational state is in 'Error', returns the Interaction Model status code of INVALID_IN_STATE.
+     */
+    void HandleCommissionNode(HandlerContext & ctx, const Commands::CommissionNode::DecodableType & req);
 };
 
 } // namespace CommissionerControl

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -37,6 +37,7 @@ CommandHandlerInterfaceOnlyClusters:
     - Sample MEI
     - Microwave Oven Control
     - Chime
+    - Commissioner Control
     - Energy EVSE
     - Energy EVSE Mode
     - Device Energy Management

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -6907,18 +6907,6 @@ bool emberAfWebRTCTransportRequestorClusterEndCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::WebRTCTransportRequestor::Commands::End::DecodableType & commandData);
 /**
- * @brief Commissioner Control Cluster RequestCommissioningApproval Command callback (from client)
- */
-bool emberAfCommissionerControlClusterRequestCommissioningApprovalCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::CommissionerControl::Commands::RequestCommissioningApproval::DecodableType & commandData);
-/**
- * @brief Commissioner Control Cluster CommissionNode Command callback (from client)
- */
-bool emberAfCommissionerControlClusterCommissionNodeCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::CommissionerControl::Commands::CommissionNode::DecodableType & commandData);
-/**
  * @brief Unit Testing Cluster Test Command callback (from client)
  */
 bool emberAfUnitTestingClusterTestCallback(chip::app::CommandHandler * commandObj,


### PR DESCRIPTION
Decouple Commissioner Control Cluster from ember and migrate to use CHI (CommandHandlerInterface) instead

Fix: https://github.com/project-chip/connectedhomeip/issues/36695

