### PR TITLE
Move the --dac_provider option from all clusters apps to common place.

### DIFF
--- a/examples/all-clusters-app/linux/AppOptions.cpp
+++ b/examples/all-clusters-app/linux/AppOptions.cpp
@@ -29,13 +29,10 @@ using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
 using chip::ArgParser::PrintArgError;
 
-constexpr uint16_t kOptionDacProviderFilePath        = 0xFF01;
 constexpr uint16_t kOptionMinCommissioningTimeout    = 0xFF02;
 constexpr uint16_t kOptionEndUserSupportFilePath     = 0xFF03;
 constexpr uint16_t kOptionNetworkDiagnosticsFilePath = 0xFF04;
 constexpr uint16_t kOptionCrashFilePath              = 0xFF05;
-
-static chip::Credentials::Examples::TestHarnessDACProvider mDacProvider;
 
 static chip::Optional<std::string> sEndUserSupportLogFilePath;
 static chip::Optional<std::string> sNetworkDiagnosticsLogFilePath;
@@ -51,9 +48,6 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
     bool retval = true;
     switch (identifier)
     {
-    case kOptionDacProviderFilePath:
-        mDacProvider.Init(value);
-        break;
     case kOptionMinCommissioningTimeout: {
         auto & commissionMgr = chip::Server::GetInstance().GetCommissioningWindowManager();
         commissionMgr.OverrideMinCommissioningTimeout(chip::System::Clock::Seconds16(static_cast<uint16_t>(atoi(value))));
@@ -92,7 +86,6 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
 OptionSet * AppOptions::GetOptions()
 {
     static OptionDef optionsDef[] = {
-        { "dac_provider", kArgumentRequired, kOptionDacProviderFilePath },
         { "min_commissioning_timeout", kArgumentRequired, kOptionMinCommissioningTimeout },
         { "end_user_support_log", kArgumentRequired, kOptionEndUserSupportFilePath },
         { "network_diagnostics_log", kArgumentRequired, kOptionNetworkDiagnosticsFilePath },
@@ -102,8 +95,6 @@ OptionSet * AppOptions::GetOptions()
 
     static OptionSet options = {
         AppOptions::HandleOptions, optionsDef, "PROGRAM OPTIONS",
-        "  --dac_provider <filepath>\n"
-        "       A json file with data used by the example dac provider to validate device attestation procedure.\n"
         "  --min_commissioning_timeout <value>\n"
         "       The minimum time in seconds during which commissioning session establishment is allowed by the Node.\n"
         "  --end_user_support_log <value>\n"
@@ -115,11 +106,6 @@ OptionSet * AppOptions::GetOptions()
     };
 
     return &options;
-}
-
-chip::Credentials::DeviceAttestationCredentialsProvider * AppOptions::GetDACProvider()
-{
-    return &mDacProvider;
 }
 
 chip::Optional<std::string> AppOptions::GetEndUserSupportLogFilePath()

--- a/examples/all-clusters-app/linux/AppOptions.h
+++ b/examples/all-clusters-app/linux/AppOptions.h
@@ -20,15 +20,12 @@
 
 #include "AppMain.h"
 
-#include <app/tests/suites/credentials/TestHarnessDACProvider.h>
-
 #include <string>
 
 class AppOptions
 {
 public:
     static chip::ArgParser::OptionSet * GetOptions();
-    static chip::Credentials::DeviceAttestationCredentialsProvider * GetDACProvider();
     static chip::Optional<std::string> GetEndUserSupportLogFilePath();
     static chip::Optional<std::string> GetNetworkDiagnosticsLogFilePath();
     static chip::Optional<std::string> GetCrashLogFilePath();

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -93,7 +93,6 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/examples/all-clusters-app/all-clusters-common",
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app:attribute-persistence",
-    "${chip_root}/src/app/tests/suites/credentials:dac_provider",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/examples/all-clusters-app/linux/main.cpp
+++ b/examples/all-clusters-app/linux/main.cpp
@@ -31,8 +31,6 @@ int main(int argc, char * argv[])
         ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), chip::MakeOptional(kNetworkCommissioningEndpointSecondary)) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
-    LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
-
     ChipLinuxAppMainLoop();
 
     return 0;

--- a/examples/all-clusters-minimal-app/linux/AppOptions.cpp
+++ b/examples/all-clusters-minimal-app/linux/AppOptions.cpp
@@ -25,19 +25,13 @@ using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
 using chip::ArgParser::PrintArgError;
 
-constexpr uint16_t kOptionDacProviderFilePath     = 0xFF01;
 constexpr uint16_t kOptionMinCommissioningTimeout = 0xFF02;
-
-static chip::Credentials::Examples::TestHarnessDACProvider mDacProvider;
 
 bool AppOptions::HandleOptions(const char * program, OptionSet * options, int identifier, const char * name, const char * value)
 {
     bool retval = true;
     switch (identifier)
     {
-    case kOptionDacProviderFilePath:
-        mDacProvider.Init(value);
-        break;
     case kOptionMinCommissioningTimeout: {
         auto & commissionMgr = chip::Server::GetInstance().GetCommissioningWindowManager();
         commissionMgr.OverrideMinCommissioningTimeout(chip::System::Clock::Seconds16(static_cast<uint16_t>(atoi(value))));
@@ -55,23 +49,14 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
 OptionSet * AppOptions::GetOptions()
 {
     static OptionDef optionsDef[] = {
-        { "dac_provider", chip::ArgParser::kArgumentRequired, kOptionDacProviderFilePath },
         { "min_commissioning_timeout", chip::ArgParser::kArgumentRequired, kOptionMinCommissioningTimeout },
         {},
     };
 
     static OptionSet options = {
         AppOptions::HandleOptions, optionsDef, "PROGRAM OPTIONS",
-        "  --dac_provider <filepath>\n"
-        "       A json file with data used by the example dac provider to validate device attestation procedure.\n"
         "  --min_commissioning_timeout <value>\n"
         "       The minimum time in seconds during which commissioning session establishment is allowed by the Node.\n"
     };
-
     return &options;
-}
-
-chip::Credentials::DeviceAttestationCredentialsProvider * AppOptions::GetDACProvider()
-{
-    return &mDacProvider;
 }

--- a/examples/all-clusters-minimal-app/linux/AppOptions.h
+++ b/examples/all-clusters-minimal-app/linux/AppOptions.h
@@ -20,13 +20,10 @@
 
 #include "AppMain.h"
 
-#include <app/tests/suites/credentials/TestHarnessDACProvider.h>
-
 class AppOptions
 {
 public:
     static chip::ArgParser::OptionSet * GetOptions();
-    static chip::Credentials::DeviceAttestationCredentialsProvider * GetDACProvider();
 
 private:
     static bool HandleOptions(const char * program, chip::ArgParser::OptionSet * options, int identifier, const char * name,

--- a/examples/all-clusters-minimal-app/linux/BUILD.gn
+++ b/examples/all-clusters-minimal-app/linux/BUILD.gn
@@ -34,7 +34,6 @@ source_set("chip-all-clusters-common") {
   deps = [
     "${chip_root}/examples/all-clusters-minimal-app/all-clusters-common",
     "${chip_root}/examples/platform/linux:app-main",
-    "${chip_root}/src/app/tests/suites/credentials:dac_provider",
     "${chip_root}/src/lib",
   ]
 

--- a/examples/all-clusters-minimal-app/linux/main.cpp
+++ b/examples/all-clusters-minimal-app/linux/main.cpp
@@ -31,8 +31,6 @@ int main(int argc, char * argv[])
         ChipLinuxAppInit(argc, argv, AppOptions::GetOptions(), chip::MakeOptional(kNetworkCommissioningEndpointSecondary)) == 0);
     VerifyOrDie(InitBindingHandlers() == CHIP_NO_ERROR);
 
-    LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
-
     ChipLinuxAppMainLoop();
     return 0;
 }

--- a/examples/placeholder/linux/AppOptions.cpp
+++ b/examples/placeholder/linux/AppOptions.cpp
@@ -22,11 +22,9 @@ using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
 using chip::ArgParser::PrintArgError;
 
-constexpr uint16_t kOptionDacProviderFilePath = 0xFF01;
 constexpr uint16_t kOptionInteractiveMode     = 0xFF02;
 constexpr uint16_t kOptionInteractiveModePort = 0xFF03;
 
-static chip::Credentials::Examples::TestHarnessDACProvider mDacProvider;
 static bool gInteractiveMode = false;
 static chip::Optional<uint16_t> gInteractiveModePort;
 
@@ -35,9 +33,6 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
     bool retval = true;
     switch (identifier)
     {
-    case kOptionDacProviderFilePath:
-        mDacProvider.Init(value);
-        break;
     case kOptionInteractiveMode:
         gInteractiveMode = true;
         break;
@@ -56,28 +51,18 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
 OptionSet * AppOptions::GetOptions()
 {
     static OptionDef optionsDef[] = {
-        { "dac_provider", chip::ArgParser::kArgumentRequired, kOptionDacProviderFilePath },
         { "interactive", chip::ArgParser::kNoArgument, kOptionInteractiveMode },
         { "port", chip::ArgParser::kArgumentRequired, kOptionInteractiveModePort },
         {},
     };
 
-    static OptionSet options = {
-        AppOptions::HandleOptions, optionsDef, "PROGRAM OPTIONS",
-        "  --dac_provider <filepath>\n"
-        "       A json file with data used by the example dac provider to validate device attestation procedure.\n"
-        "  --interactive\n"
-        "       Enable server interactive mode.\n"
-        "  --port <port>\n"
-        "       Specify the listening port for the server interactive mode.\n"
-    };
+    static OptionSet options = { AppOptions::HandleOptions, optionsDef, "PROGRAM OPTIONS",
+                                 "  --interactive\n"
+                                 "       Enable server interactive mode.\n"
+                                 "  --port <port>\n"
+                                 "       Specify the listening port for the server interactive mode.\n" };
 
     return &options;
-}
-
-chip::Credentials::DeviceAttestationCredentialsProvider * AppOptions::GetDACProvider()
-{
-    return &mDacProvider;
 }
 
 bool AppOptions::GetInteractiveMode()

--- a/examples/placeholder/linux/AppOptions.h
+++ b/examples/placeholder/linux/AppOptions.h
@@ -20,13 +20,10 @@
 
 #include "AppMain.h"
 
-#include <app/tests/suites/credentials/TestHarnessDACProvider.h>
-
 class AppOptions
 {
 public:
     static chip::ArgParser::OptionSet * GetOptions();
-    static chip::Credentials::DeviceAttestationCredentialsProvider * GetDACProvider();
     static bool GetInteractiveMode();
     static chip::Optional<uint16_t> GetInteractiveModePort();
 

--- a/examples/placeholder/linux/main.cpp
+++ b/examples/placeholder/linux/main.cpp
@@ -65,8 +65,6 @@ int main(int argc, char * argv[])
 {
     VerifyOrDie(ChipLinuxAppInit(argc, argv, AppOptions::GetOptions()) == 0);
 
-    LinuxDeviceOptions::GetInstance().dacProvider = AppOptions::GetDACProvider();
-
     auto & server = InteractiveServer::GetInstance();
     if (AppOptions::GetInteractiveMode())
     {

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -102,6 +102,7 @@ source_set("app-main") {
     ":ota-test-event-trigger",
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/app/server",
+    "${chip_root}/src/app/tests/suites/credentials:dac_provider",
   ]
 
   if (current_os != "nuttx") {

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -34,6 +34,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
+#include <app/tests/suites/credentials/TestHarnessDACProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #if ENABLE_TRACING
@@ -126,6 +127,7 @@ enum
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     kDeviceOption_WiFi_PAF,
 #endif
+    kDeviceOption_DacProvider,
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -140,7 +142,7 @@ OptionDef sDeviceOptionDefs[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     { "wifipaf", kArgumentRequired, kDeviceOption_WiFi_PAF },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 #if CHIP_ENABLE_OPENTHREAD
     { "thread", kNoArgument, kDeviceOption_Thread },
 #endif // CHIP_ENABLE_OPENTHREAD
@@ -201,6 +203,7 @@ OptionDef sDeviceOptionDefs[] = {
 #if CHIP_WITH_NLFAULTINJECTION
     { "faults", kArgumentRequired, kDeviceOption_FaultInjection },
 #endif
+    { "dac_provider", kArgumentRequired, kDeviceOption_DacProvider },
     {}
 };
 
@@ -363,6 +366,8 @@ const char * sDeviceOptionHelp =
     "  --faults <fault-string,...>\n"
     "       Inject specified fault(s) at runtime.\n"
 #endif
+    "   --dac_provider <filepath>\n"
+    "       A json file with data used by the example dac provider to validate device attestation procedure.\n"
     "\n";
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
@@ -734,6 +739,14 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         break;
     }
 #endif
+    case kDeviceOption_DacProvider: {
+        LinuxDeviceOptions::GetInstance().dacProviderFile.SetValue(aValue);
+        static chip::Credentials::Examples::TestHarnessDACProvider testDacProvider;
+        testDacProvider.Init(gDeviceOptions.dacProviderFile.Value().c_str());
+
+        LinuxDeviceOptions::GetInstance().dacProvider = &testDacProvider;
+        break;
+    }
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;
@@ -777,5 +790,6 @@ LinuxDeviceOptions & LinuxDeviceOptions::GetInstance()
     {
         gDeviceOptions.dacProvider = chip::Credentials::Examples::GetExampleDACProvider();
     }
+
     return gDeviceOptions;
 }

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -49,6 +49,7 @@ struct LinuxDeviceOptions
     chip::Optional<uint16_t> discriminator;
     chip::Optional<std::vector<uint8_t>> spake2pVerifier;
     chip::Optional<std::vector<uint8_t>> spake2pSalt;
+    chip::Optional<std::string> dacProviderFile;
     uint32_t spake2pIterations = 0; // When not provided (0), will default elsewhere
     uint32_t mBleDevice        = 0;
     bool wifiSupports5g        = false;

--- a/src/app/tests/suites/credentials/BUILD.gn
+++ b/src/app/tests/suites/credentials/BUILD.gn
@@ -33,7 +33,7 @@ source_set("dac_provider") {
   ]
 
   # nuttx keeps a copy of jsoncpp, so don't add it as a dependency
-  # when building for nuttx, otherwise the build will fails at link
+  # when building for nuttx, otherwise the build will fail at link
   # time due to duplicate symbols
   if (current_os != "nuttx") {
     deps += [ "${chip_root}/third_party/jsoncpp" ]

--- a/src/app/tests/suites/credentials/BUILD.gn
+++ b/src/app/tests/suites/credentials/BUILD.gn
@@ -30,8 +30,14 @@ source_set("dac_provider") {
     "${chip_root}/src/credentials",
     "${chip_root}/src/crypto",
     "${chip_root}/src/lib",
-    "${chip_root}/third_party/jsoncpp",
   ]
+
+  # nuttx keeps a copy of jsoncpp, so don't add it as a dependency
+  # when building for nuttx, otherwise the build will fails at link
+  # time due to duplicate symbols
+  if (current_os != "nuttx") {
+    deps += [ "${chip_root}/third_party/jsoncpp" ]
+  }
 
   public_configs = [ ":default_config" ]
 }


### PR DESCRIPTION
all-clusters-app and all-clusters-minimal-app has the `--dac_provider` option which lets us inject the custom dacs in the applications.

moved this option from these apps to examples/platform/linux so that wide range of applications can levarage this.

This would be useful in testing device attestation revocation cases.

Fixes #26434

This is a building block towards creating the integration tests for dac revocation

#### Testing
Tested manually with all-clusters-app, all-clusters-minimal-app, and lighting-app that the `--dac_provider` option works, and the DACs provided in the json file does reflect.

This option is used in the `src/app/tests/suites/certification/Test_TC_DA_1_8.yaml` and  `src/app/tests/suites/certification/Test_TC_DA_1_4.yaml` tests, and few TC_DA python tests as well. So, this will be tested in the CI.

Also generated the revocation set from the injected DAC and verified that the attestation revocation error shows up.