### PR TITLE
Updating unit test runner script for EFR32 and associated documentation.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -158,6 +158,30 @@
             }
         },
         {
+            "label": "Build EFR32 Unit Tests and Test Runner",
+            "type": "shell",
+            "command": "source scripts/activate.sh; scripts/build/build_examples.py --target efr32-${input:efr32Board}-unit-test build; scripts/build/build_examples.py --target linux-x64-efr32-test-runner build; pip3 install out/linux-x64-efr32-test-runner/chip_pw_test_runner_wheels/*.whl --force-reinstall",
+            "problemMatcher": []
+        },
+        {
+            "label": "Rebuild EFR32 Unit Tests and Test Runner",
+            "type": "shell",
+            "command": "source scripts/activate.sh; rm -rf out/efr32-brd*-unit-test out/linux-x64-efr32-test-runner; scripts/build/build_examples.py --target efr32-${input:efr32Board}-unit-test build; scripts/build/build_examples.py --target linux-x64-efr32-test-runner build; pip3 install out/linux-x64-efr32-test-runner/chip_pw_test_runner_wheels/*.whl --force-reinstall",
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean EFR32 Unit Tests and Test Runner",
+            "type": "shell",
+            "command": "rm -rf out/efr32-brd*-unit-test out/linux-x64-efr32-test-runner",
+            "problemMatcher": []
+        },
+        {
+            "label": "Run EFR32 Unit Tests",
+            "type": "shell",
+            "command": "source scripts/activate.sh; python -m src.test_driver.efr32.py.pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/efr32-brd2703a-unit-test/tests -o out.log",
+            "problemMatcher": []
+        },
+        {
             "label": "Flash EFR32 board",
             "type": "shell",
             "command": "python3",
@@ -646,6 +670,27 @@
                 "telink-tlsr9518adk80d-thermostat",
                 "telink-tlsr9518adk80d-window-covering",
                 "tizen-arm-light"
+            ]
+        },
+        {
+            "type": "pickString",
+            "id": "efr32Board",
+            "description": "Which board",
+            "options": [
+                "brd2704b",
+                "brd4316a",
+                "brd4317a",
+                "brd4318a",
+                "brd4319a",
+                "brd4186a",
+                "brd4187a",
+                "brd2601b",
+                "brd4187c",
+                "brd4186c",
+                "brd2703a",
+                "brd4338a",
+                "brd2605a",
+                "brd4343a"
             ]
         },
         {

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -4,9 +4,8 @@ tests that can be flashed onto a device and run. The device is controlled using
 the included RPCs through the python test runner.
 
 -   [Prerequisites](#prerequisites)
--   [Building the Unit Tests](#building-the-unit-tests)
--   [Building and Installing the Runner](#building-and-installing-the-runner)
--   [Running the Unit Tests](#running-the-unit-tests)
+-   [Building and Running the Unit Tests](#building-and-running-the-unit-tests)
+-   [Building and Running the Unit Tests with the build_examples Script](#building-and-running-the-unit-tests-with-the-build_examples-script)
 
 ## Prerequisites
 
@@ -37,9 +36,11 @@ the included RPCs through the python test runner.
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-## Building the Unit Tests
+## Building and Running the Unit Tests
 
-The unit tests can be built using gn and ninja:
+### Building the Unit Tests
+
+The unit tests can be built using gn and ninja. Set the appropriate board name.
 
     source scripts/activate.sh
     cd src/test_driver/efr32
@@ -47,15 +48,36 @@ The unit tests can be built using gn and ninja:
     gn gen out/debug
     ninja -C out/debug
 
-## Building and Installing the Runner
+### Building and Installing the Runner
 
 The python wheels for the runner can be built and installed like this:
 
     ninja -C out/debug runner
     pip3 install out/debug/chip_pw_test_runner_wheels/*.whl --force-reinstall
 
-## Running the Unit Tests
+### Running the Unit Tests
 
 The unit tests can be run using the test runner python script:
 
     python -m py.pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/debug/tests -o out.log
+
+## Building and Running the Unit Tests with the build_examples Script
+
+### Building the Unit Tests
+
+The unit tests can be built using the build_examples script. Set the appropriate board name.
+
+    scripts/build/build_examples.py --target efr32-brd2703a-unit-test build
+
+### Building and Installing the Runner
+
+The python wheels for the runner can be built and installed like this:
+
+    scripts/build/build_examples.py --target linux-x64-efr32-test-runner build
+    pip3 install out/linux-x64-efr32-test-runner/chip_pw_test_runner_wheels/*.whl --force-reinstall
+
+### Running the Unit Tests
+
+The unit tests can be run using the test runner python script:
+
+    python -m src.test_driver.efr32.py.pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/efr32-brd2703a-unit-test/tests -o out.log

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -48,6 +48,6 @@ The unit tests can be built using gn and ninja:
 
 ## Running The Unit Tests
 
-The unit tests can be run using the test runner python script:   
+The unit tests can be run using the test runner python script:  
  python py/pw_test_runner/pw_test_runner.py -d /dev/ttyACM1 -f out/debug/tests -o
 out.log

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -46,8 +46,15 @@ The unit tests can be built using gn and ninja:
     gn gen out/debug
     ninja -C out/debug
 
+## Building and Installing the Runner
+
+The python wheels for the runner can be built and installed like this:
+
+    ninja -C out/debug runner
+    pip3 install out/debug/chip_pw_test_runner_wheels/*.whl --force-reinstall
+
 ## Running The Unit Tests
 
-The unit tests can be run using the test runner python script:  
- python py/pw_test_runner/pw_test_runner.py -d /dev/ttyACM1 -f out/debug/tests -o
-out.log
+The unit tests can be run using the test runner python script:
+
+    python -m py.pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/debug/tests -o out.log

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -1,30 +1,17 @@
-#CHIP EFR32 Test Driver
+This is a test driver for the Matter unit tests to be run on an EFR32 device.
+It builds a set of test binaries, each of which contains one directory of unit tests
+that can be flashed onto a device and run. The device is controlled using the included
+RPCs through the python test runner.
 
-This builds and runs the unit tests on the efr32 device.
+-   [Prerequisites](#prerequisites)
+-   [Building The Unit Tests](#building-the-unit-tests)
+-   [Running The Unit Tests](#running-the-unit-tests)
 
-<hr>
-
--   [Introduction](#introduction)
--   [Building](#building)
--   [Running The Tests](#running-the-tests)
-
-<hr>
-
-<a name="introduction"></a>
-
-## Introduction
-
-This builds a set of test binaries which contain the unit tests and can be
-flashed onto a device. The device is controlled using the included RPCs, through
-the python test runner.
-
-<a name="building"></a>
-
-## Building
+## Prerequisites
 
 -   Download the
     [Simplicity Commander](https://www.silabs.com/mcu/programming-options)
-    command line tool, and ensure that `commander` is your shell search path.
+    command line tool, and ensure that `commander` is in your shell search path.
     (For Mac OS X, `commander` is located inside
     `Commander.app/Contents/MacOS/`.)
 
@@ -32,11 +19,11 @@ the python test runner.
     bootstrap already installs the toolchain):
     [GNU Arm Embedded Toolchain 12.2 Rel1](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools:
 
-#Linux `sudo apt-get install git libwebkitgtk-1.0-0 ninja-build`
+    For Linux: `sudo apt-get install git libwebkitgtk-1.0-0 ninja-build`
 
-#Mac OS X `brew install ninja`
+    For Mac OS: `brew install ninja`
 
 -   Supported hardware:
 
@@ -49,60 +36,18 @@ the python test runner.
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-OR use GN/Ninja directly
+## Building The Unit Tests
 
-          ```
-          cd ~/connectedhomeip/src/test_driver/efr32/
-          git submodule update --init
-          source third_party/connectedhomeip/scripts/activate.sh
-          export SILABS_BOARD=BRD4187C
-          gn gen out/debug
-          ninja -C out/debug
-          ```
+The unit tests can be built using gn and ninja:
 
--   To delete generated executable, libraries and object files use:
-
-          ```
-          cd ~/connectedhomeip/src/test_driver/efr32/
-          rm -rf out/
-          ```
-
-<a name="running-the-tests"></a>
-
-## Running The Tests
-
-Build the runner using gn:
-
-    ```
-    cd <connectedhomeip>/src/test_driver/efr32
+    source scripts/activate.sh
+    cd src/test_driver/efr32
+    export SILABS_BOARD=BRD2703A
     gn gen out/debug
-    ninja -C out/debug runner
-    ```
+    ninja -C out/debug
 
-Or build using build script from the root
+## Running The Unit Tests
 
-    ```
-    cd <connectedhomeip>
-    ./scripts/build/build_examples.py --target linux-x64-pw-test-runner build
-    ```
-
-The runner will be installed into the venv and python wheels will be packaged in
-the output folder for deploying.
-
-Then the python wheels need to installed using pip3.
-
-    ```
-    pip3 install out/debug/chip_pw_test_runner_wheels/*.whl
-    ```
-
-Other python libraries may need to be installed such as
-
-    ```
-    pip3 install pyserial
-    ```
-
--   To run all tests:
-
-    ```
-    python -m pw_test_runner.pw_test_runner -d /dev/ttyACM1 -f out/debug/matter-silabs-device_tests.s37 -o out.log
-    ```
+The unit tests can be run using the test runner python script:
+    
+    python py/pw_test_runner/pw_test_runner.py -d /dev/ttyACM1 -f out/debug/tests -o out.log

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -65,7 +65,8 @@ The unit tests can be run using the test runner python script:
 
 ### Building the Unit Tests
 
-The unit tests can be built using the build_examples script. Set the appropriate board name.
+The unit tests can be built using the build_examples script. Set the appropriate
+board name.
 
     scripts/build/build_examples.py --target efr32-brd2703a-unit-test build
 

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -4,8 +4,9 @@ tests that can be flashed onto a device and run. The device is controlled using
 the included RPCs through the python test runner.
 
 -   [Prerequisites](#prerequisites)
--   [Building The Unit Tests](#building-the-unit-tests)
--   [Running The Unit Tests](#running-the-unit-tests)
+-   [Building the Unit Tests](#building-the-unit-tests)
+-   [Building and Installing the Runner](#building-and-installing-the-runner)
+-   [Running the Unit Tests](#running-the-unit-tests)
 
 ## Prerequisites
 
@@ -36,7 +37,7 @@ the included RPCs through the python test runner.
     -   BRD4187A / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
     -   BRD4187C / SLWSTK6006A / Wireless Starter Kit / 2.4GHz@20dBm
 
-## Building The Unit Tests
+## Building the Unit Tests
 
 The unit tests can be built using gn and ninja:
 
@@ -53,7 +54,7 @@ The python wheels for the runner can be built and installed like this:
     ninja -C out/debug runner
     pip3 install out/debug/chip_pw_test_runner_wheels/*.whl --force-reinstall
 
-## Running The Unit Tests
+## Running the Unit Tests
 
 The unit tests can be run using the test runner python script:
 

--- a/src/test_driver/efr32/README.md
+++ b/src/test_driver/efr32/README.md
@@ -1,7 +1,7 @@
-This is a test driver for the Matter unit tests to be run on an EFR32 device.
-It builds a set of test binaries, each of which contains one directory of unit tests
-that can be flashed onto a device and run. The device is controlled using the included
-RPCs through the python test runner.
+This is a test driver for the Matter unit tests to be run on an EFR32 device. It
+builds a set of test binaries, each of which contains one directory of unit
+tests that can be flashed onto a device and run. The device is controlled using
+the included RPCs through the python test runner.
 
 -   [Prerequisites](#prerequisites)
 -   [Building The Unit Tests](#building-the-unit-tests)
@@ -48,6 +48,6 @@ The unit tests can be built using gn and ninja:
 
 ## Running The Unit Tests
 
-The unit tests can be run using the test runner python script:
-    
-    python py/pw_test_runner/pw_test_runner.py -d /dev/ttyACM1 -f out/debug/tests -o out.log
+The unit tests can be run using the test runner python script:   
+ python py/pw_test_runner/pw_test_runner.py -d /dev/ttyACM1 -f out/debug/tests -o
+out.log

--- a/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
+++ b/src/test_driver/efr32/py/pw_test_runner/pw_test_runner.py
@@ -105,8 +105,7 @@ def run(args) -> int:
 
 
 def list_images(flash_directory: str) -> list[str]:
-    filenames: list[str] = glob.glob(os.path.join(flash_directory, "*.s37"))
-    return list(map(lambda x: os.path.join(flash_directory, x), filenames))
+    return glob.glob(os.path.join(flash_directory, "*.s37"))
 
 
 def main() -> int:


### PR DESCRIPTION
- Updated README.md to reflect the current procedure for building and running unit tests on ESP32.
- Added VSCode tasks for building and running.
- Fixed an error in the test runner, causing it to look for images in the wrong directory.