### PR TITLE
Protect against invalid enums being returned

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,14 +66,20 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
+                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                 : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
+                                  : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                  : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -113,16 +119,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-        NSStringFromClass(self.class), self,
-        _deviceController.compressedFabricID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        [self vendorID],
-        [self productID],
-        wifi,
-        thread,
-        _deviceController.uniqueIdentifier,
-        (unsigned long) self.state];
+                     NSStringFromClass(self.class), self,
+                     _deviceController.compressedFabricID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     [self vendorID],
+                     [self productID],
+                     wifi,
+                     thread,
+                     _deviceController.uniqueIdentifier,
+                     (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -317,14 +323,14 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 {
     NSNumber * stateNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceState], NSNumber);
     switch (static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) {
-        case MTRDeviceStateUnknown:
-            return MTRDeviceStateUnknown;
+    case MTRDeviceStateUnknown:
+        return MTRDeviceStateUnknown;
 
-        case MTRDeviceStateUnreachable:
-            return MTRDeviceStateUnreachable;
+    case MTRDeviceStateUnreachable:
+        return MTRDeviceStateUnreachable;
 
-        case MTRDeviceStateReachable:
-            return MTRDeviceStateReachable;
+    case MTRDeviceStateReachable:
+        return MTRDeviceStateReachable;
     }
 
     return MTRDeviceStateUnknown;
@@ -349,18 +355,40 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
-    ReadAttributeResponseType,
-    nil,
-    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID params
+                                     : (MTRReadParams * _Nullable) params,
+                                     ReadAttributeResponseType,
+                                     nil,
+                                     readAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID params
+                                     : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID value
+                                     : (id) value expectedValueInterval
+                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
+                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID value
+                                     : value expectedValueInterval
+                                     : expectedValueInterval timedWriteTimeout
+                                     : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-    ReadAttributePathsResponseType,
-    [NSArray array], // Default return value
-    readAttributePaths : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
+                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+                                     ReadAttributePathsResponseType,
+                                     [NSArray array], // Default return value
+                                     readAttributePaths
+                                     : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,20 +66,14 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
-                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                 : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
-                                  : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                  : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -119,16 +113,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-                     NSStringFromClass(self.class), self,
-                     _deviceController.compressedFabricID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     [self vendorID],
-                     [self productID],
-                     wifi,
-                     thread,
-                     _deviceController.uniqueIdentifier,
-                     (unsigned long) self.state];
+        NSStringFromClass(self.class), self,
+        _deviceController.compressedFabricID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        [self vendorID],
+        [self productID],
+        wifi,
+        thread,
+        _deviceController.uniqueIdentifier,
+        (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -333,6 +327,8 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
         return MTRDeviceStateReachable;
     }
 
+    MTR_LOG_ERROR("stateNumber from internal state is an invalid value: %@", stateNumber);
+
     return MTRDeviceStateUnknown;
 }
 
@@ -355,40 +351,18 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID params
-                                     : (MTRReadParams * _Nullable) params,
-                                     ReadAttributeResponseType,
-                                     nil,
-                                     readAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID params
-                                     : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
+    ReadAttributeResponseType,
+    nil,
+    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID value
-                                     : (id) value expectedValueInterval
-                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
-                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID value
-                                     : value expectedValueInterval
-                                     : expectedValueInterval timedWriteTimeout
-                                     : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
-                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-                                     ReadAttributePathsResponseType,
-                                     [NSArray array], // Default return value
-                                     readAttributePaths
-                                     : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+    ReadAttributePathsResponseType,
+    [NSArray array], // Default return value
+    readAttributePaths : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -323,14 +323,14 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 {
     NSNumber * stateNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceState], NSNumber);
     switch (static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) {
-        case MTRDeviceStateUnknown:
-            return MTRDeviceStateUnknown;
+    case MTRDeviceStateUnknown:
+        return MTRDeviceStateUnknown;
 
-        case MTRDeviceStateUnreachable:
-            return MTRDeviceStateUnreachable;
+    case MTRDeviceStateUnreachable:
+        return MTRDeviceStateUnreachable;
 
-        case MTRDeviceStateReachable:
-            return MTRDeviceStateReachable;
+    case MTRDeviceStateReachable:
+        return MTRDeviceStateReachable;
     }
 
     return MTRDeviceStateUnknown;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -323,14 +323,14 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 {
     NSNumber * stateNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceState], NSNumber);
     switch (static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) {
-    case MTRDeviceStateUnknown:
-        return MTRDeviceStateUnknown;
+        case MTRDeviceStateUnknown:
+            return MTRDeviceStateUnknown;
 
-    case MTRDeviceStateUnreachable:
-        return MTRDeviceStateUnreachable;
+        case MTRDeviceStateUnreachable:
+            return MTRDeviceStateUnreachable;
 
-    case MTRDeviceStateReachable:
-        return MTRDeviceStateReachable;
+        case MTRDeviceStateReachable:
+            return MTRDeviceStateReachable;
     }
 
     return MTRDeviceStateUnknown;

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,14 +66,20 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
+                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                 : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
+                                  : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                  : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -113,16 +119,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-        NSStringFromClass(self.class), self,
-        _deviceController.compressedFabricID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        [self vendorID],
-        [self productID],
-        wifi,
-        thread,
-        _deviceController.uniqueIdentifier,
-        (unsigned long) self.state];
+                     NSStringFromClass(self.class), self,
+                     _deviceController.compressedFabricID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     [self vendorID],
+                     [self productID],
+                     wifi,
+                     thread,
+                     _deviceController.uniqueIdentifier,
+                     (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -338,18 +344,40 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
-    ReadAttributeResponseType,
-    nil,
-    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID params
+                                     : (MTRReadParams * _Nullable) params,
+                                     ReadAttributeResponseType,
+                                     nil,
+                                     readAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID params
+                                     : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID value
+                                     : (id) value expectedValueInterval
+                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
+                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID value
+                                     : value expectedValueInterval
+                                     : expectedValueInterval timedWriteTimeout
+                                     : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-    ReadAttributePathsResponseType,
-    [NSArray array], // Default return value
-    readAttributePaths : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
+                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+                                     ReadAttributePathsResponseType,
+                                     [NSArray array], // Default return value
+                                     readAttributePaths
+                                     : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,20 +66,14 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
-                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                 : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
-                                  : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                  : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -119,16 +113,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-                     NSStringFromClass(self.class), self,
-                     _deviceController.compressedFabricID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     [self vendorID],
-                     [self productID],
-                     wifi,
-                     thread,
-                     _deviceController.uniqueIdentifier,
-                     (unsigned long) self.state];
+        NSStringFromClass(self.class), self,
+        _deviceController.compressedFabricID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        [self vendorID],
+        [self productID],
+        wifi,
+        thread,
+        _deviceController.uniqueIdentifier,
+        (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -322,7 +316,18 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 - (MTRDeviceState)state
 {
     NSNumber * stateNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceState], NSNumber);
-    return stateNumber ? MIN(MTRDeviceStateUnreachable, static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) : MTRDeviceStateUnknown;
+    switch (static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) {
+        case MTRDeviceStateUnknown:
+            return MTRDeviceStateUnknown;
+
+        case MTRDeviceStateUnreachable:
+            return MTRDeviceStateUnreachable;
+
+        case MTRDeviceStateReachable:
+            return MTRDeviceStateReachable;
+    }
+
+    return MTRDeviceStateUnknown;
 }
 
 - (BOOL)deviceCachePrimed
@@ -344,40 +349,18 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID params
-                                     : (MTRReadParams * _Nullable) params,
-                                     ReadAttributeResponseType,
-                                     nil,
-                                     readAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID params
-                                     : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
+    ReadAttributeResponseType,
+    nil,
+    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID value
-                                     : (id) value expectedValueInterval
-                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
-                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID value
-                                     : value expectedValueInterval
-                                     : expectedValueInterval timedWriteTimeout
-                                     : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
-                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-                                     ReadAttributePathsResponseType,
-                                     [NSArray array], // Default return value
-                                     readAttributePaths
-                                     : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+    ReadAttributePathsResponseType,
+    [NSArray array], // Default return value
+    readAttributePaths : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,14 +66,20 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
+                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                 : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
+                                  : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
+                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
+                                  : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -113,16 +119,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-        NSStringFromClass(self.class), self,
-        _deviceController.compressedFabricID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        _nodeID.unsignedLongLongValue,
-        [self vendorID],
-        [self productID],
-        wifi,
-        thread,
-        _deviceController.uniqueIdentifier,
-        (unsigned long) self.state];
+                     NSStringFromClass(self.class), self,
+                     _deviceController.compressedFabricID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     _nodeID.unsignedLongLongValue,
+                     [self vendorID],
+                     [self productID],
+                     wifi,
+                     thread,
+                     _deviceController.uniqueIdentifier,
+                     (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -351,18 +357,40 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
-    ReadAttributeResponseType,
-    nil,
-    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID params
+                                     : (MTRReadParams * _Nullable) params,
+                                     ReadAttributeResponseType,
+                                     nil,
+                                     readAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID params
+                                     : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
+                                     : (NSNumber *) endpointID clusterID
+                                     : (NSNumber *) clusterID attributeID
+                                     : (NSNumber *) attributeID value
+                                     : (id) value expectedValueInterval
+                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
+                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
+                                     : endpointID clusterID
+                                     : clusterID attributeID
+                                     : attributeID value
+                                     : value expectedValueInterval
+                                     : expectedValueInterval timedWriteTimeout
+                                     : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-    ReadAttributePathsResponseType,
-    [NSArray array], // Default return value
-    readAttributePaths : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
+                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+                                     ReadAttributePathsResponseType,
+                                     [NSArray array], // Default return value
+                                     readAttributePaths
+                                     : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -66,20 +66,14 @@
 
 #import <os/lock.h>
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController \
-                                 : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                 : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_GETTER(NAME, TYPE, DEFAULT_VALUE, GETTER_NAME) \
+    MTR_SIMPLE_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], NAME, TYPE, DEFAULT_VALUE, GETTER_NAME, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                                         \
-                                  : [self nodeID])
+#define MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS) \
+    MTR_COMPLEX_REMOTE_XPC_GETTER([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], SIGNATURE, TYPE, DEFAULT_VALUE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
-#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS)                                                                            \
-    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController \
-                                  : [[self deviceController] uniqueIdentifier] nodeID                                                                           \
-                                  : [self nodeID])
+#define MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS) \
+    MTR_SIMPLE_REMOTE_XPC_COMMAND([(MTRDeviceController_XPC *) [self deviceController] xpcConnection], METHOD_SIGNATURE, ADDITIONAL_ARGUMENTS, deviceController : [[self deviceController] uniqueIdentifier] nodeID : [self nodeID])
 
 @implementation MTRDevice_XPC
 
@@ -119,16 +113,16 @@
     // MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyLastSubscriptionFailureTime, _lastSubscriptionFailureTimeForDescription, properties);
 
     return [NSString stringWithFormat:@"<%@: %p, node: %016llX-%016llX (%llu), VID: %@, PID: %@, WiFi: %@, Thread: %@, controller: %@ state: %lu>",
-                     NSStringFromClass(self.class), self,
-                     _deviceController.compressedFabricID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     _nodeID.unsignedLongLongValue,
-                     [self vendorID],
-                     [self productID],
-                     wifi,
-                     thread,
-                     _deviceController.uniqueIdentifier,
-                     (unsigned long) self.state];
+        NSStringFromClass(self.class), self,
+        _deviceController.compressedFabricID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        _nodeID.unsignedLongLongValue,
+        [self vendorID],
+        [self productID],
+        wifi,
+        thread,
+        _deviceController.uniqueIdentifier,
+        (unsigned long) self.state];
 }
 
 - (nullable NSNumber *)vendorID
@@ -322,7 +316,7 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 - (MTRDeviceState)state
 {
     NSNumber * stateNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceState], NSNumber);
-    return stateNumber ? static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue) : MTRDeviceStateUnknown;
+    return stateNumber ? MIN(MTRDeviceStateUnreachable, static_cast<MTRDeviceState>(stateNumber.unsignedIntegerValue)) : MTRDeviceStateUnknown;
 }
 
 - (BOOL)deviceCachePrimed
@@ -344,40 +338,18 @@ static const auto * optionalInternalStateKeys = @[ kMTRDeviceInternalPropertyKey
 #pragma mark - Remote Commands
 
 typedef NSDictionary<NSString *, id> * _Nullable ReadAttributeResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID params
-                                     : (MTRReadParams * _Nullable) params,
-                                     ReadAttributeResponseType,
-                                     nil,
-                                     readAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID params
-                                     : params withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID params : (MTRReadParams * _Nullable) params,
+    ReadAttributeResponseType,
+    nil,
+    readAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID params : params withReply)
 
-MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID
-                                     : (NSNumber *) endpointID clusterID
-                                     : (NSNumber *) clusterID attributeID
-                                     : (NSNumber *) attributeID value
-                                     : (id) value expectedValueInterval
-                                     : (NSNumber *) expectedValueInterval timedWriteTimeout
-                                     : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID
-                                     : endpointID clusterID
-                                     : clusterID attributeID
-                                     : attributeID value
-                                     : value expectedValueInterval
-                                     : expectedValueInterval timedWriteTimeout
-                                     : timeout)
+MTR_DEVICE_SIMPLE_REMOTE_XPC_COMMAND(writeAttributeWithEndpointID : (NSNumber *) endpointID clusterID : (NSNumber *) clusterID attributeID : (NSNumber *) attributeID value : (id) value expectedValueInterval : (NSNumber *) expectedValueInterval timedWriteTimeout : (NSNumber * _Nullable) timeout, writeAttributeWithEndpointID : endpointID clusterID : clusterID attributeID : attributeID value : value expectedValueInterval : expectedValueInterval timedWriteTimeout : timeout)
 
 typedef NSArray<NSDictionary<NSString *, id> *> * ReadAttributePathsResponseType;
-MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
-                                     : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
-                                     ReadAttributePathsResponseType,
-                                     [NSArray array], // Default return value
-                                     readAttributePaths
-                                     : attributePaths withReply)
+MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths : (NSArray<MTRAttributeRequestPath *> *) attributePaths,
+    ReadAttributePathsResponseType,
+    [NSArray array], // Default return value
+    readAttributePaths : attributePaths withReply)
 
 - (void)_invokeCommandWithEndpointID:(NSNumber *)endpointID
                            clusterID:(NSNumber *)clusterID


### PR DESCRIPTION
Had a crash reported where we're responding the wrong state, this is the only spot that can happen, so adding protection here.