### PR TITLE
[Fabric-Admin] Adjust the Subscribe Interval to align with test spec

### DIFF
--- a/examples/fabric-admin/device_manager/BridgeSubscription.cpp
+++ b/examples/fabric-admin/device_manager/BridgeSubscription.cpp
@@ -28,7 +28,7 @@ namespace admin {
 namespace {
 
 constexpr uint16_t kSubscribeMinInterval = 0;
-constexpr uint16_t kSubscribeMaxInterval = 60;
+constexpr uint16_t kSubscribeMaxInterval = 30;
 
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {

--- a/examples/fabric-admin/device_manager/DeviceSubscription.cpp
+++ b/examples/fabric-admin/device_manager/DeviceSubscription.cpp
@@ -37,6 +37,9 @@ namespace admin {
 
 namespace {
 
+constexpr uint16_t kSubscribeMinInterval = 0;
+constexpr uint16_t kSubscribeMaxInterval = 10;
+
 void OnDeviceConnectedWrapper(void * context, Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     reinterpret_cast<DeviceSubscription *>(context)->OnDeviceConnected(exchangeMgr, sessionHandle);
@@ -162,7 +165,9 @@ void DeviceSubscription::OnDeviceConnected(Messaging::ExchangeManager & exchange
 
     readParams.mpAttributePathParamsList    = readPaths;
     readParams.mAttributePathParamsListSize = 1;
-    readParams.mMaxIntervalCeilingSeconds   = 5 * 60;
+    readParams.mMinIntervalFloorSeconds     = kSubscribeMinInterval;
+    readParams.mMaxIntervalCeilingSeconds   = kSubscribeMaxInterval;
+    readParams.mKeepSubscriptions           = true;
 
     CHIP_ERROR err = mClient->SendRequest(readParams);
 


### PR DESCRIPTION
Cherry-pick the fix(https://github.com/project-chip/connectedhomeip/pull/36806) from fabric-sync to fabric-admin 



