### PR TITLE
Fix Global Buffer Overflow in MediaInputManager.cpp

### DIFF
--- a/examples/tv-app/tv-common/clusters/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/media-input/MediaInputManager.cpp
@@ -99,6 +99,11 @@ bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharS
     {
         if (input.index == index)
         {
+            if (sizeof(mCharDataBuffer[index]) < name.size())
+            {
+                return mediaInputRenamed;
+            }
+
             mediaInputRenamed = true;
             memcpy(this->Data(index), name.data(), name.size());
             input.name = chip::CharSpan(this->Data(index), name.size());


### PR DESCRIPTION
### Description

This pull request fixes a global-buffer-overflow in the `MediaInputManager::HandleRenameInput` function of the MediaInput cluster.

The `mCharDataBuffer` has a fixed size of 32 for each index. 
```cpp
class MediaInputManager : public chip::app::Clusters::MediaInput::Delegate
{
public:
    MediaInputManager();

protected:
    char mCharDataBuffer[10][32]; // Fixed size of 32 for each buffer
};
```
However, the `memcpy` operation in the `HandleRenameInput` function does not verify that the `name.size()` does not exceed the buffer size. This leads to a buffer overflow when the input size is larger than 32 bytes. This is triggered by passing a string larger than 32 bytes, as demonstrated in the reproduction steps.

### Reproduce

1. Run the following commands in separate terminals:

   **tv-app:**
   ```bash
   ./chip-tv-app
   ```

   **chip-tool:**
   ```bash
   ./chip-tool interactive start
   ```

2. Execute the `rename-input` command in the MediaInput cluster with a long string argument:
   ```bash
   mediainput rename-input 1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1
   ```

3. Observe the AddressSanitizer log for buffer overflow errors.
[ASAN Log.txt](https://github.com/user-attachments/files/18146979/ASAN.Log.txt)


### Changes

The fix introduces a size check to prevent buffer overflow. Before executing `memcpy`, it verifies that the input size (`name.size()`) does not exceed the buffer size (`sizeof(mCharDataBuffer[index])`). The updated function is as follows:

```cpp
bool MediaInputManager::HandleRenameInput(const uint8_t index, const chip::CharSpan & name)
{
    // TODO: Insert code here
    bool mediaInputRenamed = false;

    for (InputInfoType & input : mInputs)
    {
        if (input.index == index)
        {
            if (sizeof(mCharDataBuffer[index]) < name.size()) // Prevent buffer overflow
            {
                return mediaInputRenamed;
            }
            
            mediaInputRenamed = true;
            memcpy(this->Data(index), name.data(), name.size());
            input.name = chip::CharSpan(this->Data(index), name.size());
        }
    }

    return mediaInputRenamed;
}
```
