### PR TITLE
[Darwin] Add a MdnsContexts::Print method for debugging purposes

### DIFF
--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -15,10 +15,23 @@
 import("//build_overrides/chip.gni")
 import("//build_overrides/nlassert.gni")
 
+import("${chip_root}/build/chip/buildconfig_header.gni")
+
 import("${chip_root}/src/platform/device.gni")
 import("${chip_root}/src/system/system.gni")
 
 assert(chip_device_platform == "darwin")
+
+declare_args() {
+  dnssd_verbose_context_print = false
+}
+
+buildconfig_header("dnssd_buildconfig") {
+  header = "dnssd_config.h"
+  header_dir = "dnssd"
+
+  defines = [ "DNSSD_VERBOSE_CONTEXT_PRINT=${dnssd_verbose_context_print}" ]
+}
 
 config("darwin_config") {
   frameworks = [
@@ -104,6 +117,7 @@ static_library("Darwin") {
   }
 
   deps = [
+    ":dnssd_buildconfig",
     ":logging",
     ":tracing",
     "${chip_root}/src/app:app_config",

--- a/src/platform/Darwin/dnssd/DnssdContexts.cpp
+++ b/src/platform/Darwin/dnssd/DnssdContexts.cpp
@@ -259,6 +259,37 @@ CHIP_ERROR MdnsContexts::Has(GenericContext * context)
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
+#if DNSSD_VERBOSE_CONTEXT_PRINT
+void MdnsContexts::Print() const
+{
+    ChipLogDetail(Discovery, "MdnsContexts:");
+    std::vector<GenericContext *>::const_iterator iter = mContexts.cbegin();
+    while (iter != mContexts.cend())
+    {
+        const char * contextType = "Unknown";
+        switch ((*iter)->type)
+        {
+        case ContextType::Register:
+            contextType = "Register";
+            break;
+        case ContextType::Browse:
+            contextType = "Browse";
+            break;
+        case ContextType::BrowseWithDelegate:
+            contextType = "BrowseWithDelegate";
+            break;
+        case ContextType::Resolve:
+            contextType = "Resolve";
+            break;
+        }
+
+        // Print the pointer as a unique identifier so concurrent contexts can be distinguished in logs
+        ChipLogDetail(Discovery, "\t%p: %s", *iter, contextType);
+        iter++;
+    }
+}
+#endif // DNSSD_VERBOSE_CONTEXT_PRINT
+
 CHIP_ERROR MdnsContexts::GetRegisterContextOfTypeAndName(const char * type, const char * name, RegisterContext ** context)
 {
     bool found = false;

--- a/src/platform/Darwin/dnssd/DnssdImpl.h
+++ b/src/platform/Darwin/dnssd/DnssdImpl.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <dns_sd.h>
+#include <dnssd/dnssd_config.h>
 #include <lib/core/Global.h>
 #include <lib/dnssd/platform/Dnssd.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -80,6 +81,9 @@ public:
     CHIP_ERROR Remove(GenericContext * context);
     CHIP_ERROR RemoveAllOfType(ContextType type);
     CHIP_ERROR Has(GenericContext * context);
+#if DNSSD_VERBOSE_CONTEXT_PRINT
+    void Print() const;
+#endif
 
     /**
      * @brief


### PR DESCRIPTION
#### Summary

This PR adds a `MdnsContexts::Print` method for listing the different contexts currently registered. That is for debugging purposes.

#### Related issues

N/A

#### Testing

I have tested it locally by turning on the flag and dumping some `Print` in the code where I was looking at.

