### PR TITLE
[ESP32]: increment the total operational hours inline without log

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -58,6 +58,8 @@ uint32_t ConfigurationManagerImpl::mTotalOperationalHours = 0;
 
 void ConfigurationManagerImpl::TotalOperationalHoursTimerCallback(TimerHandle_t timer)
 {
+    // This function is called from the FreeRTOS timer task. Since the task stack is limited,
+    // we avoid logging error messages here to prevent stack overflows.
     (void) ConfigurationMgrImpl().StoreTotalOperationalHours(++mTotalOperationalHours);
 }
 
@@ -176,6 +178,9 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     }
 
     {
+        // The total-operational-hours is critical information. It intentionally uses the FreeRTOS timer
+        // to increment the value, this ensures it is not affected by PostEvent failures.
+
         // Start a timer which reloads every one hour and bumps the total operational hours
         TickType_t reloadPeriod   = (1000 * 60 * 60) / portTICK_PERIOD_MS;
         TimerHandle_t timerHandle = xTimerCreate("tOpHrs", reloadPeriod, pdPASS, nullptr, TotalOperationalHoursTimerCallback);

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -58,7 +58,7 @@ uint32_t ConfigurationManagerImpl::mTotalOperationalHours = 0;
 
 void ConfigurationManagerImpl::TotalOperationalHoursTimerCallback(TimerHandle_t timer)
 {
-    (void)ConfigurationMgrImpl().StoreTotalOperationalHours(++mTotalOperationalHours);
+    (void) ConfigurationMgrImpl().StoreTotalOperationalHours(++mTotalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::Init()

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -30,6 +30,7 @@
 #include <platform/ConfigurationManager.h>
 #include <platform/ESP32/ESP32Config.h>
 #include <platform/ESP32/ESP32Utils.h>
+#include <platform/ESP32/ScopedNvsHandle.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
@@ -57,14 +58,7 @@ uint32_t ConfigurationManagerImpl::mTotalOperationalHours = 0;
 
 void ConfigurationManagerImpl::TotalOperationalHoursTimerCallback(TimerHandle_t timer)
 {
-    mTotalOperationalHours++;
-
-    CHIP_ERROR err = ConfigurationMgrImpl().StoreTotalOperationalHours(mTotalOperationalHours);
-
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to store total operational hours: %" CHIP_ERROR_FORMAT, err.Format());
-    }
+    (void)ConfigurationMgrImpl().StoreTotalOperationalHours(++mTotalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
@@ -226,7 +220,13 @@ CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOp
 
 CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
 {
-    return WriteConfigValue(ESP32Config::kCounterKey_TotalOperationalHours, totalOperationalHours);
+    ScopedNvsHandle handle;
+    ESP32Config::Key key = ESP32Config::kCounterKey_TotalOperationalHours;
+
+    ReturnErrorOnFailure(handle.Open(key.Namespace, NVS_READWRITE, ESP32Config::GetPartitionLabelByNamespace(key.Namespace)));
+    ReturnMappedErrorOnFailure(nvs_set_u32(handle, key.Name, totalOperationalHours));
+    ReturnMappedErrorOnFailure(nvs_commit(handle));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t bufSize)

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -132,7 +132,6 @@ public:
 
     static void RunConfigUnitTest(void);
 
-private:
     static const char * GetPartitionLabelByNamespace(const char * ns);
 };
 


### PR DESCRIPTION
Since total-operational-hours is a critical information, it intentionally uses the FreeRTOS timer to increment the values, so that it should not be a victim of PostEvent failures.

Earlier it used to call WriteConfigValues which has the ChipLogProgress and logging from the timer stack may overflow the timer stack. So, inlined the implementation which do not log.

#### Testing
- Read the total-operational-hours using chip-tool and verified the correct value is being received, on first boot and post-reboot. (NOTE: adjusted the timer values to verify this)