### PR TITLE
[nrfconnect] Fix USB device initialization

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/main.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/main.cpp
@@ -33,9 +33,9 @@ static int InitUSB()
 {
     int err = usb_enable(nullptr);
 
-    if (err)
+    if ((err != 0) && (err != -EALREADY))
     {
-        LOG_ERR("Failed to initialize USB device");
+        LOG_ERR("Failed to initialize USB device %d", err);
         return err;
     }
 

--- a/examples/all-clusters-minimal-app/nrfconnect/main/main.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/main.cpp
@@ -33,9 +33,9 @@ static int InitUSB()
 {
     int err = usb_enable(nullptr);
 
-    if (err)
+    if ((err != 0) && (err != -EALREADY))
     {
-        LOG_ERR("Failed to initialize USB device");
+        LOG_ERR("Failed to initialize USB device %d", err);
         return err;
     }
 

--- a/examples/lighting-app/nrfconnect/main/main.cpp
+++ b/examples/lighting-app/nrfconnect/main/main.cpp
@@ -40,9 +40,9 @@ static int InitUSB()
 {
     int err = usb_enable(nullptr);
 
-    if (err)
+    if ((err != 0) && (err != -EALREADY))
     {
-        LOG_ERR("Failed to initialize USB device");
+        LOG_ERR("Failed to initialize USB device %d", err);
         return err;
     }
 

--- a/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
+++ b/examples/platform/nrfconnect/pw_sys_io/sys_io_nrfconnect.cc
@@ -32,7 +32,7 @@ extern "C" void pw_sys_io_Init()
 
 #ifdef CONFIG_USB
     err = usb_enable(nullptr);
-    assert(err == 0);
+    assert(err == 0 || err == (-EALREADY));
 #endif
 
     err = console_init();


### PR DESCRIPTION
Ensure proper initialization of the USB device by allowing the `usb_enable` API to be called multiple times without errors.

