### PR TITLE
Do not cancel PRs for `PR validity` checks

### DIFF
--- a/.github/workflows/cancel_workflows_for_pr.yaml
+++ b/.github/workflows/cancel_workflows_for_pr.yaml
@@ -49,5 +49,4 @@ jobs:
                     --require "Lint Code Base" \
                     --require "ZAP"            \
                     --require "Run misspell"   \
-                    --require "PR validity"    \
                     --max-pr-age-minutes 20


### PR DESCRIPTION
Since validity checks can be fixed without commits, cancelling PRs for them is not useful.

### Testing
Change is one-line/obvious
