### PR TITLE
Fix missing include in transport/SessionDelegate.h

### DIFF
--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -18,7 +18,7 @@
 
 #include <inttypes.h>
 
-#include "lib/core/CHIPError.h"
+#include <lib/core/CHIPError.h>
 #include <lib/support/DLLUtil.h>
 
 namespace chip {

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -18,6 +18,7 @@
 
 #include <inttypes.h>
 
+#include "lib/core/CHIPError.h"
 #include <lib/support/DLLUtil.h>
 
 namespace chip {


### PR DESCRIPTION
Should include `CHIPError.h`

