### PR TITLE
Restore original order of transports in TransportMgr.

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -116,6 +116,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mUserDirectedCommissioningPort = initParams.userDirectedCommissioningPort;
     mInterfaceId                   = initParams.interfaceId;
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+    auto tcpListenParams = TcpListenParameters(DeviceLayer::TCPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv6)
+                               .SetListenPort(mOperationalServicePort);
+#endif
+
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     VerifyOrExit(initParams.persistentStorageDelegate != nullptr, err = CHIP_ERROR_INVALID_ARGUMENT);
@@ -226,12 +232,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #endif
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
                                ,
-                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv6)
-                               .SetListenPort(mOperationalServicePort)
+                           tcpListenParams
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-                               ,
+                           ,
                            Transport::WiFiPAFListenParameters(DeviceLayer::ConnectivityMgr().GetWiFiPAF())
 #endif
     );
@@ -330,8 +334,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    // Enable the TCP Server based on the TCPListenParameters setting in TransportMgr Init.
-    app::DnssdServer::Instance().SetTCPServerEnabled(true);
+    // Enable the TCP Server based on the TCPListenParameters setting.
+    app::DnssdServer::Instance().SetTCPServerEnabled(tcpListenParams.IsServerListenEnabled());
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     if (GetFabricTable().FabricCount() != 0)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -214,12 +214,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                .SetAddressType(IPAddressType::kIPv6)
                                .SetListenPort(mOperationalServicePort)
                                .SetNativeParams(initParams.endpointNativeParams)
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                               ,
-                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
-                               .SetAddressType(IPAddressType::kIPv6)
-                               .SetListenPort(mOperationalServicePort)
-#endif
 #if INET_CONFIG_ENABLE_IPV4
                                ,
                            UdpListenParameters(DeviceLayer::UDPEndPointManager())
@@ -229,6 +223,12 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #if CONFIG_NETWORK_LAYER_BLE
                                ,
                            BleListenParameters(DeviceLayer::ConnectivityMgr().GetBleLayer())
+#endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                               ,
+                           TcpListenParameters(DeviceLayer::TCPEndPointManager())
+                               .SetAddressType(IPAddressType::kIPv6)
+                               .SetListenPort(mOperationalServicePort)
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                                ,
@@ -330,7 +330,8 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
-    app::DnssdServer::Instance().SetTCPServerEnabled(mTransports.GetTransport().GetImplAtIndex<1>().IsServerListenEnabled());
+    // Enable the TCP Server based on the TCPListenParameters setting in TransportMgr Init.
+    app::DnssdServer::Instance().SetTCPServerEnabled(true);
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     if (GetFabricTable().FabricCount() != 0)

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -96,10 +96,6 @@ inline constexpr size_t kMaxTcpPendingPackets = CHIP_CONFIG_MAX_TCP_PENDING_PACK
 //       in the Server impl depends on this.
 //
 using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                                              ,
-                                              chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>
-#endif
 #if INET_CONFIG_ENABLE_IPV4
                                               ,
                                               chip::Transport::UDP
@@ -107,6 +103,10 @@ using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 #if CONFIG_NETWORK_LAYER_BLE
                                               ,
                                               chip::Transport::BLE<kMaxBlePendingPackets>
+#endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                                              ,
+                                              chip::Transport::TCP<kMaxTcpActiveConnectionCount, kMaxTcpPendingPackets>
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                                               ,

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -167,15 +167,8 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     ReturnErrorOnFailure(stateParams.transportMgr->Init(Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv6)
                                                             .SetListenPort(params.listenPort)
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                                                            ,
-                                                        Transport::TcpListenParameters(stateParams.tcpEndPointManager)
-                                                            .SetAddressType(IPAddressType::kIPv6)
-                                                            .SetListenPort(params.listenPort)
-                                                            .SetServerListenEnabled(false) // Initialize as a TCP Client
-#endif
 #if INET_CONFIG_ENABLE_IPV4
-                                                        ,
+                                                            ,
                                                         Transport::UdpListenParameters(stateParams.udpEndPointManager)
                                                             .SetAddressType(Inet::IPAddressType::kIPv4)
                                                             .SetListenPort(params.listenPort)
@@ -184,8 +177,15 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
                                                             ,
                                                         Transport::BleListenParameters(stateParams.bleLayer)
 #endif
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
                                                             ,
+                                                        Transport::TcpListenParameters(stateParams.tcpEndPointManager)
+                                                            .SetAddressType(IPAddressType::kIPv6)
+                                                            .SetListenPort(params.listenPort)
+                                                            .SetServerListenEnabled(false) // Initialize as a TCP Client
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+                                                        ,
                                                         Transport::WiFiPAFListenParameters()
 #endif
                                                             ));
@@ -285,6 +285,9 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         // Consequently, reach in set the fabric table pointer to point to the right version.
         //
         app::DnssdServer::Instance().SetFabricTable(stateParams.fabricTable);
+
+        // Disable the TCP Server based on the TCPListenParameters setting in TransportMgr Init.
+        app::DnssdServer::Instance().SetTCPServerEnabled(false);
     }
 
     stateParams.sessionSetupPool = Platform::New<DeviceControllerSystemStateParams::SessionSetupPool>();

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -71,10 +71,6 @@ inline constexpr size_t kMaxDeviceTransportTcpPendingPackets = CHIP_CONFIG_MAX_T
 
 using DeviceTransportMgr =
     TransportMgr<Transport::UDP /* IPv6 */
-#if INET_CONFIG_ENABLE_TCP_ENDPOINT
-                 ,
-                 Transport::TCP<kMaxDeviceTransportTcpActiveConnectionCount, kMaxDeviceTransportTcpPendingPackets>
-#endif
 #if INET_CONFIG_ENABLE_IPV4
                  ,
                  Transport::UDP /* IPv4 */
@@ -82,6 +78,10 @@ using DeviceTransportMgr =
 #if CONFIG_NETWORK_LAYER_BLE
                  ,
                  Transport::BLE<kMaxDeviceTransportBlePendingPackets> /* BLE */
+#endif
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                 ,
+                 Transport::TCP<kMaxDeviceTransportTcpActiveConnectionCount, kMaxDeviceTransportTcpPendingPackets>
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                  ,

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -44,11 +44,6 @@ void TransportMgrBase::TCPDisconnect(Transport::ActiveTCPConnectionState * conn,
 {
     mTransport->TCPDisconnect(conn, shouldAbort);
 }
-
-bool TransportMgrBase::IsServerListenEnabled()
-{
-    return mTransport->IsServerListenEnabled();
-}
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
 CHIP_ERROR TransportMgrBase::Init(Transport::Base * transport)

--- a/src/transport/TransportMgrBase.h
+++ b/src/transport/TransportMgrBase.h
@@ -50,8 +50,6 @@ public:
 
     void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0);
 
-    bool IsServerListenEnabled();
-
     void HandleConnectionReceived(Transport::ActiveTCPConnectionState * conn) override;
 
     void HandleConnectionAttemptComplete(Transport::ActiveTCPConnectionState * conn, CHIP_ERROR conErr) override;

--- a/src/transport/raw/Base.h
+++ b/src/transport/raw/Base.h
@@ -114,8 +114,6 @@ public:
      * Disconnect on the active connection that is passed in.
      */
     virtual void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0) {}
-
-    virtual bool IsServerListenEnabled() { return true; }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -78,14 +78,12 @@ CHIP_ERROR TCPBase::Init(TcpListenParameters & params)
 
     mEndpointType = params.GetAddressType();
 
-    mIsServerListenEnabled = params.IsServerListenEnabled();
-
     // Primary socket endpoint created to help get EndPointManager handle for creating multiple
     // connection endpoints at runtime.
     err = params.GetEndPointManager()->NewEndPoint(&mListenSocket);
     SuccessOrExit(err);
 
-    if (mIsServerListenEnabled)
+    if (params.IsServerListenEnabled())
     {
         err = mListenSocket->Bind(params.GetAddressType(), Inet::IPAddress::Any, params.GetListenPort(),
                                   params.GetInterfaceId().IsPresent());
@@ -675,11 +673,6 @@ void TCPBase::TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool sho
     {
         CloseConnectionInternal(conn, CHIP_NO_ERROR, SuppressCallback::Yes);
     }
-}
-
-bool TCPBase::IsServerListenEnabled()
-{
-    return mIsServerListenEnabled;
 }
 
 bool TCPBase::HasActiveConnections() const

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -187,8 +187,6 @@ public:
     // and release from the pool.
     void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = false) override;
 
-    bool IsServerListenEnabled();
-
     bool CanSendToPeer(const PeerAddress & address) override
     {
         return (mState == TCPState::kInitialized) && (address.GetTransportType() == Type::kTcp) &&
@@ -312,7 +310,6 @@ private:
     Inet::TCPEndPoint * mListenSocket = nullptr;                       ///< TCP socket used by the transport
     Inet::IPAddressType mEndpointType = Inet::IPAddressType::kUnknown; ///< Socket listening type
     TCPState mState                   = TCPState::kNotReady;           ///< State of the TCP transport
-    bool mIsServerListenEnabled       = true;                          ///< TCP Server mode enabled
 
     // The configured timeout for the connection attempt to the peer, before
     // giving up.

--- a/src/transport/raw/TCP.h
+++ b/src/transport/raw/TCP.h
@@ -187,7 +187,7 @@ public:
     // and release from the pool.
     void TCPDisconnect(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = false) override;
 
-    bool IsServerListenEnabled() override;
+    bool IsServerListenEnabled();
 
     bool CanSendToPeer(const PeerAddress & address) override
     {

--- a/src/transport/raw/Tuple.h
+++ b/src/transport/raw/Tuple.h
@@ -107,7 +107,6 @@ public:
         return TCPDisconnectImpl<0>(conn, shouldAbort);
     }
 
-    bool IsServerListenEnabled() override { return IsServerListenEnabledImpl<0>(); }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     void Close() override { return CloseImpl<0>(); }
@@ -224,18 +223,6 @@ private:
     template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
     void TCPDisconnectImpl(Transport::ActiveTCPConnectionState * conn, bool shouldAbort = 0)
     {}
-
-    template <size_t N, typename std::enable_if<(N < sizeof...(TransportTypes))>::type * = nullptr>
-    bool IsServerListenEnabledImpl()
-    {
-        return std::get<N>(mTransports).IsServerListenEnabled() || IsServerListenEnabledImpl<N + 1>();
-    }
-
-    template <size_t N, typename std::enable_if<(N >= sizeof...(TransportTypes))>::type * = nullptr>
-    bool IsServerListenEnabledImpl()
-    {
-        return false;
-    }
 #endif // INET_CONFIG_ENABLE_TCP_ENDPOINT
 
     /**

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -555,29 +555,26 @@ TEST_F(TestTCP, CheckSimpleInitTest6)
 TEST_F(TestTCP, InitializeAsTCPClient)
 {
     TCPImpl tcp;
-
-    CHIP_ERROR err = tcp.Init(Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager())
-                                  .SetAddressType(IPAddressType::kIPv6)
-                                  .SetListenPort(gChipTCPPort)
-                                  .SetServerListenEnabled(false));
+    auto tcpListenParams = Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager());
+    CHIP_ERROR err =
+        tcp.Init(tcpListenParams.SetAddressType(IPAddressType::kIPv6).SetListenPort(gChipTCPPort).SetServerListenEnabled(false));
 
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    bool isServerEnabled = tcp.IsServerListenEnabled();
+    bool isServerEnabled = tcpListenParams.IsServerListenEnabled();
     EXPECT_EQ(isServerEnabled, false);
 }
 
 TEST_F(TestTCP, InitializeAsTCPClientServer)
 {
     TCPImpl tcp;
+    auto tcpListenParams = Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager());
 
-    CHIP_ERROR err = tcp.Init(Transport::TcpListenParameters(mIOContext->GetTCPEndPointManager())
-                                  .SetAddressType(IPAddressType::kIPv6)
-                                  .SetListenPort(gChipTCPPort));
+    CHIP_ERROR err = tcp.Init(tcpListenParams.SetAddressType(IPAddressType::kIPv6).SetListenPort(gChipTCPPort));
 
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
-    bool isServerEnabled = tcp.IsServerListenEnabled();
+    bool isServerEnabled = tcpListenParams.IsServerListenEnabled();
     EXPECT_EQ(isServerEnabled, true);
 }
 


### PR DESCRIPTION
Address post-merge comments from PR #36979.

Keep original order of raw transports in the TransportMgr tuple because it is part of the public API on the controller side.

When setting the TCPServerListen flag in DnssdServer, use the same value as in TcpListenParams directly, instead of fetching from the TransportMgr.

#### Testing
