### PR TITLE
[Fabric-Admin] Reset PairingManager state before next command

### DIFF
--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -83,6 +83,7 @@ void FabricSyncAddBridgeCommand::OnCommissioningComplete(NodeId deviceId, CHIP_E
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    PairingManager::Instance().ResetForNextCommand();
     mBridgeNodeId = kUndefinedNodeId;
 }
 
@@ -123,6 +124,7 @@ void FabricSyncRemoveBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_ERROR 
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    PairingManager::Instance().ResetForNextCommand();
     mBridgeNodeId = kUndefinedNodeId;
 }
 
@@ -174,6 +176,7 @@ void FabricSyncAddLocalBridgeCommand::OnCommissioningComplete(NodeId deviceId, C
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    PairingManager::Instance().ResetForNextCommand();
     mLocalBridgeNodeId = kUndefinedNodeId;
 }
 
@@ -215,6 +218,7 @@ void FabricSyncRemoveLocalBridgeCommand::OnDeviceRemoved(NodeId deviceId, CHIP_E
                      ChipLogValueX64(deviceId), err.Format());
     }
 
+    PairingManager::Instance().ResetForNextCommand();
     mLocalBridgeNodeId = kUndefinedNodeId;
 }
 
@@ -290,6 +294,8 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERRO
         ChipLogError(NotSpecified, "Failed to pair synced device (0x:" ChipLogFormatX64 ") with error: %" CHIP_ERROR_FORMAT,
                      ChipLogValueX64(deviceId), err.Format());
     }
+
+    PairingManager::Instance().ResetForNextCommand();    
 }
 
 CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteEndpointId)

--- a/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
+++ b/examples/fabric-admin/commands/fabric-sync/FabricSyncCommand.cpp
@@ -295,7 +295,7 @@ void FabricSyncDeviceCommand::OnCommissioningComplete(NodeId deviceId, CHIP_ERRO
                      ChipLogValueX64(deviceId), err.Format());
     }
 
-    PairingManager::Instance().ResetForNextCommand();    
+    PairingManager::Instance().ResetForNextCommand();
 }
 
 CHIP_ERROR FabricSyncDeviceCommand::RunCommand(EndpointId remoteEndpointId)

--- a/examples/fabric-admin/device_manager/PairingManager.cpp
+++ b/examples/fabric-admin/device_manager/PairingManager.cpp
@@ -661,4 +661,35 @@ CHIP_ERROR PairingManager::UnpairDevice(NodeId nodeId)
     });
 }
 
+void PairingManager::ResetForNextCommand()
+{
+    mCommissioningWindowDelegate = nullptr;
+    mPairingDelegate             = nullptr;
+    mNodeId                      = chip::kUndefinedNodeId;
+    mVerifier                    = chip::ByteSpan();
+    mSalt                        = chip::ByteSpan();
+    mDiscriminator               = 0;
+    mSetupPINCode                = 0;
+    mDeviceIsICD                 = false;
+
+    memset(mRandomGeneratedICDSymmetricKey, 0, sizeof(mRandomGeneratedICDSymmetricKey));
+    memset(mVerifierBuffer, 0, sizeof(mVerifierBuffer));
+    memset(mSaltBuffer, 0, sizeof(mSaltBuffer));
+    memset(mRemoteIpAddr, 0, sizeof(mRemoteIpAddr));
+    memset(mOnboardingPayload, 0, sizeof(mOnboardingPayload));
+
+    mICDRegistration.ClearValue();
+    mICDCheckInNodeId.ClearValue();
+    mICDClientType.ClearValue();
+    mICDSymmetricKey.ClearValue();
+    mICDMonitoredSubject.ClearValue();
+    mICDStayActiveDurationMsec.ClearValue();
+
+    mWindowOpener.reset();
+    mOnOpenCommissioningWindowCallback.Cancel();
+    mOnOpenCommissioningWindowVerifierCallback.Cancel();
+    mCurrentFabricRemover.reset();
+    mCurrentFabricRemoveCallback.Cancel();
+}
+
 } // namespace admin

--- a/examples/fabric-admin/device_manager/PairingManager.h
+++ b/examples/fabric-admin/device_manager/PairingManager.h
@@ -134,6 +134,12 @@ public:
      */
     CHIP_ERROR UnpairDevice(chip::NodeId nodeId);
 
+    /**
+     * Resets the PairingManager's internal state to a baseline, making it ready to handle a new command.
+     * This method clears all internal states and resets all members to their initial values.
+     */
+    void ResetForNextCommand();
+
 private:
     // Constructors
     PairingManager();


### PR DESCRIPTION
Cherry-pick the fix from fabric-sync. After refactoring to use PairingManager to process multiple commands instead of relying on text-based CLI commands, ensure PairingManager state is reset before processing the next command.

