### PR TITLE
Bridge app: remove binding client

### DIFF
--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -521,27 +521,6 @@ cluster Descriptor = 29 {
   readonly attribute int16u clusterRevision = 65533;
 }
 
-/** The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table. */
-cluster Binding = 30 {
-  revision 1; // NOTE: Default/not specifically set
-
-  fabric_scoped struct TargetStruct {
-    optional node_id node = 1;
-    optional group_id group = 2;
-    optional endpoint_no endpoint = 3;
-    optional cluster_id cluster = 4;
-    fabric_idx fabricIndex = 254;
-  }
-
-  attribute access(write: manage) TargetStruct binding[] = 0;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute event_id eventList[] = 65530;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-}
-
 /** The Access Control Cluster exposes a data model view of a
       Node's Access Control List (ACL), which codifies the rules used to manage
       and enforce Access Control for the Node's endpoints and their associated
@@ -2496,7 +2475,6 @@ endpoint 0 {
 endpoint 1 {
   device type ma_aggregator = 14, version 1;
 
-  binding cluster Binding;
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0;

--- a/examples/bridge-app/bridge-common/bridge-app.zap
+++ b/examples/bridge-app/bridge-common/bridge-app.zap
@@ -4714,14 +4714,6 @@
           ]
         },
         {
-          "name": "Binding",
-          "code": 30,
-          "mfgCode": null,
-          "define": "BINDING_CLUSTER",
-          "side": "client",
-          "enabled": 1
-        },
-        {
           "name": "Actions",
           "code": 37,
           "mfgCode": null,


### PR DESCRIPTION
A binding client means that this device would be reaching out and writing to the binding cluster on another endpoint, which is likely NOT what was intended here since it doesn't do that.

The current app now shows no clusters listed in the client list on any cluster (from device dump).

