### PR TITLE
Add nullptr check for String TLV data with zero length

### DIFF
--- a/src/lib/support/BufferWriter.cpp
+++ b/src/lib/support/BufferWriter.cpp
@@ -30,7 +30,7 @@ BufferWriter & BufferWriter::Put(const void * buf, size_t len)
 {
     size_t available = Available();
 
-    if (available > 0)
+    if (available > 0 && buf != nullptr)
     {
         memmove(mBuf + mNeeded, buf, available < len ? available : len);
     }

--- a/src/lib/support/BufferWriter.cpp
+++ b/src/lib/support/BufferWriter.cpp
@@ -30,7 +30,7 @@ BufferWriter & BufferWriter::Put(const void * buf, size_t len)
 {
     size_t available = Available();
 
-    if (available > 0 && buf != nullptr)
+    if (available > 0 && len > 0)
     {
         memmove(mBuf + mNeeded, buf, available < len ? available : len);
     }


### PR DESCRIPTION
### Description

- In TLVReader.cpp:501, setting the length value of the String TLV data to 0 causes `GetDataPtr` to return a nullptr
- In EmberAttributeDataBuffer.cpp:246, the returned nullptr is assigned to the `tlvData` pointer variable and passed as an argument to `writer.Put()`
- When `writer.Put()` is executed, `memmove` is called in BufferWriter.cpp:35, and the `buf` argument holds a `nullptr`
- However, since the length value being copied is 0, only a UBSan log is printed, and no crash occurs.
![image](https://github.com/user-attachments/assets/c7f61cf7-c52f-4179-9fab-2e538fb6b422)

### Reproduce
![image2](https://github.com/user-attachments/assets/ba66596a-bcec-406b-bb1f-61274d6e2920)
- 0x2c : UTF8String_1BtyeLength
- 0x02 : Tag
- 0x00 : String Length Value
    - Setting the String data length value to 0x00 results in a `nullptr` being returned.

### Changes

- If `buf` is nullptr, `memmove` is not executed in BufferWriter.cpp:35 
    
    ```cpp
    BufferWriter & BufferWriter::Put(const void * buf, size_t len)
    {
        size_t available = Available();
    
        [+] if (available > 0 && buf != nullptr)
        {
            memmove(mBuf + mNeeded, buf, available < len ? available : len);
        }
    
        mNeeded += len;
        return *this;
    }
    ```