### PR TITLE
Make `DecodeMRPParametersIfPresent()`  and `ParseSigma1()` methods static + fix for TLV reading corner case

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1097,9 +1097,10 @@ CASESession::NextStep CASESession::HandleSigma1(System::PacketBufferHandle && ms
     ChipLogDetail(SecureChannel, "Peer assigned session key ID %d", parsedSigma1.initiatorSessionId);
     SetPeerSessionId(parsedSigma1.initiatorSessionId);
 
-    // Set the MRP parameters provided in the Sigma1 message
-    if (parsedSigma1.initiatorMrpParamsPresent)
+    // Set the Session parameters provided in the Sigma1 message
+    if (parsedSigma1.initiatorSessionParamsPresent)
     {
+        SetRemoteSessionParameters(parsedSigma1.initiatorSessionParams);
         mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
             GetRemoteSessionParameters());
     }
@@ -2326,8 +2327,8 @@ CHIP_ERROR CASESession::ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, 
     if (err == CHIP_NO_ERROR && tlvReader.GetTag() == AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams))
     {
         ReturnErrorOnFailure(DecodeSessionParametersIfPresent(AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams), tlvReader,
-                                                              mRemoteSessionParams));
-        outParsedSigma1.initiatorMrpParamsPresent = true;
+                                                              outParsedSigma1.initiatorSessionParams));
+        outParsedSigma1.initiatorSessionParamsPresent = true;
 
         err = tlvReader.Next();
     }

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1098,7 +1098,7 @@ CASESession::NextStep CASESession::HandleSigma1(System::PacketBufferHandle && ms
     SetPeerSessionId(parsedSigma1.initiatorSessionId);
 
     // Set the Session parameters provided in the Sigma1 message
-    if (parsedSigma1.initiatorSessionParamsPresent)
+    if (parsedSigma1.initiatorSessionParamStructPresent)
     {
         SetRemoteSessionParameters(parsedSigma1.initiatorSessionParams);
         mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
@@ -2328,7 +2328,7 @@ CHIP_ERROR CASESession::ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, 
     {
         ReturnErrorOnFailure(DecodeSessionParametersIfPresent(AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams), tlvReader,
                                                               outParsedSigma1.initiatorSessionParams));
-        outParsedSigma1.initiatorSessionParamsPresent = true;
+        outParsedSigma1.initiatorSessionParamStructPresent = true;
 
         err = tlvReader.Next();
     }

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1436,7 +1436,7 @@ CHIP_ERROR CASESession::HandleSigma2Resume(System::PacketBufferHandle && msg)
 
     if (tlvReader.Next() != CHIP_END_OF_TLV)
     {
-        SuccessOrExit(err = DecodeMRPParametersIfPresent(TLV::ContextTag(4), tlvReader));
+        SuccessOrExit(err = DecodeSessionParametersIfPresent(TLV::ContextTag(4), tlvReader, mRemoteSessionParams));
         mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
             GetRemoteSessionParameters());
     }
@@ -1638,7 +1638,8 @@ CHIP_ERROR CASESession::HandleSigma2(System::PacketBufferHandle && msg)
     // Retrieve responderMRPParams if present
     if (tlvReader.Next() != CHIP_END_OF_TLV)
     {
-        SuccessOrExit(err = DecodeMRPParametersIfPresent(AsTlvContextTag(Sigma2Tags::kResponderSessionParams), tlvReader));
+        SuccessOrExit(err = DecodeSessionParametersIfPresent(AsTlvContextTag(Sigma2Tags::kResponderSessionParams), tlvReader,
+                                                             mRemoteSessionParams));
         mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
             GetRemoteSessionParameters());
     }
@@ -2324,7 +2325,8 @@ CHIP_ERROR CASESession::ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, 
     CHIP_ERROR err = tlvReader.Next();
     if (err == CHIP_NO_ERROR && tlvReader.GetTag() == AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams))
     {
-        ReturnErrorOnFailure(DecodeMRPParametersIfPresent(AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams), tlvReader));
+        ReturnErrorOnFailure(DecodeSessionParametersIfPresent(AsTlvContextTag(Sigma1Tags::kInitiatorSessionParams), tlvReader,
+                                                              mRemoteSessionParams));
         outParsedSigma1.initiatorMrpParamsPresent = true;
 
         err = tlvReader.Next();

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -222,7 +222,7 @@ protected:
     struct ParsedSigma1 : Sigma1Param
     {
         ByteSpan initiatorEphPubKey;
-        bool initiatorSessionParamsPresent = false;
+        bool initiatorSessionParamStructPresent = false;
         SessionParameters initiatorSessionParams;
     };
 
@@ -275,6 +275,8 @@ protected:
      * On success, either the sessionResumptionRequested field will be set to true
      * and the resumptionID and initiatorResumeMIC fields will be set to
      * valid values, or the sessionResumptionRequested field will be set to false.
+     *
+     *  @note Calls to this function must always be made with a newly created and fresh ParsedSigma1 parameter.
      */
     static CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ParsedSigma1 & parsedMessage);
 

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -222,7 +222,8 @@ protected:
     struct ParsedSigma1 : Sigma1Param
     {
         ByteSpan initiatorEphPubKey;
-        bool initiatorMrpParamsPresent = false;
+        bool initiatorSessionParamsPresent = false;
+        SessionParameters initiatorSessionParams;
     };
 
     struct EncodeSigma2Inputs
@@ -275,7 +276,7 @@ protected:
      * and the resumptionID and initiatorResumeMIC fields will be set to
      * valid values, or the sessionResumptionRequested field will be set to false.
      */
-    CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ParsedSigma1 & parsedMessage);
+    static CHIP_ERROR ParseSigma1(TLV::ContiguousBufferTLVReader & tlvReader, ParsedSigma1 & parsedMessage);
 
     /**
      * @brief  Encodes a Sigma2 message into TLV format and allocates a buffer for it, which is owned by the PacketBufferHandle

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -372,7 +372,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamRequest(System::PacketBufferHandle && ms
 
     if (tlvReader.Next() != CHIP_END_OF_TLV)
     {
-        SuccessOrExit(err = DecodeMRPParametersIfPresent(TLV::ContextTag(5), tlvReader));
+        SuccessOrExit(err = DecodeSessionParametersIfPresent(TLV::ContextTag(5), tlvReader, mRemoteSessionParams));
         mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
             GetRemoteSessionParameters());
     }
@@ -493,7 +493,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
     {
         if (tlvReader.Next() != CHIP_END_OF_TLV)
         {
-            SuccessOrExit(err = DecodeMRPParametersIfPresent(TLV::ContextTag(5), tlvReader));
+            SuccessOrExit(err = DecodeSessionParametersIfPresent(TLV::ContextTag(5), tlvReader, mRemoteSessionParams));
             mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
                 GetRemoteSessionParameters());
         }
@@ -519,7 +519,7 @@ CHIP_ERROR PASESession::HandlePBKDFParamResponse(System::PacketBufferHandle && m
 
         if (tlvReader.Next() != CHIP_END_OF_TLV)
         {
-            SuccessOrExit(err = DecodeMRPParametersIfPresent(TLV::ContextTag(5), tlvReader));
+            SuccessOrExit(err = DecodeSessionParametersIfPresent(TLV::ContextTag(5), tlvReader, mRemoteSessionParams));
             mExchangeCtxt.Value()->GetSessionHandle()->AsUnauthenticatedSession()->SetRemoteSessionParameters(
                 GetRemoteSessionParameters());
         }

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -144,7 +144,8 @@ CHIP_ERROR PairingSession::EncodeSessionParameters(TLV::Tag tag, const ReliableM
     return tlvWriter.EndContainer(mrpParamsContainer);
 }
 
-CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TLV::ContiguousBufferTLVReader & tlvReader)
+CHIP_ERROR PairingSession::DecodeSessionParametersIfPresent(TLV::Tag expectedTag, TLV::ContiguousBufferTLVReader & tlvReader,
+                                                            SessionParameters & outSessionParameters)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -167,7 +168,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint32_t idleRetransTimeout;
         ReturnErrorOnFailure(tlvReader.Get(idleRetransTimeout));
-        mRemoteSessionParams.SetMRPIdleRetransTimeout(System::Clock::Milliseconds32(idleRetransTimeout));
+        outSessionParameters.SetMRPIdleRetransTimeout(System::Clock::Milliseconds32(idleRetransTimeout));
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -177,7 +178,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint32_t activeRetransTimeout;
         ReturnErrorOnFailure(tlvReader.Get(activeRetransTimeout));
-        mRemoteSessionParams.SetMRPActiveRetransTimeout(System::Clock::Milliseconds32(activeRetransTimeout));
+        outSessionParameters.SetMRPActiveRetransTimeout(System::Clock::Milliseconds32(activeRetransTimeout));
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -187,7 +188,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint16_t activeThresholdTime;
         ReturnErrorOnFailure(tlvReader.Get(activeThresholdTime));
-        mRemoteSessionParams.SetMRPActiveThresholdTime(System::Clock::Milliseconds16(activeThresholdTime));
+        outSessionParameters.SetMRPActiveThresholdTime(System::Clock::Milliseconds16(activeThresholdTime));
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -197,7 +198,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint16_t dataModelRevision;
         ReturnErrorOnFailure(tlvReader.Get(dataModelRevision));
-        mRemoteSessionParams.SetDataModelRevision(dataModelRevision);
+        outSessionParameters.SetDataModelRevision(dataModelRevision);
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -207,7 +208,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint16_t interactionModelRevision;
         ReturnErrorOnFailure(tlvReader.Get(interactionModelRevision));
-        mRemoteSessionParams.SetInteractionModelRevision(interactionModelRevision);
+        outSessionParameters.SetInteractionModelRevision(interactionModelRevision);
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -217,7 +218,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint32_t specificationVersion;
         ReturnErrorOnFailure(tlvReader.Get(specificationVersion));
-        mRemoteSessionParams.SetSpecificationVersion(specificationVersion);
+        outSessionParameters.SetSpecificationVersion(specificationVersion);
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());
@@ -227,7 +228,7 @@ CHIP_ERROR PairingSession::DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TL
     {
         uint16_t maxPathsPerInvoke;
         ReturnErrorOnFailure(tlvReader.Get(maxPathsPerInvoke));
-        mRemoteSessionParams.SetMaxPathsPerInvoke(maxPathsPerInvoke);
+        outSessionParameters.SetMaxPathsPerInvoke(maxPathsPerInvoke);
 
         // The next element is optional. If it's not present, return CHIP_NO_ERROR.
         SuccessOrExit(err = tlvReader.Next());

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -236,7 +236,7 @@ CHIP_ERROR PairingSession::DecodeSessionParametersIfPresent(TLV::Tag expectedTag
 
     // Future proofing - Don't error out if there are other tags
 exit:
-    if (err == CHIP_END_OF_TLV)
+    if (err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR)
     {
         return tlvReader.ExitContainer(containerType);
     }

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -100,7 +100,6 @@ public:
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteSessionParams.GetMRPConfig(); }
     const SessionParameters & GetRemoteSessionParameters() const { return mRemoteSessionParams; }
-    void SetRemoteSessionParameters(const SessionParameters & sessionParams) { mRemoteSessionParams = sessionParams; }
     void SetRemoteMRPConfig(const ReliableMessageProtocolConfig & config) { mRemoteSessionParams.SetMRPConfig(config); }
 
     /**
@@ -130,6 +129,9 @@ protected:
     void DiscardExchange(); // Clear our reference to our exchange context pointer so that it can close itself at some later time.
 
     void SetPeerSessionId(uint16_t id) { mPeerSessionId.SetValue(id); }
+
+    void SetRemoteSessionParameters(const SessionParameters & sessionParams) { mRemoteSessionParams = sessionParams; }
+
     virtual void OnSuccessStatusReport() {}
 
     // Handle a failure StatusReport message from the server.  protocolData will

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -100,6 +100,7 @@ public:
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteSessionParams.GetMRPConfig(); }
     const SessionParameters & GetRemoteSessionParameters() const { return mRemoteSessionParams; }
+    void SetRemoteSessionParameters(const SessionParameters & sessionParams) { mRemoteSessionParams = sessionParams; }
     void SetRemoteMRPConfig(const ReliableMessageProtocolConfig & config) { mRemoteSessionParams.SetMRPConfig(config); }
 
     /**
@@ -207,16 +208,17 @@ protected:
     }
 
     /**
-     * Try to decode the current element (pointed by the TLV reader) as MRP parameters.
-     * If the MRP parameters are found, mRemoteSessionParams is updated with the devoded values.
+     * Try to decode the current element (pointed by the TLV reader) as Session parameters (which include MRP parameters).
+     * If the Session parameters are found, outparam sessionParameters is updated with the decoded values.
      *
-     * MRP parameters are optional. So, if the TLV reader is not pointing to the MRP parameters,
+     * Session parameters are optional. So, if the TLV reader is not pointing to the Session parameters,
      * the function is a noop.
      *
      * If the parameters are present, but TLV reader fails to correctly parse it, the function will
      * return the corresponding error.
      */
-    CHIP_ERROR DecodeMRPParametersIfPresent(TLV::Tag expectedTag, TLV::ContiguousBufferTLVReader & tlvReader);
+    static CHIP_ERROR DecodeSessionParametersIfPresent(TLV::Tag expectedTag, TLV::ContiguousBufferTLVReader & tlvReader,
+                                                       SessionParameters & sessionParameters);
 
     bool IsSessionEstablishmentInProgress();
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -760,10 +760,9 @@ static CHIP_ERROR EncodeSigma1Helper(MutableByteSpan & buf)
                                                                                                                                    \
         TLV::ContiguousBufferTLVReader reader;                                                                                     \
         reader.Init(buf);                                                                                                          \
-        CASESessionAccess session;                                                                                                 \
         CASESessionAccess::ParsedSigma1 parsedSigma1;                                                                              \
                                                                                                                                    \
-        EXPECT_EQ(session.ParseSigma1(reader, parsedSigma1) == CHIP_NO_ERROR, params::kExpectSuccess);                             \
+        EXPECT_EQ(CASESessionAccess::ParseSigma1(reader, parsedSigma1) == CHIP_NO_ERROR, params::kExpectSuccess);                  \
         if (params::kExpectSuccess)                                                                                                \
         {                                                                                                                          \
             EXPECT_EQ(parsedSigma1.sessionResumptionRequested,                                                                     \
@@ -936,10 +935,9 @@ TEST_F(TestCASESession, EncodeSigma1Test)
         System::PacketBufferTLVReader tlvReader;
         tlvReader.Init(std::move(msg1));
 
-        CASESessionAccess session;
         CASESessionAccess::ParsedSigma1 parsedMessage;
 
-        EXPECT_EQ(CHIP_NO_ERROR, session.ParseSigma1(tlvReader, parsedMessage));
+        EXPECT_EQ(CHIP_NO_ERROR, CASESessionAccess::ParseSigma1(tlvReader, parsedMessage));
 
         // compare parsed values with original values
         EXPECT_TRUE(parsedMessage.initiatorRandom.data_equal(encodeParams.initiatorRandom));
@@ -970,10 +968,9 @@ TEST_F(TestCASESession, EncodeSigma1Test)
         System::PacketBufferTLVReader tlvReader;
         tlvReader.Init(std::move(msg2));
 
-        CASESessionAccess session;
         CASESessionAccess::ParsedSigma1 parsedMessage;
 
-        EXPECT_EQ(CHIP_NO_ERROR, session.ParseSigma1(tlvReader, parsedMessage));
+        EXPECT_EQ(CHIP_NO_ERROR, CASESessionAccess::ParseSigma1(tlvReader, parsedMessage));
 
         // RoundTrip
         EXPECT_TRUE(parsedMessage.initiatorRandom.data_equal(encodeParams.initiatorRandom));
@@ -984,7 +981,7 @@ TEST_F(TestCASESession, EncodeSigma1Test)
 
         EXPECT_TRUE(parsedMessage.resumptionId.data_equal(encodeParams.resumptionId));
         EXPECT_TRUE(parsedMessage.initiatorResumeMIC.data_equal(encodeParams.initiatorResumeMIC));
-        EXPECT_TRUE(parsedMessage.initiatorMrpParamsPresent);
+        EXPECT_TRUE(parsedMessage.sessionResumptionRequested);
     }
     // Release EphemeralKeyPair
     gDeviceOperationalKeystore.ReleaseEphemeralKeypair(ephemeralKey);

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -58,10 +58,7 @@ public:
 
     CHIP_ERROR DeriveSecureSession(CryptoContext & session) override { return CHIP_NO_ERROR; }
 
-    CHIP_ERROR DecodeMRPParametersIfPresent(TLV::Tag expectedTag, System::PacketBufferTLVReader & tlvReader)
-    {
-        return PairingSession::DecodeMRPParametersIfPresent(expectedTag, tlvReader);
-    }
+    using PairingSession::DecodeSessionParametersIfPresent;
 };
 
 TEST_F(TestPairingSession, PairingSessionEncodeDecodeMRPParams)
@@ -88,7 +85,7 @@ TEST_F(TestPairingSession, PairingSessionEncodeDecodeMRPParams)
     EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
 
     EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
-    EXPECT_EQ(DecodeMRPParametersIfPresent(TLV::ContextTag(1), reader), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeSessionParametersIfPresent(TLV::ContextTag(1), reader, mRemoteSessionParams), CHIP_NO_ERROR);
 
     EXPECT_EQ(GetRemoteMRPConfig(), config);
 }
@@ -112,7 +109,7 @@ TEST_F(TestPairingSession, PairingSessionTryDecodeMissingMRPParams)
     EXPECT_EQ(reader.Next(containerType, TLV::AnonymousTag()), CHIP_NO_ERROR);
     EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
     EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
-    EXPECT_EQ(DecodeMRPParametersIfPresent(TLV::ContextTag(2), reader), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeSessionParametersIfPresent(TLV::ContextTag(2), reader, mRemoteSessionParams), CHIP_NO_ERROR);
 
     EXPECT_EQ(GetRemoteMRPConfig(), GetDefaultMRPConfig());
 }

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -117,7 +117,7 @@ TEST_F(TestPairingSession, PairingSessionTryDecodeMissingMRPParams)
 
 struct DecodeSessionParamsTestCase
 {
-    char testCaseName[100];
+    std::string testCaseName;
     ReliableMessageProtocolConfig mrpConfig;
     bool includeVersionInfo;
     uint16_t dataModelRev;
@@ -364,11 +364,11 @@ TEST_F(TestPairingSession, TestDecodeSessionParameters)
 
         if (!testCaseFailed)
         {
-            printf("\n[PASSED] TestCaseName%s\n\n", testCase.testCaseName);
+            printf("\n[PASSED] TestCaseName%s\n\n", testCase.testCaseName.c_str());
         }
         else
         {
-            printf("\n[FAILED] TestCaseName: %s\n\n", testCase.testCaseName);
+            printf("\n[FAILED] TestCaseName: %s\n\n", testCase.testCaseName.c_str());
             testFailed = true;
         }
     }

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -130,11 +130,14 @@ struct DecodeSessionParamsTestCase
     bool includeEndContainer                   = true;
 };
 
+constexpr uint8_t kSessionParamsStructTag = 1;
+
 void EncodeSessionParamsHelper(const DecodeSessionParamsTestCase & testCase, TLV::TLVWriter & writer)
 {
 
     TLVType sessionParamsContainer = kTLVType_NotSpecified;
-    EXPECT_EQ(writer.StartContainer(ContextTag(1), kTLVType_Structure, sessionParamsContainer), CHIP_NO_ERROR);
+    EXPECT_EQ(writer.StartContainer(ContextTag(kSessionParamsStructTag), kTLVType_Structure, sessionParamsContainer),
+              CHIP_NO_ERROR);
 
     writer.Put(ContextTag(SessionParameters::Tag::kSessionIdleInterval), testCase.mrpConfig.mIdleRetransTimeout.count());
     writer.Put(ContextTag(SessionParameters::Tag::kSessionActiveInterval), testCase.mrpConfig.mActiveRetransTimeout.count());
@@ -150,8 +153,11 @@ void EncodeSessionParamsHelper(const DecodeSessionParamsTestCase & testCase, TLV
 
     if (testCase.testFutureProofing)
     {
+        // Choosing a tag that is much higher than the current highest tag value in the Specification
+        constexpr uint8_t kFutureProofTlvElementTag = 17;
+
         uint32_t futureProofTlvElement = 0x777666;
-        writer.Put(ContextTag(8), futureProofTlvElement);
+        writer.Put(ContextTag(kFutureProofTlvElementTag), futureProofTlvElement);
     }
 
     if (testCase.includeEndContainer)
@@ -336,7 +342,7 @@ TEST_F(TestPairingSession, TestDecodeSessionParameters)
         bool testCaseFailed = false;
         CHIP_ERROR err      = CHIP_NO_ERROR;
 
-        err = DecodeSessionParametersIfPresent(ContextTag(1), reader, decodedParams);
+        err = DecodeSessionParametersIfPresent(ContextTag(kSessionParamsStructTag), reader, decodedParams);
         if (err != testCase.expectedErrorDecodeParams)
         {
             printf("\nDecodeSessionParametersIfPresent returned Unexpected error code: %" CHIP_ERROR_FORMAT, err.Format());

--- a/src/protocols/secure_channel/tests/TestPairingSession.cpp
+++ b/src/protocols/secure_channel/tests/TestPairingSession.cpp
@@ -36,6 +36,7 @@
 
 using namespace chip;
 using namespace chip::System::Clock;
+using namespace TLV;
 
 class TestPairingSession : public PairingSession, public ::testing::Test
 {
@@ -63,31 +64,31 @@ public:
 
 TEST_F(TestPairingSession, PairingSessionEncodeDecodeMRPParams)
 {
-    ReliableMessageProtocolConfig config(Milliseconds32(100), Milliseconds32(200), Milliseconds16(4000));
+    ReliableMessageProtocolConfig mrpConfig(Milliseconds32(100), Milliseconds32(200), Milliseconds16(4000));
 
     System::PacketBufferHandle buf = System::PacketBufferHandle::New(64, 0);
     System::PacketBufferTLVWriter writer;
     writer.Init(buf.Retain());
 
-    TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    EXPECT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
+    TLVType outerContainerType = kTLVType_NotSpecified;
+    EXPECT_EQ(writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
 
-    EXPECT_EQ(PairingSession::EncodeSessionParameters(TLV::ContextTag(1), config, writer), CHIP_NO_ERROR);
+    EXPECT_EQ(PairingSession::EncodeSessionParameters(ContextTag(1), mrpConfig, writer), CHIP_NO_ERROR);
 
     EXPECT_EQ(writer.EndContainer(outerContainerType), CHIP_NO_ERROR);
     EXPECT_EQ(writer.Finalize(&buf), CHIP_NO_ERROR);
 
     System::PacketBufferTLVReader reader;
-    TLV::TLVType containerType = TLV::kTLVType_Structure;
+    TLVType containerType = kTLVType_Structure;
 
     reader.Init(std::move(buf));
-    EXPECT_EQ(reader.Next(containerType, TLV::AnonymousTag()), CHIP_NO_ERROR);
+    EXPECT_EQ(reader.Next(containerType, AnonymousTag()), CHIP_NO_ERROR);
     EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
 
     EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
-    EXPECT_EQ(DecodeSessionParametersIfPresent(TLV::ContextTag(1), reader, mRemoteSessionParams), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeSessionParametersIfPresent(ContextTag(1), reader, mRemoteSessionParams), CHIP_NO_ERROR);
 
-    EXPECT_EQ(GetRemoteMRPConfig(), config);
+    EXPECT_EQ(GetRemoteMRPConfig(), mrpConfig);
 }
 
 TEST_F(TestPairingSession, PairingSessionTryDecodeMissingMRPParams)
@@ -96,22 +97,282 @@ TEST_F(TestPairingSession, PairingSessionTryDecodeMissingMRPParams)
     System::PacketBufferTLVWriter writer;
     writer.Init(buf.Retain());
 
-    TLV::TLVType outerContainerType = TLV::kTLVType_NotSpecified;
-    EXPECT_EQ(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
-    EXPECT_EQ(writer.Put(TLV::ContextTag(1), static_cast<uint16_t>(0x1234)), CHIP_NO_ERROR);
+    TLVType outerContainerType = kTLVType_NotSpecified;
+    EXPECT_EQ(writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
+    EXPECT_EQ(writer.Put(ContextTag(1), static_cast<uint16_t>(0x1234)), CHIP_NO_ERROR);
     EXPECT_EQ(writer.EndContainer(outerContainerType), CHIP_NO_ERROR);
     EXPECT_EQ(writer.Finalize(&buf), CHIP_NO_ERROR);
 
     System::PacketBufferTLVReader reader;
-    TLV::TLVType containerType = TLV::kTLVType_Structure;
+    TLVType containerType = kTLVType_Structure;
 
     reader.Init(std::move(buf));
-    EXPECT_EQ(reader.Next(containerType, TLV::AnonymousTag()), CHIP_NO_ERROR);
+    EXPECT_EQ(reader.Next(containerType, AnonymousTag()), CHIP_NO_ERROR);
     EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
     EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
-    EXPECT_EQ(DecodeSessionParametersIfPresent(TLV::ContextTag(2), reader, mRemoteSessionParams), CHIP_NO_ERROR);
+    EXPECT_EQ(DecodeSessionParametersIfPresent(ContextTag(2), reader, mRemoteSessionParams), CHIP_NO_ERROR);
 
     EXPECT_EQ(GetRemoteMRPConfig(), GetDefaultMRPConfig());
+}
+
+struct DecodeSessionParamsTestCase
+{
+    char testCaseName[100];
+    ReliableMessageProtocolConfig mrpConfig;
+    bool includeVersionInfo;
+    uint16_t dataModelRev;
+    uint16_t interactionModelRev;
+    uint32_t specVersion;
+    uint16_t maxPaths;
+    CHIP_ERROR expectedErrorDecodeParams; // Expected Error from DecodeSessionParameters
+    CHIP_ERROR expectedErrorOuterExitContainer = CHIP_NO_ERROR;
+    bool testFutureProofing                    = false;
+    bool includeEndContainer                   = true;
+};
+
+void EncodeSessionParamsHelper(const DecodeSessionParamsTestCase & testCase, TLV::TLVWriter & writer)
+{
+
+    TLVType sessionParamsContainer = kTLVType_NotSpecified;
+    EXPECT_EQ(writer.StartContainer(ContextTag(1), kTLVType_Structure, sessionParamsContainer), CHIP_NO_ERROR);
+
+    writer.Put(ContextTag(SessionParameters::Tag::kSessionIdleInterval), testCase.mrpConfig.mIdleRetransTimeout.count());
+    writer.Put(ContextTag(SessionParameters::Tag::kSessionActiveInterval), testCase.mrpConfig.mActiveRetransTimeout.count());
+    writer.Put(ContextTag(SessionParameters::Tag::kSessionActiveThreshold), testCase.mrpConfig.mActiveThresholdTime.count());
+
+    if (testCase.includeVersionInfo)
+    {
+        writer.Put(ContextTag(SessionParameters::Tag::kDataModelRevision), testCase.dataModelRev);
+        writer.Put(ContextTag(SessionParameters::Tag::kInteractionModelRevision), testCase.interactionModelRev);
+        writer.Put(ContextTag(SessionParameters::Tag::kSpecificationVersion), testCase.specVersion);
+        writer.Put(ContextTag(SessionParameters::Tag::kMaxPathsPerInvoke), testCase.maxPaths);
+    }
+
+    if (testCase.testFutureProofing)
+    {
+        uint32_t futureProofTlvElement = 0x777666;
+        writer.Put(ContextTag(8), futureProofTlvElement);
+    }
+
+    if (testCase.includeEndContainer)
+    {
+        EXPECT_EQ(writer.EndContainer(sessionParamsContainer), CHIP_NO_ERROR);
+    }
+}
+
+bool VerifyDecodedParameters(const DecodeSessionParamsTestCase & testCase, const SessionParameters & params)
+{
+    if (testCase.mrpConfig.mIdleRetransTimeout.count() > 0)
+    {
+        if ((params.GetMRPConfig().mIdleRetransTimeout.count()) != testCase.mrpConfig.mIdleRetransTimeout.count())
+        {
+            printf("Idle retrans timeout mismatch: expected %" PRIu32 "ms, got %" PRIu32 "ms\n",
+                   testCase.mrpConfig.mIdleRetransTimeout.count(), params.GetMRPConfig().mIdleRetransTimeout.count());
+            return false;
+        }
+    }
+
+    if (testCase.mrpConfig.mActiveRetransTimeout.count() > 0)
+    {
+        if (params.GetMRPConfig().mActiveRetransTimeout.count() != testCase.mrpConfig.mActiveRetransTimeout.count())
+        {
+            printf("Active retrans timeout mismatch: expected %" PRIu32 "ms, got %" PRIu32 "ms\n",
+                   testCase.mrpConfig.mActiveRetransTimeout.count(), params.GetMRPConfig().mActiveRetransTimeout.count());
+            return false;
+        }
+    }
+
+    if (testCase.mrpConfig.mActiveThresholdTime.count() > 0)
+    {
+        if (params.GetMRPConfig().mActiveThresholdTime.count() != testCase.mrpConfig.mActiveThresholdTime.count())
+        {
+            printf("Active threshold time mismatch: expected %u, got %u\n", testCase.mrpConfig.mActiveThresholdTime.count(),
+                   params.GetMRPConfig().mActiveThresholdTime.count());
+            return false;
+        }
+    }
+
+    if (testCase.includeVersionInfo)
+    {
+        if (params.GetDataModelRevision() != testCase.dataModelRev)
+        {
+            printf("Data model revision mismatch: expected %u, got %u\n", testCase.dataModelRev,
+                   params.GetDataModelRevision().Value());
+            return false;
+        }
+        if (params.GetInteractionModelRevision() != testCase.interactionModelRev)
+        {
+            printf("Interaction model revision mismatch: expected %u, got %u\n", testCase.interactionModelRev,
+                   params.GetInteractionModelRevision().Value());
+            return false;
+        }
+        if (params.GetSpecificationVersion() != testCase.specVersion)
+        {
+            printf("Specification version mismatch: expected %" PRIu32 ", got %" PRIu32 "\n", testCase.specVersion,
+                   params.GetSpecificationVersion().Value());
+            return false;
+        }
+        if (params.GetMaxPathsPerInvoke() != testCase.maxPaths)
+        {
+            printf("Max paths mismatch: expected %u, got %u\n", testCase.maxPaths, params.GetMaxPathsPerInvoke());
+            return false;
+        }
+    }
+
+    return true;
+}
+
+TEST_F(TestPairingSession, TestDecodeSessionParameters)
+{
+    const DecodeSessionParamsTestCase testCases[] = {
+        { .testCaseName       = "1. Empty parameters",
+          .mrpConfig          = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(0), System::Clock::Milliseconds32(0),
+                                                              System::Clock::Milliseconds16(0)),
+          .includeVersionInfo = false,
+          .expectedErrorDecodeParams = CHIP_NO_ERROR },
+
+        { .testCaseName = "2. Only MRP parameters",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1200), System::Clock::Milliseconds32(2200),
+                                                        System::Clock::Milliseconds16(450)),
+          .includeVersionInfo        = false,
+          .expectedErrorDecodeParams = CHIP_NO_ERROR },
+
+        { .testCaseName = "3. All parameters",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1600), System::Clock::Milliseconds32(2100),
+                                                        System::Clock::Milliseconds16(1300)),
+          .includeVersionInfo        = true,
+          .dataModelRev              = 1,
+          .interactionModelRev       = 2,
+          .specVersion               = 1,
+          .maxPaths                  = 10,
+          .expectedErrorDecodeParams = CHIP_NO_ERROR },
+
+        { .testCaseName = "4. Maximum Value of All parameters",
+          .mrpConfig =
+              ReliableMessageProtocolConfig(System::Clock::Milliseconds32(UINT32_MAX), // Test max value
+                                            System::Clock::Milliseconds32(UINT32_MAX), System::Clock::Milliseconds16(UINT16_MAX)),
+          .includeVersionInfo        = true,
+          .dataModelRev              = UINT16_MAX,
+          .interactionModelRev       = UINT16_MAX,
+          .specVersion               = UINT32_MAX,
+          .maxPaths                  = UINT16_MAX,
+          .expectedErrorDecodeParams = CHIP_NO_ERROR },
+
+        // Future-proofing: Ensure that TLV elements being added to the specification in the future do not trigger an error in
+        // DecodeSessionParametersIfPresent.
+        { .testCaseName = "5. All parameters AND Test for Future Proofing",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1600), System::Clock::Milliseconds32(2100),
+                                                        System::Clock::Milliseconds16(1300)),
+          .includeVersionInfo              = true,
+          .dataModelRev                    = 1,
+          .interactionModelRev             = 2,
+          .specVersion                     = 1,
+          .maxPaths                        = 10,
+          .expectedErrorDecodeParams       = CHIP_NO_ERROR,
+          .expectedErrorOuterExitContainer = CHIP_NO_ERROR,
+          .testFutureProofing              = true },
+
+        // test case is expected to fail since the nested end container is not included in the encoded TLV packet. However, The
+        // failure will occur at the outer ExitContainer since the inner ExitContainer will SkipToEndOfContainer
+        { .testCaseName = "6. All parameters AND Exclude End Container",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1500), System::Clock::Milliseconds32(2500),
+                                                        System::Clock::Milliseconds16(1500)),
+          .includeVersionInfo              = true,
+          .dataModelRev                    = 1,
+          .interactionModelRev             = 2,
+          .specVersion                     = 1,
+          .maxPaths                        = 10,
+          .expectedErrorDecodeParams       = CHIP_NO_ERROR,
+          .expectedErrorOuterExitContainer = CHIP_END_OF_TLV,
+          .includeEndContainer             = false },
+
+        { .testCaseName = "7. Only MRP Params AND Exclude End Container",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1500), System::Clock::Milliseconds32(2500),
+                                                        System::Clock::Milliseconds16(1500)),
+          .includeVersionInfo              = false,
+          .expectedErrorDecodeParams       = CHIP_NO_ERROR,
+          .expectedErrorOuterExitContainer = CHIP_END_OF_TLV,
+          .includeEndContainer             = false },
+
+        // Testing the corner case where a TLV element is added to the specification in the future, yet no EndContainer is
+        // included in the nested session-parameter-struct
+        { .testCaseName = "8. All parameters AND Test Future Proofing AND Exclude End Container",
+          .mrpConfig    = ReliableMessageProtocolConfig(System::Clock::Milliseconds32(1500), System::Clock::Milliseconds32(2500),
+                                                        System::Clock::Milliseconds16(1500)),
+          .includeVersionInfo              = true,
+          .dataModelRev                    = 1,
+          .interactionModelRev             = 2,
+          .specVersion                     = 1,
+          .maxPaths                        = 10,
+          .expectedErrorDecodeParams       = CHIP_NO_ERROR,
+          .expectedErrorOuterExitContainer = CHIP_END_OF_TLV,
+          .testFutureProofing              = true,
+          .includeEndContainer             = false },
+
+    };
+
+    bool testFailed = false;
+
+    for (const auto & testCase : testCases)
+    {
+        System::PacketBufferHandle msg = System::PacketBufferHandle::New(64, 0);
+        System::PacketBufferTLVWriter writer;
+        writer.Init(msg.Retain());
+        TLVType outerContainerType = kTLVType_NotSpecified;
+
+        EXPECT_EQ(writer.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType), CHIP_NO_ERROR);
+        EncodeSessionParamsHelper(testCase, writer);
+        EXPECT_EQ(writer.EndContainer(outerContainerType), CHIP_NO_ERROR);
+        EXPECT_EQ(writer.Finalize(&msg), CHIP_NO_ERROR);
+
+        SessionParameters decodedParams;
+        System::PacketBufferTLVReader reader;
+        TLVType containerType = kTLVType_Structure;
+        reader.Init(std::move(msg));
+        EXPECT_EQ(reader.Next(containerType, AnonymousTag()), CHIP_NO_ERROR);
+        EXPECT_EQ(reader.EnterContainer(containerType), CHIP_NO_ERROR);
+        EXPECT_EQ(reader.Next(), CHIP_NO_ERROR);
+
+        bool testCaseFailed = false;
+        CHIP_ERROR err      = CHIP_NO_ERROR;
+
+        err = DecodeSessionParametersIfPresent(ContextTag(1), reader, decodedParams);
+        if (err != testCase.expectedErrorDecodeParams)
+        {
+            printf("\nDecodeSessionParametersIfPresent returned Unexpected error code: %" CHIP_ERROR_FORMAT, err.Format());
+            printf("\nExpected Error Code: %" CHIP_ERROR_FORMAT "\n", testCase.expectedErrorDecodeParams.Format());
+
+            testCaseFailed = true;
+        }
+        err = reader.Next();
+        EXPECT_TRUE(err == CHIP_NO_ERROR || err == CHIP_END_OF_TLV);
+        if (reader.ExitContainer(containerType) != testCase.expectedErrorOuterExitContainer)
+        {
+            printf("\nOuter ExitContainer() returned Unexpected error code: %" CHIP_ERROR_FORMAT, err.Format());
+            printf("\nExpected Error Code: %" CHIP_ERROR_FORMAT "\n", testCase.expectedErrorOuterExitContainer.Format());
+            testCaseFailed = true;
+        }
+
+        if (!testCaseFailed)
+        {
+            bool verifyResult = VerifyDecodedParameters(testCase, decodedParams);
+            if (!verifyResult)
+            {
+                testCaseFailed = true;
+            }
+        }
+
+        if (!testCaseFailed)
+        {
+            printf("\n[PASSED] TestCaseName%s\n\n", testCase.testCaseName);
+        }
+        else
+        {
+            printf("\n[FAILED] TestCaseName: %s\n\n", testCase.testCaseName);
+            testFailed = true;
+        }
+    }
+    EXPECT_FALSE(testFailed);
 }
 
 // Test Suite


### PR DESCRIPTION
- A follow-up to #36679 based on the comment at the bottom of the PR.
- A fix related to #36959
### Changes in the PR:
1. decoupling `DecodeMRPParametersIfPresent()`  from class state and making it static; this is needed to make the factored out TLV Parsing Functions in CASESession and PASESession self-contained and indepedent of class state.

2. Fix for Corner Case in `DecodeMRPParametersIfPresent`:  If the received TLV-encoded SessionParameters structure contains extra TLV elements not known by the receiver (newly added to the specification) but is not terminated with an EndOfContainer element, we must ENSURE that `ExitContainer` is called to ensure that an error is triggered.

3. Added Unit Tests, which also covers above Corner case.

3. Change the name of  `DecodeMRPParametersIfPresent()` to `DecodeSessionParametersIfPresent()` since it is not ONLY decoding MRP but also other Session Parameters (I believe in Matter 1.2 Session Parameters only Included MRP hence the name?)

4. Make `ParseSigma1()` static and completely self-contained.

### Testing

- Added a Unit Test 
-----

              So this is pre-existing, but it looks like the Sigma1 message is partially parsed into parsedSigma1 and partially into the `mRemoteSessionParams` member?

             Followup (do not do this in this PR): we should be passing a `SessionParameters &` to ParseSigma1, and I suspect that method should eventually become a static method that does not touch any class state at all.  There are other places where it does touch state right now, though...

_Originally posted by @bzbarsky-apple in https://github.com/project-chip/connectedhomeip/pull/36679#discussion_r1889527736_

           