### PR TITLE
Make timeouts in ResetCommisionnee log the node ID involved.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2873,7 +2873,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     // Reset our commissionees.
     for (NSNumber * deviceID in orderedDeviceIDs) {
         __auto_type * baseDevice = [MTRBaseDevice deviceWithNodeID:deviceID controller:controller];
-        ResetCommissionee(baseDevice, queue, self, kTimeoutInSeconds);
+        ResetCommissioneeWithNodeID(baseDevice, queue, self, kTimeoutInSeconds, deviceID);
     }
 
     [controller shutdown];

--- a/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
@@ -163,8 +163,8 @@ class MTRSwiftDeviceTests : XCTestCase {
     }
     
     static override func tearDown() {
-        ResetCommissionee(sConnectedDevice, DispatchQueue.main, nil, UInt16(DeviceConstants.timeoutInSeconds))
-
+        XCTAssertNotNil(sConnectedDevice)
+        ResetCommissionee(sConnectedDevice!, DispatchQueue.main, nil, UInt16(DeviceConstants.timeoutInSeconds))
         let controller = sController
         XCTAssertNotNil(controller)
         controller!.shutdown()

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.h
@@ -20,4 +20,12 @@
 
 #pragma once
 
-void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcase, uint16_t commandTimeout);
+NS_ASSUME_NONNULL_BEGIN
+
+void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * _Nullable testcase, uint16_t commandTimeout);
+
+// MTRBaseDevice does not expose its node ID, so for now just allow callers to
+// pass that in out-of-band.
+void ResetCommissioneeWithNodeID(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * _Nullable testcase, uint16_t commandTimeout, NSNumber * _Nullable nodeID);
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestResetCommissioneeHelper.m
@@ -16,7 +16,7 @@
 
 #import "MTRTestResetCommissioneeHelper.h"
 
-void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcaseUnused, uint16_t commandTimeout)
+void ResetCommissioneeWithNodeID(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcaseUnused, uint16_t commandTimeout, NSNumber * _Nullable nodeID)
 {
     // Put the device back in the state we found it: open commissioning window, no fabrics commissioned.
     // Get our current fabric index, for later deletion.
@@ -65,5 +65,11 @@ void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCas
                              [removeFabricExpectation fulfill];
                          }];
 
-    XCTAssertEqual([XCTWaiter waitForExpectations:@[ removeFabricExpectation ] timeout:commandTimeout], XCTWaiterResultCompleted);
+    XCTAssertEqual([XCTWaiter waitForExpectations:@[ removeFabricExpectation ] timeout:commandTimeout], XCTWaiterResultCompleted,
+        "Resetting commissionnee 0x%llx", nodeID.unsignedLongLongValue);
+}
+
+void ResetCommissionee(MTRBaseDevice * device, dispatch_queue_t queue, XCTestCase * testcaseUnused, uint16_t commandTimeout)
+{
+    return ResetCommissioneeWithNodeID(device, queue, testcaseUnused, commandTimeout, nil);
 }


### PR DESCRIPTION
In some of our tests we have dozens of commissionees, so when one of them times out on RemoveFabric it's really hard to tell which one.

### Testing

These are changes to tests.