### PR TITLE
Fix typo in doc comment for CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1082,7 +1082,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
- * @def CHIP_CONFIG_MAX_GROUPS_PER_FABRIC
+ * @def CHIP_CONFIG_MAX_GROUP_KEYS_PER_FABRIC
  *
  * @brief Defines the number of groups key sets supported per fabric, see Group Key Management Cluster in specification.
  *


### PR DESCRIPTION
#### Testing
- Just a typo fix in a comment