### PR TITLE
Fix OnOff state shadowing by the LevelControl cluster while OnOff tra…

### DIFF
--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -50,6 +50,12 @@ void emberAfPluginLevelControlClusterServerPostInitCallback(chip::EndpointId end
  */
 bool LevelControlHasFeature(chip::EndpointId endpoint, chip::app::Clusters::LevelControl::Feature feature);
 
+/**
+ * Check whether the instance of the Level Control cluster on the given endpoint
+ * is currently performing an On/Off transition.
+ */
+bool LevelControlIsOnOffTransitionActive(chip::EndpointId endpoint, bool * const targetState);
+
 namespace LevelControlServer {
 
 chip::Protocols::InteractionModel::Status

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -373,16 +373,78 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
         return status;
     }
 
-    // if the value is already what we want to set it to then do nothing
-    if ((!currentValue && command == Commands::Off::Id) || (currentValue && command == Commands::On::Id))
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+    // the level control cluster supports on/off transitions or effects, e.g., controlled via
+    // the OnOffTransitionTime attribute: in a transition to "off", the level control cluster
+    // changes the CurrentLevel attribute using a timer until it reaches the minimum supported value
+    // and only then changes the OnOff value in the OnOff cluster. therefore, comparing the current
+    // OnOff state with the required state is not sufficient for OnOff cluster values that support
+    // level control:
+    // - the current state might be "On"
+    // - even though the level control cluster changes the state towards "Off"
+    // - and thus any other "On" value should prevent the cluster from turning off.
+    //
+    // this restriction does not exist for the "Off" command since level movements by definition
+    // are only available while the OnOff state is "On".
+    if (!LevelControlWithOnOffFeaturePresent(endpoint) || (command == Commands::Off::Id))
+#endif
     {
-        ChipLogProgress(Zcl, "Endpoint %x On/off already set to new value", endpoint);
-        return Status::Success;
+        // if the value is already what we want to set it to then do nothing
+        if ((!currentValue && command == Commands::Off::Id) || (currentValue && command == Commands::On::Id))
+        {
+            ChipLogProgress(Zcl, "Endpoint %x On/off already set to new value", endpoint);
+            return Status::Success;
+        }
     }
 
-    // we either got a toggle, or an on when off, or an off when on,
-    // so we need to swap the value
-    newValue = !currentValue;
+    switch (command)
+    {
+    case Commands::Off::Id:
+        newValue = false;
+        break;
+
+    case Commands::On::Id:
+        newValue = true;
+        break;
+
+    case Commands::Toggle::Id:
+        newValue = !currentValue;
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+        if (LevelControlWithOnOffFeaturePresent(endpoint))
+        {
+            bool targetValueOn    = false;
+            bool transitionActive = LevelControlIsOnOffTransitionActive(endpoint, &targetValueOn);
+            if (transitionActive)
+            {
+                newValue = !targetValueOn;
+            }
+        }
+#endif
+        break;
+
+    case Commands::OffWithEffect::Id:
+    case Commands::OnWithRecallGlobalScene::Id:
+    case Commands::OnWithTimedOff::Id:
+    default:
+        // this function is only supposed to be called for the commands On, Off, and Toggle
+        ChipLogProgress(Zcl, "ERR: unknown/unsupported command " ChipLogFormatMEI, ChipLogValueMEI(command));
+        return Status::Failure;
+        break;
+    }
+
+#ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
+    if (LevelControlWithOnOffFeaturePresent(endpoint))
+    {
+        bool targetValueOn    = false;
+        bool transitionActive = LevelControlIsOnOffTransitionActive(endpoint, &targetValueOn);
+        if (!transitionActive && (newValue == currentValue))
+        {
+            ChipLogProgress(Zcl, "Endpoint %x On/off already set to new value", endpoint);
+            return Status::Success;
+        }
+    }
+#endif
+
     ChipLogProgress(Zcl, "Toggle ep%x on/off from state %x to %x", endpoint, currentValue, newValue);
 
     // the sequence of updating on/off attribute and kick off level change effect should
@@ -415,11 +477,14 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
         }
 
         // write the new on/off value
-        status = Attributes::OnOff::Set(endpoint, newValue);
-        if (status != Status::Success)
+        if (newValue != currentValue)
         {
-            ChipLogProgress(Zcl, "ERR: writing on/off %x", to_underlying(status));
-            return status;
+            status = Attributes::OnOff::Set(endpoint, newValue);
+            if (status != Status::Success)
+            {
+                ChipLogProgress(Zcl, "ERR: writing on/off %x", to_underlying(status));
+                return status;
+            }
         }
 
 #ifdef MATTER_DM_PLUGIN_LEVEL_CONTROL
@@ -461,11 +526,14 @@ Status OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::CommandId com
 #endif
         {
             // write the new on/off value
-            status = Attributes::OnOff::Set(endpoint, newValue);
-            if (status != Status::Success)
+            if (newValue != currentValue)
             {
-                ChipLogProgress(Zcl, "ERR: writing on/off %x", to_underlying(status));
-                return status;
+                status = Attributes::OnOff::Set(endpoint, newValue);
+                if (status != Status::Success)
+                {
+                    ChipLogProgress(Zcl, "ERR: writing on/off %x", to_underlying(status));
+                    return status;
+                }
             }
 
             if (SupportsLightingApplications(endpoint))
@@ -517,7 +585,7 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
         Status status             = getOnOffValueForStartUp(endpoint, onOffValueForStartUp);
         if (status == Status::Success)
         {
-            status = setOnOffValue(endpoint, onOffValueForStartUp, true);
+            status = setOnOffValue(endpoint, onOffValueForStartUp ? Commands::On::Id : Commands::Off::Id, true);
         }
 
 #ifdef MATTER_DM_PLUGIN_MODE_SELECT

--- a/src/app/tests/suites/TestLevelControlWithOnOffTransition.yaml
+++ b/src/app/tests/suites/TestLevelControlWithOnOffTransition.yaml
@@ -1,0 +1,176 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name:
+    Dependency with the On/Off cluster. Verifies that the CurrentLevel
+    manipulation by the On/Off transition has no effect on the stored
+    CurrentLevel.
+
+config:
+    nodeId: 0x12344321
+    cluster: "Level Control"
+    endpoint: 1
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label:
+          "Send a MoveToLevelWithOnOff command with Level =127 and
+          TransitionTime =0 (immediate). This also sets the On/Off state"
+      command: "MoveToLevelWithOnOff"
+      arguments:
+          values:
+              - name: "Level"
+                value: 127
+              - name: "TransitionTime"
+                value: 0
+              - name: "OptionsMask"
+                value: 1
+              - name: "OptionsOverride"
+                value: 1
+
+    - label: "Wait 100 ms"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Check that the On/Off attribute value is 'On'"
+      cluster: "On/Off"
+      command: "readAttribute"
+      attribute: "OnOff"
+      response:
+          value: 1
+
+    - label: "Wait 100 ms"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 100
+
+    - label: "Verify that the CurrentLevel is at the configured value"
+      command: "readAttribute"
+      attribute: "CurrentLevel"
+      response:
+          value: 127
+
+    - label: "Set the OnOffTransitionTime attribute to 2 seconds"
+      command: "writeAttribute"
+      attribute: "OnOffTransitionTime"
+      arguments:
+          # sets the OnOffTransitionTime to a reasonably large value for the following steps
+          # to happen within the On/Off transition effect (specified in 1/10 seconds).
+          value: 20
+
+    - label: "Verify the OnOffTransitionTime attribute"
+      command: "readAttribute"
+      attribute: "OnOffTransitionTime"
+      response:
+          value: 20
+
+    - label: "Send an 'Off' Command, initiating transition to the 'Off' state"
+      cluster: "On/Off"
+      command: "Off"
+
+    - label: "Wait for 1 second (half of the OnOffTransitionTime)"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 1000
+
+    - label: "Check that the On/Off attribute value is 'On'"
+      cluster: "On/Off"
+      command: "readAttribute"
+      attribute: "OnOff"
+      response:
+          value: 1
+
+    - label:
+          "Read the CurrentLevel, check that the transition is still in progress"
+      command: "readAttribute"
+      attribute: "CurrentLevel"
+      response:
+          constraints:
+              minValue: 50
+              maxValue: 126
+
+    - label:
+          "Send a Toggle Command to initiate a transition back to the configured
+          CurrentLevel"
+      cluster: "On/Off"
+      command: "Toggle"
+
+    - label: "Wait for 1/2 second (quarter of the OnOffTransitionTime)"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 500
+
+    - label:
+          "Read the CurrentLevel, verify that the CurrentLevel has not been
+          reached yet"
+      command: "readAttribute"
+      attribute: "CurrentLevel"
+      response:
+          constraints:
+              minValue: 50
+              maxValue: 126
+
+    - label: "Send a Toggle Command to initiate a transition to 'Off'"
+      cluster: "On/Off"
+      command: "Toggle"
+
+    - label: "Wait for the configured OnOffTransitionTime (2 seconds)"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 2000
+
+    - label: "Check that the On/Off attribute value is 'Off'"
+      cluster: "On/Off"
+      command: "readAttribute"
+      attribute: "OnOff"
+      response:
+          value: 0
+
+    - label:
+          "Read the CurrentLevel, check that the CurrentLevel is restored
+          correctly to the initial value of 127 and thus unaffected unaffected
+          by the On/Off transition."
+      command: "readAttribute"
+      attribute: "CurrentLevel"
+      response:
+          value: 127
+
+    - label: "Reset the OnOffTransitionTime attribute to zero"
+      command: "writeAttribute"
+      attribute: "OnOffTransitionTime"
+      arguments:
+          value: 0

--- a/src/app/tests/suites/ciTests.json
+++ b/src/app/tests/suites/ciTests.json
@@ -257,6 +257,7 @@
         "TestFanControl",
         "TestAccessControlConstraints",
         "TestLevelControlWithOnOffDependency",
+        "TestLevelControlWithOnOffTransition",
         "TestCommissioningWindow",
         "TestCommissionerNodeId",
         "TestTimeSynchronization",


### PR DESCRIPTION
### Description

The `LevelControl` server shadows the `OnOff` state if it is performing an On/Off transition and incorrectly changes the `CurrentLevel` in case an On transition is interrupted by an `OnOff::Command::Off`. 

In short: When receiving a new command, the `CurrentLevel` is updated with the temporary level that is used by an On/Off effect transition. For lighting applications this is very undesirable since you don't want to change the lighting level just because you pushed the On/Off switch while a dimming effect was in progress.

Fixes/see #36579

### Discussion

This PR introduces a new `emberAfOnOffClusterLevelControlIsEffectActiveCallback` - I didn't know what else to use since the information about a state transition is stored in the `LevelControl` cluster.

I'm also not very happy with the way I'm checking whether a transition is in progress (comparing against the levels) but I didn't want to introduce too many breaking changes to the state information tracked by the `LevelControl` and `OnOff` clusters.

### Testing

Added the YAML test `src/app/tests/suites/TestLevelControlWithOnOffTransition.yaml` which verifies that the `CurrentLevel` remains unaffected when toggling twice during an `OnOff` transition.