### PR TITLE
Disable flaky test for diagnostics logs in java.

### DIFF
--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -236,17 +236,19 @@ jobs:
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
-            - name: Run Pairing Onnetwork and get diagnostic log Test
-              run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
-                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
-                     --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
-                     --tool-path out/linux-x64-java-matter-controller \
-                     --tool-cluster "bdx" \
-                     --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
-                     --factoryreset \
-                  '
+            # TODO: test below is disabled because it seems flaky (crashes on pool not being empty on app exit)
+            #       See: https://github.com/project-chip/connectedhomeip/issues/36734
+            # - name: Run Pairing Onnetwork and get diagnostic log Test
+            #   run: |
+            #       scripts/run_in_python_env.sh out/venv \
+            #       './scripts/tests/run_java_test.py \
+            #          --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+            #          --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
+            #          --tool-path out/linux-x64-java-matter-controller \
+            #          --tool-cluster "bdx" \
+            #          --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
+            #          --factoryreset \
+            #       '
             - name: Run Pairing Onnetwork Test
               run: |
                   scripts/run_in_python_env.sh out/venv \

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -191,18 +191,19 @@ jobs:
                      --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
                   '
-            # Disabled due to failure: https://github.com/project-chip/connectedhomeip/issues/27361
-            # - name: Run Pairing Address-PaseOnly Test
-            #   run: |
-            #      scripts/run_in_python_env.sh out/venv \
-            #       './scripts/tests/run_java_test.py \
-            #          --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
-            #          --app-args "--discriminator 3840 --interface-id -1" \
-            #          --tool-path out/linux-x64-java-matter-controller \
-            #          --tool-cluster "pairing" \
-            #          --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
-            #          --factoryreset \
-            #       '
+            - name: Run Pairing Address-PaseOnly Test
+              # Disabled due to failure: https://github.com/project-chip/connectedhomeip/issues/27361
+              if: false
+              run: |
+                 scripts/run_in_python_env.sh out/venv \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "pairing" \
+                     --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
+                     --factoryreset \
+                  '
             - name: Run Pairing SetupQRCode Test
               run: |
                   scripts/run_in_python_env.sh out/venv \

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -236,19 +236,20 @@ jobs:
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
                   '
-            # TODO: test below is disabled because it seems flaky (crashes on pool not being empty on app exit)
-            #       See: https://github.com/project-chip/connectedhomeip/issues/36734
-            # - name: Run Pairing Onnetwork and get diagnostic log Test
-            #   run: |
-            #       scripts/run_in_python_env.sh out/venv \
-            #       './scripts/tests/run_java_test.py \
-            #          --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
-            #          --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
-            #          --tool-path out/linux-x64-java-matter-controller \
-            #          --tool-cluster "bdx" \
-            #          --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
-            #          --factoryreset \
-            #       '
+            - name: Run Pairing Onnetwork and get diagnostic log Test
+              # TODO: test below is disabled because it seems flaky (crashes on pool not being empty on app exit)
+              #       See: https://github.com/project-chip/connectedhomeip/issues/36734
+              if: false
+              run: |
+                  scripts/run_in_python_env.sh out/venv \
+                  './scripts/tests/run_java_test.py \
+                     --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
+                     --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
+                     --tool-path out/linux-x64-java-matter-controller \
+                     --tool-cluster "bdx" \
+                     --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
+                     --factoryreset \
+                  '
             - name: Run Pairing Onnetwork Test
               run: |
                   scripts/run_in_python_env.sh out/venv \


### PR DESCRIPTION
#36591 added a new test, however that test seems flaky.
Have #36734 as an issue to fix things, however in the mean time disable the flaky test.

Made the `disabling` the same throughout: rather than commenting tests out, used `if: false` to make them show up as skipped tests.