### PR TITLE
Redo time sync in Matter.framework if we discover the server's clock is way off.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRConversion.h
+++ b/src/darwin/Framework/CHIP/MTRConversion.h
@@ -18,6 +18,7 @@
 #import "NSStringSpanConversion.h"
 
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h> // For USEC_PER_SEC
 
 #include <chrono>
 #include <lib/core/CASEAuthTag.h>
@@ -40,6 +41,13 @@ inline NSDate * MatterEpochSecondsAsDate(uint32_t matterEpochSeconds)
 {
     const auto interval = static_cast<uint64_t>(chip::kChipEpochSecondsSinceUnixEpoch) + static_cast<uint64_t>(matterEpochSeconds);
     return [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval) interval];
+}
+
+inline NSDate * MatterEpochMicrosecondsAsDate(uint64_t matterEpochMicroseconds)
+{
+    const auto microseconds = static_cast<uint64_t>(chip::kChipEpochSecondsSinceUnixEpoch) * USEC_PER_SEC + static_cast<uint64_t>(matterEpochMicroseconds);
+    const auto interval = ((NSTimeInterval) microseconds) / USEC_PER_SEC;
+    return [NSDate dateWithTimeIntervalSince1970:interval];
 }
 
 template <typename Rep, typename Period>


### PR DESCRIPTION
If a server is powered down for a while and its clock loses sync, when it reboots we will re-subscribe to it.  At that point we can detect whether its clock is off by too much and adjust it, if so.

#### Testing

Manual testing; doing anything with clocks in CI is hard.