### PR TITLE
Inject event management into report engine

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -163,6 +163,7 @@ static_library("interaction-model") {
     "CommandSender.h",
     "DeviceProxy.cpp",
     "DeviceProxy.h",
+    "EventScheduler.h",
     "InteractionModelDelegatePointers.cpp",
     "InteractionModelDelegatePointers.h",
     "InteractionModelEngine.cpp",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -149,6 +149,12 @@ source_set("test-event-trigger") {
   sources = [ "TestEventTriggerDelegate.h" ]
 }
 
+source_set("event-reporter") {
+  sources = [
+    "EventReporter.h",
+  ]
+}
+
 # interaction-model is a static-library because it currently requires global functions (app/util/...) that are stubbed in different test files that depend on the app static_library
 # which in tern depens on the interaction-model.
 # Using source_set prevents the unit test to build correctly.
@@ -163,7 +169,6 @@ static_library("interaction-model") {
     "CommandSender.h",
     "DeviceProxy.cpp",
     "DeviceProxy.h",
-    "EventScheduler.h",
     "InteractionModelDelegatePointers.cpp",
     "InteractionModelDelegatePointers.h",
     "InteractionModelEngine.cpp",
@@ -211,6 +216,7 @@ static_library("interaction-model") {
     ":app_config",
     ":command-handler-impl",
     ":constants",
+    ":event-reporter",
     ":paths",
     ":subscription-info-provider",
     "${chip_root}/src/app/MessageDef",
@@ -456,6 +462,7 @@ static_library("app") {
     ":app_config",
     ":attribute-access",
     ":constants",
+    ":event-reporter",
     ":global-attributes",
     ":interaction-model",
     "${chip_root}/src/app/data-model",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -150,9 +150,7 @@ source_set("test-event-trigger") {
 }
 
 source_set("event-reporter") {
-  sources = [
-    "EventReporter.h",
-  ]
+  sources = [ "EventReporter.h" ]
 }
 
 # interaction-model is a static-library because it currently requires global functions (app/util/...) that are stubbed in different test files that depend on the app static_library

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -83,7 +83,7 @@ struct CopyAndAdjustDeltaTimeContext
 void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint32_t aNumBuffers,
                            CircularEventBuffer * apCircularEventBuffer, const LogStorageResources * const apLogStorageResources,
                            MonotonicallyIncreasingCounter<EventNumber> * apEventNumberCounter,
-                           System::Clock::Milliseconds64 aMonotonicStartupTime)
+                           System::Clock::Milliseconds64 aMonotonicStartupTime, EventScheduler * apEventScheduler)
 {
     CircularEventBuffer * current = nullptr;
     CircularEventBuffer * prev    = nullptr;
@@ -124,6 +124,15 @@ void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint3
     mBytesWritten = 0;
 
     mMonotonicStartupTime = aMonotonicStartupTime;
+
+    if (apEventScheduler == nullptr)
+    {
+        mpEventScheduler = &InteractionModelEngine::GetInstance()->GetReportingEngine();
+    }
+    else
+    {
+        mpEventScheduler = apEventScheduler;
+    }
 }
 
 CHIP_ERROR EventManagement::CopyToNextBuffer(CircularEventBuffer * apEventBuffer)
@@ -490,7 +499,10 @@ exit:
                       opts.mTimestamp.mType == Timestamp::Type::kSystem ? "Sys" : "Epoch", ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
-        err = InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleEventDelivery(opts.mPath, mBytesWritten);
+        if (mpEventScheduler)
+        {
+            err = mpEventScheduler->ScheduleEventDelivery(opts.mPath, mBytesWritten);
+        }
     }
 
     return err;

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -125,7 +125,7 @@ void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint3
 
     mMonotonicStartupTime = aMonotonicStartupTime;
 
-    // Should remove using the global instance and rely only on passed in variable.
+    // TODO(#36890): Should remove using the global instance and rely only on passed in variable.
     if (apEventReporter == nullptr)
     {
         mpEventReporter = &InteractionModelEngine::GetInstance()->GetReportingEngine();
@@ -500,10 +500,7 @@ exit:
                       opts.mTimestamp.mType == Timestamp::Type::kSystem ? "Sys" : "Epoch", ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
-        if (mpEventReporter)
-        {
-            err = mpEventReporter->NewEventGenerated(opts.mPath, mBytesWritten);
-        }
+        err = mpEventReporter->NewEventGenerated(opts.mPath, mBytesWritten);
     }
 
     return err;

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -83,7 +83,7 @@ struct CopyAndAdjustDeltaTimeContext
 void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint32_t aNumBuffers,
                            CircularEventBuffer * apCircularEventBuffer, const LogStorageResources * const apLogStorageResources,
                            MonotonicallyIncreasingCounter<EventNumber> * apEventNumberCounter,
-                           System::Clock::Milliseconds64 aMonotonicStartupTime, EventScheduler * apEventScheduler)
+                           System::Clock::Milliseconds64 aMonotonicStartupTime, EventReporter * apEventReporter)
 {
     CircularEventBuffer * current = nullptr;
     CircularEventBuffer * prev    = nullptr;
@@ -125,13 +125,14 @@ void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint3
 
     mMonotonicStartupTime = aMonotonicStartupTime;
 
-    if (apEventScheduler == nullptr)
+    // Should remove using the global instance and rely only on passed in variable.
+    if (apEventReporter == nullptr)
     {
-        mpEventScheduler = &InteractionModelEngine::GetInstance()->GetReportingEngine();
+        mpEventReporter = &InteractionModelEngine::GetInstance()->GetReportingEngine();
     }
     else
     {
-        mpEventScheduler = apEventScheduler;
+        mpEventReporter = apEventReporter;
     }
 }
 
@@ -499,9 +500,9 @@ exit:
                       opts.mTimestamp.mType == Timestamp::Type::kSystem ? "Sys" : "Epoch", ChipLogValueX64(opts.mTimestamp.mValue));
 #endif // CHIP_CONFIG_EVENT_LOGGING_VERBOSE_DEBUG_LOGS
 
-        if (mpEventScheduler)
+        if (mpEventReporter)
         {
-            err = mpEventScheduler->ScheduleEventDelivery(opts.mPath, mBytesWritten);
+            err = mpEventReporter->NewEventGenerated(opts.mPath, mBytesWritten);
         }
     }
 

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -226,8 +226,7 @@ public:
      *                                   time 0" for cases when we use
      *                                   system-time event timestamps.
      *
-     * @param[in] apEventReporter       Event reporter to deliver the event, default is the reporting
-     *                                   engine in InteractionModelEngine.
+     * @param[in] apEventReporter       Event reporter to be notified when events are generated.
      *
      */
     void Init(Messaging::ExchangeManager * apExchangeManager, uint32_t aNumBuffers, CircularEventBuffer * apCircularEventBuffer,

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -225,7 +225,7 @@ public:
      * @param[in] aMonotonicStartupTime  Time we should consider as "monotonic
      *                                   time 0" for cases when we use
      *                                   system-time event timestamps.
-     * 
+     *
      * @param[in] apEventScheduler       Scheduler to deliver the event, default is the reporting
      *                                   engine in InteractionModelEngine.
      *

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -29,7 +29,7 @@
 #include "EventLoggingDelegate.h"
 #include <access/SubjectDescriptor.h>
 #include <app/EventLoggingTypes.h>
-#include <app/EventScheduler.h>
+#include <app/EventReporter.h>
 #include <app/MessageDef/EventDataIB.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/data-model-provider/EventsGenerator.h>
@@ -226,14 +226,14 @@ public:
      *                                   time 0" for cases when we use
      *                                   system-time event timestamps.
      *
-     * @param[in] apEventScheduler       Scheduler to deliver the event, default is the reporting
+     * @param[in] apEventReporter       Event reporter to deliver the event, default is the reporting
      *                                   engine in InteractionModelEngine.
      *
      */
     void Init(Messaging::ExchangeManager * apExchangeManager, uint32_t aNumBuffers, CircularEventBuffer * apCircularEventBuffer,
               const LogStorageResources * const apLogStorageResources,
               MonotonicallyIncreasingCounter<EventNumber> * apEventNumberCounter,
-              System::Clock::Milliseconds64 aMonotonicStartupTime, EventScheduler * apEventScheduler = nullptr);
+              System::Clock::Milliseconds64 aMonotonicStartupTime, EventReporter * apEventReporter = nullptr);
 
     static EventManagement & GetInstance();
 
@@ -568,7 +568,7 @@ private:
 
     System::Clock::Milliseconds64 mMonotonicStartupTime;
 
-    EventScheduler * mpEventScheduler = nullptr;
+    EventReporter * mpEventReporter = nullptr;
 };
 
 } // namespace app

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -29,6 +29,7 @@
 #include "EventLoggingDelegate.h"
 #include <access/SubjectDescriptor.h>
 #include <app/EventLoggingTypes.h>
+#include <app/EventScheduler.h>
 #include <app/MessageDef/EventDataIB.h>
 #include <app/MessageDef/StatusIB.h>
 #include <app/data-model-provider/EventsGenerator.h>
@@ -224,12 +225,15 @@ public:
      * @param[in] aMonotonicStartupTime  Time we should consider as "monotonic
      *                                   time 0" for cases when we use
      *                                   system-time event timestamps.
+     * 
+     * @param[in] apEventScheduler       Scheduler to deliver the event, default is the reporting
+     *                                   engine in InteractionModelEngine.
      *
      */
     void Init(Messaging::ExchangeManager * apExchangeManager, uint32_t aNumBuffers, CircularEventBuffer * apCircularEventBuffer,
               const LogStorageResources * const apLogStorageResources,
               MonotonicallyIncreasingCounter<EventNumber> * apEventNumberCounter,
-              System::Clock::Milliseconds64 aMonotonicStartupTime);
+              System::Clock::Milliseconds64 aMonotonicStartupTime, EventScheduler * apEventScheduler = nullptr);
 
     static EventManagement & GetInstance();
 
@@ -563,6 +567,8 @@ private:
     Timestamp mLastEventTimestamp;    ///< The timestamp of the last event in this buffer
 
     System::Clock::Milliseconds64 mMonotonicStartupTime;
+
+    EventScheduler * mpEventScheduler = nullptr;
 };
 
 } // namespace app

--- a/src/app/EventReporter.h
+++ b/src/app/EventReporter.h
@@ -20,7 +20,7 @@
  * @file
  *
  * @brief
- *   Define EventScheduler interface. Event scheduler is used by EventManagement to notify that events are ready to be scheduled.
+ *   Define EventReporter interface. Event reproter is used by EventManagement to notify that events are ready to be reported.
  *   Usually this is implemented by the Reporting Engine to find the proper ReadHandlers and deliver the events.
  *
  */
@@ -32,19 +32,19 @@
 namespace chip {
 namespace app {
 
-class EventScheduler
+class EventReporter
 {
 public:
-    virtual ~EventScheduler() = default;
+    virtual ~EventReporter() = default;
 
     /**
      * @brief
-     *  Schedule the event delivery
+     *  Notify of a new event generated.
      *
      * @param[in] aPath          The path to the event.
      * @param[in] aBytesWritten  Bytes that the event is written into the buffer in EventManagement.
      */
-    CHIP_ERROR virtual ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten) = 0;
+    CHIP_ERROR virtual NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten) = 0;
 };
 
 } // namespace app

--- a/src/app/EventReporter.h
+++ b/src/app/EventReporter.h
@@ -25,8 +25,7 @@ namespace chip {
 namespace app {
 
 /**
- *   Define EventReporter interface. Event reporter is used by EventManagement to notify that events are ready to be reported.
- *   Usually this is implemented by the Reporting Engine to find the proper ReadHandlers and deliver the events.
+ *   Interface that EventManagement can use to notify when events are generated and may need reporting.
  *
  */
 class EventReporter
@@ -35,12 +34,12 @@ public:
     virtual ~EventReporter() = default;
 
     /**
-     *  Notify of a new event generated.
+     *  Notify that an event was generated.
      *
-     * @param[in] aPath          The path to the event.
-     * @param[in] aBytesWritten  Bytes that the event is written into the buffer in EventManagement.
+     * @param[in] aPath           The path that identifies the kind of event that was generated.
+     * @param[in] aBytesConsumed  The number of bytes needed to store the event in EventManagement.
      */
-    CHIP_ERROR virtual NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten) = 0;
+    CHIP_ERROR virtual NewEventGenerated(ConcreteEventPath & aPath, uint32_t  aBytesConsumed) = 0;
 };
 
 } // namespace app

--- a/src/app/EventReporter.h
+++ b/src/app/EventReporter.h
@@ -16,14 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- * @file
- *
- * @brief
- *   Define EventReporter interface. Event reproter is used by EventManagement to notify that events are ready to be reported.
- *   Usually this is implemented by the Reporting Engine to find the proper ReadHandlers and deliver the events.
- *
- */
 #pragma once
 
 #include <app/ConcreteEventPath.h>
@@ -32,13 +24,17 @@
 namespace chip {
 namespace app {
 
+/**
+ *   Define EventReporter interface. Event reporter is used by EventManagement to notify that events are ready to be reported.
+ *   Usually this is implemented by the Reporting Engine to find the proper ReadHandlers and deliver the events.
+ *
+ */
 class EventReporter
 {
 public:
     virtual ~EventReporter() = default;
 
     /**
-     * @brief
      *  Notify of a new event generated.
      *
      * @param[in] aPath          The path to the event.

--- a/src/app/EventReporter.h
+++ b/src/app/EventReporter.h
@@ -39,7 +39,7 @@ public:
      * @param[in] aPath           The path that identifies the kind of event that was generated.
      * @param[in] aBytesConsumed  The number of bytes needed to store the event in EventManagement.
      */
-    CHIP_ERROR virtual NewEventGenerated(ConcreteEventPath & aPath, uint32_t  aBytesConsumed) = 0;
+    CHIP_ERROR virtual NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesConsumed) = 0;
 };
 
 } // namespace app

--- a/src/app/EventScheduler.h
+++ b/src/app/EventScheduler.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <app/ConcreteEventPath.h>
+#include <lib/core/CHIPError.h>
 
 namespace chip {
 namespace app {

--- a/src/app/EventScheduler.h
+++ b/src/app/EventScheduler.h
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ *
+ * @brief
+ *   Define EventScheduler interface. Event scheduler is used by EventManagement to notify that events are ready to be scheduled.
+ *   Usually this is implemented by the Reporting Engine to find the proper ReadHandlers and deliver the events.
+ *
+ */
+#pragma once
+
+#include <app/ConcreteEventPath.h>
+
+namespace chip {
+namespace app {
+
+class EventScheduler
+{
+public:
+    virtual ~EventScheduler() = default;
+
+    /**
+     * @brief
+     *  Schedule the event delivery
+     *
+     * @param[in] aPath          The path to the event.
+     * @param[in] aBytesWritten  Bytes that the event is written into the buffer in EventManagement.
+     */
+    CHIP_ERROR virtual ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten) = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -149,7 +149,8 @@ InteractionModelEngine * InteractionModelEngine::GetInstance()
 
 CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,
                                         reporting::ReportScheduler * reportScheduler, CASESessionManager * apCASESessionMgr,
-                                        SubscriptionResumptionStorage * subscriptionResumptionStorage)
+                                        SubscriptionResumptionStorage * subscriptionResumptionStorage,
+                                        EventManagement * eventManagement)
 {
     VerifyOrReturnError(apFabricTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(apExchangeMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -165,7 +166,7 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     ReturnErrorOnFailure(mpFabricTable->AddFabricDelegate(this));
     ReturnErrorOnFailure(mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this));
 
-    mReportingEngine.Init();
+    mReportingEngine.Init(eventManagement);
 
     StatusIB::RegisterErrorFormatter();
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -166,7 +166,7 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
     ReturnErrorOnFailure(mpFabricTable->AddFabricDelegate(this));
     ReturnErrorOnFailure(mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this));
 
-    mReportingEngine.Init(eventManagement);
+    mReportingEngine.Init((eventManagement != nullptr) ? eventManagement : &EventManagement::GetInstance());
 
     StatusIB::RegisterErrorFormatter();
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -126,7 +126,7 @@ public:
      *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
      *  @param[in]    apFabricTable    A pointer to the FabricTable object.
      *  @param[in]    apCASESessionMgr An optional pointer to a CASESessionManager (used for re-subscriptions).
-     *  @parma[in]    eventManagement  An optional pointer to a EventManagement. Use the global instance if not presented.
+     *  @parma[in]    eventManagement  An optional pointer to a EventManagement. If null, the global instance will be used.
      *
      */
     CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -126,11 +126,13 @@ public:
      *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
      *  @param[in]    apFabricTable    A pointer to the FabricTable object.
      *  @param[in]    apCASESessionMgr An optional pointer to a CASESessionManager (used for re-subscriptions).
+     *  @parma[in]    eventManagement  An optional pointer to a EventManagement. Use the global instance if not presented.
      *
      */
     CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,
                     reporting::ReportScheduler * reportScheduler, CASESessionManager * apCASESessionMgr = nullptr,
-                    SubscriptionResumptionStorage * subscriptionResumptionStorage = nullptr);
+                    SubscriptionResumptionStorage * subscriptionResumptionStorage = nullptr,
+                    EventManagement * eventManagement                             = nullptr);
 
     void Shutdown();
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -1131,7 +1131,7 @@ CHIP_ERROR Engine::ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Engine::NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten)
+CHIP_ERROR Engine::NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesConsumed)
 {
     // If we literally have no read handlers right now that care about any events,
     // we don't need to call schedule run for event.
@@ -1169,7 +1169,7 @@ CHIP_ERROR Engine::NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesW
         return CHIP_NO_ERROR;
     }
 
-    return ScheduleBufferPressureEventDelivery(aBytesWritten);
+    return ScheduleBufferPressureEventDelivery(aBytesConsumed);
 }
 
 void Engine::ScheduleUrgentEventDeliverySync(Optional<FabricIndex> fabricIndex)

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -223,17 +223,10 @@ Engine::Engine(InteractionModelEngine * apImEngine) : mpImEngine(apImEngine) {}
 
 CHIP_ERROR Engine::Init(EventManagement * apEventManagement)
 {
+    VerifyOrReturnError(apEventManagement != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mNumReportsInFlight = 0;
     mCurReadHandlerIdx  = 0;
-
-    if (apEventManagement == nullptr)
-    {
-        mpEventManagement = &EventManagement::GetInstance();
-    }
-    else
-    {
-        mpEventManagement = apEventManagement;
-    }
+    mpEventManagement = apEventManagement;
 
     return CHIP_NO_ERROR;
 }
@@ -1138,7 +1131,7 @@ CHIP_ERROR Engine::ScheduleBufferPressureEventDelivery(uint32_t aBytesWritten)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten)
+CHIP_ERROR Engine::NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten)
 {
     // If we literally have no read handlers right now that care about any events,
     // we don't need to call schedule run for event.

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -226,7 +226,7 @@ CHIP_ERROR Engine::Init(EventManagement * apEventManagement)
     VerifyOrReturnError(apEventManagement != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     mNumReportsInFlight = 0;
     mCurReadHandlerIdx  = 0;
-    mpEventManagement = apEventManagement;
+    mpEventManagement   = apEventManagement;
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -570,9 +570,9 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
     size_t eventCount     = 0;
     bool hasEncodedStatus = false;
     TLV::TLVWriter backup;
-    bool eventClean                = true;
-    auto & eventMin                = apReadHandler->GetEventMin();
-    bool hasMoreChunks             = false;
+    bool eventClean    = true;
+    auto & eventMin    = apReadHandler->GetEventMin();
+    bool hasMoreChunks = false;
 
     aReportDataBuilder.Checkpoint(backup);
 
@@ -603,8 +603,8 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
         err = CheckAccessDeniedEventPaths(*(eventReportIBs.GetWriter()), hasEncodedStatus, apReadHandler);
         SuccessOrExit(err);
 
-        err = mpEventManagement->FetchEventsSince(*(eventReportIBs.GetWriter()), apReadHandler->GetEventPathList(), eventMin, eventCount,
-                                            apReadHandler->GetSubjectDescriptor());
+        err = mpEventManagement->FetchEventsSince(*(eventReportIBs.GetWriter()), apReadHandler->GetEventPathList(), eventMin,
+                                                  eventCount, apReadHandler->GetSubjectDescriptor());
 
         if ((err == CHIP_END_OF_TLV) || (err == CHIP_ERROR_TLV_UNDERRUN) || (err == CHIP_NO_ERROR))
         {

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -179,10 +179,10 @@ private:
                                    const ConcreteReadAttributePath & aPath);
 
     /**
-     *  EventReporter implementations.
+     *  EventReporter implementation.
      *
      */
-    CHIP_ERROR NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten) override;
+    CHIP_ERROR NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesConsumed) override;
 
     /**
      * Send Report via ReadHandler

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -55,7 +55,7 @@ namespace reporting {
  *         At its core, it  tries to gather and pack as much relevant attributes changes and/or events as possible into a report
  * message before sending that to the reader. It continues to do so until it has no more work to do.
  */
-class Engine : public DataModel::ProviderChangeListener
+class Engine : public DataModel::ProviderChangeListener, public EventScheduler
 {
 public:
     /**
@@ -65,11 +65,13 @@ public:
 
     /**
      * Initializes the reporting engine. Should only be called once.
+     * 
+     * @param[in] A pointer to EventManagement. Use the global one by default.
      *
      * @retval #CHIP_NO_ERROR On success.
      * @retval other           Was unable to retrieve data and write it into the writer.
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR Init(EventManagement * apEventManagement = nullptr);
 
     void Shutdown();
 
@@ -101,7 +103,7 @@ public:
      *  Schedule the event delivery
      *
      */
-    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten);
+    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten) override;
 
     /*
      * Resets the tracker that tracks the currently serviced read handler.
@@ -287,6 +289,8 @@ private:
 #endif
 
     InteractionModelEngine * mpImEngine = nullptr;
+
+    EventManagement * mpEventManagement = nullptr;
 };
 
 }; // namespace reporting

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <access/AccessControl.h>
-#include <app/EventScheduler.h>
+#include <app/EventReporter.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <app/ReadHandler.h>
 #include <app/data-model-provider/ProviderChangeListener.h>
@@ -56,7 +56,7 @@ namespace reporting {
  *         At its core, it  tries to gather and pack as much relevant attributes changes and/or events as possible into a report
  * message before sending that to the reader. It continues to do so until it has no more work to do.
  */
-class Engine : public DataModel::ProviderChangeListener, public EventScheduler
+class Engine : public DataModel::ProviderChangeListener, public EventReporter
 {
 public:
     /**
@@ -67,12 +67,12 @@ public:
     /**
      * Initializes the reporting engine. Should only be called once.
      *
-     * @param[in] A pointer to EventManagement. Use the global one by default.
+     * @param[in] A pointer to EventManagement, should not be a nullptr.
      *
      * @retval #CHIP_NO_ERROR On success.
      * @retval other           Was unable to retrieve data and write it into the writer.
      */
-    CHIP_ERROR Init(EventManagement * apEventManagement = nullptr);
+    CHIP_ERROR Init(EventManagement * apEventManagement);
 
     void Shutdown();
 
@@ -98,13 +98,6 @@ public:
      * Application marks mutated change path and would be sent out in later report.
      */
     CHIP_ERROR SetDirty(const AttributePathParams & aAttributePathParams);
-
-    /**
-     * @brief
-     *  Schedule the event delivery
-     *
-     */
-    CHIP_ERROR ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBytesWritten) override;
 
     /*
      * Resets the tracker that tracks the currently serviced read handler.
@@ -184,6 +177,12 @@ private:
     // match the current data version of that cluster.
     bool IsClusterDataVersionMatch(const SingleLinkedListNode<DataVersionFilter> * aDataVersionFilterList,
                                    const ConcreteReadAttributePath & aPath);
+
+    /**
+     *  EventReporter implementations.
+     *
+     */
+    CHIP_ERROR NewEventGenerated(ConcreteEventPath & aPath, uint32_t aBytesWritten) override;
 
     /**
      * Send Report via ReadHandler

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <access/AccessControl.h>
+#include <app/EventScheduler.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <app/ReadHandler.h>
 #include <app/data-model-provider/ProviderChangeListener.h>

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -65,7 +65,7 @@ public:
 
     /**
      * Initializes the reporting engine. Should only be called once.
-     * 
+     *
      * @param[in] A pointer to EventManagement. Use the global one by default.
      *
      * @retval #CHIP_NO_ERROR On success.


### PR DESCRIPTION
This PR is to decouple EventManagement with IMEngine singleton.

Inject EventManagement into ReportingEngine so it doesn't look for the global instance.
Creates EventScheduler interface (which is implemented by reporting engine) and inject into EventManagement to schedule events.
Created the EventScheduler to avoid both classes depends on each others. Also both classes are injected during Init call and takes the global one if not provided.

This is beneficial and allow us to have in-process testing (e.g. one client and one server running in parallel as different IM engines).

testing: Code changes are tested by existed unit tests, the tests verify that event are generated.
 - TestReadInteraction.TestSubscribeEarlyReport
 - TestReadInteraction.TestSubscribeUrgentWildcardEvent
 - TestReadInteractionSync.TestSubscribeEarlyReport
 - TestReadInteractionSync.TestSubscribeUrgentWildcardEvent

