### PR TITLE
Fix GH Actions job to run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/cancel_workflows_for_pr.yaml
+++ b/.github/workflows/cancel_workflows_for_pr.yaml
@@ -35,15 +35,16 @@ jobs:
                 python-version: '3.12'
             - name: Setup pip modules we use
               run: |
-                  pip install         \
+                  python3 -m venv venv
+                  venv/bin/pip3 install \
                       click           \
                       coloredlogs     \
                       python-dateutil \
                       pygithub        \
-                      && echo "DONE installint python prerequisites"
+                      && echo "DONE installing python prerequisites"
             - name: Cancel runs
               run: |
-                  scripts/tools/cancel_workflows_for_pr.py       \
+                  venv/bin/python3 scripts/tools/cancel_workflows_for_pr.py \
                     --gh-api-token "${{ secrets.GITHUB_TOKEN }}" \
                     --require "Restyled"       \
                     --require "Lint Code Base" \

--- a/.github/workflows/docbuild.yaml
+++ b/.github/workflows/docbuild.yaml
@@ -29,17 +29,19 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.12
           cache-dependency-path: matter/docs/requirements.txt
           cache: pip
       - name: Install base dependencies
         working-directory: matter
         run: |
-          sudo pip3 install -U pip
-          pip3 install -r docs/requirements.txt
+          python3 -m venv venv
+          venv/bin/pip3 install -U pip
+          venv/bin/pip3 install -r docs/requirements.txt
       - name: Build documentation
         working-directory: matter/docs
         run: |
+          source ../venv/bin/activate
           mkdir -p _build/src
           make html
           touch _build/html/.nojekyll

--- a/.github/workflows/docbuild.yaml
+++ b/.github/workflows/docbuild.yaml
@@ -36,7 +36,6 @@ jobs:
         working-directory: matter
         run: |
           python3 -m venv venv
-          venv/bin/pip3 install -U pip
           venv/bin/pip3 install -r docs/requirements.txt
       - name: Build documentation
         working-directory: matter/docs

--- a/.github/workflows/protocol_compatibility.yaml
+++ b/.github/workflows/protocol_compatibility.yaml
@@ -30,11 +30,11 @@ jobs:
        - name: Setup python
          uses: actions/setup-python@v5
          with:
-           python-version: 3.11
+           python-version: 3.12
        - name: Install dependencies
          run: |
-           python -m pip install --upgrade pip
-           pip install click coloredlogs lark
+           python3 -m venv venv
+           venv/bin/pip3 install click coloredlogs lark
        - name: Create old/new copies
          run: |
            mkdir -p out
@@ -45,5 +45,4 @@ jobs:
            patch -p1 <out/patch.diff
        - name: Check backwards compatibility
          run: |
-           scripts/backwards_compatibility_checker.py out/old_version.matter out/new_version.matter
-
+           venv/bin/python3 scripts/backwards_compatibility_checker.py out/old_version.matter out/new_version.matter


### PR DESCRIPTION
Github is scheduled to finish upgrading the 'ubuntu-latest' workers to Ubuntu 24.04 on 2025-01-17 (https://github.com/actions/runner-images/issues/10636).

Current docbuild job fails on a ubuntu-24.04 runner as can be evidenced by a failed run on my fork (https://github.com/enkiusz/connectedhomeip/actions/runs/12765165078/job/35578813277).
The reason for this is that built-in pip is no longer allowed to upgrade itself. I altered this job to use a venv instead.

Additionally, I bumped the Python version.

#### Testing

The new job has ran successfully on ubuntu-24.04 (https://github.com/enkiusz/connectedhomeip/actions/runs/12767259766/job/35585278460) and ubuntu 22.04 (https://github.com/enkiusz/connectedhomeip/actions/runs/12767352931/job/35585563551).
