### PR TITLE
Re-validate submodules when labels are modified

### DIFF
--- a/.github/workflows/third-party-check.yaml
+++ b/.github/workflows/third-party-check.yaml
@@ -21,6 +21,7 @@ on:
         paths:
             - "third_party/**"
             - ".gitmodules"
+        types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
     check-submodule-update-label:
@@ -32,7 +33,7 @@ jobs:
               run: |
                   echo This pull request attempts to update submodules without the changing-submodules-on-purpose label. Please apply that label if the changes are intentional, or remove those changes.
                   exit 1
-            - if: ${{ contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose') }} 
+            - if: ${{ contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose') }}
               name: Success
               run: |
                   echo PR looks good.

--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -69,7 +69,8 @@ parser.add_argument(
     help=("host directory to share with the guest"))
 parser.add_argument(
     '--runner', type=str,
-    help=("path to the runner script which will run automatically after boot. path should be relative to shared directory"))
+    help=("path to the runner script which will be executed after boot; "
+          "it should be relative to the shared directory"))
 parser.add_argument(
     '--output', metavar='FILE', default="/dev/null",
     help="store the QEMU output in a FILE")


### PR DESCRIPTION
#### Problem

When PR which changes submodule is raised without `changing-submodules-on-purpose` label, CI fails.
And the only way to fix it is to push changes again, which is not good for the environment: [CO₂ emission](https://www.co2levels.org)

#### Changes

- Re-trigger validation on labels change
- Changed submodule to verify that it will work

#### Testing

CI will verify.