### PR TITLE
tv-casting-app fix double call to OnCompleted() on connection success

### DIFF
--- a/examples/tv-casting-app/APIs.md
+++ b/examples/tv-casting-app/APIs.md
@@ -71,13 +71,20 @@ In order to illustrate these steps, refer to the figure below
 The Casting Client is expected to consume the Matter TV Casting library built
 for its respective platform which implements the APIs described in this
 document. Refer to the tv-casting-app READMEs for [Linux](linux/README.md),
-Android and [iOS](darwin/TvCasting/README.md) to understand how to build and
-consume each platform's specific libraries. The libraries MUST be built with the
+[Android](https://github.com/project-chip/connectedhomeip/blob/master/examples/tv-casting-app/android/README.md)
+and [iOS](darwin/TvCasting/README.md) to understand how to build and consume
+each platform's specific libraries. The libraries MUST be built with the
 client's specific values for `CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID` and
 `CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID` updated in the
 [CHIPProjectAppConfig.h](tv-casting-common/include/CHIPProjectAppConfig.h) file.
 Other values like the `CHIP_DEVICE_CONFIG_DEVICE_NAME` may be updated as well to
 correspond to the client being built.
+
+`CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID` and `CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID`
+can be obtained during the CSA certification of your mobile app. The Matter SDK
+has pre-configured sample/test values for them in the
+[CHIPDeviceConfig.h](https://github.com/project-chip/connectedhomeip/blob/master/src/include/platform/CHIPDeviceConfig.h)
+file.
 
 ### Initialize the Casting Client
 

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -211,7 +211,7 @@ public class ConnectionExampleFragment extends Fragment {
 
                       FragmentActivity activity = getActivity();
                       // Prevent possible NullPointerException. This callback could be called when
-                      // this Fragment is not attached to its host activity or when the fragment's
+                      // this fragment is not attached to its host activity or when the fragment's
                       // lifecycle is not in a valid state for interacting with the activity.
                       if (activity != null && !activity.isFinishing()) {
                         activity.runOnUiThread(

--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -7,6 +7,10 @@ commissioning mode, advertises itself as a Commissionable Node and gets
 commissioned. Then it allows the user to send Matter ContentLauncher commands to
 the TV.
 
+Refer to the
+[Matter Casting APIs documentation](https://project-chip.github.io/connectedhomeip-doc/examples/tv-casting-app/APIs.html)
+to build the Matter “Casting Client” into your consumer-facing mobile app.
+
 <hr>
 
 -   [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
@@ -15,6 +19,8 @@ the TV.
         -   [Gradle \& JDK Version](#gradle--jdk-version)
     -   [Preparing for build](#preparing-for-build)
     -   [Building \& Installing the app](#building--installing-the-app)
+    -   [Common build environment issues](#common-build-environment-issues)
+    -   [Running the app](#running-the-app)
 
 <hr>
 
@@ -50,10 +56,24 @@ We are using Gradle 7.1.1 for all android project which does not support Java 17
 (https://docs.gradle.org/current/userguide/compatibility.html) while the default
 JDK version on MacOS for Apple Silicon is 'openjdk 17.0.1' or above.
 
-Using JDK bundled with Android Studio will help with that.
+If you attempt to build with an incompatible Java version, you may encounter the
+following error:
+
+```text
+Unsupported class file major version XX
+```
+
+This error occurs when the Java version being used is not compatible with the
+Gradle version in your project.
+
+See the
+[Building Android](../../../docs/platforms/android/android_building.md#gradle--jdk-version)
+guide for more info about the supported Gradle & JDK Version.
+
+You can verify your current Java version by running:
 
 ```shell
-export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home/
+java -version
 ```
 
 <hr>
@@ -107,3 +127,23 @@ adb install out/android-$TARGET_CPU-tv-casting-app/outputs/apk/debug/app-debug.a
 You can use Android Studio to edit the Android app itself and run it after
 build_examples.py, but you will not be able to edit Matter Android code from
 `src/controller/java`, or other Matter C++ code within Android Studio.
+
+## Common build environment issues
+
+1. If you see an error like `kotlinc: command not found`, install the Kotlin in
+   your build environment. Eg. on MacOS, this can be done with the command:
+
+```shell
+brew install kotlin
+```
+
+## Running the app
+
+This example Matter TV Casting Android app can be tested with the following
+video players:
+
+1. With the
+   [example Matter tv-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/tv-app)
+   running on a Raspberry Pi - works out of the box.
+2. With a FireTV device - requires your Amazon Customer ID to be allow-listed
+   first.

--- a/examples/tv-casting-app/darwin/TvCasting/README.md
+++ b/examples/tv-casting-app/darwin/TvCasting/README.md
@@ -7,6 +7,10 @@ commissioning mode, advertises itself as a Commissionable Node and gets
 commissioned. Then it allows the user to send Matter ContentLauncher commands to
 the TV.
 
+Refer to the
+[Matter Casting APIs documentation](https://project-chip.github.io/connectedhomeip-doc/examples/tv-casting-app/APIs.html)
+to build the Matter “Casting Client” into your consumer-facing mobile app.
+
 ---
 
 -   [Matter TV Casting iOS App Example](#matter-tv-casting-ios-app-example)
@@ -14,6 +18,8 @@ the TV.
         -   [Building through command line](#building-through-command-line)
         -   [Compilation Fixes](#compilation-fixes)
     -   [Installing the Application](#installing-the-application)
+    -   [Debugging](#debugging)
+    -   [Running the Application](#running-the-application)
 
 ---
 
@@ -98,3 +104,14 @@ the run button once more.
 
 Use the "TvCasting" scheme when building to enable debugging. If you wish to
 build the app without any debugging symbols, use the "TvCasting Release" scheme.
+
+## Running the Application
+
+This example Matter TV Casting iOS application can be tested with the following
+video players:
+
+1. With the
+   [example Matter tv-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/tv-app)
+   running on a Raspberry Pi - works out of the box.
+2. With a FireTV device - requires your Amazon Customer ID to be allow-listed
+   first.

--- a/examples/tv-casting-app/linux/README.md
+++ b/examples/tv-casting-app/linux/README.md
@@ -6,6 +6,10 @@ select one, sends the TV a User Directed Commissioning request, enters
 commissioning mode, advertises itself as a Commissionable Node and gets
 commissioned. Then it allows the user to send CHIP commands to the TV.
 
+Refer to the
+[Matter Casting APIs documentation](https://project-chip.github.io/connectedhomeip-doc/examples/tv-casting-app/APIs.html)
+to build the Matter “Casting Client” into your consumer-facing mobile app.
+
 <hr>
 
 -   [CHIP TV Casting App Example](#chip-tv-casting-app-example)
@@ -63,10 +67,15 @@ commissioned. Then it allows the user to send CHIP commands to the TV.
 
 ### Commissioning the tv-casting-app
 
-The tv-casting-app will automatically discover video players and print these out
-upon startup. The user-directed-commissioning (UDC) process can be initiated
-using the shell by specifying the index of the discovered video player in the
-printed list.
+This example Matter TV Casting iOS application can be tested with the following
+video players:
+
+1. With the
+   [example Matter tv-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/tv-app)
+   running on a Raspberry Pi - works out of the box. The tv-casting-app will
+   automatically discover video players and print these out upon startup. The
+   user-directed-commissioning (UDC) process can be initiated using the shell by
+   specifying the index of the discovered video player in the printed list.
 
 -   Initiate UDC for the discovered video player with index 0
 
@@ -80,6 +89,9 @@ printed list.
 -   Re-run commissioner discovery
 
         tv-casting-app> cast discover
+
+2. With a FireTV device - requires your Amazon Customer ID to be allow-listed
+   first.
 
 ### Re-Running the Example on Linux with Cached Fabrics
 

--- a/examples/tv-casting-app/linux/simple-app-helper.cpp
+++ b/examples/tv-casting-app/linux/simple-app-helper.cpp
@@ -318,12 +318,15 @@ void ConnectionHandler(CHIP_ERROR err, matter::casting::core::CastingPlayer * ca
             castingPlayer->GetId(), endpoints[index]->GetId());
 
         // demonstrate invoking a command
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling InvokeContentLauncherLaunchURL()");
         InvokeContentLauncherLaunchURL(endpoints[index]);
 
         // demonstrate reading an attribute
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling ReadApplicationBasicVendorID()");
         ReadApplicationBasicVendorID(endpoints[index]);
 
         // demonstrate subscribing to an attribute
+        ChipLogProgress(AppServer, "simple-app-helper.cpp::ConnectionHandler() calling SubscribeToMediaPlaybackCurrentState()");
         SubscribeToMediaPlaybackCurrentState(endpoints[index]);
     }
     else

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -44,6 +44,7 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
     if (event->Type == chip::DeviceLayer::DeviceEventType::kFailSafeTimerExpired &&
         CastingPlayer::GetTargetCastingPlayer()->mConnectionState == CASTING_PLAYER_CONNECTING)
     {
+        ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() event kFailSafeTimerExpired");
         HandleFailSafeTimerExpired();
     }
     else if (event->Type == chip::DeviceLayer::DeviceEventType::kBindingsChangedViaCluster &&
@@ -53,16 +54,19 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
     }
     else if (event->Type == chip::DeviceLayer::DeviceEventType::kCommissioningComplete)
     {
+        // True when device completes initial commissioning (PASE).
+        // Note: Not triggered for subsequent CASE sessions established via CastingPlayer::FindOrEstablishSession()
         HandleCommissioningComplete(event, arg, runPostCommissioning, targetNodeId, targetFabricIndex);
     }
 
+    // Run post commissioing for kBindingsChangedViaCluster and kCommissioningComplete events.
     if (runPostCommissioning)
     {
         sUdcInProgress = false;
         CastingPlayer::GetTargetCastingPlayer()->SetNodeId(targetNodeId);
         CastingPlayer::GetTargetCastingPlayer()->SetFabricIndex(targetFabricIndex);
 
-        ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() calling FindOrEstablishSession()");
+        ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() calling CastingPlayer FindOrEstablishSession()");
         CastingPlayer::GetTargetCastingPlayer()->FindOrEstablishSession(
             nullptr,
             [](void * context, chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle) {


### PR DESCRIPTION
Fix double call to OnCompleted() simple-app-helper.cpp::ConnectionHandler(): Successfully connected to CastingPlayer (ID: 88665A3712045650). 
OnCompleted() should not be called when the node/CastingPlayer does not have any endpoints loaded.
Update examples/tv-casting-app APIs.md and README.md.

### Change summary
1.	Updated connectedhomeip/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp Complete() method to call the connectedhomeip/examples/tv-casting-app/linux/simple-app-helper.cpp ConnectionHandler() method when the target CastingPlayer has 1 or more loaded endpoints. 
2.	After successful commissioning (PASE session) with a node/CastingPLayer there is an additional step to load the CastingPlayer’s endpoints/clusters before we can read any attributes or invoke commands.
3.	Update examples/tv-casting-app APIs.md and the platform’s README.md quoting the main build error messages and potential root causes/resolutions. 

### Testing

Verified and tested locally with the Linux tv-casting-app (mobile app) and the Linux tv-app (CastingPlayer). Able to build and commission with the example app using both the commissionee and commissioner generated passcode flows. Able to re-establish connection with a CastingPlayer which has already been commissioned. 

Commissioning logs before and after the fix (first time commissioning and re-connect):

[before1stAttempt.log](https://github.com/user-attachments/files/18402577/before1stAttempt.log)
[before2ndAttempt.log](https://github.com/user-attachments/files/18402578/before2ndAttempt.log)
[fix1stAttempt.log](https://github.com/user-attachments/files/18402579/fix1stAttempt.log)
[fix2ndAttempt.log](https://github.com/user-attachments/files/18402580/fix2ndAttempt.log)

