### PR TITLE
[TC_DGSW] Simplify Validation Assertions

### DIFF
--- a/src/python_testing/TC_DGSW_2_1.py
+++ b/src/python_testing/TC_DGSW_2_1.py
@@ -54,6 +54,18 @@ class TC_DGSW_2_1(MatterBaseTest):
     def is_valid_str_value(value):
         return isinstance(value, str) and len(value) > 0
 
+    def assert_valid_uint64(self, value, field_name):
+        """Asserts that the value is a valid uint64."""
+        asserts.assert_true(self.is_valid_uint64_value(value), f"{field_name} field should be a uint64 type")
+
+    def assert_valid_uint32(self, value, field_name):
+        """Asserts that the value is a valid uint32."""
+        asserts.assert_true(self.is_valid_uint32_value(value), f"{field_name} field should be a uint32 type")
+
+    def assert_valid_str(self, value, field_name):
+        """Asserts that the value is a non-empty string."""
+        asserts.assert_true(self.is_valid_str_value(value), f"{field_name} field should be a non-empty string")
+
     async def read_dgsw_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.SoftwareDiagnostics
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
@@ -94,44 +106,41 @@ class TC_DGSW_2_1(MatterBaseTest):
             # Validate each element in the thread_metrics_list
             for metric in thread_metrics_list:
                 # The Id field is mandatory
-                asserts.assert_true(self.is_valid_uint64_value(metric.id), "Id field should be a uint64 type")
+                self.assert_valid_uint64(metric.id, "Id")
 
                 # Validate the optional Name field
                 if metric.name is not None:
-                    asserts.assert_true(self.is_valid_str_value(metric.name), "Name field should be a string type")
+                    self.assert_valid_str(metric.name, "Name")
 
                 # Validate the optional StackFreeCurrent field
                 if metric.stackFreeCurrent is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeCurrent),
-                                        "StackFreeCurrent field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeCurrent, "StackFreeCurrent")
 
                 # Validate the optional StackFreeMinimum field
                 if metric.stackFreeMinimum is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeMinimum),
-                                        "StackFreeMinimum field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeMinimum, "StackFreeMinimum")
 
                 # Validate the optional StackSize field
                 if metric.stackSize is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackSize), "StackSize field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackSize, "StackSize")
 
         # STEP 3: TH reads from the DUT the CurrentHeapFree attribute
         self.step(3)
         if self.pics_guard(attributes.CurrentHeapFree.attribute_id in attribute_list):
             current_heap_free_attr = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapFree)
-            asserts.assert_true(self.is_valid_uint64_value(current_heap_free_attr), "CurrentHeapFree field should be a uint64 type")
+            self.assert_valid_uint64(current_heap_free_attr, "CurrentHeapFree")
 
         # STEP 4: TH reads from the DUT the CurrentHeapUsed attribute
         self.step(4)
         if self.pics_guard(attributes.CurrentHeapUsed.attribute_id in attribute_list):
             current_heap_used_attr = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapUsed)
-            asserts.assert_true(self.is_valid_uint64_value(current_heap_used_attr), "CurrentHeapUsed field should be a uint64 type")
+            self.assert_valid_uint64(current_heap_used_attr, "CurrentHeapUsed")
 
         # STEP 5: TH reads from the DUT the CurrentHeapHighWatermark attribute
         self.step(5)
         if self.pics_guard(attributes.CurrentHeapHighWatermark.attribute_id in attribute_list):
             current_heap_high_watermark_attr = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapHighWatermark)
-            asserts.assert_true(self.is_valid_uint64_value(current_heap_high_watermark_attr),
-                                "CurrentHeapHighWatermark field should be a uint64 type")
+            self.assert_valid_uint64(current_heap_high_watermark_attr, "CurrentHeapHighWatermark")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DGSW_2_3.py
+++ b/src/python_testing/TC_DGSW_2_3.py
@@ -56,6 +56,18 @@ class TC_DGSW_2_3(MatterBaseTest):
     def is_valid_str_value(value):
         return isinstance(value, str) and len(value) > 0
 
+    def assert_valid_uint64(self, value, field_name):
+        """Asserts that the value is a valid uint64."""
+        asserts.assert_true(self.is_valid_uint64_value(value), f"{field_name} field should be a uint64 type")
+
+    def assert_valid_uint32(self, value, field_name):
+        """Asserts that the value is a valid uint32."""
+        asserts.assert_true(self.is_valid_uint32_value(value), f"{field_name} field should be a uint32 type")
+
+    def assert_valid_str(self, value, field_name):
+        """Asserts that the value is a non-empty string."""
+        asserts.assert_true(self.is_valid_str_value(value), f"{field_name} field should be a non-empty string")
+
     async def read_dgsw_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.SoftwareDiagnostics
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
@@ -67,7 +79,7 @@ class TC_DGSW_2_3(MatterBaseTest):
 
     def desc_TC_DGSW_2_3(self) -> str:
         """Returns a description of this test"""
-        return "[TC-DGSW-2.1] Attributes with Server as DUT"
+        return "[TC-DGSW-2.3] Attributes with Server as DUT"
 
     def pics_TC_DGSW_2_3(self) -> list[str]:
         return ["DGSW.S"]
@@ -106,35 +118,32 @@ class TC_DGSW_2_3(MatterBaseTest):
             # Iterate over all items in the list and validate each one
             for metric in thread_metrics_original:
                 # The Id field is mandatory
-                asserts.assert_true(self.is_valid_uint64_value(metric.id), "Id field should be a uint64 type")
+                self.assert_valid_uint64(metric.id, "Id")
 
                 if metric.name is not None:
-                    asserts.assert_true(self.is_valid_str_value(metric.name), "Name field should be a string type")
+                    self.assert_valid_str(metric.name, "Name")
 
                 if metric.stackFreeCurrent is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeCurrent),
-                                        "StackFreeCurrent field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeCurrent, "StackFreeCurrent")
 
                 if metric.stackFreeMinimum is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeMinimum),
-                                        "StackFreeMinimum field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeMinimum, "StackFreeMinimum")
 
                 if metric.stackSize is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackSize), "StackSize field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackSize, "StackSize")
 
         # STEP 4: TH reads from the DUT the CurrentHeapHighWatermark attribute
         self.step(4)
         if self.pics_guard(attributes.CurrentHeapHighWatermark.attribute_id in attribute_list):
             high_watermark_original = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapHighWatermark)
-            asserts.assert_true(self.is_valid_uint64_value(high_watermark_original),
-                                "CurrentHeapHighWatermark field should be a uint64 type")
+            self.assert_valid_uint64(high_watermark_original, "CurrentHeapHighWatermark")
 
         # STEP 5: TH reads from the DUT the CurrentHeapUsed attribute
         self.step(5)
         if self.pics_guard(attributes.CurrentHeapUsed.attribute_id in attribute_list):
             current_heap_used_original = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapUsed)
-            asserts.assert_true(self.is_valid_uint64_value(current_heap_used_original),
-                                "CurrentHeapUsed field should be a uint64 type")
+            self.assert_valid_uint64(current_heap_used_original, "CurrentHeapUsed")
+
             if high_watermark_original is not None:
                 asserts.assert_true(current_heap_used_original <= high_watermark_original,
                                     "CurrentHeapUsed should be less than or equal to CurrentHeapHighWatermark")
@@ -148,8 +157,7 @@ class TC_DGSW_2_3(MatterBaseTest):
         self.step(7)
         if self.pics_guard(attributes.CurrentHeapHighWatermark.attribute_id in attribute_list):
             current_heap_high_watermark = await self.read_dgsw_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentHeapHighWatermark)
-            asserts.assert_true(self.is_valid_uint64_value(current_heap_high_watermark),
-                                "CurrentHeapHighWatermark field should be a uint64 type")
+            self.assert_valid_uint64(current_heap_high_watermark, "CurrentHeapHighWatermark")
 
             # Verify that the returned value is <= high_watermark_original
             asserts.assert_true(current_heap_high_watermark <= high_watermark_original,
@@ -168,22 +176,19 @@ class TC_DGSW_2_3(MatterBaseTest):
 
             # Validate all elements in the list
             for metric in thread_metrics_reset:
-                # The Id field is mandatory
-                asserts.assert_true(self.is_valid_uint64_value(metric.id), "Id field should be a uint64 type")
+                self.assert_valid_uint64(metric.id, "Id")
 
                 if metric.name is not None:
-                    asserts.assert_true(self.is_valid_str_value(metric.name), "Name field should be a string type")
+                    self.assert_valid_str(metric.name, "Name")
 
                 if metric.stackFreeCurrent is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeCurrent),
-                                        "StackFreeCurrent field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeCurrent, "StackFreeCurrent")
 
                 if metric.stackFreeMinimum is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeMinimum),
-                                        "StackFreeMinimum field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackFreeMinimum, "StackFreeMinimum")
 
                 if metric.stackSize is not None:
-                    asserts.assert_true(self.is_valid_uint32_value(metric.stackSize), "StackSize field should be a uint32 type")
+                    self.assert_valid_uint32(metric.stackSize, "StackSize")
 
             # Ensure the list length matches thread_metrics_original to simplify matching
             asserts.assert_equal(len(thread_metrics_reset), len(thread_metrics_original),


### PR DESCRIPTION
The current validation logic for fields like stackFreeCurrent in ThreadMetrics uses overly verbose assertions such as:

`asserts.assert_true(self.is_valid_uint32_value(metric.stackFreeCurrent), "StackFreeCurrent field should be a uint32 type")`

This verbosity can be reduced by encapsulating the validation and assertion logic into more concise helper methods, such as self.assert_valid_uint32(value, field_name). For example:

`self.assert_valid_uint32(metric.stackFreeCurrent, "StackFreeCurrent")`

Fixes #36968 