### PR TITLE
Fix Null Pointer Dereference in TCP Packet Handling

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -343,12 +343,15 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
             // We have not yet received the complete message.
             return CHIP_NO_ERROR;
         }
+
+        state->mReceived.Consume(kPacketSizeBytes);
+
         if (messageSize == 0)
         {
             // No payload but considered a valid message. Return success to keep the connection alive.
             return CHIP_NO_ERROR;
         }
-        state->mReceived.Consume(kPacketSizeBytes);
+
         ReturnErrorOnFailure(ProcessSingleMessage(peerAddress, state, messageSize));
     }
 

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -343,8 +343,12 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
             // We have not yet received the complete message.
             return CHIP_NO_ERROR;
         }
+        if (messageSize == 0)
+        {
+            // No payload but considered a valid message. Return success to keep the connection alive.
+            return CHIP_NO_ERROR;
+        }
         state->mReceived.Consume(kPacketSizeBytes);
-        VerifyOrReturnError(!state->mReceived.IsNull(), CHIP_ERROR_MESSAGE_INCOMPLETE);
         ReturnErrorOnFailure(ProcessSingleMessage(peerAddress, state, messageSize));
     }
 

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -344,6 +344,7 @@ CHIP_ERROR TCPBase::ProcessReceivedBuffer(Inet::TCPEndPoint * endPoint, const Pe
             return CHIP_NO_ERROR;
         }
         state->mReceived.Consume(kPacketSizeBytes);
+        VerifyOrReturnError(!state->mReceived.IsNull(), CHIP_ERROR_MESSAGE_INCOMPLETE);
         ReturnErrorOnFailure(ProcessSingleMessage(peerAddress, state, messageSize));
     }
 

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -202,30 +202,6 @@ public:
         SetCallback(nullptr);
     }
 
-    void MessageSizeTest(TCPImpl & tcp, const IPAddress & addr)
-    {
-        chip::System::PacketBufferHandle buffer = chip::System::PacketBufferHandle::NewWithData(messageSize_TEST, sizeof(messageSize_TEST));
-        ASSERT_FALSE(buffer.IsNull());
-
-        PacketHeader header;
-        header.SetSourceNodeId(kSourceNodeId).SetDestinationNodeId(kDestinationNodeId).SetMessageCounter(kMessageCounter);
-
-        SetCallback([](const uint8_t * message, size_t length, int count, void * data) { return memcmp(message, data, length); },
-                    const_cast<void *>(static_cast<const void *>(PAYLOAD)));
-
-        CHIP_ERROR err = header.EncodeBeforeData(buffer);
-        EXPECT_EQ(err, CHIP_NO_ERROR);
-
-        // Should be able to send a message to itself by just calling send.
-        err = tcp.SendMessage(Transport::PeerAddress::TCP(addr, gChipTCPPort), std::move(buffer));
-        EXPECT_EQ(err, CHIP_NO_ERROR);
-
-        mIOContext->DriveIOUntil(chip::System::Clock::Seconds16(5), [this]() { return mReceiveHandlerCallCount != 0; });
-        EXPECT_EQ(mReceiveHandlerCallCount, 1);
-
-        SetCallback(nullptr);
-    }
-
     void ConnectTest(TCPImpl & tcp, const IPAddress & addr)
     {
         // Connect and wait for seeing active connection

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -64,7 +64,7 @@ constexpr NodeId kSourceNodeId      = 123654;
 constexpr NodeId kDestinationNodeId = 111222333;
 constexpr uint32_t kMessageCounter  = 18;
 
-const char PAYLOAD[] = "Hello!";
+const char PAYLOAD[]          = "Hello!";
 const char messageSize_TEST[] = "\x00\x00\x00\x00";
 
 class MockTransportMgrDelegate : public chip::TransportMgrDelegate

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -610,32 +610,6 @@ TEST_F(TestTCP, HandleConnCloseCalledTest6)
     HandleConnCloseTest(addr);
 }
 
-TEST_F(TestTCP, MessageSizeTest)
-{
-    TCPImpl tcp;
-
-    IPAddress addr;
-    IPAddress::FromString("::1", addr);
-
-    MockTransportMgrDelegate gMockTransportMgrDelegate(mIOContext);
-    gMockTransportMgrDelegate.InitializeMessageTest(tcp, addr);
-
-    gMockTransportMgrDelegate.SingleMessageTest(tcp, addr);
-
-    Transport::PeerAddress lPeerAddress = Transport::PeerAddress::TCP(addr, gChipTCPPort);
-    void * state                        = TestAccess::FindActiveConnection(tcp, lPeerAddress);
-    ASSERT_NE(state, nullptr);
-    TCPEndPoint * lEndPoint = TestAccess::GetEndpoint(state);
-    ASSERT_NE(lEndPoint, nullptr);
-
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(messageSize_TEST, sizeof(messageSize_TEST));
-    ASSERT_NE(&buf, nullptr);
-    err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(buf));
-    EXPECT_EQ(err, CHIP_NO_ERROR);
-}
-
 TEST_F(TestTCP, CheckProcessReceivedBuffer)
 {
     TCPImpl tcp;
@@ -659,6 +633,12 @@ TEST_F(TestTCP, CheckProcessReceivedBuffer)
     CHIP_ERROR err = CHIP_NO_ERROR;
     TestData testData[2];
     gMockTransportMgrDelegate.SetCallback(TestDataCallbackCheck, testData);
+
+    // Test a single packet buffer with zero message size.
+    System::PacketBufferHandle buf = System::PacketBufferHandle::NewWithData(messageSize_TEST, 4);
+    ASSERT_NE(&buf, nullptr);
+    err = TestAccess::ProcessReceivedBuffer(tcp, lEndPoint, lPeerAddress, std::move(buf));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
 
     // Test a single packet buffer.
     gMockTransportMgrDelegate.mReceiveHandlerCallCount = 0;


### PR DESCRIPTION
**Description**

This PR fixes https://github.com/project-chip/connectedhomeip/issues/36750 a null pointer dereference in `TCPBase::ProcessSingleMessage` caused by malformed TCP packets. The issue could lead to a Denial of Service (DoS) attack.

**Changes**

- Added a null pointer validation for `state->mReceived` before calling `ProcessSingleMessage`.

- This change prevents crash and print error log:
  ```cpp
  [1733488993.071785][31090:31090] CHIP:IN: Incoming connection established with peer at fe80::46c0:aa19:6d9:c653.
  [1733488993.071895][31090:31090] CHIP:IN: Received TCP connection request from TCP:[fe80::46c0:aa19:6d9:c653%ens33]:42740.
  [1733488993.072182][31090:31090] CHIP:IN: Failed to accept received TCP message: src/transport/raw/TCP.cpp:347: CHIP Error 0x0000000D: Message incomplete
  [1733488993.072304][31090:31090] CHIP:IN: Closing connection with peer TCP:[fe80::46c0:aa19:6d9:c653%ens33]:42740.
  ```

**Testing**

- Tested against malformed packets to confirm the fix.
- Verified with valid packet. (e.g. `onoff on 1 1 --allow-large-payload 1`)