### PR TITLE
[chip-tool][darwin-framework-tool] Add libs to the declare_args secti…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -25,6 +25,10 @@ if (config_use_interactive_mode) {
 
 assert(chip_build_tools)
 
+declare_args() {
+  libs = []
+}
+
 config("config") {
   include_dirs = [
     ".",

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -49,6 +49,8 @@ declare_args() {
 
   # Use Network.framework instead of POSIX sockets
   use_network_framework = false
+
+  libs = []
 }
 
 sdk = "macosx"
@@ -299,7 +301,7 @@ executable("darwin-framework-tool") {
   # Other SDKs are linked statically to Matter.framework but the macosx SDK is linked dynamically but needs some symbols that are
   # not exposed by the dylib.
   if (sdk == "macosx" || sdk_root_parts[0] == "macosx") {
-    libs = [ "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/lib/libCHIP.a" ]
+    libs += [ "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/lib/libCHIP.a" ]
   }
 
   if (enable_provisional_features) {


### PR DESCRIPTION
…on of BUILD.gn

#### Problem

This PR introduces the `libs` argument to the `declare_args` sections of both `chip-tool/BUILD.gn` and `darwin-framework-tool/BUILD.gn`.

Adding the libs argument facilitates testing against custom libraries.
