### PR TITLE
Remove stale comment from Thermostat XML.

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thermostat-cluster.xml
@@ -208,7 +208,6 @@ limitations under the License.
 
   <struct name="WeeklyScheduleTransitionStruct">
     <cluster code="0x0201"/>
-    <!-- See https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/6217 for HeatSetpoint and CoolSetpoint.  They might end up being nullable. -->
     <item fieldId="0" name="TransitionTime" type="int16u" max="1439"/>
     <item fieldId="1" name="HeatSetpoint" type="temperature" isNullable="true"/>
     <item fieldId="2" name="CoolSetpoint" type="temperature" isNullable="true"/>


### PR DESCRIPTION
The relevant fields are nullable in both XML and spec, and the spec issue is long-resolved.

