### PR TITLE
[Silabs][Docker]Bump sdk versions in Silabs docker. 

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-94 : [Telink] Update Docker image (Zephyr update)
+95 : [Silabs] Update Silabs sisdk to v2024.12.0 and wifisdk to 3.4.0

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -13,8 +13,8 @@ RUN set -x \
     && : # last line
 
 
-# Download Simplicity SDK v2024.6.2 (36e12f0)
-RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.6.2/gecko-sdk.zip -O /tmp/simplicity_sdk.zip \
+# Download Simplicity SDK v2024.12.0 (8627f84)
+RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.12.0/gecko-sdk.zip -O /tmp/simplicity_sdk.zip \
     && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
     && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space
@@ -35,8 +35,8 @@ RUN git clone --depth=1 --single-branch --branch=2.10.3 https://github.com/Silic
     rm -rf .git examples \
     && : # last line
 
-# Clone WiSeConnect SDK v3.3.3 (a6390dd)
-RUN git clone --depth=1 --single-branch --branch=v3.3.3 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.4.0 (9f6db89)
+RUN git clone --depth=1 --single-branch --branch=v3.4.0 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git examples components/device/stm32 \
     && : # last line

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -113,6 +113,7 @@ ENV SILABS_BOARD=BRD4186C
 # Keep GSDK_ROOT name until rename transition to SISDK is completed
 ENV GSDK_ROOT=/opt/silabs/simplicity_sdk/
 ENV SISDK_ROOT=/opt/silabs/simplicity_sdk/
+ENV PATH $PATH:/opt/silabs/slc_cli/
 ENV WISECONNECT_SDK_ROOT=/opt/silabs/wiseconnect-wifi-bt-sdk/
 ENV WIFI_SDK_ROOT=/opt/silabs/wifi_sdk
 ENV IDF_PATH=/opt/espressif/esp-idf/


### PR DESCRIPTION
Bump sisdk to v2024.12.0 and wifisdk to v3.4.0 in silabs docker image for upcoming update.

fixes #35647 Add slc_cli in the env paths of vscode docker to allow platform and config code generation build variants within that image.


