### PR TITLE
TC_CNET_4.9 and 4.11 Fix Verification issue and incorrect parameter check

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CNET_4_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CNET_4_11.yaml
@@ -99,11 +99,6 @@ tests:
           "Step 4: TH sends RemoveNetwork Command to the DUT with NetworkID
           field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and Breadcrumb field
           set to 1"
-      verification: |
-          Verify that DUT sends NetworkConfigResponse to command with the following fields:
-          NetworkingStatus is success
-
-          NetworkIndex is 'Userwifi_netidx'
       PICS: CNET.S.C04.Rsp && CNET.S.C05.Tx
       command: "RemoveNetwork"
       arguments:
@@ -161,6 +156,7 @@ tests:
           field set to PIXIT.CNET.WIFI_2ND_ACCESSPOINT_SSID and Breadcrumb field
           set to 2"
       PICS: CNET.C.C06.Tx
+
       timedInteractionTimeoutMs: 5000
       command: "ConnectNetwork"
       arguments:
@@ -287,11 +283,6 @@ tests:
           "Step 15: TH sends RemoveNetwork Command to the DUT with NetworkID
           field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and Breadcrumb field
           set to 1"
-      verification: |
-          Verify that DUT sends NetworkConfigResponse to command with the following fields:
-          NetworkingStatus is success
-
-          NetworkIndex is 'Userwifi_netidx'
       PICS: CNET.S.C04.Rsp && CNET.S.C05.Tx
       command: "RemoveNetwork"
       arguments:

--- a/src/app/tests/suites/certification/Test_TC_CNET_4_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CNET_4_9.yaml
@@ -93,11 +93,6 @@ tests:
           "Step 4: TH sends RemoveNetwork Command to the DUT with NetworkID
           field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and Breadcrumb field
           set to 1"
-      verification: |
-          Verify that DUT sends NetworkConfigResponse to command with the following fields:
-          NetworkingStatus is success
-
-          NetworkIndex is 'Userwifi_netidx'
       PICS: CNET.S.C04.Rsp && CNET.S.C05.Tx
       command: "RemoveNetwork"
       arguments:
@@ -133,17 +128,17 @@ tests:
       command: "readAttribute"
       attribute: "LastNetworkingStatus"
       response:
-          value: 0
           constraints:
               type: NetworkCommissioningStatusEnum
+              anyOf: [0, null]
 
     - label: "Step 7: TH reads LastNetworkID attribute from the DUT"
       PICS: CNET.S.A0006
       command: "readAttribute"
       attribute: "LastNetworkID"
       response:
-          value: PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID
           constraints:
+              anyOf: [PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID, null]
               type: octet_string
               minLength: 1
               maxLength: 32
@@ -247,11 +242,6 @@ tests:
           "Step 14: TH sends RemoveNetwork Command to the DUT with NetworkID
           field set to PIXIT.CNET.WIFI_1ST_ACCESSPOINT_SSID and Breadcrumb field
           set to 1"
-      verification: |
-          Verify that DUT sends NetworkConfigResponse to command with the following fields:
-          NetworkingStatus is success
-
-          NetworkIndex is 'Userwifi_netidx'
       PICS: CNET.S.C04.Rsp && CNET.S.C05.Tx
       command: "RemoveNetwork"
       arguments:


### PR DESCRIPTION
Issue https://github.com/project-chip/matter-test-scripts/issues/455

Test Step Error using "verification" key as neither "disabled: true" or "PICS: PICS_USER_PROMPT" are used and two steps do not correctly check variable contents.

Tested locally and tests pass, TC-CNET-4.11 also requires https://github.com/project-chip/connectedhomeip/pull/36701
