### PR TITLE
Don't use default ctor for ChipDeviceEvent

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -452,8 +452,7 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
         publisher->mState = State::kInitialized;
 
         // Post an event that will start advertising
-        DeviceLayer::ChipDeviceEvent event;
-        event.Type = DeviceLayer::DeviceEventType::kDnssdInitialized;
+        DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kDnssdInitialized };
 
         CHIP_ERROR error = DeviceLayer::PlatformMgr().PostEvent(&event);
         if (error != CHIP_NO_ERROR)
@@ -477,8 +476,7 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
         // Restore dnssd state before restart, also needs to call ChipDnssdShutdown()
         publisher->Shutdown();
 
-        DeviceLayer::ChipDeviceEvent event;
-        event.Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded;
+        DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded };
         error      = DeviceLayer::PlatformMgr().PostEvent(&event);
 
         if (error != CHIP_NO_ERROR)

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -477,7 +477,7 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
         publisher->Shutdown();
 
         DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kDnssdRestartNeeded };
-        error      = DeviceLayer::PlatformMgr().PostEvent(&event);
+        error = DeviceLayer::PlatformMgr().PostEvent(&event);
 
         if (error != CHIP_NO_ERROR)
         {

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -81,8 +81,7 @@ void PairingSession::Finish()
     if (err == CHIP_NO_ERROR)
     {
         VerifyOrDie(mSecureSessionHolder);
-        DeviceLayer::ChipDeviceEvent event;
-        event.Type                                   = DeviceLayer::DeviceEventType::kSecureSessionEstablished;
+        DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kSecureSessionEstablished };
         event.SecureSessionEstablished.TransportType = to_underlying(address.GetTransportType());
         event.SecureSessionEstablished.SecureSessionType =
             to_underlying(mSecureSessionHolder->AsSecureSession()->GetSecureSessionType());


### PR DESCRIPTION
This PR updates the instantiation of `ChipDeviceEvent` to avoid using the default constructor. This fixes some build errors such as:

```
src/protocols/secure_channel/PairingSession.cpp:84:38: error: call to implicitly-deleted default constructor of 'DeviceLayer::ChipDeviceEvent'
   84 |         DeviceLayer::ChipDeviceEvent event;
      |                                      ^
src/include/platform/CHIPDeviceEvent.h:499:11: note: default constructor of 'ChipDeviceEvent' is implicitly deleted because variant field 'CHIPoBLEConnectionError' has a non-trivial default constructor
  499 |         } CHIPoBLEConnectionError;
      |           ^
1 error generated.
```