### PR TITLE
[ESP32] Added new Matter Traces in esp32 platform for diagnosis

### DIFF
--- a/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
+++ b/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
@@ -106,6 +106,7 @@ static_library("ESP32_custom") {
     "${chip_root}/src/lib/dnssd:platform_header",
     "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
+    "${chip_root}/src/tracing:macros",
   ]
 
   public_deps = [

--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -71,6 +71,7 @@ static_library("ESP32") {
     "${chip_root}/src/lib/dnssd:platform_header",
     "${chip_root}/src/platform/logging:headers",
     "${chip_root}/src/setup_payload",
+    "${chip_root}/src/tracing:macros",
   ]
 
   public = [

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -138,6 +138,9 @@ private:
     void OnStationDisconnected(void);
     void ChangeWiFiStationState(WiFiStationState newState);
     static void DriveStationState(::chip::System::Layer * aLayer, void * aAppState);
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+    void LogWiFiInfo(void);
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
     WiFiAPMode _GetWiFiAPMode(void);

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -41,12 +41,20 @@
 #include <lwip/nd6.h>
 #include <lwip/netif.h>
 
+#include <tracing/macros.h>
+#include <tracing/metric_event.h>
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using chip::DeviceLayer::Internal::ESP32Utils;
+
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+static int current_rssi                            = 1;
+constexpr chip::Tracing::MetricKey kMetricWiFiRSSI = "wifi_rssi";
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
 
 namespace chip {
 namespace DeviceLayer {
@@ -554,6 +562,15 @@ void ConnectivityManagerImpl::_OnWiFiStationProvisionChange()
 
 void ConnectivityManagerImpl::DriveStationState()
 {
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+    esp_wifi_sta_get_rssi(&current_rssi);
+    if (current_rssi != 1)
+    {
+        MATTER_LOG_METRIC(kMetricWiFiRSSI, static_cast<int32_t>(current_rssi));
+    }
+    MATTER_TRACE_INSTANT("WiFi_State", WiFiStationStateToStr(mWiFiStationState));
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+
     bool stationConnected;
 
     // Refresh the current station mode.  Specifically, this reads the ESP auto_connect flag,
@@ -598,6 +615,7 @@ void ConnectivityManagerImpl::DriveStationState()
             if (err != ESP_OK)
             {
                 ChipLogError(DeviceLayer, "esp_wifi_disconnect() failed: %s", esp_err_to_name(err));
+                MATTER_TRACE_INSTANT("WiFi_Error", "DisconnectFailed");
                 return;
             }
 
@@ -641,12 +659,15 @@ void ConnectivityManagerImpl::DriveStationState()
             {
                 ChipLogProgress(DeviceLayer, "Attempting to connect WiFi station interface");
                 esp_err_t err = esp_wifi_connect();
+                MATTER_TRACE_COUNTER("WiFi_con_attempt");
+
                 if (err != ESP_OK)
                 {
                     ChipLogError(DeviceLayer, "esp_wifi_connect() failed: %s", esp_err_to_name(err));
+                    MATTER_TRACE_INSTANT("WiFi_Error", esp_err_to_name(err));
+                    MATTER_TRACE_COUNTER("WiFi_fail_attempt");
                     return;
                 }
-
                 ChangeWiFiStationState(kWiFiStationState_Connecting);
             }
 
@@ -670,12 +691,16 @@ void ConnectivityManagerImpl::DriveStationState()
 
 void ConnectivityManagerImpl::OnStationConnected()
 {
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+    LogWiFiInfo();
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
     // Assign an IPv6 link local address to the station interface.
     esp_err_t err = esp_netif_create_ip6_linklocal(esp_netif_get_handle_from_ifkey(ESP32Utils::kDefaultWiFiStationNetifKey));
     if (err != ESP_OK)
     {
         ChipLogError(DeviceLayer, "esp_netif_create_ip6_linklocal() failed for %s interface, err:%s",
                      ESP32Utils::kDefaultWiFiStationNetifKey, esp_err_to_name(err));
+        MATTER_TRACE_INSTANT("WiFi_Error", esp_err_to_name(err));
     }
     NetworkCommissioning::ESPWiFiDriver::GetInstance().OnConnectWiFiNetwork();
     // TODO Invoke WARM to perform actions that occur when the WiFi station interface comes up.
@@ -698,6 +723,8 @@ void ConnectivityManagerImpl::OnStationConnected()
 
 void ConnectivityManagerImpl::OnStationDisconnected()
 {
+    MATTER_TRACE_INSTANT("WiFi", "StationDisconnected");
+
     // TODO Invoke WARM to perform actions that occur when the WiFi station interface goes down.
 
     // Alert other components of the new state.
@@ -707,6 +734,7 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     PlatformMgr().PostEventOrDie(&event);
     WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
     uint16_t reason                    = NetworkCommissioning::ESPWiFiDriver::GetInstance().GetLastDisconnectReason();
+    MATTER_TRACE_INSTANT("WiFi_disconnect_Reason", esp_err_to_name(reason));
     uint8_t associationFailureCause =
         chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCauseEnum::kUnknown);
 
@@ -1152,6 +1180,107 @@ CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseco
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+void ConnectivityManagerImpl::LogWiFiInfo()
+{
+    esp_err_t err;
+    uint8_t protocol_bitmap;
+    wifi_bandwidth_t bandwidth;
+    wifi_ps_type_t ps_type;
+    wifi_second_chan_t secondary_channel;
+
+    // Get AP protocol
+    err = esp_wifi_get_protocol(WIFI_IF_STA, &protocol_bitmap);
+    if (err == ESP_OK)
+    {
+        const char * protocol;
+        if (protocol_bitmap & WIFI_PROTOCOL_11B)
+            protocol = "802.11b";
+        else if (protocol_bitmap & WIFI_PROTOCOL_11G)
+            protocol = "802.11g";
+        else if (protocol_bitmap & WIFI_PROTOCOL_11N)
+            protocol = "802.11n";
+        else
+            protocol = "Unknown";
+        MATTER_TRACE_INSTANT("AP_protocol", protocol);
+    }
+    else
+    {
+        ESP_LOGE("LogWiFiInfo", "Failed to get AP protocol: %d", err);
+        MATTER_TRACE_INSTANT("WiFi_Error", "ProtocolQueryFailed");
+    }
+
+    // Get bandwidth
+    err = esp_wifi_get_bandwidth(WIFI_IF_STA, &bandwidth);
+    if (err == ESP_OK)
+    {
+        const char * bandwidth_str = (bandwidth == WIFI_BW_HT20) ? "20MHz" : "40MHz";
+        MATTER_TRACE_INSTANT("Bandwidth", bandwidth_str);
+    }
+    else
+    {
+        ESP_LOGE("LogWiFiInfo", "Failed to get bandwidth: %d", err);
+        MATTER_TRACE_INSTANT("WiFi_Error", "BandwidthQueryFailed");
+    }
+
+    // Get power save type
+    err = esp_wifi_get_ps(&ps_type);
+    if (err == ESP_OK)
+    {
+        const char * ps_type_str;
+        switch (ps_type)
+        {
+        case WIFI_PS_NONE:
+            ps_type_str = "None";
+            break;
+        case WIFI_PS_MIN_MODEM:
+            ps_type_str = "MinModem";
+            break;
+        case WIFI_PS_MAX_MODEM:
+            ps_type_str = "MaxModem";
+            break;
+        default:
+            ps_type_str = "Unknown";
+            break;
+        }
+        MATTER_TRACE_INSTANT("Power_save_type", ps_type_str);
+    }
+    else
+    {
+        ESP_LOGE("LogWiFiInfo", "Failed to get power save type: %d", err);
+        MATTER_TRACE_INSTANT("WiFi_Error", "PowerSaveQueryFailed");
+    }
+
+    // Get secondary channel
+    err = esp_wifi_get_channel(NULL, &secondary_channel);
+    if (err == ESP_OK)
+    {
+        const char * second_ch;
+        switch (secondary_channel)
+        {
+        case WIFI_SECOND_CHAN_NONE:
+            second_ch = "None";
+            break;
+        case WIFI_SECOND_CHAN_ABOVE:
+            second_ch = "AbovePrimary";
+            break;
+        case WIFI_SECOND_CHAN_BELOW:
+            second_ch = "BelowPrimary";
+            break;
+        default:
+            second_ch = "Unknown";
+            break;
+        }
+        MATTER_TRACE_INSTANT("Secondary_channel", second_ch);
+    }
+    else
+    {
+        ESP_LOGE("LogWiFiInfo", "Failed to get secondary channel: %d", esp_err_to_name(err));
+        MATTER_TRACE_INSTANT("WiFi_Error", "ChannelQueryFailed");
+    }
+}
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -35,8 +35,41 @@
 #include "esp_wifi.h"
 #include "nvs.h"
 
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+#include "esp_heap_caps.h"
+#include <lib/support/CHIPMemString.h>
+#include <string.h>
+#include <system/SystemTimer.h>
+#include <tracing/macros.h>
+#include <tracing/metric_event.h>
+
+using namespace chip::DeviceLayer;
+using namespace chip::Tracing;
+
+// Heap Diagnostics (internal)
+constexpr MetricKey kMetricHeapInternalFree         = "internal_free";
+constexpr MetricKey kMetricHeapInternalMinFree      = "internal_min_free";
+constexpr MetricKey kMetricHeapInternalLargestBlock = "internal_largest_free";
+
+// Heap Diagnostics (external)
+constexpr MetricKey kMetricHeapExternalFree         = "external_free";
+constexpr MetricKey kMetricHeapExternalMinFree      = "external_min_free";
+constexpr MetricKey kMetricHeapExternalLargestBlock = "external_largest_block";
+
+constexpr MetricKey kMetricHeapSystemMemory         = "system_memory";
+constexpr MetricKey kMetricTaskCPUUsage             = "task_cpu";
+constexpr MetricKey kMetricTaskPriority             = "task_priority";
+constexpr MetricKey kMetricTaskStackUsage           = "task_stack";
+constexpr MetricKey kMetricHeapTotalAllocatedBlocks = "total_allocated_blocks";
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+
 using namespace ::chip::DeviceLayer::Internal;
 using chip::DeviceLayer::Internal::DeviceNetworkInfo;
+
+#ifndef CONFIG_HEAP_LOG_INTERVAL
+#define CONFIG_HEAP_LOG_INTERVAL 86400000
+#endif // CONFIG_HEAP_LOG_INTERVAL
+
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
 CHIP_ERROR ESP32Utils::IsAPEnabled(bool & apEnabled)
 {
@@ -370,6 +403,150 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+
+void LogHeapDataCallback(chip::System::Layer * systemLayer, void * appState)
+{
+    multi_heap_info_t info;
+    heap_caps_get_info(&info, MALLOC_CAP_INTERNAL);
+    MATTER_LOG_METRIC(kMetricHeapInternalFree, static_cast<int32_t>(info.total_free_bytes));
+    MATTER_LOG_METRIC(kMetricHeapInternalMinFree, static_cast<int32_t>(info.minimum_free_bytes));
+    MATTER_LOG_METRIC(kMetricHeapInternalLargestBlock, static_cast<int32_t>(info.largest_free_block));
+
+    int32_t memoryPercentage =
+        (info.total_allocated_bytes > 0) ? static_cast<int32_t>((info.total_allocated_bytes * 100) / info.total_free_bytes) : 0;
+    MATTER_LOG_METRIC(kMetricHeapSystemMemory, memoryPercentage);
+    int32_t blockPercentage = (info.total_blocks > 0) ? static_cast<int32_t>((info.allocated_blocks * 100) / info.total_blocks) : 0;
+    MATTER_LOG_METRIC(kMetricHeapTotalAllocatedBlocks, blockPercentage);
+
+#ifdef CONFIG_SPIRAM
+    // External RAM (if PSRAM is enabled)
+    uint32_t external_free               = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    uint32_t external_largest_free_block = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+    uint32_t external_min_free           = heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM);
+
+    MATTER_LOG_METRIC(kMetricHeapExternalFree, static_cast<int32_t>(external_free));
+    MATTER_LOG_METRIC(kMetricHeapExternalMinFree, static_cast<int32_t>(external_min_free));
+    MATTER_LOG_METRIC(kMetricHeapExternalLargestBlock, static_cast<int32_t>(external_largest_free_block));
+    int32_t externalMemoryPercentage = (total_external > 0) ? static_cast<int32_t>((allocated_external * 100) / total_external) : 0;
+    MATTER_LOG_METRIC(kMetricHeapExternalMemory, externalMemoryPercentage);
+#endif // CONFIG_SPIRAM
+
+    if (appState != nullptr)
+    {
+        bool setTimer = *static_cast<bool *>(appState);
+        if (setTimer)
+        {
+            CHIP_ERROR err = SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(CONFIG_HEAP_LOG_INTERVAL),
+                                                      LogHeapDataCallback, &setTimer);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Failed to reschedule heap log timer");
+                MATTER_TRACE_INSTANT("Heap_Monitor", "RescheduleFailed");
+            }
+        }
+    }
+}
+
+void FailedAllocCallback(size_t size, uint32_t caps, const char * function_name)
+{
+    MATTER_TRACE_COUNTER("Failed_memory_allocations");
+    ChipLogError(DeviceLayer, "Memory allocation failed!");
+}
+
+// Function to initialize and start periodic heap logging
+void ESP32Utils::LogHeapInfo(bool setTimer)
+{
+    if (CONFIG_HEAP_LOG_INTERVAL <= 0)
+    {
+        setTimer = false;
+        return;
+    }
+
+    static bool timerState = setTimer;
+
+    if (!setTimer)
+    {
+        SystemLayer().CancelTimer(LogHeapDataCallback, &timerState);
+        MATTER_TRACE_INSTANT("Heap_Monitor", "Stopped");
+        return;
+    }
+
+    MATTER_TRACE_INSTANT("Heap_Monitor", "Started");
+    esp_err_t err = heap_caps_register_failed_alloc_callback(FailedAllocCallback);
+    if (err != ESP_OK)
+    {
+        ChipLogError(DeviceLayer, "Failed to register callback. Error: 0x%08x", err);
+        MATTER_TRACE_INSTANT("Heap_Monitor", "RegisterFailed");
+    }
+
+    LogHeapDataCallback(&SystemLayer(), &timerState);
+    if (setTimer)
+    {
+        CHIP_ERROR error = SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(CONFIG_HEAP_LOG_INTERVAL),
+                                                    LogHeapDataCallback, &timerState);
+        if (error != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Failed to schedule heap log timer. Error: %s", chip::ErrorStr(error));
+            MATTER_TRACE_INSTANT("Heap_Monitor", "ScheduleFailed");
+        }
+    }
+}
+
+const char * StateToString(eTaskState state)
+{
+    switch (state)
+    {
+    case eRunning:
+        return "Running";
+    case eReady:
+        return "Ready";
+    case eBlocked:
+        return "Blocked";
+    case eSuspended:
+        return "Suspended";
+    case eDeleted:
+        return "Deleted";
+    default:
+        return "Unknown";
+    }
+}
+
+CHIP_ERROR ESP32Utils::LogTaskSnapshotInfo()
+{
+#ifdef CONFIG_FREERTOS_USE_TRACE_FACILITY
+    uint32_t arraySize = uxTaskGetNumberOfTasks();
+
+    MATTER_TRACE_INSTANT("Task_Monitor", "TasksSnapshot");
+
+    chip::Platform::ScopedMemoryBuffer<TaskStatus_t> taskStatusArray;
+    VerifyOrReturnError(taskStatusArray.Calloc(arraySize), CHIP_ERROR_NO_MEMORY);
+
+    uint32_t totalRunTime;
+    arraySize = uxTaskGetSystemState(taskStatusArray.Get(), arraySize, &totalRunTime);
+
+    if (totalRunTime == 0)
+    {
+        totalRunTime = 1;
+    }
+
+    for (uint32_t i = 0; i < arraySize; i++)
+    {
+        TaskStatus_t task = taskStatusArray[i];
+        MATTER_TRACE_INSTANT(task.pcTaskName, StateToString(task.eCurrentState));
+        MATTER_LOG_METRIC(kMetricTaskPriority, static_cast<int32_t>(task.uxCurrentPriority));
+        MATTER_LOG_METRIC(kMetricTaskStackUsage, static_cast<int32_t>(task.usStackHighWaterMark));
+#ifdef CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+        uint32_t percentage = (totalRunTime > 0) ? (task.ulRunTimeCounter * 100 / totalRunTime) : 0;
+
+        MATTER_LOG_METRIC(kMetricTaskCPUUsage, static_cast<int32_t>(percentage));
+#endif // CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
+    }
+#endif // CONFIG_FREERTOS_USE_TRACE_FACILITY
+    return CHIP_NO_ERROR;
+}
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
 
 struct netif * ESP32Utils::GetNetif(const char * ifKey)
 {

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -48,6 +48,28 @@ public:
     static CHIP_ERROR ClearWiFiStationProvision(void);
     static CHIP_ERROR InitWiFiStack(void);
 
+#ifdef CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+    /**
+     * @brief Logs the current heap usage information.
+     *
+     * This function logs details about the current heap usage and can optionally set up
+     * a periodic timer to log heap usage at regular intervals.
+     *
+     * @param setTimer Indicates whether to set a periodic timer for logging. Default is false.
+     */
+    static void LogHeapInfo(bool setTimer = false);
+
+    /**
+     * @brief Captures and logs information about the current task snapshots.
+     *
+     * This function retrieves a snapshot of all running tasks and logs details about
+     * their states.
+     *
+     * @return CHIP_ERROR Returns a CHIP_ERROR code indicating the success or failure of the operation.
+     */
+    static CHIP_ERROR LogTaskSnapshotInfo();
+#endif // CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE
+
     static CHIP_ERROR MapError(esp_err_t error);
     static void RegisterESP32ErrorFormatter();
     static bool FormatError(char * buf, uint16_t bufSize, CHIP_ERROR err);


### PR DESCRIPTION
### Problem:
Additional diagnostics are needed to improve the efficiency of debugging and monitoring on the ESP32 platform.

### Change Overview:
Added BLE, WiFi, Heap and FreeRTOS Task snapshot related diagnostics in esp32 platform for diagnosis purpose.

### Testing
Successfully retrieved the added diagnostics using the Platform Diagnostics Framework.

