### PR TITLE
Patch unsafe strlen in TLVWriter

### DIFF
--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -292,7 +292,7 @@ CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf)
 {
     if (buf == nullptr)
         return CHIP_ERROR_INVALID_ARGUMENT;
-    else if (mMaxLen == 0)
+    if (mMaxLen == 0)
         return CHIP_ERROR_INCORRECT_STATE;
 
     // Calculate length with a hard limit to prevent unbounded reads.
@@ -309,8 +309,7 @@ CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf)
     // Null terminator was not found within the allocated space.
     if (stringLen == mMaxLen)
         return CHIP_ERROR_BUFFER_TOO_SMALL;
-    else
-        return PutString(tag, buf, stringLen);
+    return PutString(tag, buf, stringLen);
 }
 
 CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf, uint32_t len)

--- a/src/lib/core/TLVWriter.cpp
+++ b/src/lib/core/TLVWriter.cpp
@@ -295,9 +295,10 @@ CHIP_ERROR TLVWriter::PutString(Tag tag, const char * buf)
     else if (mMaxLen == 0)
         return CHIP_ERROR_INCORRECT_STATE;
 
-    // No length is provided, so we cannot assume a well-formed C string.
-    // Use the container size as the limit when dereferencing the buffer.
-    // This may exceed mRemainingLen in CircularTLVWriter, so use mMaxLen.
+    // Calculate length with a hard limit to prevent unbounded reads.
+    // Use mMaxLen instead of mRemainingLen to account for CircularTLVWriter.
+    // Note: Overrun is still possible if buf is not null-terminated, and this
+    // check cannot prevent all invalid memory reads.
     size_t len = strnlen(buf, mMaxLen);
 
     if (!CanCastTo<uint32_t>(len))

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -2608,7 +2608,7 @@ TEST_F(TestTLV, CheckCircularTLVBufferEdge)
 
 TEST_F(TestTLV, CheckTLVPutStringOverrun)
 {
-    const size_t bufSize = 8;
+    const size_t bufSize          = 8;
     uint8_t backingStore[bufSize] = {};
 
     const char * badPointer = "Foo <segfault here>";

--- a/src/lib/core/tests/TestTLV.cpp
+++ b/src/lib/core/tests/TestTLV.cpp
@@ -2605,6 +2605,22 @@ TEST_F(TestTLV, CheckCircularTLVBufferEdge)
 
     TestEnd<TLVReader>(reader);
 }
+
+TEST_F(TestTLV, CheckTLVPutStringOverrun)
+{
+    const size_t bufSize = 8;
+    uint8_t backingStore[bufSize] = {};
+
+    const char * badPointer = "Foo <segfault here>";
+
+    TLVWriter writer;
+
+    writer.Init(backingStore, bufSize);
+
+    CHIP_ERROR err = writer.PutString(ProfileTag(TestProfile_1, 1), badPointer);
+    EXPECT_EQ(err, CHIP_ERROR_BUFFER_TOO_SMALL);
+}
+
 TEST_F(TestTLV, CheckTLVPutStringF)
 {
     const size_t bufsize = 24;


### PR DESCRIPTION
This is a vulnerability from Weave that was recently fixed. Apply the patch to Matter TLVWriter as well. This avoids reading bad pointers beyond stack-allocated memory.

> One of the PutString function overloads makes a call to strlen
> without safeguards. This has caused faults on several products when
> passing in uninitialized memory. While these call sites have been
> fixed with explicit initialization, we can also make the core
> library more secure. Use the container to determine a maximum length
> and avoid buffer overflow.

#### Testing

* Verified that device builds crashing on TLV serialization due to strings without proper null termination are now fixed.
* Added a unit test