### PR TITLE
[darwin-framework-tool] Add an #ifdef around CHIPLogging.h include if…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/ControllerStorage.mm
+++ b/examples/darwin-framework-tool/commands/common/ControllerStorage.mm
@@ -19,7 +19,9 @@
 #import "ControllerStorage.h"
 #import "PreferencesStorage.h"
 
+#ifdef LOG_DEBUG_CONTROLLER_STORAGE
 #include <lib/support/logging/CHIPLogging.h>
+#endif // LOG_DEBUG_CONTROLLER_STORAGE
 
 NSString * const kDarwinFrameworkToolControllerDomain = @"com.apple.darwin-framework-tool.controller";
 


### PR DESCRIPTION
… it is not needed

#### Problem

This PR simply introduce conditional inclusion of `#include <lib/support/logging/CHIPLogging.h>` by wrapping it with #ifdef statements.
