### PR TITLE
Map the return error from AppendUserLabel to RESOURCE_EXHAUSTED

### DIFF
--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -151,7 +151,14 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         ReturnErrorOnFailure(aDecoder.Decode(entry));
         VerifyOrReturnError(IsValidLabelEntry(entry), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
-        return provider->AppendUserLabel(endpoint, entry);
+        // Append the single user label entry
+        CHIP_ERROR err = provider->AppendUserLabel(endpoint, entry);
+        if (err == CHIP_ERROR_NO_MEMORY)
+        {
+            return CHIP_IM_GLOBAL_STATUS(ResourceExhausted);
+        }
+        
+        return err;
     }
 
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -157,7 +157,7 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         {
             return CHIP_IM_GLOBAL_STATUS(ResourceExhausted);
         }
-        
+
         return err;
     }
 

--- a/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
+++ b/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
@@ -85,5 +85,5 @@ tests:
               ]
       response:
           # When the cluster runs out of capacity to store these entries,
-          # we expect a FAILURE get returned.
-          error: FAILURE
+          # we expect a RESOURCE_EXHAUSTED get returned.
+          error: RESOURCE_EXHAUSTED

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -97,7 +97,6 @@ public:
      *
      * @param[in] endpoint The endpoint ID associated with the user label list.
      * @param[in] labelList The new list of user labels to store.
-     *                      The size of the list cannot exceed `kMaxUserLabelListLength`.
      *
      * @return CHIP_NO_ERROR on success.
      * @return CHIP_ERROR if an error occurs.

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -89,8 +89,48 @@ public:
      */
     void SetStorageDelegate(PersistentStorageDelegate * storage);
 
+    /**
+     * @brief Sets the user label list for a specified endpoint.
+     *
+     * Replaces the current user label list with a new list. If the new list is smaller
+     * than the existing one, excess labels are deleted to free up space.
+     *
+     * @param[in] endpoint The endpoint ID associated with the user label list.
+     * @param[in] labelList The new list of user labels to store.
+     *                      The size of the list cannot exceed `kMaxUserLabelListLength`.
+     *
+     * @return CHIP_NO_ERROR on success.
+     * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND if no previous value exists.
+     * @return CHIP_ERROR if an error occurs while storing or deleting labels.
+     */
     CHIP_ERROR SetUserLabelList(EndpointId endpoint, const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList);
+
+    /**
+     * @brief Clears the user label list for a specified endpoint.
+     *
+     * Deletes all user labels associated with the given endpoint, resetting the list length to zero.
+     * If no previous list exists, this function has no effect.
+     *
+     * @param[in] endpoint The endpoint ID whose user label list will be cleared.
+     *
+     * @return CHIP_NO_ERROR on success or if no previous value exists.
+     * @return CHIP_ERROR if an error occurs during deletion.
+     */
     CHIP_ERROR ClearUserLabelList(EndpointId endpoint);
+
+    /**
+     * @brief Appends a user label to the user label list for a specified endpoint.
+     *
+     * Adds a new label to the end of the existing user label list. The list size must not
+     * exceed `kMaxUserLabelListLength`. If the list is full, the function returns an error.
+     *
+     * @param[in] endpoint The endpoint ID to which the user label will be added.
+     * @param[in] label The user label to append to the list.
+     *
+     * @return CHIP_NO_ERROR on success.
+     * @return CHIP_ERROR_NO_MEMORY if the list is already at its maximum size.
+     * @return CHIP_ERROR if an error occurs during storage.
+     */
     CHIP_ERROR AppendUserLabel(EndpointId endpoint, const UserLabelType & label);
 
     // Iterators

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -100,8 +100,7 @@ public:
      *                      The size of the list cannot exceed `kMaxUserLabelListLength`.
      *
      * @return CHIP_NO_ERROR on success.
-     * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND if no previous value exists.
-     * @return CHIP_ERROR if an error occurs while storing or deleting labels.
+     * @return CHIP_ERROR if an error occurs.
      */
     CHIP_ERROR SetUserLabelList(EndpointId endpoint, const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList);
 


### PR DESCRIPTION
The current error returned from AppendUserLabel is mapped to a generic FAILURE. We need to  correctly map it to RESOURCE_EXHAUSTED or an appropriate error code by the callers

Fixes #36866

