### PR TITLE
[NXP][Zephyr] Migrate to nxp-zsdk v4.0.0

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -40,7 +40,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp:93
+            image: ghcr.io/project-chip/chip-build-nxp:94
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
@@ -240,7 +240,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:93
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:94
 
         steps:
             - name: Checkout

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -252,6 +252,15 @@ choice SCHED_ALGORITHM
 	default SCHED_MULTIQ
 endchoice
 
+config WIFI_NM_MAX_MANAGED_INTERFACES
+	default 2
+
+config WIFI_NM_WPA_SUPPLICANT_WQ_PRIO
+	default 3
+
+config WIFI_NM_WPA_SUPPLICANT_PRIO
+	default 3
+
 choice WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_CHOICE
 	default WIFI_NM_WPA_SUPPLICANT_LOG_LEVEL_INF
 endchoice
@@ -320,6 +329,9 @@ config HEAP_MEM_POOL_SIZE
 config CHIP_MALLOC_SYS_HEAP_SIZE
 	default 28672 # 28 kB
 
+config ETH_DRIVER
+	default n
+
 endif
 
 if CHIP_ETHERNET || CHIP_WIFI
@@ -354,10 +366,10 @@ config MBEDTLS_USER_CONFIG_ENABLE
 config MBEDTLS_USER_CONFIG_FILE
     default "nxp-zephyr-mbedtls-config.h"
 
-config MBEDTLS_ENTROPY_ENABLED
+config MBEDTLS_ENTROPY_C
 	default y
 
-config MBEDTLS_ZEPHYR_ENTROPY
+config MBEDTLS_ENTROPY_POLL_ZEPHYR
 	default y
 
 config MBEDTLS_SSL_MAX_CONTENT_LEN

--- a/examples/all-clusters-app/nxp/zephyr/README.md
+++ b/examples/all-clusters-app/nxp/zephyr/README.md
@@ -38,6 +38,7 @@ The example supports:
 The supported boards are:
 
 -   `rd_rw612_bga`
+-   `frdm_rw612`
 
 <a name="building"></a>
 
@@ -51,12 +52,12 @@ Prerequisites:
 -   Follow instruction from [BUILDING.md](../../../../docs/guides/BUILDING.md)
     to setup the Matter environment
 -   Follow instruction from
-    [Getting Started Guide](https://docs.zephyrproject.org/3.7.0/develop/getting_started/index.html)
+    [Getting Started Guide](https://docs.zephyrproject.org/4.0.0/develop/getting_started/index.html)
     to setup a Zephyr workspace, however, the west init command to use is as
     follows:
 
 ```shell
-$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v3.7.0
+$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.0.0
 ```
 
 > **Note**: While some of NXP platforms are supported in Zephyr upstream, we
@@ -64,10 +65,10 @@ $ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp
 > not upstream yet. While you can decide to use nxp-zsdk top of tree, we
 > recommend using a proper release tag delivered by NXP. This will ensure a
 > certain level of quality of the nxp-zsdk in use. Currently, we highly
-> recommend using the `nxp-v3.7.0` tag, based on Zephyr 3.7 LTS release. Reach
-> to your NXP contact for more details.
+> recommend using the `nxp-v4.0.0` tag, based on Zephyr 4.0 release. Reach to
+> your NXP contact for more details.
 
-Steps to build the example, targeting `rd_rw612_bga` board:
+Steps to build the example:
 
 1. Activate your Matter env:
 
@@ -84,7 +85,13 @@ source <path to zephyr repo>/zephyr-env.sh
 3. Run west build command:
 
 ```shell
-west build -b rd_rw612_bga -p auto -d build_zephyr <path to example folder>
+west build -b <board> -p auto -d build_zephyr <path to example folder>
+```
+
+As an example with the `frdm_rw612` board:
+
+```shell
+west build -b frdm_rw612 -p auto -d build_zephyr examples/all-clusters-app/nxp/zephyr
 ```
 
 A folder `build_zephyr` will be created in the same folder you run the command
@@ -102,7 +109,7 @@ You can get more details on `west build` with
 
 ### Flashing without debugging
 
-`west` can be used to flash a target, as an example for `rd_rw612_bga` board:
+`west` can be used to flash a target:
 
 ```shell
 west flash -i <J-Link serial number>
@@ -132,30 +139,30 @@ To debug a Matter with Zephyr application, you could use several methods:
 NXP Zephyr examples are not using factory data support by default. Please refer
 the the section below to build with factory data.
 
-You may refer to `src/platform/nxp/zephyr/boards/<board>/<board>.overlay` file
-to obtain the memory region used by this partition.
+You may refer to `<board>.overlay` file in each examples boards folder to obtain
+the memory region used by this partition.
 
-For example, the factory data partition on `rd_rw612_bga` is reserved in the
-last sector of the `flexspi` flash of `RD BGA` board, at `0x1BFFF000`.
+For example, the factory data partition on `frdm_rw612` is reserved in the last
+sector of the `flexspi` flash, at `0x1BFFF000`.
 
 ```
-&flexspi {
-  status = "okay";
+w25q512jvfiq: w25q512jvfiq@0 {
+    status = "okay";
 
-  mx25u51245g: mx25u51245g@0 {
-      ...
-      factory_partition: partition@3FFF000 {
-        label = "factory-data";
-        reg = <0x03FFF000 DT_SIZE_K(4)>;
-      };
-  };
+    partitions {
+        ...
+        factory_partition: partition@3FFF000 {
+            label = "factory-data";
+            reg = <0x03FFF000 DT_SIZE_K(4)>;
+        };
+
+    };
 };
 ```
 
-> **Note**: You may also refer to
-> `src/platform/nxp/zephyr/boards/<board>/<board>.overlay` file to check other
-> memory partitions used by the platform, such as the file system partition
-> mentioned with the `storage` label.
+> **Note**: You may also refer to `<board>.overlay` file in each NXP Zephyr
+> examples folder to check other memory partitions used by the platform, such as
+> the file system partition mentioned with the `storage` label.
 
 ### Build with factory data support
 
@@ -165,7 +172,7 @@ To build the example with factory data support, you can add
 Example:
 
 ```bash
-west build -b rd_rw612_bga -p  <path to example folder> -- -DFILE_SUFFIX=fdata
+west build -b <board> -p  <path to example folder> -- -DFILE_SUFFIX=fdata
 ```
 
 `prj_fdata.conf` configuration file will enable `CONFIG_CHIP_FACTORY_DATA`
@@ -233,13 +240,14 @@ configured for the example. The binding `zephyr,console` is used to print the
 logs, while the binding `zephyr,shell-uart` is used for the CLI. If the logs and
 the CLI are split among two serial interfaces, you will have to open both ports.
 
-As an example, the Matter CLI on `rd_rw612_bga` is configured to be output on
+As an example, the Matter CLI on `frdm_rw612` is configured to be output on
 `flexcomm3` with a baudrate of `115200`. The logs are configured to be output on
 `flexcomm0` with a baudrate of `115200`.
 
-> **Note**: `flexcomm3` is wired to the USB `FTDI` port of the `RD BGA` board by
-> default. `flexcomm0` is wired to `GPIO2` (RX) and `GPIO3` (TX). Those pins are
-> accessible on `HD2` pin header.
+> **Note**: `frdm_rw612` and ` frdm_rw612``flexcomm3 ` is wired to the USB
+> `MCULINK` port of the board by default. `rd_rw612_bga` `flexcomm0` is wired to
+> `GPIO2` (RX) and `GPIO3` (TX). Those pins are accessible on `HD2` pin header.
+> `frdm_rw612` `flexcomm0` is wired to RX and TX pins located at `J5 mikroBUS`.
 
 To access the CLI console, use a serial terminal emulator of your choice, like
 Minicom or GNU Screen. Use the baud rate set to `115200`.

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.conf
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2023-2024 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,11 +55,10 @@
 	};
 };
 
-
 &flexspi {
 	status = "okay";
 
-	mx25u51245g: mx25u51245g@0 {
+	w25q512jvfiq: w25q512jvfiq@0 {
 		status = "okay";
 
 		partitions {

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2023-2024 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,11 +55,10 @@
 	};
 };
 
-
 &flexspi {
 	status = "okay";
 
-	mx25u51245g: mx25u51245g@0 {
+	w25q512jvfiq: w25q512jvfiq@0 {
 		status = "okay";
 
 		partitions {

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -38,21 +38,23 @@
 	pinctrl-names = "default";
 };
 
+/delete-node/ &sram_data;
+/delete-node/ &sram_code;
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
 &sram {
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	sram_data: memory@40000 {
+	sram_data: memory@0 {
 		compatible = "mmio-sram";
-		reg = <0x40000 DT_SIZE_K(1216)>;
+		reg = <0x0 DT_SIZE_K(1216)>;
 	};
 };
 
-/delete-node/ &boot_partition;
-/delete-node/ &slot0_partition;
-/delete-node/ &slot1_partition;
-/delete-node/ &fw_storage;
-/delete-node/ &storage_partition;
 
 &flexspi {
 	status = "okay";

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612.conf
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612.conf
@@ -1,0 +1,18 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612.overlay
@@ -1,5 +1,5 @@
 /*
- *    Copyright (c) 2023-2024 Project CHIP Authors
+ *    Copyright (c) 2024 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,11 +55,10 @@
 	};
 };
 
-
 &flexspi {
 	status = "okay";
 
-	mx25u51245g: mx25u51245g@0 {
+	w25q512jvfiq: w25q512jvfiq@0 {
 		status = "okay";
 
 		partitions {

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,0 +1,26 @@
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+CONFIG_SETTINGS_NVS_SECTOR_COUNT=16
+
+# 0xA226
+CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
+CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
+CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
+CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
+
+# Workaround for nxp-zsdk v4.0.0 release
+CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
+++ b/examples/thermostat/nxp/zephyr/boards/rd_rw612_bga.overlay
@@ -38,21 +38,22 @@
 	pinctrl-names = "default";
 };
 
+/delete-node/ &sram_data;
+/delete-node/ &sram_code;
+/delete-node/ &boot_partition;
+/delete-node/ &slot0_partition;
+/delete-node/ &slot1_partition;
+/delete-node/ &storage_partition;
+
 &sram {
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	sram_data: memory@40000 {
+	sram_data: memory@0 {
 		compatible = "mmio-sram";
-		reg = <0x40000 DT_SIZE_K(1216)>;
+		reg = <0x0 DT_SIZE_K(1216)>;
 	};
 };
-
-/delete-node/ &boot_partition;
-/delete-node/ &slot0_partition;
-/delete-node/ &slot1_partition;
-/delete-node/ &fw_storage;
-/delete-node/ &storage_partition;
 
 &flexspi {
 	status = "okay";

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -71,7 +71,7 @@ class NxpBoard(Enum):
                 if self == NxpBoard.RW61X_ETH:
                     return 'rd_rw612_bga/rw612/ethernet'
                 else:
-                    return 'rd_rw612_bga'
+                    return 'frdm_rw612'
             else:
                 return 'rw61x'
         elif self == NxpBoard.MCXW71:

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021,2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,8 +33,11 @@ namespace DeviceLayer {
 
 // Maximum length of vendor defined name or prefix of the software thread that is
 // static for the duration of the thread.
+#if defined(CONFIG_THREAD_MAX_NAME_LEN)
+static constexpr size_t kMaxThreadNameLength = CONFIG_THREAD_MAX_NAME_LEN - 1;
+#else
 static constexpr size_t kMaxThreadNameLength = 8;
-
+#endif
 // 48-bit IEEE MAC Address or a 64-bit IEEE MAC Address (e.g. EUI-64).
 inline constexpr size_t kMaxHardwareAddrSize = 8;
 

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021,2024 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ public:
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR ResetWatermarks() override;
-
+    CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
+    void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -45,7 +45,7 @@ PlatformManagerImpl PlatformManagerImpl::sInstance{ sChipThreadStack };
 
 static k_timer sOperationalHoursSavingTimer;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
 static bool sChipStackEntropySourceAdded = false;
 static int app_entropy_source(void * data, unsigned char * output, size_t len, size_t * olen)
 {
@@ -72,7 +72,7 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 
     return ret;
 }
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
 
 void PlatformManagerImpl::OperationalHoursSavingTimerEventHandler(k_timer * timer)
 {
@@ -109,16 +109,16 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
     // Minimum required from source before entropy is released ( with mbedtls_entropy_func() ) (in bytes)
     const size_t kThreshold = 16;
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
 
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
 
-#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#if !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
     if (!sChipStackEntropySourceAdded)
     {
         // Add entropy source based on Zephyr entropy driver
@@ -126,7 +126,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
         SuccessOrExit(err);
         sChipStackEntropySourceAdded = true;
     }
-#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#endif // !defined(CONFIG_NRF_SECURITY) && !defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_MBEDTLS_ENTROPY_POLL_ZEPHYR)
 
     // Call _InitChipStack() on the generic implementation base class to finish the initialization process.
     err = Internal::GenericPlatformManagerImpl_Zephyr<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/wifi/WiFiManager.h
+++ b/src/platform/Zephyr/wifi/WiFiManager.h
@@ -133,6 +133,7 @@ public:
         int8_t mRssi{};
         uint8_t mSsid[DeviceLayer::Internal::kMaxWiFiSSIDLength];
         size_t mSsidLen{ 0 };
+        uint64_t mCurrentPhyRate{};
     };
 
     struct NetworkStatistics
@@ -143,6 +144,7 @@ public:
         uint32_t mPacketUnicastTxCount{};
         uint32_t mBeaconsSuccessCount{};
         uint32_t mBeaconsLostCount{};
+        uint32_t mOverRunCount{};
     };
 
     struct WiFiNetwork

--- a/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.h
+++ b/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.h
@@ -28,6 +28,17 @@
 namespace chip {
 namespace DeviceLayer {
 
+struct WiFiStatistics
+{
+    uint32_t beaconLostCount        = 0;
+    uint32_t beaconRxCount          = 0;
+    uint32_t packetMulticastRxCount = 0;
+    uint32_t packetMulticastTxCount = 0;
+    uint32_t packetUnicastRxCount   = 0;
+    uint32_t packetUnicastTxCount   = 0;
+    uint64_t overrunCount           = 0;
+};
+
 class DiagnosticDataProviderImplNxp : public DiagnosticDataProviderImpl
 {
 public:
@@ -52,6 +63,7 @@ public:
 
 private:
     DiagnosticDataProviderImplNxp() = default;
+    WiFiStatistics mOldStats;
 };
 
 DiagnosticDataProvider & GetDiagnosticDataProviderImpl();


### PR DESCRIPTION
- Kconfigs/CMake updates for nxp-zsdk v4.0.0 (Zephyr 4.0 base)
- Add ThreadMetrics support for Zephyr platforms
- Add missing WiFi Diagnostic support for NXP Zephyr
- Add Matter over WiFi support for frdm_rw612
- Update and fix memory overlays

This PR depends on a Docker image update PR: https://github.com/project-chip/connectedhomeip/pull/36748

