### PR TITLE
Disable chef build of tempcontrol cabinet.

### DIFF
--- a/examples/chef/common/clusters/temperature-control/static-supported-temperature-levels.cpp
+++ b/examples/chef/common/clusters/temperature-control/static-supported-temperature-levels.cpp
@@ -21,6 +21,7 @@
 #ifdef MATTER_DM_PLUGIN_TEMPERATURE_CONTROL_SERVER
 #include "static-supported-temperature-levels.h"
 #include <app/clusters/temperature-control-server/supported-temperature-levels-manager.h>
+#include <lib/support/CodeUtils.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -29,7 +29,7 @@ steps:
       args:
           - >-
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
-              ./examples/chef/chef.py --build_all --build_exclude noip
+              ./examples/chef/chef.py --build_all --build_exclude "noip|temperaturecontrolledcabinet"
       id: CompileAll
       waitFor:
           - Bootstrap


### PR DESCRIPTION
I believe some PRs crossed paths: #35872 and #36105

As a result we have:

```
./examples/chef/chef.py -d rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680 -t linux -b
```

failing because static-supported-temperature-levels.cpp expects a single endpoint with temperature control yet we have 2.

This disables the failing build from CI.