### PR TITLE
TC-VALCC: Update wording on test steps

### DIFF
--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -49,15 +49,15 @@ class TC_VALCC_3_1(MatterBaseTest):
 
     def steps_TC_VALCC_3_1(self) -> list[TestStep]:
         steps = [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(1, "Commission DUT if required", is_commissioning=True),
             TestStep(2, "Set up a subscription to all attributes on the DUT"),
             TestStep(3, "Send a close command to the DUT and wait until the CurrentState is closed", "DUT returns SUCCESS"),
             TestStep(4, "Send Open command", "DUT returns SUCCESS"),
-            TestStep(5, "Wait until TH receives and data report for TargetState set to NULL and an attribute report for CurrentState set to Open (ordering does not matter)",
+            TestStep(5, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, CurrentState set to Open",
                      "Expected attribute reports are received"),
             TestStep(6, "Read CurrentState and TargetState attribute", "CurrentState is Open, TargetState is NULL"),
             TestStep(7, "Send Close command", "DUT returns SUCCESS"),
-            TestStep(8, "Wait until TH receives and data report for TargetState set to NULL and an attribute report for CurrentState set to Closed (ordering does not matter)",
+            TestStep(8, "Wait until TH receives the following reports  (ordering does not matter): TargetState set to NULL, CurrentState set to Closed",
                      "Expected attribute reports are received"),
             TestStep(9, "Read CurrentState and TargetState attribute", "CurrentState is Closed, TargetState is NULL"),
         ]

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -63,7 +63,7 @@ class TC_VALCC_3_2(MatterBaseTest):
             TestStep(7, "Send Close command", "DUT returns SUCCESS"),
             TestStep(8, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Closed, CurrentLevel set to 0",
                      "Expected reports are received"),
-            TestStep(6, "Read CurrentState, CurrentLevel, TargetState and TargetLevel attributes",
+            TestStep(9, "Read CurrentState, CurrentLevel, TargetState and TargetLevel attributes",
                      "CurrentState is Closed, CurrentLevel is 0, TargetState is NULL, TargetLevel is NULL"),
         ]
         return steps

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -51,19 +51,20 @@ class TC_VALCC_3_2(MatterBaseTest):
 
     def steps_TC_VALCC_3_2(self) -> list[TestStep]:
         steps = [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(1, "Commission DUT if required", is_commissioning=True),
             TestStep(2, "Set up a subscription to all attributes on the DUT"),
             TestStep(3, "Send a close command to the DUT and wait until the CurrentState is closed", "DUT returns SUCCESS"),
             TestStep(4, "TH sends command Open command with TargetLevel field set to 100 and the remaining fields not populated.",
                      "Verify DUT responds w/ status SUCCESS(0x00)."),
-            TestStep(5, "Wait until TH receives data reports for TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Open and CurrentLevel set to 100 (ordering does not matter)",
-                     "Expected attribute reports are received"),
+            TestStep(5, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Open, CurrentLevel set to 100",
+                     "Expected reports are received"),
             TestStep(6, "Read CurrentState, CurrentLevel, TargetState and TargetLevel attributes",
-                     "CurrentState is Open, CurrentLevel is 100, TargetState is NULL and TargetLevel is NULL"),
+                     "CurrentState is Open, CurrentLevel is 100, TargetState is NULL, TargetLevel is NULL"),
             TestStep(7, "Send Close command", "DUT returns SUCCESS"),
-            TestStep(8, "Wait until TH receives and data report for TargetState set to NULL and an attribute report for CurrentState set to Closed (ordering does not matter)",
-                     "Expected attribute reports are received"),
-            TestStep(9, "Read CurrentState and TargetState attribute", "CurrentState is Closed, TargetState is NULL"),
+            TestStep(8, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Closed, CurrentLevel set to 0",
+                     "Expected reports are received"),
+            TestStep(6, "Read CurrentState, CurrentLevel, TargetState and TargetLevel attributes",
+                     "CurrentState is Closed, CurrentLevel is 0, TargetState is NULL, TargetLevel is NULL"),
         ]
         return steps
 

--- a/src/python_testing/TC_VALCC_3_3.py
+++ b/src/python_testing/TC_VALCC_3_3.py
@@ -49,7 +49,7 @@ class TC_VALCC_3_3(MatterBaseTest):
 
     def steps_TC_VALCC_3_3(self) -> list[TestStep]:
         steps = [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(1, "Commission DUT if required", is_commissioning=True),
             TestStep(2, "Read AttributeList attribute", "Verify that the DUT response contains the AttributeList attribute."),
             TestStep(3, "If the DefaultOpenLevel is not supported, skip all remaining steps in this test"),
             TestStep(4, "TH reads from the DUT the DefaultOpenLevel attribute. Store the value as defaultOpenLevel."),
@@ -57,12 +57,12 @@ class TC_VALCC_3_3(MatterBaseTest):
             TestStep(6, "Send a close command to the DUT and wait until the CurrentState is reported as closed", "DUT returns SUCCESS"),
             # TODO: this test should probably SET the default open attribute as well and un-set it at the end, so we're not testing against the default.
             TestStep(7, "Send Open command with no fields populated", "DUT returns SUCCESS"),
-            TestStep(8, "Wait until TH receives the following data reports (ordering not checked): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Open, CurrentLevel set to defaultOpenLevel",
+            TestStep(8, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Open, CurrentLevel set to defaultOpenLevel",
                      "Expected attribute reports are received"),
             TestStep(9, "Read CurrentState and TargetState attribute", "CurrentState is Open, TargetState is NULL"),
             TestStep(10, "Read CurrentLevel and TargetLevel attribute", "CurrentLevel is defaultOpenLevel, TargetLevel is NULL"),
             TestStep(11, "Send Close command", "DUT returns SUCCESS"),
-            TestStep(12, "Wait until TH receives the following data reports (ordering not checked): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Closed, CurrentLevel set to 0",
+            TestStep(12, "Wait until TH receives the following reports (ordering does not matter): TargetState set to NULL, TargetLevel set to NULL, CurrentState set to Closed, CurrentLevel set to 0",
                      "Expected attribute reports are received"),
             TestStep(13, "Read CurrentState and TargetState attribute", "CurrentState is Closed, TargetState is NULL"),
             TestStep(14, "Read CurrentLevel and TargetLevel attribute", "CurrentLevel is 0, TargetLevel is NULL"),


### PR DESCRIPTION
No functional changes, only changes to wording.

Test: Tests are all run in repl CI.

