### PR TITLE
Update `CommandHandlerInterface` to have a `bool accepts/generates` instead of an iterator-based callback

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -68,14 +68,14 @@ independent of the InteractionModelEngine class.
 
 The following replacements exist:
 
--   `chip::app::InteractionModelEngine::RegisterCommandHandler` replaced by
-    `chip::app::CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler`
--   `chip::app::InteractionModelEngine::UnregisterCommandHandler` replaced by
-    `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler`
--   `chip::app::InteractionModelEngine::FindCommandHandler` replaced by
-    `chip::app::CommandHandlerInterfaceRegistry::Instance().GetCommandHandler`
--   `chip::app::InteractionModelEngine::UnregisterCommandHandlers` replaced by
-    `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterAllCommandHandlersForEndpoint`
+- `chip::app::InteractionModelEngine::RegisterCommandHandler` replaced by
+  `chip::app::CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler`
+- `chip::app::InteractionModelEngine::UnregisterCommandHandler` replaced by
+  `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler`
+- `chip::app::InteractionModelEngine::FindCommandHandler` replaced by
+  `chip::app::CommandHandlerInterfaceRegistry::Instance().GetCommandHandler`
+- `chip::app::InteractionModelEngine::UnregisterCommandHandlers` replaced by
+  `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterAllCommandHandlersForEndpoint`
 
 ### AttributeAccessInterface registration and removal
 
@@ -84,14 +84,14 @@ A new object exists for the attribute access interface registry, accessible as
 
 Replacements for methods are:
 
--   `registerAttributeAccessOverride` replaced by
-    `chip::app::AttributeAccessInterfaceRegistry::Instance().Register`
--   `unregisterAttributeAccessOverride` replaced by
-    `chip::app::AttributeAccessInterfaceRegistry::Instance().Unregister`
--   `unregisterAllAttributeAccessOverridesForEndpoint` replaced by
-    `chip::app::AttributeAccessInterfaceRegistry::Instance().UnregisterAllForEndpoint`
--   `chip::app::GetAttributeAccessOverride` replaced by
-    `chip::app::AttributeAccessInterfaceRegistry::Instance().Get`
+- `registerAttributeAccessOverride` replaced by
+  `chip::app::AttributeAccessInterfaceRegistry::Instance().Register`
+- `unregisterAttributeAccessOverride` replaced by
+  `chip::app::AttributeAccessInterfaceRegistry::Instance().Unregister`
+- `unregisterAllAttributeAccessOverridesForEndpoint` replaced by
+  `chip::app::AttributeAccessInterfaceRegistry::Instance().UnregisterAllForEndpoint`
+- `chip::app::GetAttributeAccessOverride` replaced by
+  `chip::app::AttributeAccessInterfaceRegistry::Instance().Get`
 
 ### `ServerInitParams::dataModelProvider` in `Server::Init` and `FactoryInitParams`
 
@@ -107,3 +107,13 @@ To use default attribute persistence, you need to pass in a
 `PersistentStorageDelegate` to `CodegenDataModelProviderInstance`. See example
 changes in [36658](https://github.com/project-chip/connectedhomeip/pull/36658)
 ).
+
+### `EnumerateAcceptedCommands` and `EnumerateGeneratedCommands` in `CommandHandlerInterface`
+
+Commands are generally highly coupled with metadata. Code was changed to allow
+the interfaces to filter out accepted/generated commands, however they cannot
+control the actual list of commands anymore since they must reside in metadata
+(e.g. ember/zap).provider
+
+Replace these functions with `AcceptsCommandId` and `GeneratesCommandId`. See
+[36809](https://github.com/project-chip/connectedhomeip/pull/36809) for changes.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -68,14 +68,14 @@ independent of the InteractionModelEngine class.
 
 The following replacements exist:
 
-- `chip::app::InteractionModelEngine::RegisterCommandHandler` replaced by
-  `chip::app::CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler`
-- `chip::app::InteractionModelEngine::UnregisterCommandHandler` replaced by
-  `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler`
-- `chip::app::InteractionModelEngine::FindCommandHandler` replaced by
-  `chip::app::CommandHandlerInterfaceRegistry::Instance().GetCommandHandler`
-- `chip::app::InteractionModelEngine::UnregisterCommandHandlers` replaced by
-  `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterAllCommandHandlersForEndpoint`
+-   `chip::app::InteractionModelEngine::RegisterCommandHandler` replaced by
+    `chip::app::CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler`
+-   `chip::app::InteractionModelEngine::UnregisterCommandHandler` replaced by
+    `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler`
+-   `chip::app::InteractionModelEngine::FindCommandHandler` replaced by
+    `chip::app::CommandHandlerInterfaceRegistry::Instance().GetCommandHandler`
+-   `chip::app::InteractionModelEngine::UnregisterCommandHandlers` replaced by
+    `chip::app::CommandHandlerInterfaceRegistry::Instance().UnregisterAllCommandHandlersForEndpoint`
 
 ### AttributeAccessInterface registration and removal
 
@@ -84,14 +84,14 @@ A new object exists for the attribute access interface registry, accessible as
 
 Replacements for methods are:
 
-- `registerAttributeAccessOverride` replaced by
-  `chip::app::AttributeAccessInterfaceRegistry::Instance().Register`
-- `unregisterAttributeAccessOverride` replaced by
-  `chip::app::AttributeAccessInterfaceRegistry::Instance().Unregister`
-- `unregisterAllAttributeAccessOverridesForEndpoint` replaced by
-  `chip::app::AttributeAccessInterfaceRegistry::Instance().UnregisterAllForEndpoint`
-- `chip::app::GetAttributeAccessOverride` replaced by
-  `chip::app::AttributeAccessInterfaceRegistry::Instance().Get`
+-   `registerAttributeAccessOverride` replaced by
+    `chip::app::AttributeAccessInterfaceRegistry::Instance().Register`
+-   `unregisterAttributeAccessOverride` replaced by
+    `chip::app::AttributeAccessInterfaceRegistry::Instance().Unregister`
+-   `unregisterAllAttributeAccessOverridesForEndpoint` replaced by
+    `chip::app::AttributeAccessInterfaceRegistry::Instance().UnregisterAllForEndpoint`
+-   `chip::app::GetAttributeAccessOverride` replaced by
+    `chip::app::AttributeAccessInterfaceRegistry::Instance().Get`
 
 ### `ServerInitParams::dataModelProvider` in `Server::Init` and `FactoryInitParams`
 

--- a/src/app/CommandHandlerInterface.h
+++ b/src/app/CommandHandlerInterface.h
@@ -101,55 +101,24 @@ public:
      */
     virtual void InvokeCommand(HandlerContext & handlerContext) = 0;
 
-    typedef Loop (*CommandIdCallback)(CommandId id, void * context);
+    /**
+     * Returns true if the given command path can be processed by an InvokeCommand request.
+     *
+     * Intent for this is that actual command metadata is available somewhere else, so generally code
+     * is aware of 'all possible commands that a cluster could accept/generate', however this
+     * allows a command handler interface to filter such commands to a subset.
+     */
+    virtual bool AcceptsCommandId(const ConcreteCommandPath & commandPath) { return true; }
 
     /**
-     * Function that may be implemented to enumerate accepted (client-to-server)
-     * commands for the given cluster.
+     * Returns true if the given command id will be returned as a generated command (i.e. as a response of some InvokeCommand
+     * request.)
      *
-     * If this function returns CHIP_ERROR_NOT_IMPLEMENTED, the list of accepted
-     * commands will come from the endpoint metadata for the cluster.
-     *
-     * If this function returns any other error, that will be treated as an
-     * error condition by the caller, and handling will depend on the caller.
-     *
-     * Otherwise the list of accepted commands will be the list of values passed
-     * to the provided callback.
-     *
-     * The implementation _must_ pass the provided context to the callback.
-     *
-     * If the callback returns Loop::Break, there must be no more calls to it.
-     * This is used by callbacks that just look for a particular value in the
-     * list.
+     * Intent for this is that actual command metadata is available somewhere else, so generally code
+     * is aware of 'all possible commands that a cluster could accept/generate', however this
+     * allows a command handler interface to filter such commands to a subset.
      */
-    virtual CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
-    /**
-     * Function that may be implemented to enumerate generated (response)
-     * commands for the given cluster.
-     *
-     * If this function returns CHIP_ERROR_NOT_IMPLEMENTED, the list of
-     * generated commands will come from the endpoint metadata for the cluster.
-     *
-     * If this function returns any other error, that will be treated as an
-     * error condition by the caller, and handling will depend on the caller.
-     *
-     * Otherwise the list of generated commands will be the list of values
-     * passed to the provided callback.
-     *
-     * The implementation _must_ pass the provided context to the callback.
-     *
-     * If the callback returns Loop::Break, there must be no more calls to it.
-     * This is used by callbacks that just look for a particular value in the
-     * list.
-     */
-    virtual CHIP_ERROR EnumerateGeneratedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
+    virtual bool GeneratesCommandId(const ConcreteCommandPath & commandPath) { return true; }
 
     /**
      * Mechanism for keeping track of a chain of CommandHandlerInterface.

--- a/src/app/clusters/device-energy-management-server/device-energy-management-server.h
+++ b/src/app/clusters/device-energy-management-server/device-energy-management-server.h
@@ -235,7 +235,7 @@ private:
 
     // CommandHandlerInterface
     void InvokeCommand(HandlerContext & handlerContext) override;
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
+    bool AcceptsCommandId(const ConcreteCommandPath & commandPath) override;
 
     Protocols::InteractionModel::Status CheckOptOutAllowsRequest(AdjustmentCauseEnum adjustmentCause);
     void HandlePowerAdjustRequest(HandlerContext & ctx, const Commands::PowerAdjustRequest::DecodableType & commandData);

--- a/src/app/clusters/energy-evse-server/energy-evse-server.h
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.h
@@ -200,7 +200,7 @@ private:
 
     // CommandHandlerInterface
     void InvokeCommand(HandlerContext & handlerContext) override;
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
+    bool AcceptsCommandId(const ConcreteCommandPath & commandPath) override;
 
     void HandleDisable(HandlerContext & ctx, const Commands::Disable::DecodableType & commandData);
     void HandleEnableCharging(HandlerContext & ctx, const Commands::EnableCharging::DecodableType & commandData);

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1386,22 +1386,18 @@ bool Instance::AcceptsCommandId(const ConcreteCommandPath & commandPath)
 bool Instance::GeneratesCommandId(const ConcreteCommandPath & commandPath)
 {
     using namespace Clusters::NetworkCommissioning::Commands;
-
-    if (mFeatureFlags.HasAny(Feature::kWiFiNetworkInterface, Feature::kThreadNetworkInterface))
+    switch (commandPath.mCommandId)
     {
-        for (auto && cmd : { ScanNetworksResponse::Id, NetworkConfigResponse::Id, ConnectNetworkResponse::Id })
-        {
-            VerifyOrExit(callback(cmd, context) == Loop::Continue, /**/);
-        }
-    }
+    case ScanNetworksResponse::Id:
+    case NetworkConfigResponse::Id:
+    case ConnectNetworkResponse::Id:
+        return mFeatureFlags.HasAny(Feature::kWiFiNetworkInterface, Feature::kThreadNetworkInterface);
+    case QueryIdentityResponse::Id:
 
-    if (mFeatureFlags.Has(Feature::kPerDeviceCredentials))
-    {
-        VerifyOrExit(callback(QueryIdentityResponse::Id, context) == Loop::Continue, /**/);
+        return mFeatureFlags.Has(Feature::kPerDeviceCredentials);
+    default:
+        return false;
     }
-
-exit:
-    return CHIP_NO_ERROR;
 }
 
 bool NullNetworkDriver::GetEnabled()

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1393,7 +1393,6 @@ bool Instance::GeneratesCommandId(const ConcreteCommandPath & commandPath)
     case ConnectNetworkResponse::Id:
         return mFeatureFlags.HasAny(Feature::kWiFiNetworkInterface, Feature::kThreadNetworkInterface);
     case QueryIdentityResponse::Id:
-
         return mFeatureFlags.Has(Feature::kPerDeviceCredentials);
     default:
         return false;

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1360,47 +1360,30 @@ void Instance::OnFailSafeTimerExpired()
     }
 }
 
-CHIP_ERROR Instance::EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
+bool Instance::AcceptsCommandId(const ConcreteCommandPath & commandPath)
 {
     using namespace Clusters::NetworkCommissioning::Commands;
 
-    if (mFeatureFlags.Has(Feature::kThreadNetworkInterface))
+    switch (commandPath.mCommandId)
     {
-        for (auto && cmd : {
-                 ScanNetworks::Id,
-                 AddOrUpdateThreadNetwork::Id,
-                 RemoveNetwork::Id,
-                 ConnectNetwork::Id,
-                 ReorderNetwork::Id,
-             })
-        {
-            VerifyOrExit(callback(cmd, context) == Loop::Continue, /**/);
-        }
-    }
-    else if (mFeatureFlags.Has(Feature::kWiFiNetworkInterface))
-    {
-        for (auto && cmd : {
-                 ScanNetworks::Id,
-                 AddOrUpdateWiFiNetwork::Id,
-                 RemoveNetwork::Id,
-                 ConnectNetwork::Id,
-                 ReorderNetwork::Id,
-             })
-        {
-            VerifyOrExit(callback(cmd, context) == Loop::Continue, /**/);
-        }
-    }
+    case AddOrUpdateThreadNetwork::Id:
+        return mFeatureFlags.Has(Feature::kThreadNetworkInterface);
+    case AddOrUpdateWiFiNetwork::Id:
+        return mFeatureFlags.Has(Feature::kWiFiNetworkInterface);
+    case ScanNetworks::Id:
+    case RemoveNetwork::Id:
+    case ConnectNetwork::Id:
+    case ReorderNetwork::Id:
+        return mFeatureFlags.HasAny(Feature::kThreadNetworkInterface, Feature::kWiFiNetworkInterface);
+    case QueryIdentity::Id:
 
-    if (mFeatureFlags.Has(Feature::kPerDeviceCredentials))
-    {
-        VerifyOrExit(callback(QueryIdentity::Id, context) == Loop::Continue, /**/);
+        return mFeatureFlags.Has(Feature::kPerDeviceCredentials);
+    default:
+        return false;
     }
-
-exit:
-    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Instance::EnumerateGeneratedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context)
+bool Instance::GeneratesCommandId(const ConcreteCommandPath & commandPath)
 {
     using namespace Clusters::NetworkCommissioning::Commands;
 

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -59,8 +59,8 @@ public:
 
     // CommandHandlerInterface
     void InvokeCommand(HandlerContext & ctx) override;
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
-    CHIP_ERROR EnumerateGeneratedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
+    bool AcceptsCommandId(const ConcreteCommandPath & commandPath) override;
+    bool GeneratesCommandId(const ConcreteCommandPath & commandPath) override;
 
     // AttributeAccessInterface
     CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-server.cpp
@@ -186,17 +186,16 @@ void Instance::InvokeCommand(HandlerContext & handlerContext)
     }
 }
 
-// List the commands supported by this instance.
-CHIP_ERROR Instance::EnumerateAcceptedCommands(const ConcreteClusterPath & cluster,
-                                               CommandHandlerInterface::CommandIdCallback callback, void * context)
+// Commands supported by this instance.
+bool Instance::AcceptsCommandId(const ConcreteCommandPath & commandPath)
 {
-    ChipLogDetail(Zcl, "resourcemonitoring: EnumerateAcceptedCommands");
-    if (mResetConditionCommandSupported)
+    switch (commandPath.mCommandId)
     {
-        callback(ResourceMonitoring::Commands::ResetCondition::Id, context);
+    case ResourceMonitoring::Commands::ResetCondition::Id:
+        return mResetConditionCommandSupported;
+    default:
+        return false;
     }
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR Instance::ReadReplaceableProductList(AttributeValueEncoder & aEncoder)

--- a/src/app/clusters/resource-monitoring-server/resource-monitoring-server.h
+++ b/src/app/clusters/resource-monitoring-server/resource-monitoring-server.h
@@ -132,7 +132,7 @@ private:
 
     // CommandHandlerInterface
     void InvokeCommand(HandlerContext & ctx) override;
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
+    bool AcceptsCommandId(const ConcreteCommandPath & commandPath) override;
 
     // AttributeAccessInterface
     CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -177,7 +177,9 @@ bool SoftwareDiagnosticsCommandHandler::AcceptsCommandId(const ConcreteCommandPa
     default:
         return false;
     }
-} // anonymous namespace
+}
+
+} // namespace
 
 namespace chip {
 namespace app {

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -62,7 +62,7 @@ public:
 
     void InvokeCommand(HandlerContext & handlerContext) override;
 
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override;
+    bool AcceptsCommandId(const ConcreteCommandPath & commandPath) override;
 };
 
 SoftwareDiagosticsAttrAccess gAttrAccess;
@@ -168,20 +168,15 @@ void SoftwareDiagnosticsCommandHandler::InvokeCommand(HandlerContext & handlerCo
     handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath, status);
 }
 
-CHIP_ERROR SoftwareDiagnosticsCommandHandler::EnumerateAcceptedCommands(const ConcreteClusterPath & cluster,
-                                                                        CommandIdCallback callback, void * context)
+bool SoftwareDiagnosticsCommandHandler::AcceptsCommandId(const ConcreteCommandPath & commandPath)
 {
-    if (!DeviceLayer::GetDiagnosticDataProvider().SupportsWatermarks())
+    switch (commandPath.mCommandId)
     {
-        // No commmands.
-        return CHIP_NO_ERROR;
+    case Commands::ResetWatermarks::Id:
+        return DeviceLayer::GetDiagnosticDataProvider().SupportsWatermarks();
+    default:
+        return false;
     }
-
-    callback(Commands::ResetWatermarks::Id, context);
-
-    return CHIP_NO_ERROR;
-}
-
 } // anonymous namespace
 
 namespace chip {

--- a/src/app/util/ember-global-attribute-access-interface.h
+++ b/src/app/util/ember-global-attribute-access-interface.h
@@ -42,13 +42,6 @@ public:
     GlobalAttributeReader(const EmberAfCluster * aCluster) : MandatoryGlobalAttributeReader(aCluster) {}
 
     CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
-
-private:
-    typedef CHIP_ERROR (CommandHandlerInterface::*CommandListEnumerator)(const ConcreteClusterPath & cluster,
-                                                                         CommandHandlerInterface::CommandIdCallback callback,
-                                                                         void * context);
-    static CHIP_ERROR EncodeCommandList(const ConcreteClusterPath & aClusterPath, AttributeValueEncoder & aEncoder,
-                                        CommandListEnumerator aEnumerator, const CommandId * aClusterCommandList);
 };
 
 } // namespace Compatibility

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -17,12 +17,12 @@
  */
 #include <pw_unit_test/framework.h>
 
-#include <app/ConcreteCommandPath.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/CommandHandlerInterfaceRegistry.h>
+#include <app/ConcreteCommandPath.h>
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>
 #include <app/util/attribute-storage.h>

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -374,7 +374,8 @@ TEST_F(TestServerCommandDispatch, TestDataResponseHandlerOverride1)
     TestClusterCommandHandler commandHandler;
     commandHandler.OverrideAcceptedCommands();
 
-    // Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::Id exists on Endpoint1
+    // Clusters::UnitTesting exists on testEndpoint1, so metadata about generated commands
+    // exists
     TestDataResponseHelper(&testEndpoint1, true);
 }
 
@@ -383,7 +384,7 @@ TEST_F(TestServerCommandDispatch, TestDataResponseHandlerOverride2)
     TestClusterCommandHandler commandHandler;
     commandHandler.OverrideAcceptedCommands();
 
-    // Clusters::UnitTesting::Commands::TestSimpleArgumentRequest::Id DOES NOT exist on endpoint1
+    // Clusters::UnitTesting DOES NOT exist on testEndpoint3
     // so overriding accepting does nothing (there is no metadata to accept it)
     TestDataResponseHelper(&testEndpoint3, false);
 }

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -800,7 +800,7 @@ ConcreteCommandPath CodegenDataModelProvider::FirstGeneratedCommand(const Concre
         {
             return commandPath;
         }
-        mCommand = mAcceptedCommandsIterator.Next(cluster->acceptedCommandList, *mCommand);
+        mCommand = mAcceptedCommandsIterator.Next(cluster->generatedCommandList(), *mCommand);
     }
     return {};
 }

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -800,7 +800,7 @@ ConcreteCommandPath CodegenDataModelProvider::FirstGeneratedCommand(const Concre
         {
             return commandPath;
         }
-        mCommand = mAcceptedCommandsIterator.Next(cluster->generatedCommandList(), *mCommand);
+        mCommand = mGeneratedCommandsIterator.Next(cluster->generatedCommandList, *mCommand);
     }
     return {};
 }

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -814,7 +814,7 @@ ConcreteCommandPath CodegenDataModelProvider::FirstGeneratedCommand(const Concre
     for (unsigned i = 0; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
     {
         const ConcreteCommandPath commandPath(path.mEndpointId, path.mClusterId, cluster->generatedCommandList[i]);
-        if ((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath))
+        if ((commandHandler == nullptr) || commandHandler->GeneratesCommandId(commandPath))
         {
             mGeneratedCommandHint = i;
             return commandPath;
@@ -848,7 +848,7 @@ ConcreteCommandPath CodegenDataModelProvider::NextGeneratedCommand(const Concret
     for (unsigned i = beforeIdx + 1; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
     {
         const ConcreteCommandPath commandPath(before.mEndpointId, before.mClusterId, cluster->generatedCommandList[i]);
-        if ((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath))
+        if ((commandHandler == nullptr) || commandHandler->GeneratesCommandId(commandPath))
         {
             mAcceptedCommandHint = i;
             return commandPath;

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -727,12 +727,12 @@ DataModel::CommandEntry CodegenDataModelProvider::FirstAcceptedCommand(const Con
     const EmberAfCluster * cluster = FindServerCluster(path);
 
     VerifyOrReturnValue(cluster != nullptr, DataModel::CommandEntry::kInvalid);
-    VerifyOrReturnValue(cluster->generatedCommandList != nullptr, DataModel::CommandEntry::kInvalid);
+    VerifyOrReturnValue(cluster->acceptedCommandList != nullptr, DataModel::CommandEntry::kInvalid);
 
     auto * commandHandler = CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(path.mEndpointId, path.mClusterId);
-    for (unsigned i = 0; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
+    for (unsigned i = 0; cluster->acceptedCommandList[i] != kInvalidCommandId; i++)
     {
-        const ConcreteCommandPath commandPath(path.mEndpointId, path.mClusterId, cluster->generatedCommandList[i]);
+        const ConcreteCommandPath commandPath(path.mEndpointId, path.mClusterId, cluster->acceptedCommandList[i]);
         if ((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath))
         {
             mAcceptedCommandHint = i;
@@ -747,26 +747,26 @@ DataModel::CommandEntry CodegenDataModelProvider::NextAcceptedCommand(const Conc
     const EmberAfCluster * cluster = FindServerCluster(before);
 
     VerifyOrReturnValue(cluster != nullptr, DataModel::CommandEntry::kInvalid);
-    VerifyOrReturnValue(cluster->generatedCommandList != nullptr, DataModel::CommandEntry::kInvalid);
+    VerifyOrReturnValue(cluster->acceptedCommandList != nullptr, DataModel::CommandEntry::kInvalid);
 
     // TODO: this does NOT make use of the hint because the command list is NOT sized (it is value-terminated)
     //       and we have no way to check `is hint in bounds`
     auto * commandHandler = CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(before.mEndpointId, before.mClusterId);
     unsigned beforeIdx;
-    for (beforeIdx = 0; cluster->generatedCommandList[beforeIdx] != kInvalidCommandId; beforeIdx++)
+    for (beforeIdx = 0; cluster->acceptedCommandList[beforeIdx] != kInvalidCommandId; beforeIdx++)
     {
-        if (cluster->generatedCommandList[beforeIdx] == before.mCommandId)
+        if (cluster->acceptedCommandList[beforeIdx] == before.mCommandId)
         {
             break; // found it
         }
     }
 
-    VerifyOrReturnValue(cluster->generatedCommandList[beforeIdx] == before.mCommandId, DataModel::CommandEntry::kInvalid);
+    VerifyOrReturnValue(cluster->acceptedCommandList[beforeIdx] == before.mCommandId, DataModel::CommandEntry::kInvalid);
 
     // find the first "accepted" index out if thios
-    for (unsigned i = beforeIdx + 1; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
+    for (unsigned i = beforeIdx + 1; cluster->acceptedCommandList[i] != kInvalidCommandId; i++)
     {
-        const ConcreteCommandPath commandPath(before.mEndpointId, before.mClusterId, cluster->generatedCommandList[i]);
+        const ConcreteCommandPath commandPath(before.mEndpointId, before.mClusterId, cluster->acceptedCommandList[i]);
         if ((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath))
         {
             mAcceptedCommandHint = i;
@@ -781,19 +781,19 @@ std::optional<DataModel::CommandInfo> CodegenDataModelProvider::GetAcceptedComma
     const EmberAfCluster * cluster = FindServerCluster(path);
 
     VerifyOrReturnValue(cluster != nullptr, std::nullopt);
-    VerifyOrReturnValue(cluster->generatedCommandList != nullptr, std::nullopt);
+    VerifyOrReturnValue(cluster->acceptedCommandList != nullptr, std::nullopt);
 
     // TODO: this does NOT make use of the hint because the command list is NOT sized (it is value-terminated)
     //       and we have no way to check `is hint in bounds`
     auto * commandHandler = CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(path.mEndpointId, path.mClusterId);
-    for (unsigned i = 0; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
+    for (unsigned i = 0; cluster->acceptedCommandList[i] != kInvalidCommandId; i++)
     {
-        if (cluster->generatedCommandList[i] != path.mCommandId)
+        if (cluster->acceptedCommandList[i] != path.mCommandId)
         {
             continue;
         }
 
-        const ConcreteCommandPath commandPath(path.mEndpointId, path.mClusterId, cluster->generatedCommandList[i]);
+        const ConcreteCommandPath commandPath(path.mEndpointId, path.mClusterId, cluster->acceptedCommandList[i]);
         VerifyOrReturnValue((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath), std::nullopt);
 
         mAcceptedCommandHint = i;
@@ -808,7 +808,7 @@ ConcreteCommandPath CodegenDataModelProvider::FirstGeneratedCommand(const Concre
     const EmberAfCluster * cluster = FindServerCluster(path);
 
     VerifyOrReturnValue(cluster != nullptr, ConcreteCommandPath());
-    VerifyOrReturnValue(cluster->acceptedCommandList != nullptr, ConcreteCommandPath());
+    VerifyOrReturnValue(cluster->generatedCommandList != nullptr, ConcreteCommandPath());
 
     auto * commandHandler = CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(path.mEndpointId, path.mClusterId);
     for (unsigned i = 0; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
@@ -828,26 +828,26 @@ ConcreteCommandPath CodegenDataModelProvider::NextGeneratedCommand(const Concret
     const EmberAfCluster * cluster = FindServerCluster(before);
 
     VerifyOrReturnValue(cluster != nullptr, ConcreteCommandPath());
-    VerifyOrReturnValue(cluster->acceptedCommandList != nullptr, ConcreteCommandPath());
+    VerifyOrReturnValue(cluster->generatedCommandList != nullptr, ConcreteCommandPath());
 
     // TODO: this does NOT make use of the hint because the command list is NOT sized (it is value-terminated)
     //       and we have no way to check `is hint in bounds`
     auto * commandHandler = CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(before.mEndpointId, before.mClusterId);
     unsigned beforeIdx;
-    for (beforeIdx = 0; cluster->acceptedCommandList[beforeIdx] != kInvalidCommandId; beforeIdx++)
+    for (beforeIdx = 0; cluster->generatedCommandList[beforeIdx] != kInvalidCommandId; beforeIdx++)
     {
-        if (cluster->acceptedCommandList[beforeIdx] == before.mCommandId)
+        if (cluster->generatedCommandList[beforeIdx] == before.mCommandId)
         {
             break; // found it
         }
     }
 
-    VerifyOrReturnValue(cluster->acceptedCommandList[beforeIdx] == before.mCommandId, ConcreteCommandPath());
+    VerifyOrReturnValue(cluster->generatedCommandList[beforeIdx] == before.mCommandId, ConcreteCommandPath());
 
     // find the first "accepted" index out if thios
-    for (unsigned i = beforeIdx + 1; cluster->acceptedCommandList[i] != kInvalidCommandId; i++)
+    for (unsigned i = beforeIdx + 1; cluster->generatedCommandList[i] != kInvalidCommandId; i++)
     {
-        const ConcreteCommandPath commandPath(before.mEndpointId, before.mClusterId, cluster->acceptedCommandList[i]);
+        const ConcreteCommandPath commandPath(before.mEndpointId, before.mClusterId, cluster->generatedCommandList[i]);
         if ((commandHandler == nullptr) || commandHandler->AcceptsCommandId(commandPath))
         {
             mAcceptedCommandHint = i;

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -141,8 +141,6 @@ private:
     unsigned mAttributeIterationHint     = 0;
     unsigned mDeviceTypeIterationHint    = 0;
     unsigned mSemanticTagIterationHint   = 0;
-    unsigned mAcceptedCommandHint        = 0;
-    unsigned mGeneratedCommandHint       = 0;
     EmberCommandListIterator mAcceptedCommandsIterator;
     EmberCommandListIterator mGeneratedCommandsIterator;
 

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -27,61 +27,6 @@
 namespace chip {
 namespace app {
 
-namespace detail {
-
-/// Handles going through callback-based enumeration of generated/accepted commands
-/// for CommandHandlerInterface based items.
-///
-/// Offers the ability to focus on some operation for finding a given
-/// command id:
-///   - FindFirst will return the first found element
-///   - FindExact finds the element with the given id
-///   - FindNext finds the element following the given id
-class EnumeratorCommandFinder
-{
-public:
-    using HandlerCallbackFunction = CHIP_ERROR (CommandHandlerInterface::*)(const ConcreteClusterPath &,
-                                                                            CommandHandlerInterface::CommandIdCallback, void *);
-
-    enum class Operation
-    {
-        kFindFirst, // Find the first value in the list
-        kFindExact, // Find the given value
-        kFindNext   // Find the value AFTER this value
-    };
-
-    EnumeratorCommandFinder(HandlerCallbackFunction callback) :
-        mCallback(callback), mOperation(Operation::kFindFirst), mTarget(kInvalidCommandId)
-    {}
-
-    /// Find the given command ID that matches the given operation/path.
-    ///
-    /// If operation is kFindFirst, then path commandID is ignored. Otherwise it is used as a key to
-    /// kFindExact or kFindNext.
-    ///
-    /// Returns:
-    ///    - std::nullopt if no command found using the command handler interface
-    ///    - kInvalidCommandId if the find failed (but command handler interface does provide a list)
-    ///    - valid id if command handler interface usage succeeds
-    std::optional<CommandId> FindCommandId(Operation operation, const ConcreteCommandPath & path);
-
-private:
-    HandlerCallbackFunction mCallback;
-    Operation mOperation;
-    CommandId mTarget;
-    std::optional<CommandId> mFound = std::nullopt;
-
-    Loop HandlerCallback(CommandId id);
-
-    static Loop HandlerCallbackFn(CommandId id, void * context)
-    {
-        auto self = static_cast<EnumeratorCommandFinder *>(context);
-        return self->HandlerCallback(id);
-    }
-};
-
-} // namespace detail
-
 /// An implementation of `InteractionModel::Model` that relies on code-generation
 /// via zap/ember.
 ///
@@ -196,6 +141,8 @@ private:
     unsigned mAttributeIterationHint     = 0;
     unsigned mDeviceTypeIterationHint    = 0;
     unsigned mSemanticTagIterationHint   = 0;
+    unsigned mAcceptedCommandHint        = 0;
+    unsigned mGeneratedCommandHint       = 0;
     EmberCommandListIterator mAcceptedCommandsIterator;
     EmberCommandListIterator mGeneratedCommandsIterator;
 
@@ -236,10 +183,6 @@ private:
     std::optional<unsigned> TryFindEndpointIndex(EndpointId id) const;
 
     using CommandListGetter = const CommandId *(const EmberAfCluster &);
-
-    CommandId FindCommand(const ConcreteCommandPath & path, detail::EnumeratorCommandFinder & handlerFinder,
-                          detail::EnumeratorCommandFinder::Operation operation,
-                          CodegenDataModelProvider::EmberCommandListIterator & emberIterator, CommandListGetter commandListGetter);
 };
 
 } // namespace app

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -266,7 +266,7 @@ private:
 const MockNodeConfig gTestNodeConfig({
     MockEndpointConfig(kMockEndpoint1, {
         MockClusterConfig(
-            MockClusterId(1), 
+            MockClusterId(1),
             {
                 ClusterRevision::Id, FeatureMap::Id,
             },  /* attributes */

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -220,32 +220,14 @@ public:
 
     void InvokeCommand(HandlerContext & handlerContext) override { handlerContext.SetCommandNotHandled(); }
 
-    CHIP_ERROR EnumerateAcceptedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override
+    bool AcceptsCommandId(const app::ConcreteCommandPath & path) override
     {
-        VerifyOrReturnError(mOverrideAccepted, CHIP_ERROR_NOT_IMPLEMENTED);
-
-        for (auto id : mAccepted)
-        {
-            if (callback(id, context) != Loop::Continue)
-            {
-                break;
-            }
-        }
-        return CHIP_NO_ERROR;
+        return mOverrideAccepted && std::find(mAccepted.cbegin(), mAccepted.cend(), path.mCommandId) != mAccepted.cend();
     }
 
-    CHIP_ERROR EnumerateGeneratedCommands(const ConcreteClusterPath & cluster, CommandIdCallback callback, void * context) override
+    bool GeneratesCommandId(const app::ConcreteCommandPath & path) override
     {
-        VerifyOrReturnError(mOverrideGenerated, CHIP_ERROR_NOT_IMPLEMENTED);
-
-        for (auto id : mGenerated)
-        {
-            if (callback(id, context) != Loop::Continue)
-            {
-                break;
-            }
-        }
-        return CHIP_NO_ERROR;
+        return mOverrideGenerated && std::find(mGenerated.cbegin(), mGenerated.cend(), path.mCommandId) != mGenerated.cend();
     }
 
     void SetOverrideAccepted(bool o) { mOverrideAccepted = o; }

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -265,11 +265,17 @@ private:
 // clang-format off
 const MockNodeConfig gTestNodeConfig({
     MockEndpointConfig(kMockEndpoint1, {
-        MockClusterConfig(MockClusterId(1), {
-            ClusterRevision::Id, FeatureMap::Id,
-        }, {
+        MockClusterConfig(
+            MockClusterId(1), 
+            {
+                ClusterRevision::Id, FeatureMap::Id,
+            },  /* attributes */
+            {
             MockEventId(1), MockEventId(2),
-        }),
+            }, /* events */
+            {100, 1234, 999, 2000, 3000}, /* acceptedCommands */
+            {33, 44, 55, 66}      /* generatedCommands */
+        ),
         MockClusterConfig(MockClusterId(2), {
             ClusterRevision::Id, FeatureMap::Id, MockAttributeId(1),
         }),


### PR DESCRIPTION
CommandHandlerInterface is still highly tied to metadata that is outside of it: commands still need invoke privileges and qualities (timed invoke, supports large objects, fabric scoped) and cannot function independently.

This changes the logic from using CHI to iterate through commands and allowing it to report commands that are missing in metadata to be able to filter-out commands that do exist in metadata.


