### PR TITLE
adding matter_assert.py module for keeping matter-specific assertions

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -50,6 +50,7 @@ pw_python_package("chip-testing-module") {
   tests = [
     "chip/testing/test_metadata.py",
     "chip/testing/test_tasks.py",
+    "chip/testing/test_matter_asserts.py",
   ]
 }
 

--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -39,6 +39,7 @@ pw_python_package("chip-testing-module") {
     "chip/testing/choice_conformance.py",
     "chip/testing/conformance.py",
     "chip/testing/global_attribute_ids.py",
+    "chip/testing/matter_asserts.py",
     "chip/testing/matter_testing.py",
     "chip/testing/metadata.py",
     "chip/testing/pics.py",

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -1,0 +1,172 @@
+"""
+Matter-specific assertions building on top of Mobly asserts.
+"""
+
+from typing import Any, List, Optional, Type, TypeVar
+
+from mobly import asserts
+
+T = TypeVar('T')
+
+
+def assert_uint32(value: Any, description: str) -> None:
+    """
+    Asserts that the value is a valid uint32.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+
+    Raises:
+        AssertionError: If value is not an integer or outside the uint32 range (0 to 0xFFFFFFFF)
+    """
+    asserts.assert_true(isinstance(value, int), f"{description} must be an integer")
+    asserts.assert_true(0 <= value <= 0xFFFFFFFF, f"{description} must be between 0 and 0xFFFFFFFF")
+
+
+def assert_uint64(value: Any, description: str) -> None:
+    """
+    Asserts that the value is a valid uint64.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+
+    Raises:
+        AssertionError: If value is not an integer or outside the uint64 range (0 to 0xFFFFFFFFFFFFFFFF)
+    """
+    asserts.assert_true(isinstance(value, int), f"{description} must be an integer")
+    asserts.assert_true(0 <= value <= 0xFFFFFFFFFFFFFFFF, f"{description} must be between 0 and 0xFFFFFFFFFFFFFFFF")
+
+
+def assert_string(value: Any, description: str) -> None:
+    """
+    Asserts that the value is a string.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+
+    Raises:
+        AssertionError: If value is not a string
+    """
+    asserts.assert_true(isinstance(value, str), f"{description} must be a string")
+
+
+def assert_non_empty_string(value: Any, description: str) -> None:
+    """
+    Asserts that the value is a non-empty string.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+
+    Raises:
+        AssertionError: If value is not a string or is empty
+    """
+    assert_string(value, description)
+    asserts.assert_true(len(value) > 0, f"{description} cannot be empty")
+
+
+def assert_string_length(value: Any, description: str, min_length: Optional[int] = None, max_length: Optional[int] = None) -> None:
+    """
+    Asserts that the string length is within the specified bounds.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+        min_length: Optional minimum length (inclusive)
+        max_length: Optional maximum length (inclusive)
+
+    Raises:
+        AssertionError: If value is not a string or fails length constraints
+
+    Note:
+        - Use min_length=1 instead of assert_non_empty_string when you want to ensure non-emptiness
+        - Use min_length=None, max_length=None to only validate string type (same as assert_string)
+    """
+    assert_string(value, description)
+
+    if min_length is not None:
+        asserts.assert_true(len(value) >= min_length,
+                            f"{description} length must be at least {min_length} characters")
+
+    if max_length is not None:
+        asserts.assert_true(len(value) <= max_length,
+                            f"{description} length must not exceed {max_length} characters")
+
+
+def assert_list(value: Any, description: str, min_length: Optional[int] = None, max_length: Optional[int] = None) -> None:
+    """
+    Asserts that the value is a list with optional length constraints.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+        min_length: Optional minimum length (inclusive)
+        max_length: Optional maximum length (inclusive)
+
+    Raises:
+        AssertionError: If value is not a list or fails length constraints
+    """
+    asserts.assert_true(isinstance(value, list), f"{description} must be a list")
+
+    if min_length is not None:
+        asserts.assert_true(len(value) >= min_length, f"{description} must have at least {min_length} elements")
+
+    if max_length is not None:
+        asserts.assert_true(len(value) <= max_length, f"{description} must not exceed {max_length} elements")
+
+
+def assert_list_element_type(value: List[Any], description: str, expected_type: Type[T]) -> None:
+    """
+    Asserts that all elements in the list are of the expected type.
+
+    Args:
+        value: The list to validate
+        description: User-defined description for error messages
+        expected_type: The type that all elements should match
+
+    Raises:
+        AssertionError: If value is not a list or contains elements of wrong type
+    """
+    assert_list(value, description)
+    for i, item in enumerate(value):
+        asserts.assert_true(isinstance(item, expected_type),
+                            f"{description}[{i}] must be of type {expected_type.__name__}")
+
+
+def assert_string_matches_pattern(value: str, field_name: str, pattern: str) -> None:
+    """Asserts that the string matches the given regex pattern."""
+    import re
+    asserts.assert_true(isinstance(value, str), f"{field_name} must be a string")
+    asserts.assert_true(bool(re.match(pattern, value)),
+                        f"{field_name} must match pattern: {pattern}")
+
+
+def assert_valid_attribute_id(id: int, allow_test: bool = False) -> None:
+    """Asserts that the given ID is a valid attribute ID."""
+    from chip.testing.global_attribute_ids import is_valid_attribute_id
+    asserts.assert_true(is_valid_attribute_id(id, allow_test),
+                        f"Invalid attribute ID: {hex(id)}")
+
+
+def assert_standard_attribute_id(id: int) -> None:
+    """Asserts that the given ID is a standard attribute ID."""
+    from chip.testing.global_attribute_ids import is_standard_attribute_id
+    asserts.assert_true(is_standard_attribute_id(id),
+                        f"Not a standard attribute ID: {hex(id)}")
+
+
+def assert_valid_command_id(id: int, allow_test: bool = False) -> None:
+    """Asserts that the given ID is a valid command ID."""
+    from chip.testing.global_attribute_ids import is_valid_command_id
+    asserts.assert_true(is_valid_command_id(id, allow_test),
+                        f"Invalid command ID: {hex(id)}")
+
+
+def assert_standard_command_id(id: int) -> None:
+    """Asserts that the given ID is a standard command ID."""
+    from chip.testing.global_attribute_ids import is_standard_command_id
+    asserts.assert_true(is_standard_command_id(id),
+                        f"Not a standard command ID: {hex(id)}")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -8,6 +8,8 @@ from mobly import asserts
 
 T = TypeVar('T')
 
+# Integer assertions
+
 
 def assert_uint32(value: Any, description: str) -> None:
     """
@@ -21,7 +23,8 @@ def assert_uint32(value: Any, description: str) -> None:
         AssertionError: If value is not an integer or outside the uint32 range (0 to 0xFFFFFFFF)
     """
     asserts.assert_true(isinstance(value, int), f"{description} must be an integer")
-    asserts.assert_true(0 <= value <= 0xFFFFFFFF, f"{description} must be between 0 and 0xFFFFFFFF")
+    asserts.assert_greater_equal(value, 0, f"{description} must be non-negative")
+    asserts.assert_less_equal(value, 0xFFFFFFFF, f"{description} must not exceed 0xFFFFFFFF")
 
 
 def assert_uint64(value: Any, description: str) -> None:
@@ -36,7 +39,54 @@ def assert_uint64(value: Any, description: str) -> None:
         AssertionError: If value is not an integer or outside the uint64 range (0 to 0xFFFFFFFFFFFFFFFF)
     """
     asserts.assert_true(isinstance(value, int), f"{description} must be an integer")
-    asserts.assert_true(0 <= value <= 0xFFFFFFFFFFFFFFFF, f"{description} must be between 0 and 0xFFFFFFFFFFFFFFFF")
+    asserts.assert_greater_equal(value, 0, f"{description} must be non-negative")
+    asserts.assert_less_equal(value, 0xFFFFFFFFFFFFFFFF, f"{description} must not exceed 0xFFFFFFFFFFFFFFFF")
+
+# List assertions
+
+
+def assert_list(value: Any, description: str, min_length: Optional[int] = None, max_length: Optional[int] = None) -> None:
+    """
+    Asserts that the value is a list with optional length constraints.
+
+    Args:
+        value: The value to check
+        description: User-defined description for error messages
+        min_length: Optional minimum length (inclusive)
+        max_length: Optional maximum length (inclusive)
+
+    Raises:
+        AssertionError: If value is not a list or fails length constraints
+    """
+    asserts.assert_true(isinstance(value, list), f"{description} must be a list")
+
+    if min_length is not None:
+        asserts.assert_greater_equal(len(value), min_length,
+                                     f"{description} must have at least {min_length} elements")
+
+    if max_length is not None:
+        asserts.assert_less_equal(len(value), max_length,
+                                  f"{description} must not exceed {max_length} elements")
+
+
+def assert_list_element_type(value: List[Any], description: str, expected_type: Type[T]) -> None:
+    """
+    Asserts that all elements in the list are of the expected type.
+
+    Args:
+        value: The list to validate
+        description: User-defined description for error messages
+        expected_type: The type that all elements should match
+
+    Raises:
+        AssertionError: If value is not a list or contains elements of wrong type
+    """
+    assert_list(value, description)
+    for i, item in enumerate(value):
+        asserts.assert_true(isinstance(item, expected_type),
+                            f"{description}[{i}] must be of type {expected_type.__name__}")
+
+# String assertions
 
 
 def assert_string(value: Any, description: str) -> None:
@@ -51,21 +101,6 @@ def assert_string(value: Any, description: str) -> None:
         AssertionError: If value is not a string
     """
     asserts.assert_true(isinstance(value, str), f"{description} must be a string")
-
-
-def assert_non_empty_string(value: Any, description: str) -> None:
-    """
-    Asserts that the value is a non-empty string.
-
-    Args:
-        value: The value to check
-        description: User-defined description for error messages
-
-    Raises:
-        AssertionError: If value is not a string or is empty
-    """
-    assert_string(value, description)
-    asserts.assert_true(len(value) > 0, f"{description} cannot be empty")
 
 
 def assert_string_length(value: Any, description: str, min_length: Optional[int] = None, max_length: Optional[int] = None) -> None:
@@ -88,97 +123,105 @@ def assert_string_length(value: Any, description: str, min_length: Optional[int]
     assert_string(value, description)
 
     if min_length is not None:
-        asserts.assert_true(len(value) >= min_length,
-                            f"{description} length must be at least {min_length} characters")
+        asserts.assert_greater_equal(len(value), min_length,
+                                     f"{description} length must be at least {min_length} characters")
 
     if max_length is not None:
-        asserts.assert_true(len(value) <= max_length,
-                            f"{description} length must not exceed {max_length} characters")
+        asserts.assert_less_equal(len(value), max_length,
+                                  f"{description} length must not exceed {max_length} characters")
 
 
-def assert_list(value: Any, description: str, min_length: Optional[int] = None, max_length: Optional[int] = None) -> None:
+def assert_non_empty_string(value: Any, description: str) -> None:
     """
-    Asserts that the value is a list with optional length constraints.
+    Asserts that the value is a non-empty string.
 
     Args:
         value: The value to check
         description: User-defined description for error messages
-        min_length: Optional minimum length (inclusive)
-        max_length: Optional maximum length (inclusive)
 
     Raises:
-        AssertionError: If value is not a list or fails length constraints
-
-    Examples:
-        >>> assert_list([1, 2, 3], "Test list", min_length=1, max_length=5)  # Passes
-        >>> assert_list([], "Empty list", min_length=1)  # Raises AssertionError
-        >>> assert_list([1, 2, 3, 4, 5, 6], "Long list", max_length=5)  # Raises AssertionError
-        >>> assert_list("not a list", "Not a list")  # Raises AssertionError
+        AssertionError: If value is not a string or is empty
     """
-    asserts.assert_true(isinstance(value, list), f"{description} must be a list")
+    assert_string_length(value, description, min_length=1)
 
-    if min_length is not None:
-        asserts.assert_true(len(value) >= min_length, f"{description} must have at least {min_length} elements")
-
-    if max_length is not None:
-        asserts.assert_true(len(value) <= max_length, f"{description} must not exceed {max_length} elements")
+# Matter-specific assertions
 
 
-def assert_list_element_type(value: List[Any], description: str, expected_type: Type[T]) -> None:
+def assert_string_matches_pattern(value: str, description: str, pattern: str) -> None:
     """
-    Asserts that all elements in the list are of the expected type.
+    Asserts that the string matches the given regex pattern.
 
     Args:
-        value: The list to validate
+        value: The string to check
         description: User-defined description for error messages
-        expected_type: The type that all elements should match
+        pattern: Regular expression pattern to match against
 
     Raises:
-        AssertionError: If value is not a list or contains elements of wrong type
-
-    Examples:
-        >>> assert_list_element_type([1, 2, 3], "Integer list", int)  # Passes
-        >>> assert_list_element_type(["a", "b", "c"], "String list", str)  # Passes
-        >>> assert_list_element_type([1, "2", 3], "Mixed list", int)  # Raises AssertionError
-        >>> assert_list_element_type("not a list", "Not a list", int)  # Raises AssertionError
+        AssertionError: If value is not a string or doesn't match the pattern
     """
-    assert_list(value, description)
-    for i, item in enumerate(value):
-        asserts.assert_true(isinstance(item, expected_type),
-                            f"{description}[{i}] must be of type {expected_type.__name__}")
-
-
-def assert_string_matches_pattern(value: str, field_name: str, pattern: str) -> None:
-    """Asserts that the string matches the given regex pattern."""
     import re
-    asserts.assert_true(isinstance(value, str), f"{field_name} must be a string")
+    assert_string(value, description)
     asserts.assert_true(bool(re.match(pattern, value)),
-                        f"{field_name} must match pattern: {pattern}")
+                        f"{description} must match pattern: {pattern}")
 
 
 def assert_valid_attribute_id(id: int, allow_test: bool = False) -> None:
-    """Asserts that the given ID is a valid attribute ID."""
+    """
+    Asserts that the given ID is a valid attribute ID.
+
+    Args:
+        id: The attribute ID to validate
+        allow_test: Whether to allow test attribute IDs
+
+    Raises:
+        AssertionError: If the ID is not a valid attribute ID
+    """
     from chip.testing.global_attribute_ids import is_valid_attribute_id
     asserts.assert_true(is_valid_attribute_id(id, allow_test),
                         f"Invalid attribute ID: {hex(id)}")
 
 
 def assert_standard_attribute_id(id: int) -> None:
-    """Asserts that the given ID is a standard attribute ID."""
+    """
+    Asserts that the given ID is a standard attribute ID.
+
+    Args:
+        id: The attribute ID to validate
+
+    Raises:
+        AssertionError: If the ID is not a standard attribute ID
+    """
     from chip.testing.global_attribute_ids import is_standard_attribute_id
     asserts.assert_true(is_standard_attribute_id(id),
                         f"Not a standard attribute ID: {hex(id)}")
 
 
 def assert_valid_command_id(id: int, allow_test: bool = False) -> None:
-    """Asserts that the given ID is a valid command ID."""
+    """
+    Asserts that the given ID is a valid command ID.
+
+    Args:
+        id: The command ID to validate
+        allow_test: Whether to allow test command IDs
+
+    Raises:
+        AssertionError: If the ID is not a valid command ID
+    """
     from chip.testing.global_attribute_ids import is_valid_command_id
     asserts.assert_true(is_valid_command_id(id, allow_test),
                         f"Invalid command ID: {hex(id)}")
 
 
 def assert_standard_command_id(id: int) -> None:
-    """Asserts that the given ID is a standard command ID."""
+    """
+    Asserts that the given ID is a standard command ID.
+
+    Args:
+        id: The command ID to validate
+
+    Raises:
+        AssertionError: If the ID is not a standard command ID
+    """
     from chip.testing.global_attribute_ids import is_standard_command_id
     asserts.assert_true(is_standard_command_id(id),
                         f"Not a standard command ID: {hex(id)}")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -11,7 +11,7 @@ T = TypeVar('T')
 # Integer assertions
 
 
-def assert_uint32(value: Any, description: str) -> None:
+def assert_valid_uint32(value: Any, description: str) -> None:
     """
     Asserts that the value is a valid uint32.
 
@@ -27,7 +27,7 @@ def assert_uint32(value: Any, description: str) -> None:
     asserts.assert_less_equal(value, 0xFFFFFFFF, f"{description} must not exceed 0xFFFFFFFF")
 
 
-def assert_uint64(value: Any, description: str) -> None:
+def assert_valid_uint64(value: Any, description: str) -> None:
     """
     Asserts that the value is a valid uint64.
 
@@ -89,7 +89,7 @@ def assert_list_element_type(value: List[Any], description: str, expected_type: 
 # String assertions
 
 
-def assert_string(value: Any, description: str) -> None:
+def assert_is_string(value: Any, description: str) -> None:
     """
     Asserts that the value is a string.
 
@@ -118,9 +118,9 @@ def assert_string_length(value: Any, description: str, min_length: Optional[int]
 
     Note:
         - Use min_length=1 instead of assert_non_empty_string when you want to ensure non-emptiness
-        - Use min_length=None, max_length=None to only validate string type (same as assert_string)
+        - Use min_length=None, max_length=None to only validate string type (same as assert_is_string)
     """
-    assert_string(value, description)
+    assert_is_string(value, description)
 
     if min_length is not None:
         asserts.assert_greater_equal(len(value), min_length,
@@ -160,7 +160,7 @@ def assert_string_matches_pattern(value: str, description: str, pattern: str) ->
         AssertionError: If value is not a string or doesn't match the pattern
     """
     import re
-    assert_string(value, description)
+    assert_is_string(value, description)
     asserts.assert_true(bool(re.match(pattern, value)),
                         f"{description} must match pattern: {pattern}")
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -108,6 +108,12 @@ def assert_list(value: Any, description: str, min_length: Optional[int] = None, 
 
     Raises:
         AssertionError: If value is not a list or fails length constraints
+
+    Examples:
+        >>> assert_list([1, 2, 3], "Test list", min_length=1, max_length=5)  # Passes
+        >>> assert_list([], "Empty list", min_length=1)  # Raises AssertionError
+        >>> assert_list([1, 2, 3, 4, 5, 6], "Long list", max_length=5)  # Raises AssertionError
+        >>> assert_list("not a list", "Not a list")  # Raises AssertionError
     """
     asserts.assert_true(isinstance(value, list), f"{description} must be a list")
 
@@ -129,6 +135,12 @@ def assert_list_element_type(value: List[Any], description: str, expected_type: 
 
     Raises:
         AssertionError: If value is not a list or contains elements of wrong type
+
+    Examples:
+        >>> assert_list_element_type([1, 2, 3], "Integer list", int)  # Passes
+        >>> assert_list_element_type(["a", "b", "c"], "String list", str)  # Passes
+        >>> assert_list_element_type([1, "2", 3], "Mixed list", int)  # Raises AssertionError
+        >>> assert_list_element_type("not a list", "Not a list", int)  # Raises AssertionError
     """
     assert_list(value, description)
     for i, item in enumerate(value):

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -42,6 +42,24 @@ def assert_valid_uint64(value: Any, description: str) -> None:
     asserts.assert_greater_equal(value, 0, f"{description} must be non-negative")
     asserts.assert_less_equal(value, 0xFFFFFFFFFFFFFFFF, f"{description} must not exceed 0xFFFFFFFFFFFFFFFF")
 
+
+def assert_int_in_range(value: Any, min_value: int, max_value: int, description: str) -> None:
+    """
+    Asserts that the value is an integer within the specified range (inclusive).
+
+    Args:
+        value: The value to check
+        min_value: Minimum allowed value (inclusive)
+        max_value: Maximum allowed value (inclusive)
+        description: User-defined description for error messages
+
+    Raises:
+        AssertionError: If value is not an integer or outside the specified range
+    """
+    asserts.assert_true(isinstance(value, int), f"{description} must be an integer")
+    asserts.assert_greater_equal(value, min_value, f"{description} must be greater than or equal to {min_value}")
+    asserts.assert_less_equal(value, max_value, f"{description} must be less than or equal to {max_value}")
+
 # List assertions
 
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
@@ -1,0 +1,168 @@
+"""Unit tests for matter_asserts module."""
+
+import unittest
+
+from chip.testing import matter_asserts
+from mobly import signals
+
+
+class TestMatterAsserts(unittest.TestCase):
+    """Unit tests for matter_asserts module."""
+
+    # Integer assertion tests
+    def test_assert_valid_uint32(self):
+        """Test assert_valid_uint32 with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_valid_uint32(0, "test_min")
+        matter_asserts.assert_valid_uint32(0xFFFFFFFF, "test_max")
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint32(-1, "test_negative")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint32(0x100000000, "test_too_large")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint32("42", "test_string")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint32(42.0, "test_float")
+
+    def test_assert_valid_uint64(self):
+        """Test assert_valid_uint64 with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_valid_uint64(0, "test_min")
+        matter_asserts.assert_valid_uint64(0xFFFFFFFFFFFFFFFF, "test_max")
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint64(-1, "test_negative")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint64(0x10000000000000000, "test_too_large")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint64("42", "test_string")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_uint64(42.0, "test_float")
+
+    def test_assert_int_in_range(self):
+        """Test assert_int_in_range with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_int_in_range(0, 0, 10, "test_min")
+        matter_asserts.assert_int_in_range(10, 0, 10, "test_max")
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_int_in_range(-1, 0, 10, "test_below_min")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_int_in_range(11, 0, 10, "test_above_max")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_int_in_range("5", 0, 10, "test_string")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_int_in_range(5.0, 0, 10, "test_float")
+
+    # List assertion tests
+    def test_assert_list(self):
+        """Test assert_list with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_list([], "test_empty")
+        matter_asserts.assert_list([1, 2, 3], "test_nonempty")
+        matter_asserts.assert_list([1, 2], "test_length", min_length=1, max_length=3)
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list("not_a_list", "test_string")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list([], "test_min_length", min_length=1)
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list([1, 2, 3], "test_max_length", max_length=2)
+
+    def test_assert_list_element_type(self):
+        """Test assert_list_element_type with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_list_element_type([], "test_empty", str)
+        matter_asserts.assert_list_element_type(["a", "b"], "test_strings", str)
+        matter_asserts.assert_list_element_type([1, 2, 3], "test_ints", int)
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list_element_type("not_a_list", "test_not_list", str)
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list_element_type([1, "2", 3], "test_mixed", int)
+
+    # String assertion tests
+    def test_assert_is_string(self):
+        """Test assert_is_string with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_is_string("", "test_empty")
+        matter_asserts.assert_is_string("hello", "test_nonempty")
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_is_string(42, "test_int")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_is_string(["str"], "test_list")
+
+    def test_assert_string_length(self):
+        """Test assert_string_length with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_string_length("", "test_empty")
+        matter_asserts.assert_string_length("abc", "test_length", min_length=1, max_length=5)
+        matter_asserts.assert_string_length("abc", "test_exact", min_length=3, max_length=3)
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_string_length(42, "test_not_string")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_string_length("", "test_min", min_length=1)
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_string_length("toolong", "test_max", max_length=5)
+
+    def test_assert_non_empty_string(self):
+        """Test assert_non_empty_string with valid and invalid values."""
+        # Valid cases
+        matter_asserts.assert_non_empty_string("a", "test_single")
+
+        # Invalid cases
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_non_empty_string("", "test_empty")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_non_empty_string(42, "test_not_string")
+
+    # Matter-specific assertion tests
+    def test_assert_valid_attribute_id(self):
+        """Test assert_valid_attribute_id with valid and invalid values."""
+        # Valid case - standard global attribute
+        matter_asserts.assert_valid_attribute_id(0x0000_F000)
+
+        # Invalid case - standard global bad attribute
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_attribute_id(0x0000_FFFF)
+
+    def test_assert_standard_attribute_id(self):
+        """Test assert_standard_attribute_id with valid and invalid values."""
+        # Valid case - standard global attribute
+        matter_asserts.assert_standard_attribute_id(0x0000_F000)
+
+        # Invalid case - manufacturer bad attribute
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_standard_attribute_id(0x0001_0000)
+
+    def test_assert_valid_command_id(self):
+        """Test assert_valid_command_id with valid and invalid values."""
+        # Valid case - standard global command
+        matter_asserts.assert_valid_command_id(0x0000_00E0)
+
+        # Invalid case - standard global bad command
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_valid_command_id(0x0000_FFFF)
+
+    def test_assert_standard_command_id(self):
+        """Test assert_standard_command_id with valid and invalid values."""
+        # Valid case - standard global command
+        matter_asserts.assert_standard_command_id(0x0000_00E0)
+
+        # Invalid case - manufacturer command
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_standard_command_id(0x0001_0000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adding a `matter_asserts.py` file that contains custom assertions for most used checks in Python tests, built upon Mobly assertions. They are split into  categories:

- integer assertions
- string assertions
- list assertions
- matter-specific assertions


### Testing
Local testing + Unit tests