### PR TITLE
[Android][BDX] Fix crash when calling ResetTransfer

### DIFF
--- a/src/controller/java/BdxOTASender.cpp
+++ b/src/controller/java/BdxOTASender.cpp
@@ -73,15 +73,12 @@ CHIP_ERROR BdxOTASender::Init(System::Layer * systemLayer, Messaging::ExchangeMa
 CHIP_ERROR BdxOTASender::Shutdown()
 {
     assertChipStackLockedByCurrentThread();
-
-    VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     mExchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id);
     ResetState();
 
     mExchangeMgr = nullptr;
-    mSystemLayer = nullptr;
 
     return CHIP_NO_ERROR;
 }

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -44,6 +44,7 @@ void TransferFacilitator::ResetTransfer()
 
     VerifyOrReturn(mSystemLayer != nullptr);
     mSystemLayer->CancelTimer(PollTimerHandler, this);
+    mSystemLayer = nullptr;
 }
 
 CHIP_ERROR TransferFacilitator::OnMessageReceived(chip::Messaging::ExchangeContext * ec, const chip::PayloadHeader & payloadHeader,

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -97,7 +97,7 @@ protected:
 
     TransferSession mTransfer;
     Messaging::ExchangeContext * mExchangeCtx = nullptr;
-    System::Layer * mSystemLayer = nullptr;
+    System::Layer * mSystemLayer              = nullptr;
     System::Clock::Timeout mPollFreq;
     static constexpr System::Clock::Timeout kDefaultPollFreq    = System::Clock::Milliseconds32(500);
     static constexpr System::Clock::Timeout kImmediatePollDelay = System::Clock::Milliseconds32(1);

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -96,8 +96,8 @@ protected:
     void ScheduleImmediatePoll();
 
     TransferSession mTransfer;
-    Messaging::ExchangeContext * mExchangeCtx;
-    System::Layer * mSystemLayer;
+    Messaging::ExchangeContext * mExchangeCtx = nullptr;
+    System::Layer * mSystemLayer = nullptr;
     System::Clock::Timeout mPollFreq;
     static constexpr System::Clock::Timeout kDefaultPollFreq    = System::Clock::Milliseconds32(500);
     static constexpr System::Clock::Timeout kImmediatePollDelay = System::Clock::Milliseconds32(1);


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/34538/files leads to the crash in https://github.com/project-chip/connectedhomeip/issues/36352, where application may call ResetTransfer, and destructor for TransferFacilitator is also calling ResetTransfer, mSystemLayer has not yet cleared out inside ResetTransfer, potentially mSystemLayer may be in unknown state, mSystemLayer needs to clear out inside ResetTransfer

