### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-93 : [Telink] Update Docker image (Zephyr update)
+94 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=f9197e14795e602c35c97cd1194f1d03671dce88
+ARG ZEPHYR_REVISION=ffdbfe7560c0b628e03ab487ab110eeed9bdc8c7
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=8b29ee6b118ebe6eeec3224dbe343474e11403d8
+ARG ZEPHYR_REVISION=f9197e14795e602c35c97cd1194f1d03671dce88
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**
- riscv: tl321x: update west.yaml.
- riscv: tl3218x: save bin size for dlm.
- drivers: ieee802154: b9x/tlx: Update cca features and function.
- telink: b9x: update b9x dts to use it for matter.
- telink: tl321x: update tl3218x dts to use it for matter
- west.yml: update hal telink

**Changes of N22 binary:**
- None (latest hash 7771c2fd73347f217919cb9fcf458b0fc6568a0c)

Testing
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully