### PR TITLE
[Fabric-Sync] Fix deadlock when removing device

### DIFF
--- a/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
@@ -250,7 +250,6 @@ int BridgedDeviceManager::RemoveDeviceEndpoint(BridgedDevice * dev)
     {
         if (mDevices[index].get() == dev)
         {
-            DeviceLayer::StackLock lock;
             // Silence complaints about unused ep when progress logging
             // disabled.
             [[maybe_unused]] EndpointId ep = emberAfClearDynamicEndpoint(index);
@@ -332,7 +331,6 @@ std::optional<uint16_t> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::S
     {
         if (mDevices[index] && mDevices[index]->GetScopedNodeId() == scopedNodeId)
         {
-            DeviceLayer::StackLock lock;
             EndpointId ep   = emberAfClearDynamicEndpoint(index);
             mDevices[index] = nullptr;
             ChipLogProgress(NotSpecified, "Removed device with Id=[%d:0x" ChipLogFormatX64 "] from dynamic endpoint %d (index=%d)",

--- a/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
+++ b/examples/fabric-sync/bridge/src/BridgedDeviceManager.cpp
@@ -245,6 +245,8 @@ std::optional<uint16_t> BridgedDeviceManager::AddDeviceEndpoint(std::unique_ptr<
 
 int BridgedDeviceManager::RemoveDeviceEndpoint(BridgedDevice * dev)
 {
+    assertChipStackLockedByCurrentThread();
+
     uint8_t index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
     {
@@ -265,6 +267,8 @@ int BridgedDeviceManager::RemoveDeviceEndpoint(BridgedDevice * dev)
 
 BridgedDevice * BridgedDeviceManager::GetDevice(chip::EndpointId endpointId) const
 {
+    assertChipStackLockedByCurrentThread();
+
     for (uint8_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
     {
         if (mDevices[index] && mDevices[index]->GetEndpointId() == endpointId)
@@ -303,6 +307,8 @@ std::string BridgedDeviceManager::GenerateUniqueId()
 
 BridgedDevice * BridgedDeviceManager::GetDeviceByUniqueId(const std::string & id)
 {
+    assertChipStackLockedByCurrentThread();
+
     for (uint8_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
     {
         if (mDevices[index] && mDevices[index]->GetBridgedAttributes().uniqueId == id)
@@ -315,6 +321,8 @@ BridgedDevice * BridgedDeviceManager::GetDeviceByUniqueId(const std::string & id
 
 BridgedDevice * BridgedDeviceManager::GetDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId) const
 {
+    assertChipStackLockedByCurrentThread();
+
     for (uint8_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
     {
         if (mDevices[index] && mDevices[index]->GetScopedNodeId() == scopedNodeId)
@@ -327,6 +335,8 @@ BridgedDevice * BridgedDeviceManager::GetDeviceByScopedNodeId(chip::ScopedNodeId
 
 std::optional<uint16_t> BridgedDeviceManager::RemoveDeviceByScopedNodeId(chip::ScopedNodeId scopedNodeId)
 {
+    assertChipStackLockedByCurrentThread();
+
     for (uint16_t index = 0; index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT; ++index)
     {
         if (mDevices[index] && mDevices[index]->GetScopedNodeId() == scopedNodeId)


### PR DESCRIPTION
### Problem

Deadlock when running shell command: `app remove-device X`.
Fabric-Sync app performs all actions on CHIP thread (shell commands are processed via `DeviceLayer::PlatformMgr().ScheduleWork()` if `CONFIG_DEVICE_LAYER` is enabled). Using stack locks when processing command will lead to deadlock.

### Changes

- do not use CHIP stack lock in fabric-sync app

### Testing

Tested locally that `remove-device` does not deadlock.