### PR TITLE
[Fabric-Sync] Adjust the Subscribe Max Interval to align with test spec

### DIFF
--- a/examples/fabric-sync/admin/BridgeSubscription.cpp
+++ b/examples/fabric-sync/admin/BridgeSubscription.cpp
@@ -28,7 +28,7 @@ namespace admin {
 namespace {
 
 constexpr uint16_t kSubscribeMinInterval = 0;
-constexpr uint16_t kSubscribeMaxInterval = 60;
+constexpr uint16_t kSubscribeMaxInterval = 30;
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {

--- a/examples/fabric-sync/admin/DeviceSubscription.cpp
+++ b/examples/fabric-sync/admin/DeviceSubscription.cpp
@@ -32,6 +32,9 @@ namespace admin {
 
 namespace {
 
+constexpr uint16_t kSubscribeMinInterval = 0;
+constexpr uint16_t kSubscribeMaxInterval = 10;
+
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     reinterpret_cast<DeviceSubscription *>(context)->OnDeviceConnected(exchangeMgr, sessionHandle);
@@ -160,7 +163,9 @@ void DeviceSubscription::OnDeviceConnected(Messaging::ExchangeManager & exchange
 
     readParams.mpAttributePathParamsList    = readPaths;
     readParams.mAttributePathParamsListSize = 1;
-    readParams.mMaxIntervalCeilingSeconds   = 5 * 60;
+    readParams.mMinIntervalFloorSeconds     = kSubscribeMinInterval;
+    readParams.mMaxIntervalCeilingSeconds   = kSubscribeMaxInterval;
+    readParams.mKeepSubscriptions           = true;
 
     CHIP_ERROR err = mClient->SendRequest(readParams);
 


### PR DESCRIPTION
This is a bug I found during Fabric-sync CI integration, we need to align the Subscribe Max Interval with test spec to make sure the report is sent by the IM before the timeout.

1. Align the kSubscribeMaxInterval of BridgeSubscription with MCORE_FS_1_5, step 3
2. Align the kSubscribeMaxInterval of DeviceSubscription with MCORE_FS_1_5, step 10
3.  Set mKeepSubscriptions for DeviceSubscription to true to make sure the established subscription is not accidentally overwritten. 
