### PR TITLE
Try to reduce the codesize needed by EncodeListItem.

### DIFF
--- a/src/app/AttributeReportBuilder.h
+++ b/src/app/AttributeReportBuilder.h
@@ -58,19 +58,18 @@ public:
     /**
      * EncodeValue encodes the value field of the report, it should be called exactly once.
      */
-    template <typename T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, bool> = true, typename... Ts>
-    CHIP_ERROR EncodeValue(AttributeReportIBs::Builder & aAttributeReportIBs, TLV::Tag tag, T && item, Ts &&... aArgs)
+    template <typename T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, bool> = true>
+    CHIP_ERROR EncodeValue(AttributeReportIBs::Builder & aAttributeReportIBs, TLV::Tag tag, const T & item)
     {
-        return DataModel::Encode(*(aAttributeReportIBs.GetAttributeReport().GetAttributeData().GetWriter()), tag, item,
-                                 std::forward<Ts>(aArgs)...);
+        return DataModel::Encode(*(aAttributeReportIBs.GetAttributeReport().GetAttributeData().GetWriter()), tag, item);
     }
 
-    template <typename T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, bool> = true, typename... Ts>
-    CHIP_ERROR EncodeValue(AttributeReportIBs::Builder & aAttributeReportIBs, TLV::Tag tag, FabricIndex accessingFabricIndex,
-                           T && item, Ts &&... aArgs)
+    template <typename T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, bool> = true>
+    CHIP_ERROR EncodeValue(AttributeReportIBs::Builder & aAttributeReportIBs, TLV::Tag tag, const T & item,
+                           FabricIndex accessingFabricIndex)
     {
         return DataModel::EncodeForRead(*(aAttributeReportIBs.GetAttributeReport().GetAttributeData().GetWriter()), tag,
-                                        accessingFabricIndex, item, std::forward<Ts>(aArgs)...);
+                                        accessingFabricIndex, item);
     }
 };
 


### PR DESCRIPTION
We shouldn't need separate specializations of EncodeListItem for T, T&, const T, and const T&.  Try to collapse those all down to "const T&".

#### Testing

No functional changes expected; CI should check this.