### PR TITLE
[NXP][border router] Sync Matter BR code with updates from ot-nxp

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -483,7 +483,6 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState()
 
         ChipLogProgress(DeviceLayer, "%s Internet connectivity %s", "IPv6", (haveIPv6Conn) ? "ESTABLISHED" : "LOST");
     }
-
 }
 
 void ConnectivityManagerImpl::_NetifExtCallback(struct netif * netif, netif_nsc_reason_t reason,

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -149,14 +149,10 @@ private:
     static constexpr uint32_t kWlanInitWaitMs = CHIP_DEVICE_CONFIG_WIFI_STATION_RECONNECT_INTERVAL;
 
 #if CHIP_ENABLE_OPENTHREAD
-    static constexpr uint8_t kMaxIp6Addr = 3;
-
     Inet::InterfaceId mThreadNetIf;
     Inet::InterfaceId mExternalNetIf;
 
     char mHostname[chip::Dnssd::kHostNameMaxLength + 1] = "";
-    otIp6Address mIp6AddrList[kMaxIp6Addr];
-    uint32_t mIp6AddrNum = 0;
 #endif
 
     static int _WlanEventCallback(enum wlan_event_reason event, void * data);
@@ -166,9 +162,7 @@ private:
     void OnStationDisconnected(void);
     void UpdateInternetConnectivityState(void);
 #if CHIP_ENABLE_OPENTHREAD
-    void BrHandleStateChange(bool bLinkState);
-    void UpdateMdnsHost(void);
-    bool UpdateIp6AddrList(void);
+    void BrHandleStateChange();
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
 #endif
     /* CHIP_DEVICE_CONFIG_ENABLE_WPA */


### PR DESCRIPTION
This commit moves all of the BR processing inside the ot-nxp platform code. On Matter side we are keeping only the initialization of the border router function.

#### Testing
Tested with Thermostat boarder router (wifi + thread) and Thermostat Thread app by ATL with matter 1.4 certification tests

Environment: NXP RW612 board

Automated testing is not possible as it is a platform specific update

