### PR TITLE
[NXP][platform][RT][RW61x] Disable "chip_inet_config_enable_tcp_endpoint" gn arg

### DIFF
--- a/src/platform/nxp/rt/rt1060/args.gni
+++ b/src/platform/nxp/rt/rt1060/args.gni
@@ -32,6 +32,9 @@ chip_ble_project_config_include = "<CHIPProjectConfig.h>"
 
 chip_build_tests = false
 
+# Disable TCP endpoint.
+chip_inet_config_enable_tcp_endpoint = false
+
 #This enables the EventList global attribute
 enable_eventlist_attribute = true
 

--- a/src/platform/nxp/rt/rt1170/args.gni
+++ b/src/platform/nxp/rt/rt1170/args.gni
@@ -32,6 +32,9 @@ chip_ble_project_config_include = "<CHIPProjectConfig.h>"
 
 chip_build_tests = false
 
+# Disable TCP endpoint.
+chip_inet_config_enable_tcp_endpoint = false
+
 #This enables the EventList global attribute
 enable_eventlist_attribute = true
 

--- a/src/platform/nxp/rt/rw61x/args.gni
+++ b/src/platform/nxp/rt/rw61x/args.gni
@@ -34,6 +34,9 @@ chip_ble_project_config_include = "<CHIPProjectConfig.h>"
 
 chip_build_tests = false
 
+# Disable TCP endpoint.
+chip_inet_config_enable_tcp_endpoint = false
+
 declare_args() {
   spinel_interface_rpmsg = true
 


### PR DESCRIPTION
Disabling "chip_inet_config_enable_tcp_endpoint" GN arg for RT1060, RT1170 and RW61x platforms.