### PR TITLE
[Tizen] Forward stderr from Tizen Studio CLI tool

### DIFF
--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -22,6 +22,7 @@ import logging as log
 import os
 import random
 import secrets
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timedelta
@@ -185,7 +186,7 @@ def gen_test_certs(chip_cert: str,
                        "--pai", pai_cert,
                        "--paa", paa_cert,
                        ]
-                log.info("Verify Certificate Chain: {}".format(" ".join(cmd)))
+                log.info("Verify Certificate Chain: {}".format(shlex.join(cmd)))
                 subprocess.run(cmd)
 
     def gen_dac_certificate(chip_cert, device_name, vendor_id, product_id, pai_cert, pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date):
@@ -214,7 +215,7 @@ def gen_test_certs(chip_cert: str,
                    "--valid-from", valid_from,
                    "--lifetime", str(lifetime),
                    ]
-            log.info("Generate DAC: {}".format(" ".join(cmd)))
+            log.info("Generate DAC: {}".format(shlex.join(cmd)))
             subprocess.run(cmd)
 
     def convert_pem_to_der(chip_cert, action, pem):
@@ -254,7 +255,7 @@ def gen_test_certs(chip_cert: str,
                     "--dac-origin-product-id", hex(dac_product_id),
                     ]
 
-        log.info("Generate CD: {}".format(" ".join(cmd)))
+        log.info("Generate CD: {}".format(shlex.join(cmd)))
         subprocess.run(cmd)
 
     pai_vendor_id, pai_product_id, pai_issue_date, pai_expire_date = parse_cert_file(pai_cert)

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -20,6 +20,7 @@ import logging
 import multiprocessing
 import os
 import os.path
+import shlex
 import shutil
 import subprocess
 import sys
@@ -209,7 +210,7 @@ class ZAPGenerateTarget:
         """Runs a ZAP generate command on the configured zap/template/outputs.
         """
         cmd = self.build_cmd()
-        logging.info("Generating target: %s" % " ".join(cmd))
+        logging.info("Generating target: %s" % shlex.join(cmd))
 
         generate_start = time.time()
         subprocess.check_call(cmd)

--- a/third_party/tizen/tizen_dev_certificate.py
+++ b/third_party/tizen/tizen_dev_certificate.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import os
+import shlex
 import subprocess
 import sys
 
@@ -29,7 +30,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def run(cmd):
-    logging.debug("Run: %s", " ".join(cmd))
+    logging.debug("Run: %s", shlex.join(cmd))
     proc = subprocess.Popen(cmd, errors='replace',
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)


### PR DESCRIPTION
### Problem

In case of issues with `$TIZEN_SDK_ROOT/tools/ide/bin/tizen` tool, there is no error output to help resolve problem.

### Changes

Forward `stderr` from the tool.


### Testing

Locally tested that in case of setup issues (e.g. missing Java runtime), the errors are printed:
```
...
INFO    DEBUG:root:Run: /opt/tizen-sdk/tools/ide/bin/tizen security-profiles list --name CHIP
INFO    ERROR:root:/opt/tizen-sdk/tools/ide/bin/tizen.sh: line 143: java: command not found
INFO    DEBUG:root:Run: /opt/tizen-sdk/tools/ide/bin/tizen certificate --name Matter Example --email matter@tizen.org
INFO    ERROR:root:/opt/tizen-sdk/tools/ide/bin/tizen.sh: line 143: java: command not found
INFO    ERROR:root:Failed to create author certificate
...
```

CI will verify for regressions.