### PR TITLE
Use ProviderChangeListener directly to report attrbiute change

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.h
@@ -80,6 +80,17 @@ private:
     }
 };
 
+class DefaultProviderChangeListener : public DataModel::ProviderChangeListener
+{
+public:
+    explicit DefaultProviderChangeListener(DataModel::Provider & provider) : mProvider(provider) {}
+
+    void MarkDirty(const AttributePathParams & path) override;
+
+private:
+    DataModel::Provider & mProvider;
+};
+
 } // namespace detail
 
 /// An implementation of `InteractionModel::Model` that relies on code-generation
@@ -126,6 +137,8 @@ private:
     };
 
 public:
+    CodegenDataModelProvider() : mChangeListener(*this) {}
+
     /// clears out internal caching. Especially useful in unit tests,
     /// where path caching does not really apply (the same path may result in different outcomes)
     void Reset()
@@ -185,7 +198,7 @@ public:
     ConcreteCommandPath FirstGeneratedCommand(const ConcreteClusterPath & cluster) override;
     ConcreteCommandPath NextGeneratedCommand(const ConcreteCommandPath & before) override;
 
-    void Temporary_ReportAttributeChanged(const AttributePathParams & path) override;
+    DataModel::ProviderChangeListener & GetAttributeChangeReporter() override { return mChangeListener; }
 
 private:
     // Iteration is often done in a tight loop going through all values.
@@ -220,6 +233,8 @@ private:
 
     // Ember requires a persistence provider, so we make sure we can always have something
     PersistentStorageDelegate * mPersistentStorageDelegate = nullptr;
+
+    detail::DefaultProviderChangeListener mChangeListener;
 
     /// Finds the specified ember cluster
     ///

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -221,24 +221,6 @@ public:
     // returned as responses.
     virtual ConcreteCommandPath FirstGeneratedCommand(const ConcreteClusterPath & cluster) = 0;
     virtual ConcreteCommandPath NextGeneratedCommand(const ConcreteCommandPath & before)   = 0;
-
-    /// Workaround function to report attribute change.
-    ///
-    /// When this is invoked, the caller is expected to increment the cluster data version, and the attribute path
-    /// should be marked as `dirty` by the data model provider listener so that the reporter can notify the subscriber
-    /// of attribute changes.
-    /// This function should be invoked when attribute managed by attribute access interface is modified but not
-    /// through an actual Write interaction.
-    /// For example, if the LastNetworkingStatus attribute changes because the NetworkCommissioning driver detects a
-    /// network connection status change and calls SetLastNetworkingStatusValue(). The data model provider can recognize
-    /// this change by invoking this function at the point of change.
-    ///
-    /// This is a workaround function as we cannot notify the attribute change to the data model provider. The provider
-    /// should own its data and versions.
-    ///
-    /// TODO: We should remove this function when the AttributeAccessInterface/CommandHandlerInterface is able to report
-    /// the attribute changes.
-    virtual void Temporary_ReportAttributeChanged(const AttributePathParams & path) = 0;
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -97,6 +97,15 @@ public:
     virtual std::optional<ActionReturnStatus> Invoke(const InvokeRequest & request, chip::TLV::TLVReader & input_arguments,
                                                      CommandHandler * handler) = 0;
 
+    /// Returns a reference to the ProviderChangeListener used for reporting attribute changes.
+    ///
+    /// This is used to notify listeners about changes in attributes managed by the provider.
+    /// Listeners can be used to react to updates in the underlying data model.
+    ///
+    /// It is expected that implementations provide a valid reference, ensuring that
+    /// attribute change reporting is functional throughout the lifecycle of the Provider.
+    virtual ProviderChangeListener & GetAttributeChangeReporter() = 0;
+
 private:
     InteractionModelContext mContext = { nullptr };
 };

--- a/src/app/reporting/reporting.cpp
+++ b/src/app/reporting/reporting.cpp
@@ -30,8 +30,9 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint, ClusterId clust
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    InteractionModelEngine::GetInstance()->GetDataModelProvider()->Temporary_ReportAttributeChanged(
-        AttributePathParams(endpoint, clusterId, attributeId));
+    DataModel::ProviderChangeListener & changeListener =
+        InteractionModelEngine::GetInstance()->GetDataModelProvider()->GetAttributeChangeReporter();
+    changeListener.MarkDirty(AttributePathParams(endpoint, clusterId, attributeId));
 }
 
 void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)
@@ -40,8 +41,9 @@ void MatterReportingAttributeChangeCallback(const ConcreteAttributePath & aPath)
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    InteractionModelEngine::GetInstance()->GetDataModelProvider()->Temporary_ReportAttributeChanged(
-        AttributePathParams(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId));
+    DataModel::ProviderChangeListener & changeListener =
+        InteractionModelEngine::GetInstance()->GetDataModelProvider()->GetAttributeChangeReporter();
+    changeListener.MarkDirty(AttributePathParams(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId));
 }
 
 void MatterReportingAttributeChangeCallback(EndpointId endpoint)
@@ -50,5 +52,7 @@ void MatterReportingAttributeChangeCallback(EndpointId endpoint)
     // applications notifying about changes from their end.
     assertChipStackLockedByCurrentThread();
 
-    InteractionModelEngine::GetInstance()->GetDataModelProvider()->Temporary_ReportAttributeChanged(AttributePathParams(endpoint));
+    DataModel::ProviderChangeListener & changeListener =
+        InteractionModelEngine::GetInstance()->GetDataModelProvider()->GetAttributeChangeReporter();
+    changeListener.MarkDirty(AttributePathParams(endpoint));
 }

--- a/src/app/tests/test-interaction-model-api.cpp
+++ b/src/app/tests/test-interaction-model-api.cpp
@@ -60,6 +60,14 @@ private:
     AttributeValueDecoder & mDecoder;
 };
 
+class TestProviderChangeListener : public DataModel::ProviderChangeListener
+{
+public:
+    explicit TestProviderChangeListener() {}
+
+    void MarkDirty(const AttributePathParams & path) override {}
+};
+
 // strong defintion in TestCommandInteraction.cpp
 __attribute__((weak)) void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath,
                                                         chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
@@ -147,6 +155,12 @@ std::optional<ActionReturnStatus> TestImCustomDataModel::Invoke(const InvokeRequ
                                                                 chip::TLV::TLVReader & input_arguments, CommandHandler * handler)
 {
     return std::make_optional<ActionReturnStatus>(CHIP_ERROR_NOT_IMPLEMENTED);
+}
+
+ProviderChangeListener & TestImCustomDataModel::GetAttributeChangeReporter()
+{
+    static TestProviderChangeListener changeListener;
+    return changeListener;
 }
 
 DataModel::EndpointEntry TestImCustomDataModel::FirstEndpoint()

--- a/src/app/tests/test-interaction-model-api.h
+++ b/src/app/tests/test-interaction-model-api.h
@@ -109,6 +109,7 @@ public:
                                                  AttributeValueDecoder & decoder) override;
     std::optional<DataModel::ActionReturnStatus> Invoke(const DataModel::InvokeRequest & request,
                                                         chip::TLV::TLVReader & input_arguments, CommandHandler * handler) override;
+    DataModel::ProviderChangeListener & GetAttributeChangeReporter() override;
 
     DataModel::EndpointEntry FirstEndpoint() override;
     DataModel::EndpointEntry NextEndpoint(EndpointId before) override;
@@ -131,7 +132,6 @@ public:
     std::optional<DataModel::CommandInfo> GetAcceptedCommandInfo(const ConcreteCommandPath & path) override;
     ConcreteCommandPath FirstGeneratedCommand(const ConcreteClusterPath & cluster) override;
     ConcreteCommandPath NextGeneratedCommand(const ConcreteCommandPath & before) override;
-    void Temporary_ReportAttributeChanged(const AttributePathParams & path) override {}
 };
 
 } // namespace app

--- a/src/controller/tests/data_model/DataModelFixtures.cpp
+++ b/src/controller/tests/data_model/DataModelFixtures.cpp
@@ -67,6 +67,14 @@ private:
     AttributeValueDecoder & mDecoder;
 };
 
+class TestProviderChangeListener : public DataModel::ProviderChangeListener
+{
+public:
+    explicit TestProviderChangeListener() {}
+
+    void MarkDirty(const AttributePathParams & path) override {}
+};
+
 namespace DataModelTests {
 
 ScopedChangeOnly<ReadResponseDirective> gReadResponseDirective(ReadResponseDirective::kSendDataResponse);
@@ -472,6 +480,12 @@ std::optional<ActionReturnStatus> CustomDataModel::Invoke(const InvokeRequest & 
 {
     DispatchSingleClusterCommand(request.path, input_arguments, handler);
     return std::nullopt; // handler status is set by the dispatch
+}
+
+ProviderChangeListener & CustomDataModel::GetAttributeChangeReporter()
+{
+    static TestProviderChangeListener changeListener;
+    return changeListener;
 }
 
 DataModel::EndpointEntry CustomDataModel::FirstEndpoint()

--- a/src/controller/tests/data_model/DataModelFixtures.h
+++ b/src/controller/tests/data_model/DataModelFixtures.h
@@ -121,6 +121,7 @@ public:
                                                  AttributeValueDecoder & decoder) override;
     std::optional<DataModel::ActionReturnStatus> Invoke(const DataModel::InvokeRequest & request,
                                                         chip::TLV::TLVReader & input_arguments, CommandHandler * handler) override;
+    DataModel::ProviderChangeListener & GetAttributeChangeReporter() override;
 
     DataModel::EndpointEntry FirstEndpoint() override;
     DataModel::EndpointEntry NextEndpoint(EndpointId before) override;
@@ -143,7 +144,6 @@ public:
     std::optional<DataModel::CommandInfo> GetAcceptedCommandInfo(const ConcreteCommandPath & path) override;
     ConcreteCommandPath FirstGeneratedCommand(const ConcreteClusterPath & cluster) override;
     ConcreteCommandPath NextGeneratedCommand(const ConcreteCommandPath & before) override;
-    void Temporary_ReportAttributeChanged(const AttributePathParams & path) override {}
 };
 
 } // namespace DataModelTests


### PR DESCRIPTION
Currently, MarkDirty in ProviderChangeListener does exactly what Temporary_ReportAttributeChanged does.

Instead of calling Temporary_ReportAttributeChanged or interacting with Provider, consumers would now use:

Consumers call Provider::GetAttributeChangeReporter() to obtain a ProviderChangeListener reference. For testing, they can mock just the ProviderChangeListener.

This approach simplifies unit testing and mocking. By focusing on the ProviderChangeListener, which has a single method, we avoid the complexity of mocking the entire DataModel::Provider interface with its approximately 30 methods.


Unit Test:
A mock ProviderChangeListener can now be used for simplified testing.

```
class MockProviderChangeListener : public ProviderChangeListener
{
public:
    MOCK_METHOD(void, MarkDirty, (const AttributePathParams & path), (override));
};
```

Fix: #36661 

