### PR TITLE
fix: Invert boolean return in GetAcknowledgementsRequest

### DIFF
--- a/src/app/server/DefaultTermsAndConditionsProvider.cpp
+++ b/src/app/server/DefaultTermsAndConditionsProvider.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR chip::app::DefaultTermsAndConditionsProvider::GetAcknowledgementsRequ
     TermsAndConditions acceptedTermsAndConditions = acceptedTermsAndConditionsMaybe.Value();
 
     bool requiredTermsAndConditionsAreAccepted = requiredTermsAndConditions.Validate(acceptedTermsAndConditions);
-    outAcknowledgementsRequired = !requiredTermsAndConditionsAreAccepted;
+    outAcknowledgementsRequired                = !requiredTermsAndConditionsAreAccepted;
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/server/DefaultTermsAndConditionsProvider.cpp
+++ b/src/app/server/DefaultTermsAndConditionsProvider.cpp
@@ -211,7 +211,9 @@ CHIP_ERROR chip::app::DefaultTermsAndConditionsProvider::GetAcknowledgementsRequ
 
     TermsAndConditions requiredTermsAndConditions = requiredTermsAndConditionsMaybe.Value();
     TermsAndConditions acceptedTermsAndConditions = acceptedTermsAndConditionsMaybe.Value();
-    outAcknowledgementsRequired                   = requiredTermsAndConditions.Validate(acceptedTermsAndConditions);
+
+    bool requiredTermsAndConditionsAreAccepted = requiredTermsAndConditions.Validate(acceptedTermsAndConditions);
+    outAcknowledgementsRequired = !requiredTermsAndConditionsAreAccepted;
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
The GetAcknowledgementsRequest was returning an incorrect boolean value, causing unexpected behavior. This change inverts the return value to fix the logical error.

#### Testing

- Issue identified during test plan script development
- Test plan changes will be referenced in a separate change
