### PR TITLE
Update `generate_spec_xml.py`

### DIFF
--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -76,12 +76,9 @@ def make_asciidoc(target: str, include_in_progress: str, spec_dir: str, dry_run:
     default=False,
     is_flag=True,
     help='Flag for dry run')
-@click.option(
-    '--include-in-progress',
-    type=click.Choice(['All', 'None', 'Current']), default='All')
 def main(scraper, spec_root, output_dir, dry_run, include_in_progress):
     if not output_dir:
-        output_dir_map = {'All': DEFAULT_OUTPUT_DIR_TOT, 'None': DEFAULT_OUTPUT_DIR_1_3, 'Current': DEFAULT_OUTPUT_DIR_IN_PROGRESS}
+        output_dir_map = {'All': DEFAULT_OUTPUT_DIR_TOT, 'None': DEFAULT_OUTPUT_DIR_1_3}
         output_dir = output_dir_map[include_in_progress]
     scrape_clusters(scraper, spec_root, output_dir, dry_run, include_in_progress)
     scrape_device_types(scraper, spec_root, output_dir, dry_run, include_in_progress)

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -31,7 +31,8 @@ CURRENT_IN_PROGRESS_DEFINES = get_in_progress_defines()
 
 # Replace hardcoded paths with dynamic paths using paths.py functions
 DEFAULT_CHIP_ROOT = get_chip_root()
-DEFAULT_OUTPUT_DIR_1_3 = get_data_model_path(Branch.V1_3)
+DEFAULT_OUTPUT_DIR_1_4 = get_data_model_path(Branch.V1_4)
+DEFAULT_OUTPUT_DIR_IN_PROGRESS = get_data_model_path(Branch.IN_PROGRESS)
 DEFAULT_OUTPUT_DIR_TOT = get_data_model_path(Branch.MASTER)
 DEFAULT_DOCUMENTATION_FILE = get_documentation_file_path()
 
@@ -76,9 +77,12 @@ def make_asciidoc(target: str, include_in_progress: str, spec_dir: str, dry_run:
     default=False,
     is_flag=True,
     help='Flag for dry run')
+@click.option(
+    '--include-in-progress',
+    type=click.Choice(['All', 'None', 'Current']), default='All')
 def main(scraper, spec_root, output_dir, dry_run, include_in_progress):
     if not output_dir:
-        output_dir_map = {'All': DEFAULT_OUTPUT_DIR_TOT, 'None': DEFAULT_OUTPUT_DIR_1_3}
+        output_dir_map = {'All': DEFAULT_OUTPUT_DIR_TOT, 'None': DEFAULT_OUTPUT_DIR_1_4, 'Current': DEFAULT_OUTPUT_DIR_IN_PROGRESS}
         output_dir = output_dir_map[include_in_progress]
     scrape_clusters(scraper, spec_root, output_dir, dry_run, include_in_progress)
     scrape_device_types(scraper, spec_root, output_dir, dry_run, include_in_progress)

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -32,7 +32,6 @@ CURRENT_IN_PROGRESS_DEFINES = get_in_progress_defines()
 # Replace hardcoded paths with dynamic paths using paths.py functions
 DEFAULT_CHIP_ROOT = get_chip_root()
 DEFAULT_OUTPUT_DIR_1_3 = get_data_model_path(Branch.V1_3)
-DEFAULT_OUTPUT_DIR_IN_PROGRESS = get_data_model_path(Branch.IN_PROGRESS)
 DEFAULT_OUTPUT_DIR_TOT = get_data_model_path(Branch.MASTER)
 DEFAULT_DOCUMENTATION_FILE = get_documentation_file_path()
 

--- a/scripts/spec_xml/paths.py
+++ b/scripts/spec_xml/paths.py
@@ -24,7 +24,6 @@ class Branch(Enum):
     MASTER = "master"
     V1_3 = "1.4"
     V1_4 = "1.4"
-    IN_PROGRESS = "in_progress"
 
 
 def get_chip_root():

--- a/scripts/spec_xml/paths.py
+++ b/scripts/spec_xml/paths.py
@@ -22,8 +22,9 @@ from enum import Enum
 
 class Branch(Enum):
     MASTER = "master"
-    V1_3 = "1.4"
+    V1_3 = "1.3"
     V1_4 = "1.4"
+    IN_PROGRESS = "in_progress"
 
 
 def get_chip_root():

--- a/scripts/spec_xml/paths.py
+++ b/scripts/spec_xml/paths.py
@@ -22,8 +22,8 @@ from enum import Enum
 
 class Branch(Enum):
     MASTER = "master"
-    V1_3 = "v1_3"
-    V1_4 = "v1_4"
+    V1_3 = "1.4"
+    V1_4 = "1.4"
     IN_PROGRESS = "in_progress"
 
 


### PR DESCRIPTION
## Changes 

Update `generate_spec_xml.py`:
- Correct branches directory names
- Rename `DEFAULT_OUTPUT_DIR_1_3` to `DEFAULT_OUTPUT_DIR_1_4` 

## Testing

```
./scripts/spec_xml/generate_spec_xml.py     \
   --scraper ~/Downloads/scrape-adoc-linux  \
   --spec-root ~/work/connectedhomeip-spec  \
   --output-dir data_model
```
But I can't test it because I don't have access to Specification repository https://github.com/CHIP-Specifications/connectedhomeip-spec
