### PR TITLE
Follow Up Fix PR #36596 - Remove indents for returns (shorten the code/indent level on early return instead of if/else)

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -536,7 +536,7 @@ class DataModelLevel(Enum):
             return "device_types"
         raise KeyError("Invalid enum: %r" % self)
 
-    
+
 def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable], data_model_level: DataModelLevel = DataModelLevel.kCluster) -> Traversable:
     """
     Get the directory of the data model for a specific version and level from the installed package.
@@ -551,7 +551,6 @@ def get_data_model_directory(data_model_directory: Union[PrebuiltDataModelDirect
     # If it's a prebuilt directory, build the path based on the version and data model level
     return pkg_resources.files(importlib.import_module('chip.testing')).joinpath(
         'data_model').joinpath(data_model_directory.dirname).joinpath(data_model_level.dirname)
-
 
 
 def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, Traversable] = PrebuiltDataModelDirectory.k1_4) -> typing.Tuple[dict[int, dict], list]:
@@ -615,7 +614,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
         remove_problem(CommandPathLocation(endpoint_id=0, cluster_id=action_id, command_id=c))
 
     combine_derived_clusters_with_base(clusters, pure_base_clusters, ids_by_name, problems)
-
 
     # TODO: All these fixups should be removed BEFORE SVE if at all possible
     # Workaround for Color Control cluster - the spec uses a non-standard conformance. Set all to optional now, will need

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -571,7 +571,6 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
     top = get_data_model_directory(data_model_directory, DataModelLevel.kCluster)
     logging.info("Reading XML clusters from %r", top)
 
-    # Early return if no XML files are found
     found_xmls = 0
     for f in top.iterdir():
         if not f.name.endswith('.xml'):

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -599,13 +599,10 @@ def build_xml_clusters(data_model_directory: Union[PrebuiltDataModelDirectory, T
     # Actions cluster - all commands - these need to be listed in the ActionsList attribute to be supported.
     #                                  We do not currently have a test for this. Please see https://github.com/CHIP-Specifications/chip-test-plans/issues/3646.
 
-
-    # Continue the rest of the processing for known problems
     def remove_problem(location: typing.Union[CommandPathLocation, FeaturePathLocation]):
         nonlocal problems
         problems = [p for p in problems if p.location != location]
 
-    # Marking conformance as optional for certain clusters
     descriptor_id = Clusters.Descriptor.id
     code = 'TAGLIST'
     mask = clusters[descriptor_id].feature_map[code]


### PR DESCRIPTION
Work for Issue #31317 

PR 24 - Follow-up fix from PR #36596  
Script `spec_parsing.py` Remove indents for returns (shorten the code/indent level on early return instead of if/else)
