### PR TITLE
Added a public API to RefreshKeySender to retrieve ICDClientInfo

### DIFF
--- a/src/app/icd/client/CheckInDelegate.h
+++ b/src/app/icd/client/CheckInDelegate.h
@@ -70,8 +70,8 @@ public:
      * @brief Callback used to let the application know that the re-registration process is done. This callback will be called for
      * both success and failure cases. On failure, the callee should take appropriate corrective action based on the error.
      *
-     * @param[in] refreshKeySender - pointer to the RefreshKeySender object that was used for the key refresh process. The caller
-     *                               will NOT use this pointer any more.
+     * @param[in] refreshKeySender - pointer to the RefreshKeySender object that was used for the key refresh process. It will NOT
+     *                               be null regardless the key refresh status. The caller will NOT use this pointer any more.
      * @param[in] error - CHIP_NO_ERROR indicates successful re-registration using the new key
      *                     Other errors indicate the failure reason.
      */

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -66,29 +66,24 @@ RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
 
 void DefaultCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error)
 {
-    ICDClientInfo icdClientInfo;
-    if (refreshKeySender != nullptr)
-    {
-        icdClientInfo = refreshKeySender->getICDClientInfo();
-        Platform::Delete(refreshKeySender);
-        refreshKeySender = nullptr;
-    }
-    else
+    if (refreshKeySender == nullptr)
     {
         ChipLogError(ICD, "RefreshKeySender is null");
         return;
     }
+    auto icdClientInfo = refreshKeySender->GetICDClientInfo();
+    Platform::Delete(refreshKeySender);
+    refreshKeySender = nullptr;
     if (error == CHIP_NO_ERROR)
     {
-        ChipLogProgress(ICD, "Re-registration with new key completed successfully for peer node :" ChipLogFormatScopedNodeId,
+        ChipLogProgress(ICD, "Re-registration with new key completed successfully for peer node " ChipLogFormatScopedNodeId,
                         ChipLogValueScopedNodeId(icdClientInfo.peer_node));
     }
     else
     {
-        ChipLogError(ICD,
-                     "Re-registration with new key failed with error : %" CHIP_ERROR_FORMAT
-                     " for peer node :" ChipLogFormatScopedNodeId,
-                     error.Format(), ChipLogValueScopedNodeId(icdClientInfo.peer_node));
+        ChipLogError(
+            ICD, "Re-registration with new key failed with error %" CHIP_ERROR_FORMAT " for peer node " ChipLogFormatScopedNodeId,
+            error.Format(), ChipLogValueScopedNodeId(icdClientInfo.peer_node));
         // The callee can take corrective action  based on the error received.
     }
 }

--- a/src/app/icd/client/DefaultCheckInDelegate.cpp
+++ b/src/app/icd/client/DefaultCheckInDelegate.cpp
@@ -66,19 +66,30 @@ RefreshKeySender * DefaultCheckInDelegate::OnKeyRefreshNeeded(ICDClientInfo & cl
 
 void DefaultCheckInDelegate::OnKeyRefreshDone(RefreshKeySender * refreshKeySender, CHIP_ERROR error)
 {
-    if (error == CHIP_NO_ERROR)
+    ICDClientInfo icdClientInfo;
+    if (refreshKeySender != nullptr)
     {
-        ChipLogProgress(ICD, "Re-registration with new key completed successfully");
+        icdClientInfo = refreshKeySender->getICDClientInfo();
+        Platform::Delete(refreshKeySender);
+        refreshKeySender = nullptr;
     }
     else
     {
-        ChipLogError(ICD, "Re-registration with new key failed with error : %" CHIP_ERROR_FORMAT, error.Format());
-        // The callee can take corrective action  based on the error received.
+        ChipLogError(ICD, "RefreshKeySender is null");
+        return;
     }
-    if (refreshKeySender != nullptr)
+    if (error == CHIP_NO_ERROR)
     {
-        Platform::Delete(refreshKeySender);
-        refreshKeySender = nullptr;
+        ChipLogProgress(ICD, "Re-registration with new key completed successfully for peer node :" ChipLogFormatScopedNodeId,
+                        ChipLogValueScopedNodeId(icdClientInfo.peer_node));
+    }
+    else
+    {
+        ChipLogError(ICD,
+                     "Re-registration with new key failed with error : %" CHIP_ERROR_FORMAT
+                     " for peer node :" ChipLogFormatScopedNodeId,
+                     error.Format(), ChipLogValueScopedNodeId(icdClientInfo.peer_node));
+        // The callee can take corrective action  based on the error received.
     }
 }
 } // namespace app

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -36,6 +36,11 @@ RefreshKeySender::RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDC
     mOnConnectedCallback(HandleDeviceConnected, this), mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 {}
 
+const ICDClientInfo & RefreshKeySender::getICDClientInfo()
+{
+    return mICDClientInfo;
+}
+
 CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [&](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -36,7 +36,7 @@ RefreshKeySender::RefreshKeySender(CheckInDelegate * checkInDelegate, const ICDC
     mOnConnectedCallback(HandleDeviceConnected, this), mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 {}
 
-const ICDClientInfo & RefreshKeySender::getICDClientInfo()
+const ICDClientInfo & RefreshKeySender::GetICDClientInfo()
 {
     return mICDClientInfo;
 }

--- a/src/app/icd/client/RefreshKeySender.h
+++ b/src/app/icd/client/RefreshKeySender.h
@@ -52,6 +52,14 @@ public:
      */
     CHIP_ERROR EstablishSessionToPeer();
 
+    /**
+     * @brief Used to retrieve ICDClientInfo from RefreshKeySender.
+     *
+     * @return ICDClientInfo - ICDClientInfo object representing the state associated with the
+                               node that requested a key refresh.
+     */
+    const ICDClientInfo & getICDClientInfo();
+
 private:
     // CASE session callbacks
     /**

--- a/src/app/icd/client/RefreshKeySender.h
+++ b/src/app/icd/client/RefreshKeySender.h
@@ -58,7 +58,8 @@ public:
      * @return ICDClientInfo - ICDClientInfo object representing the state associated with the
                                node that requested a key refresh.
      */
-    const ICDClientInfo & getICDClientInfo();
+    const ICDClientInfo & GetICDClientInfo();
+
 
 private:
     // CASE session callbacks

--- a/src/app/icd/client/RefreshKeySender.h
+++ b/src/app/icd/client/RefreshKeySender.h
@@ -60,7 +60,6 @@ public:
      */
     const ICDClientInfo & GetICDClientInfo();
 
-
 private:
     // CASE session callbacks
     /**


### PR DESCRIPTION
When a key refresh is done, the callback sent to the application provides a reference to the RefreshKeySender object provided during the key refresh process. However, there is no way for the application to retrieve ICDClientInfo from the RefreshKeySender object in order to determine the peer node ID where the re-registration was processed. So, added a public API for clients to retrieve ICDClientInfo from RefreshKeySender.

#### Testing
Existing test cover this part
