### PR TITLE
[ESP32]fix crash issue which caused by data model init after thread stack init in examples

### DIFF
--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -210,9 +210,10 @@ extern "C" void app_main()
     {
         ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed : %" CHIP_ERROR_FORMAT, error.Format());
     }
-    ESPOpenThreadInit();
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 }
 
 bool lowPowerClusterSleep()

--- a/examples/all-clusters-minimal-app/esp32/main/main.cpp
+++ b/examples/all-clusters-minimal-app/esp32/main/main.cpp
@@ -186,8 +186,9 @@ extern "C" void app_main()
         ESP_LOGE(TAG, "GetAppTask().StartAppTask() failed : %" CHIP_ERROR_FORMAT, error.Format());
     }
 
-    ESPOpenThreadInit();
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 }
 
 bool lowPowerClusterSleep()

--- a/examples/energy-management-app/esp32/main/main.cpp
+++ b/examples/energy-management-app/esp32/main/main.cpp
@@ -294,7 +294,8 @@ extern "C" void app_main()
 #endif
 
     SetDeviceAttestationCredentialsProvider(get_dac_provider());
-    ESPOpenThreadInit();
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 }

--- a/examples/light-switch-app/esp32/main/main.cpp
+++ b/examples/light-switch-app/esp32/main/main.cpp
@@ -19,6 +19,7 @@
 #include "DeviceCallbacks.h"
 #include <common/CHIPDeviceManager.h>
 #include <common/Esp32AppServer.h>
+#include <common/Esp32ThreadInit.h>
 
 #include "AppTask.h"
 #include "BindingHandler.h"
@@ -135,20 +136,9 @@ extern "C" void app_main()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
 
-#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-    if (DeviceLayer::ThreadStackMgr().InitThreadStack() != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Failed to initialize Thread stack");
-        return;
-    }
-    if (DeviceLayer::ThreadStackMgr().StartThreadTask() != CHIP_NO_ERROR)
-    {
-        ESP_LOGE(TAG, "Failed to launch Thread task");
-        return;
-    }
-#endif
-
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 
     error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -210,9 +210,10 @@ extern "C" void app_main()
 #endif
 
     SetDeviceAttestationCredentialsProvider(get_dac_provider());
-    ESPOpenThreadInit();
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 
     error = GetAppTask().StartAppTask();
     if (error != CHIP_NO_ERROR)

--- a/examples/lit-icd-app/esp32/main/main.cpp
+++ b/examples/lit-icd-app/esp32/main/main.cpp
@@ -130,10 +130,11 @@ extern "C" void app_main()
 #else
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-    ESPOpenThreadInit();
     static UatButton sButton;
     sButton.Init(UAT_GPIO, ESP_EXT1_WAKEUP_ANY_LOW);
     sButton.SetUatButtonPressCallback(UatButtonHandler);
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 }

--- a/examples/thread-br-app/esp32/main/main.cpp
+++ b/examples/thread-br-app/esp32/main/main.cpp
@@ -149,9 +149,10 @@ extern "C" void app_main()
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
     esp_openthread_set_backbone_netif(esp_netif_get_handle_from_ifkey("WIFI_STA_DEF"));
-    ESPOpenThreadInit();
 
     chip::DeviceLayer::PlatformMgr().ScheduleWork(InitServer, reinterpret_cast<intptr_t>(nullptr));
+
+    ESPOpenThreadInit();
 }
 
 extern "C" void otSysProcessDrivers(otInstance * aInstance)


### PR DESCRIPTION
In the original logic, the data model provider was initialized after the OpenThread stack was initialized. However, during Thread network connection after OpenThread initialization, the content initialized by the data model provider would be invoked, but at that time, it had not yet been initialized, which could lead to a crash. Therefore, in this PR, the OpenThread stack initialization is moved to occur after the data model provider initialization.

#### Testing
Tested on lighting-app example with esp32h2, after pairing with ble-thread, then reset the device, the device can run without crash. 