### PR TITLE
binding: Add supports of self binding and enable multicast loop back by default

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -89,7 +89,12 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
             ChipLogError(NotSpecified, "OnOff command failed: %" CHIP_ERROR_FORMAT, error.Format());
         };
 
-        VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
+        if (!peer_device)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
+        VerifyOrDie(peer_device->ConnectionReady());
         if (sSwitchOnOffState)
         {
             Clusters::OnOff::Commands::On::Type onCommand;

--- a/examples/all-clusters-app/ameba/main/BindingHandler.cpp
+++ b/examples/all-clusters-app/ameba/main/BindingHandler.cpp
@@ -60,6 +60,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         // It should always enter here if isReadAttribute is true
         if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
         {
+            if (!peer_device)
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+                return;
+            }
             switch (data->clusterId)
             {
             case Clusters::Identify::Id:
@@ -105,6 +110,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         }
         else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
         {
+            if (!peer_device)
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+                return;
+            }
             switch (data->clusterId)
             {
             case Clusters::Identify::Id:

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -80,6 +80,12 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         return;
     }
 
+    if (binding.type == MATTER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
+        return;
+    }
+
     if (binding.type == MATTER_UNICAST_BINDING && binding.local == 1 &&
         binding.clusterId.value_or(Clusters::OnOff::Id) == Clusters::OnOff::Id)
     {

--- a/examples/light-switch-app/ameba/main/BindingHandler.cpp
+++ b/examples/light-switch-app/ameba/main/BindingHandler.cpp
@@ -124,6 +124,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -216,6 +216,11 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & aB
     }
     else if (aBinding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->ClusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/asr/src/BindingHandler.cpp
+++ b/examples/light-switch-app/asr/src/BindingHandler.cpp
@@ -216,7 +216,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & aB
     }
     else if (aBinding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
-        if (peer_device == nullptr)
+        if (deviceProxy == nullptr)
         {
             ChipLogProgress(NotSpecified, "Binding to self");
             return;

--- a/examples/light-switch-app/cc13x4_26x4/src/BindingHandler.cpp
+++ b/examples/light-switch-app/cc13x4_26x4/src/BindingHandler.cpp
@@ -101,6 +101,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -120,6 +120,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/genio/src/BindingHandler.cpp
+++ b/examples/light-switch-app/genio/src/BindingHandler.cpp
@@ -130,6 +130,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -230,6 +230,11 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->ClusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/BindingHandler.cpp
@@ -230,7 +230,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
-        if (peer_device == nullptr)
+        if (deviceProxy == nullptr)
         {
             ChipLogProgress(NotSpecified, "Binding to self");
             return;

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -215,6 +215,11 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->ClusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -215,7 +215,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->IsGroup)
     {
-        if (peer_device == nullptr)
+        if (deviceProxy == nullptr)
         {
             ChipLogProgress(NotSpecified, "Binding to self");
             return;

--- a/examples/light-switch-app/qpg/src/binding-handler.cpp
+++ b/examples/light-switch-app/qpg/src/binding-handler.cpp
@@ -179,8 +179,7 @@ static void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Op
         case Clusters::OnOff::Id:
         case Clusters::LevelControl::Id:
         case Clusters::ColorControl::Id:
-            // TODO should not happen?
-            VerifyOrReturn(peer_device != nullptr, ChipLogError(NotSpecified, "Peer is nullptr"));
+            VerifyOrReturn(peer_device != nullptr, ChipLogProgress(NotSpecified, "Binding to self"));
 
             ProcessSwitchUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
                                                peer_device->GetSecureSession().Value(), data);

--- a/examples/light-switch-app/silabs/src/BindingHandler.cpp
+++ b/examples/light-switch-app/silabs/src/BindingHandler.cpp
@@ -101,6 +101,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
     }
     else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
     {
+        if (peer_device == nullptr)
+        {
+            ChipLogProgress(NotSpecified, "Binding to self");
+            return;
+        }
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -118,6 +118,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         // It should always enter here if isReadAttribute is true
         if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
         {
+            if (peer_device == nullptr)
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+                return;
+            }
             switch (data->clusterId)
             {
             case Clusters::Identify::Id:
@@ -142,6 +147,11 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         }
         else if (binding.type == MATTER_UNICAST_BINDING && !data->isGroup)
         {
+            if (peer_device == nullptr)
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+                return;
+            }
             switch (data->clusterId)
             {
             case Clusters::Identify::Id:

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -67,7 +67,10 @@ BindingManager BindingManager::sBindingManager;
 
 CHIP_ERROR BindingManager::UnicastBindingCreated(uint8_t fabricIndex, NodeId nodeId)
 {
-    return EstablishConnection(ScopedNodeId(nodeId, fabricIndex));
+    if (!IsSelfNodeId(ScopedNodeId(nodeId, fabricIndex))) {
+        return EstablishConnection(ScopedNodeId(nodeId, fabricIndex));
+    }
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BindingManager::UnicastBindingRemoved(uint8_t bindingEntryId)

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -67,7 +67,8 @@ BindingManager BindingManager::sBindingManager;
 
 CHIP_ERROR BindingManager::UnicastBindingCreated(uint8_t fabricIndex, NodeId nodeId)
 {
-    if (!IsSelfNodeId(ScopedNodeId(nodeId, fabricIndex))) {
+    if (!IsSelfNodeId(ScopedNodeId(nodeId, fabricIndex)))
+    {
         return EstablishConnection(ScopedNodeId(nodeId, fabricIndex));
     }
     return CHIP_NO_ERROR;

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -32,7 +32,8 @@ namespace chip {
  * The connection is managed by the stack and peer_device is guaranteed to be available.
  * The application shall decide the content to be sent to the peer.
  *
- * For unicast bindings peer_device will be a connected peer and group will be empty.
+ * For unicast bindings to other devices, peer_device will be a connected peer.
+ * For unicast bindings to self, peer_device will be nullptr.
  * For multicast bindings peer_device will be nullptr.
  *
  * E.g. The application will send on/off commands to peer for the OnOff cluster.

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -129,6 +129,7 @@ uint16_t UDPEndPointImplLwIP::GetBoundPort() const
 
 CHIP_ERROR UDPEndPointImplLwIP::ListenImpl()
 {
+    mLwIPEndPointType = LwIPEndPointType::UDP;
     RunOnTCPIP([this]() { udp_recv(mUDP, LwIPReceiveUDPMessage, this); });
     return CHIP_NO_ERROR;
 }
@@ -420,11 +421,11 @@ CHIP_ERROR UDPEndPointImplLwIP::SetMulticastLoopback(IPVersion aIPVersion, bool 
     {
         if (aLoopback)
         {
-            udp_set_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
+            RunOnTCPIP([this]() { udp_set_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP); });
         }
         else
         {
-            udp_clear_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP);
+            RunOnTCPIP([this]() { udp_clear_flags(mUDP, UDP_FLAGS_MULTICAST_LOOP); });
         }
         return CHIP_NO_ERROR;
     }

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -145,6 +145,17 @@ CHIP_ERROR UDP::MulticastGroupJoinLeave(const Transport::PeerAddress & address, 
 
     if (join)
     {
+#if INET_CONFIG_ENABLE_IPV4
+        if (mUDPEndPoint->SetMulticastLoopback(address.GetIPAddress().IsIPv4() ? Inet::kIPVersion_4 : Inet::kIPVersion_6, true) !=
+            CHIP_NO_ERROR)
+#else
+        if (mUDPEndPoint->SetMulticastLoopback(Inet::kIPVersion_6, true) != CHIP_NO_ERROR)
+#endif
+        {
+            ChipLogError(Inet,
+                         "Failed to set multicast loop back, this could lead to that the device cannot receive multicast message "
+                         "sent by itself");
+        }
         ChipLogProgress(Inet, "Joining Multicast Group with address %s", addressStr);
         return mUDPEndPoint->JoinMulticastGroup(mUDPEndPoint->GetBoundInterface(), address.GetIPAddress());
     }


### PR DESCRIPTION
Reopen #21623

And enable multicast loopback by default to fix the follow scenario:
Light endpoint and Switch endpoint are on the same node and the two endpoints join the same group which is bound to the switch  endpoint's binding cluster. When triggering the bound changed callback, the light endpoint cannot receive the multicast command.

### Test

Test with light-switch example which adds an extra on-off light endpoint on endpoint 3.
```
./chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42,
"groupKeySecurityPolicy": 0, "epochKey0":
"d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000,"epochKey1":
"d0d1d2d3d4d5d6d7d8d9dadbdcdddede", "epochStartTime1": 2230000,"epochKey2":
"d0d1d2d3d4d5d6d7d8d9dadbdcdddedd", "epochStartTime2": 2240000 }' 1 0

./chip-tool groupkeymanagement write group-key-map '[{"groupId": 1, "groupKeySetID": 42, "fabricIndex": 1}]' 1 0

# Add endpoint 1(onoff switch) and endpoint 3(onoff light) to the same groups
./chip-tool groups add-group 1 grp1 1 1
./chip-tool groups add-group 1 grp1 1 3

# ACL configuration
./chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null }, {"fabricIndex": 1, "privilege": 4, "authMode": 3, "subjects": [1], "targets": null}]' 1 0

# Bind endpoint 3 to the endpoint 1
./chip-tool binding write binding '[{"fabricIndex": 1, "node":1, "endpoint": 3, "cluster":6}]' 1 1
# Then trigger the binding notifier, the device print "Bind to self" to notify there is a local bound change

# Bind group 1 to endpoint 1
./chip-tool binding write binding '[{"fabricIndex": 1, "group":1, "cluster":6}]' 1 1
# Then trigger the binding notifier, the device can receive the group command sent by itself.
```