### PR TITLE
Fix Global Buffer Overflow in AudioOutputManager.cpp

### DIFF
--- a/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
+++ b/examples/tv-app/tv-common/clusters/audio-output/AudioOutputManager.cpp
@@ -62,6 +62,11 @@ bool AudioOutputManager::HandleRenameOutput(const uint8_t & index, const chip::C
     {
         if (output.index == index)
         {
+            if (sizeof(mCharDataBuffer[index]) < name.size())
+            {
+                return audioOutputRenamed;
+            }
+
             audioOutputRenamed = true;
             memcpy(this->Data(index), name.data(), name.size());
             output.name = chip::CharSpan(this->Data(index), name.size());


### PR DESCRIPTION
### Description
This pull request fixes a global-buffer-overflow in the `AudioOutputManager::HandleRenameOutput` function of the AudioOutput cluster.

Similar to PR #36856 for the MediaInput cluster, this bug arises from an unchecked memcpy operation that allows oversized input to overflow a fixed-size buffer.
The mCharDataBuffer in AudioOutputManager is a statically allocated buffer with a fixed size of 32 for each entry:
```cpp
char mCharDataBuffer[10][32];
```
However, the HandleRenameOutput function does not validate the size of the input string (name.size()) before copying it into the buffer. If the input string exceeds 32 bytes, this leads to a buffer overflow, as demonstrated in the reproduction steps.

### Reproduce

1. Run the following commands in separate terminals:

   **tv-app:**
   ```bash
   ./chip-tv-app
   ```

   **chip-tool:**
   ```bash
   ./chip-tool interactive start
   ```

2. Execute the `rename-output` command in the AudioOutput cluster with a long string argument:
   ```bash
   audiooutput rename-output 1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1
   ```

3. Observe the AddressSanitizier Log
[ASAN Log.txt](https://github.com/user-attachments/files/18150543/ASAN.Log.txt)

### Changes
The fix applies the same solution introduced in PR #36856. A size check is added before the memcpy operation to ensure the input does not exceed the buffer's capacity.

Updated HandleRenameOutput function:
```cpp
bool AudioOutputManager::HandleRenameOutput(const uint8_t & index, const chip::CharSpan & name)
{
    // TODO: Insert code here
    bool audioOutputRenamed = false;

    for (OutputInfoType & output : mOutputs)
    {
        if (output.index == index)
        {
            if (sizeof(mCharDataBuffer[index]) < name.size())
            {
                return audioOutputRenamed;
            }
            
            audioOutputRenamed = true;
            memcpy(this->Data(index), name.data(), name.size());
            output.name = chip::CharSpan(this->Data(index), name.size());
        }
    }

    return audioOutputRenamed;
}
```