### PR TITLE
[NXP] cli and zap fixes

### DIFF
--- a/examples/thermostat/nxp/zap/thermostat_matter_br.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_br.matter
@@ -291,56 +291,6 @@ cluster Identify = 3 {
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
 
-/** Attributes and commands for putting a device into Identification mode (e.g. flashing a light). */
-cluster Identify = 3 {
-  revision 4;
-
-  enum EffectIdentifierEnum : enum8 {
-    kBlink = 0;
-    kBreathe = 1;
-    kOkay = 2;
-    kChannelChange = 11;
-    kFinishEffect = 254;
-    kStopEffect = 255;
-  }
-
-  enum EffectVariantEnum : enum8 {
-    kDefault = 0;
-  }
-
-  enum IdentifyTypeEnum : enum8 {
-    kNone = 0;
-    kLightOutput = 1;
-    kVisibleIndicator = 2;
-    kAudibleBeep = 3;
-    kDisplay = 4;
-    kActuator = 5;
-  }
-
-  attribute int16u identifyTime = 0;
-  readonly attribute IdentifyTypeEnum identifyType = 1;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute event_id eventList[] = 65530;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  request struct IdentifyRequest {
-    int16u identifyTime = 0;
-  }
-
-  request struct TriggerEffectRequest {
-    EffectIdentifierEnum effectIdentifier = 0;
-    EffectVariantEnum effectVariant = 1;
-  }
-
-  /** Command description for Identify */
-  command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
-  /** Command description for TriggerEffect */
-  command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
-}
-
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;
@@ -2423,7 +2373,6 @@ endpoint 0 {
 endpoint 1 {
   device type ma_thermostat = 769, version 1;
 
-  binding cluster Identify;
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/thermostat/nxp/zap/thermostat_matter_br.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_br.zap
@@ -3004,32 +3004,6 @@
           "code": 3,
           "mfgCode": null,
           "define": "IDENTIFY_CLUSTER",
-          "side": "client",
-          "enabled": 1,
-          "commands": [
-            {
-              "name": "Identify",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
-              "name": "TriggerEffect",
-              "code": 64,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            }
-          ]
-        },
-        {
-          "name": "Identify",
-          "code": 3,
-          "mfgCode": null,
-          "define": "IDENTIFY_CLUSTER",
           "side": "server",
           "enabled": 1,
           "commands": [

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
@@ -291,56 +291,6 @@ cluster Identify = 3 {
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
 
-/** Attributes and commands for putting a device into Identification mode (e.g. flashing a light). */
-cluster Identify = 3 {
-  revision 4;
-
-  enum EffectIdentifierEnum : enum8 {
-    kBlink = 0;
-    kBreathe = 1;
-    kOkay = 2;
-    kChannelChange = 11;
-    kFinishEffect = 254;
-    kStopEffect = 255;
-  }
-
-  enum EffectVariantEnum : enum8 {
-    kDefault = 0;
-  }
-
-  enum IdentifyTypeEnum : enum8 {
-    kNone = 0;
-    kLightOutput = 1;
-    kVisibleIndicator = 2;
-    kAudibleBeep = 3;
-    kDisplay = 4;
-    kActuator = 5;
-  }
-
-  attribute int16u identifyTime = 0;
-  readonly attribute IdentifyTypeEnum identifyType = 1;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute event_id eventList[] = 65530;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  request struct IdentifyRequest {
-    int16u identifyTime = 0;
-  }
-
-  request struct TriggerEffectRequest {
-    EffectIdentifierEnum effectIdentifier = 0;
-    EffectVariantEnum effectVariant = 1;
-  }
-
-  /** Command description for Identify */
-  command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
-  /** Command description for TriggerEffect */
-  command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
-}
-
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;
@@ -2348,7 +2298,6 @@ endpoint 0 {
 endpoint 1 {
   device type ma_thermostat = 769, version 1;
 
-  binding cluster Identify;
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
@@ -3757,32 +3757,6 @@
           "code": 3,
           "mfgCode": null,
           "define": "IDENTIFY_CLUSTER",
-          "side": "client",
-          "enabled": 1,
-          "commands": [
-            {
-              "name": "Identify",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
-              "name": "TriggerEffect",
-              "code": 64,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            }
-          ]
-        },
-        {
-          "name": "Identify",
-          "code": 3,
-          "mfgCode": null,
-          "define": "IDENTIFY_CLUSTER",
           "side": "server",
           "enabled": 1,
           "commands": [

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
@@ -291,56 +291,6 @@ cluster Identify = 3 {
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
 
-/** Attributes and commands for putting a device into Identification mode (e.g. flashing a light). */
-cluster Identify = 3 {
-  revision 4;
-
-  enum EffectIdentifierEnum : enum8 {
-    kBlink = 0;
-    kBreathe = 1;
-    kOkay = 2;
-    kChannelChange = 11;
-    kFinishEffect = 254;
-    kStopEffect = 255;
-  }
-
-  enum EffectVariantEnum : enum8 {
-    kDefault = 0;
-  }
-
-  enum IdentifyTypeEnum : enum8 {
-    kNone = 0;
-    kLightOutput = 1;
-    kVisibleIndicator = 2;
-    kAudibleBeep = 3;
-    kDisplay = 4;
-    kActuator = 5;
-  }
-
-  attribute int16u identifyTime = 0;
-  readonly attribute IdentifyTypeEnum identifyType = 1;
-  readonly attribute command_id generatedCommandList[] = 65528;
-  readonly attribute command_id acceptedCommandList[] = 65529;
-  readonly attribute event_id eventList[] = 65530;
-  readonly attribute attrib_id attributeList[] = 65531;
-  readonly attribute bitmap32 featureMap = 65532;
-  readonly attribute int16u clusterRevision = 65533;
-
-  request struct IdentifyRequest {
-    int16u identifyTime = 0;
-  }
-
-  request struct TriggerEffectRequest {
-    EffectIdentifierEnum effectIdentifier = 0;
-    EffectVariantEnum effectVariant = 1;
-  }
-
-  /** Command description for Identify */
-  command access(invoke: manage) Identify(IdentifyRequest): DefaultSuccess = 0;
-  /** Command description for TriggerEffect */
-  command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
-}
-
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;
@@ -2213,7 +2163,6 @@ endpoint 0 {
 endpoint 1 {
   device type ma_thermostat = 769, version 1;
 
-  binding cluster Identify;
 
   server cluster Identify {
     ram      attribute identifyTime default = 0x0000;

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
@@ -3004,32 +3004,6 @@
           "code": 3,
           "mfgCode": null,
           "define": "IDENTIFY_CLUSTER",
-          "side": "client",
-          "enabled": 1,
-          "commands": [
-            {
-              "name": "Identify",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            },
-            {
-              "name": "TriggerEffect",
-              "code": 64,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 0,
-              "isEnabled": 1
-            }
-          ]
-        },
-        {
-          "name": "Identify",
-          "code": 3,
-          "mfgCode": null,
-          "define": "IDENTIFY_CLUSTER",
           "side": "server",
           "enabled": 1,
           "commands": [

--- a/src/lib/shell/streamer_nxp.cpp
+++ b/src/lib/shell/streamer_nxp.cpp
@@ -221,6 +221,9 @@ ssize_t streamer_nxp_read(streamer_t * streamer, char * buffer, size_t length)
         if (bytesRead == 0)
         {
             readDone = true;
+            /* Return -1 to cancel the cli command, this command is empty as we are reading uart input until it
+            is empty but for matter shell empty command is meaning stop the shell loop */
+            return -1;
         }
     }
 

--- a/src/platform/nxp/common/Logging.cpp
+++ b/src/platform/nxp/common/Logging.cpp
@@ -41,6 +41,7 @@ namespace Platform {
  */
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
+    static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutex();
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = { 0 };
     size_t prefixLen;
 
@@ -77,7 +78,9 @@ void LogV(const char * module, uint8_t category, const char * msg, va_list v)
     /* Add CR+LF */
     snprintf(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, "%s", "\r\n");
 
+    xSemaphoreTake(xLoggingSemaphore, portMAX_DELAY);
     PRINTF("%s", formattedMsg);
+    xSemaphoreGive(xLoggingSemaphore);
 }
 
 /**

--- a/src/platform/nxp/common/Logging.cpp
+++ b/src/platform/nxp/common/Logging.cpp
@@ -34,6 +34,9 @@
 namespace chip {
 namespace Logging {
 namespace Platform {
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+StaticSemaphore_t xLoggingSemaphoreBuffer;
+#endif
 
 /**
  * CHIP log output function.
@@ -41,7 +44,13 @@ namespace Platform {
  */
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-    static SemaphoreHandle_t xLoggingSemaphore          = xSemaphoreCreateMutex();
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutexStatic(&xLoggingSemaphoreBuffer);
+#else
+    static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutex();
+#endif
+    assert(xLoggingSemaphore != NULL);
+
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = { 0 };
     size_t prefixLen;
 

--- a/src/platform/nxp/common/Logging.cpp
+++ b/src/platform/nxp/common/Logging.cpp
@@ -41,7 +41,7 @@ namespace Platform {
  */
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-    static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutex();
+    static SemaphoreHandle_t xLoggingSemaphore          = xSemaphoreCreateMutex();
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE] = { 0 };
     size_t prefixLen;
 

--- a/src/platform/nxp/common/Logging.cpp
+++ b/src/platform/nxp/common/Logging.cpp
@@ -34,7 +34,7 @@
 namespace chip {
 namespace Logging {
 namespace Platform {
-#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
 StaticSemaphore_t xLoggingSemaphoreBuffer;
 #endif
 
@@ -44,7 +44,7 @@ StaticSemaphore_t xLoggingSemaphoreBuffer;
  */
 void LogV(const char * module, uint8_t category, const char * msg, va_list v)
 {
-#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
     static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutexStatic(&xLoggingSemaphoreBuffer);
 #else
     static SemaphoreHandle_t xLoggingSemaphore = xSemaphoreCreateMutex();


### PR DESCRIPTION
The aim of this PR is to fix some NXP issue:

1. NXP CLI was broken after stack [PR 36675](https://github.com/project-chip/connectedhomeip/pull/36675) (exit from CLI loop at the first command received due to bad return value)
2. Fix non-thread safe logs print, logs getting mixed up
3. Zap update to remove identify client cluster from thermostat app as it is currently not supported and not mandatory

### Testing
Manual tests were ran using the NXP thermostat app and NXP RW612 board:

1. Fix NXP CLI: check multiple commands can be sent over the CLI and check the board response
2. Fix non-thread safe logs: check in the app boot logs there is no mixed up logs from different tasks as it was the case before apply the fix
3. Certification test were failing(TC-I-3.2), PICS file updated accordingly, test is no longer run because PICS is disabled

