### PR TITLE
Stop shell read loop if the input stream was closed

### DIFF
--- a/src/lib/shell/MainLoopDefault.cpp
+++ b/src/lib/shell/MainLoopDefault.cpp
@@ -57,6 +57,15 @@ size_t ReadLine(char * buffer, size_t max)
             break;
         }
 
+        // Stop the loop if the input stream is closed.
+        if (ret == 0)
+        {
+            if (line_sz > 0)
+                // Return current buffer if it is not empty.
+                buffer[line_sz++] = '\0';
+            break;
+        }
+
         if (ret != 1)
             continue;
 


### PR DESCRIPTION
### Problem

In case when standard input is closed the shell read loop uses 100% CPU.

### Changes

- stop shell read loop on EOF

### Testing

Tested locally, CI will verify for regressions.