### PR TITLE
[Darwin] Print the queue name (or a shorter version for common queues) when using the stdio logging backend

### DIFF
--- a/examples/darwin-framework-tool/logging/logging.mm
+++ b/examples/darwin-framework-tool/logging/logging.mm
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/Darwin/DispatchQueueNames.h>
 #include <pthread.h>
 
 namespace dft {
@@ -56,9 +57,17 @@ namespace logging {
         int pid = [[NSProcessInfo processInfo] processIdentifier];
 
         auto tid = pthread_mach_thread_np(pthread_self());
+        const char * label = chip::darwin::queues::CurrentLabel();
 
-        fprintf(stdout, "%s%s [%d:%u] [%s]: %s%s\n", loggingColor.UTF8String, formattedDate.UTF8String, pid, tid,
-            component.UTF8String, message.UTF8String, kLoggingColorEnd.UTF8String);
+        fprintf(stdout, "%s%s [%d:%u:%s] [%s]: %s%s\n",
+            loggingColor.UTF8String,
+            formattedDate.UTF8String,
+            pid,
+            tid,
+            label,
+            component.UTF8String,
+            message.UTF8String,
+            kLoggingColorEnd.UTF8String);
     }
 
     void LogRedirectCallback(const char * moduleName, uint8_t category, const char * format, va_list args)

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -149,6 +149,8 @@ source_set("tracing") {
 
 static_library("logging") {
   sources = [
+    "DispatchQueueNames.cpp",
+    "DispatchQueueNames.h",
     "Logging.h",
     "Logging.mm",
   ]

--- a/src/platform/Darwin/DispatchQueueNames.cpp
+++ b/src/platform/Darwin/DispatchQueueNames.cpp
@@ -1,0 +1,81 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "DispatchQueueNames.h"
+
+#include <dispatch/dispatch.h>
+
+namespace {
+constexpr const char * kMainQueue              = "com.apple.main-thread";
+constexpr const char * kChipQueue              = "org.csa-iot.matter.workqueue";
+constexpr const char * kBleQueue               = "org.csa-iot.matter.framework.ble.workqueue";
+constexpr const char * kXPCQueue               = "org.csa-iot.matter.framework.xpc.workqueue";
+constexpr const char * kDeviceQueue            = "org.csa-iot.matter.framework.device.workqueue";
+constexpr const char * kOTAProviderQueue       = "org.csa-iot.matter.framework.otaprovider.workqueue";
+constexpr const char * kDeviceAttestationQueue = "org.csa-iot.matter.framework.device_attestation.workqueue";
+
+constexpr const char * kMainQueueShort              = "main";
+constexpr const char * kChipQueueShort              = "chip";
+constexpr const char * kBleQueueShort               = "ble";
+constexpr const char * kXPCQueueShort               = "xpc";
+constexpr const char * kDeviceQueueShort            = "device";
+constexpr const char * kOTAProviderQueueShort       = "ota-provider";
+constexpr const char * kDeviceAttestationQueueShort = "device-attestation";
+} // namespace
+
+namespace chip {
+namespace darwin {
+namespace queues {
+
+const char * CurrentLabel()
+{
+    const char * label = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
+
+    if (strcmp(label, kMainQueue) == 0)
+    {
+        label = kMainQueueShort;
+    }
+    else if (strcmp(label, kChipQueue) == 0)
+    {
+        label = kChipQueueShort;
+    }
+    else if (strcmp(label, kBleQueue) == 0)
+    {
+        label = kBleQueueShort;
+    }
+    else if (strcmp(label, kXPCQueue) == 0)
+    {
+        label = kXPCQueueShort;
+    }
+    else if (strcmp(label, kDeviceQueue) == 0)
+    {
+        label = kDeviceQueueShort;
+    }
+    else if (strcmp(label, kOTAProviderQueue) == 0)
+    {
+        label = kOTAProviderQueueShort;
+    }
+    else if (strcmp(label, kDeviceAttestationQueue) == 0)
+    {
+        label = kDeviceAttestationQueueShort;
+    }
+
+    return label;
+}
+
+} // namespace queues
+} // namespace darwin
+} // namespace chip

--- a/src/platform/Darwin/DispatchQueueNames.h
+++ b/src/platform/Darwin/DispatchQueueNames.h
@@ -1,0 +1,27 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+namespace chip {
+namespace darwin {
+namespace queues {
+
+const char * CurrentLabel();
+
+} // namespace queues
+} // namespace darwin
+} // namespace chip

--- a/src/platform/logging/impl/Stdio.cpp
+++ b/src/platform/logging/impl/Stdio.cpp
@@ -24,6 +24,7 @@
 #include <time.h>
 
 #if defined(__APPLE__)
+#include <platform/Darwin/DispatchQueueNames.h>
 #include <pthread.h>
 #include <unistd.h>
 #elif defined(__gnu_linux__)
@@ -65,7 +66,8 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 #if defined(__APPLE__)
     uint64_t ktid;
     pthread_threadid_np(nullptr, &ktid);
-    printf("[%lld:%lld] ", static_cast<long long>(getpid()), static_cast<long long>(ktid));
+    const char * label = darwin::queues::CurrentLabel();
+    printf("[%lld:%lld:%s] ", static_cast<long long>(getpid()), static_cast<long long>(ktid), label);
 #elif defined(__gnu_linux__) && !defined(__NuttX__)
     // TODO: change to getpid() and gettid() after glib upgrade
     printf("[%lld:%lld] ", static_cast<long long>(syscall(SYS_getpid)), static_cast<long long>(syscall(SYS_gettid)));


### PR DESCRIPTION
#### Problem

This PR enhances the console logging by including the names of the queues that are currently running.
Specifically, it dumps the queue name to the console output. For queues that are commonly used, a shortened version of the name is displayed, making it easier to identify and focus on less frequently used or uncommon queues.