### PR TITLE
[ESP32]:  Update WiFi Scan Network Implementation for New API

### DIFF
--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -389,11 +389,12 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
     if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().ScheduleLambda([ap_number]() {
-            ESPScanResponseIteratorV2 iter(ap_number);
+            ESPScanResponseIterator iter(ap_number);
             if (GetInstance().mpScanCallback)
             {
                 GetInstance().mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);
                 GetInstance().mpScanCallback = nullptr;
+                iter.Release();
             }
             else
             {

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -394,12 +394,12 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
             {
                 GetInstance().mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);
                 GetInstance().mpScanCallback = nullptr;
-                iter.Release();
             }
             else
             {
                 ChipLogError(DeviceLayer, "can't find the ScanCallback function");
             }
+            iter.Release();
         }))
     {
     }
@@ -453,7 +453,7 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
         mpScanCallback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
         mpScanCallback = nullptr;
     }
-#endif
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
 }
 
 void ESPWiFiDriver::OnNetworkStatusChange()

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -389,7 +389,7 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
     if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().ScheduleLambda([ap_number]() {
-            ESPScanResponseIterator2 iter(ap_number);
+            ESPScanResponseIteratorV2 iter(ap_number);
             if (GetInstance().mpScanCallback)
             {
                 GetInstance().mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -45,18 +45,18 @@ public:
 
     bool Next(WiFiScanResponse & item) override
     {
-        if (mIternum >= mSize)
-        {
-            return false;
-        }
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
         wifi_ap_record_t ap_record;
         VerifyOrReturnValue(esp_wifi_scan_get_ap_record(&ap_record) == ESP_OK, false);
         SetApData(item, ap_record);
 #else
+        if (mIternum >= mSize)
+        {
+            return false;
+        }
         SetApData(item, mpScanResults[mIternum]);
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
         mIternum++;
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
         return true;
     }
 
@@ -84,8 +84,8 @@ private:
     const size_t mSize;
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 3)
     const wifi_ap_record_t * mpScanResults;
-#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 3)
     size_t mIternum = 0;
+#endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 3)
 };
 
 class ESPWiFiDriver final : public WiFiDriver

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -34,10 +34,10 @@ inline constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 30;
 BitFlags<WiFiSecurityBitmap> ConvertSecurityType(wifi_auth_mode_t authMode);
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
-class ESPScanResponseIteratorV2 : public Iterator<WiFiScanResponse>
+class ESPScanResponseIterator : public Iterator<WiFiScanResponse>
 {
 public:
-    ESPScanResponseIteratorV2(const size_t size) : mSize(size) {}
+    ESPScanResponseIterator(const size_t size) : mSize(size) {}
     size_t Count() override { return mSize; }
 
     bool Next(WiFiScanResponse & item) override

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -60,19 +60,6 @@ public:
         return true;
     }
 
-    void SetApData(WiFiScanResponse & item, wifi_ap_record_t ap_record)
-    {
-        item.security = ConvertSecurityType(ap_record.authmode);
-        static_assert(chip::DeviceLayer::Internal::kMaxWiFiSSIDLength <= UINT8_MAX, "SSID length might not fit in item.ssidLen");
-        item.ssidLen = static_cast<uint8_t>(
-            strnlen(reinterpret_cast<const char *>(ap_record.ssid), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength));
-        item.channel  = ap_record.primary;
-        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        item.rssi     = ap_record.rssi;
-        memcpy(item.ssid, ap_record.ssid, item.ssidLen);
-        memcpy(item.bssid, ap_record.bssid, 6);
-    }
-
     void Release() override
     {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 3)
@@ -86,6 +73,19 @@ private:
     const wifi_ap_record_t * mpScanResults;
     size_t mIternum = 0;
 #endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 1, 3)
+
+    void SetApData(WiFiScanResponse & item, wifi_ap_record_t ap_record)
+    {
+        item.security = ConvertSecurityType(ap_record.authmode);
+        static_assert(chip::DeviceLayer::Internal::kMaxWiFiSSIDLength <= UINT8_MAX, "SSID length might not fit in item.ssidLen");
+        item.ssidLen = static_cast<uint8_t>(
+            strnlen(reinterpret_cast<const char *>(ap_record.ssid), chip::DeviceLayer::Internal::kMaxWiFiSSIDLength));
+        item.channel  = ap_record.primary;
+        item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
+        item.rssi     = ap_record.rssi;
+        memcpy(item.ssid, ap_record.ssid, item.ssidLen);
+        memcpy(item.bssid, ap_record.bssid, sizeof(item.bssid));
+    }
 };
 
 class ESPWiFiDriver final : public WiFiDriver


### PR DESCRIPTION
**Problem:**
Starting from **ESP-IDF v5.1.3**, a new API was introduced that allows fetching individual AP records one at a time, eliminating the need for preallocating a list of AP records.

**Change Overview:**

1. ESP32 Platform Updates: Updated **NetworkCommissioningDriver.cpp** and **NetworkCommissioningDriver.h** to support the new API introduced in **ESP-IDF v5.1.3** while maintaining backward compatibility with earlier versions.
2. Refactored ESPScanResponseIterator and OnScanWiFiNetworkDone() method to handle WiFi scan results differently based on the ESP-IDF versions.

**Testing:**
The changes were tested on an ESP32-S3 chip using **ESP-IDF** versions **v5.1**, **v5.1.2**, **v5.1.3**, **v5.2.1** and  **v5.2.2**
Both versions successfully read WiFi scan result lists using the CHIP tool with the following command:
`./chip-tool networkcommissioning scan-networks 1 0`


