### PR TITLE
Some code updates on composition logic after #36493

### DIFF
--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -105,8 +105,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
             return CHIP_NO_ERROR;
         });
     }
-    else if (endpointInfo.has_value() &&
-             endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kFullFamily)
+    else if (endpointInfo.has_value() && endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kFullFamily)
     {
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             auto endpointEntry = InteractionModelEngine::GetInstance()->GetDataModelProvider()->FirstEndpoint();

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -106,7 +106,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
         });
     }
     else if (endpointInfo.has_value() &&
-             endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kFullFamilyPattern)
+             endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kFullFamily)
     {
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             auto endpointEntry = InteractionModelEngine::GetInstance()->GetDataModelProvider()->FirstEndpoint();
@@ -134,7 +134,7 @@ CHIP_ERROR DescriptorAttrAccess::ReadPartsAttribute(EndpointId endpoint, Attribu
             return CHIP_NO_ERROR;
         });
     }
-    else if (endpointInfo.has_value() && endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kTreePattern)
+    else if (endpointInfo.has_value() && endpointInfo->compositionPattern == DataModel::EndpointCompositionPattern::kTree)
     {
         err = aEncoder.EncodeList([endpoint](const auto & encoder) -> CHIP_ERROR {
             auto endpointEntry = InteractionModelEngine::GetInstance()->GetDataModelProvider()->FirstEndpoint();

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -321,11 +321,11 @@ std::optional<DataModel::EndpointInfo> GetEndpointInfoAtIndex(uint16_t endpointI
     EndpointId parent = emberAfParentEndpointFromIndex(endpointIndex);
     if (GetCompositionForEndpointIndex(endpointIndex) == EndpointComposition::kFullFamily)
     {
-        return DataModel::EndpointInfo(parent, DataModel::EndpointCompositionPattern::kFullFamilyPattern);
+        return DataModel::EndpointInfo(parent, DataModel::EndpointCompositionPattern::kFullFamily);
     }
     if (GetCompositionForEndpointIndex(endpointIndex) == EndpointComposition::kTree)
     {
-        return DataModel::EndpointInfo(parent, DataModel::EndpointCompositionPattern::kTreePattern);
+        return DataModel::EndpointInfo(parent, DataModel::EndpointCompositionPattern::kTree);
     }
     return std::nullopt;
 }

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -898,15 +898,15 @@ TEST(TestCodegenModelViaMocks, IterateOverEndpoints)
     EndpointEntry ep = model.FirstEndpoint();
     EXPECT_EQ(ep.id, kMockEndpoint1);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.NextEndpoint(kMockEndpoint1);
     EXPECT_EQ(ep.id, kMockEndpoint2);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTreePattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTree);
     ep = model.NextEndpoint(kMockEndpoint2);
     EXPECT_EQ(ep.id, kMockEndpoint3);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.NextEndpoint(kMockEndpoint3);
     EXPECT_EQ(ep.id, kInvalidEndpointId);
 
@@ -914,27 +914,27 @@ TEST(TestCodegenModelViaMocks, IterateOverEndpoints)
     ep = model.NextEndpoint(kMockEndpoint2);
     EXPECT_EQ(ep.id, kMockEndpoint3);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.NextEndpoint(kMockEndpoint2);
     EXPECT_EQ(ep.id, kMockEndpoint3);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.NextEndpoint(kMockEndpoint1);
     EXPECT_EQ(ep.id, kMockEndpoint2);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTreePattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTree);
     ep = model.NextEndpoint(kMockEndpoint1);
     EXPECT_EQ(ep.id, kMockEndpoint2);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTreePattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTree);
     ep = model.NextEndpoint(kMockEndpoint2);
     EXPECT_EQ(ep.id, kMockEndpoint3);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.NextEndpoint(kMockEndpoint1);
     EXPECT_EQ(ep.id, kMockEndpoint2);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTreePattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kTree);
     ep = model.NextEndpoint(kMockEndpoint3);
     EXPECT_EQ(ep.id, kInvalidEndpointId);
     ep = model.NextEndpoint(kMockEndpoint3);
@@ -942,11 +942,11 @@ TEST(TestCodegenModelViaMocks, IterateOverEndpoints)
     ep = model.FirstEndpoint();
     EXPECT_EQ(ep.id, kMockEndpoint1);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
     ep = model.FirstEndpoint();
     EXPECT_EQ(ep.id, kMockEndpoint1);
     EXPECT_EQ(ep.info.parentId, kInvalidEndpointId);
-    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamilyPattern);
+    EXPECT_EQ(ep.info.compositionPattern, EndpointCompositionPattern::kFullFamily);
 
     // invalid endpoiunts
     ep = model.NextEndpoint(kInvalidEndpointId);
@@ -964,17 +964,17 @@ TEST(TestCodegenModelViaMocks, GetEndpointInfo)
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->parentId, kInvalidEndpointId); // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(info->compositionPattern,            // NOLINT(bugprone-unchecked-optional-access)
-              EndpointCompositionPattern::kFullFamilyPattern);
+              EndpointCompositionPattern::kFullFamily);
     info = model.GetEndpointInfo(kMockEndpoint2);
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->parentId, kInvalidEndpointId); // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(info->compositionPattern,            // NOLINT(bugprone-unchecked-optional-access)
-              EndpointCompositionPattern::kTreePattern);
+              EndpointCompositionPattern::kTree);
     info = model.GetEndpointInfo(kMockEndpoint3);
     ASSERT_TRUE(info.has_value());
     EXPECT_EQ(info->parentId, kInvalidEndpointId); // NOLINT(bugprone-unchecked-optional-access)
     EXPECT_EQ(info->compositionPattern,            // NOLINT(bugprone-unchecked-optional-access)
-              EndpointCompositionPattern::kFullFamilyPattern);
+              EndpointCompositionPattern::kFullFamily);
 
     // invalid endpoiunts
     info = model.GetEndpointInfo(kInvalidEndpointId);

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -39,7 +39,7 @@ enum class EndpointCompositionPattern : uint8_t
 {
     // Tree pattern supports a general tree of endpoints. Commonly used for
     // device types that support physical device composition (e.g. Refrigerator)
-    kTree       = 0x1,
+    kTree = 0x1,
 
     // A full-family pattern is a list fo all descendant endpoints, with no
     // imposed hierarchy.
@@ -56,8 +56,7 @@ struct EndpointInfo
     EndpointId parentId;
     EndpointCompositionPattern compositionPattern;
 
-    explicit EndpointInfo(EndpointId parent) : parentId(parent), compositionPattern(EndpointCompositionPattern::kFullFamily)
-    {}
+    explicit EndpointInfo(EndpointId parent) : parentId(parent), compositionPattern(EndpointCompositionPattern::kFullFamily) {}
     EndpointInfo(EndpointId parent, EndpointCompositionPattern pattern) : parentId(parent), compositionPattern(pattern) {}
 };
 

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -33,9 +33,19 @@ namespace chip {
 namespace app {
 namespace DataModel {
 
+/// Represents various endpoint composition patters as defined in the spec
+/// as `9.2.1. Endpoint Composition patters`
 enum class EndpointCompositionPattern : uint8_t
 {
+    // Tree pattern supports a general tree of endpoints. Commonly used for
+    // device types that support physical device composition (e.g. Refrigerator)
     kTree       = 0x1,
+
+    // A full-family pattern is a list fo all descendant endpoints, with no
+    // imposed hierarchy.
+    //
+    // For example the Root Node and Aggregator device types use the full-familiy
+    // pattern, as defined in their device type specification
     kFullFamily = 0x2,
 };
 
@@ -48,7 +58,7 @@ struct EndpointInfo
 
     explicit EndpointInfo(EndpointId parent) : parentId(parent), compositionPattern(EndpointCompositionPattern::kFullFamily)
     {}
-    explicit EndpointInfo(EndpointId parent, EndpointCompositionPattern pattern) : parentId(parent), compositionPattern(pattern) {}
+    EndpointInfo(EndpointId parent, EndpointCompositionPattern pattern) : parentId(parent), compositionPattern(pattern) {}
 };
 
 struct EndpointEntry

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -34,7 +34,7 @@ namespace app {
 namespace DataModel {
 
 /// Represents various endpoint composition patters as defined in the spec
-/// as `9.2.1. Endpoint Composition patters`
+/// as `9.2.1. Endpoint Composition patterns`
 enum class EndpointCompositionPattern : uint8_t
 {
     // Tree pattern supports a general tree of endpoints. Commonly used for

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -35,8 +35,8 @@ namespace DataModel {
 
 enum class EndpointCompositionPattern : uint8_t
 {
-    kTreePattern       = 0x1,
-    kFullFamilyPattern = 0x2,
+    kTree       = 0x1,
+    kFullFamily = 0x2,
 };
 
 struct EndpointInfo
@@ -46,7 +46,7 @@ struct EndpointInfo
     EndpointId parentId;
     EndpointCompositionPattern compositionPattern;
 
-    explicit EndpointInfo(EndpointId parent) : parentId(parent), compositionPattern(EndpointCompositionPattern::kFullFamilyPattern)
+    explicit EndpointInfo(EndpointId parent) : parentId(parent), compositionPattern(EndpointCompositionPattern::kFullFamily)
     {}
     explicit EndpointInfo(EndpointId parent, EndpointCompositionPattern pattern) : parentId(parent), compositionPattern(pattern) {}
 };


### PR DESCRIPTION
### Changes

- Remove the `Pattern` stuttering in both enum name and constant name (since this is an enum class, enum name is repeated anyway)
- Added a few comments from the spec about what the endpoint composition is.
- Removed an explicit tag from a constructor that takes multiple arguments: since this is no auto-conversion, there are less changes of mistaken casts here.