### PR TITLE
[Draft] Evict the longer time stamp subscription

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1128,6 +1128,15 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
         {
             candidate = handler;
         }
+        // The last report time of this handler is longer
+        else if (handler->GetLastReportTime() < candidate->GetLastReportTime() &&
+                // Not older and the level of resource usage is the same (both exceed or neither exceed)
+                 handler->GetTransactionStartGeneration() >= candidate->GetTransactionStartGeneration() &&
+                 ((attributePathsUsed > perFabricPathCapacity || eventPathsUsed > perFabricPathCapacity) ==
+                  (candidateAttributePathsUsed > perFabricPathCapacity || candidateEventPathsUsed > perFabricPathCapacity)))
+        {
+            candidate = handler;
+        }
         return Loop::Continue;
     });
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -70,6 +70,7 @@ ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeCon
     mInteractionType            = aInteractionType;
     mLastWrittenEventsBytes     = 0;
     mTransactionStartGeneration = mManagementCallback.GetInteractionModelEngine()->GetReportingEngine().GetDirtySetGeneration();
+    mLastReportTime = System::SystemClock().GetMonotonicTimestamp();
     mFlags.ClearAll();
     SetStateFlag(ReadHandlerFlags::PrimingReports);
 
@@ -363,6 +364,7 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
         {
             mObserver->OnSubscriptionReportSent(this);
         }
+        mLastReportTime = System::SystemClock().GetMonotonicTimestamp();
     }
     if (!aMoreChunks)
     {

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -435,6 +435,8 @@ private:
 
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
+    auto GetLastReportTime() const { return mLastReportTime; }
+
     /// @brief Forces the read handler into a dirty state, regardless of what's going on with attributes.
     /// This can lead to scheduling of a reporting run immediately, if the min interval has been reached,
     /// or after the min interval is reached if it has not yet been reached.
@@ -560,6 +562,8 @@ private:
     // When we don't have enough resources for a new subscription, the oldest subscription might be evicted by interaction model
     // engine, the "oldest" subscription is the subscription with the smallest generation.
     uint64_t mTransactionStartGeneration = 0;
+    // If not older, the subscription with the longest timestamp might be evicted.
+    System::Clock::Timestamp mLastReportTime;
 
     SubscriptionId mSubscriptionId           = 0;
     uint16_t mMinIntervalFloorSeconds        = 0;


### PR DESCRIPTION
Current  mechanism of `EnsureResourceForSubscription` may evict the Readhandler with more resources or less genaration (older). If same, the latest created one will be selected, in this case, only one subscription can be used for that the new subscription will evict the last one. So add a report timestamp and evict the longest timestamp subscription in this case.