### PR TITLE
Ensure SYSTEM_STATS_INCREMENT only on successful Timer allocation in SystemTimer.h

### DIFF
--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -204,7 +204,8 @@ public:
     Timer * Create(Layer & systemLayer, System::Clock::Timestamp awakenTime, TimerCompleteCallback onComplete, void * appState)
     {
         Timer * timer = mTimerPool.CreateObject(systemLayer, awakenTime, onComplete, appState);
-        if (timer != nullptr) {
+        if (timer != nullptr)
+        {
             SYSTEM_STATS_INCREMENT(Stats::kSystemLayer_NumTimers);
         }
 

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -204,7 +204,10 @@ public:
     Timer * Create(Layer & systemLayer, System::Clock::Timestamp awakenTime, TimerCompleteCallback onComplete, void * appState)
     {
         Timer * timer = mTimerPool.CreateObject(systemLayer, awakenTime, onComplete, appState);
-        SYSTEM_STATS_INCREMENT(Stats::kSystemLayer_NumTimers);
+        if (timer != nullptr) {
+            SYSTEM_STATS_INCREMENT(Stats::kSystemLayer_NumTimers);
+        }
+
         return timer;
     }
 


### PR DESCRIPTION
### Description
- Fixes an issue in `SystemTimer.h` where `SYSTEM_STATS_INCREMENT` is called even when `Timer` allocation fails, leading to incorrect timer statistics.
- Added a `nullptr` check for the `Timer` object to ensure that `Stats::kSystemLayer_NumTimers` is incremented only when allocation is successful.

### Changes
- Adjusted the position of `SYSTEM_STATS_INCREMENT(Stats::kSystemLayer_NumTimers)` in `SystemTimer.h` to be executed only after verifying `timer` is not `nullptr`.
