### PR TITLE
PR validation: write the pullrequest body as a separate file and an end marker

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -13,13 +13,21 @@ jobs:
         id: check-testing
         continue-on-error: true
         run: |
-          python -c 'import sys; pr_summary = """${{ github.event.pull_request.body }}"""; sys.exit(0 if "### Testing" in pr_summary else 1)'
+          cat >/tmp/pr-summary.txt << "EndMarkerForPrSummary"
+          ${{ github.event.pull_request.body }}
+          EndMarkerForPrSummary
+
+          python -c 'import sys; pr_summary = open("/tmp/pr-summary.txt", "rt").read(); sys.exit(0 if "### Testing" in pr_summary else 1)'
 
       - name: Check for PR starting instructions
         id: check-instructions
         continue-on-error: true
         run: |
-          python -c 'import sys; pr_summary = """${{ github.event.pull_request.body }}"""; sys.exit(1 if "Make sure you delete these instructions" in pr_summary else 0)'
+          cat >/tmp/pr-summary.txt << "EndMarkerForPrSummary"
+          ${{ github.event.pull_request.body }}
+          EndMarkerForPrSummary
+
+          python -c 'import sys; pr_summary = open("/tmp/pr-summary.txt", "rt").read(); sys.exit(1 if "Make sure you delete these instructions" in pr_summary else 0)'
 
       # NOTE: comments disabled for now as separate permissions are required
       #       failing CI step may be sufficient to start (although it contains less information about why it failed)

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -8,7 +8,6 @@ jobs:
   check_testing_header:
     runs-on: ubuntu-latest
     steps:
-
       - name: Check for `### Testing` section in PR
         id: check-testing
         continue-on-error: true


### PR DESCRIPTION
This avoids having quotes or other text considered special. Tried to name the marker in a way that is reasonably unique and unlikely to be part of real PR summaries. We can change it more if we really need to.

This will support ' quotes that are common in text (e.g. logs or even writing `can't` or `won't` or similar text)

#### Testing

This PR summary in particular contains single quotes and backticks, so `PR validity` passing on it will self-verify.
Edited the summary to not have the testing header, observed check failed

![image](https://github.com/user-attachments/assets/8194cadd-4d35-4f1f-a566-c70d479d43af)

