### PR TITLE
Fix running async functions without event loop during testing

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1156,17 +1156,14 @@ class MatterBaseTest(base_test.BaseTestClass):
                 self.step(1)
 
     def teardown_class(self):
-        """Final teardown after all tests: log all problems"""
-        if len(self.problems) == 0:
-            return
-
-        logging.info("###########################################################")
-        logging.info("Problems found:")
-        logging.info("===============")
-        for problem in self.problems:
-            logging.info(str(problem))
-        logging.info("###########################################################")
-
+        """Final teardown after all tests: log all problems."""
+        if len(self.problems) > 0:
+            logging.info("###########################################################")
+            logging.info("Problems found:")
+            logging.info("===============")
+            for problem in self.problems:
+                logging.info(str(problem))
+            logging.info("###########################################################")
         super().teardown_class()
 
     def check_pics(self, pics_key: str) -> bool:

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -36,6 +36,7 @@
 # pip install opencv-python requests click_option_group
 # python src/python_testing/post_certification_tests/production_device_checks.py
 
+import asyncio
 import base64
 import hashlib
 import importlib
@@ -390,9 +391,9 @@ def run_test(test_class: MatterBaseTest, tests: typing.List[str], test_config: T
     stack = test_config.get_stack()
     controller = test_config.get_controller()
     matter_config = test_config.get_config(tests)
-    ok = run_tests_no_exit(test_class, matter_config, hooks, controller, stack)
-    if not ok:
-        print(f"Test failure. Failed on step: {hooks.get_failures()}")
+    with asyncio.Runner() as runner:
+        if not run_tests_no_exit(test_class, matter_config, runner.get_loop(), hooks, controller, stack):
+            print(f"Test failure. Failed on step: {hooks.get_failures()}")
     return hooks.get_failures()
 
 

--- a/src/python_testing/test_testing/MockTestRunner.py
+++ b/src/python_testing/test_testing/MockTestRunner.py
@@ -15,6 +15,7 @@
 #    limitations under the License.
 #
 
+import asyncio
 import importlib
 import os
 import sys
@@ -75,4 +76,6 @@ class MockTestRunner():
         self.default_controller.Read = AsyncMock(return_value=read_cache)
         # This doesn't need to do anything since we are overriding the read anyway
         self.default_controller.FindOrEstablishPASESession = AsyncMock(return_value=None)
-        return run_tests_no_exit(self.test_class, self.config, hooks, self.default_controller, self.stack)
+        with asyncio.Runner() as runner:
+            return run_tests_no_exit(self.test_class, self.config, runner.get_loop(),
+                                     hooks, self.default_controller, self.stack)

--- a/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
+++ b/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 
+import asyncio
 import base64
 import os
 import pathlib
@@ -166,7 +167,9 @@ class MyMock(MockTestRunner):
         self.default_controller.FindOrEstablishPASESession = AsyncMock(return_value=None)
         self.default_controller.ReadEvent = AsyncMock(return_value=[], side_effect=dynamic_event_return)
 
-        return run_tests_no_exit(self.test_class, self.config, hooks, self.default_controller, self.stack)
+        with asyncio.Runner() as runner:
+            return run_tests_no_exit(self.test_class, self.config, runner.get_loop(),
+                                     hooks, self.default_controller, self.stack)
 
 
 @click.command()

--- a/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
+++ b/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
@@ -16,6 +16,7 @@
 #    limitations under the License.
 #
 
+import asyncio
 import base64
 import os
 import pathlib
@@ -137,7 +138,9 @@ class MyMock(MockTestRunner):
         self.default_controller.FindOrEstablishPASESession = AsyncMock(return_value=None)
         self.default_controller.ReadEvent = AsyncMock(return_value=[], side_effect=dynamic_event_return)
 
-        return run_tests_no_exit(self.test_class, self.config, hooks, self.default_controller, self.stack)
+        with asyncio.Runner() as runner:
+            return run_tests_no_exit(self.test_class, self.config, runner.get_loop(),
+                                     hooks, self.default_controller, self.stack)
 
 
 @click.command()


### PR DESCRIPTION
### Problem

Python testing uses `mobly` which is not async-oriented. To "fix" that the "asyncio.run" decorator is used for async functions. However, this provides async event loop with a event context only for the time of the test function execution, not for the entire mobly runtime lifetime. This firebacks on us when the CHIP stack returns some future object after wrapped async test function returns:

```python
Exception ignored on calling ctypes callback function: <function _OnReadDoneCallback at 0x799104ffdda0>
Traceback (most recent call last):
  File ".../lib/python3.12/site-packages/chip/clusters/Attribute.py", line 939, in _OnReadDoneCallback
    closure.handleDone()
  File ".../lib/python3.12/site-packages/chip/clusters/Attribute.py", line 817, in handleDone
    self._event_loop.call_soon_threadsafe(self._handleDone)
  File "/usr/lib/python3.12/asyncio/base_events.py", line 840, in call_soon_threadsafe
    self._check_closed()
  File "/usr/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

### Changes

- Create one global async context and use it to synchronize all async functions.
- Keep device commissioning method in `CommissionDeviceTest` class

### Testing

Tested locally that there are no exceptions like before. CI will verify for potential breaks.