### PR TITLE
chip-tool: DeviceScanner.cpp should be ifdef'd for Darwin

### DIFF
--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "DeviceScanner.h"
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
 
 using namespace chip;
 using namespace chip::Dnssd;
@@ -243,3 +244,5 @@ DeviceScanner & GetDeviceScanner()
     static DeviceScanner scanner;
     return scanner;
 }
+
+#endif // CHIP_DEVICE_LAYER_TARGET_DARWIN


### PR DESCRIPTION
`#if CHIP_DEVICE_LAYER_TARGET_DARWIN` is used in the header file `DeviceScanner.h` to exclude code from building for other targets but it's not used in `DeviceScanner.cpp`. This causes build failures for non-Darwin targets because some types, such as `DeviceScanner` are defined in the header and referred to in the .cpp file.

This PR fixes it by enclosing the code in the cpp file between  `CHIP_DEVICE_LAYER_TARGET_DARWIN`.
