### PR TITLE
Documentation: Fix incorrect paths in fuzz_testing.md and yaml.md

### DIFF
--- a/docs/testing/fuzz_testing.md
+++ b/docs/testing/fuzz_testing.md
@@ -79,10 +79,10 @@ for an example of a simple fuzz test.
     -   Another example:
         [src/setup_payload/tests/BUILD.gn](https://github.com/project-chip/connectedhomeip/blob/b367512f519e5e109346e81a0d84fd85cd9192f7/src/setup_payload/tests/BUILD.gn#L43)
 
--   Add to `src/BUILD.gn`
+-   Add to `${chip_root}/BUILD.gn`
 
     -   Add the Fuzzing Target in this part of the code :
-        [src/BUILD.gn](https://github.com/project-chip/connectedhomeip/blob/b367512f519e5e109346e81a0d84fd85cd9192f7/BUILD.gn#L52)
+        [${chip_root}/BUILD.gn](https://github.com/project-chip/connectedhomeip/blob/b367512f519e5e109346e81a0d84fd85cd9192f7/BUILD.gn#L52)
 
     -   Add Fuzzing Target like that
 

--- a/docs/testing/fuzz_testing.md
+++ b/docs/testing/fuzz_testing.md
@@ -82,7 +82,7 @@ for an example of a simple fuzz test.
 -   Add to `${chip_root}/BUILD.gn`
 
     -   Add the Fuzzing Target in this part of the code :
-        [${chip_root}/BUILD.gn](https://github.com/project-chip/connectedhomeip/blob/b367512f519e5e109346e81a0d84fd85cd9192f7/BUILD.gn#L52)
+        [\${chip_root}/BUILD.gn](https://github.com/project-chip/connectedhomeip/blob/b367512f519e5e109346e81a0d84fd85cd9192f7/BUILD.gn#L52)
 
     -   Add Fuzzing Target like that
 

--- a/docs/testing/yaml.md
+++ b/docs/testing/yaml.md
@@ -330,12 +330,11 @@ or
 bootstrap.sh should be used for for the first setup, activate.sh may be used for
 subsequent setups as it is faster.
 
-Next build the python wheels and create a venv (called `py` here, but any name
-may be used)
+Next build the python wheels and create a venv
 
 ```
 ./scripts/build_python.sh -i out/python_env
-source py/bin/activate
+source out/python_env/bin/activate
 ```
 
 Compile chip-tool:


### PR DESCRIPTION
This PR corrects inaccurate file paths in the documentation for `fuzz_testing.md` and `yaml.md` to ensure consistency and accuracy.

### Changes

1. fuzz_testing.md:
   - Updated references to `src/BUILD.gn` to `${chip_root}/BUILD.gn` to match the actual file path.
2. yaml.md:
    - Adjusted the virtual environment activation path from `py/bin/activate` to `out/python_env/bin/activate` to align with the `out/python_env` path mentioned earlier in the same section.