### PR TITLE
da_revocation: option to load test data from the test without using file

### DIFF
--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -126,16 +126,14 @@ bool TestDACRevocationDelegateImpl::CrossValidateCert(const Json::Value & revoke
 bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & akidHexStr, const std::string & issuerNameBase64Str,
                                                            const std::string & serialNumberHexStr)
 {
-    Json::CharReaderBuilder readerBuilder;
     Json::Value jsonData;
-    std::string errs;
 
     // Try direct data first, then fall back to file
-
     if (!mRevocationData.empty())
     {
+        std::string errs;
         std::istringstream jsonStream(!mRevocationData.empty() ? mRevocationData : "[]");
-        if (!Json::parseFromStream(readerBuilder, jsonStream, &jsonData, &errs))
+        if (!Json::parseFromStream(Json::CharReaderBuilder(), jsonStream, &jsonData, &errs))
         {
             ChipLogError(NotSpecified, "Failed to parse JSON data: %s", errs.c_str());
             return false;
@@ -143,6 +141,7 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
     }
     else if (!mDeviceAttestationRevocationSetPath.empty())
     {
+        std::string errs;
         std::ifstream file(mDeviceAttestationRevocationSetPath.c_str());
         if (!file.is_open())
         {
@@ -150,7 +149,7 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
             return false;
         }
 
-        bool parsingSuccessful = Json::parseFromStream(readerBuilder, file, &jsonData, &errs);
+        bool parsingSuccessful = Json::parseFromStream(Json::CharReaderBuilder(), file, &jsonData, &errs);
         file.close();
 
         if (!parsingSuccessful)
@@ -161,6 +160,7 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
     }
     else
     {
+        ChipLogDetail(NotSpecified, "No revocation data available");
         // No revocation data available
         return false;
     }

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -131,10 +131,10 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
     std::string errs;
 
     // Try direct data first, then fall back to file
-    std::istringstream jsonStream(!mRevocationData.empty() ? mRevocationData : "[]");
 
     if (!mRevocationData.empty())
     {
+        std::istringstream jsonStream(!mRevocationData.empty() ? mRevocationData : "[]");
         if (!Json::parseFromStream(readerBuilder, jsonStream, &jsonData, &errs))
         {
             ChipLogError(NotSpecified, "Failed to parse JSON data: %s", errs.c_str());

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.h
@@ -52,6 +52,10 @@ public:
     // This can be used to skip the revocation check
     void ClearDeviceAttestationRevocationSetPath();
 
+    // Set JSON data directly for unit test purposes.
+    CHIP_ERROR SetDeviceAttestationRevocationData(const std::string & jsonData);
+    void ClearDeviceAttestationRevocationData();
+
 private:
     enum class KeyIdType : uint8_t
     {
@@ -83,6 +87,7 @@ private:
     bool IsCertificateRevoked(const ByteSpan & certDer);
 
     std::string mDeviceAttestationRevocationSetPath;
+    std::string mRevocationData; // Stores direct JSON data
 };
 
 } // namespace Credentials


### PR DESCRIPTION
Fixes #34588

Added APIs for loading and clearing json data and modified unit tests to use those APIs.