### PR TITLE
[FIX] Changing To Correct Wheels Path for v1.4 in Dockerfile

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -328,5 +328,5 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
 RUN pip install --break-system-packages --no-cache-dir \
-    python_lib/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
+    python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
     python_lib/controller/python/chip*.whl


### PR DESCRIPTION
The wheels path in Dockerfile is wrong for the expected path of this `v1.4-branch` as `master` has a different one.
Adding missing `python` folder to the path.