### PR TITLE
Fix PostAttributeChangeCallback value ctypes typing

### DIFF
--- a/src/controller/python/chip/server/__init__.py
+++ b/src/controller/python/chip/server/__init__.py
@@ -17,11 +17,20 @@
 import ctypes
 
 from chip import native
-from chip.native import PostAttributeChangeCallback
+from chip.native import PostAttributeChangeCallback, c_PostAttributeChangeCallback
+
+__all__ = [
+    "GetLibraryHandle",
+    "PostAttributeChangeCallback",
+]
 
 
-def GetLibraryHandle(cb: PostAttributeChangeCallback) -> ctypes.CDLL:
-    """Get a memoized handle to the chip native code dll."""
+def GetLibraryHandle(cb: c_PostAttributeChangeCallback) -> ctypes.CDLL:
+    """Get a memoized handle to the chip native code dll.
+
+    Args:
+      cb: A callback decorated by PostAttributeChangeCallback decorator.
+    """
 
     handle = native._GetLibraryHandle(native.Library.SERVER, False)
     if not handle.initialized:


### PR DESCRIPTION
This PR fixes the incorrect PostAttributeChangeCallback's value argument ctypes typing, which is documented in the TODO.
>   TODO: This should be a pointer to uint8_t, but ctypes does not provide
>         such a type. The best approximation is c_char_p, however, this
>         requires the caller to pass NULL-terminate C-string which might
>         not be the case here.

The callback requires the caller to pass a NULL-terminated C-string, but it’s actually a length-buffer pair. The python lighting example receives values with incorrect length due to this issue.

With this PR, the `PostAttributeChangeCallback` decorator will wrap the callback function, and converts the length-buffer pair to a proper python bytes value.

To keep it backward-compatible, the length argument will still be passed to the callback, although it becomes redundant.