### PR TITLE
python testing: add test functions for IDs

### DIFF
--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -295,7 +295,7 @@ class DeviceConformanceTests(BasicCompositionTests):
                 continue
 
             device_type_list = endpoint[Clusters.Descriptor][Clusters.Descriptor.Attributes.DeviceTypeList]
-            invalid_device_types = [x for x in device_type_list if not is_valid_device_type_id(device_type_id_type(x.deviceType))]
+            invalid_device_types = [x for x in device_type_list if not is_valid_device_type_id(x.deviceType)]
             standard_device_types = [x for x in endpoint[Clusters.Descriptor]
                                      [Clusters.Descriptor.Attributes.DeviceTypeList] if device_type_id_type(x.deviceType) == DeviceTypeIdType.kStandard]
             endpoint_clusters = []

--- a/src/python_testing/TestIdChecks.py
+++ b/src/python_testing/TestIdChecks.py
@@ -16,8 +16,10 @@
 #
 
 from chip.testing.global_attribute_ids import (AttributeIdType, ClusterIdType, CommandIdType, DeviceTypeIdType, attribute_id_type,
-                                               cluster_id_type, command_id_type, device_type_id_type, is_valid_attribute_id,
-                                               is_valid_cluster_id, is_valid_command_id, is_valid_device_type_id)
+                                               cluster_id_type, command_id_type, device_type_id_type, is_standard_attribute_id,
+                                               is_standard_cluster_id, is_standard_command_id, is_standard_device_type_id,
+                                               is_valid_attribute_id, is_valid_cluster_id, is_valid_command_id,
+                                               is_valid_device_type_id)
 from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from mobly import asserts
 
@@ -39,29 +41,33 @@ class TestIdChecks(MatterBaseTest):
             id_type = device_type_id_type(id)
             msg = f"Incorrect device type range assessment, expecting standard {id:08x}, type = {id_type}"
             asserts.assert_equal(device_type_id_type(id), DeviceTypeIdType.kStandard, msg)
-            asserts.assert_true(is_valid_device_type_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_device_type_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_device_type_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_device_type_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_device_type_id(id), msg)
 
         def check_manufacturer(id):
             id_type = device_type_id_type(id)
             msg = f"Incorrect device type range assessment, expecting manufacturer {id:08x}, type = {id_type}"
             asserts.assert_equal(device_type_id_type(id), DeviceTypeIdType.kManufacturer, msg)
-            asserts.assert_true(is_valid_device_type_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_device_type_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_device_type_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_device_type_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_device_type_id(id), msg)
 
         def check_test(id):
             id_type = device_type_id_type(id)
             msg = f"Incorrect device type range assessment, expecting test {id:08x}, type = {id_type}"
             asserts.assert_equal(device_type_id_type(id), DeviceTypeIdType.kTest, msg)
-            asserts.assert_true(is_valid_device_type_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_device_type_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_device_type_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_device_type_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_device_type_id(id), msg)
 
         def check_all_bad(id):
             id_type = device_type_id_type(id)
             msg = f"Incorrect device type range assessment, expecting invalid {id:08x}, type = {id_type}"
             asserts.assert_equal(device_type_id_type(id), DeviceTypeIdType.kInvalid, msg)
-            asserts.assert_false(is_valid_device_type_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_device_type_id(id_type, allow_test=False), msg)
+            asserts.assert_false(is_valid_device_type_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_device_type_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_device_type_id(id), msg)
 
         for id in standard_good:
             check_standard(id)
@@ -100,29 +106,33 @@ class TestIdChecks(MatterBaseTest):
             id_type = cluster_id_type(id)
             msg = f"Incorrect cluster range assessment, expecting standard {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, ClusterIdType.kStandard, msg)
-            asserts.assert_true(is_valid_cluster_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_cluster_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_cluster_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_cluster_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_cluster_id(id), msg)
 
         def check_manufacturer(id):
             id_type = cluster_id_type(id)
             msg = f"Incorrect cluster range assessment, expecting manufacturer {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, ClusterIdType.kManufacturer, msg)
-            asserts.assert_true(is_valid_cluster_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_cluster_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_cluster_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_cluster_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_cluster_id(id), msg)
 
         def check_test(id):
             id_type = cluster_id_type(id)
             msg = f"Incorrect cluster range assessment, expecting test {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, ClusterIdType.kTest, msg)
-            asserts.assert_true(is_valid_cluster_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_cluster_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_cluster_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_cluster_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_cluster_id(id), msg)
 
         def check_all_bad(id):
             id_type = cluster_id_type(id)
             msg = f"Incorrect cluster range assessment, expecting invalid {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, ClusterIdType.kInvalid, msg)
-            asserts.assert_false(is_valid_cluster_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_cluster_id(id_type, allow_test=False), msg)
+            asserts.assert_false(is_valid_cluster_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_cluster_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_cluster_id(id), msg)
 
         for id in standard_good:
             check_standard(id)
@@ -160,36 +170,41 @@ class TestIdChecks(MatterBaseTest):
             id_type = attribute_id_type(id)
             msg = f"Incorrect attribute range assessment, expecting standard global {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, AttributeIdType.kStandardGlobal, msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_attribute_id(id), msg)
 
         def check_standard_non_global(id):
             id_type = attribute_id_type(id)
             msg = f"Incorrect attribute range assessment, expecting standard non-global {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, AttributeIdType.kStandardNonGlobal, msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_attribute_id(id), msg)
 
         def check_manufacturer(id):
             id_type = attribute_id_type(id)
             msg = f"Incorrect attribute range assessment, expecting manufacturer {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, AttributeIdType.kManufacturer, msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_attribute_id(id), msg)
 
         def check_test(id):
             id_type = attribute_id_type(id)
             msg = f"Incorrect attribute range assessment, expecting test {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, AttributeIdType.kTest, msg)
-            asserts.assert_true(is_valid_attribute_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_attribute_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_attribute_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_attribute_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_attribute_id(id), msg)
 
         def check_all_bad(id):
             id_type = attribute_id_type(id)
             msg = f"Incorrect attribute range assessment, expecting invalid {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, AttributeIdType.kInvalid, msg)
-            asserts.assert_false(is_valid_attribute_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_attribute_id(id_type, allow_test=False), msg)
+            asserts.assert_false(is_valid_attribute_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_attribute_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_attribute_id(id), msg)
 
         for id in standard_global_good:
             check_standard_global(id)
@@ -225,36 +240,41 @@ class TestIdChecks(MatterBaseTest):
             id_type = command_id_type(id)
             msg = f"Incorrect command range assessment, expecting standard global {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, CommandIdType.kStandardGlobal, msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_command_id(id), msg)
 
         def check_scoped_non_global(id):
             id_type = command_id_type(id)
             msg = f"Incorrect command range assessment, expecting scoped non-global {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, CommandIdType.kScopedNonGlobal, msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=False), msg)
+            asserts.assert_true(is_standard_command_id(id), msg)
 
         def check_manufacturer(id):
             id_type = command_id_type(id)
             msg = f"Incorrect command range assessment, expecting manufacturer {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, CommandIdType.kManufacturer, msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=True), msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=True), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_command_id(id), msg)
 
         def check_test(id):
             id_type = command_id_type(id)
             msg = f"Incorrect command range assessment, expecting test {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, CommandIdType.kTest, msg)
-            asserts.assert_true(is_valid_command_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_command_id(id_type, allow_test=False), msg)
+            asserts.assert_true(is_valid_command_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_command_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_command_id(id), msg)
 
         def check_all_bad(id):
             id_type = command_id_type(id)
             msg = f"Incorrect command range assessment, expecting invalid {id:08x}, type = {id_type}"
             asserts.assert_equal(id_type, CommandIdType.kInvalid, msg)
-            asserts.assert_false(is_valid_command_id(id_type, allow_test=True), msg)
-            asserts.assert_false(is_valid_command_id(id_type, allow_test=False), msg)
+            asserts.assert_false(is_valid_command_id(id, allow_test=True), msg)
+            asserts.assert_false(is_valid_command_id(id, allow_test=False), msg)
+            asserts.assert_false(is_standard_command_id(id), msg)
 
         for id in standard_global_good:
             check_standard_global(id)

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/global_attribute_ids.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/global_attribute_ids.py
@@ -116,7 +116,13 @@ def device_type_id_type(id: int) -> DeviceTypeIdType:
     return DeviceTypeIdType.kInvalid
 
 
-def is_valid_device_type_id(id_type: DeviceTypeIdType, allow_test=False) -> bool:
+def is_standard_device_type_id(id: int) -> bool:
+    id_type = device_type_id_type(id)
+    return id_type == DeviceTypeIdType.kStandard
+
+
+def is_valid_device_type_id(id: int, allow_test=False) -> bool:
+    id_type = device_type_id_type(id)
     valid = [DeviceTypeIdType.kStandard, DeviceTypeIdType.kManufacturer]
     if allow_test:
         valid.append(DeviceTypeIdType.kTest)
@@ -133,7 +139,13 @@ def cluster_id_type(id: int) -> ClusterIdType:
     return ClusterIdType.kInvalid
 
 
-def is_valid_cluster_id(id_type: ClusterIdType, allow_test: bool = False) -> bool:
+def is_standard_cluster_id(id: int) -> bool:
+    id_type = cluster_id_type(id)
+    return id_type in [ClusterIdType.kStandard]
+
+
+def is_valid_cluster_id(id: int, allow_test: bool = False) -> bool:
+    id_type = cluster_id_type(id)
     valid = [ClusterIdType.kStandard, ClusterIdType.kManufacturer]
     if allow_test:
         valid.append(ClusterIdType.kTest)
@@ -152,11 +164,17 @@ def attribute_id_type(id: int) -> AttributeIdType:
     return AttributeIdType.kInvalid
 
 
-def is_valid_attribute_id(id_type: AttributeIdType, allow_test: bool = False):
+def is_valid_attribute_id(id: int, allow_test: bool = False):
+    id_type = attribute_id_type(id)
     valid = [AttributeIdType.kStandardGlobal, AttributeIdType.kStandardNonGlobal, AttributeIdType.kManufacturer]
     if allow_test:
         valid.append(AttributeIdType.kTest)
     return id_type in valid
+
+
+def is_standard_attribute_id(id: int):
+    id_type = attribute_id_type(id)
+    return id_type in [AttributeIdType.kStandardGlobal, AttributeIdType.kStandardNonGlobal]
 
 
 def command_id_type(id: int) -> CommandIdType:
@@ -171,7 +189,13 @@ def command_id_type(id: int) -> CommandIdType:
     return CommandIdType.kInvalid
 
 
-def is_valid_command_id(id_type: CommandIdType, allow_test: bool = False):
+def is_standard_command_id(id: int):
+    id_type = command_id_type(id)
+    return id_type in [CommandIdType.kScopedNonGlobal, CommandIdType.kStandardGlobal]
+
+
+def is_valid_command_id(id: int, allow_test: bool = False):
+    id_type = command_id_type(id)
     valid = [CommandIdType.kStandardGlobal, CommandIdType.kScopedNonGlobal, CommandIdType.kManufacturer]
     if allow_test:
         valid.append(CommandIdType.kTest)

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/global_attribute_ids.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/global_attribute_ids.py
@@ -141,7 +141,7 @@ def cluster_id_type(id: int) -> ClusterIdType:
 
 def is_standard_cluster_id(id: int) -> bool:
     id_type = cluster_id_type(id)
-    return id_type in [ClusterIdType.kStandard]
+    return id_type == ClusterIdType.kStandard
 
 
 def is_valid_cluster_id(id: int, allow_test: bool = False) -> bool:


### PR DESCRIPTION
- Add functions to say whether an ID is in the standard range
- simplify API to accept an int ID rather than the enum since this is how they appear on the device.
- fix tests

TEST: see unit test

