### PR TITLE
Fix missing include in CompatEnumNames.h

### DIFF
--- a/src/app/common/CompatEnumNames.h
+++ b/src/app/common/CompatEnumNames.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <lib/support/TypeTraits.h>
 
 namespace chip {


### PR DESCRIPTION
This PR adds the missing cluster-enums.h header.
