### PR TITLE
[Silabs] Refactor network scan wifi abstraction function

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -266,7 +266,15 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
-    return StartNetworkScan(ssid, OnScanWiFiNetworkDone) == CHIP_NO_ERROR;
+    CHIP_ERROR err = StartNetworkScan(ssid, OnScanWiFiNetworkDone);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "StartNetworkScan failed: %s", chip::ErrorStr(err));
+        return false;
+    }
+
+    return true;
 }
 
 void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -265,17 +265,16 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
 
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
-    bool scanStarted = false;
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
-
     return StartNetworkScan(ssid, OnScanWiFiNetworkDone) == CHIP_NO_ERROR;
 }
 
 void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
 {
-    ChipLogProgress(DeviceLayer, "OnScanWiFiNetworkDone");
     if (!aScanResult)
     {
+        ChipLogProgress(DeviceLayer, "OnScanWiFiNetworkDone: Receive all scanned networks information.");
+
         if (GetInstance().mpScanCallback != nullptr)
         {
             if (mScanResponseIter.Count() == 0)

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -267,17 +267,8 @@ bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
     bool scanStarted = false;
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");
-    if (!ssid.empty()) // ssid is given, only scan this network
-    {
-        char cSsid[DeviceLayer::Internal::kMaxWiFiSSIDLength] = {};
-        memcpy(cSsid, ssid.data(), ssid.size());
-        scanStarted = wfx_start_scan(cSsid, OnScanWiFiNetworkDone);
-    }
-    else // scan all networks
-    {
-        scanStarted = wfx_start_scan(nullptr, OnScanWiFiNetworkDone);
-    }
-    return scanStarted;
+
+    return StartNetworkScan(ssid, OnScanWiFiNetworkDone) == CHIP_NO_ERROR;
 }
 
 void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
@@ -309,7 +300,7 @@ void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
         scanResponse.security.Set(GetInstance().ConvertSecuritytype(aScanResult->security));
         scanResponse.channel = aScanResult->chan;
         scanResponse.rssi    = aScanResult->rssi;
-        scanResponse.ssidLen = strnlen(aScanResult->ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);
+        scanResponse.ssidLen = aScanResult->ssid_length;
         memcpy(scanResponse.ssid, aScanResult->ssid, scanResponse.ssidLen);
         memcpy(scanResponse.bssid, aScanResult->bssid, sizeof(scanResponse.bssid));
 

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -21,7 +21,6 @@ import("${chip_root}/third_party/silabs/silabs_board.gni")
 declare_args() {
   # Wifi related stuff - they are overridden by gn -args="use_wf200=true"
   sl_wfx_config_softap = false
-  sl_wfx_config_scan = true
 
   # Argument to force enable WPA3 security on rs91x
   rs91x_wpa3_transition = true
@@ -83,10 +82,6 @@ config("wifi-platform-config") {
 
   if (sl_wfx_config_softap) {
     defines += [ "SL_WFX_CONFIG_SOFTAP" ]
-  }
-
-  if (sl_wfx_config_scan) {
-    defines += [ "SL_WFX_CONFIG_SCAN" ]
   }
 
   if (chip_enable_wifi_ipv4) {

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -205,7 +205,7 @@ constexpr uint16_t kWifiScanTimeoutTicks = 10000;
  */
 sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * result, uint32_t result_length, void * arg)
 {
-    SL_WIFI_ARGS_CHECK_NULL_POINTER(result);
+    VerifyOrReturnError(result != nullptr, SL_STATUS_NULL_POINTER);
     VerifyOrReturnError(wfx_rsi.scan_cb != nullptr, SL_STATUS_INVALID_HANDLE);
 
     uint32_t nbreResults = result->scan_count;
@@ -871,7 +871,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -871,7 +871,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -869,7 +869,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -187,6 +187,7 @@ constexpr uint8_t kAdvActiveScanDuration     = 15;
 constexpr uint8_t kAdvPassiveScanDuration    = 20;
 constexpr uint8_t kAdvMultiProbe             = 1;
 constexpr uint8_t kAdvScanPeriodicity        = 10;
+constexpr uint8_t kAdvEnableInstantbgScan    = 1;
 
 // TODO: Confirm that this value works for size and timing
 constexpr uint8_t kWfxQueueSize = 10;
@@ -745,12 +746,14 @@ void ProcessEvent(WifiPlatformEvent event)
                 wifi_scan_configuration.periodic_scan_interval = kAdvScanPeriodicity;
             }
 
-            sl_wifi_advanced_scan_configuration_t advanced_scan_configuration = { 0 };
-            advanced_scan_configuration.active_channel_time                   = kAdvActiveScanDuration;
-            advanced_scan_configuration.passive_channel_time                  = kAdvPassiveScanDuration;
-            advanced_scan_configuration.trigger_level                         = kAdvScanThreshold;
-            advanced_scan_configuration.trigger_level_change                  = kAdvRssiToleranceThreshold;
-            advanced_scan_configuration.enable_multi_probe                    = kAdvMultiProbe;
+            sl_wifi_advanced_scan_configuration_t advanced_scan_configuration = { .active_channel_time  = kAdvActiveScanDuration,
+                                                                                  .passive_channel_time = kAdvPassiveScanDuration,
+                                                                                  .trigger_level        = kAdvScanThreshold,
+                                                                                  .trigger_level_change =
+                                                                                      kAdvRssiToleranceThreshold,
+                                                                                  .enable_multi_probe  = kAdvMultiProbe,
+                                                                                  .enable_instant_scan = kAdvEnableInstantbgScan };
+
             status = sl_wifi_set_advanced_scan_configuration(&advanced_scan_configuration);
             if (SL_STATUS_OK != status)
             {

--- a/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterface.cpp
@@ -867,7 +867,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -168,11 +168,9 @@ typedef struct wfx_rsi_s
     chip::BitFlags<WifiState> dev_state;
     uint16_t ap_chan; /* The chan our STA is using	*/
     wfx_wifi_provision_t sec;
-#ifdef SL_WFX_CONFIG_SCAN
     ScanCallback scan_cb;
     uint8_t * scan_ssid; /* Which one are we scanning for */
     size_t scan_ssid_length;
-#endif
 #ifdef SL_WFX_CONFIG_SOFTAP
     MacAddress softap_mac;
 #endif

--- a/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
+++ b/src/platform/silabs/wifi/WifiInterfaceAbstraction.h
@@ -131,13 +131,14 @@ typedef enum
 
 typedef struct wfx_wifi_scan_result
 {
-    char ssid[WFX_MAX_SSID_LENGTH + 1];
+    uint8_t ssid[WFX_MAX_SSID_LENGTH]; // excludes null-character
     size_t ssid_length;
     wfx_sec_t security;
     uint8_t bssid[kWifiMacAddressLength];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
 } wfx_wifi_scan_result_t;
+using ScanCallback = void (*)(wfx_wifi_scan_result_t *);
 
 typedef struct wfx_wifi_scan_ext
 {
@@ -168,8 +169,8 @@ typedef struct wfx_rsi_s
     uint16_t ap_chan; /* The chan our STA is using	*/
     wfx_wifi_provision_t sec;
 #ifdef SL_WFX_CONFIG_SCAN
-    void (*scan_cb)(wfx_wifi_scan_result_t *);
-    char * scan_ssid; /* Which one are we scanning for */
+    ScanCallback scan_cb;
+    uint8_t * scan_ssid; /* Which one are we scanning for */
     size_t scan_ssid_length;
 #endif
 #ifdef SL_WFX_CONFIG_SOFTAP
@@ -234,6 +235,22 @@ void NotifyConnection(const MacAddress & ap);
  */
 CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, chip::MutableByteSpan & addr);
 
+/**
+ * @brief Triggers a network scan
+ *        The function is asynchronous and the result is provided via the callback.
+ *
+ * @param ssid The SSID to scan for. If empty, all networks are scanned
+ * @param callback The callback to be called when the scan is complete. Cannot be nullptr.
+ *                 The callback is called asynchrounously.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR if the network scan was successfully started
+ *                    CHIP_INVALID_ARGUMENT if the callback is nullptr
+ *                    CHIP_ERROR_IN_PROGRESS, if there is already a network scan in progress
+ *                    CHIP_ERROR_INVALID_STRING_LENGTH, if there SSID length exceeds handled limit
+ *                    other, if there is a platform error when starting the scan
+ */
+CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback);
+
 /* Function to update */
 
 sl_status_t wfx_wifi_start(void);
@@ -256,7 +273,6 @@ bool wfx_have_ipv4_addr(sl_wfx_interface_t);
 
 bool wfx_have_ipv6_addr(sl_wfx_interface_t);
 wifi_mode_t wfx_get_wifi_mode(void);
-bool wfx_start_scan(char * ssid, void (*scan_cb)(wfx_wifi_scan_result_t *)); /* true returned if successfully started */
 void wfx_cancel_scan(void);
 
 /*

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -811,7 +811,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -699,7 +699,8 @@ void ProcessEvent(WifiPlatformEvent event)
             chip::ByteSpan requestedSsid(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length);
             if (!requestedSsid.empty() && !requestedSsid.data_equal(scannedSsid))
             {
-                continue; // we found the targeted ssid.
+                // Scanned SSID entry does not match the requested SSID. Continue to the next.
+                continue;
             }
 
             // TODO: convert security mode from RSI to WFX
@@ -810,7 +811,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -810,7 +810,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterface.cpp
@@ -677,68 +677,60 @@ void ProcessEvent(WifiPlatformEvent event)
         // TODO: Currently unimplemented
         break;
     case WifiPlatformEvent::kScan: {
-#ifdef SL_WFX_CONFIG_SCAN
         rsi_rsp_scan_t scan_rsp = { 0 };
-        memset(&scan_rsp, 0, sizeof(scan_rsp));
-        int32_t status = rsi_wlan_bgscan_profile(1, &scan_rsp, sizeof(scan_rsp));
+        int32_t status          = rsi_wlan_bgscan_profile(1, &scan_rsp, sizeof(scan_rsp));
 
-        if (status != RSI_SUCCESS)
+        VerifyOrReturn(status == RSI_SUCCESS, ChipLogError(DeviceLayer, "rsi_wlan_bgscan_profile failed: %ld", status));
+        VerifyOrReturn(wfx_rsi.scan_cb != nullptr, ChipLogError(DeviceLayer, "wfx_rsi.scan_cb is nullptr"));
+
+        uint8_t nbreOfScannedNetworks = scan_rsp.scan_count[0];
+        for (int i = 0; i < nbreOfScannedNetworks; i++)
         {
-            ChipLogError(DeviceLayer, "rsi_wlan_bgscan failed: %ld ", status);
-            return;
-        }
+            rsi_scan_info_t scan      = scan_rsp.scan_info[i];
+            wfx_wifi_scan_result_t ap = { 0 };
 
-        if (wfx_rsi.scan_cb == NULL)
-        {
-            ChipLogError(DeviceLayer, "wfx_rsi.scan_cb is NULL");
-            return;
-        }
+            ap.ssid_length = strnlen(reinterpret_cast<char *>(scan.ssid), WFX_MAX_SSID_LENGTH);
 
-        rsi_scan_info_t * scan;
-        wfx_wifi_scan_result_t ap;
+            chip::ByteSpan scannedSsid(scan.ssid, ap.ssid_length);
+            chip::MutableByteSpan outputSsid(ap.ssid, WFX_MAX_SSID_LENGTH);
+            chip::CopySpanToMutableSpan(scannedSsid, outputSsid);
 
-        for (int x = 0; x < scan_rsp.scan_count[0]; x++)
-        {
-            scan = &scan_rsp.scan_info[x];
-            // clear structure and calculate size of SSID
-            memset(&ap, 0, sizeof(ap));
-            ap.ssid_length =
-                strnlen(reinterpret_cast<char *>(scan->ssid), std::min<size_t>(sizeof(scan->ssid), WFX_MAX_SSID_LENGTH));
-            chip::Platform::CopyString(ap.ssid, ap.ssid_length, reinterpret_cast<char *>(scan->ssid));
-
-            // check if the scanned ssid is the one we are looking for
-            if (wfx_rsi.scan_ssid_length != 0 && strncmp(wfx_rsi.scan_ssid, ap.ssid, WFX_MAX_SSID_LENGTH) != 0)
+            // Check if the scanned ssid is the requested Ssid
+            chip::ByteSpan requestedSsid(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length);
+            if (!requestedSsid.empty() && !requestedSsid.data_equal(scannedSsid))
             {
                 continue; // we found the targeted ssid.
             }
+
             // TODO: convert security mode from RSI to WFX
-            ap.security = static_cast<wfx_sec_t>(scan->security_mode);
-            ap.rssi     = (-1) * scan->rssi_val;
+            ap.security = static_cast<wfx_sec_t>(scan.security_mode);
+            ap.rssi     = (-1) * scan.rssi_val;
 
             configASSERT(sizeof(ap.bssid) == kWifiMacAddressLength);
-            configASSERT(sizeof(scan->bssid) == kWifiMacAddressLength);
-            memcpy(ap.bssid, scan->bssid, kWifiMacAddressLength);
-            (*wfx_rsi.scan_cb)(&ap);
+            configASSERT(sizeof(scan.bssid) == kWifiMacAddressLength);
 
-            // no ssid filter set, return all results
-            if (wfx_rsi.scan_ssid_length == 0)
+            chip::MutableByteSpan bssidSpan(ap.bssid, kWifiMacAddressLength);
+            chip::ByteSpan scanBssidSpan(scan.bssid, kWifiMacAddressLength);
+            chip::CopySpanToMutableSpan(scanBssidSpan, bssidSpan);
+
+            wfx_rsi.scan_cb(&ap);
+
+            // If we reach this and the requestedSsid is not empty, it means we found the requested SSID and we can exit
+            if (!requestedSsid.empty())
             {
-                continue;
+                break;
             }
-
-            break;
         }
+        // Notify the stack that we have finishes scanning for Networks
+        wfx_rsi.scan_cb(nullptr);
 
-        /* Terminate with end of scan which is no ap sent back */
-        (*wfx_rsi.scan_cb)((wfx_wifi_scan_result_t *) NULL);
+        // Clean up
         wfx_rsi.scan_cb = nullptr;
-
         if (wfx_rsi.scan_ssid)
         {
             chip::Platform::MemoryFree(wfx_rsi.scan_ssid);
             wfx_rsi.scan_ssid = NULL;
         }
-#endif /* SL_WFX_CONFIG_SCAN */
     }
     break;
     case WifiPlatformEvent::kStationStartJoin: {
@@ -818,7 +810,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1239,7 +1239,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -310,6 +310,13 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
     // SSID Max Length that is supported by the Wi-Fi SDK is 32
     VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
 
+    // Make sure memory is cleared before starting a new scan
+    if (scan_ssid)
+    {
+        chip::Platform::MemoryFree(scan_ssid);
+        scan_ssid = nullptr;
+    }
+
     if (ssid.empty())
     {
         scan_ssid_length = 0;
@@ -1232,7 +1239,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) &0xFF;
+    ip4_addr[0] = (ip) & 0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1232,7 +1232,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1240,7 +1240,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -115,7 +115,6 @@ bool hasNotifiedWifiConnectivity = false;
 static uint8_t retryJoin         = 0;
 bool retryInProgress             = false;
 
-#ifdef SL_WFX_CONFIG_SCAN
 static struct scan_result_holder
 {
     struct scan_result_holder * next;
@@ -127,7 +126,6 @@ static uint8_t * scan_ssid     = nullptr; /* Which one are we scanning for */
 static size_t scan_ssid_length = 0;
 static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_result);
 static void sl_wfx_scan_complete_callback(uint32_t status);
-#endif /* SL_WFX_CONFIG_SCAN */
 
 static void wfx_events_task(void * p_arg);
 
@@ -384,7 +382,6 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         }
         break;
     }
-#ifdef SL_WFX_CONFIG_SCAN
     case SL_WFX_SCAN_RESULT_IND_ID: {
         sl_wfx_scan_result_ind_t * scan_result = (sl_wfx_scan_result_ind_t *) event_payload;
         sl_wfx_scan_result_callback(&scan_result->body);
@@ -395,7 +392,6 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         sl_wfx_scan_complete_callback(scan_complete->body.status);
         break;
     }
-#endif /* SL_WFX_CONFIG_SCAN */
 #ifdef SL_WFX_CONFIG_SOFTAP
     case SL_WFX_START_AP_IND_ID: {
         sl_wfx_start_ap_ind_t * start_ap_indication = (sl_wfx_start_ap_ind_t *) event_payload;
@@ -706,10 +702,7 @@ static void wfx_events_task(void * p_arg)
 #ifdef SL_WFX_CONFIG_SOFTAP
                                         | SL_WFX_START_AP | SL_WFX_STOP_AP
 #endif /* SL_WFX_CONFIG_SOFTAP */
-#ifdef SL_WFX_CONFIG_SCAN
-                                        | SL_WFX_SCAN_START | SL_WFX_SCAN_COMPLETE
-#endif /* SL_WFX_CONFIG_SCAN */
-                                        | BITS_TO_WAIT,
+                                        | SL_WFX_SCAN_START | SL_WFX_SCAN_COMPLETE | BITS_TO_WAIT,
                                     pdTRUE, pdFALSE, pdMS_TO_TICKS(250)); /* 250 msec delay converted to ticks */
         if (flags & SL_WFX_RETRY_CONNECT)
         {
@@ -793,7 +786,6 @@ static void wfx_events_task(void * p_arg)
             wfx_lwip_set_sta_link_down();
         }
 
-#ifdef SL_WFX_CONFIG_SCAN
         if (flags & SL_WFX_SCAN_START)
         {
 
@@ -854,7 +846,6 @@ static void wfx_events_task(void * p_arg)
             }
             scan_cb = nullptr;
         }
-#endif /* SL_WFX_CONFIG_SCAN */
     }
 }
 

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -1241,7 +1241,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -122,9 +122,9 @@ static struct scan_result_holder
     wfx_wifi_scan_result scan;
 } * scan_save;
 static uint8_t scan_count = 0;
-static void (*scan_cb)(wfx_wifi_scan_result_t *); /* user-callback - when scan is done */
-static char * scan_ssid;                          /* Which one are we scanning for */
-size_t scan_ssid_length = 0;
+static ScanCallback scan_cb;              /* user-callback - when scan is done */
+static uint8_t * scan_ssid     = nullptr; /* Which one are we scanning for */
+static size_t scan_ssid_length = 0;
 static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_result);
 static void sl_wfx_scan_complete_callback(uint32_t status);
 #endif /* SL_WFX_CONFIG_SCAN */
@@ -305,6 +305,33 @@ CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, MutableByteSpan & address
     return CopySpanToMutableSpan(byteSpan, address);
 }
 
+CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
+{
+    VerifyOrReturnError(callback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // SSID Max Length that is supported by the Wi-Fi SDK is 32
+    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    if (ssid.empty())
+    {
+        scan_ssid_length = 0;
+        scan_ssid        = nullptr;
+    }
+    else
+    {
+        scan_ssid_length = ssid.size();
+        scan_ssid        = reinterpret_cast<uint8_t *>(chip::Platform::MemoryAlloc(scan_ssid_length));
+        VerifyOrReturnError(scan_ssid != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        chip::MutableByteSpan scannedSsidSpan(scan_ssid, scan_ssid_length);
+        chip::CopySpanToMutableSpan(ssid, scannedSsidSpan);
+    }
+    scan_cb = callback;
+
+    xEventGroupSetBits(sl_wfx_event_group, SL_WFX_SCAN_START);
+    return CHIP_NO_ERROR;
+}
+
 /***************************************************************************
  * @brief
  * Creates WFX events processing task.
@@ -390,8 +417,8 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         break;
     }
     case SL_WFX_AP_CLIENT_DISCONNECTED_IND_ID: {
-        sl_wfx_ap_client_disconnected_ind_t * ap_client_disconnected_indication =
-            (sl_wfx_ap_client_disconnected_ind_t *) event_payload;
+        sl_wfx_ap_client_disconnected_indication_t * ap_client_disconnected_indication =
+            (sl_wfx_ap_client_disconnected_indication_t *) event_payload;
         sl_wfx_ap_client_disconnected_callback(ap_client_disconnected_indication->body.reason,
                                                ap_client_disconnected_indication->body.mac);
         break;
@@ -435,7 +462,6 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
     return SL_STATUS_OK;
 }
 
-#ifdef SL_WFX_CONFIG_SCAN
 /****************************************************************************
  * @brief
  * Callback for individual scan result
@@ -443,56 +469,60 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
  *****************************************************************************/
 static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_result)
 {
-    struct scan_result_holder * ap;
 
     ChipLogDetail(DeviceLayer, "# %2d %2d  %03d %02X:%02X:%02X:%02X:%02X:%02X  %s", scan_count, scan_result->channel,
                   ((int16_t) (scan_result->rcpi - 220) / 2), scan_result->mac[0], scan_result->mac[1], scan_result->mac[2],
                   scan_result->mac[3], scan_result->mac[4], scan_result->mac[5], scan_result->ssid_def.ssid);
-    /* Report one AP information */
-    /* don't save if filter only wants specific ssid */
-    if (scan_ssid != nullptr)
+
+    chip::ByteSpan requestedSsid(scan_ssid, scan_ssid_length);
+    chip::ByteSpan scannedSsid(scan_result->ssid_def.ssid, scan_result->ssid_def.ssid_length);
+
+    // Verify that there was no requested SSID or that the SSID matches the requested SSID
+    VerifyOrReturn(requestedSsid.empty() || requestedSsid.data_equal(scannedSsid));
+
+    struct scan_result_holder * ap = reinterpret_cast<struct scan_result_holder *>(chip::Platform::MemoryAlloc(sizeof(*ap)));
+    VerifyOrReturn(ap != nullptr, ChipLogError(DeviceLayer, "Scan Callback: No Memory for scanned network."));
+
+    // Add Scan to the linked list
+    ap->next  = scan_save;
+    scan_save = ap;
+
+    // Copy scanned SSID to the output buffer
+    ap->scan.ssid_length = scan_result->ssid_def.ssid_length;
+    chip::MutableByteSpan outputSsid(ap->scan.ssid, ap->scan.ssid_length);
+    chip::CopySpanToMutableSpan(scannedSsid, outputSsid);
+
+    // Set Network Security - We start by WPA3 to set the most secure type
+    ap->scan.security = WFX_SEC_UNSPECIFIED;
+    if (scan_result->security_mode.wpa3)
     {
-        if (strcmp(scan_ssid, (char *) &scan_result->ssid_def.ssid[0]) != 0)
-            return;
+        ap->scan.security = WFX_SEC_WPA3;
     }
-    if ((ap = (struct scan_result_holder *) (chip::Platform::MemoryAlloc(sizeof(*ap)))) == (struct scan_result_holder *) 0)
+    else if (scan_result->security_mode.wpa2)
     {
-        ChipLogError(DeviceLayer, "Scan: No Mem");
+        ap->scan.security = WFX_SEC_WPA2;
+    }
+    else if (scan_result->security_mode.wpa)
+    {
+        ap->scan.security = WFX_SEC_WPA;
+    }
+    else if (scan_result->security_mode.wep)
+    {
+        ap->scan.security = WFX_SEC_WEP;
     }
     else
     {
-        ap->next  = scan_save;
-        scan_save = ap;
-        /* Not checking if scan_result->ssid_length is < 33 */
-        chip::Platform::CopyString(ap->scan.ssid, sizeof(ap->scan.ssid), (char *) &scan_result->ssid_def.ssid[0]);
-        /* We do it in this order WPA3 first */
-        /* No EAP supported - Is this required */
-        ap->scan.security = WFX_SEC_UNSPECIFIED;
-        if (scan_result->security_mode.wpa3)
-        {
-            ap->scan.security = WFX_SEC_WPA3;
-        }
-        else if (scan_result->security_mode.wpa2)
-        {
-            ap->scan.security = WFX_SEC_WPA2;
-        }
-        else if (scan_result->security_mode.wpa)
-        {
-            ap->scan.security = WFX_SEC_WPA;
-        }
-        else if (scan_result->security_mode.wep)
-        {
-            ap->scan.security = WFX_SEC_WEP;
-        }
-        else
-        {
-            ap->scan.security = WFX_SEC_NONE;
-        }
-        ap->scan.chan = scan_result->channel;
-        ap->scan.rssi = scan_result->rcpi;
-        memcpy(&ap->scan.bssid[0], &scan_result->mac[0], kWifiMacAddressLength);
-        scan_count++;
+        ap->scan.security = WFX_SEC_NONE;
     }
+
+    ap->scan.chan = scan_result->channel;
+    ap->scan.rssi = (scan_result->rcpi - 220) / 2;
+
+    chip::ByteSpan scannedBssid(scan_result->mac, kWifiMacAddressLength);
+    chip::MutableByteSpan outputBssid(ap->scan.bssid, kWifiMacAddressLength);
+    chip::CopySpanToMutableSpan(scannedBssid, outputBssid);
+
+    scan_count++;
 }
 
 /****************************************************************************
@@ -507,7 +537,6 @@ static void sl_wfx_scan_complete_callback(uint32_t status)
     /* Use scan_count value and reset it */
     xEventGroupSetBits(sl_wfx_event_group, SL_WFX_SCAN_COMPLETE);
 }
-#endif /* SL_WFX_CONFIG_SCAN */
 
 /****************************************************************************
  * @brief
@@ -767,24 +796,27 @@ static void wfx_events_task(void * p_arg)
 #ifdef SL_WFX_CONFIG_SCAN
         if (flags & SL_WFX_SCAN_START)
         {
-            /*
-             * Start the Scan
-             */
-            sl_wfx_ssid_def_t ssid, *sp;
-            uint16_t num_ssid, slen;
+
+            // Start the Scan
+            sl_wfx_ssid_def_t ssid       = { 0 };
+            sl_wfx_ssid_def_t * ssidPtr  = nullptr;
+            uint16_t nbreScannedNetworks = 0;
+
             if (scan_ssid)
             {
-                memset(&ssid, 0, sizeof(ssid));
-                slen = strlen(scan_ssid);
-                memcpy(&ssid.ssid[0], scan_ssid, slen);
-                ssid.ssid_length = slen;
-                num_ssid         = 1;
-                sp               = &ssid;
+                ssid.ssid_length = scan_ssid_length;
+
+                chip::ByteSpan ssidSpan(scan_ssid, scan_ssid_length);
+                chip::MutableByteSpan ssidMutableSpan(ssid.ssid, ssid.ssid_length);
+                chip::CopySpanToMutableSpan(ssidSpan, ssidMutableSpan);
+
+                nbreScannedNetworks = 1;
+                ssidPtr             = &ssid;
             }
             else
             {
-                num_ssid = 0;
-                sp       = (sl_wfx_ssid_def_t *) 0;
+                nbreScannedNetworks = 0;
+                ssidPtr             = nullptr;
             }
 
             ChipLogDetail(DeviceLayer,
@@ -792,9 +824,9 @@ static void wfx_events_task(void * p_arg)
                           "Channel Time: %d, Number of prob: %d",
                           ACTIVE_CHANNEL_TIME, PASSIVE_CHANNEL_TIME, NUM_PROBE_REQUEST);
             (void) sl_wfx_set_scan_parameters(ACTIVE_CHANNEL_TIME, PASSIVE_CHANNEL_TIME, NUM_PROBE_REQUEST);
-            (void) sl_wfx_send_scan_command(WFM_SCAN_MODE_ACTIVE, CHANNEL_LIST, /* Channel list */
-                                            CHANNEL_COUNT,                      /* Scan all chans */
-                                            sp, num_ssid, IE_DATA,              /* IE we're looking for */
+            (void) sl_wfx_send_scan_command(WFM_SCAN_MODE_ACTIVE, CHANNEL_LIST,    /* Channel list */
+                                            CHANNEL_COUNT,                         /* Scan all chans */
+                                            ssidPtr, nbreScannedNetworks, IE_DATA, /* IE we're looking for */
                                             IE_DATA_LENGTH, BSSID_SCAN);
         }
         if (flags & SL_WFX_SCAN_COMPLETE)
@@ -805,19 +837,21 @@ static void wfx_events_task(void * p_arg)
             for (hp = scan_save; hp; hp = next)
             {
                 next = hp->next;
-                (*scan_cb)(&hp->scan);
+                scan_cb(&hp->scan);
                 chip::Platform::MemoryFree(hp);
             }
-            (*scan_cb)((wfx_wifi_scan_result *) 0);
-            scan_save  = (struct scan_result_holder *) 0;
+            scan_cb(nullptr);
+
+            // Clean up
+            scan_save  = nullptr;
             scan_count = 0;
+
             if (scan_ssid)
             {
                 chip::Platform::MemoryFree(scan_ssid);
                 scan_ssid = NULL;
             }
-            /* Terminate scan */
-            scan_cb = 0;
+            scan_cb = nullptr;
         }
 #endif /* SL_WFX_CONFIG_SCAN */
     }
@@ -906,23 +940,31 @@ static void wfx_wifi_hw_start(void)
  **************************************************************************/
 int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
 {
-    int32_t signal_strength;
+    uint32_t signal_strength = 0;
 
-    ap->ssid_length = strnlen(ap_info.ssid, std::min<size_t>(sizeof(ap_info.ssid), WFX_MAX_SSID_LENGTH));
-    chip::Platform::CopyString(ap->ssid, ap->ssid_length, ap_info.ssid);
-    memcpy(ap->bssid, ap_info.bssid, sizeof(ap_info.bssid));
+    chip::ByteSpan apSsidSpan(ap_info.ssid, ap_info.ssid_length);
+    chip::MutableByteSpan apSsidMutableSpan(ap->ssid, WFX_MAX_SSID_LENGTH);
+    chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
+    ap->ssid_length = apSsidMutableSpan.size();
+
+    chip::ByteSpan apBssidSpan(ap_info.bssid, kWifiMacAddressLength);
+    chip::MutableByteSpan apBssidMutableSpan(ap->bssid, kWifiMacAddressLength);
+    chip::CopySpanToMutableSpan(apBssidSpan, apBssidMutableSpan);
+
     ap->security = ap_info.security;
     ap->chan     = ap_info.chan;
-    ChipLogDetail(DeviceLayer, "WIFI:SSID     :: %s", &ap_info.ssid[0]);
-    ChipLogDetail(DeviceLayer, "WIFI:BSSID    :: %02x:%02x:%02x:%02x:%02x:%02x", ap_info.bssid[0], ap_info.bssid[1],
-                  ap_info.bssid[2], ap_info.bssid[3], ap_info.bssid[4], ap_info.bssid[5]);
-    ChipLogDetail(DeviceLayer, "WIFI:security :: %d", ap->security);
-    ChipLogDetail(DeviceLayer, "WIFI:channel  ::  %d", ap->chan);
 
-    sl_status_t status = sl_wfx_get_signal_strength((uint32_t *) &signal_strength);
+    sl_status_t status = sl_wfx_get_signal_strength(&signal_strength);
     VerifyOrReturnError(status == SL_STATUS_OK, status);
-    ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
     ap->rssi = (signal_strength - 220) / 2;
+
+    ChipLogDetail(DeviceLayer, "WIFI:SSID     : %s", ap_info.ssid);
+    ChipLogDetail(DeviceLayer, "WIFI:BSSID    : %02x:%02x:%02x:%02x:%02x:%02x", ap_info.bssid[0], ap_info.bssid[1],
+                  ap_info.bssid[2], ap_info.bssid[3], ap_info.bssid[4], ap_info.bssid[5]);
+    ChipLogDetail(DeviceLayer, "WIFI:security : %d", ap->security);
+    ChipLogDetail(DeviceLayer, "WIFI:channel  :  %d", ap->chan);
+    ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
+
     return status;
 }
 
@@ -1198,7 +1240,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) &0xFF;
+    ip4_addr[0] = (ip) & 0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;
@@ -1218,29 +1260,6 @@ void wfx_enable_sta_mode(void)
 {
     /* Nothing to do - default is that it is
        place holder */
-}
-
-/****************************************************************************
- * @brief
- * driver scan start
- * @param[in]  callback: Callback from the wifi scan  results
- * @return returns true if sucessful,
- *         false otherwise
- *****************************************************************************/
-#ifdef SL_WFX_CONFIG_SCAN
-bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
-{
-    VerifyOrReturnError(scan_cb != nullptr, false);
-    if (ssid)
-    {
-        scan_ssid_length = strnlen(ssid, WFX_MAX_SSID_LENGTH);
-        scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(scan_ssid_length));
-        VerifyOrReturnError(scan_ssid != nullptr, false);
-        Platform::CopyString(scan_ssid, scan_ssid_length, ssid);
-    }
-    scan_cb = callback;
-    xEventGroupSetBits(sl_wfx_event_group, SL_WFX_SCAN_START);
-    return true;
 }
 
 /****************************************************************************
@@ -1267,4 +1286,3 @@ void wfx_cancel_scan(void)
     }
     scan_cb = nullptr;
 }
-#endif /* SL_WFX_CONFIG_SCAN */

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -417,8 +417,8 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         break;
     }
     case SL_WFX_AP_CLIENT_DISCONNECTED_IND_ID: {
-        sl_wfx_ap_client_disconnected_indication_t * ap_client_disconnected_indication =
-            (sl_wfx_ap_client_disconnected_indication_t *) event_payload;
+        sl_wfx_ap_client_disconnected_ind_t * ap_client_disconnected_indication =
+            (sl_wfx_ap_client_disconnected_ind_t *) event_payload;
         sl_wfx_ap_client_disconnected_callback(ap_client_disconnected_indication->body.reason,
                                                ap_client_disconnected_indication->body.mac);
         break;
@@ -1241,7 +1241,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) &0xFF;
+    ip4_addr[0] = (ip) & 0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterface.cpp
@@ -319,12 +319,12 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
     }
     else
     {
-        scan_ssid = reinterpret_cast<uint8_t *>(chip::Platform::MemoryAlloc(scan_ssid_length));
+        scan_ssid_length = ssid.size();
+        scan_ssid        = reinterpret_cast<uint8_t *>(chip::Platform::MemoryAlloc(scan_ssid_length));
         VerifyOrReturnError(scan_ssid != nullptr, CHIP_ERROR_NO_MEMORY);
 
         chip::MutableByteSpan scannedSsidSpan(scan_ssid, WFX_MAX_SSID_LENGTH);
         chip::CopySpanToMutableSpan(ssid, scannedSsidSpan);
-        scan_ssid_length = scannedSsidSpan.size();
     }
     scan_cb = callback;
 
@@ -1241,7 +1241,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) &0xFF;
+    ip4_addr[0] = (ip) & 0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -50,6 +50,38 @@ CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, chip::MutableByteSpan & a
     return CopySpanToMutableSpan(byteSpan, address);
 }
 
+CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
+{
+    VerifyOrReturnError(callback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(!wfx_rsi.dev_state.Has(WifiState::kScanStarted), CHIP_ERROR_IN_PROGRESS);
+
+    // SSID Max Length that is supported by the Wi-Fi SDK is 32
+    VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    wfx_rsi.scan_cb = callback;
+
+    if (ssid.empty()) // Scan all networks
+    {
+        wfx_rsi.scan_ssid_length = 0;
+        wfx_rsi.scan_ssid        = nullptr;
+    }
+    else // Scan specific SSID
+    {
+        wfx_rsi.scan_ssid_length = ssid.size();
+        wfx_rsi.scan_ssid        = reinterpret_cast<uint8_t *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
+        VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        chip::MutableByteSpan scanSsidSpan(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length);
+        chip::CopySpanToMutableSpan(ssid, scanSsidSpan);
+    }
+
+    // TODO: We should be calling the start function directly instead of doing it asynchronously
+    WifiPlatformEvent event = WifiPlatformEvent::kScan;
+    sl_matter_wifi_post_event(event);
+
+    return CHIP_NO_ERROR;
+}
+
 /*********************************************************************
  * @fn  sl_status_t wfx_wifi_start(void)
  * @brief
@@ -302,33 +334,6 @@ int32_t wfx_reset_counts(void)
     return wfx_rsi_reset_count();
 }
 
-#ifdef SL_WFX_CONFIG_SCAN
-/*******************************************************************************
- * @fn   bool wfx_start_scan(char *ssid, void (*callback)(wfx_wifi_scan_result_t *))
- * @brief
- *       called fuction when driver start scaning
- * @param[in]  ssid:
- * @return returns ture if successful,
- *          false otherwise
- *******************************************************************************/
-bool wfx_start_scan(char * ssid, void (*callback)(wfx_wifi_scan_result_t *))
-{
-    // check if already in progress
-    VerifyOrReturnError(wfx_rsi.scan_cb != nullptr, false);
-    wfx_rsi.scan_cb = callback;
-
-    VerifyOrReturnError(ssid != nullptr, false);
-    wfx_rsi.scan_ssid_length = strnlen(ssid, std::min<size_t>(sizeof(ssid), WFX_MAX_SSID_LENGTH));
-    wfx_rsi.scan_ssid        = reinterpret_cast<char *>(chip::Platform::MemoryAlloc(wfx_rsi.scan_ssid_length));
-    VerifyOrReturnError(wfx_rsi.scan_ssid != nullptr, false);
-    chip::Platform::CopyString(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length, ssid);
-
-    WifiPlatformEvent event = WifiPlatformEvent::kScan;
-    sl_matter_wifi_post_event(event);
-
-    return true;
-}
-
 /***************************************************************************
  * @fn   void wfx_cancel_scan(void)
  * @brief
@@ -342,4 +347,3 @@ void wfx_cancel_scan(void)
     /* Not possible */
     ChipLogError(DeviceLayer, "cannot cancel scan");
 }
-#endif /* SL_WFX_CONFIG_SCAN */

--- a/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-abstraction/WiseconnectInterfaceAbstraction.cpp
@@ -58,8 +58,6 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
     // SSID Max Length that is supported by the Wi-Fi SDK is 32
     VerifyOrReturnError(ssid.size() <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    wfx_rsi.scan_cb = callback;
-
     if (ssid.empty()) // Scan all networks
     {
         wfx_rsi.scan_ssid_length = 0;
@@ -74,6 +72,7 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
         chip::MutableByteSpan scanSsidSpan(wfx_rsi.scan_ssid, wfx_rsi.scan_ssid_length);
         chip::CopySpanToMutableSpan(ssid, scanSsidSpan);
     }
+    wfx_rsi.scan_cb = callback;
 
     // TODO: We should be calling the start function directly instead of doing it asynchronously
     WifiPlatformEvent event = WifiPlatformEvent::kScan;

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -577,7 +577,6 @@ template("efr32_sdk") {
           "EXP_BOARD=1",
           "CHIP_917",
           "SLI_SI917=1",
-          "SL_WFX_CONFIG_SCAN=1",
           "CHIP_9117",
           "SL_WIFI_COMPONENT_INCLUDED",
         ]


### PR DESCRIPTION
#### Description
The goal of the PR is to refactor the public API from the Wifi Abstraction Interface. The refactor is focused on the WifiInterfaceAbstraction.h/.cpp files with the associated changes in the platform implementations. Improvements to the stack implementations will be in follow up PRs.

- Refactors the scan callstack to clean up the code
- Change the stored SSID from char[] to uint8_t[] to be able to leverage bytespan APIs.

#### Tests
- Validate the `networkcommissioning scan-networks` commands with and without a provide SSID with the BRD338A and the WF200.


