### PR TITLE
[Fabric-Sync] Fix ICD check-in handler registration

### DIFF
--- a/examples/fabric-sync/admin/FabricAdmin.cpp
+++ b/examples/fabric-sync/admin/FabricAdmin.cpp
@@ -16,8 +16,10 @@
  */
 
 #include "FabricAdmin.h"
+
 #include <AppMain.h>
 #include <CommissionerMain.h>
+#include <app/server/Server.h>
 #include <bridge/include/FabricBridge.h>
 #include <controller/CHIPDeviceControllerFactory.h>
 
@@ -45,9 +47,8 @@ CHIP_ERROR FabricAdmin::Init()
     VerifyOrReturnError(engine != nullptr, CHIP_ERROR_INCORRECT_STATE);
     ReturnLogErrorOnFailure(IcdManager::Instance().Init(&sICDClientStorage, engine));
 
-    auto exchangeMgr = Controller::DeviceControllerFactory::GetInstance().GetSystemState()->ExchangeMgr();
-    VerifyOrReturnError(exchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    ReturnLogErrorOnFailure(sCheckInHandler.Init(exchangeMgr, &sICDClientStorage, &IcdManager::Instance(), engine));
+    ReturnLogErrorOnFailure(sCheckInHandler.Init(&chip::Server::GetInstance().GetExchangeManager(), &sICDClientStorage,
+                                                 &IcdManager::Instance(), engine));
 
     ReturnLogErrorOnFailure(PairingManager::Instance().Init(GetDeviceCommissioner()));
 


### PR DESCRIPTION
### Problem

The fabric-sync app enables commissioner and commissionee code. When doing so, we have two exchange managers registered due to a common platform code. In such case the default exchange is the server one, not the controller one. Because of that the fabric-app is not able to receive unsolicited ICD messages, because the handler is registered on the controller exchange.

### Change

Use server exchange instead.

### Testing

Tested locally with BRBINFO