### PR TITLE
Fix missing include in platform/Linux/DeviceInstanceInfoProviderImpl.cpp

### DIFF
--- a/src/platform/Linux/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInstanceInfoProviderImpl.cpp
@@ -19,6 +19,7 @@
 #include "DeviceInstanceInfoProviderImpl.h"
 
 #include <platform/Linux/PosixConfig.h>
+#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
It needs to include `platform/internal/GenericDeviceInstanceInfoProvider.ipp` to avoid errors, such as:

```
ld: error: undefined symbol: chip::DeviceLayer::Internal::GenericDeviceInstanceInfoProvider<chip::DeviceLayer::Internal::PosixConfig>::GetVendorName(char*, unsigned long)
>>> referenced by DeviceInstanceInfoProviderImpl.cpp
```


