### PR TITLE
[Silabs] Bugfix: PSA Crypto keystore for Wi-fi.

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -199,7 +199,7 @@ else
                     exit 1
                 fi
                 USE_WIFI=true
-                optArgs+="chip_device_platform =\"efr32\" "
+                optArgs+="chip_device_platform =\"efr32\" chip_crypto_keystore=\"psa\""
                 shift
                 shift
                 ;;


### PR DESCRIPTION
Tested on Si971 BRD4338A.

