### PR TITLE
[Fabric-Sync] Add --enable-icd-registration option to pair-device command

### DIFF
--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -669,12 +669,12 @@ void PairingManager::ResetForNextCommand()
 {
     mCommissioningWindowDelegate = nullptr;
     mPairingDelegate             = nullptr;
-    mNodeId         = chip::kUndefinedNodeId;
-    mVerifier       = chip::ByteSpan();
-    mSalt           = chip::ByteSpan();
-    mDiscriminator  = 0;
-    mSetupPINCode   = 0;
-    mDeviceIsICD    = false;
+    mNodeId                      = chip::kUndefinedNodeId;
+    mVerifier                    = chip::ByteSpan();
+    mSalt                        = chip::ByteSpan();
+    mDiscriminator               = 0;
+    mSetupPINCode                = 0;
+    mDeviceIsICD                 = false;
 
     memset(mRandomGeneratedICDSymmetricKey, 0, sizeof(mRandomGeneratedICDSymmetricKey));
     memset(mVerifierBuffer, 0, sizeof(mVerifierBuffer));

--- a/examples/fabric-sync/admin/PairingManager.cpp
+++ b/examples/fabric-sync/admin/PairingManager.cpp
@@ -572,8 +572,10 @@ void PairingManager::InitPairingCommand()
     mDeviceIsICD = false;
 }
 
-CHIP_ERROR PairingManager::PairDeviceWithCode(NodeId nodeId, const char * payload)
+CHIP_ERROR PairingManager::PairDeviceWithCode(NodeId nodeId, const char * payload, bool icdRegistration)
 {
+    mICDRegistration.SetValue(icdRegistration);
+
     if (payload == nullptr || strlen(payload) > kMaxManualCodeLength + 1)
     {
         ChipLogError(NotSpecified, "PairDeviceWithCode failed: Invalid pairing payload");
@@ -661,6 +663,37 @@ CHIP_ERROR PairingManager::UnpairDevice(NodeId nodeId)
             ChipLogError(NotSpecified, "Failed to unpair device, error: %s", ErrorStr(err));
         }
     });
+}
+
+void PairingManager::ResetForNextCommand()
+{
+    mCommissioningWindowDelegate = nullptr;
+    mPairingDelegate             = nullptr;
+    mNodeId         = chip::kUndefinedNodeId;
+    mVerifier       = chip::ByteSpan();
+    mSalt           = chip::ByteSpan();
+    mDiscriminator  = 0;
+    mSetupPINCode   = 0;
+    mDeviceIsICD    = false;
+
+    memset(mRandomGeneratedICDSymmetricKey, 0, sizeof(mRandomGeneratedICDSymmetricKey));
+    memset(mVerifierBuffer, 0, sizeof(mVerifierBuffer));
+    memset(mSaltBuffer, 0, sizeof(mSaltBuffer));
+    memset(mRemoteIpAddr, 0, sizeof(mRemoteIpAddr));
+    memset(mOnboardingPayload, 0, sizeof(mOnboardingPayload));
+
+    mICDRegistration.ClearValue();
+    mICDCheckInNodeId.ClearValue();
+    mICDClientType.ClearValue();
+    mICDSymmetricKey.ClearValue();
+    mICDMonitoredSubject.ClearValue();
+    mICDStayActiveDurationMsec.ClearValue();
+
+    mWindowOpener.reset();
+    mOnOpenCommissioningWindowCallback.Cancel();
+    mOnOpenCommissioningWindowVerifierCallback.Cancel();
+    mCurrentFabricRemover.reset();
+    mCurrentFabricRemoveCallback.Cancel();
 }
 
 } // namespace admin

--- a/examples/fabric-sync/admin/PairingManager.h
+++ b/examples/fabric-sync/admin/PairingManager.h
@@ -106,10 +106,11 @@ public:
      *
      * @param nodeId The target node ID for pairing.
      * @param payload The setup code payload, which typically contains device-specific pairing information.
+     * @param icdRegistration The boolean value to set for mICDRegistration.*
      *
      * @return CHIP_NO_ERROR on successful initiation of the pairing process, or an appropriate CHIP_ERROR if pairing fails.
      */
-    CHIP_ERROR PairDeviceWithCode(chip::NodeId nodeId, const char * payload);
+    CHIP_ERROR PairDeviceWithCode(chip::NodeId nodeId, const char * payload, bool icdRegistration = false);
 
     /**
      * Pairs a device using its setup PIN code and remote IP address.
@@ -131,6 +132,12 @@ public:
      * @return CHIP_NO_ERROR if the device is successfully unpaired, or an appropriate CHIP_ERROR if the process fails.
      */
     CHIP_ERROR UnpairDevice(chip::NodeId nodeId);
+
+    /**
+     * Resets the PairingManager's internal state to a baseline, making it ready to handle a new command.
+     * This method clears all internal states and resets all members to their initial values.
+     */
+    void ResetForNextCommand();
 
 private:
     // Constructors

--- a/examples/fabric-sync/shell/AddBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/AddBridgeCommand.cpp
@@ -71,6 +71,7 @@ void AddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 

--- a/examples/fabric-sync/shell/AddDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/AddDeviceCommand.cpp
@@ -59,6 +59,7 @@ void AddDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 

--- a/examples/fabric-sync/shell/PairDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/PairDeviceCommand.cpp
@@ -25,7 +25,9 @@ using namespace ::chip;
 
 namespace commands {
 
-PairDeviceCommand::PairDeviceCommand(chip::NodeId nodeId, const char * payload) : mNodeId(nodeId), mPayload(payload) {}
+PairDeviceCommand::PairDeviceCommand(chip::NodeId nodeId, const char * payload, bool enableICDRegistration) :
+    mNodeId(nodeId), mPayload(payload), mEnableICDRegistration(enableICDRegistration)
+{}
 
 void PairDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
 {
@@ -57,6 +59,7 @@ void PairDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 
@@ -74,7 +77,7 @@ CHIP_ERROR PairDeviceCommand::RunCommand()
 
     admin::PairingManager::Instance().SetPairingDelegate(this);
 
-    return admin::PairingManager::Instance().PairDeviceWithCode(mNodeId, mPayload);
+    return admin::PairingManager::Instance().PairDeviceWithCode(mNodeId, mPayload, mEnableICDRegistration);
 }
 
 } // namespace commands

--- a/examples/fabric-sync/shell/PairDeviceCommand.h
+++ b/examples/fabric-sync/shell/PairDeviceCommand.h
@@ -26,13 +26,14 @@ namespace commands {
 class PairDeviceCommand : public Command, public admin::PairingDelegate
 {
 public:
-    PairDeviceCommand(chip::NodeId nodeId, const char * payload);
+    PairDeviceCommand(chip::NodeId nodeId, const char * payload, bool enableICDRegistration);
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR err) override;
     CHIP_ERROR RunCommand() override;
 
 private:
     chip::NodeId mNodeId;
     const char * mPayload;
+    bool mEnableICDRegistration;
 };
 
 } // namespace commands

--- a/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveBridgeCommand.cpp
@@ -46,6 +46,7 @@ void RemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 

--- a/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/RemoveDeviceCommand.cpp
@@ -47,6 +47,7 @@ void RemoveDeviceCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 

--- a/examples/fabric-sync/shell/SyncDeviceCommand.cpp
+++ b/examples/fabric-sync/shell/SyncDeviceCommand.cpp
@@ -92,6 +92,7 @@ void SyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERROR err)
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    admin::PairingManager::Instance().ResetForNextCommand();
     CommandRegistry::Instance().ResetActiveCommand();
 }
 


### PR DESCRIPTION
Add --enable-icd-registration option to 'app pair-device' command, this it will be required for TC_BRBINFO_4_1

