### PR TITLE
[ESP32]: Fixed the documentation related to ScanResponse data usage in application.

### DIFF
--- a/docs/platforms/esp32/ble_settings.md
+++ b/docs/platforms/esp32/ble_settings.md
@@ -13,13 +13,14 @@ advertising packets.
 
 ```
 {
-    uint8_t scanResponse[31]; // 0x05, 0x09, a, b, c, d
-    scanResponse[0] = 0x05;
-    scanResponse[1] = 0x09;
-    scanResponse[2] = 0x61;
-    scanResponse[3] = 0x62;
-    scanResponse[4] = 0x63;
-    scanResponse[5] = 0x64;
+
+    // Max length is 31 bytes
+    // Enter data in (length, type, value) format
+    // 0x05 - length of data
+    // 0x09 - Type (Complete Local Name)
+    // 0x61, 0x62, 0x63, 0x64 - Data (a,b,c,d)
+    uint8_t scanResponse[] = { 0x05, 0x09, 0x61, 0x62, 0x63, 0x64};
+
     chip::ByteSpan data(scanResponse);
     CHIP_ERROR err = chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureScanResponseData(data);
     if (err != CHIP_NO_ERROR)
@@ -27,6 +28,8 @@ advertising packets.
         ESP_LOGE(TAG, "Failed to configure scan response, err:%" CHIP_ERROR_FORMAT, err.Format());
     }
 }
+
+
 ```
 
 Note: Scan response should be configure before `InitServer`.

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -132,7 +132,6 @@ class BLEManagerImpl final : public BLEManager,
 #endif // CONFIG_ENABLE_ESP32_BLE_CONTROLLER
 {
 public:
-    uint8_t scanResponseBuffer[MAX_SCAN_RSP_DATA_LEN];
     BLEManagerImpl() {}
 #ifdef CONFIG_ENABLE_ESP32_BLE_CONTROLLER
     CHIP_ERROR ConfigureBle(uint32_t aAdapterId, bool aIsCentral);
@@ -146,6 +145,7 @@ public:
 
 private:
     chip::Optional<chip::ByteSpan> mScanResponse;
+    uint8_t scanResponseBuffer[MAX_SCAN_RSP_DATA_LEN];
 
     // Allow the BLEManager interface class to delegate method calls to
     // the implementation methods provided by this class.

--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -1118,7 +1118,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureScanResponseData(ByteSpan data)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
     memcpy(scanResponseBuffer, data.data(), data.size());
-    ByteSpan scanResponseSpan(scanResponseBuffer);
+    ByteSpan scanResponseSpan(scanResponseBuffer, data.size());
     mScanResponse = chip::Optional<ByteSpan>(scanResponseSpan);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
**Problem**
- The device was not visible in Scan list when additional manufacturer specific and other data set through the ConfigureScanResponse  for greater lengths of data.

**Change Overview**
-  Fixed the README and tried out with updated changes in the application.

**Testing**
- Tested the guide in ble_settings.md with lighting-app esp32 and verified for greater data lengths with and without the changes 
for the scan list with nrfconnect app.




