### PR TITLE
[FIX] Changing Wheels Path Of The Chip-Cert-Bins Dockerfile

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -305,5 +305,5 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
 RUN pip install --break-system-packages --no-cache-dir \
-    python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
+    python_lib/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
     python_lib/controller/python/chip*.whl


### PR DESCRIPTION
This simply updates the a Dockerfile path for the chip-cert-bins images.

The build is broken on the pip install step (stage 2, step 42 of 42) for the required wheels.
It seems the current SDK has removed a folder from the path resulting in the "file not found error".

Refer to the attached log file below for the error:
[sdk_build_error.txt](https://github.com/user-attachments/files/18274945/sdk_build_error.txt)

**Older path:**
`python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl`

**New Path:**
`python_lib/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl`