### PR TITLE
[ESP32] Modify Return Error Code for GetLogForIntent() method in DiagnosticLogsProviderDelegate

### DIFF
--- a/examples/temperature-measurement-app/esp32/main/diagnostic-logs-provider-delegate-impl.cpp
+++ b/examples/temperature-measurement-app/esp32/main/diagnostic-logs-provider-delegate-impl.cpp
@@ -63,12 +63,10 @@ CHIP_ERROR LogProvider::GetLogForIntent(IntentEnum intent, MutableByteSpan & out
 
     bool unusedOutIsEndOfLog;
     err = CollectLog(sessionHandle, outBuffer, unusedOutIsEndOfLog);
-    VerifyOrReturnError(CHIP_NO_ERROR == err, err, outBuffer.reduce_size(0));
+    VerifyOrDo(err == CHIP_NO_ERROR, outBuffer.reduce_size(0));
 
-    err = EndLogCollection(sessionHandle, err);
-    VerifyOrReturnError(CHIP_NO_ERROR == err, err, outBuffer.reduce_size(0));
-
-    return CHIP_NO_ERROR;
+    EndLogCollection(sessionHandle, err);
+    return err;
 }
 
 size_t LogProvider::GetSizeForIntent(IntentEnum intent)

--- a/examples/temperature-measurement-app/esp32/main/diagnostic-logs-provider-delegate-impl.cpp
+++ b/examples/temperature-measurement-app/esp32/main/diagnostic-logs-provider-delegate-impl.cpp
@@ -62,11 +62,12 @@ CHIP_ERROR LogProvider::GetLogForIntent(IntentEnum intent, MutableByteSpan & out
     VerifyOrReturnError(CHIP_NO_ERROR == err, err, outBuffer.reduce_size(0));
 
     bool unusedOutIsEndOfLog;
-    err = CollectLog(sessionHandle, outBuffer, unusedOutIsEndOfLog);
-    VerifyOrDo(err == CHIP_NO_ERROR, outBuffer.reduce_size(0));
+    CHIP_ERROR collectErr = CollectLog(sessionHandle, outBuffer, unusedOutIsEndOfLog);
+    VerifyOrDo(collectErr == CHIP_NO_ERROR, outBuffer.reduce_size(0));
 
-    EndLogCollection(sessionHandle, err);
-    return err;
+    CHIP_ERROR endErr = EndLogCollection(sessionHandle, collectErr);
+
+    return (collectErr != CHIP_NO_ERROR) ? collectErr : endErr;
 }
 
 size_t LogProvider::GetSizeForIntent(IntentEnum intent)
@@ -291,7 +292,7 @@ CHIP_ERROR LogProvider::EndLogCollection(LogSessionHandle sessionHandle, CHIP_ER
     Platform::MemoryFree(context);
     mSessionContextMap.erase(sessionHandle);
 
-    return error;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LogProvider::CollectLog(LogSessionHandle sessionHandle, MutableByteSpan & outBuffer, bool & outIsEndOfLog)

--- a/src/app/clusters/diagnostic-logs-server/DiagnosticLogsProviderDelegate.h
+++ b/src/app/clusters/diagnostic-logs-server/DiagnosticLogsProviderDelegate.h
@@ -78,6 +78,8 @@ public:
      * @param[in] error          A CHIP_ERROR value indicating the reason for ending the log collection.
      *                           It is permissible to pass CHIP_NO_ERROR to indicate normal termination.
      * @return CHIP_ERROR_NOT_IMPLEMENTED by default unless overridden.
+     *         CHIP_NO_ERROR on successful termination of the log collection.
+     *         Appropriate CHIP_ERROR code if an error occurs while ending the log collection.
      *
      */
     virtual CHIP_ERROR EndLogCollection(LogSessionHandle sessionHandle, CHIP_ERROR error)


### PR DESCRIPTION
### Problem
The VerifyOrReturn statement after the CollectLog() method caused an early return in case of an error, preventing EndLogCollection() from being called. This behavior is incorrect, as EndLogCollection() must be called in both success and failure scenarios.

### Change Overview
Removed the VerifyOrReturn statement following the CollectLog() method.
Modified the code to ensure that EndLogCollection() is called regardless of the success or failure of CollectLog().