### PR TITLE
[bouffalo lab] fix crash issues in route hook and rpc uart driver mod…

### DIFF
--- a/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
+++ b/examples/platform/bouffalolab/bl602/lwipopts/lwipopts.h
@@ -61,7 +61,7 @@ a lot of data that needs to be copied, this should be set high. */
 
 /* MEMP_NUM_UDP_PCB: the number of UDP protocol control blocks. One
    per active UDP "connection". */
-#define MEMP_NUM_UDP_PCB 8
+#define MEMP_NUM_UDP_PCB 12
 
 /* MEMP_NUM_TCP_PCB: the number of simulatenously active TCP
    connections. */

--- a/examples/platform/bouffalolab/common/route_hook/bl_route_hook.c
+++ b/examples/platform/bouffalolab/common/route_hook/bl_route_hook.c
@@ -168,12 +168,12 @@ int8_t bl_route_hook_init(void)
         goto exit;
     }
 
-    for (bl_route_hook_t * iter = s_hooks; iter != NULL; iter++)
+    for (bl_route_hook_t * iter = s_hooks; iter != NULL; iter = iter->next)
     {
         if (iter->netif == lwip_netif)
         {
             ret = 0;
-            break;
+            goto exit;
         }
     }
 
@@ -194,6 +194,11 @@ int8_t bl_route_hook_init(void)
 
     hook->netif = lwip_netif;
     hook->pcb   = raw_new_ip_type(IPADDR_TYPE_V6, IP6_NEXTH_ICMP6);
+    if (NULL == hook->pcb) {
+        ret = -1;
+        goto exit;
+    }
+
     hook->pcb->flags |= RAW_FLAGS_MULTICAST_LOOP;
     hook->pcb->chksum_reqd = 1;
     // The ICMPv6 header checksum offset

--- a/examples/platform/bouffalolab/common/route_hook/bl_route_hook.c
+++ b/examples/platform/bouffalolab/common/route_hook/bl_route_hook.c
@@ -194,7 +194,8 @@ int8_t bl_route_hook_init(void)
 
     hook->netif = lwip_netif;
     hook->pcb   = raw_new_ip_type(IPADDR_TYPE_V6, IP6_NEXTH_ICMP6);
-    if (NULL == hook->pcb) {
+    if (NULL == hook->pcb)
+    {
         ret = -1;
         goto exit;
     }

--- a/examples/platform/bouffalolab/common/rpc/pw_sys_io/sys_io.cc
+++ b/examples/platform/bouffalolab/common/rpc/pw_sys_io/sys_io.cc
@@ -31,14 +31,14 @@ Status ReadByte(std::byte * dest)
         return Status::InvalidArgument();
 
     int16_t ret = uartRead(reinterpret_cast<char *>(dest), 1);
-    return ret <= 0 ? Status::FailedPrecondition() : OkStatus();
+    return ret < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 Status WriteByte(std::byte b)
 {
     int16_t ret = uartWrite(reinterpret_cast<const char *>(&b), 1);
 
-    return ret <= 0 ? Status::FailedPrecondition() : OkStatus();
+    return ret < 0 ? Status::FailedPrecondition() : OkStatus();
 }
 
 // Writes a string using pw::sys_io, and add newline characters at the end.


### PR DESCRIPTION
- fix crash issue in route hook module
    - fix iteration issue on s_hooks
    - add failure handling on lwip pcb allocation 
- fix the issue with the UART driver in the PRC module that causes the RPC task to exit

### Testing 
- repeat crash issue in route hook module with **bouffalolab-bl602dk-light-wifi-littlefs** target.
  Commission BL602DK and after connect to Wi-Fi router. Changing IPv6 address prefix of Wi-Fi router four times will get BL602 crashed.
  With this PR, changing IPv6 address prefix of Wi-Fi router four more times will not get BL602 crashed.
- repeat PRC UART driver issue with **bouffalolab-bl602dk-light-wifi-littlefs-rpc-115200** target
  The uartRead function returning 0 results in Status::FailedPrecondition, which causes an unexpected exit of the RPC and leads to a crash.
  uartRead begins to retrieve the last byte from the data queue while a UART FIFO RX timeout interrupt occurs. At that point, the last byte has not yet been read, but it signals to the RPC task that data is available. The last byte is then read by uartRead, and when uartRead is called again by the RPC task, it returns 0.
  The fault occurs in extreme environments and during stress testing. We have conducted tests using the Matter auto-test framework, which employs the PRC protocol to communicate with the device for Matter testing. After dozens of tests, we observe this fault occurring once.









