### PR TITLE
ESP32: Fix dependency of esp_secure_cert_mgr

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -432,6 +432,10 @@ if (CONFIG_OPENTHREAD_BORDER_ROUTER)
     list(APPEND matter_requires espressif__esp_rcp_update)
 endif()
 
+if (CONFIG_SEC_CERT_DAC_PROVIDER)
+    list(APPEND matter_requires espressif__esp_secure_cert_mgr)
+endif()
+
 add_prebuilt_library(matterlib "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a"
                      REQUIRES ${matter_requires})
 

--- a/src/platform/ESP32/ESP32EndpointQueueFilter.h
+++ b/src/platform/ESP32/ESP32EndpointQueueFilter.h
@@ -84,8 +84,8 @@ private:
     {
         for (size_t i = 0; i < size; ++i)
         {
-            uint8_t byte1 = (buf1[i] >= 'A' && buf1[i] <= 'Z') ? buf1[i] - 'A' + 'a' : buf1[i];
-            uint8_t byte2 = (buf2[i] >= 'A' && buf2[i] <= 'Z') ? buf2[i] - 'A' + 'a' : buf2[i];
+            uint8_t byte1 = static_cast<uint8_t>((buf1[i] >= 'A' && buf1[i] <= 'Z') ? (buf1[i] - 'A' + 'a') : buf1[i]);
+            uint8_t byte2 = static_cast<uint8_t>((buf2[i] >= 'A' && buf2[i] <= 'Z') ? (buf2[i] - 'A' + 'a') : buf2[i]);
             if (byte1 != byte2)
             {
                 return false;


### PR DESCRIPTION
There are link errors for esp_secure_cert_mgr when enabling ESPSecureCertDACProvider. Add the `esp_secure_cert_mgr` component to the requires of libCHIP.a

