### PR TITLE
Update YAML file Test_TC_OPCREDS_3_7

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -139,7 +139,6 @@ tests:
               - name: "RootCACertificate"
                 value: Root_CA_Certificate_TH2
 
-      # verification: "Verify the commissioner node ID is retrieved from TH2 and saved as Commissioner_Node_Id_TH2"
     - label: 
           "Step 6: Retrieve the commissioner node ID from TH2"
       identity: "beta"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -95,9 +95,9 @@ tests:
                 saveAs: attestationSignature
 
     - label:
-          "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC
-          using the CSR elements from Step 3.
-          Save ICAC as Intermediate_Certificate_TH2. Save NOC as
+          "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC using
+          the CSR elements from Step 3. Save ICAC as
+          Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
           RCAC public key and save as Root_Public_Key_TH2."
       identity: "beta"
@@ -130,7 +130,8 @@ tests:
                 saveAs: Root_CA_Certificate_TH2
 
     - label:
-          "Step 5.1: TH1 sends TH2 root certificate to DUT in the AddTrustedRootCertificate chain."
+          "Step 5.1: TH1 sends TH2 root certificate to DUT in the
+          AddTrustedRootCertificate chain."
       identity: "alpha"
       command: "AddTrustedRootCertificate"
       cluster: "Operational Credentials"
@@ -139,8 +140,7 @@ tests:
               - name: "RootCACertificate"
                 value: Root_CA_Certificate_TH2
 
-    - label:
-          "Step 6: Retrieve the commissioner node ID from TH2"
+    - label: "Step 6: Retrieve the commissioner node ID from TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "GetCommissionerNodeId"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -129,7 +129,6 @@ tests:
               - name: "RCAC"
                 saveAs: Root_CA_Certificate_TH2
 
-      # verification: "Verify that the AddTrustedRootCertificate comand is sent and completes"
     - label:
           "Step 5.1: TH1 sends TH2 root certificate to DUT in the AddTrustedRootCertificate chain."
       identity: "alpha"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -94,11 +94,11 @@ tests:
               - name: "AttestationSignature"
                 saveAs: attestationSignature
       
-      # verification: "Verify TH2 generates the NOC, Root CA Certificate, and ICAC, and selects the IPK and certificates are saved correctly."
+      # verification: "Verify TH2 generates the NOC, Root CA Certificate, and ICAC, and certificates are saved correctly."
     - label:
           "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC
-          using the CSR elements from Step 3 and selects an IPK, all for use by
-          TH2. Save ICAC as Intermediate_Certificate_TH2. Save NOC as
+          using the CSR elements from Step 3.
+          Save ICAC as Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
           RCAC public key and save as Root_Public_Key_TH2."
       identity: "beta"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -94,7 +94,6 @@ tests:
               - name: "AttestationSignature"
                 saveAs: attestationSignature
       
-      # verification: "Verify TH2 generates the NOC, Root CA Certificate, and ICAC, and certificates are saved correctly."
     - label:
           "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC
           using the CSR elements from Step 3.

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -93,22 +93,10 @@ tests:
                 saveAs: NOCSRElements
               - name: "AttestationSignature"
                 saveAs: attestationSignature
-
-      # verification: "Verify that the DUT responds with the CSRResponse command."
+      
+      # verification: "Verify TH2 generates the NOC, Root CA Certificate, and ICAC, and selects the IPK and certificates are saved correctly."
     - label:
-          "Step 4: Read the commissioner root certificate from TH2's fabric.
-          Save RCAC as Root_CA_Certificate_TH2"
-      identity: "beta"
-      cluster: "CommissionerCommands"
-      command: "GetCommissionerRootCertificate"
-      response:
-          values:
-              - name: "RCAC"
-                saveAs: Root_CA_Certificate_TH2
-
-      # verification: ""
-    - label:
-          "Step 4.1: TH2 generates the NOC, the Root CA Certificate and ICAC
+          "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC
           using the CSR elements from Step 3 and selects an IPK, all for use by
           TH2. Save ICAC as Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
@@ -131,18 +119,19 @@ tests:
               - name: "IPK"
                 saveAs: IPK_TH2
 
-      # verification: ""
-    - label: 
-          "Step 5: Read the commissioner node ID from TH2"
+      # verification: "Verify that the commissioner root certificate is retrieved from TH2 and saved as Root_CA_Certificate_TH2"
+    - label:
+          "StepN 5: Retrieve the the commissioner root certificate from TH2.
+          Save RCAC as Root_CA_Certificate_TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
-      command: "GetCommissionerNodeId"
+      command: "GetCommissionerRootCertificate"
       response:
           values:
-              - name: "nodeId"
-                saveAs: Commissioner_Node_Id_TH2
+              - name: "RCAC"
+                saveAs: Root_CA_Certificate_TH2
 
-      # verification: ""
+      # verification: "Verify that the AddTrustedRootCertificate comand is sent and completes"
     - label:
           "Step 5.1: TH1 sends TH2 root certificate to DUT in the AddTrustedRootCertificate chain."
       identity: "alpha"
@@ -153,9 +142,20 @@ tests:
               - name: "RootCACertificate"
                 value: Root_CA_Certificate_TH2
 
-      # verification: "Verify that AddTrustedRootCertificate command succeeds by sending the status code as SUCCESS"
+      # verification: "Verify the commissioner node ID is retrieved from TH2 and saved as Commissioner_Node_Id_TH2"
+    - label: 
+          "Step 6: Retrieve the commissioner node ID from TH2"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "GetCommissionerNodeId"
+      response:
+          values:
+              - name: "nodeId"
+                saveAs: Commissioner_Node_Id_TH2
+
+      # verification: "Verify AddNOC command is sent to DUT with the correct NOC, ICAC, and IPK certificates. Verify status code is 0 (OK)"
     - label:
-          "Step 6: TH1 sends the AddNOC command to DUT with the following
+          "Step 6.1: TH1 sends the AddNOC command to DUT with the following
           fields: NOCValue as Node_Operational_Certificate_TH2. ICACValue as
           Intermediate_Certificate_TH2. IpkValue as IPK_TH2. CaseAdminSubject as
           the NodeID of TH2. AdminVendorId as the Vendor ID of TH2."

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -118,7 +118,6 @@ tests:
               - name: "IPK"
                 saveAs: IPK_TH2
 
-      # verification: "Verify that the commissioner root certificate is retrieved from TH2 and saved as Root_CA_Certificate_TH2"
     - label:
           "StepN 5: Retrieve the the commissioner root certificate from TH2.
           Save RCAC as Root_CA_Certificate_TH2"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -37,23 +37,7 @@ tests:
                 value: nodeId
 
     - label:
-          "Step 1: Factory Reset DUT (to ensure NOC list is empty at the
-          beginning of the following steps)"
-      # verification: ""
-      # Disabling this step, because the test starts with a DUT device that has just been commissioned by the TH1 commissioner
-      disabled: true
-
-    - label:
-          "Step 2: Start the commissioning process of DUT by TH1 on the first
-          Fabric."
-      # PICS: ""
-      # verification: "Verify that TH1 successfully completes commissioning, including establishing a CASE session on the operational network and issuing a CommissioningComplete command."
-      # Disabling this step, because the test starts with a DUT device that has just been commissioned by the TH1 commissioner
-
-      disabled: true
-
-    - label:
-          "Step 3.1: Save the FabricIndex for TH1 as TH1_Fabric_Index for future
+          "Step 1.1: Save the FabricIndex for TH1 as TH1_Fabric_Index for future
           use."
       identity: "alpha"
       command: "readAttribute"
@@ -63,7 +47,7 @@ tests:
           saveAs: TH1_Fabric_Index
 
     - label:
-          "Step 3.2: TH1 does a fabric-filtered read of the Fabrics attribute
+          "Step 1.2: TH1 does a fabric-filtered read of the Fabrics attribute
           from the Node Operational Credentials cluster. Save the FabricIndex
           for TH1 as TH1_Fabric_Index for future use."
       identity: "alpha"
@@ -78,7 +62,7 @@ tests:
 
       # verification: "Verify that there is a single entry in the list and the FabricIndex for that entry matches TH1_Fabric_Index."
     - label:
-          "Step 4: TH1 sends ArmFailSafe command to the DUT with the
+          "Step 2: TH1 sends ArmFailSafe command to the DUT with the
           ExpiryLengthSeconds field set to 60 seconds"
       identity: "alpha"
       cluster: "General Commissioning"
@@ -95,7 +79,7 @@ tests:
                 value: 0 # OK
 
       # verification: "Verify that the DUT sends ArmFailSafeResponse command to TH1 with field ErrorCode as OK(0)"
-    - label: "Step 5: TH1 Sends CSRRequest command with a random 32-byte nonce."
+    - label: "Step 3: TH1 Sends CSRRequest command with a random 32-byte nonce."
       identity: "alpha"
       command: "CSRRequest"
       cluster: "Operational Credentials"
@@ -110,9 +94,9 @@ tests:
               - name: "AttestationSignature"
                 saveAs: attestationSignature
 
-      # verification: "Step 5: Verify that the DUT responds with the CSRResponse command."
+      # verification: "Verify that the DUT responds with the CSRResponse command."
     - label:
-          "Step 6.1: Read the commissioner root certificate from TH2's fabric.
+          "Step 4.1: Read the commissioner root certificate from TH2's fabric.
           Save RCAC as Root_CA_Certificate_TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
@@ -124,8 +108,8 @@ tests:
 
       # verification: ""
     - label:
-          "Step 6.2: TH2 generates the NOC, the Root CA Certificate and ICAC
-          using the CSR elements from Step 5 and selects an IPK, all for use by
+          "Step 4.2: TH2 generates the NOC, the Root CA Certificate and ICAC
+          using the CSR elements from Step 3 and selects an IPK, all for use by
           TH2. Save ICAC as Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
           RCAC public key and save as Root_Public_Key_TH2."
@@ -148,7 +132,7 @@ tests:
                 saveAs: IPK_TH2
 
       # verification: ""
-    - label: "Step 7.1: Read the commissioner node ID from TH2"
+    - label: "Step 5.1: Read the commissioner node ID from TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "GetCommissionerNodeId"
@@ -159,7 +143,7 @@ tests:
 
       # verification: ""
     - label:
-          "Step 7.2: TH1 sends AddTrustedRootCertificate command to DUT with
+          "Step 5.2: TH1 sends AddTrustedRootCertificate command to DUT with
           RootCACertificate set to Root_CA_Certificate_TH2"
       identity: "alpha"
       command: "AddTrustedRootCertificate"
@@ -171,7 +155,7 @@ tests:
 
       # verification: "Verify that AddTrustedRootCertificate command succeeds by sending the status code as SUCCESS"
     - label:
-          "Step 8: TH1 sends the AddNOC command to DUT with the following
+          "Step 6: TH1 sends the AddNOC command to DUT with the following
           fields: NOCValue as Node_Operational_Certificate_TH2. ICACValue as
           Intermediate_Certificate_TH2. IpkValue as IPK_TH2. CaseAdminSubject as
           the NodeID of TH2. AdminVendorId as the Vendor ID of TH2."
@@ -196,13 +180,13 @@ tests:
                 value: 0
 
       # verification: "Verify that DUT responds with NOCResponse with status code OK"
-    - label: "Step 9: TH2 starts discovery of DUT using Operational Discovery"
+    - label: "Step 7: TH2 starts discovery of DUT using Operational Discovery"
       # verification: ""
       # Disabling this step as this occurs from the AddNOC command being run
       disabled: true
 
     - label:
-          "Step 10: TH2 opens a CASE session with DUT over operational network."
+          "Step 8: TH2 opens a CASE session with DUT over operational network."
       identity: "beta"
       cluster: "DelayCommands"
       command: "WaitForCommissionee"
@@ -212,7 +196,7 @@ tests:
                 value: 0x43211234
 
       # verification: "DUT is able to open the CASE session with TH2"
-    - label: "Step 11: TH2 sends CommissioningComplete command"
+    - label: "Step 9: TH2 sends CommissioningComplete command"
       nodeId: 0x43211234
       identity: "beta"
       cluster: "General Commissioning"
@@ -224,7 +208,7 @@ tests:
 
       # verification: "DUT respond with SUCCESS at CommissioningComplete command sent by TH2"
     - label:
-          "Step 12: TH2 reads the Current Fabric Index attribute from the Node
+          "Step 10: TH2 reads the Current Fabric Index attribute from the Node
           Operational Credentials cluster. Save the FabricIndex for TH2 as
           TH2_Fabric_Index."
       identity: "beta"
@@ -237,7 +221,7 @@ tests:
 
       # verification: ""
     - label:
-          "Step 13a: TH1 does a fabric-filtered read of the Fabrics attribute
+          "Step 11a: TH1 does a fabric-filtered read of the Fabrics attribute
           from the Node Operational Credentials cluster"
       nodeId: 0x43211234
       command: "readAttribute"
@@ -251,7 +235,7 @@ tests:
 
       # verification: ""
     - label:
-          "Step 13b: TH2 does a fabric-filtered read of the Fabrics attribute
+          "Step 11b: TH2 does a fabric-filtered read of the Fabrics attribute
           from the Node Operational Credentials cluster"
       identity: "beta"
       nodeId: 0x43211234
@@ -266,7 +250,7 @@ tests:
 
       # verification: "Verify that there are 2 entries in the list where one entry matches TH1_Fabric_Index and the other matches TH2_Fabric_Index."
     - label:
-          "Step 14: TH1 sends RemoveFabric command to DUT with the FabricIndex
+          "Step 12: TH1 sends RemoveFabric command to DUT with the FabricIndex
           field set to TH2_Fabric_Index."
       identity: "alpha"
       command: "RemoveFabric"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -96,7 +96,7 @@ tests:
 
       # verification: "Verify that the DUT responds with the CSRResponse command."
     - label:
-          "Step 4.1: Read the commissioner root certificate from TH2's fabric.
+          "Step 4: Read the commissioner root certificate from TH2's fabric.
           Save RCAC as Root_CA_Certificate_TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
@@ -108,7 +108,7 @@ tests:
 
       # verification: ""
     - label:
-          "Step 4.2: TH2 generates the NOC, the Root CA Certificate and ICAC
+          "Step 4.1: TH2 generates the NOC, the Root CA Certificate and ICAC
           using the CSR elements from Step 3 and selects an IPK, all for use by
           TH2. Save ICAC as Intermediate_Certificate_TH2. Save NOC as
           Node_Operational_Certificate_TH2. Save IPK as IPK_TH2. Extract the
@@ -132,7 +132,8 @@ tests:
                 saveAs: IPK_TH2
 
       # verification: ""
-    - label: "Step 5.1: Read the commissioner node ID from TH2"
+    - label: 
+          "Step 5: Read the commissioner node ID from TH2"
       identity: "beta"
       cluster: "CommissionerCommands"
       command: "GetCommissionerNodeId"
@@ -143,8 +144,7 @@ tests:
 
       # verification: ""
     - label:
-          "Step 5.2: TH1 sends AddTrustedRootCertificate command to DUT with
-          RootCACertificate set to Root_CA_Certificate_TH2"
+          "Step 5.1: TH1 sends TH2 root certificate to DUT in the AddTrustedRootCertificate chain."
       identity: "alpha"
       command: "AddTrustedRootCertificate"
       cluster: "Operational Credentials"

--- a/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OPCREDS_3_7.yaml
@@ -93,7 +93,7 @@ tests:
                 saveAs: NOCSRElements
               - name: "AttestationSignature"
                 saveAs: attestationSignature
-      
+
     - label:
           "Step 4: TH2 generates the NOC, the Root CA Certificate and ICAC
           using the CSR elements from Step 3.
@@ -139,7 +139,7 @@ tests:
               - name: "RootCACertificate"
                 value: Root_CA_Certificate_TH2
 
-    - label: 
+    - label:
           "Step 6: Retrieve the commissioner node ID from TH2"
       identity: "beta"
       cluster: "CommissionerCommands"


### PR DESCRIPTION
This PR updates the **TC_OPCREDS_3_7 YAML file** by removing steps to align the test procedure with the **Fixes**: [#423](https://github.com/project-chip/matter-test-scripts/issues/423)

### Updates:
- The **YAML test script** was updated to reflect these changes.
- The **TC_OPCREDS_3_7 test procedure** in the test plan has been updated in [PR #4820](https://github.com/CHIP-Specifications/chip-test-plans/pull/4820).

### Testing for Multiple Fabrics:
This test validates the TC_OPCREDS_3_7 procedure when two fabrics, gamma and the default alpha, are present on the Device Under Test (DUT). The process includes commissioning the DUT with gamma using the --commissioner-name gamma flag, opening a commissioning window, re-commissioning with alpha, and confirming the test passes successfully with both fabrics in use.

**Example of Test Steps (Passed):**
1. In the first console, Run the all-clusters app:
   ```bash
   rm /tmp/chip_*                                        
   ./out/darwin-arm64-all-clusters/chip-all-clusters-app
2. In the second console, Perform the first commissioning:
   ```bash
   ./out/darwin-arm64-chip-tool/chip-tool pairing code 0x12344321 749701123365521327694 --commissioner-name gamma
   Note: As example I use the manual pairing code 749701123365521327694 instead of the QR code payload ID MT:Y.K9042C00KA0648G00.

3. Opened the commissioning window and searched for "Manual pairing code" in the output:
   ```bash
   ./out/darwin-arm64-chip-tool/chip-tool pairing open-commissioning-window 0x12344321 1 300 1000 2365 --commissioner-name gamma
4. Re-commissioned with a second commissioner (alpha):
   ```bash
   ./out/darwin-arm64-chip-tool/chip-tool pairing code 0x12344321 23064351703 --commissioner-name alpha
5. In the third console, Run the test:
   ```bash
   ./scripts/tests/chipyaml/chiptool.py tests Test_TC_OPCREDS_3_7 --server_path ./out/darwin-arm64-chip-tool/chip-tool.
6. As result:
   ```bash
   ***** Test Complete: Test_TC_OPCREDS_3_7
   ✓ Test finished in 1344ms with 35 success, 0 errors and 0 warnings
   ✓ Parsing finished in 8ms with 1 success and 0 errors.
   Run finished in 2548ms with 16 steps runned and 0 steps skipped.

**Changes made**:
- Removed the factory reset from the YAML file.
- Adjusted the test procedure to align with the updated format from the linked test plan PR.


