### PR TITLE
Bash completion for chip example applications

### DIFF
--- a/scripts/helpers/bash-completion.sh
+++ b/scripts/helpers/bash-completion.sh
@@ -28,6 +28,58 @@ _chip_tool_get_options() {
     "$@" --help 2>&1 | awk -F'[[]|[]]' '/^[[]--/{ print $2 }'
 }
 
+_chip_app() {
+
+    local cur prev words cword split
+    _init_completion -s || return
+
+    case "$prev" in
+        --ble-device)
+            readarray -t words < <(ls -I '*:*' /sys/class/bluetooth)
+            # Get the list of Bluetooth devices without the 'hci' prefix.
+            readarray -t COMPREPLY < <(compgen -W "${words[*]#hci}" -- "$cur")
+            return
+            ;;
+        --custom-flow)
+            readarray -t COMPREPLY < <(compgen -W "0 1 2" -- "$cur")
+            return
+            ;;
+        --capabilities)
+            # The capabilities option is a bit-field with 3 bits currently defined.
+            readarray -t COMPREPLY < <(compgen -W "001 010 011 100 101 111" -- "$cur")
+            return
+            ;;
+        --KVS)
+            _filedir
+            return
+            ;;
+        --PICS)
+            _filedir
+            return
+            ;;
+        --trace_file)
+            _filedir
+            return
+            ;;
+        --trace_log | --trace_decode)
+            readarray -t COMPREPLY < <(compgen -W "0 1" -- "$cur")
+            return
+            ;;
+        --trace-to)
+            readarray -t COMPREPLY < <(compgen -W "json perfetto" -- "$cur")
+            compopt -o nospace
+            return
+            ;;
+    esac
+
+    case "$cur" in
+        -*)
+            readarray -t COMPREPLY < <(compgen -W "$(_parse_help "$1")" -- "$cur")
+            ;;
+    esac
+
+}
+
 _chip_tool() {
 
     local cur prev words cword split
@@ -36,34 +88,56 @@ _chip_tool() {
     # Get command line arguments up to the cursor position
     local args=("${COMP_WORDS[@]:0:$cword+1}")
 
-    local command=0
     case "$prev" in
         --commissioner-name)
             readarray -t COMPREPLY < <(compgen -W "alpha beta gamma 4 5 6 7 8 9" -- "$cur")
+            return
             ;;
-        --paa-trust-store-path | --cd-trust-store-path)
+        --only-allow-trusted-cd-keys)
+            readarray -t COMPREPLY < <(compgen -W "0 1" -- "$cur")
+            return
+            ;;
+        --paa-trust-store-path | --cd-trust-store-path | --dac-revocation-set-path)
             _filedir -d
+            return
             ;;
         --storage-directory)
             _filedir -d
+            return
             ;;
-        *)
-            command=1
+        --trace-to)
+            readarray -t COMPREPLY < <(compgen -W "json perfetto" -- "$cur")
+            compopt -o nospace
+            return
             ;;
     esac
 
-    if [ "$command" -eq 1 ]; then
-        case "$cur" in
-            -*)
-                words=$(_chip_tool_get_options "${args[@]}")
-                ;;
-            *)
-                words=$(_chip_tool_get_commands "${args[@]}")
-                ;;
-        esac
-        readarray -t COMPREPLY < <(compgen -W "$words" -- "$cur")
-    fi
+    case "$cur" in
+        -*)
+            words=$(_chip_tool_get_options "${args[@]}")
+            ;;
+        *)
+            words=$(_chip_tool_get_commands "${args[@]}")
+            ;;
+    esac
+    readarray -t COMPREPLY < <(compgen -W "$words" -- "$cur")
 
 }
+
+complete -F _chip_app chip-air-purifier-app
+complete -F _chip_app chip-all-clusters-app
+complete -F _chip_app chip-bridge-app
+complete -F _chip_app chip-dishwasher-app
+complete -F _chip_app chip-energy-management-app
+complete -F _chip_app chip-lighting-app
+complete -F _chip_app chip-lock-app
+complete -F _chip_app chip-log-source-app
+complete -F _chip_app chip-microwave-oven-app
+complete -F _chip_app chip-ota-provider-app
+complete -F _chip_app chip-ota-requestor-app
+complete -F _chip_app chip-refrigerator-app
+complete -F _chip_app chip-rvc-app
+complete -F _chip_app chip-tv-app
+complete -F _chip_app chip-tv-casting-app
 
 complete -F _chip_tool chip-tool


### PR DESCRIPTION
This PR provides support for most example applications found in the examples folder.

### Testing

```sh
source scripts/activate.sh
# build some app, e.g. chip-all-clusters-app
out/linux-x64-chip-all-clusters-app -<TAB><TAB>
```

Why it's not automatically tested? Hmmm... creating a test harness for bash autocompletion seems a bit like an overkill... but of course is doable :D