### PR TITLE
Select least peer active session

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -1297,7 +1297,7 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
             {
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
                 // Set up a TCP transport based session as standby
-                if ((tcpSession == nullptr || tcpSession->GetLastActivityTime() < session->GetLastActivityTime()) &&
+                if ((tcpSession == nullptr || tcpSession->GetLastPeerActivityTime() < session->GetLastPeerActivityTime()) &&
                     session->GetTCPConnection() != nullptr)
                 {
                     tcpSession = session;
@@ -1305,7 +1305,7 @@ Optional<SessionHandle> SessionManager::FindSecureSessionForNode(ScopedNodeId pe
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
             }
 
-            if ((mrpSession == nullptr) || (mrpSession->GetLastActivityTime() < session->GetLastActivityTime()))
+            if ((mrpSession == nullptr) || (mrpSession->GetLastPeerActivityTime() < session->GetLastPeerActivityTime()))
             {
                 mrpSession = session;
             }

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -998,19 +998,19 @@ TEST_F(TestSessionManager, TestFindSecureSessionForNode)
     CHIP_ERROR err = sessionManager.InjectCaseSessionWithTestKey(aliceToBobSession, 2, 1, aliceNodeId, bobNodeId, aliceFabricIndex,
                                                                  peer, CryptoContext::SessionRole::kInitiator);
     EXPECT_EQ(err, CHIP_NO_ERROR);
-    aliceToBobSession->AsSecureSession()->MarkActive();
+    aliceToBobSession->AsSecureSession()->MarkActiveRx();
 
     SessionHolder newAliceToBobSession;
     err = sessionManager.InjectCaseSessionWithTestKey(newAliceToBobSession, 3, 4, aliceNodeId, bobNodeId, aliceFabricIndex, peer,
                                                       CryptoContext::SessionRole::kInitiator);
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    while (System::SystemClock().GetMonotonicTimestamp() <= aliceToBobSession->AsSecureSession()->GetLastActivityTime())
+    while (System::SystemClock().GetMonotonicTimestamp() <= aliceToBobSession->AsSecureSession()->GetLastPeerActivityTime())
     {
         // Wait for the clock to advance so the new session is
         // more-recently-active.
     }
-    newAliceToBobSession->AsSecureSession()->MarkActive();
+    newAliceToBobSession->AsSecureSession()->MarkActiveRx();
 
     auto foundSession = sessionManager.FindSecureSessionForNode(ScopedNodeId(bobNodeId, aliceFabricIndex),
                                                                 MakeOptional(SecureSession::Type::kCASE));


### PR DESCRIPTION
MRP RetransTable will refresh the active time, which may result in selecting an old session for retransmit instead of a new one initiated by the peer. Avoid this by selecting the least peer active one.