### PR TITLE
Shutdown subscriptions before shutting down CHIP stack

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -1581,8 +1581,7 @@ class ChipDeviceControllerBase():
 
         if result := transaction.GetSubscriptionHandler():
             return result
-        else:
-            return transaction.GetReadResponse()
+        return transaction.GetReadResponse()
 
     async def ReadAttribute(
         self,

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -184,10 +184,10 @@ class ChipStack(object):
         return self._enableServerInteractions
 
     def RegisterSubscription(self, subscription: ClusterAttribute.SubscriptionTransaction):
-        self._subscriptions[subscription.subscriptionId] = subscription
+        self._subscriptions[id(subscription)] = subscription
 
     def UnregisterSubscription(self, subscription: ClusterAttribute.SubscriptionTransaction):
-        del self._subscriptions[subscription.subscriptionId]
+        del self._subscriptions[id(subscription)]
 
     def Shutdown(self):
 

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -191,7 +191,10 @@ class ChipStack(object):
 
     def Shutdown(self):
 
-        # Shutdown all subscriptions before shutting down the stack.
+        # Shutdown all subscriptions before shutting down the stack. Please note it is not
+        # possible to directly iterate over the dictionary values, because when the subscription
+        # is shut down, it will remove itself from the dictionary - causing the iterator to be
+        # invalidated. Hence, we need to create a local copy of the values before iterating.
         for subscription in tuple(self._subscriptions.values()):
             subscription.Shutdown()
 

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -28,7 +28,6 @@ from __future__ import absolute_import, print_function
 
 import asyncio
 import builtins
-import os
 from ctypes import CFUNCTYPE, Structure, c_bool, c_char_p, c_uint16, c_uint32, c_void_p, py_object, pythonapi
 from threading import Condition, Lock
 from typing import Any, Optional
@@ -259,16 +258,6 @@ class ChipStack(object):
     def LocateChipDLL(self):
         self._loadLib()
         return self._chipDLLPath
-
-    # ----- Private Members -----
-    def _AllDirsToRoot(self, dir):
-        dir = os.path.abspath(dir)
-        while True:
-            yield dir
-            parent = os.path.dirname(dir)
-            if parent == "" or parent == dir:
-                break
-            dir = parent
 
     def _loadLib(self):
         if self._ChipStackLib is None:

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -448,6 +448,7 @@ class SubscriptionTransaction:
             SubscriptionTransaction], None]] = None
         self._onResubscriptionSucceededCb_isAsync = False
         self._onResubscriptionAttemptedCb_isAsync = False
+        builtins.chipStack.RegisterSubscription(self)
 
     def GetAttributes(self):
         ''' Returns the attribute value cache tracking the latest state on the publisher.
@@ -578,12 +579,13 @@ class SubscriptionTransaction:
         return self._subscriptionId
 
     def Shutdown(self):
-        if (self._isDone):
+        if self._isDone:
             LOGGER.warning(
                 "Subscription 0x%08x was already terminated previously!", self.subscriptionId)
             return
 
         handle = chip.native.GetLibraryHandle()
+        builtins.chipStack.UnregisterSubscription(self)
         builtins.chipStack.Call(
             lambda: handle.pychip_ReadClient_ShutdownSubscription(
                 self._readTransaction._pReadClient))
@@ -779,7 +781,7 @@ class AsyncReadTransaction:
         pass
 
     def _handleReportEnd(self):
-        if (self._subscription_handler is not None):
+        if self._subscription_handler is not None:
             for change in self._changedPathSet:
                 try:
                     attribute_path = TypedAttributePath(Path=change)

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -591,9 +591,6 @@ class SubscriptionTransaction:
                 self._readTransaction._pReadClient))
         self._isDone = True
 
-    def __del__(self):
-        self.Shutdown()
-
     def __repr__(self):
         return f'<Subscription (Id={self._subscriptionId})>'
 
@@ -638,7 +635,7 @@ def _BuildEventIndex():
                         if inspect.isclass(event):
                             base_classes = inspect.getmro(event)
 
-                            # Only match on classes that extend the ClusterEventescriptor class
+                            # Only match on classes that extend the ClusterEvent class
                             matched = [
                                 value for value in base_classes if 'ClusterEvent' in str(value)]
                             if (matched == []):

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -556,7 +556,7 @@ class SubscriptionTransaction:
 
     def SetErrorCallback(self, callback: Callable[[int, SubscriptionTransaction], None]):
         '''
-        Sets the callback function in case a subscription error occured,
+        Sets the callback function in case a subscription error occurred,
         accepts a Callable accepts an error code and the cached data.
         '''
         if callback is not None:
@@ -766,7 +766,7 @@ class AsyncReadTransaction:
     def handleResubscriptionAttempted(self, terminationCause: PyChipError, nextResubscribeIntervalMsec: int):
         if not self._subscription_handler:
             return
-        if (self._subscription_handler._onResubscriptionAttemptedCb_isAsync):
+        if self._subscription_handler._onResubscriptionAttemptedCb_isAsync:
             self._event_loop.create_task(self._subscription_handler._onResubscriptionAttemptedCb(
                 self._subscription_handler, terminationCause.code, nextResubscribeIntervalMsec))
         else:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1022,8 +1022,8 @@ class BaseTestHelper:
     async def TestResubscription(self, nodeid: int):
         ''' This validates the re-subscription logic by triggering a liveness failure caused by the expiration
             of the underlying CASE session and the resultant failure to receive reports from the server. This should
-            trigger CASE session establishment and subscription restablishment. Both the attempt and successful
-            restablishment of the subscription are validated.
+            trigger CASE session establishment and subscription reestablishment. Both the attempt and successful
+            reestablishment of the subscription are validated.
         '''
         cv = asyncio.Condition()
         resubAttempted = False
@@ -1053,7 +1053,7 @@ class BaseTestHelper:
         subscription.SetResubscriptionSucceededCallback(OnResubscriptionSucceeded, True)
 
         #
-        # Over-ride the default liveness timeout (which is set quite high to accomodate for
+        # Over-ride the default liveness timeout (which is set quite high to accommodate for
         # transport delays) to something very small. This ensures that our liveness timer will
         # fire quickly and cause a re-subscription to occur naturally.
         #

--- a/src/python_testing/TC_ACE_1_2.py
+++ b/src/python_testing/TC_ACE_1_2.py
@@ -95,11 +95,11 @@ def WaitForEventReport(q: queue.Queue, expected_event: ClusterObjects.ClusterEve
 
 
 class TC_ACE_1_2(MatterBaseTest):
-    def __init__(self, *args):
+
+    def setup_class(self):
+        super().setup_class()
         self.breadcrumb = 1
         self.breadcrumb_queue = queue.Queue()
-        self.subscription_breadcrumb = None
-        super().__init__(*args)
 
     async def write_acl(self, acl):
         # This returns an attribute status
@@ -109,9 +109,11 @@ class TC_ACE_1_2(MatterBaseTest):
     async def steps_subscribe_breadcrumb(self, print_steps: bool):
         if print_steps:
             self.print_step(3, "TH2 subscribes to the Breadcrumb attribute")
-        self.subscription_breadcrumb = await self.TH2.ReadAttribute(nodeid=self.dut_node_id, attributes=[(0, Clusters.GeneralCommissioning.Attributes.Breadcrumb)], reportInterval=(1, 5), keepSubscriptions=False, autoResubscribe=False)
+        subscription_breadcrumb = await self.TH2.ReadAttribute(
+            nodeid=self.dut_node_id, attributes=[(0, Clusters.GeneralCommissioning.Attributes.Breadcrumb)],
+            reportInterval=(1, 5), keepSubscriptions=False, autoResubscribe=False)
         breadcrumb_cb = AttributeChangeCallback(Clusters.GeneralCommissioning.Attributes.Breadcrumb, self.breadcrumb_queue)
-        self.subscription_breadcrumb.SetAttributeUpdateCallback(breadcrumb_cb)
+        subscription_breadcrumb.SetAttributeUpdateCallback(breadcrumb_cb)
 
     async def steps_receive_breadcrumb(self, print_steps: bool):
         if print_steps:


### PR DESCRIPTION
#### Problem

During work on https://github.com/project-chip/connectedhomeip/pull/36859 I've discovered issue with `SubscriptionTransaction` lifetime management. Currently subscription is managed by Python garbage collector. The problem with that approach is that if the subscription is held by a global variable it might not be garbage collected before the CHIP stack is shut down. When the Python process is properly terminated (#36859 tries to do that) this might lead to:

```python
[TEST]Exception ignored in: <function SubscriptionTransaction.__del__ at 0x771e2bc096c0>
[TEST]Traceback (most recent call last):
[TEST]  File ".environment/pigweed-venv/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 597, in __del__
[TEST]    self.Shutdown()
[TEST]  File ".environment/pigweed-venv/lib/python3.12/site-packages/chip/clusters/Attribute.py", line 591, in Shutdown
[TEST]    builtins.chipStack.Call(
[TEST]    ^^^^^^^^^^^^^^^^^^
[TEST]AttributeError: module 'builtins' has no attribute 'chipStack'
```

#### Changes

- register all subscriptions in the `ChipStack` singleton and close them before stack is shut down
- do not shut down subscriptions on `__del__` which is error prone, prefer explicit lifetime management
- remove unused `_AllDirsToRoot`

#### Testing

Modified TC_ACE_1_2 to check whether subscription is not shut down when leaving scope. Locally tested with #36915 and #36859 (still WIP) that Python process terminates cleanly.