### PR TITLE
[NXP] Update NXP Zephyr Docker image for nxp-zsdk v4.0.0 migration

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -33,7 +33,7 @@ on:
               required: false
               type: boolean
               default: false
-  
+
 jobs:
     build_images_base:
         name: Build Docker CHIP Build images - base
@@ -102,6 +102,7 @@ jobs:
                     # - "-imx"
                     - "-java"
                     - "-nxp"
+                    - "-nxp-zephyr"
                     - "-nrf-platform"
                     - "-telink"
                     - "-ti"
@@ -120,7 +121,7 @@ jobs:
               run: |
                   cd integrations/docker/images/stage-2/chip-build${{ matrix.img }}
                   ./build.sh --latest
-                    
+
     build_images_stage_3:
         needs: [build_images_base, build_images_stage_1, build_images_stage_2]
         name: Build Docker CHIP Build images - stage 3

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -10,12 +10,9 @@ RUN set -x \
 
 WORKDIR /opt/nxp-zephyr
 RUN set -x \
-    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.8/zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
-    && tar xvf zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
-    && rm -rf zephyr-sdk-0.16.8_linux-x86_64_minimal.tar.xz \
-    && zephyr-sdk-0.16.8/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v3.7.0 \
+    && west sdk install -t arm-zephyr-eabi --install-dir /opt/nxp-zephyr --version 0.17.0 \
+    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.0.0 \
     && cd zephyrproject \
     && west update -o=--depth=1 -n \
     && west zephyr-export \
@@ -23,10 +20,10 @@ RUN set -x \
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 
-COPY --from=build /opt/nxp-zephyr/zephyr-sdk-0.16.8/ /opt/nxp-zephyr/zephyr-sdk-0.16.8/
+COPY --from=build /opt/nxp-zephyr/zephyr-sdk-0.17.0/ /opt/nxp-zephyr/zephyr-sdk-0.17.0/
 COPY --from=build /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
 
 WORKDIR /opt/nxp-zephyr
 
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
-ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.8
+ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.17.0

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -10,8 +10,11 @@ RUN set -x \
 
 WORKDIR /opt/nxp-zephyr
 RUN set -x \
+    && wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
+    && tar xvf zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
+    && rm -rf zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
+    && zephyr-sdk-0.17.0/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && west sdk install -t arm-zephyr-eabi --install-dir /opt/nxp-zephyr --version 0.17.0 \
     && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.0.0 \
     && cd zephyrproject \
     && west update -o=--depth=1 -n \

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=ameba /opt/ameba /opt/ameba
 
 COPY --from=nxp /opt/nxp /opt/nxp
 
-COPY --from=nxpzephyr /opt/nxp-zephyr/zephyr-sdk-0.16.8/ /opt/nxp-zephyr/zephyr-sdk-0.16.8/
+COPY --from=nxpzephyr /opt/nxp-zephyr/zephyr-sdk-0.17.0/ /opt/nxp-zephyr/zephyr-sdk-0.17.0/
 COPY --from=nxpzephyr /opt/nxp-zephyr/zephyrproject/ /opt/nxp-zephyr/zephyrproject/
 
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
@@ -131,7 +131,7 @@ ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
 ENV ZEPHYR_SDK_INSTALL_DIR=/opt/NordicSemiconductor/nRF5_tools/zephyr-sdk-0.16.5
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
 ENV ZEPHYR_NXP_BASE=/opt/nxp-zephyr/zephyrproject/zephyr
-ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.16.8
+ENV ZEPHYR_NXP_SDK_INSTALL_DIR=/opt/nxp-zephyr/zephyr-sdk-0.17.0
 ENV NXP_UPDATE_SDK_SCRIPT_DOCKER=/opt/nxp/nxp_matter_support/scripts/update_nxp_sdk.py
 ENV NXP_SDK_PATH=/opt/nxp
 


### PR DESCRIPTION
Update the NXP Zephyr Docker image for nxp-zsdk v4.0.0 migration.

