### PR TITLE
Update PR template to contain the testing header pre-filled

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,18 @@
-> !!!!!!!!!! Please delete the instructions below and replace with PR description
+> !!!!!!!!!! Please delete the instructions below and replace with PR
+> description
 >
-> If you have an issue number, please use a syntax of
-> `Fixes #12345` and a brief change description
+> If you have an issue number, please use a syntax of `Fixes #12345` and a brief
+> change description
 >
-> If you do not have an issue number, please have a good description of
-> the problem and the fix. Help the reviewer understand what to expect.
+> If you do not have an issue number, please have a good description of the
+> problem and the fix. Help the reviewer understand what to expect.
 >
-> Add a `### Testing` section to your PR to describe how testing was done.
-> See <https://github.com/project-chip/connectedhomeip/blob/master/CONTRIBUTING.md#pull-requests>
+> Complete/append to the `### Testing` section below, to describe how testing
+> was done. See
+> <https://github.com/project-chip/connectedhomeip/blob/master/CONTRIBUTING.md#pull-requests>
 >
 > Make sure you delete these instructions (to prove you have read them).
 >
 > !!!!!!!!!! Instructions end
+
+#### Testing


### PR DESCRIPTION
This makes it easier to write PR descriptions faster in a way that the validator accepts.

This addresses https://github.com/project-chip/connectedhomeip/pull/37013#discussion_r1909527853

#### Testing

Change is in a text file only, should be obviously taking effect.