### PR TITLE
Fix for Bug #36731.

### DIFF
--- a/src/transport/raw/ActiveTCPConnectionState.h
+++ b/src/transport/raw/ActiveTCPConnectionState.h
@@ -62,7 +62,10 @@ struct ActiveTCPConnectionState
 
     void Free()
     {
-        mEndPoint->Free();
+        if (mEndPoint)
+        {
+            mEndPoint->Free();
+        }
         mPeerAddr = PeerAddress::Uninitialized();
         mEndPoint = nullptr;
         mReceived = nullptr;

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -55,14 +55,8 @@ constexpr int kListenBacklogSize = 2;
 
 TCPBase::~TCPBase()
 {
-    if (mListenSocket != nullptr)
-    {
-        // endpoint is only non null if it is initialized and listening
-        mListenSocket->Free();
-        mListenSocket = nullptr;
-    }
-
-    CloseActiveConnections();
+    // Call Close to free the listening socket and close all active connections.
+    Close();
 }
 
 void TCPBase::CloseActiveConnections()
@@ -125,6 +119,9 @@ void TCPBase::Close()
         mListenSocket->Free();
         mListenSocket = nullptr;
     }
+
+    CloseActiveConnections();
+
     mState = TCPState::kNotReady;
 }
 

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -610,6 +610,29 @@ TEST_F(TestTCP, HandleConnCloseCalledTest6)
     HandleConnCloseTest(addr);
 }
 
+TEST_F(TestTCP, CheckTCPEndpointAfterCloseTest)
+{
+    TCPImpl tcp;
+
+    IPAddress addr;
+    IPAddress::FromString("::1", addr);
+
+    MockTransportMgrDelegate gMockTransportMgrDelegate(mIOContext);
+    gMockTransportMgrDelegate.InitializeMessageTest(tcp, addr);
+    gMockTransportMgrDelegate.ConnectTest(tcp, addr);
+
+    Transport::PeerAddress lPeerAddress = Transport::PeerAddress::TCP(addr, gChipTCPPort);
+    void * state                        = TestAccess::FindActiveConnection(tcp, lPeerAddress);
+    ASSERT_NE(state, nullptr);
+    TCPEndPoint * lEndPoint = TestAccess::GetEndpoint(state);
+    ASSERT_NE(lEndPoint, nullptr);
+
+    // Call Close and check the TCPEndpoint
+    tcp.Close();
+    lEndPoint = TestAccess::GetEndpoint(state);
+    ASSERT_EQ(lEndPoint, nullptr);
+}
+
 TEST_F(TestTCP, CheckProcessReceivedBuffer)
 {
     TCPImpl tcp;


### PR DESCRIPTION
Add CloseActiveConnections() call in TCPBase::Close(), which is called as part of Server::Shutdown().
Active connections should be closed as part of Server shutdown. This allows the TCPConnectionState to also close the associated TCPEndpoint object as part of this shutdown flow.

Previously, the CloseActiveConnections() call was present in the TCPBase destructor alone.

Fixes https://github.com/project-chip/connectedhomeip/issues/36731