### PR TITLE
[SIlabs] Refactor GetMacAddress function and initial clean up of the Notify functions

### DIFF
--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -174,7 +174,8 @@ source_set("efr32-common") {
     "${silabs_common_plat_dir}/syscalls_stubs.cpp",
   ]
 
-  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli) {
+  if (chip_enable_pw_rpc || chip_build_libshell || enable_openthread_cli ||
+      sl_uart_log_output) {
     sources += [ "${silabs_common_plat_dir}/uart.cpp" ]
   }
 

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 #include "sl_uartdrv_instances.h"
 #if SL_WIFI
-#include <platform/silabs/wifi/wf200/platform/spi_multiplex.h>
+#include <platform/silabs/wifi/ncp/spi_multiplex.h>
 #endif // SL_WIFI
 #ifdef SL_CATALOG_UARTDRV_EUSART_PRESENT
 #include "sl_uartdrv_eusart_vcom_config.h"

--- a/src/platform/silabs/CHIPDevicePlatformEvent.h
+++ b/src/platform/silabs/CHIPDevicePlatformEvent.h
@@ -63,32 +63,12 @@ struct ChipDevicePlatformEvent final
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
         struct
         {
-            wfx_event_base_t eventBase;
             union
             {
                 sl_wfx_generic_message_t genericMsgEvent;
                 sl_wfx_startup_ind_t startupEvent;
                 sl_wfx_connect_ind_t connectEvent;
                 sl_wfx_disconnect_ind_t disconnectEvent;
-
-                /*
-                 * NOT CURRENTLY USED
-                 *Some structs might be bigger in size than the one we use
-                 * so we reduce the union size by commenting them out.
-                 * Keep for possible future implementation.
-                 */
-
-                // sl_wfx_generic_ind_t genericEvent;
-                // sl_wfx_exception_ind_t exceptionEvent;
-                // sl_wfx_error_ind_t errorEvent;
-                // sl_wfx_received_ind_t receivedEvent;
-                // sl_wfx_scan_result_ind_t scanResultEvent;
-                // sl_wfx_scan_complete_ind_t scanCompleteEvent;
-                // sl_wfx_start_ap_ind_t startApEvent;
-                // sl_wfx_stop_ap_ind_t stopApEvent;
-                // sl_wfx_ap_client_connected_ind_t apClientConnectedEvent;
-                // sl_wfx_ap_client_rejected_ind_t apClientRejectedEvent;
-                // sl_wfx_ap_client_disconnected_ind_t apClientDisconnectedEvent;
             } data;
         } WFXSystemEvent;
 #endif

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -313,11 +313,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 #ifdef SL_WIFI
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
-    sl_wfx_mac_address_t macaddr;
-    GetMacAddress(SL_WFX_STA_INTERFACE, &macaddr);
-    memcpy(buf, &macaddr.octet[0], sizeof(macaddr.octet));
+    VerifyOrReturnError(buf != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    return CHIP_NO_ERROR;
+    MutableByteSpan byteSpan(buf, kPrimaryMACAddressLength);
+    return GetMacAddress(SL_WFX_STA_INTERFACE, byteSpan);
 }
 #endif
 

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -314,7 +314,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     sl_wfx_mac_address_t macaddr;
-    wfx_get_wifi_mac_addr(SL_WFX_STA_INTERFACE, &macaddr);
+    GetMacAddress(SL_WFX_STA_INTERFACE, &macaddr);
     memcpy(buf, &macaddr.octet[0], sizeof(macaddr.octet));
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/PlatformManagerImpl.cpp
+++ b/src/platform/silabs/PlatformManagerImpl.cpp
@@ -152,6 +152,10 @@ void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData)
 
     switch (eventData->header.id)
     {
+// TODO: Work around until we unify the data structures behind a Matter level common structure
+#if WF200_WIFI
+    case SL_WFX_STARTUP_IND_ID:
+#endif
     case to_underlying(WifiEvent::kStartUp):
         memcpy(&event.Platform.WFXSystemEvent.data.startupEvent, eventData,
                sizeof(event.Platform.WFXSystemEvent.data.startupEvent));

--- a/src/platform/silabs/PlatformManagerImpl.cpp
+++ b/src/platform/silabs/PlatformManagerImpl.cpp
@@ -141,71 +141,41 @@ void PlatformManagerImpl::_Shutdown()
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 // This function needs to be global so it can be used from the platform implementation without depending on the platfrom itself.
 // This is a workaround to avoid a circular dependency.
-void HandleWFXSystemEvent(wfx_event_base_t eventBase, sl_wfx_generic_message_t * eventData)
+void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData)
 {
     using namespace chip;
     using namespace chip::DeviceLayer;
 
     ChipDeviceEvent event;
     memset(&event, 0, sizeof(event));
-    event.Type                              = DeviceEventType::kWFXSystemEvent;
-    event.Platform.WFXSystemEvent.eventBase = eventBase;
+    event.Type = DeviceEventType::kWFXSystemEvent;
 
-    if (eventBase == WIFI_EVENT)
+    switch (eventData->header.id)
     {
-        switch (eventData->header.id)
-        {
-        case SL_WFX_STARTUP_IND_ID:
-            memcpy(&event.Platform.WFXSystemEvent.data.startupEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.startupEvent));
-            break;
-        case SL_WFX_CONNECT_IND_ID:
-            memcpy(&event.Platform.WFXSystemEvent.data.connectEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.connectEvent));
-            break;
-        case SL_WFX_DISCONNECT_IND_ID:
-            memcpy(&event.Platform.WFXSystemEvent.data.disconnectEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.disconnectEvent));
-            break;
-        // case SL_WFX_RECEIVED_IND_ID:
-        //     memcpy(&event.Platform.WFXSystemEvent.data.receivedEvent, eventData,
-        //            sizeof(event.Platform.WFXSystemEvent.data.receivedEvent));
-        //     break;
-        // case SL_WFX_GENERIC_IND_ID:
-        //     memcpy(&event.Platform.WFXSystemEvent.data.genericEvent, eventData,
-        //            sizeof(event.Platform.WFXSystemEvent.data.genericEvent));
-        //     break;
-        // case SL_WFX_EXCEPTION_IND_ID:
-        //     memcpy(&event.Platform.WFXSystemEvent.data.exceptionEvent, eventData,
-        //            sizeof(event.Platform.WFXSystemEvent.data.exceptionEvent));
-        //     break;
-        // case SL_WFX_ERROR_IND_ID:
-        //     memcpy(&event.Platform.WFXSystemEvent.data.errorEvent, eventData,
-        //            sizeof(event.Platform.WFXSystemEvent.data.errorEvent));
-        //     break;
-        default:
-            break;
-        }
-    }
-    else if (eventBase == IP_EVENT)
-    {
-        switch (eventData->header.id)
-        {
-        case IP_EVENT_STA_GOT_IP:
-            memcpy(&event.Platform.WFXSystemEvent.data.genericMsgEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.genericMsgEvent));
-            break;
-        case IP_EVENT_GOT_IP6:
-            memcpy(&event.Platform.WFXSystemEvent.data.genericMsgEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.genericMsgEvent));
-            break;
-        case IP_EVENT_STA_LOST_IP:
-            memcpy(&event.Platform.WFXSystemEvent.data.genericMsgEvent, eventData,
-                   sizeof(event.Platform.WFXSystemEvent.data.genericMsgEvent));
-            break;
-        default:
-            break;
-        }
+    case to_underlying(WifiEvent::kStartUp):
+        memcpy(&event.Platform.WFXSystemEvent.data.startupEvent, eventData,
+               sizeof(event.Platform.WFXSystemEvent.data.startupEvent));
+        break;
+
+    case to_underlying(WifiEvent::kConnect):
+        memcpy(&event.Platform.WFXSystemEvent.data.connectEvent, eventData,
+               sizeof(event.Platform.WFXSystemEvent.data.connectEvent));
+        break;
+
+    case to_underlying(WifiEvent::kDisconnect):
+        memcpy(&event.Platform.WFXSystemEvent.data.disconnectEvent, eventData,
+               sizeof(event.Platform.WFXSystemEvent.data.disconnectEvent));
+        break;
+
+    case to_underlying(WifiEvent::kGotIPv4):
+    case to_underlying(WifiEvent::kLostIP):
+    case to_underlying(WifiEvent::kGotIPv6):
+        memcpy(&event.Platform.WFXSystemEvent.data.genericMsgEvent, eventData,
+               sizeof(event.Platform.WFXSystemEvent.data.genericMsgEvent));
+        break;
+
+    default:
+        break;
     }
 
     // TODO: We should add error processing here

--- a/src/platform/silabs/PlatformManagerImpl.cpp
+++ b/src/platform/silabs/PlatformManagerImpl.cpp
@@ -155,6 +155,8 @@ void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData)
     case to_underlying(WifiEvent::kStartUp):
         memcpy(&event.Platform.WFXSystemEvent.data.startupEvent, eventData,
                sizeof(event.Platform.WFXSystemEvent.data.startupEvent));
+        // TODO: This is a workaround until we unify the Matter Data structures
+        event.Platform.WFXSystemEvent.data.startupEvent.header.id = to_underlying(WifiEvent::kStartUp);
         break;
 
     case to_underlying(WifiEvent::kConnect):

--- a/src/platform/silabs/PlatformManagerImpl.h
+++ b/src/platform/silabs/PlatformManagerImpl.h
@@ -31,7 +31,7 @@
 #include <cmsis_os2.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-void HandleWFXSystemEvent(wfx_event_base_t eventBase, sl_wfx_generic_message_t * eventData);
+void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData);
 #endif
 
 namespace chip {

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -699,9 +699,6 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
     mFlags.Clear(Flags::kRestartAdvertising);
 
-    sl_wfx_mac_address_t macaddr;
-    GetMacAddress(SL_WFX_STA_INTERFACE, &macaddr);
-
     status = sInstance.SendBLEAdvertisementCommand();
 
     if (status == RSI_SUCCESS)

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -700,7 +700,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     mFlags.Clear(Flags::kRestartAdvertising);
 
     sl_wfx_mac_address_t macaddr;
-    wfx_get_wifi_mac_addr(SL_WFX_STA_INTERFACE, &macaddr);
+    GetMacAddress(SL_WFX_STA_INTERFACE, &macaddr);
 
     status = sInstance.SendBLEAdvertisementCommand();
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -257,7 +257,7 @@ sl_status_t sl_wifi_siwx917_init(void)
     ChipLogDetail(DeviceLayer, "Firmware version is: %x%x.%d.%d.%d.%d.%d.%d", version.chip_id, version.rom_id, version.major,
                   version.minor, version.security_version, version.patch_num, version.customer_id, version.build_num);
 
-    status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, (sl_mac_address_t *) &wfx_rsi.sta_mac.octet[0]);
+    status = sl_wifi_get_mac_address(SL_WIFI_CLIENT_INTERFACE, reinterpret_cast<sl_mac_address_t *>(wfx_rsi.sta_mac.data()));
     VerifyOrReturnError(status == SL_STATUS_OK, status,
                         ChipLogError(DeviceLayer, "sl_wifi_get_mac_address failed: 0x%lx", static_cast<uint32_t>(status)));
 
@@ -300,7 +300,7 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
     {
         security        = static_cast<sl_wifi_security_t>(scan_result->scan_info[0].security_mode);
         wfx_rsi.ap_chan = scan_result->scan_info[0].rf_channel;
-        memcpy(&wfx_rsi.ap_mac.octet, scan_result->scan_info[0].bssid, kWifiMacAddressLength);
+        memcpy(wfx_rsi.ap_mac.data(), scan_result->scan_info[0].bssid, kWifiMacAddressLength);
     }
 
     osSemaphoreRelease(sScanCompleteSemaphore);
@@ -480,7 +480,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
     ap->security       = wfx_rsi.sec.security;
     ap->chan           = wfx_rsi.ap_chan;
     chip::Platform::CopyString(ap->ssid, ap->ssid_length, wfx_rsi.sec.ssid);
-    memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], kWifiMacAddressLength);
+    memcpy(&ap->bssid[0], wfx_rsi.ap_mac.data(), kWifiMacAddressLength);
     sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &rssi);
     ap->rssi = rssi;
     return status;
@@ -606,7 +606,7 @@ sl_status_t bg_scan_callback_handler(sl_wifi_event_t event, sl_wifi_scan_result_
 void NotifyConnectivity(void)
 {
     VerifyOrReturn(!hasNotifiedWifiConnectivity);
-    NotifyConnection(&wfx_rsi.ap_mac);
+    NotifyConnection(wfx_rsi.ap_mac);
     hasNotifiedWifiConnectivity = true;
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -839,7 +839,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -128,7 +128,7 @@ void sl_matter_wifi_task_started(void)
     evt.header.id     = to_underlying(WifiEvent::kStartUp);
     evt.header.length = sizeof evt;
     evt.body.status   = 0;
-    wfx_get_wifi_mac_addr(SL_WFX_STA_INTERFACE, &mac);
+    GetMacAddress(SL_WFX_STA_INTERFACE, &mac);
     memcpy(&evt.body.mac_addr[0], &mac.octet[0], kWifiMacAddressLength);
 
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.cpp
@@ -21,6 +21,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TypeTraits.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/silabs/wifi/WifiInterfaceAbstraction.h>
 #include <stdbool.h>
@@ -35,7 +36,7 @@ using namespace chip::DeviceLayer;
 
 // TODO: This is a workaround because we depend on the platform lib which depends on the platform implementation.
 //       As such we can't depend on the platform here as well
-extern void HandleWFXSystemEvent(wfx_event_base_t eventBase, sl_wfx_generic_message_t * eventData);
+extern void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData);
 
 namespace {
 
@@ -61,6 +62,52 @@ void RetryConnectionTimerHandler(void * arg)
 
 } // namespace
 
+/* Updated functions */
+
+void NotifyIPv6Change(bool gotIPv6Addr)
+{
+    sl_wfx_generic_message_t eventData = {};
+    eventData.header.id                = gotIPv6Addr ? to_underlying(WifiEvent::kGotIPv6) : to_underlying(WifiEvent::kLostIP);
+    eventData.header.length            = sizeof(eventData.header);
+
+    HandleWFXSystemEvent(&eventData);
+}
+
+void NotifyIPv4Change(bool gotIPv4Addr)
+{
+    sl_wfx_generic_message_t eventData;
+
+    memset(&eventData, 0, sizeof(eventData));
+    eventData.header.id     = gotIPv4Addr ? to_underlying(WifiEvent::kGotIPv4) : to_underlying(WifiEvent::kLostIP);
+    eventData.header.length = sizeof(eventData.header);
+    HandleWFXSystemEvent(&eventData);
+}
+
+void NotifyDisconnection(WifiDisconnectionReasons reason)
+{
+    sl_wfx_disconnect_ind_t evt = {};
+    evt.header.id               = to_underlying(WifiEvent::kDisconnect);
+    evt.header.length           = sizeof evt;
+    evt.body.reason             = to_underlying(reason);
+
+    HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
+}
+
+void NotifyConnection(sl_wfx_mac_address_t * ap)
+{
+    sl_wfx_connect_ind_t evt = {};
+    evt.header.id            = to_underlying(WifiEvent::kConnect);
+    evt.header.length        = sizeof evt;
+#ifdef RS911X_WIFI
+    evt.body.channel = wfx_rsi.ap_chan;
+#endif
+    memcpy(&evt.body.mac[0], &ap->octet[0], kWifiMacAddressLength);
+
+    HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
+}
+
+/* Function to update */
+
 /***********************************************************************************
  * @fn  sl_matter_wifi_task_started(void)
  * @brief
@@ -78,92 +125,13 @@ void sl_matter_wifi_task_started(void)
     VerifyOrReturn(sRetryTimer != NULL);
 
     memset(&evt, 0, sizeof(evt));
-    evt.header.id     = SL_WFX_STARTUP_IND_ID;
+    evt.header.id     = to_underlying(WifiEvent::kStartUp);
     evt.header.length = sizeof evt;
     evt.body.status   = 0;
     wfx_get_wifi_mac_addr(SL_WFX_STA_INTERFACE, &mac);
-    memcpy(&evt.body.mac_addr[0], &mac.octet[0], MAC_ADDRESS_FIRST_OCTET);
+    memcpy(&evt.body.mac_addr[0], &mac.octet[0], kWifiMacAddressLength);
 
-    HandleWFXSystemEvent(WIFI_EVENT, (sl_wfx_generic_message_t *) &evt);
-}
-
-/***********************************************************************************
- * @fn  void wfx_connected_notify(int32_t status, sl_wfx_mac_address_t *ap)
- * @brief
- * For now we are not notifying anything other than AP Mac -
- * Other stuff such as DTIM etc. may be required for later
- * @param[in] status:
- * @param[in] ap: access point
- * @return None
- *************************************************************************************/
-void wfx_connected_notify(int32_t status, sl_wfx_mac_address_t * ap)
-{
-    sl_wfx_connect_ind_t evt;
-
-    VerifyOrReturn(status == SUCCESS_STATUS);
-
-    memset(&evt, 0, sizeof(evt));
-    evt.header.id     = SL_WFX_CONNECT_IND_ID;
-    evt.header.length = sizeof evt;
-
-#ifdef RS911X_WIFI
-    evt.body.channel = wfx_rsi.ap_chan;
-#endif
-    memcpy(&evt.body.mac[0], &ap->octet[0], MAC_ADDRESS_FIRST_OCTET);
-
-    HandleWFXSystemEvent(WIFI_EVENT, (sl_wfx_generic_message_t *) &evt);
-}
-
-/**************************************************************************************
- * @fn  void wfx_disconnected_notify(int32_t status)
- * @brief
- *    notification of disconnection
- * @param[in] status:
- * @return None
- *************************************************************************************/
-void wfx_disconnected_notify(int32_t status)
-{
-    sl_wfx_disconnect_ind_t evt;
-
-    memset(&evt, 0, sizeof(evt));
-    evt.header.id     = SL_WFX_DISCONNECT_IND_ID;
-    evt.header.length = sizeof evt;
-    evt.body.reason   = status;
-    HandleWFXSystemEvent(WIFI_EVENT, (sl_wfx_generic_message_t *) &evt);
-}
-
-/**************************************************************************************
- * @fn  void wfx_ipv6_notify(int got_ip)
- * @brief
- *      notification of ipv6
- * @param[in]  got_ip:
- * @return None
- *************************************************************************************/
-void wfx_ipv6_notify(int got_ip)
-{
-    sl_wfx_generic_message_t eventData;
-
-    memset(&eventData, 0, sizeof(eventData));
-    eventData.header.id     = got_ip ? IP_EVENT_GOT_IP6 : IP_EVENT_STA_LOST_IP;
-    eventData.header.length = sizeof(eventData.header);
-    HandleWFXSystemEvent(IP_EVENT, &eventData);
-}
-
-/**************************************************************************************
- * @fn   void wfx_ip_changed_notify(int got_ip)
- * @brief
- *      notification of ip change
- * @param[in]  got_ip:
- * @return None
- *************************************************************************************/
-void wfx_ip_changed_notify(int got_ip)
-{
-    sl_wfx_generic_message_t eventData;
-
-    memset(&eventData, 0, sizeof(eventData));
-    eventData.header.id     = got_ip ? IP_EVENT_STA_GOT_IP : IP_EVENT_STA_LOST_IP;
-    eventData.header.length = sizeof(eventData.header);
-    HandleWFXSystemEvent(IP_EVENT, &eventData);
+    HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }
 
 /**************************************************************************************

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -216,11 +216,21 @@ void NotifyDisconnection(WifiDisconnectionReasons reason);
  */
 void NotifyConnection(sl_wfx_mac_address_t * ap);
 
+/**
+ * @brief Returns the provide interfaces MAC address
+ *        Valid buffer large enough for the MAC address must be provided to the function
+ *
+ * @param[in] interface SL_WFX_STA_INTERFACE or SL_WFX_SOFTAP_INTERFACE.
+ *                      If soft AP is not enabled, the interface is ignored and the function always returns the Station MAC
+ *                      address
+ * @param[out] addr     Interface MAC addres
+ */
+void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr);
+
 /* Function to update */
 
 sl_status_t wfx_wifi_start(void);
 void wfx_enable_sta_mode(void);
-void wfx_get_wifi_mac_addr(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr);
 void wfx_set_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_is_sta_mode_enabled(void);

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -64,13 +64,13 @@ using MacAddress = std::array<uint8_t, kWifiMacAddressLength>;
 
 enum class WifiEvent : uint8_t
 {
-    kStartUp      = 1,
-    kConnect      = 2,
-    kDisconnect   = 3,
-    kScanComplete = 4,
-    kGotIPv4      = 5,
-    kGotIPv6      = 6,
-    kLostIP       = 7,
+    kStartUp      = 0,
+    kConnect      = 1,
+    kDisconnect   = 2,
+    kScanComplete = 3,
+    kGotIPv4      = 4,
+    kGotIPv6      = 5,
+    kLostIP       = 6,
 };
 
 enum class WifiState : uint16_t

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -81,24 +81,18 @@ enum class WifiState : uint16_t
     kScanStarted        = (1 << 10), /* Scan Started */
 };
 
-enum class WifiEvent : uint8_t
+enum class WifiPlatformEvent : uint8_t
 {
-    kStationConnect    = 0,
-    kStationDisconnect = 1,
-    kAPStart           = 2,
-    kAPStop            = 3,
-    kScan              = 4, /* This is used as scan result and start */
-    kStationStartJoin  = 5,
-    kStationDoDhcp     = 6,
-    kStationDhcpDone   = 7,
-    kStationDhcpPoll   = 8
+    kStationConnect    = 1,
+    kStationDisconnect = 2,
+    kAPStart           = 3,
+    kAPStop            = 4,
+    kScan              = 5, /* This is used as scan result and start */
+    kStationStartJoin  = 6,
+    kStationDoDhcp     = 7,
+    kStationDhcpDone   = 8,
+    kStationDhcpPoll   = 9,
 };
-
-typedef enum
-{
-    WIFI_EVENT,
-    IP_EVENT,
-} wfx_event_base_t;
 
 /* Note that these are same as RSI_security */
 typedef enum

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -19,6 +19,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <cmsis_os2.h>
 #include <lib/support/BitFlags.h>
+#include <lib/support/Span.h>
 #include <platform/silabs/wifi/wfx_msgs.h>
 #include <sl_cmsis_os2_common.h>
 
@@ -40,7 +41,7 @@
 
 /* Updated constants */
 
-constexpr uint8_t kWifiMacAddressLength = 6;
+constexpr size_t kWifiMacAddressLength = 6;
 
 /* Defines to update */
 
@@ -57,7 +58,9 @@ constexpr uint8_t kWifiMacAddressLength = 6;
 #define WFX_MAX_SSID_LENGTH (32)
 #define MAX_JOIN_RETRIES_COUNT (5)
 
-/* Update Enums */
+/* Updated types */
+
+using MacAddress = std::array<uint8_t, kWifiMacAddressLength>;
 
 enum class WifiEvent : uint8_t
 {
@@ -170,11 +173,11 @@ typedef struct wfx_rsi_s
     size_t scan_ssid_length;
 #endif
 #ifdef SL_WFX_CONFIG_SOFTAP
-    sl_wfx_mac_address_t softap_mac;
+    MacAddress softap_mac;
 #endif
-    sl_wfx_mac_address_t sta_mac;
-    sl_wfx_mac_address_t ap_mac;   /* To which our STA is connected */
-    sl_wfx_mac_address_t ap_bssid; /* To which our STA is connected */
+    MacAddress sta_mac;
+    MacAddress ap_mac;   /* To which our STA is connected */
+    MacAddress ap_bssid; /* To which our STA is connected */
     uint16_t join_retries;
     uint8_t ip4_addr[4]; /* Not sure if this is enough */
 } WfxRsi_t;
@@ -214,7 +217,7 @@ void NotifyDisconnection(WifiDisconnectionReasons reason);
  *
  * @param[in] ap pointer to the structure that contains the MAC address of the AP
  */
-void NotifyConnection(sl_wfx_mac_address_t * ap);
+void NotifyConnection(const MacAddress & ap);
 
 /**
  * @brief Returns the provide interfaces MAC address
@@ -224,8 +227,12 @@ void NotifyConnection(sl_wfx_mac_address_t * ap);
  *                      If soft AP is not enabled, the interface is ignored and the function always returns the Station MAC
  *                      address
  * @param[out] addr     Interface MAC addres
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR on success
+ *                    CHIP_ERROR_BUFFER_TOO_SMALL if the provided ByteSpan size is too small
+ *
  */
-void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr);
+CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, chip::MutableByteSpan & addr);
 
 /* Function to update */
 

--- a/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
+++ b/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
@@ -90,7 +90,7 @@ static void low_level_init(struct netif * netif)
     /* Set netif MAC hardware address */
     sl_wfx_mac_address_t mac_addr;
 
-    wfx_get_wifi_mac_addr(SL_WFX_STA_INTERFACE, &mac_addr);
+    GetMacAddress(SL_WFX_STA_INTERFACE, &mac_addr);
 
     netif->hwaddr[0] = mac_addr.octet[0];
     netif->hwaddr[1] = mac_addr.octet[1];

--- a/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
+++ b/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
@@ -88,16 +88,8 @@ static void low_level_init(struct netif * netif)
     netif->hwaddr_len = ETH_HWADDR_LEN;
 
     /* Set netif MAC hardware address */
-    sl_wfx_mac_address_t mac_addr;
-
-    GetMacAddress(SL_WFX_STA_INTERFACE, &mac_addr);
-
-    netif->hwaddr[0] = mac_addr.octet[0];
-    netif->hwaddr[1] = mac_addr.octet[1];
-    netif->hwaddr[2] = mac_addr.octet[2];
-    netif->hwaddr[3] = mac_addr.octet[3];
-    netif->hwaddr[4] = mac_addr.octet[4];
-    netif->hwaddr[5] = mac_addr.octet[5];
+    chip::MutableByteSpan byteSpan(netif->hwaddr, ETH_HWADDR_LEN);
+    GetMacAddress(SL_WFX_STA_INTERFACE, byteSpan);
 
     /* Set netif maximum transfer unit */
     netif->mtu = 1500;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -154,7 +154,7 @@ int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
     uint8_t rssi;
     ap->security = wfx_rsi.sec.security;
     ap->chan     = wfx_rsi.ap_chan;
-    memcpy(&ap->bssid[0], &wfx_rsi.ap_mac.octet[0], kWifiMacAddressLength);
+    memcpy(&ap->bssid[0], wfx_rsi.ap_mac.data(), kWifiMacAddressLength);
     status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
     if (status == RSI_SUCCESS)
     {
@@ -375,14 +375,14 @@ static int32_t sl_matter_wifi_init(void)
     /* initializes wlan radio parameters and WLAN supplicant parameters.
      */
     (void) rsi_wlan_radio_init(); /* Required so we can get MAC address */
-    if ((status = rsi_wlan_get(RSI_MAC_ADDRESS, &wfx_rsi.sta_mac.octet[0], RESP_BUFF_SIZE)) != RSI_SUCCESS)
+    if ((status = rsi_wlan_get(RSI_MAC_ADDRESS, wfx_rsi.sta_mac.data(), RESP_BUFF_SIZE)) != RSI_SUCCESS)
     {
         ChipLogError(DeviceLayer, "rsi_wlan_get(RSI_MAC_ADDRESS) failed: %ld", status);
         return status;
     }
 
-    ChipLogDetail(DeviceLayer, "MAC: %02x:%02x:%02x %02x:%02x:%02x", wfx_rsi.sta_mac.octet[0], wfx_rsi.sta_mac.octet[1],
-                  wfx_rsi.sta_mac.octet[2], wfx_rsi.sta_mac.octet[3], wfx_rsi.sta_mac.octet[4], wfx_rsi.sta_mac.octet[5]);
+    ChipLogDetail(DeviceLayer, "MAC: %02x:%02x:%02x %02x:%02x:%02x", wfx_rsi.sta_mac.at(0), wfx_rsi.sta_mac.at(1),
+                  wfx_rsi.sta_mac.at(2), wfx_rsi.sta_mac.at(3), wfx_rsi.sta_mac.at(4), wfx_rsi.sta_mac.at(5));
 
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(WFX_QUEUE_SIZE, sizeof(WifiPlatformEvent), NULL);
@@ -451,7 +451,7 @@ static void wfx_rsi_save_ap_info(void) // translation
     }
     wfx_rsi.sec.security = WFX_SEC_UNSPECIFIED;
     wfx_rsi.ap_chan      = rsp.scan_info->rf_channel;
-    memcpy(&wfx_rsi.ap_mac.octet[0], &rsp.scan_info->bssid[0], kWifiMacAddressLength);
+    memcpy(wfx_rsi.ap_mac.data(), &rsp.scan_info->bssid[0], kWifiMacAddressLength);
 
     switch (rsp.scan_info->security_mode)
     {
@@ -563,7 +563,7 @@ void NotifyConnectivity(void)
 {
     if (!hasNotifiedWifiConnectivity)
     {
-        NotifyConnection(&wfx_rsi.ap_mac);
+        NotifyConnection(wfx_rsi.ap_mac);
         hasNotifiedWifiConnectivity = true;
     }
 }

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -818,7 +818,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1198,7 +1198,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1087,7 +1087,7 @@ sl_status_t wfx_connect_to_ap(void)
  * @param[in] interface:
  * @param[in] addr : address
  *****************************************************************************/
-void wfx_get_wifi_mac_addr(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr)
+void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr)
 {
     sl_wfx_mac_address_t * mac;
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -336,9 +336,6 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
     /******** INDICATION ********/
     case SL_WFX_STARTUP_IND_ID: {
         ChipLogProgress(DeviceLayer, "startup completed.");
-
-        // TODO: This is a workaround until we unify the Matter Data structures
-        event_payload->header.id = to_underlying(WifiEvent::kStartUp);
         HandleWFXSystemEvent(event_payload);
         break;
     }

--- a/src/platform/silabs/wifi/wfx_msgs.h
+++ b/src/platform/silabs/wifi/wfx_msgs.h
@@ -27,14 +27,6 @@
 #include "sl_wfx_constants.h"
 #else
 
-// These names exists in the Si SDK as typedef enum. If they are present in the WF200 builds, we end up with conflicting
-// definitions but no erros because one is a define the other is a typedef enum. This causes different files to use different
-// values.
-#define SL_WFX_STARTUP_IND_ID (1)
-#define SL_WFX_CONNECT_IND_ID (2)
-#define SL_WFX_DISCONNECT_IND_ID (3)
-#define SL_WFX_SCAN_COMPLETE_ID (4)
-
 typedef struct
 {
     uint8_t octet[6]; ///< Table to store a MAC address

--- a/src/platform/silabs/wifi/wfx_msgs.h
+++ b/src/platform/silabs/wifi/wfx_msgs.h
@@ -27,10 +27,6 @@
 #include "sl_wfx_constants.h"
 #else
 
-typedef struct
-{
-    uint8_t octet[6]; ///< Table to store a MAC address
-} sl_wfx_mac_address_t;
 /**
  * @brief General Message header structure
  *

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -37,6 +37,19 @@ constexpr osThreadAttr_t kWlanTaskAttr = { .name       = "wlan_rsi",
 
 } // namespace
 
+CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, chip::MutableByteSpan & address)
+{
+    VerifyOrReturnError(address.size() >= kWifiMacAddressLength, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+#ifdef SL_WFX_CONFIG_SOFTAP
+    chip::ByteSpan byteSpan((interface == SL_WFX_SOFTAP_INTERFACE) ? wfx_rsi.softap_mac : wfx_rsi.sta_mac);
+#else
+    chip::ByteSpan byteSpan(wfx_rsi.sta_mac);
+#endif
+
+    return CopySpanToMutableSpan(byteSpan, address);
+}
+
 /*********************************************************************
  * @fn  sl_status_t wfx_wifi_start(void)
  * @brief
@@ -82,25 +95,6 @@ void wfx_enable_sta_mode(void)
 bool wfx_is_sta_mode_enabled(void)
 {
     return wfx_rsi.dev_state.Has(WifiState::kStationMode);
-}
-
-/*********************************************************************
- * @fn  void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t *addr)
- * @brief
- *      get the wifi mac address
- * @param[in]  Interface:
- * @param[in]  addr : address
- * @return
- *       None
- ***********************************************************************/
-void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr)
-{
-    VerifyOrReturn(addr != nullptr);
-#ifdef SL_WFX_CONFIG_SOFTAP
-    *addr = (interface == SL_WFX_SOFTAP_INTERFACE) ? wfx_rsi.softap_mac : wfx_rsi.sta_mac;
-#else
-    *addr = wfx_rsi.sta_mac;
-#endif
 }
 
 /*********************************************************************

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -18,6 +18,8 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h>
 
+extern WfxRsi_t wfx_rsi;
+
 namespace {
 
 // Thread for the WLAN RSI

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -85,7 +85,7 @@ bool wfx_is_sta_mode_enabled(void)
 }
 
 /*********************************************************************
- * @fn  void wfx_get_wifi_mac_addr(sl_wfx_interface_t interface, sl_wfx_mac_address_t *addr)
+ * @fn  void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t *addr)
  * @brief
  *      get the wifi mac address
  * @param[in]  Interface:
@@ -93,7 +93,7 @@ bool wfx_is_sta_mode_enabled(void)
  * @return
  *       None
  ***********************************************************************/
-void wfx_get_wifi_mac_addr(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr)
+void GetMacAddress(sl_wfx_interface_t interface, sl_wfx_mac_address_t * addr)
 {
     VerifyOrReturn(addr != nullptr);
 #ifdef SL_WFX_CONFIG_SOFTAP

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -160,7 +160,7 @@ sl_status_t wfx_connect_to_ap(void)
     VerifyOrReturnError(wfx_rsi.sec.ssid_length <= WFX_MAX_SSID_LENGTH, SL_STATUS_HAS_OVERFLOWED);
     ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.sec.ssid);
 
-    WifiEvent event = WifiEvent::kStationStartJoin;
+    WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
     sl_matter_wifi_post_event(event);
     return SL_STATUS_OK;
 }
@@ -327,7 +327,7 @@ bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
     VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
     chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
 
-    WifiEvent event = WifiEvent::kScan;
+    WifiPlatformEvent event = WifiPlatformEvent::kScan;
     sl_matter_wifi_post_event(event);
 
     return true;

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
@@ -29,7 +29,7 @@ enum class WifiPlatformEvent : uint8_t
     kStationDisconnect = 2,
     kAPStart           = 3,
     kAPStop            = 4,
-    kScan              = 5, /* This is used as scan result and start */
+    kScan              = 5, /* This combines the scan start and scan result events  */
     kStationStartJoin  = 6,
     kStationDoDhcp     = 7,
     kStationDhcpDone   = 8,

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
@@ -25,15 +25,15 @@
 
 enum class WifiPlatformEvent : uint8_t
 {
-    kStationConnect    = 1,
-    kStationDisconnect = 2,
-    kAPStart           = 3,
-    kAPStop            = 4,
-    kScan              = 5, /* This combines the scan start and scan result events  */
-    kStationStartJoin  = 6,
-    kStationDoDhcp     = 7,
-    kStationDhcpDone   = 8,
-    kStationDhcpPoll   = 9,
+    kStationConnect    = 0,
+    kStationDisconnect = 1,
+    kAPStart           = 2,
+    kAPStop            = 3,
+    kScan              = 4, /* This combines the scan start and scan result events  */
+    kStationStartJoin  = 5,
+    kStationDoDhcp     = 6,
+    kStationDhcpDone   = 7,
+    kStationDhcpPoll   = 8,
 };
 
 void sl_matter_wifi_task(void * arg);

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
@@ -44,4 +44,4 @@ sl_status_t sl_matter_wifi_platform_init(void);
  *
  * @param[in] event Event to process.
  */
-void sl_matter_wifi_post_event(WifiEvent event);
+void sl_matter_wifi_post_event(WifiPlatformEvent event);

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.h
@@ -22,15 +22,21 @@
 #include <sl_cmsis_os2_common.h>
 
 #define WFX_RSI_DHCP_POLL_INTERVAL (250) /* Poll interval in ms for DHCP */
-#define GET_IPV6_SUCCESS (1)
 
-extern WfxRsi_t wfx_rsi;
+enum class WifiPlatformEvent : uint8_t
+{
+    kStationConnect    = 1,
+    kStationDisconnect = 2,
+    kAPStart           = 3,
+    kAPStop            = 4,
+    kScan              = 5, /* This is used as scan result and start */
+    kStationStartJoin  = 6,
+    kStationDoDhcp     = 7,
+    kStationDhcpDone   = 8,
+    kStationDhcpPoll   = 9,
+};
 
 void sl_matter_wifi_task(void * arg);
-
-#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
-void wfx_ip_changed_notify(int got_ip);
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
 int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);


### PR DESCRIPTION
#### Description
PR continues the on-going Wi-Fi interface refactor.

- Refactor how the MacAddress getters work. Leverage MutableByteSpan to return the mac address value
- Refactor the Notify function to bubble up events to the Matter Stack - This is a first rework and the final version.
- Fix uart logs for Wi-Fi devices

#### Tests
Manual tests with the 917 SiWx Soc and WF200
