### PR TITLE
Update documentation file used in generate_spec_xml.py

### DIFF
--- a/scripts/spec_xml/paths.py
+++ b/scripts/spec_xml/paths.py
@@ -71,7 +71,7 @@ def get_documentation_file_path():
     Returns the path to the documentation file.
     """
     chip_root = get_chip_root()
-    documentation_file = os.path.join(chip_root, 'docs', 'spec_clusters.md')
+    documentation_file = os.path.join(chip_root, 'docs', 'ids_and_codes', 'spec_clusters.md')
     if not os.path.exists(documentation_file):
         raise FileNotFoundError(f"Documentation file does not exist: {documentation_file}")
     return documentation_file


### PR DESCRIPTION
## Changes

Fix the path to the documentation file in the script:
https://github.com/project-chip/connectedhomeip/blob/cfdaf799a6761799828108febe2c6a6fd5747470/scripts/spec_xml/paths.py#L58-L66

Broken by PR https://github.com/project-chip/connectedhomeip/pull/36208.

It should be this: [/docs/ids_and_codes/spec_clusters.md](https://github.com/project-chip/connectedhomeip/blob/master/docs/ids_and_codes/spec_clusters.md)

Fix for #36853

## Testing

```
./scripts/spec_xml/generate_spec_xml.py     \
   --scraper ~/Downloads/scrape-adoc-linux  \
   --spec-root ~/work/connectedhomeip-spec  \
   --output-dir data_model
```

validated by @andy31415 with spec repository access
