### PR TITLE
[Silabs] Clean up WifiInterface public APIs

### DIFF
--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -49,7 +49,8 @@ DOTFILE=".gn"
 SILABS_THREAD_TARGET=\""../silabs:ot-efr32-cert"\"
 USAGE="./scripts/examples/gn_silabs_example.sh <AppRootFolder> <outputFolder> <silabs_board_name> [<Build options>]"
 
-WIFI_DIR_SUFFIX=""
+PROTOCOL_DIR_SUFFIX="thread"
+NCP_DIR_SUFFIX=""
 
 if [ "$#" == "0" ]; then
     echo "Build script for EFR32 Matter apps
@@ -192,13 +193,13 @@ else
                 fi
                 if [ "$2" = "rs9116" ]; then
                     optArgs+="use_rs9116=true "
-                    WIFI_DIR_SUFFIX="_rs9116"
+                    NCP_DIR_SUFFIX="/rs9116"
                 elif [ "$2" = "SiWx917" ]; then
                     optArgs+="use_SiWx917=true "
-                    WIFI_DIR_SUFFIX="_SiWx917"
+                    NCP_DIR_SUFFIX="/SiWx917"
                 elif [ "$2" = "wf200" ]; then
                     optArgs+="use_wf200=true "
-                    WIFI_DIR_SUFFIX="_wf200"
+                    NCP_DIR_SUFFIX="/wf200"
                 else
                     echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
                     exit 1
@@ -326,18 +327,19 @@ else
         source "$CHIP_ROOT/scripts/activate.sh"
     fi
 
+    if [ "$USE_WIFI" == true ]; then
+        DOTFILE="$ROOT/build_for_wifi_gnfile.gn"
+        PROTOCOL_DIR_SUFFIX="wifi"
+    else
+        DOTFILE="$ROOT/openthread.gn"
+    fi
+
     PYTHON_PATH="$(which python3)"
-    BUILD_DIR=$OUTDIR/$SILABS_BOARD$WIFI_DIR_SUFFIX
+    BUILD_DIR=$OUTDIR/$PROTOCOL_DIR_SUFFIX/$SILABS_BOARD$NCP_DIR_SUFFIX
     echo BUILD_DIR="$BUILD_DIR"
 
     if [ "$DIR_CLEAN" == true ]; then
         rm -rf "$BUILD_DIR"
-    fi
-
-    if [ "$USE_WIFI" == true ]; then
-        DOTFILE="$ROOT/build_for_wifi_gnfile.gn"
-    else
-        DOTFILE="$ROOT/openthread.gn"
     fi
 
     if [ "$USE_DOCKER" == true ] && [ "$USE_WIFI" == false ]; then

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -191,19 +191,19 @@ else
                     echo "--wifi requires rs9116 or SiWx917 or wf200"
                     exit 1
                 fi
+                
                 if [ "$2" = "rs9116" ]; then
                     optArgs+="use_rs9116=true "
-                    NCP_DIR_SUFFIX="/"$2
                 elif [ "$2" = "SiWx917" ]; then
                     optArgs+="use_SiWx917=true "
-                    NCP_DIR_SUFFIX="/"$2
                 elif [ "$2" = "wf200" ]; then
                     optArgs+="use_wf200=true "
-                    NCP_DIR_SUFFIX="/"$2
                 else
                     echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
                     exit 1
                 fi
+
+                NCP_DIR_SUFFIX="/"$2
                 USE_WIFI=true
                 optArgs+="chip_device_platform =\"efr32\" chip_crypto_keystore=\"psa\""
                 shift

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -49,6 +49,8 @@ DOTFILE=".gn"
 SILABS_THREAD_TARGET=\""../silabs:ot-efr32-cert"\"
 USAGE="./scripts/examples/gn_silabs_example.sh <AppRootFolder> <outputFolder> <silabs_board_name> [<Build options>]"
 
+WIFI_DIR_SUFFIX=""
+
 if [ "$#" == "0" ]; then
     echo "Build script for EFR32 Matter apps
     Format:
@@ -190,10 +192,13 @@ else
                 fi
                 if [ "$2" = "rs9116" ]; then
                     optArgs+="use_rs9116=true "
+                    WIFI_DIR_SUFFIX="_rs9116"
                 elif [ "$2" = "SiWx917" ]; then
                     optArgs+="use_SiWx917=true "
+                    WIFI_DIR_SUFFIX="_SiWx917"
                 elif [ "$2" = "wf200" ]; then
                     optArgs+="use_wf200=true "
+                    WIFI_DIR_SUFFIX="_wf200"
                 else
                     echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
                     exit 1
@@ -322,7 +327,7 @@ else
     fi
 
     PYTHON_PATH="$(which python3)"
-    BUILD_DIR=$OUTDIR/$SILABS_BOARD
+    BUILD_DIR=$OUTDIR/$SILABS_BOARD$WIFI_DIR_SUFFIX
     echo BUILD_DIR="$BUILD_DIR"
 
     if [ "$DIR_CLEAN" == true ]; then

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -193,13 +193,13 @@ else
                 fi
                 if [ "$2" = "rs9116" ]; then
                     optArgs+="use_rs9116=true "
-                    NCP_DIR_SUFFIX="/rs9116"
+                    NCP_DIR_SUFFIX="/"$2
                 elif [ "$2" = "SiWx917" ]; then
                     optArgs+="use_SiWx917=true "
-                    NCP_DIR_SUFFIX="/SiWx917"
+                    NCP_DIR_SUFFIX="/"$2
                 elif [ "$2" = "wf200" ]; then
                     optArgs+="use_wf200=true "
-                    NCP_DIR_SUFFIX="/wf200"
+                    NCP_DIR_SUFFIX="/"$2
                 else
                     echo "Wifi usage: --wifi rs9116|SiWx917|wf200"
                     exit 1

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -191,7 +191,7 @@ else
                     echo "--wifi requires rs9116 or SiWx917 or wf200"
                     exit 1
                 fi
-                
+
                 if [ "$2" = "rs9116" ]; then
                     optArgs+="use_rs9116=true "
                 elif [ "$2" = "SiWx917" ]; then

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -228,7 +228,7 @@ void ConnectivityManagerImpl::DriveStationState()
     {
         // Ensure that the Wifi task is started.
         CHIP_ERROR error = StartWifiTask();
-        VerifyOrExit(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartWifiTask() failed: %s", ErrorStr(error)));
+        VerifyOrReturn(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartWifiTask() failed: %s", ErrorStr(error)));
 
         // Ensure that station mode is enabled in the WiFi layer.
         ConfigureStationMode();

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -218,8 +218,7 @@ CHIP_ERROR ConnectivityManagerImpl::_SetPollingInterval(System::Clock::Milliseco
 
 void ConnectivityManagerImpl::DriveStationState()
 {
-    sl_status_t serr;
-    bool stationConnected;
+    bool stationConnected = false;
 
     // Refresh the current station mode.
     GetWiFiStationMode();
@@ -227,13 +226,11 @@ void ConnectivityManagerImpl::DriveStationState()
     // If the station interface is NOT under application control...
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        // Ensure that the WFX is started.
-        if ((serr = wfx_wifi_start()) != SL_STATUS_OK)
-        {
-            ChipLogError(DeviceLayer, "wfx_wifi_start() failed: %lx", serr);
-            return;
-        }
-        // Ensure that station mode is enabled in the WFX WiFi layer.
+        // Ensure that the Wifi task is started.
+        CHIP_ERROR error = StartWifiTask();
+        VerifyOrExit(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartWifiTask() failed: %s", ErrorStr(error)));
+
+        // Ensure that station mode is enabled in the WiFi layer.
         wfx_enable_sta_mode();
     }
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -186,7 +186,7 @@ void SlWiFiDriver::UpdateNetworkingStatus()
     }
 
     ByteSpan networkId = ByteSpan((const unsigned char *) mStagingNetwork.ssid, mStagingNetwork.ssidLen);
-    if (!wfx_is_sta_connected())
+    if (!IsStationConnected())
     {
         // TODO: https://github.com/project-chip/connectedhomeip/issues/26861
         mpStatusChangeCallback->OnNetworkingStatusChange(Status::kUnknownError, MakeOptional(networkId),
@@ -336,7 +336,7 @@ CHIP_ERROR GetConnectedNetwork(Network & network)
     network.connected    = false;
     // we are able to fetch the wifi provision data and STA should be connected
     VerifyOrReturnError(wfx_get_wifi_provision(&wifiConfig), CHIP_ERROR_UNINITIALIZED);
-    VerifyOrReturnError(wfx_is_sta_connected(), CHIP_ERROR_NOT_CONNECTED);
+    VerifyOrReturnError(IsStationConnected(), CHIP_ERROR_NOT_CONNECTED);
     network.connected = true;
     uint8_t length    = strnlen(wifiConfig.ssid, DeviceLayer::Internal::kMaxWiFiSSIDLength);
     VerifyOrReturnError(length < sizeof(network.networkID), CHIP_ERROR_BUFFER_TOO_SMALL);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -822,7 +822,7 @@ void ProcessEvent(WifiPlatformEvent event)
 /*********************************************************************************
  * @fn  void sl_matter_wifi_task(void *arg)
  * @brief
- * The main WLAN task - started by wfx_wifi_start() that interfaces with RSI.
+ * The main WLAN task - started by StartWifiTask() that interfaces with RSI.
  * The rest of RSI stuff come in call-backs.
  * The initialization has been already done.
  * @param[in] arg:
@@ -871,7 +871,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -871,7 +871,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -84,7 +84,7 @@ enum class WifiState : uint16_t
     kStationMode        = (1 << 7), /* Enable Station Mode */
     kAPMode             = (1 << 8), /* Enable AP Mode */
     kStationReady       = (kStationConnected | kStationDhcpDone),
-    kStationStarted     = (1 << 9),  /* RSI task started */
+    kStationStarted     = (1 << 9),
     kScanStarted        = (1 << 10), /* Scan Started */
 };
 
@@ -258,19 +258,37 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback);
  */
 CHIP_ERROR StartWifiTask();
 
+/**
+ * @brief Configures the Wi-Fi devices as a Wi-Fi station
+ */
+void ConfigureStationMode();
+
+/**
+ * @brief Returns the state of the Wi-Fi connection
+ *
+ * @return true, if the Wi-Fi device is connected to an AP
+ *         false, otherwise
+ */
+bool IsStationConnected();
+
+/**
+ * @brief Returns the state of the Wi-Fi Station configuration of the Wi-Fi device
+ *
+ * @return true, if the Wi-Fi Station mode is enabled
+ *         false, otherwise
+ */
+bool IsStationModeEnabled(void);
+
 /* Function to update */
 
-void wfx_enable_sta_mode(void);
 void wfx_set_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig);
-bool wfx_is_sta_mode_enabled(void);
 int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap);
 int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
 int32_t wfx_reset_counts();
 void wfx_clear_wifi_provision(void);
 sl_status_t wfx_connect_to_ap(void);
 void wfx_setup_ip6_link_local(sl_wfx_interface_t);
-bool wfx_is_sta_connected(void);
 sl_status_t sl_matter_wifi_disconnect(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -249,9 +249,17 @@ CHIP_ERROR GetMacAddress(sl_wfx_interface_t interface, chip::MutableByteSpan & a
  */
 CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback);
 
+/**
+ * @brief Creates and starts the WiFi task that processes Wifi events and operations
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR if the task was successfully started and initialized
+ *         CHIP_ERROR_NO_MEMORY if the task failed to be created
+ *         CHIP_ERROR_INTERNAL if software or hardware initialization failed
+ */
+CHIP_ERROR StartWifiTask();
+
 /* Function to update */
 
-sl_status_t wfx_wifi_start(void);
 void wfx_enable_sta_mode(void);
 void wfx_set_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig);

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -811,7 +811,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -761,7 +761,7 @@ void ProcessEvent(WifiPlatformEvent event)
 /*********************************************************************************
  * @fn  void sl_matter_wifi_task(void *arg)
  * @brief
- * The main WLAN task - started by wfx_wifi_start () that interfaces with RSI.
+ * The main WLAN task - started by StartWifiTask () that interfaces with RSI.
  * The rest of RSI stuff come in call-backs.
  * The initialization has been already done.
  * @param[in] arg:
@@ -811,7 +811,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -1232,7 +1232,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -92,10 +92,6 @@ static wfx_wifi_scan_result_t ap_info;
 #define STA_IP_FAIL (0)
 #define WLAN_TASK_PRIORITY (1)
 
-#define WE_ST_STARTED 1
-#define WE_ST_STA_CONN 2
-#define WE_ST_HW_STARTED 4
-
 #ifdef SL_WFX_CONFIG_SOFTAP
 // Connection parameters
 char softap_ssid[32]                   = SOFTAP_SSID_DEFAULT;
@@ -120,12 +116,14 @@ static struct scan_result_holder
     struct scan_result_holder * next;
     wfx_wifi_scan_result scan;
 } * scan_save;
+
 static uint8_t scan_count = 0;
 static ScanCallback scan_cb;              /* user-callback - when scan is done */
 static uint8_t * scan_ssid     = nullptr; /* Which one are we scanning for */
 static size_t scan_ssid_length = 0;
 static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_result);
 static void sl_wfx_scan_complete_callback(uint32_t status);
+static sl_status_t wfx_wifi_hw_start(void);
 
 static void wfx_events_task(void * p_arg);
 
@@ -148,7 +146,7 @@ namespace {
 
 // wfx_fmac_driver context
 sl_wfx_context_t wifiContext;
-uint8_t wifi_extra;
+chip::BitFlags<WifiState> wifi_extra;
 
 typedef struct __attribute__((__packed__)) sl_wfx_get_counters_cnf_body_s
 {
@@ -337,21 +335,36 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR StartWifiTask(void)
+CHIP_ERROR StartWifiTask()
 {
-    if (wifi_extra & WE_ST_STARTED)
+    if (wifi_extra.Has(WifiState::kStationInit))
     {
         ChipLogDetail(DeviceLayer, "WIFI: Already started");
-        return SL_STATUS_OK;
+        return CHIP_NO_ERROR;
     }
-    wifi_extra |= WE_ST_STARTED;
+    wifi_extra.Set(WifiState::kStationInit);
 
     VerifyOrReturnError(wfx_soft_init() == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed to execute the WFX software init."));
     VerifyOrReturnError(wfx_wifi_hw_start() == SL_STATUS_OK, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed to execute the WFX HW start."));
 
-    return SL_STATUS_OK;
+    return CHIP_NO_ERROR;
+}
+
+void ConfigureStationMode()
+{
+    wifi_extra.Set(WifiState::kStationMode);
+}
+
+bool IsStationModeEnabled(void)
+{
+    return wifi_extra.Has(WifiState::kStationMode);
+}
+
+bool IsStationConnected()
+{
+    return wifi_extra.Has(WifiState::kStationConnected);
 }
 
 /***************************************************************************
@@ -734,7 +747,7 @@ static void wfx_events_task(void * p_arg)
             wfx_connect_to_ap();
         }
 
-        if (wifi_extra & WE_ST_STA_CONN)
+        if (wifi_extra.Has(WifiState::kStationConnected))
         {
             if ((now = xTaskGetTickCount()) > (last_dhcp_poll + pdMS_TO_TICKS(250)))
             {
@@ -782,7 +795,7 @@ static void wfx_events_task(void * p_arg)
             hasNotifiedIPV6             = false;
             hasNotifiedWifiConnectivity = false;
             ChipLogProgress(DeviceLayer, "connected to AP");
-            wifi_extra |= WE_ST_STA_CONN;
+            wifi_extra.Set(WifiState::kStationConnected);
             retryJoin = 0;
             wfx_lwip_set_sta_link_up();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -806,7 +819,7 @@ static void wfx_events_task(void * p_arg)
             NotifyIPv6Change(false);
             hasNotifiedIPV6             = false;
             hasNotifiedWifiConnectivity = false;
-            wifi_extra &= ~WE_ST_STA_CONN;
+            wifi_extra.Clear(WifiState::kStationConnected);
             wfx_lwip_set_sta_link_down();
         }
 
@@ -923,29 +936,32 @@ static sl_status_t wfx_init(void)
  * @return
  *    sl_status_t Shows init succes or error.
  ******************************************************************************/
-static void wfx_wifi_hw_start(void)
+static sl_status_t wfx_wifi_hw_start(void)
 {
-    sl_status_t status;
+    sl_status_t status = SL_STATUS_OK;
 
-    if (wifi_extra & WE_ST_HW_STARTED)
-        return;
+    if (wifi_extra.Has(WifiState::kStationStarted))
+    {
+        return SL_STATUS_OK;
+    }
+
     ChipLogDetail(DeviceLayer, "STARTING WF200");
-    wifi_extra |= WE_ST_HW_STARTED;
 
     sl_wfx_host_gpio_init();
-    if ((status = wfx_init()) == SL_STATUS_OK)
-    {
-        /* Initialize the LwIP stack */
-        ChipLogDetail(DeviceLayer, "WF200:Start LWIP");
-        sl_matter_lwip_start();
-        sl_matter_wifi_task_started();
-        wifiContext.state = SL_WFX_STARTED; /* Really this is a bit mask */
-        ChipLogDetail(DeviceLayer, "WF200:ready..");
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "WF200:init failed");
-    }
+
+    status = wfx_init();
+    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "WF200:init failed"));
+
+    /* Initialize the LwIP stack */
+    ChipLogDetail(DeviceLayer, "WF200:Start LWIP");
+    sl_matter_lwip_start();
+    sl_matter_wifi_task_started();
+    wifiContext.state = SL_WFX_STARTED; /* Really this is a bit mask */
+
+    ChipLogDetail(DeviceLayer, "WF200:ready.");
+    wifi_extra.Set(WifiState::kStationStarted);
+
+    return SL_STATUS_OK;
 }
 
 /***********************************************************************
@@ -1150,7 +1166,7 @@ bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
 bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
 {
     VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
-    return wfx_is_sta_connected();
+    return IsStationConnected();
 }
 
 /****************************************************************************
@@ -1162,33 +1178,12 @@ bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
 sl_status_t sl_matter_wifi_disconnect(void)
 {
     ChipLogProgress(DeviceLayer, "STA-Disconnecting");
+
     int32_t status = sl_wfx_send_disconnect_command();
-    wifi_extra &= ~WE_ST_STA_CONN;
+    wifi_extra.Clear(WifiState::kStationConnected);
+
     xEventGroupSetBits(sl_wfx_event_group, SL_WFX_RETRY_CONNECT);
     return status;
-}
-
-/****************************************************************************
- * @brief
- *     enable the STA mode
- * @return returns true
- *****************************************************************************/
-bool wfx_is_sta_mode_enabled(void)
-{
-    return true; /* It always is */
-}
-
-/****************************************************************************
- * @brief
- *     fuction called when driver is STA connected
- * @return returns true if sucessful,
- *         false otherwise
- *****************************************************************************/
-bool wfx_is_sta_connected(void)
-{
-    bool val;
-    val = (wifi_extra & WE_ST_STA_CONN) ? true : false;
-    return val;
 }
 
 /****************************************************************************
@@ -1248,16 +1243,6 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     NotifyIPv4Change(true);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-
-/*****************************************************************************
- * @brief
- *    function called from connectivityManager
- ******************************************************************************/
-void wfx_enable_sta_mode(void)
-{
-    /* Nothing to do - default is that it is
-       place holder */
-}
 
 /****************************************************************************
  * @brief

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -81,27 +81,17 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
     return CHIP_NO_ERROR;
 }
 
-/*********************************************************************
- * @fn  sl_status_t wfx_wifi_start(void)
- * @brief
- * Called from ConnectivityManagerImpl.cpp - to enable the device
- * Create the RSI task and let it deal with life.
- * @param[in]  None
- * @return  Returns SL_STATUS_OK if successful,
- *          SL_STATUS_FAIL otherwise
- ***********************************************************************/
-sl_status_t wfx_wifi_start(void)
+CHIP_ERROR StartWifiTask()
 {
-    VerifyOrReturnError(!(wfx_rsi.dev_state.Has(WifiState::kStationStarted)), SL_STATUS_OK);
+    // Verify that the Wifi task has not already been started.
+    VerifyOrReturnError(!(wfx_rsi.dev_state.Has(WifiState::kStationStarted)), CHIP_NO_ERROR);
     wfx_rsi.dev_state.Set(WifiState::kStationStarted);
 
-    // Creating a Wi-Fi driver thread
+    // Creating a Wi-Fi task thread
     sWlanThread = osThreadNew(sl_matter_wifi_task, NULL, &kWlanTaskAttr);
+    VerifyOrReturnError(sWlanThread != NULL, CHIP_ERROR_NO_MEMORY, ChipLogError(DeviceLayer, "Unable to create the WifiTask."););
 
-    VerifyOrReturnError(sWlanThread != NULL, SL_STATUS_FAIL);
-
-    ChipLogProgress(DeviceLayer, "sl_matter_wifi_task created successfully");
-    return SL_STATUS_OK;
+    return CHIP_NO_ERROR;
 }
 
 /*********************************************************************

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -94,28 +94,19 @@ CHIP_ERROR StartWifiTask()
     return CHIP_NO_ERROR;
 }
 
-/*********************************************************************
- * @fn  void wfx_enable_sta_mode(void)
- * @brief
- *      driver enable the STA mode
- * @param[in]  None
- * @return   None
- ***********************************************************************/
-void wfx_enable_sta_mode(void)
+void ConfigureStationMode()
 {
     wfx_rsi.dev_state.Set(WifiState::kStationMode);
 }
 
-/*********************************************************************
- * @fn  bool wfx_is_sta_mode_enabled(void)
- * @brief
- *      driver enabled the STA mode
- * @param[in]  None
- * @return   mode
- ***********************************************************************/
-bool wfx_is_sta_mode_enabled(void)
+bool IsStationModeEnabled()
 {
     return wfx_rsi.dev_state.Has(WifiState::kStationMode);
+}
+
+bool wfx_is_sta_connected()
+{
+    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
 /*********************************************************************
@@ -195,19 +186,6 @@ void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)
      * TODO: Implement IPV6 setup, currently in sl_matter_wifi_task()
      * This is hooked with MATTER code.
      */
-}
-
-/*********************************************************************
- * @fn  bool wfx_is_sta_connected(void)
- * @brief
- *      called fuction when driver is connected to STA
- * @param[in]  None
- * @return  returns ture if successful,
- *          false otherwise
- ***********************************************************************/
-bool wfx_is_sta_connected(void)
-{
-    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
 /*********************************************************************

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -104,7 +104,7 @@ bool IsStationModeEnabled()
     return wfx_rsi.dev_state.Has(WifiState::kStationMode);
 }
 
-bool wfx_is_sta_connected()
+bool IsStationConnected()
 {
     return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }


### PR DESCRIPTION
### Description
PR continues the Wifi interface refactor that has been on going for several PRs. The goal of the PR is to continue to clean up public APIs and not focused on refactoring the different implementations.

- Clean up WifiInterface APIs
- Transition wf200 bit operation to use the WifiState enum with the Bitflags class
- Improve build directory in the build script
```
out
└── lighting-app
    ├── thread
    │   └── BRD4186C
    │   └── BRD4187C       
    └── wifi
        ├── BRD2605A
        ├── BRD4187C
        │   ├── SiWx917
        │   └── wf200
        └── BRD4338A
```

### Testing
Validation of the changes are done manually.

- Build and commission BRD4338A (Wifi SoC)
- Build and commission BRD4187C + WF200 (Wifi RCP combo)