### PR TITLE
Return empty thread route table when thread network is not up

### DIFF
--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -248,8 +248,6 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
 
 #if CHIP_DEVICE_CONFIG_THREAD_FTD
             uint8_t maxRouterId = otThreadGetMaxRouterId(otInst);
-            CHIP_ERROR chipErr  = CHIP_ERROR_INCORRECT_STATE;
-
             for (uint8_t i = 0; i <= maxRouterId; i++)
             {
                 if (otThreadGetRouterInfo(otInst, i, &routerInfo) == OT_ERROR_NONE)
@@ -268,11 +266,10 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
                     routeTable.linkEstablished = routerInfo.mLinkEstablished;
 
                     ReturnErrorOnFailure(aEncoder.Encode(routeTable));
-                    chipErr = CHIP_NO_ERROR;
                 }
             }
-
-            return chipErr;
+            // Returning empty list with no error in case thread network is not up
+            return CHIP_NO_ERROR;
 
 #else // OPENTHREAD_MTD
             otError otErr = otThreadGetParentInfo(otInst, &routerInfo);


### PR DESCRIPTION
Fixes #36926 
Command "./chip-tool threadnetworkdiagnostics read route-table" return an error if the thread network is not up (OTBR NXP thermostat app). Issue identify by the test lab during matter 1.4 certification.
Proposal: return empty route table instead of an error when there is no route.

### Testing
Tested with the NXP thermostat OTBR example, with RW612 platform.
The chip-tool command is not failing any more with this fix and print 0 entrance for the route table when the thread network is not up.
