### PR TITLE
Add separate knob for TCP server listen enabling.

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -214,7 +214,14 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-        advertiseParameters.SetTCPSupportModes(chip::Dnssd::TCPModeAdvertise::kTCPClientServer);
+        if (mTCPServerEnabled)
+        {
+            advertiseParameters.SetTCPSupportModes(chip::Dnssd::TCPModeAdvertise::kTCPClientServer);
+        }
+        else
+        {
+            advertiseParameters.SetTCPSupportModes(chip::Dnssd::TCPModeAdvertise::kTCPClient);
+        }
 #endif
         auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -214,14 +214,8 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-        if (mTCPServerEnabled)
-        {
-            advertiseParameters.SetTCPSupportModes(chip::Dnssd::TCPModeAdvertise::kTCPClientServer);
-        }
-        else
-        {
-            advertiseParameters.SetTCPSupportModes(chip::Dnssd::TCPModeAdvertise::kTCPClient);
-        }
+        advertiseParameters.SetTCPSupportModes(mTCPServerEnabled ? chip::Dnssd::TCPModeAdvertise::kTCPClientServer
+                                                                 : chip::Dnssd::TCPModeAdvertise::kTCPClient);
 #endif
         auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -97,6 +97,10 @@ public:
     void SetICDManager(ICDManager * manager) { mICDManager = manager; };
 #endif
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    void SetTCPServerEnabled(const bool serverEnabled) { mTCPServerEnabled = serverEnabled; };
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
+
     /// Start operational advertising
     CHIP_ERROR AdvertiseOperational();
 
@@ -178,6 +182,10 @@ private:
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     ICDManager * mICDManager = nullptr;
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    bool mTCPServerEnabled = true;
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     uint16_t mSecuredPort          = CHIP_PORT;
     uint16_t mUnsecuredPort        = CHIP_UDC_PORT;

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -98,7 +98,7 @@ public:
 #endif
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    void SetTCPServerEnabled(const bool serverEnabled) { mTCPServerEnabled = serverEnabled; };
+    void SetTCPServerEnabled(bool serverEnabled) { mTCPServerEnabled = serverEnabled; };
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /// Start operational advertising

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -214,7 +214,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
                                .SetNativeParams(initParams.endpointNativeParams)
-
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                               ,
+                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv6)
+                               .SetListenPort(mOperationalServicePort)
+#endif
 #if INET_CONFIG_ENABLE_IPV4
                                ,
                            UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -224,12 +229,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #if CONFIG_NETWORK_LAYER_BLE
                                ,
                            BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
-#endif
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                               ,
-                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv6)
-                               .SetListenPort(mOperationalServicePort)
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                                ,
@@ -329,6 +328,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     // init is called.
     app::DnssdServer::Instance().SetICDManager(&mICDManager);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    app::DnssdServer::Instance().SetTCPServerEnabled(mTransports.GetTransport().GetImplAtIndex<1>().IsServerListenEnabled());
+#endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     if (GetFabricTable().FabricCount() != 0)
     {

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -96,6 +96,10 @@ inline constexpr size_t kMaxTcpPendingPackets = CHIP_CONFIG_MAX_TCP_PENDING_PACK
 //       in the Server impl depends on this.
 //
 using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                                              ,
+                                              chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>
+#endif
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                               chip::Transport::UDP
@@ -103,10 +107,6 @@ using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 #if CONFIG_NETWORK_LAYER_BLE
                                               ,
                                               chip::Transport::BLE<kMaxBlePendingPackets>
-#endif
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                                              ,
-                                              chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                                               ,

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -167,8 +167,15 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     ReturnErrorOnFailure(stateParams.transportMgr->Init(Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv6)
                                                             .SetListenPort(params.listenPort)
-#if INET_CONFIG_ENABLE_IPV4
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
                                                             ,
+                                                        Transport::TcpListenParameters(stateParams.tcpEndPointManager)
+                                                            .SetAddressType(IPAddressType::kIPv6)
+                                                            .SetListenPort(params.listenPort)
+                                                            .SetServerListenEnabled(false) // Initialize as a TCP Client
+#endif
+#if INET_CONFIG_ENABLE_IPV4
+                                                        ,
                                                         Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv4)
                                                             .SetListenPort(params.listenPort)
@@ -176,12 +183,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 #if CONFIG_NETWORK_LAYER_BLE
                                                             ,
                                                         Transport::BleListenParameters(stateParams.bleLayer)
-#endif
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                                                            ,
-                                                        Transport::TcpListenParameters(stateParams.tcpEndPointManager)
-                                                            .SetAddressType(IPAddressType::kIPv6)
-                                                            .SetListenPort(params.listenPort)
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                                                             ,

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -71,6 +71,10 @@ inline constexpr size_t kMaxDeviceTransportTcpPendingPackets = CHIP_CONFIG_MAX_T
 
 using DeviceTransportMgr =
     TransportMgr<Transport::UDP /* IPv6 */
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                 ,
+                 Transport::TCP<kMaxDeviceTransportTcpActiveConnectionCount, kMaxDeviceTransportTcpPendingPackets>
+#endif
 #if INET_CONFIG_ENABLE_IPV4
                  ,
                  Transport::UDP /* IPv4 */
@@ -78,10 +82,6 @@ using DeviceTransportMgr =
 #if CONFIG_NETWORK_LAYER_BLE
                  ,
                  Transport::BLE<kMaxDeviceTransportBlePendingPackets> /* BLE */
-#endif
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                 ,
-                 Transport::TCP<kMaxDeviceTransportTcpActiveConnectionCount, kMaxDeviceTransportTcpPendingPackets>
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                  ,

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -44,6 +44,11 @@ void TransportMgrBase::TCPDisconnect(Transport::ActiveTCPConnectionState * conn,
 {
     mTransport->TCPDisconnect(conn, shouldAbort);
 }
+
+bool TransportMgrBase::IsServerListenEnabled()
+{
+    return mTransport->IsServerListenEnabled();
+}
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 CHIP_ERROR TransportMgrBase::Init(Transport::Base * transport)

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -50,6 +50,8 @@ public:
 
     void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0);
 
+    bool IsServerListenEnabled();
+
     void HandleConnectionReceived(Transport::ActiveTCPConnectionState * conn) override;
 
     void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -114,6 +114,8 @@ public:
      * Disconnect on the active connection that is passed in.
      */
     virtual void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0) {}
+
+    virtual bool IsServerListenEnabled() { return true; }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -79,11 +79,20 @@ public:
         return *this;
     }
 
+    bool IsServerListenEnabled() const { return mServerListenEnabled; }
+    TcpListenParameters & SetServerListenEnabled(bool listenEnable)
+    {
+        mServerListenEnabled = listenEnable;
+
+        return *this;
+    }
+
 private:
     Inet::EndPointManager<Inet::TCPEndPoint> * mEndPointManager;   ///< Associated endpoint factory
     Inet::IPAddressType mAddressType = Inet::IPAddressType::kIPv6; ///< type of listening socket
     uint16_t mListenPort             = CHIP_PORT;                  ///< TCP listen port
     Inet::InterfaceId mInterfaceId   = Inet::InterfaceId::Null();  ///< Interface to listen on
+    bool mServerListenEnabled        = true;                       ///< TCP Server mode enabled
 };
 
 /**
@@ -177,6 +186,8 @@ public:
     // ActiveTCPConnectionState object)
     // and release from the pool.
     void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = false) override;
+
+    bool IsServerListenEnabled() override;
 
     bool CanSendToPeer(const PeerAddress & address) override
     {
@@ -301,6 +312,7 @@ private:
     Inet::TCPEndPoint * mListenSocket = nullptr;                       ///< TCP socket used by the transport
     Inet::IPAddressType mEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type
     TCPState mState                   = TCPState::kNotReady;           ///< State of the TCP transport
+    bool mIsServerListenEnabled       = true;                          ///< TCP Server mode enabled
 
     // The configured timeout for the connection attempt to the peer, before
     // giving up.

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -106,6 +106,8 @@ public:
     {
         return TCPDisconnectImpl<0>(conn, shouldAbort);
     }
+
+    bool IsServerListenEnabled() override { return IsServerListenEnabledImpl<0>(); }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     void Close() override { return CloseImpl<0>(); }
@@ -222,6 +224,18 @@ private:
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
     void TCPDisconnectImpl(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0)
     {}
+
+    template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
+    bool IsServerListenEnabledImpl()
+    {
+        return std::get<N>(mTransports).IsServerListenEnabled() || IsServerListenEnabledImpl<N + 1>();
+    }
+
+    template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
+    bool IsServerListenEnabledImpl()
+    {
+        return false;
+    }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -552,6 +552,35 @@ TEST_F(TestTCP, CheckSimpleInitTest6)
     CheckSimpleInitTest(IPAddressType::kIPv6);
 }
 
+TEST_F(TestTCP, InitializeAsTCPClient)
+{
+    TCPImpl tcp;
+
+    CHIP_ERROR err = tcp.Init(Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager())
+                                  .SetAddressType(IPAddressType::kIPv6)
+                                  .SetListenPort(gChipTCPPort)
+                                  .SetServerListenEnabled(false));
+
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    bool isServerEnabled = tcp.IsServerListenEnabled();
+    EXPECT_EQ(isServerEnabled, false);
+}
+
+TEST_F(TestTCP, InitializeAsTCPClientServer)
+{
+    TCPImpl tcp;
+
+    CHIP_ERROR err = tcp.Init(Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager())
+                                  .SetAddressType(IPAddressType::kIPv6)
+                                  .SetListenPort(gChipTCPPort));
+
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    bool isServerEnabled = tcp.IsServerListenEnabled();
+    EXPECT_EQ(isServerEnabled, true);
+}
+
 TEST_F(TestTCP, CheckMessageTest6)
 {
     IPAddress addr;


### PR DESCRIPTION
Use a boolean indicator for TCP server enabling in the TCPListenParameters to signal Server enabling during initialization. By default, TCP Server is enabled on the Server side, and disabled on the client/controller side.

Add API in TransportMgr to access this setting so that DNS-SD operational advertisements for TCP can be set accordingly.

#### Testing
Add 2 unit tests for checking TCP initialization as TCPClient, and both TCPClient and Server.


