### PR TITLE
Support for generating QR-code and manual code in Python chip binding

### DIFF
--- a/src/controller/python/chip/setup_payload/Generator.cpp
+++ b/src/controller/python/chip/setup_payload/Generator.cpp
@@ -15,30 +15,30 @@
  *    limitations under the License.
  */
 
+#include <string>
+#include <type_traits>
+
 #include <controller/python/chip/native/PyChipError.h>
+#include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
-#include <string>
-#include <type_traits>
-
 using namespace chip;
 
-extern "C" PyChipError pychip_SetupPayload_PrintOnboardingCodes(uint32_t passcode, uint16_t vendorId, uint16_t productId,
-                                                                uint16_t discriminator, uint8_t customFlow, uint8_t capabilities,
-                                                                uint8_t version)
+namespace {
+
+CHIP_ERROR InitSetupPayload(SetupPayload & payload, uint32_t passcode, uint16_t vendorId, uint16_t productId,
+                            uint16_t discriminator, uint8_t customFlow, uint8_t capabilities, uint8_t version)
 {
-    std::string QRCode;
-    std::string manualPairingCode;
-    SetupPayload payload;
-    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kNone;
 
     payload.version      = version;
     payload.setUpPINCode = passcode;
     payload.vendorID     = vendorId;
     payload.productID    = productId;
     payload.discriminator.SetLongValue(discriminator);
+
+    RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kNone;
     payload.rendezvousInformation.SetValue(rendezvousFlags.SetRaw(capabilities));
 
     switch (customFlow)
@@ -54,16 +54,63 @@ extern "C" PyChipError pychip_SetupPayload_PrintOnboardingCodes(uint32_t passcod
         break;
     default:
         ChipLogError(SetupPayload, "Invalid Custom Flow");
-        return ToPyChipError(CHIP_ERROR_INVALID_ARGUMENT);
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    CHIP_ERROR err = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace
+
+extern "C" PyChipError pychip_SetupPayload_PrintOnboardingCodes(uint32_t passcode, uint16_t vendorId, uint16_t productId,
+                                                                uint16_t discriminator, uint8_t customFlow, uint8_t capabilities,
+                                                                uint8_t version)
+{
+    SetupPayload payload;
+    CHIP_ERROR err = InitSetupPayload(payload, passcode, vendorId, productId, discriminator, customFlow, capabilities, version);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    std::string manualPairingCode;
+    err = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     ChipLogProgress(SetupPayload, "Manual pairing code: [%s]", manualPairingCode.c_str());
 
+    std::string QRCode;
     err = QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode);
     VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
     ChipLogProgress(SetupPayload, "SetupQRCode: [%s]", QRCode.c_str());
 
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+extern "C" PyChipError pychip_SetupPayload_GenerateQrCode(char * output, size_t size, uint32_t passcode, uint16_t vendorId,
+                                                          uint16_t productId, uint16_t discriminator, uint8_t customFlow,
+                                                          uint8_t capabilities, uint8_t version)
+{
+    SetupPayload payload;
+    CHIP_ERROR err = InitSetupPayload(payload, passcode, vendorId, productId, discriminator, customFlow, capabilities, version);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    std::string QRCode;
+    err = QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(QRCode);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    Platform::CopyString(output, size, QRCode.c_str());
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+extern "C" PyChipError pychip_SetupPayload_GenerateManualPairingCode(char * output, size_t size, uint32_t passcode,
+                                                                     uint16_t vendorId, uint16_t productId, uint16_t discriminator,
+                                                                     uint8_t customFlow, uint8_t capabilities, uint8_t version)
+{
+    SetupPayload payload;
+    CHIP_ERROR err = InitSetupPayload(payload, passcode, vendorId, productId, discriminator, customFlow, capabilities, version);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    std::string manualPairingCode;
+    err = ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, ToPyChipError(err));
+
+    Platform::CopyString(output, size, manualPairingCode.c_str());
     return ToPyChipError(CHIP_NO_ERROR);
 }

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -43,15 +43,15 @@ class SetupPayload:
         self.vendor_attribute_visitor = SetupPayload.VendorAttributeVisitor(
             AddVendorAttribute)
 
-    def GenerateQrCode(self, passcode:int, vendorId:int = 0xFFF1, productId:int = 0x8001, discriminator:int = 3840,
-                       customFlow:int = 0, capabilities:int = 4, version:int = 0) -> str:
+    def GenerateQrCode(self, passcode: int, vendorId: int = 0xFFF1, productId: int = 0x8001, discriminator: int = 3840,
+                       customFlow: int = 0, capabilities: int = 4, version: int = 0) -> str:
         buffer = create_string_buffer(256)
         self.chipLib.pychip_SetupPayload_GenerateQrCode(buffer, 256, passcode, vendorId, productId,
                                                         discriminator, customFlow, capabilities, version).raise_on_error()
         return buffer.value.decode()
 
-    def GenerateManualPairingCode(self, passcode:int, vendorId:int = 0xFFF1, productId:int = 0x8001, discriminator:int = 3840,
-                                  customFlow:int = 0, capabilities:int = 4, version:int = 0) -> str:
+    def GenerateManualPairingCode(self, passcode: int, vendorId: int = 0xFFF1, productId: int = 0x8001, discriminator: int = 3840,
+                                  customFlow: int = 0, capabilities: int = 4, version: int = 0) -> str:
         buffer = create_string_buffer(256)
         self.chipLib.pychip_SetupPayload_GenerateManualPairingCode(buffer, 256, passcode, vendorId, productId,
                                                                    discriminator, customFlow, capabilities, version).raise_on_error()

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16, c_uint32
+from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16, c_uint32, create_string_buffer, c_uint64
 from typing import Optional
 
 from chip.native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
@@ -42,6 +42,20 @@ class SetupPayload:
         self.attribute_visitor = SetupPayload.AttributeVisitor(AddAttribute)
         self.vendor_attribute_visitor = SetupPayload.VendorAttributeVisitor(
             AddVendorAttribute)
+
+    def GenerateQrCode(self, passcode:int, vendorId:int = 0xFFF1, productId:int = 0x8001, discriminator:int = 3840,
+                       customFlow:int = 0, capabilities:int = 4, version:int = 0) -> str:
+        buffer = create_string_buffer(256)
+        self.chipLib.pychip_SetupPayload_GenerateQrCode(buffer, 256, passcode, vendorId, productId,
+                                                        discriminator, customFlow, capabilities, version).raise_on_error()
+        return buffer.value.decode()
+
+    def GenerateManualPairingCode(self, passcode:int, vendorId:int = 0xFFF1, productId:int = 0x8001, discriminator:int = 3840,
+                                  customFlow:int = 0, capabilities:int = 4, version:int = 0) -> str:
+        buffer = create_string_buffer(256)
+        self.chipLib.pychip_SetupPayload_GenerateManualPairingCode(buffer, 256, passcode, vendorId, productId,
+                                                                   discriminator, customFlow, capabilities, version).raise_on_error()
+        return buffer.value.decode()
 
     def ParseQrCode(self, qrCode: str):
         self.Clear()
@@ -99,6 +113,12 @@ class SetupPayload:
         if chipLib.pychip_SetupPayload_ParseQrCode.argtypes is not None:
             return
         setter = NativeLibraryHandleMethodArguments(chipLib)
+        setter.Set("pychip_SetupPayload_GenerateQrCode",
+                   PyChipError,
+                   [c_char_p, c_uint64, c_uint32, c_uint16, c_uint16, c_uint16, c_uint8, c_uint8, c_uint8])
+        setter.Set("pychip_SetupPayload_GenerateManualPairingCode",
+                   PyChipError,
+                   [c_char_p, c_uint64, c_uint32, c_uint16, c_uint16, c_uint16, c_uint8, c_uint8, c_uint8])
         setter.Set("pychip_SetupPayload_ParseQrCode",
                    PyChipError,
                    [c_char_p, SetupPayload.AttributeVisitor, SetupPayload.VendorAttributeVisitor])

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16, c_uint32, create_string_buffer, c_uint64
+from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16, c_uint32, c_uint64, create_string_buffer
 from typing import Optional
 
 from chip.native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -52,7 +52,8 @@ from dataclasses import dataclass
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
-from chip.testing.matter_testing import MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main, type_matches
+from chip.testing.matter_testing import (MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main,
+                                         type_matches)
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -47,7 +47,6 @@ import secrets
 import struct
 import tempfile
 import time
-from dataclasses import dataclass
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -42,6 +42,7 @@ import hashlib
 import logging
 import os
 import queue
+import random
 import secrets
 import struct
 import tempfile
@@ -51,7 +52,7 @@ from dataclasses import dataclass
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from chip.testing.matter_testing import MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main, type_matches
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator
@@ -67,14 +68,6 @@ def _generate_verifier(passcode: int, salt: bytes, iterations: int) -> bytes:
     L = NIST256p.generator * w1
 
     return w0.to_bytes(NIST256p.baselen, byteorder='big') + L.to_bytes('uncompressed')
-
-
-@dataclass
-class _SetupParameters:
-    setup_qr_code: str
-    manual_code: int
-    discriminator: int
-    passcode: int
 
 
 class TC_MCORE_FS_1_2(MatterBaseTest):
@@ -105,11 +98,8 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
             self.dut_fsa_stdin = open(dut_fsa_stdin_pipe, "w")
 
         self.th_server_port = th_server_port
-        # These are default testing values.
-        self.th_server_setup_params = _SetupParameters(
-            setup_qr_code="MT:-24J0AFN00KA0648G00",
-            manual_code=34970112332,
-            discriminator=3840,
+        self.th_server_setup_params = SetupParameters(
+            discriminator=random.randint(0, 4095),
             passcode=20202021)
 
         # Start the TH_SERVER app.
@@ -133,12 +123,12 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
             self.storage.cleanup()
         super().teardown_class()
 
-    def _ask_for_vendor_commissioning_ux_operation(self, setup_params: _SetupParameters):
+    def _ask_for_vendor_commissioning_ux_operation(self, setup_params: SetupParameters):
         self.wait_for_user_input(
             prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
             f"- discriminator: {setup_params.discriminator}\n"
             f"- setupPinCode: {setup_params.passcode}\n"
-            f"- setupQRCode: {setup_params.setup_qr_code}\n"
+            f"- setupQRCode: {setup_params.qr_code}\n"
             f"- setupManualCode: {setup_params.manual_code}\n"
             f"If using FabricSync Admin test app, you may type:\n"
             f">>> pairing onnetwork 111 {setup_params.passcode}")

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -42,16 +42,16 @@ import hashlib
 import logging
 import os
 import queue
+import random
 import secrets
 import struct
 import tempfile
 import time
-from dataclasses import dataclass
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from chip.testing.matter_testing import MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main, type_matches
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator
@@ -67,14 +67,6 @@ def _generate_verifier(passcode: int, salt: bytes, iterations: int) -> bytes:
     L = NIST256p.generator * w1
 
     return w0.to_bytes(NIST256p.baselen, byteorder='big') + L.to_bytes('uncompressed')
-
-
-@dataclass
-class _SetupParameters:
-    setup_qr_code: str
-    manual_code: int
-    discriminator: int
-    passcode: int
 
 
 class TC_MCORE_FS_1_5(MatterBaseTest):
@@ -106,11 +98,8 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
             self.dut_fsa_stdin = open(dut_fsa_stdin_pipe, "w")
 
         self.th_server_port = th_server_port
-        # These are default testing values.
-        self.th_server_setup_params = _SetupParameters(
-            setup_qr_code="MT:-24J0AFN00KA0648G00",
-            manual_code=34970112332,
-            discriminator=3840,
+        self.th_server_setup_params = SetupParameters(
+            discriminator=random.randint(0, 4095),
             passcode=20202021)
 
         # Start the TH_SERVER app.
@@ -137,12 +126,12 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
             self.storage.cleanup()
         super().teardown_class()
 
-    def _ask_for_vendor_commissioning_ux_operation(self, setup_params: _SetupParameters):
+    def _ask_for_vendor_commissioning_ux_operation(self, setup_params: SetupParameters):
         self.wait_for_user_input(
             prompt_msg=f"Using the DUT vendor's provided interface, commission the ICD device using the following parameters:\n"
             f"- discriminator: {setup_params.discriminator}\n"
             f"- setupPinCode: {setup_params.passcode}\n"
-            f"- setupQRCode: {setup_params.setup_qr_code}\n"
+            f"- setupQRCode: {setup_params.qr_code}\n"
             f"- setupManualCode: {setup_params.manual_code}\n"
             f"If using FabricSync Admin test app, you may type:\n"
             f">>> pairing onnetwork 111 {setup_params.passcode}")

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -51,7 +51,8 @@ import time
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
-from chip.testing.matter_testing import MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main, type_matches
+from chip.testing.matter_testing import (MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main,
+                                         type_matches)
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -822,6 +822,27 @@ class ProblemNotice:
 
 
 @dataclass
+class SetupParameters:
+    passcode: int
+    vendor_id: int = 0xFFF1
+    product_id: int = 0x8001
+    discriminator: int = 3840
+    custom_flow: int = 0
+    capabilities: int = 0b0100
+    version: int = 0
+
+    @property
+    def qr_code(self):
+        return SetupPayload().GenerateQrCode(self.passcode, self.vendor_id, self.product_id, self.discriminator,
+                                             self.custom_flow, self.capabilities, self.version)
+
+    @property
+    def manual_code(self):
+        return SetupPayload().GenerateManualPairingCode(self.passcode, self.vendor_id, self.product_id, self.discriminator,
+                                                        self.custom_flow, self.capabilities, self.version)
+
+
+@dataclass
 class SetupPayloadInfo:
     filter_type: discovery.FilterType = discovery.FilterType.LONG_DISCRIMINATOR
     filter_value: int = 0


### PR DESCRIPTION
### Problem

There is no easy way to get QR-code or manual code in test scripts if discriminator and passcode are not constant.

### Testing

CI will verify potential breaks