### PR TITLE
[nrfconnect] Fix configuration of pigweed logger 

### DIFF
--- a/examples/chef/nrfconnect/rpc.overlay
+++ b/examples/chef/nrfconnect/rpc.overlay
@@ -48,3 +48,7 @@ CONFIG_LOG_OUTPUT=y
 
 # Increase zephyr tty rx buffer
 CONFIG_CONSOLE_GETCHAR_BUFSIZE=128
+
+# Increase BLE thread stack size
+CONFIG_BT_RX_STACK_SIZE=2048
+

--- a/examples/lighting-app/nrfconnect/rpc.overlay
+++ b/examples/lighting-app/nrfconnect/rpc.overlay
@@ -45,3 +45,7 @@ CONFIG_LOG_OUTPUT=y
 
 # Increase zephyr tty rx buffer
 CONFIG_CONSOLE_GETCHAR_BUFSIZE=128
+
+# Increase BLE thread stack size
+CONFIG_BT_RX_STACK_SIZE=2048
+

--- a/examples/platform/nrfconnect/util/PigweedLogger.cpp
+++ b/examples/platform/nrfconnect/util/PigweedLogger.cpp
@@ -100,29 +100,24 @@ void init(const log_backend *)
 
 void processMessage(const struct log_backend * const backend, union log_msg_generic * msg)
 {
+    if (sIsPanicMode || k_is_in_isr())
+    {
+        return;
+    }
+
     int ret = k_sem_take(&sLoggerLock, K_FOREVER);
     assert(ret == 0);
 
-    if (!sIsPanicMode)
-    {
-        log_format_func_t outputFunc = log_format_func_t_get(LOG_OUTPUT_TEXT);
+    log_format_func_t outputFunc = log_format_func_t_get(LOG_OUTPUT_TEXT);
 
-        outputFunc(&pigweedLogOutput, &msg->log, log_backend_std_get_flags());
-    }
+    outputFunc(&pigweedLogOutput, &msg->log, log_backend_std_get_flags());
 
     k_sem_give(&sLoggerLock);
 }
 
 void panic(const log_backend *)
 {
-    int ret = k_sem_take(&sLoggerLock, K_FOREVER);
-    assert(ret == 0);
-
-    log_backend_std_panic(&pigweedLogOutput);
-    flush();
     sIsPanicMode = true;
-
-    k_sem_give(&sLoggerLock);
 }
 
 const log_backend_api pigweedLogApi = {


### PR DESCRIPTION
This commit adjusts the Pigweed logger configuration to prevent the use of mutexes within ISR. Additionally, it increases the Bluetooth RX stack size when the Pigweed logger is enabled.