### PR TITLE
Remove direct calls for emberAfAttributeChanged from libCHIP 

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
@@ -148,6 +148,17 @@ public:
     std::optional<DataModel::ActionReturnStatus> Invoke(const DataModel::InvokeRequest & request,
                                                         chip::TLV::TLVReader & input_arguments, CommandHandler * handler) override;
 
+    void HandleAttributeChange(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
+                               chip::app::AttributesChangedListener * listener) override
+    {
+        emberAfAttributeChanged(endpoint, clusterId, attributeId, listener);
+    }
+
+    void HandleAttributeChange(chip::EndpointId endpoint, chip::app::AttributesChangedListener * listener) override
+    {
+        emberAfEndpointChanged(endpoint, listener);
+    }    
+
     /// attribute tree iteration
     DataModel::EndpointEntry FirstEndpoint() override;
     DataModel::EndpointEntry NextEndpoint(EndpointId before) override;

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -30,6 +30,7 @@
 #include <app/data-model-provider/Context.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/data-model-provider/OperationTypes.h>
+#include <app/util/af-types.h>
 
 namespace chip {
 namespace app {
@@ -96,6 +97,23 @@ public:
     ///     convenience to make writing Invoke calls easier.
     virtual std::optional<ActionReturnStatus> Invoke(const InvokeRequest & request, chip::TLV::TLVReader & input_arguments,
                                                      CommandHandler * handler) = 0;
+
+    // Handle Attribute Change
+    ///
+    /// Marks a specific attribute as having changed.
+    ///
+    ///   - endpoint The endpoint ID of the attribute.
+    ///   - clusterId The cluster ID of the attribute.
+    ///   - attributeId The attribute ID to mark as changed.
+    ///   - listener The listener responsible for marking the attribute as dirty.
+    void HandleAttributeChange(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
+                               AttributesChangedListener * listener) = 0;
+
+    /// Marks all attributes on the specified endpoint as having changed.
+    ///
+    ///   - endpoint The endpoint ID whose attributes are to be marked as changed.
+    ///   - listener The listener responsible for marking the endpoint as dirty.
+    void HandleAttributeChange(EndpointId endpoint, AttributesChangedListener * listener) = 0;
 
 private:
     InteractionModelContext mContext = { nullptr };

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -30,7 +30,8 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    emberAfAttributeChanged(endpoint, clusterId, attributeId, emberAfGlobalInteractionModelAttributesChangedListener());
+    GetDataModelProvider()->HandleAttributeChange(endpoint, clusterId, attributeId,
+                                                  emberAfGlobalInteractionModelAttributesChangedListener());
 }
 
 void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)
@@ -39,8 +40,8 @@ void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    emberAfAttributeChanged(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId,
-                            emberAfGlobalInteractionModelAttributesChangedListener());
+    GetDataModelProvider()->HandleAttributeChange(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId,
+                                                  emberAfGlobalInteractionModelAttributesChangedListener());
 }
 
 void MatterReportingAttributeChangeCallback(EndpointId endpoint)
@@ -49,5 +50,5 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint)
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    emberAfEndpointChanged(endpoint, emberAfGlobalInteractionModelAttributesChangedListener());
+    GetDataModelProvider()->HandleAttributeChange(endpoint, emberAfGlobalInteractionModelAttributesChangedListener());
 }


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/blob/master/src/app/reporting/reporting.cpp contains just a wrapper for attribute change callbacks.

However this is directly ember coupled and uses a global attribute change listener. For backwards compatibility we should maintain MatterReportingAttributeChangeCallback existing, however because it is ember-tied it should be part of the Codegen data model provider rather than direct libCHIP.

Fixes #36661

