### PR TITLE
[ICD] Fix ICDM 2.1 Cert test when the UAT feature map isn't present

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -523,7 +523,8 @@ jobs:
             - name: Verify Testing Support
               run: |
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_IDM_10_4.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_ICDM_2_1.py'
+                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py'
+                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_SC_7_1.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestDecorators.py'
                   scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestChoiceConformanceSupport.py'

--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -238,8 +238,8 @@ class TC_ICDM_2_1(MatterBaseTest):
             uatHintInstructionDepedentBitmap = uat(
                 userActiveModeTriggerHint) & kUatInstructionDependentBitMask
 
-        asserts.assert_less_equal(
-            self.set_bits_count(uatHintInstructionDepedentBitmap), 1, "UserActiveModeTriggerHint has more than 1 bit that is dependent on the UserActiveModeTriggerInstruction")
+            asserts.assert_less_equal(
+                self.set_bits_count(uatHintInstructionDepedentBitmap), 1, "UserActiveModeTriggerHint has more than 1 bit that is dependent on the UserActiveModeTriggerInstruction")
 
         # Valdate UserActiveModeTriggerInstruction
         self.step(9)
@@ -268,7 +268,7 @@ class TC_ICDM_2_1(MatterBaseTest):
                 pattern = re.compile(r'^[0-9A-F]{6}$')
                 asserts.assert_true(pattern.match(userActiveModeTriggerInstruction),
                                     "UserActiveModeTriggerInstruction is not in the correct format for the associated UserActiveModeTriggerHint")
-        else:
+        elif self.check_pics("ICDM.S.A0006"):
             # Check if the UserActiveModeTriggerInstruction was required
             asserts.assert_false(uatHintInstructionDepedentBitmap in kUatInstructionMandatoryBitMask,
                                  "UserActiveModeTriggerHint requires the UserActiveModeTriggerInstruction")

--- a/src/python_testing/test_testing/common_icdm_data.py
+++ b/src/python_testing/test_testing/common_icdm_data.py
@@ -18,10 +18,10 @@
 
 import string
 from dataclasses import dataclass
+
 import chip.clusters as Clusters
 from chip.clusters import Attribute
 from MockTestRunner import MockTestRunner
-
 
 c = Clusters.IcdManagement
 attr = c.Attributes

--- a/src/python_testing/test_testing/common_icdm_data.py
+++ b/src/python_testing/test_testing/common_icdm_data.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env -S python3 -B
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import string
+from dataclasses import dataclass
+import chip.clusters as Clusters
+from chip.clusters import Attribute
+from MockTestRunner import MockTestRunner
+
+
+c = Clusters.IcdManagement
+attr = c.Attributes
+uat = c.Bitmaps.UserActiveModeTriggerBitmap
+
+
+@dataclass
+class ICDMData():
+    FeatureMap: int
+    IdleModeDuration: int
+    ActiveModeDuration: int
+    ActiveModeThreshold: int
+    RegisteredClients: list
+    ICDCounter: int
+    ClientsSupportedPerFabric: int
+    UserActiveModeTriggerHint: int
+    UserActiveModeTriggerInstruction: string
+    OperatingMode: c.Enums.OperatingModeEnum
+    MaximumCheckInBackOff: int
+    expect_pass: bool
+
+
+def test_spec_to_attribute_cache(test_icdm: ICDMData) -> Attribute.AsyncReadTransaction.ReadResponse:
+    resp = Attribute.AsyncReadTransaction.ReadResponse({}, [], {})
+    resp.attributes = {0: {c: {attr.FeatureMap: test_icdm.FeatureMap, attr.IdleModeDuration: test_icdm.IdleModeDuration, attr.ActiveModeDuration: test_icdm.ActiveModeDuration, attr.ActiveModeThreshold: test_icdm.ActiveModeThreshold,
+                               attr.RegisteredClients: test_icdm.RegisteredClients, attr.ICDCounter: test_icdm.ICDCounter,
+                               attr.ClientsSupportedPerFabric: test_icdm.ClientsSupportedPerFabric, attr.UserActiveModeTriggerHint: test_icdm.UserActiveModeTriggerHint,
+                               attr.UserActiveModeTriggerInstruction: test_icdm.UserActiveModeTriggerInstruction, attr.OperatingMode: test_icdm.OperatingMode, attr.MaximumCheckInBackOff: test_icdm.MaximumCheckInBackOff}}}
+    return resp
+
+
+def run_tests(pics, label, test_cases, test_name):
+    test_runner = MockTestRunner(
+        label, label, test_name, 0, pics)
+    failures = []
+    for idx, t in enumerate(test_cases):
+        ok = test_runner.run_test_with_mock_read(
+            test_spec_to_attribute_cache(t)) == t.expect_pass
+        if not ok:
+            failures.append(f"Measured test case failure: {idx} {t}")
+
+    test_runner.Shutdown()
+    print(
+        f"Test of tests: run {len(test_cases)}, test response correct: {len(test_cases) - len(failures)} | test response incorrect: {len(failures)}")
+    for f in failures:
+        print(f)
+
+    return 1 if failures else 0

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
@@ -16,34 +16,9 @@
 #    limitations under the License.
 #
 
-import string
 import sys
-from dataclasses import dataclass
 
-import chip.clusters as Clusters
-from chip.clusters import Attribute
-from MockTestRunner import MockTestRunner
-
-c = Clusters.IcdManagement
-attr = c.Attributes
-uat = c.Bitmaps.UserActiveModeTriggerBitmap
-
-
-@dataclass
-class ICDMData():
-    FeatureMap: int
-    IdleModeDuration: int
-    ActiveModeDuration: int
-    ActiveModeThreshold: int
-    RegisteredClients: list
-    ICDCounter: int
-    ClientsSupportedPerFabric: int
-    UserActiveModeTriggerHint: int
-    UserActiveModeTriggerInstruction: string
-    OperatingMode: c.Enums.OperatingModeEnum
-    MaximumCheckInBackOff: int
-    expect_pass: bool
-
+from common_icdm_data import ICDMData, c, run_tests, uat
 
 long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut e"
 too_long_string = long_string + "1"
@@ -217,35 +192,11 @@ TEST_CASES = [
 ]
 
 
-def test_spec_to_attribute_cache(test_icdm: ICDMData) -> Attribute.AsyncReadTransaction.ReadResponse:
-    resp = Attribute.AsyncReadTransaction.ReadResponse({}, [], {})
-    resp.attributes = {0: {c: {attr.FeatureMap: test_icdm.FeatureMap, attr.IdleModeDuration: test_icdm.IdleModeDuration, attr.ActiveModeDuration: test_icdm.ActiveModeDuration, attr.ActiveModeThreshold: test_icdm.ActiveModeThreshold,
-                               attr.RegisteredClients: test_icdm.RegisteredClients, attr.ICDCounter: test_icdm.ICDCounter,
-                               attr.ClientsSupportedPerFabric: test_icdm.ClientsSupportedPerFabric, attr.UserActiveModeTriggerHint: test_icdm.UserActiveModeTriggerHint,
-                               attr.UserActiveModeTriggerInstruction: test_icdm.UserActiveModeTriggerInstruction, attr.OperatingMode: test_icdm.OperatingMode, attr.MaximumCheckInBackOff: test_icdm.MaximumCheckInBackOff}}}
-    return resp
-
-
 def main():
     pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": True, "ICDM.S.A0004": True,
             "ICDM.S.A0005": True, "ICDM.S.A0006": True, "ICDM.S.A0007": True, "ICDM.S.A0008": True, "ICDM.S.A0009": True, }
 
-    test_runner = MockTestRunner(
-        'TC_ICDM_2_1', 'TC_ICDM_2_1', 'test_TC_ICDM_2_1', 0, pics)
-    failures = []
-    for idx, t in enumerate(TEST_CASES):
-        ok = test_runner.run_test_with_mock_read(
-            test_spec_to_attribute_cache(t)) == t.expect_pass
-        if not ok:
-            failures.append(f"Measured test case failure: {idx} {t}")
-
-    test_runner.Shutdown()
-    print(
-        f"Test of tests: run {len(TEST_CASES)}, test response correct: {len(TEST_CASES) - len(failures)} | test response incorrect: {len(failures)}")
-    for f in failures:
-        print(f)
-
-    return 1 if failures else 0
+    return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
 
 
 if __name__ == "__main__":

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
@@ -17,7 +17,8 @@
 #
 
 import sys
-from common_icdm_data import ICDMData, run_tests, c
+
+from common_icdm_data import ICDMData, c, run_tests
 
 TEST_CASES = [
     # Validate that the test script can succeed with the minimum set of PICS

--- a/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
+++ b/src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env -S python3 -B
+#
+#    Copyright (c) 2024 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import sys
+from common_icdm_data import ICDMData, run_tests, c
+
+TEST_CASES = [
+    # Validate that the test script can succeed with the minimum set of PICS
+    ICDMData(0, 1, 0, 100, [], 0, 2, 0, "",
+             c.Enums.OperatingModeEnum.kSit, 64800, True),
+]
+
+
+def main():
+    pics = {"ICDM.S.A0000": True, "ICDM.S.A0001": True, "ICDM.S.A0002": True, "ICDM.S.A0003": False, "ICDM.S.A0004": False,
+            "ICDM.S.A0005": False, "ICDM.S.A0006": False, "ICDM.S.A0007": False, "ICDM.S.A0008": False, "ICDM.S.A0009": False, }
+
+    return run_tests(pics, 'TC_ICDM_2_1', TEST_CASES, 'test_TC_ICDM_2_1')
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### Description 
When running the ICDM 2.1 test case without the UAT feature map, certain UAT validations were being run by mistakes. 

- First incorrect check was due to indentation
- Second incorrect check was due to a missing check that the UAT hint was present

Fixes https://github.com/project-chip/matter-test-scripts/issues/456

#### Tests
CI
