### PR TITLE
Make the setup-device command work right with TriggerResubscriptionCommand.

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -132,6 +132,8 @@ protected:
 
     MTRDevice * GetLastUsedDevice();
 
+    static MTRDevice * sLastUsedDevice;
+
 private:
     CHIP_ERROR InitializeCommissioner(
         std::string key, chip::FabricId fabricId, const chip::Credentials::AttestationTrustStore * trustStore);

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -35,7 +35,7 @@
 #include <string>
 
 static CHIPToolPersistentStorageDelegate * storage = nil;
-static MTRDevice * sLastUsedDevice = nil;
+MTRDevice * CHIPCommandBridge::sLastUsedDevice = nil;
 static DeviceDelegate * sDeviceDelegate = nil;
 static dispatch_queue_t sDeviceDelegateDispatchQueue = nil;
 std::set<CHIPCommandBridge *> CHIPCommandBridge::sDeferredCleanups;

--- a/examples/darwin-framework-tool/commands/configuration/SetUpDeviceCommand.h
+++ b/examples/darwin-framework-tool/commands/configuration/SetUpDeviceCommand.h
@@ -54,6 +54,7 @@ protected:
         DeviceWithNodeId(mNodeId);
 
         mDelegate = delegate;
+        sLastUsedDevice = device;
         SetCommandExitStatus(CHIP_NO_ERROR);
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
When an MTRDevice was set up via the setup-device command, not via CHIPCommandBridge::DeviceWithNodeId, we weren't storing sLastUsedDevice, so triggering resubscription would not know to talk to that device instance.
