### PR TITLE
TC_CNET_4_11:Correct Step 7 PICS(#452)

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CNET_4_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CNET_4_11.yaml
@@ -160,7 +160,7 @@ tests:
           "Step 7: TH sends ConnectNetwork command to the DUT with NetworkID
           field set to PIXIT.CNET.WIFI_2ND_ACCESSPOINT_SSID and Breadcrumb field
           set to 2"
-      PICS: CNET.C.C06.Tx
+      PICS: CNET.S.C06.Rsp
       timedInteractionTimeoutMs: 5000
       command: "ConnectNetwork"
       arguments:


### PR DESCRIPTION
Fixes https://github.com/project-chip/matter-test-scripts/issues/452

Update Step 7 of the TC_CNET_4_11 to use the correct PICS as indicated by the R1.3 Test Specification.

