### PR TITLE
Allow to communicate with DUT via standard input

### DIFF
--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -722,6 +722,11 @@ for that run, e.g.:
 
     -   Example: `"Manual pairing code: \\[\\d+\\]"`
 
+-   `app-stdin-pipe`: Specifies the path to the named pipe that the test runner
+    might use to send input to the application.
+
+    -   Example: `/tmp/app-fifo`
+
 -   `script-args`: Specifies the arguments to be passed to the test script.
 
     -   Example:

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -71,6 +71,7 @@ def process_chip_app_output(line, is_stderr):
 def process_test_script_output(line, is_stderr):
     return process_chip_output(line, is_stderr, TAG_PROCESS_TEST)
 
+
 def forward_fifo(path: str, f_out: typing.BinaryIO, stop_event: threading.Event):
     """Forward the content of a named pipe to a file-like object."""
     if not os.path.exists(path):

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
 import glob
 import io
@@ -22,9 +23,12 @@ import os
 import os.path
 import pathlib
 import re
+import select
 import shlex
 import sys
+import threading
 import time
+import typing
 
 import click
 import coloredlogs
@@ -67,6 +71,21 @@ def process_chip_app_output(line, is_stderr):
 def process_test_script_output(line, is_stderr):
     return process_chip_output(line, is_stderr, TAG_PROCESS_TEST)
 
+def forward_fifo(path: str, f_out: typing.BinaryIO, stop_event: threading.Event):
+    """Forward the content of a named pipe to a file-like object."""
+    if not os.path.exists(path):
+        with contextlib.suppress(OSError):
+            os.mkfifo(path)
+    with open(os.open(path, os.O_RDONLY | os.O_NONBLOCK), 'rb') as f_in:
+        while not stop_event.is_set():
+            if select.select([f_in], [], [], 0.5)[0]:
+                line = f_in.readline()
+                if not line:
+                    break
+                f_out.write(line)
+                f_out.flush()
+    os.unlink(path)
+
 
 @click.command()
 @click.option("--app", type=click.Path(exists=True), default=None,
@@ -79,6 +98,8 @@ def process_test_script_output(line, is_stderr):
               help='The extra arguments passed to the device. Can use placeholders like {SCRIPT_BASE_NAME}')
 @click.option("--app-ready-pattern", type=str, default=None,
               help='Delay test script start until given regular expression pattern is found in the application output.')
+@click.option("--app-stdin-pipe", type=str, default=None,
+              help='Path for a standard input redirection named pipe to be used by the test script.')
 @click.option("--script", type=click.Path(exists=True), default=os.path.join(DEFAULT_CHIP_ROOT,
                                                                              'src',
                                                                              'controller',
@@ -94,7 +115,8 @@ def process_test_script_output(line, is_stderr):
               help="Do not print output from passing tests. Use this flag in CI to keep GitHub log size manageable.")
 @click.option("--load-from-env", default=None, help="YAML file that contains values for environment variables.")
 def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
-         app_ready_pattern: str, script: str, script_args: str, script_gdb: bool, quiet: bool, load_from_env):
+         app_ready_pattern: str, app_stdin_pipe: str, script: str, script_args: str,
+         script_gdb: bool, quiet: bool, load_from_env):
     if load_from_env:
         reader = MetadataReader(load_from_env)
         runs = reader.parse_script(script)
@@ -106,6 +128,7 @@ def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: 
                 app=app,
                 app_args=app_args,
                 app_ready_pattern=app_ready_pattern,
+                app_stdin_pipe=app_stdin_pipe,
                 script_args=script_args,
                 script_gdb=script_gdb,
             )
@@ -128,11 +151,13 @@ def main(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: 
     for run in runs:
         logging.info("Executing %s %s", run.py_script_path.split('/')[-1], run.run)
         main_impl(run.app, run.factory_reset, run.factory_reset_app_only, run.app_args or "",
-                  run.app_ready_pattern, run.py_script_path, run.script_args or "", run.script_gdb, run.quiet)
+                  run.app_ready_pattern, run.app_stdin_pipe, run.py_script_path,
+                  run.script_args or "", run.script_gdb, run.quiet)
 
 
 def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_args: str,
-              app_ready_pattern: str, script: str, script_args: str, script_gdb: bool, quiet: bool):
+              app_ready_pattern: str, app_stdin_pipe: str, script: str, script_args: str,
+              script_gdb: bool, quiet: bool):
 
     app_args = app_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
     script_args = script_args.replace('{SCRIPT_BASE_NAME}', os.path.splitext(os.path.basename(script))[0])
@@ -154,6 +179,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
             pathlib.Path(match.group("path")).unlink(missing_ok=True)
 
     app_process = None
+    app_stdin_forwarding_stop_event = threading.Event()
     app_exit_code = 0
     app_pid = 0
 
@@ -172,7 +198,13 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
                                  f_stdout=stream_output,
                                  f_stderr=stream_output)
         app_process.start(expected_output=app_ready_pattern, timeout=30)
-        app_process.p.stdin.close()
+        if app_stdin_pipe:
+            logging.info("Forwarding stdin from '%s' to app", app_stdin_pipe)
+            forwarding_thread = threading.Thread(target=forward_fifo,
+                                                 args=(app_stdin_pipe, app_process.p.stdin, app_stdin_forwarding_stop_event))
+            forwarding_thread.start()
+        else:
+            app_process.p.stdin.close()
         app_pid = app_process.p.pid
 
     script_command = [script, "--paa-trust-store-path", os.path.join(DEFAULT_CHIP_ROOT, MATTER_DEVELOPMENT_PAA_ROOT_CERTS),
@@ -205,6 +237,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
     if app_process:
         logging.info("Stopping app with SIGTERM")
         app_process.terminate()
+        app_stdin_forwarding_stop_event.set()
         app_exit_code = app_process.returncode
 
     # We expect both app and test script should exit with 0

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -85,7 +85,8 @@ def forward_fifo(path: str, f_out: typing.BinaryIO, stop_event: threading.Event)
                     break
                 f_out.write(line)
                 f_out.flush()
-    os.unlink(path)
+    with contextlib.suppress(OSError):
+        os.unlink(path)
 
 
 @click.command()
@@ -240,6 +241,7 @@ def main_impl(app: str, factory_reset: bool, factory_reset_app_only: bool, app_a
         app_process.terminate()
         app_stdin_forwarding_stop_event.set()
         app_exit_code = app_process.returncode
+        forwarding_thread.join()
 
     # We expect both app and test script should exit with 0
     exit_code = test_script_exit_code or app_exit_code

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_CCTRL_2_1.py
+++ b/src/python_testing/TC_CCTRL_2_1.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -24,8 +24,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -72,11 +72,11 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
         self.storage = None
 
         # Get the path to the TH_SERVER_NO_UID app from the user params.
-        th_server_app = self.user_params.get("th_server_no_uid_app_path", None)
-        if not th_server_app:
+        th_server_no_uid_app = self.user_params.get("th_server_no_uid_app_path", None)
+        if not th_server_no_uid_app:
             asserts.fail("This test requires a TH_SERVER_NO_UID app. Specify app path with --string-arg th_server_no_uid_app_path:<path_to_app>")
-        if not os.path.exists(th_server_app):
-            asserts.fail(f"The path {th_server_app} does not exist")
+        if not os.path.exists(th_server_no_uid_app):
+            asserts.fail(f"The path {th_server_no_uid_app} does not exist")
 
         # Create a temporary storage directory for keeping KVS files.
         self.storage = tempfile.TemporaryDirectory(prefix=self.__class__.__name__)
@@ -95,7 +95,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
 
         # Start the TH_SERVER_NO_UID app.
         self.th_server = AppServerSubprocess(
-            th_server_app,
+            th_server_no_uid_app,
             storage_dir=self.storage.name,
             port=self.th_server_port,
             discriminator=self.th_server_discriminator,

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -26,8 +26,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -26,8 +26,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -130,11 +130,11 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
             asserts.fail(f"The path {th_fsa_bridge_path} does not exist")
 
         # Get the path to the TH_SERVER_NO_UID app from the user params.
-        th_server_app = self.user_params.get("th_server_no_uid_app_path", None)
-        if not th_server_app:
+        th_server_no_uid_app = self.user_params.get("th_server_no_uid_app_path", None)
+        if not th_server_no_uid_app:
             asserts.fail("This test requires a TH_SERVER_NO_UID app. Specify app path with --string-arg th_server_no_uid_app_path:<path_to_app>")
-        if not os.path.exists(th_server_app):
-            asserts.fail(f"The path {th_server_app} does not exist")
+        if not os.path.exists(th_server_no_uid_app):
+            asserts.fail(f"The path {th_server_no_uid_app} does not exist")
 
         # Create a temporary storage directory for keeping KVS files.
         self.storage = tempfile.TemporaryDirectory(prefix=self.__class__.__name__)
@@ -172,7 +172,7 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
 
         # Start the TH_SERVER_NO_UID app.
         self.th_server = AppServerSubprocess(
-            th_server_app,
+            th_server_no_uid_app,
             storage_dir=self.storage.name,
             port=self.th_server_port,
             discriminator=self.th_server_discriminator,

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -22,8 +22,9 @@
 # test-runner-runs:
 #   run1:
 #     app: examples/fabric-admin/scripts/fabric-sync-app.py
-#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --stdin-pipe=dut-fsa-stdin --discriminator=1234
+#     app-args: --app-admin=${FABRIC_ADMIN_APP} --app-bridge=${FABRIC_BRIDGE_APP} --discriminator=1234
 #     app-ready-pattern: "Successfully opened pairing window on the device"
+#     app-stdin-pipe: dut-fsa-stdin
 #     script-args: >
 #       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --storage-path admin_storage.json

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/metadata.py
@@ -27,6 +27,7 @@ class Metadata:
     app: str = ""
     app_args: Optional[str] = None
     app_ready_pattern: Optional[str] = None
+    app_stdin_pipe: Optional[str] = None
     script_args: Optional[str] = None
     factory_reset: bool = False
     factory_reset_app_only: bool = False
@@ -148,6 +149,7 @@ class MetadataReader:
                 app=attr.get("app", ""),
                 app_args=attr.get("app-args"),
                 app_ready_pattern=attr.get("app-ready-pattern"),
+                app_stdin_pipe=attr.get("app-stdin-pipe"),
                 script_args=attr.get("script-args"),
                 factory_reset=attr.get("factory-reset", False),
                 quiet=attr.get("quiet", True),


### PR DESCRIPTION
### Problem

In order to automatize vendor specific steps in CI it is required to somehow communicate with app application from the test script. In case of `fabric-sync-app.py` that was achieved by providing named pipe communication. However, such approach is not scalable because it would require support for named pipes in all apps.

### Changes

- move named pipe approach to the script runner
- drop pipe stdin forwarder in fabric-sync-app.py

### Testing

CI will verify whether everything still works as expected.