### PR TITLE
Adding string builder adapters for Milliseconds64 and Microseconds64

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -119,6 +119,7 @@ ALLOW: Dict[str, Set[str]] = {
     # Only uses <chrono> for zero-cost types.
     'src/system/SystemClock.h': {'chrono'},
     'src/platform/mbed/MbedEventTimeout.h': {'chrono'},
+    'src/lib/core/StringBuilderAdapters.h': {'chrono'},
 
     'src/app/app-platform/ContentApp.h': {'list', 'string'},
     'src/app/app-platform/ContentAppPlatform.cpp': {'string'},

--- a/src/lib/core/StringBuilderAdapters.cpp
+++ b/src/lib/core/StringBuilderAdapters.cpp
@@ -32,14 +32,16 @@ template <>
 StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time,
                                                                      pw::span<char> buffer)
 {
-    return pw::string::Format(buffer, "%llums", time.count());
+    // Cast to llu because some platforms use lu and others use llu.
+    return pw::string::Format(buffer, "%llums", static_cast<long long unsigned int>(time.count()));
 }
 
 template <>
 StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time,
                                                                      pw::span<char> buffer)
 {
-    return pw::string::Format(buffer, "%lluus", time.count());
+    // Cast to llu because some platforms use lu and others use llu.
+    return pw::string::Format(buffer, "%lluus", static_cast<long long unsigned int>(time.count()));
 }
 
 } // namespace pw

--- a/src/lib/core/StringBuilderAdapters.cpp
+++ b/src/lib/core/StringBuilderAdapters.cpp
@@ -29,13 +29,15 @@ StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffe
 }
 
 template <>
-StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time, pw::span<char> buffer)
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time,
+                                                                     pw::span<char> buffer)
 {
     return pw::string::Format(buffer, "%llums", time.count());
 }
 
 template <>
-StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time, pw::span<char> buffer)
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time,
+                                                                     pw::span<char> buffer)
 {
     return pw::string::Format(buffer, "%lluus", time.count());
 }

--- a/src/lib/core/StringBuilderAdapters.cpp
+++ b/src/lib/core/StringBuilderAdapters.cpp
@@ -28,6 +28,18 @@ StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffe
     return pw::string::Format(buffer, "CHIP_ERROR:<%" CHIP_ERROR_FORMAT ">", err.Format());
 }
 
+template <>
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time, pw::span<char> buffer)
+{
+    return pw::string::Format(buffer, "%llums", time.count());
+}
+
+template <>
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time, pw::span<char> buffer)
+{
+    return pw::string::Format(buffer, "%lluus", time.count());
+}
+
 } // namespace pw
 
 #if CHIP_CONFIG_TEST_GOOGLETEST
@@ -42,5 +54,16 @@ void PrintTo(const CHIP_ERROR & err, std::ostream * os)
     }
     *os << "CHIP_ERROR:<" << err.Format() << ">";
 }
+
+void PrintTo(const std::chrono::duration<uint64_t, std::milli> & time, std::ostream * os)
+{
+    *os << time.count() << "ms";
+}
+
+void PrintTo(const std::chrono::duration<uint64_t, std::micro> & time, std::ostream * os)
+{
+    *os << time.count() << "us";
+}
+
 } // namespace chip
 #endif // CHIP_CONFIG_TEST_GOOGLETEST

--- a/src/lib/core/StringBuilderAdapters.h
+++ b/src/lib/core/StringBuilderAdapters.h
@@ -41,6 +41,8 @@
 ///    Expected: .... == CHIP_ERROR(0, "src/setup_payload/tests/TestAdditionalDataPayload.cpp", 234)
 ///    Actual: CHIP_ERROR:<src/lib/core/TLVReader.cpp:889: Error 0x00000022> == CHIP_NO_ERROR
 
+#include <chrono>
+
 #include <pw_string/string_builder.h>
 #include <pw_unit_test/framework.h>
 
@@ -50,6 +52,12 @@ namespace pw {
 
 template <>
 StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffer);
+
+// Adapters for chip::System::Clock::Microseconds64 and Milliseconds64
+template <>
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time, pw::span<char> buffer);
+template <>
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time, pw::span<char> buffer);
 
 } // namespace pw
 #if CHIP_CONFIG_TEST_GOOGLETEST
@@ -69,5 +77,10 @@ namespace chip {
 ///
 /// This enhances the readability and diagnostic information in GoogleTest test logs.
 void PrintTo(const CHIP_ERROR & err, std::ostream * os);
+
+// Adapters for chip::System::Clock::Microseconds64 and Milliseconds64
+void PrintTo(const std::chrono::duration<uint64_t, std::milli> & time, std::ostream * os);
+void PrintTo(const std::chrono::duration<uint64_t, std::micro> & time, std::ostream * os);
+
 } // namespace chip
 #endif // CHIP_CONFIG_TEST_GOOGLETEST

--- a/src/lib/core/StringBuilderAdapters.h
+++ b/src/lib/core/StringBuilderAdapters.h
@@ -55,9 +55,11 @@ StatusWithSize ToString<CHIP_ERROR>(const CHIP_ERROR & err, pw::span<char> buffe
 
 // Adapters for chip::System::Clock::Microseconds64 and Milliseconds64
 template <>
-StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time, pw::span<char> buffer);
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::milli>>(const std::chrono::duration<uint64_t, std::milli> & time,
+                                                                     pw::span<char> buffer);
 template <>
-StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time, pw::span<char> buffer);
+StatusWithSize ToString<std::chrono::duration<uint64_t, std::micro>>(const std::chrono::duration<uint64_t, std::micro> & time,
+                                                                     pw::span<char> buffer);
 
 } // namespace pw
 #if CHIP_CONFIG_TEST_GOOGLETEST


### PR DESCRIPTION
Adding string builder adapters for `chip::System::Clock::Milliseconds64` and `Microseconds64`.

Instead of displaying like this:
```
src/platform/tests/TestPlatformTime.cpp:114: Failure
    Expected: Tdelta > (Tdelay - margin)
      Actual: <8-byte object at 0x3ffc1938> > <8-byte object at 0x3ffc1930>
```

A failure will now display like this:
```
src/platform/tests/TestPlatformTime.cpp:114: Failure
    Expected: Tdelta > (Tdelay - margin)
      Actual: 5ms > 8ms
```
