### PR TITLE
Wait at least max_report_interval_sec for subscription report update

### DIFF
--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -166,7 +166,7 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
             nodeid=self.dut_node_id,
             attributes=subscription_contents,
             reportInterval=(min_report_interval_sec, max_report_interval_sec),
-            keepSubscriptions=False
+            keepSubscriptions=True
         )
 
         parts_list_queue = queue.Queue()

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -173,7 +173,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
             nodeid=self.dut_node_id,
             attributes=parts_list_subscription_contents,
             reportInterval=(min_report_interval_sec, max_report_interval_sec),
-            keepSubscriptions=False
+            keepSubscriptions=True
         )
 
         parts_list_queue = queue.Queue()
@@ -249,6 +249,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         await self.default_controller.CommissionOnNetwork(nodeId=self.th_server_local_nodeid, setupPinCode=passcode, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=discriminator)
 
         self.step(6)
+        max_report_interval_sec = 10
         cadmin_subscription_contents = [
             (newly_added_endpoint, Clusters.AdministratorCommissioning)
         ]
@@ -256,7 +257,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
             nodeid=self.dut_node_id,
             attributes=cadmin_subscription_contents,
             reportInterval=(min_report_interval_sec, max_report_interval_sec),
-            keepSubscriptions=False
+            keepSubscriptions=True
         )
 
         cadmin_queue = queue.Queue()
@@ -282,7 +283,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
                              current_fabric_index, "AdminFabricIndex is unexpected")
 
         self.step(10)
-        report_waiting_timeout_delay_sec = 10
+        report_waiting_timeout_delay_sec = max_report_interval_sec + 1
         logging.info("Waiting for update to AdministratorCommissioning attributes.")
         start_time = time.time()
         elapsed = 0


### PR DESCRIPTION
We discovered that the TH might fail to receive the subscription report update before the timeout in in MCORE-FS-1.5 step 10
 
1. Set keepSubscriptions = True for attribute subscriptions to align with the example app and accelerate test execution.
2. Ensure we wait at least max_report_interval_sec before timing out for a subscription report update.