### PR TITLE
[ESP32] Add matter shutdown flow in all-clusters-app.

### DIFF
--- a/examples/all-clusters-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-app/esp32/main/AppTask.cpp
@@ -69,6 +69,12 @@ CHIP_ERROR AppTask::StartAppTask()
     return (xReturned == pdPASS) ? CHIP_NO_ERROR : APP_ERROR_CREATE_TASK_FAILED;
 }
 
+void AppTask::DeleteAppTask()
+{
+    vTaskDelete(sAppTaskHandle);
+    vQueueDelete(sAppEventQueue);
+}
+
 void AppTask::TimerEventHandler(TimerHandle_t xTimer)
 {
     AppEvent event;

--- a/examples/all-clusters-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-app/esp32/main/AppTask.cpp
@@ -69,8 +69,20 @@ CHIP_ERROR AppTask::StartAppTask()
     return (xReturned == pdPASS) ? CHIP_NO_ERROR : APP_ERROR_CREATE_TASK_FAILED;
 }
 
-void AppTask::DeleteAppTask()
+void AppTask::StopAppTask()
 {
+    AppEvent event;
+    event.mType    = AppEvent::kEventType_App_Stop;
+    event.mHandler = StopEventHandler;
+    sAppTask.PostEvent(&event);
+}
+
+void AppTask::StopEventHandler(AppEvent * aEvent)
+{
+    if (aEvent->mType != AppEvent::kEventType_App_Stop)
+    {
+        return;
+    }
     vTaskDelete(sAppTaskHandle);
     vQueueDelete(sAppEventQueue);
 }

--- a/examples/all-clusters-app/esp32/main/include/AppEvent.h
+++ b/examples/all-clusters-app/esp32/main/include/AppEvent.h
@@ -30,6 +30,7 @@ struct AppEvent
         kEventType_Timer,
         kEventType_Light,
         kEventType_Install,
+        kEventType_App_Stop,
     };
 
     uint16_t mType;

--- a/examples/all-clusters-app/esp32/main/include/AppTask.h
+++ b/examples/all-clusters-app/esp32/main/include/AppTask.h
@@ -34,6 +34,7 @@ class AppTask
 {
 public:
     CHIP_ERROR StartAppTask();
+    void DeleteAppTask();
     static void AppTaskMain(void * pvParameter);
     void PostEvent(const AppEvent * event);
     void ButtonEventHandler(uint8_t btnIdx, uint8_t btnAction);

--- a/examples/all-clusters-app/esp32/main/include/AppTask.h
+++ b/examples/all-clusters-app/esp32/main/include/AppTask.h
@@ -34,7 +34,7 @@ class AppTask
 {
 public:
     CHIP_ERROR StartAppTask();
-    void DeleteAppTask();
+    void StopAppTask();
     static void AppTaskMain(void * pvParameter);
     void PostEvent(const AppEvent * event);
     void ButtonEventHandler(uint8_t btnIdx, uint8_t btnAction);
@@ -48,6 +48,7 @@ private:
 
     static void FunctionTimerEventHandler(AppEvent * aEvent);
     static void TimerEventHandler(TimerHandle_t xTimer);
+    static void StopEventHandler(AppEvent * aEvent);
 
     void DispatchEvent(AppEvent * event);
 

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -153,6 +153,7 @@ static void Shutdown(TimerHandle_t xTimer)
     DeviceLayer::StackLock lock;
 
     Esp32AppServer::Shutdown();
+    ESPOpenThreadDeinit();
     GetAppTask().StopAppTask();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -145,16 +145,16 @@ void emberAfLaundryDryerControlsClusterInitCallback(EndpointId endpoint)
     LaundryDryerControlsServer::SetDefaultDelegate(endpoint, &LaundryDryerControlDelegate::getLaundryDryerControlDelegate());
 }
 
+/** A sequence of API calls to shutdown matter server from the example.
+    usage: xTimerStart(xTimerCreate("Timer", 100, pdFALSE, nullptr, Shutdown), 0);
+*/
 static void Shutdown(TimerHandle_t xTimer)
 {
     DeviceLayer::StackLock lock;
-    ESP_LOGE(TAG, "Shutdown called");
+
     Esp32AppServer::Shutdown();
+    GetAppTask().StopAppTask();
 
-    ESP_LOGE(TAG, "Esp32AppServer Shutdown");
-    GetAppTask().DeleteAppTask();
-
-    ESP_LOGE(TAG, "DeleteAppTask");
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     if (DeviceLayer::Internal::ESP32Utils::DeInitWiFiStack() != CHIP_NO_ERROR)
     {
@@ -163,7 +163,6 @@ static void Shutdown(TimerHandle_t xTimer)
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
-    ESP_LOGE(TAG, "nvs_flash_deinit");
     esp_err_t err = nvs_flash_deinit();
     if (err != ESP_OK)
     {

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -145,6 +145,33 @@ void emberAfLaundryDryerControlsClusterInitCallback(EndpointId endpoint)
     LaundryDryerControlsServer::SetDefaultDelegate(endpoint, &LaundryDryerControlDelegate::getLaundryDryerControlDelegate());
 }
 
+static void Shutdown(TimerHandle_t xTimer)
+{
+    DeviceLayer::StackLock lock;
+    ESP_LOGE(TAG, "Shutdown called");
+    Esp32AppServer::Shutdown();
+
+    ESP_LOGE(TAG, "Esp32AppServer Shutdown");
+    GetAppTask().DeleteAppTask();
+
+    ESP_LOGE(TAG, "DeleteAppTask");
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    if (DeviceLayer::Internal::ESP32Utils::DeInitWiFiStack() != CHIP_NO_ERROR)
+    {
+        ESP_LOGE(TAG, "Failed to deinitialize the Wi-Fi stack");
+        return;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
+
+    ESP_LOGE(TAG, "nvs_flash_deinit");
+    esp_err_t err = nvs_flash_deinit();
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
+        return;
+    }
+}
+
 extern "C" void app_main()
 {
     // Initialize the ESP NVS layer.

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -157,7 +157,7 @@ static void Shutdown(TimerHandle_t xTimer)
     GetAppTask().StopAppTask();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (DeviceLayer::Internal::ESP32Utils::DeInitWiFiStack() != CHIP_NO_ERROR)
+    if (DeviceLayer::Internal::ESP32Utils::DeinitWiFiStack() != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "Failed to deinitialize the Wi-Fi stack");
         return;

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -153,13 +153,13 @@ static void Shutdown(TimerHandle_t xTimer)
     DeviceLayer::StackLock lock;
 
     Esp32AppServer::Shutdown();
-    ESPOpenThreadDeinit();
+    ESPOpenThreadShutdown();
     GetAppTask().StopAppTask();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (DeviceLayer::Internal::ESP32Utils::DeinitWiFiStack() != CHIP_NO_ERROR)
+    if (DeviceLayer::Internal::ESP32Utils::ShutdownWiFiStack() != CHIP_NO_ERROR)
     {
-        ESP_LOGE(TAG, "Failed to deinitialize the Wi-Fi stack");
+        ESP_LOGE(TAG, "Failed to shutdown the Wi-Fi stack");
         return;
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -145,33 +145,6 @@ void emberAfLaundryDryerControlsClusterInitCallback(EndpointId endpoint)
     LaundryDryerControlsServer::SetDefaultDelegate(endpoint, &LaundryDryerControlDelegate::getLaundryDryerControlDelegate());
 }
 
-/** A sequence of API calls to shutdown matter server from the example.
-    usage: xTimerStart(xTimerCreate("Timer", 100, pdFALSE, nullptr, Shutdown), 0);
-*/
-static void Shutdown(TimerHandle_t xTimer)
-{
-    DeviceLayer::StackLock lock;
-
-    Esp32AppServer::Shutdown();
-    ESPOpenThreadShutdown();
-    GetAppTask().StopAppTask();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    if (DeviceLayer::Internal::ESP32Utils::ShutdownWiFiStack() != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Failed to shutdown the Wi-Fi stack");
-        return;
-    }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
-
-    esp_err_t err = nvs_flash_deinit();
-    if (err != ESP_OK)
-    {
-        ESP_LOGE(TAG, "nvs_flash_init() failed: %s", esp_err_to_name(err));
-        return;
-    }
-}
-
 extern "C" void app_main()
 {
     // Initialize the ESP NVS layer.

--- a/examples/platform/esp32/common/CHIPDeviceManager.cpp
+++ b/examples/platform/esp32/common/CHIPDeviceManager.cpp
@@ -85,6 +85,18 @@ CHIP_ERROR CHIPDeviceManager::Init(CHIPDeviceManagerCallbacks * cb)
     // Start a task to run the CHIP Device event loop.
     return PlatformMgr().StartEventLoopTask();
 }
+
+CHIP_ERROR CHIPDeviceManager::Shutdown(CHIPDeviceManagerCallbacks * cb)
+{
+    ReturnErrorOnFailure(PlatformMgr().StopEventLoopTask());
+
+    ReturnErrorOnFailure(PlatformMgr().StopBackgroundEventLoopTask());
+    PlatformMgr().RemoveEventHandler(CHIPDeviceManager::CommonDeviceEventHandler, reinterpret_cast<intptr_t>(cb));
+
+    PlatformMgr().Shutdown();
+
+    return CHIP_NO_ERROR;
+}
 } // namespace DeviceManager
 } // namespace chip
 

--- a/examples/platform/esp32/common/CHIPDeviceManager.h
+++ b/examples/platform/esp32/common/CHIPDeviceManager.h
@@ -104,6 +104,14 @@ public:
 
     /**
      * @brief
+     *   Shutdown CHIPDeviceManager
+     *
+     * @param cb Application's instance of the CHIPDeviceManagerCallbacks
+     */
+    CHIP_ERROR Shutdown(CHIPDeviceManagerCallbacks * cb);
+
+    /**
+     * @brief
      *   Fetch a pointer to the registered CHIPDeviceManagerCallbacks object.
      *
      */

--- a/examples/platform/esp32/common/Esp32AppServer.cpp
+++ b/examples/platform/esp32/common/Esp32AppServer.cpp
@@ -115,6 +115,15 @@ void Esp32AppServer::DeInitBLEIfCommissioned(void)
 #endif /* CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING */
 }
 
+void Esp32AppServer::Shutdown()
+{
+    chip::DeviceLayer::Internal::BLEMgr().Shutdown();
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    chip::app::DnssdServer::Instance().StopServer();
+#endif
+    chip::Server::GetInstance().Shutdown();
+}
+
 void Esp32AppServer::Init(AppDelegate * sAppDelegate)
 {
     // Init ZCL Data Model and CHIP App Server

--- a/examples/platform/esp32/common/Esp32AppServer.cpp
+++ b/examples/platform/esp32/common/Esp32AppServer.cpp
@@ -117,7 +117,9 @@ void Esp32AppServer::DeInitBLEIfCommissioned(void)
 
 void Esp32AppServer::Shutdown()
 {
+#if CONFIG_BT_NIMBLE_ENABLED
     chip::DeviceLayer::Internal::BLEMgr().Shutdown();
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     chip::app::DnssdServer::Instance().StopServer();
 #endif

--- a/examples/platform/esp32/common/Esp32AppServer.h
+++ b/examples/platform/esp32/common/Esp32AppServer.h
@@ -24,4 +24,5 @@
 namespace Esp32AppServer {
 void DeInitBLEIfCommissioned(void);
 void Init(AppDelegate * context = nullptr);
+void Shutdown();
 } // namespace Esp32AppServer

--- a/examples/platform/esp32/common/Esp32ThreadInit.cpp
+++ b/examples/platform/esp32/common/Esp32ThreadInit.cpp
@@ -105,6 +105,7 @@ void ESPOpenThreadDeinit()
 #if defined(CONFIG_OPENTHREAD_BORDER_ROUTER) && defined(CONFIG_AUTO_UPDATE_RCP)
     openthread_deinit_br_rcp();
 #endif // CONFIG_OPENTHREAD_BORDER_ROUTER && CONFIG_AUTO_UPDATE_RCP
+    ThreadStackMgr().StopThreadStack();
     ThreadStackMgr().DeinitThreadStack();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }

--- a/examples/platform/esp32/common/Esp32ThreadInit.cpp
+++ b/examples/platform/esp32/common/Esp32ThreadInit.cpp
@@ -99,13 +99,13 @@ void ESPOpenThreadInit()
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }
 
-void ESPOpenThreadDeinit()
+void ESPOpenThreadShutdown()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #if defined(CONFIG_OPENTHREAD_BORDER_ROUTER) && defined(CONFIG_AUTO_UPDATE_RCP)
     openthread_deinit_br_rcp();
 #endif // CONFIG_OPENTHREAD_BORDER_ROUTER && CONFIG_AUTO_UPDATE_RCP
     ThreadStackMgr().StopThreadStack();
-    ThreadStackMgr().DeinitThreadStack();
+    ThreadStackMgr().ShutdownThreadStack();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }

--- a/examples/platform/esp32/common/Esp32ThreadInit.cpp
+++ b/examples/platform/esp32/common/Esp32ThreadInit.cpp
@@ -98,3 +98,13 @@ void ESPOpenThreadInit()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 }
+
+void ESPOpenThreadDeinit()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+#if defined(CONFIG_OPENTHREAD_BORDER_ROUTER) && defined(CONFIG_AUTO_UPDATE_RCP)
+    openthread_deinit_br_rcp();
+#endif // CONFIG_OPENTHREAD_BORDER_ROUTER && CONFIG_AUTO_UPDATE_RCP
+    ThreadStackMgr().DeinitThreadStack();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+}

--- a/examples/platform/esp32/common/Esp32ThreadInit.h
+++ b/examples/platform/esp32/common/Esp32ThreadInit.h
@@ -98,4 +98,4 @@
 #endif // CONFIG_OPENTHREAD_ENABLED
 
 void ESPOpenThreadInit();
-void ESPOpenThreadDeinit();
+void ESPOpenThreadShutdown();

--- a/examples/platform/esp32/common/Esp32ThreadInit.h
+++ b/examples/platform/esp32/common/Esp32ThreadInit.h
@@ -98,3 +98,4 @@
 #endif // CONFIG_OPENTHREAD_ENABLED
 
 void ESPOpenThreadInit();
+void ESPOpenThreadDeinit();

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -92,7 +92,7 @@ public:
     // ===== Members that define the public interface of the ThreadStackManager
 
     CHIP_ERROR InitThreadStack();
-    void DeinitThreadStack();
+    void ShutdownThreadStack();
     void ProcessThreadActivity();
     CHIP_ERROR StartThreadTask();
     void StopThreadStack();
@@ -243,9 +243,9 @@ inline CHIP_ERROR ThreadStackManager::InitThreadStack()
     return static_cast<ImplClass *>(this)->_InitThreadStack();
 }
 
-inline void ThreadStackManager::DeinitThreadStack()
+inline void ThreadStackManager::ShutdownThreadStack()
 {
-    static_cast<ImplClass *>(this)->_DeinitThreadStack();
+    static_cast<ImplClass *>(this)->_ShutdownThreadStack();
 }
 
 inline void ThreadStackManager::ProcessThreadActivity()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -95,6 +95,7 @@ public:
     void DeinitThreadStack();
     void ProcessThreadActivity();
     CHIP_ERROR StartThreadTask();
+    void StopThreadStack();
     void LockThreadStack();
     bool TryLockThreadStack();
     void UnlockThreadStack();
@@ -255,6 +256,11 @@ inline void ThreadStackManager::ProcessThreadActivity()
 inline CHIP_ERROR ThreadStackManager::StartThreadTask()
 {
     return static_cast<ImplClass *>(this)->_StartThreadTask();
+}
+
+inline void ThreadStackManager::StopThreadStack()
+{
+    static_cast<ImplClass *>(this)->_StopThreadStack();
 }
 
 inline void ThreadStackManager::LockThreadStack()

--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -92,6 +92,7 @@ public:
     // ===== Members that define the public interface of the ThreadStackManager
 
     CHIP_ERROR InitThreadStack();
+    void DeinitThreadStack();
     void ProcessThreadActivity();
     CHIP_ERROR StartThreadTask();
     void LockThreadStack();
@@ -239,6 +240,11 @@ namespace DeviceLayer {
 inline CHIP_ERROR ThreadStackManager::InitThreadStack()
 {
     return static_cast<ImplClass *>(this)->_InitThreadStack();
+}
+
+inline void ThreadStackManager::DeinitThreadStack()
+{
+    static_cast<ImplClass *>(this)->_DeinitThreadStack();
 }
 
 inline void ThreadStackManager::ProcessThreadActivity()

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -183,6 +183,7 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
         // Start a timer which reloads every one hour and bumps the total operational hours
         TickType_t reloadPeriod   = (1000 * 60 * 60) / portTICK_PERIOD_MS;
+        // TODO: Detete this timer in shutdown
         TimerHandle_t timerHandle = xTimerCreate("tOpHrs", reloadPeriod, pdPASS, nullptr, TotalOperationalHoursTimerCallback);
         if (timerHandle == nullptr)
         {

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -370,7 +370,7 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ESP32Utils::DeinitWiFiStack(void)
+CHIP_ERROR ESP32Utils::ShutdownWiFiStack(void)
 {
     esp_err_t err = esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent);
     if (err != ESP_OK)

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -369,6 +369,30 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     }
     return CHIP_NO_ERROR;
 }
+
+CHIP_ERROR ESP32Utils::DeInitWiFiStack(void)
+{
+    esp_err_t err = esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent);
+    if (err != ESP_OK)
+    {
+        return ESP32Utils::MapError(err);
+    }
+
+    // Deinitialize the ESP WiFi layer.
+    err = esp_wifi_stop();
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_wifi_stop (0x%x)", err);
+        return ESP32Utils::MapError(err);
+    }
+    err = esp_wifi_deinit();
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "esp_wifi_deinit (0x%x)", err);
+        return ESP32Utils::MapError(err);
+    }
+    return CHIP_NO_ERROR;
+}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 struct netif * ESP32Utils::GetNetif(const char * ifKey)

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -370,7 +370,7 @@ CHIP_ERROR ESP32Utils::InitWiFiStack(void)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ESP32Utils::DeInitWiFiStack(void)
+CHIP_ERROR ESP32Utils::DeinitWiFiStack(void)
 {
     esp_err_t err = esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, PlatformManagerImpl::HandleESPSystemEvent);
     if (err != ESP_OK)

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -47,6 +47,7 @@ public:
     static CHIP_ERROR SetWiFiStationProvision(const Internal::DeviceNetworkInfo & netInfo);
     static CHIP_ERROR ClearWiFiStationProvision(void);
     static CHIP_ERROR InitWiFiStack(void);
+    static CHIP_ERROR DeInitWiFiStack(void);
 
     static CHIP_ERROR MapError(esp_err_t error);
     static void RegisterESP32ErrorFormatter();

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -47,7 +47,7 @@ public:
     static CHIP_ERROR SetWiFiStationProvision(const Internal::DeviceNetworkInfo & netInfo);
     static CHIP_ERROR ClearWiFiStationProvision(void);
     static CHIP_ERROR InitWiFiStack(void);
-    static CHIP_ERROR DeinitWiFiStack(void);
+    static CHIP_ERROR ShutdownWiFiStack(void);
 
     static CHIP_ERROR MapError(esp_err_t error);
     static void RegisterESP32ErrorFormatter();

--- a/src/platform/ESP32/ESP32Utils.h
+++ b/src/platform/ESP32/ESP32Utils.h
@@ -47,7 +47,7 @@ public:
     static CHIP_ERROR SetWiFiStationProvision(const Internal::DeviceNetworkInfo & netInfo);
     static CHIP_ERROR ClearWiFiStationProvision(void);
     static CHIP_ERROR InitWiFiStack(void);
-    static CHIP_ERROR DeInitWiFiStack(void);
+    static CHIP_ERROR DeinitWiFiStack(void);
 
     static CHIP_ERROR MapError(esp_err_t error);
     static void RegisterESP32ErrorFormatter();

--- a/src/platform/ESP32/OpenthreadLauncher.cpp
+++ b/src/platform/ESP32/OpenthreadLauncher.cpp
@@ -238,6 +238,11 @@ esp_err_t openthread_init_br_rcp(const esp_rcp_update_config_t * update_config)
     esp_openthread_register_rcp_failure_handler(rcp_failure_handler);
     return err;
 }
+
+void openthread_deinit_br_rcp(void)
+{
+    esp_rcp_update_deinit();
+}
 #endif // CONFIG_OPENTHREAD_BORDER_ROUTER && CONFIG_AUTO_UPDATE_RCP
 
 esp_err_t openthread_init_stack(void)

--- a/src/platform/ESP32/OpenthreadLauncher.h
+++ b/src/platform/ESP32/OpenthreadLauncher.h
@@ -25,6 +25,7 @@
 #if defined(CONFIG_OPENTHREAD_BORDER_ROUTER) && defined(CONFIG_AUTO_UPDATE_RCP)
 #include <esp_rcp_update.h>
 esp_err_t openthread_init_br_rcp(const esp_rcp_update_config_t * update_config);
+void openthread_deinit_br_rcp(void);
 #endif // CONFIG_OPENTHREAD_BORDER_ROUTER && CONFIG_AUTO_UPDATE_RCP
 esp_err_t set_openthread_platform_config(esp_openthread_platform_config_t * config);
 esp_err_t openthread_init_stack(void);

--- a/src/platform/ESP32/ThreadStackManagerImpl.cpp
+++ b/src/platform/ESP32/ThreadStackManagerImpl.cpp
@@ -60,6 +60,12 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     return err;
 }
 
+void ThreadStackManagerImpl::_DeinitThreadStack()
+{
+    openthread_delete_task();
+    openthread_deinit_stack();
+}
+
 CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()
 {
     openthread_launch_task();

--- a/src/platform/ESP32/ThreadStackManagerImpl.cpp
+++ b/src/platform/ESP32/ThreadStackManagerImpl.cpp
@@ -62,7 +62,6 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
 void ThreadStackManagerImpl::_DeinitThreadStack()
 {
-    openthread_delete_task();
     openthread_deinit_stack();
 }
 
@@ -70,6 +69,11 @@ CHIP_ERROR ThreadStackManagerImpl::_StartThreadTask()
 {
     openthread_launch_task();
     return CHIP_NO_ERROR;
+}
+
+void ThreadStackManagerImpl::_StopThreadStack()
+{
+    openthread_delete_task();
 }
 
 void ThreadStackManagerImpl::_LockThreadStack()

--- a/src/platform/ESP32/ThreadStackManagerImpl.cpp
+++ b/src/platform/ESP32/ThreadStackManagerImpl.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     return err;
 }
 
-void ThreadStackManagerImpl::_DeinitThreadStack()
+void ThreadStackManagerImpl::_ShutdownThreadStack()
 {
     openthread_deinit_stack();
 }

--- a/src/platform/ESP32/ThreadStackManagerImpl.h
+++ b/src/platform/ESP32/ThreadStackManagerImpl.h
@@ -62,6 +62,7 @@ public:
 
 protected:
     CHIP_ERROR _StartThreadTask();
+    void _StopThreadStack();
     void _LockThreadStack();
     bool _TryLockThreadStack();
     void _UnlockThreadStack();

--- a/src/platform/ESP32/ThreadStackManagerImpl.h
+++ b/src/platform/ESP32/ThreadStackManagerImpl.h
@@ -58,6 +58,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
 public:
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack();
 
 protected:
     CHIP_ERROR _StartThreadTask();

--- a/src/platform/ESP32/ThreadStackManagerImpl.h
+++ b/src/platform/ESP32/ThreadStackManagerImpl.h
@@ -58,7 +58,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 
 public:
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack();
+    void _ShutdownThreadStack();
 
 protected:
     CHIP_ERROR _StartThreadTask();

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
@@ -45,7 +45,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
 
     void SignalThreadActivityPending();
     void SignalThreadActivityPendingFromISR();
@@ -55,6 +55,7 @@ protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _StartThreadTask();
+    void _StopThreadStack() {}
     void _LockThreadStack();
     bool _TryLockThreadStack();
     void _UnlockThreadStack();

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
@@ -45,7 +45,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
 
     void SignalThreadActivityPending();
     void SignalThreadActivityPendingFromISR();

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
@@ -45,6 +45,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
 
     void SignalThreadActivityPending();
     void SignalThreadActivityPendingFromISR();

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -50,7 +50,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -50,6 +50,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -50,10 +50,11 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank
+    void _StopThreadStack() {}                              // Intentionally left blank
     void _LockThreadStack() {}                              // Intentionally left blank
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank

--- a/src/platform/NuttX/ThreadStackManagerImpl.h
+++ b/src/platform/NuttX/ThreadStackManagerImpl.h
@@ -51,6 +51,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/NuttX/ThreadStackManagerImpl.h
+++ b/src/platform/NuttX/ThreadStackManagerImpl.h
@@ -51,7 +51,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/NuttX/ThreadStackManagerImpl.h
+++ b/src/platform/NuttX/ThreadStackManagerImpl.h
@@ -51,10 +51,11 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank
+    void _StopThreadStack() {}                              // Intentionally left blank
     void _LockThreadStack() {}                              // Intentionally left blank
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -49,6 +49,7 @@ public:
     ThreadStackManagerImpl();
 
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -49,10 +49,11 @@ public:
     ThreadStackManagerImpl();
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank
+    void _StopThreadStack() {}                              // Intentionally left blank
     void _LockThreadStack() {}                              // Intentionally left blank
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -49,7 +49,7 @@ public:
     ThreadStackManagerImpl();
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -60,6 +60,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -60,12 +60,13 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; }
+    void _StopThreadStack() {}
     void _LockThreadStack();
     bool _TryLockThreadStack();
     void _UnlockThreadStack();

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -60,7 +60,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.

--- a/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
+++ b/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
@@ -71,7 +71,8 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
+++ b/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
@@ -71,6 +71,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
+++ b/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
@@ -71,7 +71,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
@@ -102,6 +102,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
@@ -102,7 +102,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
+++ b/src/platform/cc13xx_26xx/cc13x4_26x4/ThreadStackManagerImpl.h
@@ -102,7 +102,8 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nxp/common/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/common/ThreadStackManagerImpl.h
@@ -85,7 +85,8 @@ public:
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
 private:
     // ===== Members for internal use by the following friends.

--- a/src/platform/nxp/common/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/common/ThreadStackManagerImpl.h
@@ -85,6 +85,7 @@ public:
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
 private:
     // ===== Members for internal use by the following friends.

--- a/src/platform/nxp/common/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/common/ThreadStackManagerImpl.h
@@ -85,7 +85,7 @@ public:
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
 private:

--- a/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
@@ -79,7 +79,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
@@ -79,7 +79,8 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/k32w0/ThreadStackManagerImpl.h
@@ -79,6 +79,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
@@ -79,7 +79,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
@@ -79,7 +79,8 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
+++ b/src/platform/nxp/mcxw71_k32w1/ThreadStackManagerImpl.h
@@ -79,6 +79,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/qpg/ThreadStackManagerImpl.h
+++ b/src/platform/qpg/ThreadStackManagerImpl.h
@@ -78,7 +78,8 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
+    void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/qpg/ThreadStackManagerImpl.h
+++ b/src/platform/qpg/ThreadStackManagerImpl.h
@@ -78,6 +78,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/qpg/ThreadStackManagerImpl.h
+++ b/src/platform/qpg/ThreadStackManagerImpl.h
@@ -78,7 +78,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _StopThreadStack() {}
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -80,7 +80,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     CHIP_ERROR _StartThreadTask(void);
     void _StopThreadStack() {}
     void _LockThreadStack(void);

--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -80,6 +80,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
     CHIP_ERROR _StartThreadTask(void);
     void _LockThreadStack(void);
     bool _TryLockThreadStack(void);

--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -80,8 +80,9 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     CHIP_ERROR _StartThreadTask(void);
+    void _StopThreadStack() {}
     void _LockThreadStack(void);
     bool _TryLockThreadStack(void);
     void _UnlockThreadStack(void);

--- a/src/platform/stm32/ThreadStackManagerImpl.h
+++ b/src/platform/stm32/ThreadStackManagerImpl.h
@@ -87,7 +87,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/stm32/ThreadStackManagerImpl.h
+++ b/src/platform/stm32/ThreadStackManagerImpl.h
@@ -79,6 +79,7 @@ public:
 
 protected:
     CHIP_ERROR _StartThreadTask();
+    void _StopThreadStack() {}
 
     void _ProcessThreadActivity();
 
@@ -86,7 +87,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/stm32/ThreadStackManagerImpl.h
+++ b/src/platform/stm32/ThreadStackManagerImpl.h
@@ -86,6 +86,7 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
+    void _DeinitThreadStack(){};
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -59,7 +59,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void SetRadioBlocked(bool state) { mRadioBlocked = state; }
     bool IsReadyToAttach(void) const { return mReadyToAttach; }
     void Finalize(void);

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -59,7 +59,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     void SetRadioBlocked(bool state) { mRadioBlocked = state; }
     bool IsReadyToAttach(void) const { return mReadyToAttach; }
     void Finalize(void);
@@ -68,6 +68,7 @@ protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; }
+    void _StopThreadStack() {}
     void _LockThreadStack();
     bool _TryLockThreadStack();
     void _UnlockThreadStack();

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -59,6 +59,7 @@ class ThreadStackManagerImpl final : public ThreadStackManager,
 public:
     // ===== Methods that implement the ThreadStackManager abstract interface.
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
     void SetRadioBlocked(bool state) { mRadioBlocked = state; }
     bool IsReadyToAttach(void) const { return mReadyToAttach; }
     void Finalize(void);

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -42,7 +42,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack() {}
+    void _ShutdownThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -42,10 +42,11 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
-    void _DeinitThreadStack(){};
+    void _DeinitThreadStack() {}
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank
+    void _StopThreadStack() {}                              // Intentionally left blank
     void _LockThreadStack() {}                              // Intentionally left blank
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -42,6 +42,7 @@ public:
     }
 
     CHIP_ERROR _InitThreadStack();
+    void _DeinitThreadStack(){};
     void _ProcessThreadActivity();
 
     CHIP_ERROR _StartThreadTask() { return CHIP_NO_ERROR; } // Intentionally left blank


### PR DESCRIPTION
### Problem
- The matter shutdown flow of esp32 was missing.

### Changes
- Add app shutdown example code in all-clusters-app/esp32.
- Add APIs to shutdown matter server and deinit wifi stack.

### Testing
- Tested shutdown with commissioned and uncommissioned devices.

