### PR TITLE
[Silabs] Continue WifiInterface headers clean up

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -261,7 +261,7 @@ CHIP_ERROR BaseApplication::Init()
      * Wait for the WiFi to be initialized
      */
     ChipLogProgress(AppServer, "APP: Wait WiFi Init");
-    while (!wfx_hw_ready())
+    while (!IsHardwareReady())
     {
         osDelay(pdMS_TO_TICKS(10));
     }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -261,7 +261,7 @@ CHIP_ERROR BaseApplication::Init()
      * Wait for the WiFi to be initialized
      */
     ChipLogProgress(AppServer, "APP: Wait WiFi Init");
-    while (!IsHardwareReady())
+    while (!IsStationReady())
     {
         osDelay(pdMS_TO_TICKS(10));
     }

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -27,8 +27,9 @@
 #ifdef SL_WIFI
 #include <platform/silabs/wifi/WifiInterface.h>
 
+// TODO: We shouldn't need any platform specific includes in this file
 #ifdef WF200_WIFI
-#include <platform/silabs/wifi/sl_wfx_task.h>
+#include <platform/silabs/wifi/wf200/ncp/sl_wfx_task.h>
 #endif // WF200_WIFI
 #endif // SL_WIFI
 
@@ -44,6 +45,7 @@
 #include "MemMonitoring.h"
 #endif
 
+// TODO: We shouldn't need any platform specific includes in this file
 #if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1
 #include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
 #include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -26,7 +26,11 @@
 
 #ifdef SL_WIFI
 #include <platform/silabs/wifi/WifiInterface.h>
-#endif /* SL_WIFI */
+
+#ifdef WF200_WIFI
+#include <platform/silabs/wifi/sl_wfx_task.h>
+#endif // WF200_WIFI
+#endif // SL_WIFI
 
 #if PW_RPC_ENABLED
 #include "Rpc.h"
@@ -308,17 +312,15 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #ifdef SL_WIFI
 CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 {
+    // TODO: Platform specific init should not be required here
 #ifdef WF200_WIFI
     // Start wfx bus communication task.
     wfx_bus_start();
-#ifdef SL_WFX_USE_SECURE_LINK
-    // start securelink key renegotiation task
-    wfx_securelink_task_start();
-#endif // SL_WFX_USE_SECURE_LINK
 #endif // WF200_WIFI
 
+    // TODO: Platform specific init should not be required here
 #if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1
-    VerifyOrReturnError(sl_matter_wifi_platform_init() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(InitSiWx917Wifi() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
 #endif // SLI_SI91X_MCU_INTERFACE
 
     return CHIP_NO_ERROR;

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -320,7 +320,7 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 
     // TODO: Platform specific init should not be required here
 #if defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1
-    VerifyOrReturnError(InitSiWx917Wifi() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(InitSiWxWifi() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
 #endif // SLI_SI91X_MCU_INTERFACE
 
     return CHIP_NO_ERROR;

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -205,7 +205,7 @@ else
 
                 NCP_DIR_SUFFIX="/"$2
                 USE_WIFI=true
-                optArgs+="chip_device_platform =\"efr32\" chip_crypto_keystore=\"psa\""
+                optArgs+="chip_device_platform =\"efr32\" chip_crypto_keystore=\"psa\" "
                 shift
                 shift
                 ;;

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -275,14 +275,14 @@ void ConfigurationManagerImpl::ClearThreadStack()
 
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
-    CHIP_ERROR err;
+    CHIP_ERROR error = CHIP_NO_ERROR;
 
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
-    err = SilabsConfig::FactoryResetConfig();
-    if (err != CHIP_NO_ERROR)
+    error = SilabsConfig::FactoryResetConfig();
+    if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(error));
     }
 
     GetDefaultInstance().ClearThreadStack();
@@ -290,11 +290,12 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     PersistedStorage::KeyValueStoreMgrImpl().ErasePartition();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    sl_status_t status = sl_matter_wifi_disconnect();
-    if (status != SL_STATUS_OK)
+    error = TriggerWifiDisconnection();
+    if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "sl_matter_wifi_disconnect() failed: %lx", status);
+        ChipLogError(DeviceLayer, "TriggerWifiDisconnection() failed: %s", chip::ErrorStr(error));
     }
+
     ChipLogProgress(DeviceLayer, "Clearing WiFi provision");
     wfx_clear_wifi_provision();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -290,10 +290,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     PersistedStorage::KeyValueStoreMgrImpl().ErasePartition();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
-    error = TriggerWifiDisconnection();
+    error = TriggerDisconnection();
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "TriggerWifiDisconnection() failed: %s", chip::ErrorStr(error));
+        ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %s", chip::ErrorStr(error));
     }
 
     ChipLogProgress(DeviceLayer, "Clearing WiFi provision");

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -128,8 +128,7 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        wifi_mode_t curWiFiMode = wfx_get_wifi_mode();
-        if ((curWiFiMode == WIFI_MODE_STA) || (curWiFiMode == WIFI_MODE_APSTA))
+        if (IsStationModeEnabled())
         {
             mWiFiStationMode = kWiFiStationMode_Enabled;
         }
@@ -138,6 +137,7 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
             mWiFiStationMode = kWiFiStationMode_Disabled;
         }
     }
+
     return mWiFiStationMode;
 }
 
@@ -259,14 +259,9 @@ void ConnectivityManagerImpl::DriveStationState()
             (mWiFiStationMode != kWiFiStationMode_Enabled && !IsWiFiStationProvisioned()))
         {
             ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
-            sl_status_t status = sl_matter_wifi_disconnect();
-            if (status != SL_STATUS_OK)
-            {
-                ChipLogError(DeviceLayer, "wfx_wifi_disconnect() failed: %lx", status);
 
-                // TODO: Clean the function up to remove the usage of goto
-                goto exit;
-            }
+            CHIP_ERROR error = TriggerWifiDisconnection();
+            SuccessOrExitAction(error, ChipLogError(DeviceLayer, "TriggerWifiDisconnection() failed: %s", ErrorStr(error)));
 
             ChangeWiFiStationState(kWiFiStationState_Disconnecting);
         }
@@ -344,7 +339,6 @@ exit:
 
 void ConnectivityManagerImpl::OnStationConnected()
 {
-    wfx_setup_ip6_link_local(SL_WFX_STA_INTERFACE);
     NetworkCommissioning::SlWiFiDriver::GetInstance().OnConnectWiFiNetwork();
 
     UpdateInternetConnectivityState();

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -260,8 +260,8 @@ void ConnectivityManagerImpl::DriveStationState()
         {
             ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
 
-            CHIP_ERROR error = TriggerWifiDisconnection();
-            SuccessOrExitAction(error, ChipLogError(DeviceLayer, "TriggerWifiDisconnection() failed: %s", ErrorStr(error)));
+            CHIP_ERROR error = TriggerDisconnection();
+            SuccessOrExitAction(error, ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %s", ErrorStr(error)));
 
             ChangeWiFiStationState(kWiFiStationState_Disconnecting);
         }

--- a/src/platform/silabs/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/silabs/DiagnosticDataProviderImpl.cpp
@@ -133,30 +133,30 @@ void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetr
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)
 {
-    uint32_t count = 0;
-    CHIP_ERROR err = ConfigurationMgr().GetRebootCount(count);
+    uint32_t count   = 0;
+    CHIP_ERROR error = ConfigurationMgr().GetRebootCount(count);
 
-    if (err == CHIP_NO_ERROR)
+    if (error == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(count <= UINT16_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
         rebootCount = static_cast<uint16_t>(count);
     }
 
-    return err;
+    return error;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
-    uint32_t reason = 0;
-    CHIP_ERROR err  = ConfigurationMgr().GetBootReason(reason);
+    uint32_t reason  = 0;
+    CHIP_ERROR error = ConfigurationMgr().GetBootReason(reason);
 
-    if (err == CHIP_NO_ERROR)
+    if (error == CHIP_NO_ERROR)
     {
         VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
         bootReason = static_cast<BootReasonType>(reason);
     }
 
-    return err;
+    return error;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetUpTime(uint64_t & upTime)
@@ -252,8 +252,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         Inet::InterfaceType interfaceType;
-        CHIP_ERROR err = interfaceIterator.GetInterfaceType(interfaceType);
-        if (err == CHIP_NO_ERROR || err == CHIP_ERROR_NOT_IMPLEMENTED)
+        CHIP_ERROR error = interfaceIterator.GetInterfaceType(interfaceType);
+        if (error == CHIP_NO_ERROR || error == CHIP_ERROR_NOT_IMPLEMENTED)
         {
             switch (interfaceType)
             {
@@ -336,16 +336,17 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBssId(MutableByteSpan & BssId)
 {
     constexpr size_t bssIdSize = 6;
+    wfx_wifi_scan_result_t ap  = { 0 };
+
     VerifyOrReturnError(BssId.size() >= bssIdSize, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    wfx_wifi_scan_result_t ap;
-    int32_t err = wfx_get_ap_info(&ap);
-    if (err == 0)
+    if (GetAccessPointInfo(ap) == CHIP_NO_ERROR)
     {
         memcpy(BssId.data(), ap.bssid, bssIdSize);
         BssId.reduce_size(bssIdSize);
         return CHIP_NO_ERROR;
     }
+
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
@@ -353,9 +354,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(app::Clusters::WiFiNe
 {
     using app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum;
 
-    wfx_wifi_scan_result_t ap;
-    int32_t err = wfx_get_ap_info(&ap);
-    if (err == 0)
+    wfx_wifi_scan_result_t ap = { 0 };
+    CHIP_ERROR error          = GetAccessPointInfo(ap);
+    if (error == CHIP_NO_ERROR)
     {
         // TODO: Is this actually right?  Do the wfx_wifi_scan_result_t values
         // match the Matter spec ones?
@@ -373,9 +374,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNumber)
 {
-    wfx_wifi_scan_result_t ap;
-    int32_t err = wfx_get_ap_info(&ap);
-    if (err == 0)
+    wfx_wifi_scan_result_t ap = { 0 };
+    CHIP_ERROR error          = GetAccessPointInfo(ap);
+    if (error == CHIP_NO_ERROR)
     {
         channelNumber = ap.chan;
         return CHIP_NO_ERROR;
@@ -385,9 +386,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiChannelNumber(uint16_t & channelNu
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiRssi(int8_t & rssi)
 {
-    wfx_wifi_scan_result_t ap;
-    int32_t err = wfx_get_ap_info(&ap);
-    if (err == 0)
+    wfx_wifi_scan_result_t ap = { 0 };
+    CHIP_ERROR error          = GetAccessPointInfo(ap);
+    if (error == CHIP_NO_ERROR)
     {
         rssi = ap.rssi;
         return CHIP_NO_ERROR;
@@ -397,9 +398,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiRssi(int8_t & rssi)
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         beaconLostCount = extra_info.beacon_lost_count;
         return CHIP_NO_ERROR;
@@ -414,9 +415,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiCurrentMaxRate(uint64_t & currentM
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         packetMulticastRxCount = extra_info.mcast_rx_count;
         return CHIP_NO_ERROR;
@@ -426,9 +427,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastRxCount(uint32_t & 
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         packetMulticastTxCount = extra_info.mcast_tx_count;
         return CHIP_NO_ERROR;
@@ -438,9 +439,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketMulticastTxCount(uint32_t & 
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         packetUnicastRxCount = extra_info.ucast_rx_count;
         return CHIP_NO_ERROR;
@@ -450,9 +451,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastRxCount(uint32_t & pa
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         packetUnicastTxCount = extra_info.ucast_tx_count;
         return CHIP_NO_ERROR;
@@ -462,9 +463,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiPacketUnicastTxCount(uint32_t & pa
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         overrunCount = extra_info.overrun_count;
         return CHIP_NO_ERROR;
@@ -474,9 +475,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
 {
-    wfx_wifi_scan_ext_t extra_info;
-    int32_t err = wfx_get_ap_ext(&extra_info);
-    if (err == 0)
+    wfx_wifi_scan_ext_t extra_info = { 0 };
+    CHIP_ERROR error               = GetAccessPointExtendedInfo(extra_info);
+    if (error == CHIP_NO_ERROR)
     {
         beaconRxCount = extra_info.beacon_rx_count;
         return CHIP_NO_ERROR;
@@ -486,12 +487,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiBeaconRxCount(uint32_t & beaconRxC
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 {
-    int32_t err = wfx_reset_counts();
-    if (err == 0)
-    {
-        return CHIP_NO_ERROR;
-    }
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return ResetCounters();
 }
 #endif // SL_WIFI
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -136,15 +136,10 @@ Status SlWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCh
 
 CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
-    int32_t status = SL_STATUS_OK;
     if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ChipLogProgress(DeviceLayer, "Disconecting for current wifi");
-        status = sl_matter_wifi_disconnect();
-        if (status != SL_STATUS_OK)
-        {
-            return CHIP_ERROR_INTERNAL;
-        }
+        ReturnErrorOnFailure(TriggerWifiDisconnection());
     }
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
 

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -139,7 +139,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ChipLogProgress(DeviceLayer, "Disconecting for current wifi");
-        ReturnErrorOnFailure(TriggerWifiDisconnection());
+        ReturnErrorOnFailure(TriggerDisconnection());
     }
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
 

--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -62,6 +62,8 @@ void gpio_uulp_pin_interrupt_callback(uint32_t pin_intr)
 /**
  * @brief Processing function when a button is triggered
  *
+ * TODO: Move this to SPAM
+ *
  * @param btn which button was pressed
  * @param btnAction the action that triggered the buttone vent
  */

--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -58,6 +58,7 @@ void gpio_uulp_pin_interrupt_callback(uint32_t pin_intr)
         VerifyOrReturn(status == SL_STATUS_OK, ChipLogError(DeviceLayer, "failed to mask interrupt: %ld", status));
     }
 }
+
 /**
  * @brief Processing function when a button is triggered
  *

--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -58,6 +58,13 @@ void gpio_uulp_pin_interrupt_callback(uint32_t pin_intr)
         VerifyOrReturn(status == SL_STATUS_OK, ChipLogError(DeviceLayer, "failed to mask interrupt: %ld", status));
     }
 }
+/**
+ * @brief Processing function when a button is triggered
+ *
+ * @param btn which button was pressed
+ * @param btnAction the action that triggered the buttone vent
+ */
+void sl_button_on_change(uint8_t btn, uint8_t btnAction);
 
 #endif // SLI_SI91X_MCU_INTERFACE
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -95,17 +95,11 @@ namespace {
 bool btn0_pressed = false;
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
 
-bool hasNotifiedWifiConnectivity = false;
-bool hasNotifiedIPV6             = false;
-#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
-bool hasNotifiedIPV4 = false;
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-
 wfx_wifi_scan_ext_t temp_reset;
 
 osSemaphoreId_t sScanCompleteSemaphore;
 osSemaphoreId_t sScanInProgressSemaphore;
-osTimerId_t sDHCPTimer;
+
 osMessageQueueId_t sWifiEventQueue = nullptr;
 
 sl_net_wifi_lwip_context_t wifi_client_context;
@@ -261,27 +255,6 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
     return SL_STATUS_OK;
 }
 
-void DHCPTimerEventHandler(void * arg)
-{
-    WifiPlatformEvent event = WifiPlatformEvent::kStationDhcpPoll;
-    sl_matter_wifi_post_event(event);
-}
-
-void CancelDHCPTimer(void)
-{
-    VerifyOrReturn(osTimerIsRunning(sDHCPTimer), ChipLogDetail(DeviceLayer, "CancelDHCPTimer: timer not running"));
-    VerifyOrReturn(osTimerStop(sDHCPTimer) == osOK, ChipLogError(DeviceLayer, "CancelDHCPTimer: failed to stop timer"));
-}
-
-void StartDHCPTimer(uint32_t timeout)
-{
-    // Cancel timer if already started
-    CancelDHCPTimer();
-
-    VerifyOrReturn(osTimerStart(sDHCPTimer, pdMS_TO_TICKS(timeout)) == osOK,
-                   ChipLogError(DeviceLayer, "StartDHCPTimer: failed to start timer"));
-}
-
 sl_status_t sl_wifi_siwx917_init(void)
 {
     sl_status_t status = SL_STATUS_OK;
@@ -311,9 +284,9 @@ sl_status_t sl_wifi_siwx917_init(void)
 
 #else
     // NCP Configurations
-    status = sl_matter_wifi_platform_init();
+    status = InitSiWx917Wifi();
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "sl_matter_wifi_platform_init failed: 0x%lx", static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "InitSiWx917Wifi failed: 0x%lx", static_cast<uint32_t>(status)));
 #endif // SLI_SI91X_MCU_INTERFACE
 
     sl_wifi_firmware_version_t version = { 0 };
@@ -478,7 +451,7 @@ sl_status_t JoinWifiNetwork(void)
     if (status == SL_STATUS_OK || status == SL_STATUS_IN_PROGRESS)
     {
         WifiPlatformEvent event = WifiPlatformEvent::kStationConnect;
-        sl_matter_wifi_post_event(event);
+        PostWifiPlatformEvent(event);
         return status;
     }
 
@@ -492,19 +465,79 @@ sl_status_t JoinWifiNetwork(void)
     wfx_retry_connection(++wfx_rsi.join_retries);
 
     WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
-    sl_matter_wifi_post_event(event);
+    PostWifiPlatformEvent(event);
 
     return status;
 }
 
 } // namespace
 
-/**
- * @brief Wifi initialization called from app main
- *
- * @return sl_status_t Returns underlying Wi-Fi initialization error
- */
-sl_status_t sl_matter_wifi_platform_init(void)
+sl_status_t TriggerPlatformWifiDisconnection()
+{
+    return sl_net_down((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE);
+}
+
+CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
+{
+    // TODO: Convert this to a int8
+    int32_t rssi  = 0;
+    info.security = wfx_rsi.sec.security;
+    info.chan     = wfx_rsi.ap_chan;
+
+    chip::MutableByteSpan output(info.ssid, WFX_MAX_SSID_LENGTH);
+    // Cast is a workaround until the wfx_rsi structure is refactored
+    chip::ByteSpan ssid(reinterpret_cast<uint8_t *>(wfx_rsi.sec.ssid), wfx_rsi.sec.ssid_length);
+    chip::CopySpanToMutableSpan(ssid, output);
+    info.ssid_length = output.size();
+
+    chip::ByteSpan apMacSpan(wfx_rsi.ap_mac.data(), wfx_rsi.ap_mac.size());
+    chip::MutableByteSpan bssidSpan(info.bssid, kWifiMacAddressLength);
+    chip::CopySpanToMutableSpan(apMacSpan, bssidSpan);
+
+    // TODO: add error processing
+    sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &(rssi));
+    info.rssi = rssi;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info)
+{
+    sl_wifi_statistics_t test = { 0 };
+
+    sl_status_t status = sl_wifi_get_statistics(SL_WIFI_CLIENT_INTERFACE, &test);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+
+    info.beacon_lost_count = test.beacon_lost_count - temp_reset.beacon_lost_count;
+    info.beacon_rx_count   = test.beacon_rx_count - temp_reset.beacon_rx_count;
+    info.mcast_rx_count    = test.mcast_rx_count - temp_reset.mcast_rx_count;
+    info.mcast_tx_count    = test.mcast_tx_count - temp_reset.mcast_tx_count;
+    info.ucast_rx_count    = test.ucast_rx_count - temp_reset.ucast_rx_count;
+    info.ucast_tx_count    = test.ucast_tx_count - temp_reset.ucast_tx_count;
+    info.overrun_count     = test.overrun_count - temp_reset.overrun_count;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ResetCounters()
+{
+    sl_wifi_statistics_t test = { 0 };
+
+    sl_status_t status = sl_wifi_get_statistics(SL_WIFI_CLIENT_INTERFACE, &test);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+
+    temp_reset.beacon_lost_count = test.beacon_lost_count;
+    temp_reset.beacon_rx_count   = test.beacon_rx_count;
+    temp_reset.mcast_rx_count    = test.mcast_rx_count;
+    temp_reset.mcast_tx_count    = test.mcast_tx_count;
+    temp_reset.ucast_rx_count    = test.ucast_rx_count;
+    temp_reset.ucast_tx_count    = test.ucast_tx_count;
+    temp_reset.overrun_count     = test.overrun_count;
+
+    return CHIP_NO_ERROR;
+}
+
+sl_status_t InitSiWx917Wifi(void)
 {
     sl_status_t status = SL_STATUS_OK;
 
@@ -523,115 +556,10 @@ sl_status_t sl_matter_wifi_platform_init(void)
     sWifiEventQueue = osMessageQueueNew(kWfxQueueSize, sizeof(WifiPlatformEvent), nullptr);
     VerifyOrReturnError(sWifiEventQueue != nullptr, SL_STATUS_ALLOCATION_FAILED);
 
-    // Create timer for DHCP polling
-    // TODO: Use LWIP timer instead of creating a new one here
-    sDHCPTimer = osTimerNew(DHCPTimerEventHandler, osTimerPeriodic, nullptr, nullptr);
-    VerifyOrReturnError(sDHCPTimer != nullptr, SL_STATUS_ALLOCATION_FAILED);
+    status = CreateDHCPTimer();
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     return status;
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t *ap)
- * @brief
- *       Getting the AP details
- * @param[in] ap: access point
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
-{
-    // TODO: Convert this to a int8
-    int32_t rssi = 0;
-    ap->security = wfx_rsi.sec.security;
-    ap->chan     = wfx_rsi.ap_chan;
-
-    chip::MutableByteSpan output(ap->ssid, WFX_MAX_SSID_LENGTH);
-    // Cast is a workaround until the wfx_rsi structure is refactored
-    chip::ByteSpan ssid(reinterpret_cast<uint8_t *>(wfx_rsi.sec.ssid), wfx_rsi.sec.ssid_length);
-    chip::CopySpanToMutableSpan(ssid, output);
-    ap->ssid_length = output.size();
-
-    chip::ByteSpan apMacSpan(wfx_rsi.ap_mac.data(), wfx_rsi.ap_mac.size());
-    chip::MutableByteSpan bssidSpan(ap->bssid, kWifiMacAddressLength);
-    chip::CopySpanToMutableSpan(apMacSpan, bssidSpan);
-
-    // TODO: add error processing
-    sl_wifi_get_signal_strength(SL_WIFI_CLIENT_INTERFACE, &(rssi));
-    ap->rssi = rssi;
-
-    return SL_STATUS_OK;
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t *extra_info)
- * @brief
- *       Getting the AP extra details
- * @param[in] extra info: access point extra information
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
-{
-    sl_status_t status        = SL_STATUS_OK;
-    sl_wifi_statistics_t test = { 0 };
-    status                    = sl_wifi_get_statistics(SL_WIFI_CLIENT_INTERFACE, &test);
-    VERIFY_STATUS_AND_RETURN(status);
-    extra_info->beacon_lost_count = test.beacon_lost_count - temp_reset.beacon_lost_count;
-    extra_info->beacon_rx_count   = test.beacon_rx_count - temp_reset.beacon_rx_count;
-    extra_info->mcast_rx_count    = test.mcast_rx_count - temp_reset.mcast_rx_count;
-    extra_info->mcast_tx_count    = test.mcast_tx_count - temp_reset.mcast_tx_count;
-    extra_info->ucast_rx_count    = test.ucast_rx_count - temp_reset.ucast_rx_count;
-    extra_info->ucast_tx_count    = test.ucast_tx_count - temp_reset.ucast_tx_count;
-    extra_info->overrun_count     = test.overrun_count - temp_reset.overrun_count;
-    return status;
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_reset_count(void)
- * @brief
- *       Getting the driver reset count
- * @param[in] None
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_reset_count(void)
-{
-    sl_wifi_statistics_t test = { 0 };
-    sl_status_t status        = SL_STATUS_OK;
-    status                    = sl_wifi_get_statistics(SL_WIFI_CLIENT_INTERFACE, &test);
-    VERIFY_STATUS_AND_RETURN(status);
-    temp_reset.beacon_lost_count = test.beacon_lost_count;
-    temp_reset.beacon_rx_count   = test.beacon_rx_count;
-    temp_reset.mcast_rx_count    = test.mcast_rx_count;
-    temp_reset.mcast_tx_count    = test.mcast_tx_count;
-    temp_reset.ucast_rx_count    = test.ucast_rx_count;
-    temp_reset.ucast_tx_count    = test.ucast_tx_count;
-    temp_reset.overrun_count     = test.overrun_count;
-    return status;
-}
-
-/******************************************************************
- * @fn   sl_wifi_platform_disconnect(void)
- * @brief
- *       Getting the driver disconnect status
- * @param[in] None
- * @return
- *        status
- *********************************************************************/
-int32_t sl_wifi_platform_disconnect(void)
-{
-    return sl_net_down((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE);
-}
-
-/// NotifyConnectivity
-/// @brief Notify the application about the connectivity status if it has not been notified yet.
-///        Helper function for HandleDHCPPolling.
-void NotifyConnectivity(void)
-{
-    VerifyOrReturn(!hasNotifiedWifiConnectivity);
-    NotifyConnection(wfx_rsi.ap_mac);
-    hasNotifiedWifiConnectivity = true;
 }
 
 void HandleDHCPPolling(void)
@@ -644,60 +572,44 @@ void HandleDHCPPolling(void)
 
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
     uint8_t dhcp_state = dhcpclient_poll(sta_netif);
-    if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !hasNotifiedIPV4)
+    if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !HasNotifiedIPv4Change())
     {
         wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
-        hasNotifiedIPV4 = true;
-        event           = WifiPlatformEvent::kStationDhcpDone;
-        sl_matter_wifi_post_event(event);
+        NotifyIPv4Change(true);
+        event = WifiPlatformEvent::kStationDhcpDone;
+        PostWifiPlatformEvent(event);
         NotifyConnectivity();
     }
     else if (dhcp_state == DHCP_OFF)
     {
         NotifyIPv4Change(false);
-        hasNotifiedIPV4 = false;
     }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
     /* Checks if the assigned IPv6 address is preferred by evaluating
      * the first block of IPv6 address ( block 0)
      */
-    if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
+    if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !HasNotifiedIPv6Change())
     {
         char addrStr[chip::Inet::IPAddress::kMaxStringLength] = { 0 };
         VerifyOrReturn(ip6addr_ntoa_r(netif_ip6_addr(sta_netif, 0), addrStr, sizeof(addrStr)) != nullptr);
         ChipLogProgress(DeviceLayer, "SLAAC OK: linklocal addr: %s", addrStr);
         NotifyIPv6Change(true);
-        hasNotifiedIPV6 = true;
-        event           = WifiPlatformEvent::kStationDhcpDone;
-        sl_matter_wifi_post_event(event);
+        event = WifiPlatformEvent::kStationDhcpDone;
+        PostWifiPlatformEvent(event);
         NotifyConnectivity();
     }
 }
-void sl_matter_wifi_post_event(WifiPlatformEvent event)
+
+void PostWifiPlatformEvent(WifiPlatformEvent event)
 {
     sl_status_t status = osMessageQueuePut(sWifiEventQueue, &event, 0, 0);
 
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "sl_matter_wifi_post_event: failed to post event with status: %ld", status);
+        ChipLogError(DeviceLayer, "PostWifiPlatformEvent: failed to post event with status: %ld", status);
         // TODO: Handle error, requeue event depending on queue size or notify relevant task,
         // Chipdie, etc.
     }
-}
-/// ResetDHCPNotificationFlags
-/// @brief Reset the flags that are used to notify the application about DHCP connectivity
-///        and emits a WifiPlatformEvent::kStationDoDhcp event to trigger DHCP polling checks. Helper function for ProcessEvent.
-void ResetDHCPNotificationFlags(void)
-{
-
-#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
-    hasNotifiedIPV4 = false;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
-    hasNotifiedIPV6             = false;
-    hasNotifiedWifiConnectivity = false;
-
-    WifiPlatformEvent event = WifiPlatformEvent::kStationDoDhcp;
-    sl_matter_wifi_post_event(event);
 }
 
 void ProcessEvent(WifiPlatformEvent event)
@@ -820,7 +732,7 @@ void ProcessEvent(WifiPlatformEvent event)
 }
 
 /*********************************************************************************
- * @fn  void sl_matter_wifi_task(void *arg)
+ * @fn  void MatterWifiTask(void *arg)
  * @brief
  * The main WLAN task - started by StartWifiTask() that interfaces with RSI.
  * The rest of RSI stuff come in call-backs.
@@ -830,20 +742,19 @@ void ProcessEvent(WifiPlatformEvent event)
  *       None
  **********************************************************************************/
 /* ARGSUSED */
-void sl_matter_wifi_task(void * arg)
+void MatterWifiTask(void * arg)
 {
     (void) arg;
     WifiPlatformEvent event;
     sl_status_t status = SL_STATUS_OK;
 
     status = sl_wifi_siwx917_init();
-    VerifyOrReturn(
-        status == SL_STATUS_OK,
-        ChipLogError(DeviceLayer, "sl_matter_wifi_task: sl_wifi_siwx917_init failed: 0x%lx", static_cast<uint32_t>(status)));
+    VerifyOrReturn(status == SL_STATUS_OK,
+                   ChipLogError(DeviceLayer, "MatterWifiTask: sl_wifi_siwx917_init failed: 0x%lx", static_cast<uint32_t>(status)));
 
     sl_matter_wifi_task_started();
 
-    ChipLogDetail(DeviceLayer, "sl_matter_wifi_task: starting event loop");
+    ChipLogDetail(DeviceLayer, "MatterWifiTask: starting event loop");
     for (;;)
     {
         if (osMessageQueueGet(sWifiEventQueue, &event, nullptr, osWaitForever) == osOK)
@@ -852,7 +763,7 @@ void sl_matter_wifi_task(void * arg)
         }
         else
         {
-            ChipLogError(DeviceLayer, "sl_matter_wifi_task: get event failed: 0x%lx", static_cast<uint32_t>(status));
+            ChipLogError(DeviceLayer, "MatterWifiTask: get event failed: 0x%lx", static_cast<uint32_t>(status));
         }
     }
 }
@@ -871,7 +782,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -284,9 +284,9 @@ sl_status_t sl_wifi_siwx917_init(void)
 
 #else
     // NCP Configurations
-    status = InitSiWx917Wifi();
+    status = InitSiWxWifi();
     VerifyOrReturnError(status == SL_STATUS_OK, status,
-                        ChipLogError(DeviceLayer, "InitSiWx917Wifi failed: 0x%lx", static_cast<uint32_t>(status)));
+                        ChipLogError(DeviceLayer, "InitSiWxWifi failed: 0x%lx", static_cast<uint32_t>(status)));
 #endif // SLI_SI91X_MCU_INTERFACE
 
     sl_wifi_firmware_version_t version = { 0 };
@@ -537,7 +537,7 @@ CHIP_ERROR ResetCounters()
     return CHIP_NO_ERROR;
 }
 
-sl_status_t InitSiWx917Wifi(void)
+sl_status_t InitSiWxWifi(void)
 {
     sl_status_t status = SL_STATUS_OK;
 
@@ -782,7 +782,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -45,6 +45,11 @@ constexpr uint8_t kWlanMaxRetryIntervalsInSec = 60;
 uint8_t retryInterval                         = kWlanMinRetryIntervalsInSec;
 osTimerId_t sRetryTimer;
 
+bool hasNotifiedIPV6 = false;
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
+bool hasNotifiedIPV4 = false;
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
+
 /*
  * Notifications to the upper-layer
  * All done in the context of the RSI/WiFi task (rsi_if.c)
@@ -66,15 +71,19 @@ void RetryConnectionTimerHandler(void * arg)
 
 void NotifyIPv6Change(bool gotIPv6Addr)
 {
+    hasNotifiedIPV6 = gotIPv6Addr;
+
     sl_wfx_generic_message_t eventData = {};
     eventData.header.id                = gotIPv6Addr ? to_underlying(WifiEvent::kGotIPv6) : to_underlying(WifiEvent::kLostIP);
     eventData.header.length            = sizeof(eventData.header);
 
     HandleWFXSystemEvent(&eventData);
 }
-
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
 void NotifyIPv4Change(bool gotIPv4Addr)
 {
+    hasNotifiedIPV4 = gotIPv4Addr;
+
     sl_wfx_generic_message_t eventData;
 
     memset(&eventData, 0, sizeof(eventData));
@@ -82,6 +91,7 @@ void NotifyIPv4Change(bool gotIPv4Addr)
     eventData.header.length = sizeof(eventData.header);
     HandleWFXSystemEvent(&eventData);
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
 
 void NotifyDisconnection(WifiDisconnectionReasons reason)
 {
@@ -106,6 +116,25 @@ void NotifyConnection(const MacAddress & ap)
     HandleWFXSystemEvent((sl_wfx_generic_message_t *) &evt);
 }
 
+bool HasNotifiedIPv6Change()
+{
+    return hasNotifiedIPV6;
+}
+
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
+bool HasNotifiedIPv4Change()
+{
+    return hasNotifiedIPV4;
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
+
+void ResetIPNotificationStates()
+{
+    hasNotifiedIPV6 = false;
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
+    hasNotifiedIPV4 = false;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
+}
 /* Function to update */
 
 /***********************************************************************************

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -301,12 +301,12 @@ bool IsStationConnected();
 bool IsStationModeEnabled();
 
 /**
- * @brief Returns the state of the Hardware
+ * @brief Returns the state of the Wi-Fi station initialization
  *
- * @return true, if the hardware is ready to be used
+ * @return true, if the initialization was successful
  *         false, otherwise
  */
-bool IsHardwareReady();
+bool IsStationReady();
 
 /**
  * @brief Triggers the device to disconnect from the connected Wi-Fi network
@@ -317,7 +317,7 @@ bool IsHardwareReady();
  * @return CHIP_ERROR CHIP_NO_ERROR, disconnection request was succesfully triggered
  *         otherwise, CHIP_ERROR_INTERNAL
  */
-CHIP_ERROR TriggerWifiDisconnection();
+CHIP_ERROR TriggerDisconnection();
 
 /**
  * @brief Gets the connected access point information.

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -120,15 +120,6 @@ typedef struct
     wfx_sec_t security;
 } wfx_wifi_provision_t;
 
-typedef enum
-{
-    WIFI_MODE_NULL = 0,
-    WIFI_MODE_STA,
-    WIFI_MODE_AP,
-    WIFI_MODE_APSTA,
-    WIFI_MODE_MAX,
-} wifi_mode_t;
-
 typedef struct wfx_wifi_scan_result
 {
     uint8_t ssid[WFX_MAX_SSID_LENGTH]; // excludes null-character
@@ -219,6 +210,36 @@ void NotifyDisconnection(WifiDisconnectionReasons reason);
 void NotifyConnection(const MacAddress & ap);
 
 /**
+ * @brief Returns the IPv6 notification state
+ *
+ * @note This function is necessary because the class inheritance structure has not been done as of yet.
+ *       Once the inheritance is done, sub-classes will have access to the member directly wihtout needing to use an extra guetter.
+ *
+ * @return true, IPv6 change has been notified
+           false, otherwise
+ */
+bool HasNotifiedIPv6Change();
+
+/**
+ * @brief Returns the IPv4 notification state
+ *
+ * @note This function is necessary because the class inheritance structure has not been done as of yet.
+ *       Once the inheritance is done, sub-classes will have access to the member directly wihtout needing to use an extra guetter.
+ *
+ * @return true, IPv4 change has been notified
+           false, otherwise
+ */
+bool HasNotifiedIPv4Change();
+
+/**
+ * @brief Function resets the IP notification states
+ *
+ * * @note This function is necessary because the class inheritance structure has not been done as of yet.
+ *       Once the inheritance is done, sub-classes will have access to the member directly wihtout needing to use an extra guetter.
+ */
+void ResetIPNotificationStates();
+
+/**
  * @brief Returns the provide interfaces MAC address
  *        Valid buffer large enough for the MAC address must be provided to the function
  *
@@ -277,26 +298,70 @@ bool IsStationConnected();
  * @return true, if the Wi-Fi Station mode is enabled
  *         false, otherwise
  */
-bool IsStationModeEnabled(void);
+bool IsStationModeEnabled();
+
+/**
+ * @brief Returns the state of the Hardware
+ *
+ * @return true, if the hardware is ready to be used
+ *         false, otherwise
+ */
+bool IsHardwareReady();
+
+/**
+ * @brief Triggers the device to disconnect from the connected Wi-Fi network
+ *
+ * @note The disconnection is not immediate. It can take a certain amount of time for the device to be in a disconnected state once
+ *       the function is called. When the function returns, the device might not have yet disconnected from the Wi-Fi network.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR, disconnection request was succesfully triggered
+ *         otherwise, CHIP_ERROR_INTERNAL
+ */
+CHIP_ERROR TriggerWifiDisconnection();
+
+/**
+ * @brief Gets the connected access point information.
+ *        See @wfx_wifi_scan_result_t for the information that is returned by the function.
+ *
+ * @param[out] info AP information
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR, device has succesfully pulled all the AP information
+ *                    CHIP_ERROR_INTERNAL, otherwise. If the function returns an error, the data in ap cannot be used.
+ */
+CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info);
+
+/**
+ * @brief Gets the connected access point extended information.
+ *        See @wfx_wifi_scan_ext_t for the information that is returned by the information
+ *
+ * @param[out] info AP extended information
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR, device has succesfully pulled all the AP information
+ *                    CHIP_ERROR_INTERNAL, otherwise. If the function returns an error, the data in ap cannot be used.
+ */
+CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info);
+
+/**
+ * @brief Function resets the BeaconLostCount, BeaconRxCount, PacketMulticastRxCount, PacketMulticastTxCount, PacketUnicastRxCount,
+ *        PacketUnicastTxCount back to 0
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR, the counters were succesfully reset to 0.
+ *                    CHIP_ERROR_INTERNAL, if there was an error when resetting the counter values
+ */
+CHIP_ERROR ResetCounters();
 
 /* Function to update */
 
 void wfx_set_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig);
-int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap);
-int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
-int32_t wfx_reset_counts();
 void wfx_clear_wifi_provision(void);
 sl_status_t wfx_connect_to_ap(void);
-void wfx_setup_ip6_link_local(sl_wfx_interface_t);
-sl_status_t sl_matter_wifi_disconnect(void);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
 bool wfx_have_ipv4_addr(sl_wfx_interface_t);
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
 bool wfx_have_ipv6_addr(sl_wfx_interface_t);
-wifi_mode_t wfx_get_wifi_mode(void);
 void wfx_cancel_scan(void);
 
 /*
@@ -324,8 +389,6 @@ int32_t wfx_rsi_send_data(void * p, uint16_t len);
 #endif //!(EXP_BOARD)
 #endif // RS911X_WIFI
 
-bool wfx_hw_ready(void);
-
 #ifdef RS911X_WIFI // for RS9116, 917 NCP and 917 SoC
 /* RSI Power Save */
 #if SL_ICD_ENABLED
@@ -337,27 +400,12 @@ sl_status_t wfx_power_save();
 #endif /* SL_ICD_ENABLED */
 #endif /* RS911X_WIFI */
 
-void sl_matter_wifi_task(void * arg);
-
-int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap);
-int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
-int32_t wfx_rsi_reset_count();
-int32_t sl_wifi_platform_disconnect();
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if (SLI_SI91X_MCU_INTERFACE)
-#if SL_ICD_ENABLED
-// TODO : This should be moved outside of the Wifi interface functions
-void sl_button_on_change(uint8_t btn, uint8_t btnAction);
-#endif /* SL_ICD_ENABLED */
-#endif /* SLI_SI91X_MCU_INTERFACE */
-
 #ifdef WF200_WIFI
 void sl_wfx_host_gpio_init(void);
-void wfx_bus_start(void);
 #endif /* WF200_WIFI */
 
 #ifdef __cplusplus

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -689,7 +689,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -70,24 +70,82 @@ osThreadAttr_t kDrvTaskAttr = { .name       = "drv_rsi",
                                 .stack_size = kDrvTaskSize,
                                 .priority   = osPriorityHigh };
 
-bool hasNotifiedIPV6 = false;
-#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
-bool hasNotifiedIPV4 = false;
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-bool hasNotifiedWifiConnectivity = false;
-
 #if (RSI_BLE_ENABLE)
 extern rsi_semaphore_handle_t sl_rs_ble_init_sem;
 #endif
 
-// DHCP Poll timer
-static osTimerId_t sDHCPTimer;
 static osMessageQueueId_t sWifiEventQueue = NULL;
 /*
  * This file implements the interface to the RSI SAPIs
  */
 static uint8_t wfx_rsi_drv_buf[WFX_RSI_BUF_SZ];
 static wfx_wifi_scan_ext_t temp_reset;
+
+sl_status_t TriggerPlatformWifiDisconnection()
+{
+    VerifyOrReturnError(rsi_wlan_disconnect() == RSI_SUCCESS, SL_STATUS_FAIL);
+    return SL_STATUS_OK;
+}
+
+CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
+{
+    int32_t status = RSI_SUCCESS;
+    uint8_t rssi   = 0;
+
+    info.security = wfx_rsi.sec.security;
+    info.chan     = wfx_rsi.ap_chan;
+    memcpy(&(info.bssid[0]), wfx_rsi.ap_mac.data(), kWifiMacAddressLength);
+
+    status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
+    VerifyOrReturnError(status = RSI_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    info.rssi = (-1) * rssi;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info)
+{
+    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
+
+    int32_t status = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status));
+
+    // TODO: We need to clean up this casting for the extended information
+    rsi_wlan_ext_stats_t * test = (rsi_wlan_ext_stats_t *) buff;
+
+    info.beacon_lost_count = test->beacon_lost_count - temp_reset.beacon_lost_count;
+    info.beacon_rx_count   = test->beacon_rx_count - temp_reset.beacon_rx_count;
+    info.mcast_rx_count    = test->mcast_rx_count - temp_reset.mcast_rx_count;
+    info.mcast_tx_count    = test->mcast_tx_count - temp_reset.mcast_tx_count;
+    info.ucast_rx_count    = test->ucast_rx_count - temp_reset.ucast_rx_count;
+    info.ucast_tx_count    = test->ucast_tx_count - temp_reset.ucast_tx_count;
+    info.overrun_count     = test->overrun_count - temp_reset.overrun_count;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ResetCounters()
+{
+    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
+    int32_t status                      = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status));
+
+    // TODO: We need to clean up this casting for the extended information
+    rsi_wlan_ext_stats_t * test = (rsi_wlan_ext_stats_t *) buff;
+
+    temp_reset.beacon_lost_count = test->beacon_lost_count;
+    temp_reset.beacon_rx_count   = test->beacon_rx_count;
+    temp_reset.mcast_rx_count    = test->mcast_rx_count;
+    temp_reset.mcast_tx_count    = test->mcast_tx_count;
+    temp_reset.ucast_rx_count    = test->ucast_rx_count;
+    temp_reset.ucast_tx_count    = test->ucast_tx_count;
+    temp_reset.overrun_count     = test->overrun_count;
+
+    return CHIP_NO_ERROR;
+}
 
 /******************************************************************
  * @fn   void rsi_wireless_driver_task_wrapper(void * argument)
@@ -100,138 +158,6 @@ static wfx_wifi_scan_ext_t temp_reset;
 static void rsi_wireless_driver_task_wrapper(void * argument)
 {
     rsi_wireless_driver_task();
-}
-
-static void DHCPTimerEventHandler(void * arg)
-{
-    WifiPlatformEvent event = WifiPlatformEvent::kStationDhcpPoll;
-    sl_matter_wifi_post_event(event);
-}
-
-static void CancelDHCPTimer(void)
-{
-    osStatus_t status;
-
-    // Check if timer started
-    if (!osTimerIsRunning(sDHCPTimer))
-    {
-        ChipLogError(DeviceLayer, "CancelDHCPTimer: timer not running");
-        return;
-    }
-
-    status = osTimerStop(sDHCPTimer);
-    if (status != osOK)
-    {
-        ChipLogError(DeviceLayer, "CancelDHCPTimer: failed to stop timer with status: %d", status);
-    }
-}
-
-static void StartDHCPTimer(uint32_t timeout)
-{
-    osStatus_t status;
-
-    // Cancel timer if already started
-    CancelDHCPTimer();
-
-    status = osTimerStart(sDHCPTimer, pdMS_TO_TICKS(timeout));
-    if (status != osOK)
-    {
-        ChipLogError(DeviceLayer, "StartDHCPTimer: failed to start timer with status: %d", status);
-    }
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t *ap)
- * @brief
- *       Getting the AP details
- * @param[in] ap: access point
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap)
-{
-    int32_t status = RSI_SUCCESS;
-    uint8_t rssi;
-    ap->security = wfx_rsi.sec.security;
-    ap->chan     = wfx_rsi.ap_chan;
-    memcpy(&ap->bssid[0], wfx_rsi.ap_mac.data(), kWifiMacAddressLength);
-    status = rsi_wlan_get(RSI_RSSI, &rssi, sizeof(rssi));
-    if (status == RSI_SUCCESS)
-    {
-        ap->rssi = (-1) * rssi;
-    }
-    return status;
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t *extra_info)
- * @brief
- *       Getting the AP extra details
- * @param[in] extra info: access point extra information
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
-{
-    int32_t status;
-    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
-    status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status);
-        return status;
-    }
-    rsi_wlan_ext_stats_t * test   = (rsi_wlan_ext_stats_t *) buff;
-    extra_info->beacon_lost_count = test->beacon_lost_count - temp_reset.beacon_lost_count;
-    extra_info->beacon_rx_count   = test->beacon_rx_count - temp_reset.beacon_rx_count;
-    extra_info->mcast_rx_count    = test->mcast_rx_count - temp_reset.mcast_rx_count;
-    extra_info->mcast_tx_count    = test->mcast_tx_count - temp_reset.mcast_tx_count;
-    extra_info->ucast_rx_count    = test->ucast_rx_count - temp_reset.ucast_rx_count;
-    extra_info->ucast_tx_count    = test->ucast_tx_count - temp_reset.ucast_tx_count;
-    extra_info->overrun_count     = test->overrun_count - temp_reset.overrun_count;
-    return status;
-}
-
-/******************************************************************
- * @fn   int32_t wfx_rsi_reset_count(void)
- * @brief
- *       Getting the driver reset count
- * @param[in] None
- * @return
- *        status
- *********************************************************************/
-int32_t wfx_rsi_reset_count(void)
-{
-    int32_t status;
-    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
-    status                              = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status);
-        return status;
-    }
-    rsi_wlan_ext_stats_t * test  = (rsi_wlan_ext_stats_t *) buff;
-    temp_reset.beacon_lost_count = test->beacon_lost_count;
-    temp_reset.beacon_rx_count   = test->beacon_rx_count;
-    temp_reset.mcast_rx_count    = test->mcast_rx_count;
-    temp_reset.mcast_tx_count    = test->mcast_tx_count;
-    temp_reset.ucast_rx_count    = test->ucast_rx_count;
-    temp_reset.ucast_tx_count    = test->ucast_tx_count;
-    temp_reset.overrun_count     = test->overrun_count;
-    return status;
-}
-
-/******************************************************************
- * @fn   sl_wifi_platform_disconnect(void)
- * @brief
- *       Getting the driver disconnect status
- * @param[in] None
- * @return
- *        status
- *********************************************************************/
-int32_t sl_wifi_platform_disconnect(void)
-{
-    return rsi_wlan_disconnect();
 }
 
 /******************************************************************
@@ -263,7 +189,7 @@ static void wfx_rsi_join_cb(uint16_t status, const uint8_t * buf, const uint16_t
     ChipLogProgress(DeviceLayer, "wfx_rsi_join_cb: success");
     memset(&temp_reset, 0, sizeof(wfx_wifi_scan_ext_t));
     WifiPlatformEvent event = WifiPlatformEvent::kStationConnect;
-    sl_matter_wifi_post_event(event);
+    PostWifiPlatformEvent(event);
     wfx_rsi.join_retries = 0;
 }
 
@@ -285,7 +211,7 @@ static void wfx_rsi_join_fail_cb(uint16_t status, uint8_t * buf, uint32_t len)
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting).Clear(WifiState::kStationConnected);
 
     WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
-    sl_matter_wifi_post_event(event);
+    PostWifiPlatformEvent(event);
 }
 /*************************************************************************************
  * @fn  wfx_rsi_wlan_pkt_cb(uint16_t status, uint8_t *buf, uint32_t len)
@@ -391,13 +317,9 @@ static int32_t sl_matter_wifi_init(void)
         return SL_STATUS_ALLOCATION_FAILED;
     }
 
-    // Create timer for DHCP polling
     // TODO: Use LWIP timer instead of creating a new one here
-    sDHCPTimer = osTimerNew(DHCPTimerEventHandler, osTimerPeriodic, NULL, NULL);
-    if (sDHCPTimer == NULL)
-    {
-        return SL_STATUS_ALLOCATION_FAILED;
-    }
+    status = CreateDHCPTimer();
+    VerifyOrReturnError(status == SL_STATUS_OK, status);
 
     /*
      * Register callbacks - We are only interested in the connectivity CBs
@@ -555,19 +477,6 @@ static void sl_wifi_platform_join_network(void)
     }
 }
 
-/**  NotifyConnectivity
- *   @brief Notify the application about the connectivity status if it has not been notified yet.
- *          Helper function for HandleDHCPPolling.
- */
-void NotifyConnectivity(void)
-{
-    if (!hasNotifiedWifiConnectivity)
-    {
-        NotifyConnection(wfx_rsi.ap_mac);
-        hasNotifiedWifiConnectivity = true;
-    }
-}
-
 void HandleDHCPPolling(void)
 {
     struct netif * sta_netif;
@@ -582,56 +491,36 @@ void HandleDHCPPolling(void)
     }
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
     uint8_t dhcp_state = dhcpclient_poll(sta_netif);
-    if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !hasNotifiedIPV4)
+    if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !HasNotifiedIPv4Change())
     {
         wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
-        hasNotifiedIPV4 = true;
+        NotifyIPv4Change(true);
         NotifyConnectivity();
     }
     else if (dhcp_state == DHCP_OFF)
     {
         NotifyIPv4Change(false);
-        hasNotifiedIPV4 = false;
     }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
     /* Checks if the assigned IPv6 address is preferred by evaluating
      * the first block of IPv6 address ( block 0)
      */
-    if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
+    if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !HasNotifiedIPv6Change())
     {
         NotifyIPv6Change(true);
-        hasNotifiedIPV6         = true;
         WifiPlatformEvent event = WifiPlatformEvent::kStationDhcpDone;
-        sl_matter_wifi_post_event(event);
+        PostWifiPlatformEvent(event);
         NotifyConnectivity();
     }
 }
 
-/** ResetDHCPNotificationFlags
- *  @brief Reset the flags that are used to notify the application about DHCP connectivity
- *         and emits a WifiPlatformEvent::kStationDoDhcp event to trigger DHCP polling checks. Helper function for ProcessEvent.
- */
-void ResetDHCPNotificationFlags(void)
-{
-    WifiPlatformEvent outEvent;
-
-#if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
-    hasNotifiedIPV4 = false;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
-    hasNotifiedIPV6             = false;
-    hasNotifiedWifiConnectivity = false;
-
-    outEvent = WifiPlatformEvent::kStationDoDhcp;
-    sl_matter_wifi_post_event(outEvent);
-}
-
-void sl_matter_wifi_post_event(WifiPlatformEvent event)
+void PostWifiPlatformEvent(WifiPlatformEvent event)
 {
     sl_status_t status = osMessageQueuePut(sWifiEventQueue, &event, 0, 0);
 
     if (status != osOK)
     {
-        ChipLogError(DeviceLayer, "sl_matter_wifi_post_event: failed to post event with status: %ld", status);
+        ChipLogError(DeviceLayer, "PostWifiPlatformEvent: failed to post event with status: %ld", status);
         // TODO: Handle error, requeue event depending on queue size or notify relevant task,
         // Chipdie, etc.
     }
@@ -758,31 +647,20 @@ void ProcessEvent(WifiPlatformEvent event)
     }
 }
 
-/*********************************************************************************
- * @fn  void sl_matter_wifi_task(void *arg)
- * @brief
- * The main WLAN task - started by StartWifiTask () that interfaces with RSI.
- * The rest of RSI stuff come in call-backs.
- * The initialization has been already done.
- * @param[in] arg:
- * @return
- *       None
- **********************************************************************************/
-/* ARGSUSED */
-void sl_matter_wifi_task(void * arg)
+void MatterWifiTask(void * arg)
 {
     (void) arg;
     uint32_t rsi_status = sl_matter_wifi_init();
     if (rsi_status != RSI_SUCCESS)
     {
-        ChipLogError(DeviceLayer, "sl_matter_wifi_task: sl_matter_wifi_init failed: %ld", rsi_status);
+        ChipLogError(DeviceLayer, "MatterWifiTask: sl_matter_wifi_init failed: %ld", rsi_status);
         return;
     }
     WifiPlatformEvent event;
     sl_matter_lwip_start();
     sl_matter_wifi_task_started();
 
-    ChipLogProgress(DeviceLayer, "sl_matter_wifi_task: starting event loop");
+    ChipLogProgress(DeviceLayer, "MatterWifiTask: starting event loop");
     for (;;)
     {
         osStatus_t status = osMessageQueueGet(sWifiEventQueue, &event, NULL, osWaitForever);
@@ -792,7 +670,7 @@ void sl_matter_wifi_task(void * arg)
         }
         else
         {
-            ChipLogProgress(DeviceLayer, "sl_matter_wifi_task: get event failed: %x", status);
+            ChipLogProgress(DeviceLayer, "MatterWifiTask: get event failed: %x", status);
         }
     }
 }
@@ -811,7 +689,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -106,43 +106,38 @@ CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
 
 CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info)
 {
-    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
+    rsi_wlan_ext_stats_t stats = { 0 };
 
-    int32_t status = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    int32_t status = rsi_wlan_get(RSI_WLAN_EXT_STATS, reinterpret_cast<uint8_t *>(&stats), sizeof(stats));
     VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status));
 
-    // TODO: We need to clean up this casting for the extended information
-    rsi_wlan_ext_stats_t * test = (rsi_wlan_ext_stats_t *) buff;
-
-    info.beacon_lost_count = test->beacon_lost_count - temp_reset.beacon_lost_count;
-    info.beacon_rx_count   = test->beacon_rx_count - temp_reset.beacon_rx_count;
-    info.mcast_rx_count    = test->mcast_rx_count - temp_reset.mcast_rx_count;
-    info.mcast_tx_count    = test->mcast_tx_count - temp_reset.mcast_tx_count;
-    info.ucast_rx_count    = test->ucast_rx_count - temp_reset.ucast_rx_count;
-    info.ucast_tx_count    = test->ucast_tx_count - temp_reset.ucast_tx_count;
-    info.overrun_count     = test->overrun_count - temp_reset.overrun_count;
+    info.beacon_lost_count = stats.beacon_lost_count - temp_reset.beacon_lost_count;
+    info.beacon_rx_count   = stats.beacon_rx_count - temp_reset.beacon_rx_count;
+    info.mcast_rx_count    = stats.mcast_rx_count - temp_reset.mcast_rx_count;
+    info.mcast_tx_count    = stats.mcast_tx_count - temp_reset.mcast_tx_count;
+    info.ucast_rx_count    = stats.ucast_rx_count - temp_reset.ucast_rx_count;
+    info.ucast_tx_count    = stats.ucast_tx_count - temp_reset.ucast_tx_count;
+    info.overrun_count     = stats.overrun_count - temp_reset.overrun_count;
 
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ResetCounters()
 {
-    uint8_t buff[RSI_RESPONSE_MAX_SIZE] = { 0 };
-    int32_t status                      = rsi_wlan_get(RSI_WLAN_EXT_STATS, buff, sizeof(buff));
+    rsi_wlan_ext_stats_t stats = { 0 };
+
+    int32_t status = rsi_wlan_get(RSI_WLAN_EXT_STATS, reinterpret_cast<uint8_t *>(&stats), sizeof(stats));
     VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "Failed, Error Code : 0x%lX", status));
 
-    // TODO: We need to clean up this casting for the extended information
-    rsi_wlan_ext_stats_t * test = (rsi_wlan_ext_stats_t *) buff;
-
-    temp_reset.beacon_lost_count = test->beacon_lost_count;
-    temp_reset.beacon_rx_count   = test->beacon_rx_count;
-    temp_reset.mcast_rx_count    = test->mcast_rx_count;
-    temp_reset.mcast_tx_count    = test->mcast_tx_count;
-    temp_reset.ucast_rx_count    = test->ucast_rx_count;
-    temp_reset.ucast_tx_count    = test->ucast_tx_count;
-    temp_reset.overrun_count     = test->overrun_count;
+    temp_reset.beacon_lost_count = stats.beacon_lost_count;
+    temp_reset.beacon_rx_count   = stats.beacon_rx_count;
+    temp_reset.mcast_rx_count    = stats.mcast_rx_count;
+    temp_reset.mcast_tx_count    = stats.mcast_tx_count;
+    temp_reset.ucast_rx_count    = stats.ucast_rx_count;
+    temp_reset.ucast_tx_count    = stats.ucast_tx_count;
+    temp_reset.overrun_count     = stats.overrun_count;
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -105,8 +105,6 @@ struct netif * sta_netif;
 wfx_wifi_provision_t wifi_provision;
 #define PUT_COUNTER(name) ChipLogDetail(DeviceLayer, "%-24s %lu", #name, (unsigned long) counters->body.count_##name);
 
-bool hasNotifiedIPV6             = false;
-bool hasNotifiedIPV4             = false;
 bool hasNotifiedWifiConnectivity = false;
 static uint8_t retryJoin         = 0;
 bool retryInProgress             = false;
@@ -367,6 +365,73 @@ bool IsStationConnected()
     return wifi_extra.Has(WifiState::kStationConnected);
 }
 
+bool IsHardwareReady()
+{
+    return wifi_extra.Has(WifiState::kStationInit);
+}
+
+CHIP_ERROR TriggerWifiDisconnection(void)
+{
+    ChipLogProgress(DeviceLayer, "STA-Disconnecting");
+
+    sl_status_t status = sl_wfx_send_disconnect_command();
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+
+    wifi_extra.Clear(WifiState::kStationConnected);
+
+    xEventGroupSetBits(sl_wfx_event_group, SL_WFX_RETRY_CONNECT);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
+{
+    uint32_t signal_strength = 0;
+
+    // TODO: The ap_info.ssid isn't populated anywhere. The returned value is always 0.
+    chip::ByteSpan apSsidSpan(ap_info.ssid, ap_info.ssid_length);
+    chip::MutableByteSpan apSsidMutableSpan(info.ssid, WFX_MAX_SSID_LENGTH);
+    chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
+    info.ssid_length = apSsidMutableSpan.size();
+
+    // TODO: The ap_info.bssid isn't populated anywhere. The returned value is always 0.
+    chip::ByteSpan apBssidSpan(ap_info.bssid, kWifiMacAddressLength);
+    chip::MutableByteSpan apBssidMutableSpan(info.bssid, kWifiMacAddressLength);
+    chip::CopySpanToMutableSpan(apBssidSpan, apBssidMutableSpan);
+
+    info.security = ap_info.security;
+    info.chan     = ap_info.chan;
+
+    sl_status_t status = sl_wfx_get_signal_strength(&signal_strength);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+
+    info.rssi = (signal_strength - 220) / 2;
+
+    ChipLogDetail(DeviceLayer, "WIFI:SSID     : %s", ap_info.ssid);
+    ChipLogDetail(DeviceLayer, "WIFI:BSSID    : %02x:%02x:%02x:%02x:%02x:%02x", ap_info.bssid[0], ap_info.bssid[1],
+                  ap_info.bssid[2], ap_info.bssid[3], ap_info.bssid[4], ap_info.bssid[5]);
+    ChipLogDetail(DeviceLayer, "WIFI:security : %d", info.security);
+    ChipLogDetail(DeviceLayer, "WIFI:channel  :  %d", info.chan);
+    ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info)
+{
+    sl_status_t status = get_all_counters();
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "Failed to get the couters"));
+
+    info.beacon_lost_count = counters->body.count_miss_beacon;
+    info.beacon_rx_count   = counters->body.count_rx_beacon;
+    info.mcast_rx_count    = counters->body.count_rx_multicast_frames;
+    info.mcast_tx_count    = counters->body.count_tx_multicast_frames;
+    info.ucast_rx_count    = counters->body.count_rx_packets;
+    info.ucast_tx_count    = counters->body.count_tx_packets;
+    info.overrun_count     = gOverrunCount;
+
+    return CHIP_NO_ERROR;
+}
+
 /***************************************************************************
  * @brief
  * Creates WFX events processing task.
@@ -588,8 +653,8 @@ static void sl_wfx_connect_callback(sl_wfx_connect_ind_body_t connect_indication
     case WFM_STATUS_SUCCESS: {
         ChipLogProgress(DeviceLayer, "STA-Connected");
         memcpy(ap_mac.data(), mac, kWifiMacAddressLength);
-        sl_wfx_context->state =
-            static_cast<sl_wfx_state_t>(static_cast<int>(sl_wfx_context->state) | static_cast<int>(SL_WFX_STA_INTERFACE_CONNECTED));
+
+        wifi_extra.Set(WifiState::kStationConnected);
         xEventGroupSetBits(sl_wfx_event_group, SL_WFX_CONNECT);
         break;
     }
@@ -623,8 +688,7 @@ static void sl_wfx_connect_callback(sl_wfx_connect_ind_body_t connect_indication
         retryJoin += 1;
         retryInProgress = false;
         ChipLogProgress(DeviceLayer, "Retry to connect to network count: %d", retryJoin);
-        sl_wfx_context->state =
-            static_cast<sl_wfx_state_t>(static_cast<int>(sl_wfx_context->state) & ~static_cast<int>(SL_WFX_STARTED));
+
         wfx_retry_connection(retryJoin);
     }
 }
@@ -639,8 +703,8 @@ static void sl_wfx_disconnect_callback(uint8_t * mac, uint16_t reason)
 {
     (void) (mac);
     ChipLogProgress(DeviceLayer, "Disconnected %d", reason);
-    sl_wfx_context->state =
-        static_cast<sl_wfx_state_t>(static_cast<int>(sl_wfx_context->state) & ~static_cast<int>(SL_WFX_STA_INTERFACE_CONNECTED));
+    wifi_extra.Clear(WifiState::kStationConnected);
+
     retryInProgress = false;
     wfx_retry_connection(retryJoin);
 }
@@ -654,8 +718,8 @@ static void sl_wfx_disconnect_callback(uint8_t * mac, uint16_t reason)
 static void sl_wfx_start_ap_callback(uint32_t status)
 {
     VerifyOrReturnLogError(status == AP_START_SUCCESS, CHIP_ERROR_INTERNAL);
-    sl_wfx_context->state =
-        static_cast<sl_wfx_state_t>(static_cast<int>(sl_wfx_context->state) | static_cast<int>(SL_WFX_AP_INTERFACE_UP));
+    wifi_extra.Set(WifiState::kAPReady);
+
     xEventGroupSetBits(sl_wfx_event_group, SL_WFX_START_AP);
 }
 
@@ -668,8 +732,8 @@ static void sl_wfx_stop_ap_callback(void)
     // TODO
     // dhcpserver_clear_stored_mac();
     ChipLogProgress(DeviceLayer, "SoftAP stopped");
-    sl_wfx_context->state =
-        static_cast<sl_wfx_state_t>(static_cast<int>(sl_wfx_context->state) & ~static_cast<int>(SL_WFX_AP_INTERFACE_UP));
+    wifi_extra.Clear(WifiState::kAPReady);
+
     xEventGroupSetBits(sl_wfx_event_group, SL_WFX_STOP_AP);
 }
 
@@ -754,10 +818,10 @@ static void wfx_events_task(void * p_arg)
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
                 uint8_t dhcp_state = dhcpclient_poll(sta_netif);
 
-                if ((dhcp_state == DHCP_ADDRESS_ASSIGNED) && !hasNotifiedIPV4)
+                if ((dhcp_state == DHCP_ADDRESS_ASSIGNED) && !HasNotifiedIPv4Change())
                 {
                     wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
-                    hasNotifiedIPV4 = true;
+                    NotifyIPv4Change(true);
                     if (!hasNotifiedWifiConnectivity)
                     {
                         ChipLogProgress(DeviceLayer, "will notify WiFi connectivity");
@@ -768,13 +832,11 @@ static void wfx_events_task(void * p_arg)
                 else if (dhcp_state == DHCP_OFF)
                 {
                     NotifyIPv4Change(false);
-                    hasNotifiedIPV4 = false;
                 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
-                if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !hasNotifiedIPV6)
+                if ((ip6_addr_ispreferred(netif_ip6_addr_state(sta_netif, 0))) && !HasNotifiedIPv6Change())
                 {
                     NotifyIPv6Change(true);
-                    hasNotifiedIPV6 = true;
                     if (!hasNotifiedWifiConnectivity)
                     {
                         NotifyConnection(ap_mac);
@@ -789,17 +851,15 @@ static void wfx_events_task(void * p_arg)
         {
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
             NotifyIPv4Change(false);
-            hasNotifiedIPV4 = false;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
             NotifyIPv6Change(false);
-            hasNotifiedIPV6             = false;
             hasNotifiedWifiConnectivity = false;
             ChipLogProgress(DeviceLayer, "connected to AP");
             wifi_extra.Set(WifiState::kStationConnected);
             retryJoin = 0;
             wfx_lwip_set_sta_link_up();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-            if (!(wifiContext.state & SL_WFX_AP_INTERFACE_UP))
+            if (!(wifi_extra.Has(WifiState::kAPReady)))
             {
                 // Enable the power save
                 ChipLogProgress(DeviceLayer, "WF200 going to DTIM based sleep");
@@ -814,10 +874,8 @@ static void wfx_events_task(void * p_arg)
 
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
             NotifyIPv4Change(false);
-            hasNotifiedIPV4 = false;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_IPV4
             NotifyIPv6Change(false);
-            hasNotifiedIPV6             = false;
             hasNotifiedWifiConnectivity = false;
             wifi_extra.Clear(WifiState::kStationConnected);
             wfx_lwip_set_sta_link_down();
@@ -905,7 +963,7 @@ static sl_status_t wfx_init(void)
                         wifiContext.mac_addr_0.octet[4], wifiContext.mac_addr_0.octet[5]);
         ChipLogProgress(DeviceLayer, "WF200 Init OK");
 
-        if (wifiContext.state == SL_WFX_STA_INTERFACE_CONNECTED)
+        if (wifi_extra.Has(WifiState::kStationConnected))
         {
             sl_wfx_send_disconnect_command();
         }
@@ -956,7 +1014,6 @@ static sl_status_t wfx_wifi_hw_start(void)
     ChipLogDetail(DeviceLayer, "WF200:Start LWIP");
     sl_matter_lwip_start();
     sl_matter_wifi_task_started();
-    wifiContext.state = SL_WFX_STARTED; /* Really this is a bit mask */
 
     ChipLogDetail(DeviceLayer, "WF200:ready.");
     wifi_extra.Set(WifiState::kStationStarted);
@@ -964,100 +1021,10 @@ static sl_status_t wfx_wifi_hw_start(void)
     return SL_STATUS_OK;
 }
 
-/***********************************************************************
- * @brief
- * Get AP info
- * @param[in]  ap: access point information
- * @return returns -1
- **************************************************************************/
-int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
+CHIP_ERROR ResetCounters()
 {
-    uint32_t signal_strength = 0;
-
-    chip::ByteSpan apSsidSpan(ap_info.ssid, ap_info.ssid_length);
-    chip::MutableByteSpan apSsidMutableSpan(ap->ssid, WFX_MAX_SSID_LENGTH);
-    chip::CopySpanToMutableSpan(apSsidSpan, apSsidMutableSpan);
-    ap->ssid_length = apSsidMutableSpan.size();
-
-    chip::ByteSpan apBssidSpan(ap_info.bssid, kWifiMacAddressLength);
-    chip::MutableByteSpan apBssidMutableSpan(ap->bssid, kWifiMacAddressLength);
-    chip::CopySpanToMutableSpan(apBssidSpan, apBssidMutableSpan);
-
-    ap->security = ap_info.security;
-    ap->chan     = ap_info.chan;
-
-    sl_status_t status = sl_wfx_get_signal_strength(&signal_strength);
-    VerifyOrReturnError(status == SL_STATUS_OK, status);
-    ap->rssi = (signal_strength - 220) / 2;
-
-    ChipLogDetail(DeviceLayer, "WIFI:SSID     : %s", ap_info.ssid);
-    ChipLogDetail(DeviceLayer, "WIFI:BSSID    : %02x:%02x:%02x:%02x:%02x:%02x", ap_info.bssid[0], ap_info.bssid[1],
-                  ap_info.bssid[2], ap_info.bssid[3], ap_info.bssid[4], ap_info.bssid[5]);
-    ChipLogDetail(DeviceLayer, "WIFI:security : %d", ap->security);
-    ChipLogDetail(DeviceLayer, "WIFI:channel  :  %d", ap->chan);
-    ChipLogDetail(DeviceLayer, "signal_strength: %ld", signal_strength);
-
-    return status;
-}
-
-/************************************************************************
- * @brief
- * Get AP extra info
- * @param[in]  extra_info: access point extra information
- * @return returns -1
- **************************************************************************/
-int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
-{
-    int32_t status;
-    status = get_all_counters();
-    if (status != SL_STATUS_OK)
-    {
-        ChipLogError(DeviceLayer, "Failed to get the couters");
-    }
-    else
-    {
-        extra_info->beacon_lost_count = counters->body.count_miss_beacon;
-        extra_info->beacon_rx_count   = counters->body.count_rx_beacon;
-        extra_info->mcast_rx_count    = counters->body.count_rx_multicast_frames;
-        extra_info->mcast_tx_count    = counters->body.count_tx_multicast_frames;
-        extra_info->ucast_rx_count    = counters->body.count_rx_packets;
-        extra_info->ucast_tx_count    = counters->body.count_tx_packets;
-        extra_info->overrun_count     = gOverrunCount;
-    }
-    return status;
-}
-
-/************************************************************************
- * @brief
- *    reset the count
- * @return returns -1
- **************************************************************************/
-int32_t wfx_reset_counts(void)
-{
-    /* TODO */
-    return -1;
-}
-
-/****************************************************************************
- * @brief
- *      getnetif using interface
- * @param[in]  interface:
- * @return returns selectedNetif
- *****************************************************************************/
-struct netif * wfx_GetNetif(sl_wfx_interface_t interface)
-{
-    struct netif * SelectedNetif = nullptr;
-    if (interface == SL_WFX_STA_INTERFACE)
-    {
-        SelectedNetif = sta_netif;
-    }
-#ifdef SL_WFX_CONFIG_SOFTAP
-    else if (interface == SL_WFX_SOFTAP_INTERFACE)
-    {
-        // no ap currently
-    }
-#endif
-    return SelectedNetif;
+    // TODO: Implement the function
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
 /****************************************************************************
@@ -1169,56 +1136,6 @@ bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
     return IsStationConnected();
 }
 
-/****************************************************************************
- * @brief
- * Disconnect station mode from connected AP
- * @returns Returns SL_STATUS_OK if successful,
- *             SL_STATUS_FAIL otherwise
- *****************************************************************************/
-sl_status_t sl_matter_wifi_disconnect(void)
-{
-    ChipLogProgress(DeviceLayer, "STA-Disconnecting");
-
-    int32_t status = sl_wfx_send_disconnect_command();
-    wifi_extra.Clear(WifiState::kStationConnected);
-
-    xEventGroupSetBits(sl_wfx_event_group, SL_WFX_RETRY_CONNECT);
-    return status;
-}
-
-/****************************************************************************
- * @brief
- *      It is automatically done when lwip link up
- * @return returns true if sucessful,
- *         false otherwise
- *****************************************************************************/
-void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif) {}
-
-/****************************************************************************
- * @brief
- *      get the wifi mode
- * @return returns WIFI_MODE_NULL if sucessful,
- *         WIFI_MODE_STA otherwise
- *****************************************************************************/
-wifi_mode_t wfx_get_wifi_mode(void)
-{
-    if (wifiContext.state & SL_WFX_STARTED)
-        return WIFI_MODE_STA;
-    return WIFI_MODE_NULL;
-}
-
-/*****************************************************************************
- * @brief
- * This is called from the context of AppTask
- * For WF200 - Start WIFI here
- * @return returns true if sucessful,
- *         false otherwise
- ******************************************************************************/
-bool wfx_hw_ready(void)
-{
-    return (wifiContext.state & SL_WFX_STARTED) ? true : false;
-}
-
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
 /*****************************************************************************
  * @brief
@@ -1232,7 +1149,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) &0xFF;
+    ip4_addr[0] = (ip) & 0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -1149,7 +1149,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
      */
     uint8_t ip4_addr[4];
 
-    ip4_addr[0] = (ip) & 0xFF;
+    ip4_addr[0] = (ip) &0xFF;
     ip4_addr[1] = (ip >> 8) & 0xFF;
     ip4_addr[2] = (ip >> 16) & 0xFF;
     ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -365,12 +365,12 @@ bool IsStationConnected()
     return wifi_extra.Has(WifiState::kStationConnected);
 }
 
-bool IsHardwareReady()
+bool IsStationReady()
 {
     return wifi_extra.Has(WifiState::kStationInit);
 }
 
-CHIP_ERROR TriggerWifiDisconnection(void)
+CHIP_ERROR TriggerDisconnection(void)
 {
     ChipLogProgress(DeviceLayer, "STA-Disconnecting");
 

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -14,9 +14,11 @@
  *    limitations under the License.
  */
 
+#include <cmsis_os2.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>
+#include <sl_cmsis_os2_common.h>
 
 extern WfxRsi_t wfx_rsi;
 
@@ -34,6 +36,9 @@ constexpr osThreadAttr_t kWlanTaskAttr = { .name       = "wlan_rsi",
                                            .stack_mem  = wlanStack,
                                            .stack_size = kWlanTaskSize,
                                            .priority   = osPriorityAboveNormal7 };
+
+osTimerId_t sDHCPTimer;
+bool hasNotifiedWifiConnectivity = false;
 
 } // namespace
 
@@ -76,7 +81,7 @@ CHIP_ERROR StartNetworkScan(chip::ByteSpan ssid, ScanCallback callback)
 
     // TODO: We should be calling the start function directly instead of doing it asynchronously
     WifiPlatformEvent event = WifiPlatformEvent::kScan;
-    sl_matter_wifi_post_event(event);
+    PostWifiPlatformEvent(event);
 
     return CHIP_NO_ERROR;
 }
@@ -88,7 +93,7 @@ CHIP_ERROR StartWifiTask()
     wfx_rsi.dev_state.Set(WifiState::kStationStarted);
 
     // Creating a Wi-Fi task thread
-    sWlanThread = osThreadNew(sl_matter_wifi_task, NULL, &kWlanTaskAttr);
+    sWlanThread = osThreadNew(MatterWifiTask, NULL, &kWlanTaskAttr);
     VerifyOrReturnError(sWlanThread != NULL, CHIP_ERROR_NO_MEMORY, ChipLogError(DeviceLayer, "Unable to create the WifiTask."););
 
     return CHIP_NO_ERROR;
@@ -107,6 +112,73 @@ bool IsStationModeEnabled()
 bool IsStationConnected()
 {
     return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
+}
+
+bool IsHardwareReady()
+{
+    return wfx_rsi.dev_state.Has(WifiState::kStationInit);
+}
+
+CHIP_ERROR TriggerWifiDisconnection()
+{
+    VerifyOrReturnError(TriggerPlatformWifiDisconnection() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
+    wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
+
+    return CHIP_NO_ERROR;
+}
+
+void DHCPTimerEventHandler(void * arg)
+{
+    WifiPlatformEvent event = WifiPlatformEvent::kStationDhcpPoll;
+    PostWifiPlatformEvent(event);
+}
+
+void CancelDHCPTimer(void)
+{
+    VerifyOrReturn(osTimerIsRunning(sDHCPTimer), ChipLogDetail(DeviceLayer, "CancelDHCPTimer: timer not running"));
+    VerifyOrReturn(osTimerStop(sDHCPTimer) == osOK, ChipLogError(DeviceLayer, "CancelDHCPTimer: failed to stop timer"));
+}
+
+void StartDHCPTimer(uint32_t timeout)
+{
+    // Cancel timer if already started
+    CancelDHCPTimer();
+
+    VerifyOrReturn(osTimerStart(sDHCPTimer, pdMS_TO_TICKS(timeout)) == osOK,
+                   ChipLogError(DeviceLayer, "StartDHCPTimer: failed to start timer"));
+}
+
+void NotifyConnectivity(void)
+{
+    VerifyOrReturn(!hasNotifiedWifiConnectivity);
+
+    NotifyConnection(wfx_rsi.ap_mac);
+    hasNotifiedWifiConnectivity = true;
+}
+
+sl_status_t CreateDHCPTimer()
+{
+    // TODO: Use LWIP timer instead of creating a new one here
+    sDHCPTimer = osTimerNew(DHCPTimerEventHandler, osTimerPeriodic, nullptr, nullptr);
+    VerifyOrReturnError(sDHCPTimer != nullptr, SL_STATUS_ALLOCATION_FAILED);
+
+    return SL_STATUS_OK;
+}
+
+/**
+ * @brief Reset the flags that are used to notify the application about DHCP connectivity
+ *        and emits a WifiPlatformEvent::kStationDoDhcp event to trigger DHCP polling checks.
+ *
+ * TODO: This function should be moved to the protected section once the class structure is done.
+ */
+void ResetDHCPNotificationFlags(void)
+{
+
+    ResetIPNotificationStates();
+    hasNotifiedWifiConnectivity = false;
+
+    WifiPlatformEvent event = WifiPlatformEvent::kStationDoDhcp;
+    PostWifiPlatformEvent(event);
 }
 
 /*********************************************************************
@@ -169,55 +241,10 @@ sl_status_t wfx_connect_to_ap(void)
     ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.sec.ssid);
 
     WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
-    sl_matter_wifi_post_event(event);
+    PostWifiPlatformEvent(event);
     return SL_STATUS_OK;
 }
 
-/*********************************************************************
- * @fn  void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)
- * @brief
- *      Implement the ipv6 setup
- * @param[in]  whichif:
- * @return  None
- ***********************************************************************/
-void wfx_setup_ip6_link_local(sl_wfx_interface_t whichif)
-{
-    /*
-     * TODO: Implement IPV6 setup, currently in sl_matter_wifi_task()
-     * This is hooked with MATTER code.
-     */
-}
-
-/*********************************************************************
- * @fn  wifi_mode_t wfx_get_wifi_mode(void)
- * @brief
- *      get the wifi mode
- * @param[in]  None
- * @return  return WIFI_MODE_NULL if successful,
- *          WIFI_MODE_STA otherwise
- ***********************************************************************/
-wifi_mode_t wfx_get_wifi_mode(void)
-{
-    if (wfx_rsi.dev_state.Has(WifiState::kStationInit))
-        return WIFI_MODE_STA;
-    return WIFI_MODE_NULL;
-}
-
-/*********************************************************************
- * @fn  sl_status_t sl_matter_wifi_disconnect(void)
- * @brief
- *      called fuction when STA disconnected
- * @param[in]  None
- * @return  return SL_STATUS_OK if successful,
- *          SL_STATUS_FAIL otherwise
- ***********************************************************************/
-sl_status_t sl_matter_wifi_disconnect(void)
-{
-    sl_status_t status;
-    status = sl_wifi_platform_disconnect();
-    wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
-    return status;
-}
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
 /*********************************************************************
  * @fn  bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
@@ -247,58 +274,6 @@ bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
     VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
     // TODO: WifiState::kStationConnected does not guarantee SLAAC IPv6 LLA, maybe use a different FLAG
     return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
-}
-
-/*********************************************************************
- * @fn  bool wfx_hw_ready(void)
- * @brief
- *      called fuction when driver ready
- * @param[in]  None
- * @return  returns ture if successful,
- *          false otherwise
- ***********************************************************************/
-bool wfx_hw_ready(void)
-{
-    return wfx_rsi.dev_state.Has(WifiState::kStationInit);
-}
-
-/*********************************************************************
- * @fn  int32_t wfx_get_ap_info(wfx_wifi_scan_result_t *ap)
- * @brief
- *      get the access point information
- * @param[in]  ap: access point
- * @return
- *      access point information
- ***********************************************************************/
-int32_t wfx_get_ap_info(wfx_wifi_scan_result_t * ap)
-{
-    return wfx_rsi_get_ap_info(ap);
-}
-
-/*********************************************************************
- * @fn   int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t *extra_info)
- * @brief
- *      get the access point extra information
- * @param[in]  extra_info:access point extra information
- * @return
- *      access point extra information
- ***********************************************************************/
-int32_t wfx_get_ap_ext(wfx_wifi_scan_ext_t * extra_info)
-{
-    return wfx_rsi_get_ap_ext(extra_info);
-}
-
-/***************************************************************************
- * @fn   int32_t wfx_reset_counts(void)
- * @brief
- *      get the driver reset count
- * @param[in]  None
- * @return
- *      reset count
- *****************************************************************************/
-int32_t wfx_reset_counts(void)
-{
-    return wfx_rsi_reset_count();
 }
 
 /***************************************************************************

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -114,12 +114,12 @@ bool IsStationConnected()
     return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
-bool IsHardwareReady()
+bool IsStationReady()
 {
     return wfx_rsi.dev_state.Has(WifiState::kStationInit);
 }
 
-CHIP_ERROR TriggerWifiDisconnection()
+CHIP_ERROR TriggerDisconnection()
 {
     VerifyOrReturnError(TriggerPlatformWifiDisconnection() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
     wfx_rsi.dev_state.Clear(WifiState::kStationConnected);

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -15,11 +15,8 @@
  */
 #pragma once
 
-#include <app/icd/server/ICDServerConfig.h>
-#include <cmsis_os2.h>
-#include <lib/support/BitFlags.h>
 #include <platform/silabs/wifi/WifiInterface.h>
-#include <sl_cmsis_os2_common.h>
+#include <sl_status.h>
 
 #define WFX_RSI_DHCP_POLL_INTERVAL (250) /* Poll interval in ms for DHCP */
 
@@ -36,18 +33,94 @@ enum class WifiPlatformEvent : uint8_t
     kStationDhcpPoll   = 8,
 };
 
-void sl_matter_wifi_task(void * arg);
+/**
+ * @brief Function calls the underlying platforms disconnection API.
+ *
+ * @note This abstraction layer here is used to reduce the duplication for wiseconnect platforms.
+ *       Since the only difference is the disconnection API, the common implementation is in the WiseconnectWifiInterface
+ *       which calls this abstraction function that is implemented by the different platforms.
+ *
+ * @return sl_status_t SL_STATUS_OK, the Wi-Fi disconnection was succesfully triggered
+ *                     SL_STATUS_FAILURE, otherwise
+ */
+sl_status_t TriggerPlatformWifiDisconnection();
 
-int32_t wfx_rsi_get_ap_info(wfx_wifi_scan_result_t * ap);
-int32_t wfx_rsi_get_ap_ext(wfx_wifi_scan_ext_t * extra_info);
-int32_t wfx_rsi_reset_count();
-int32_t sl_wifi_platform_disconnect();
+/**
+ * @brief Callback function for the DHCP timer event.
+ *
+ * TODO: Once the class structure is done, move this to the protected section. Should not be public.
+ */
+void DHCPTimerEventHandler(void * arg);
 
-sl_status_t sl_matter_wifi_platform_init(void);
+/**
+ * @brief Function cancels the DHCP timer if it is running.
+ *        If the timer isn't running, function doesn't do anything.
+ *
+ * TODO: Once the class structure is done, move this to the protected section. Should not be public.
+ */
+void CancelDHCPTimer(void);
+
+/**
+ * @brief Function starts the DHCP timer with the given timeout.
+ *
+ * TODO: Once the class structure is done, move this to the protected section. Should not be public.
+ *
+ * @param timeout timer duration in milliseconds
+ */
+void StartDHCPTimer(uint32_t timeout);
+
+/**
+ * @brief Reset the flags that are used to notify the application about DHCP connectivity
+ *        and emits a WifiPlatformEvent::kStationDoDhcp event to trigger DHCP polling checks.
+ *
+ * TODO: This function should be moved to the protected section once the class structure is done.
+ */
+void ResetDHCPNotificationFlags();
+
+/**
+ * @brief Function creates the DHCP timer
+ *
+ * @note This function is necessary for the time being since the WifiInterface don't leverage inheritance for the time being and as
+ *       such don't have access to all data structures. Once the class structure is done, this function will not be necessary
+ *       anymore.
+ *
+ * @return sl_status_t SL_STATUS_OK, the timer was successfully created
+ */
+sl_status_t CreateDHCPTimer();
+
+/**
+ * @brief Notify the application about the connectivity status if it has not been notified yet.
+ *
+ * TODO: This function should be moved to the protected section once the class structure is done.
+ */
+void NotifyConnectivity(void);
 
 /**
  * @brief Posts an event to the Wi-Fi task
  *
+ * TODO: Once the class structure is in place, the function implementation can be in the protected section of this class instead of
+ *       implemented twice.
+ *
  * @param[in] event Event to process.
  */
-void sl_matter_wifi_post_event(WifiPlatformEvent event);
+void PostWifiPlatformEvent(WifiPlatformEvent event);
+
+/**
+ * @brief Main worker function for the Matter Wi-Fi task responsible of processing Wi-Fi platform events.
+ *        Function is used in the StartWifiTask.
+ *
+ * @param[in] arg context pointer
+ */
+void MatterWifiTask(void * arg);
+
+/**
+ * @brief Function initializes SiWx917 Wi-Fi interface
+ *
+ * TODO: This function is specific to the SiWx platform and should not be present in the WiseconnectWifiInterface.
+ *       Once the SoC and NCP init sequence are harmonised, remove this API.
+ *
+ * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
+ *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
+ *                     SL_STATUS_FAILURE, otherwise
+ */
+sl_status_t InitSiWx917Wifi();

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -123,4 +123,4 @@ void MatterWifiTask(void * arg);
  *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
  *                     SL_STATUS_FAILURE, otherwise
  */
-sl_status_t InitSiWx917Wifi();
+sl_status_t InitSiWxWifi();

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -114,7 +114,7 @@ void PostWifiPlatformEvent(WifiPlatformEvent event);
 void MatterWifiTask(void * arg);
 
 /**
- * @brief Function initializes SiWx917 Wi-Fi interface
+ * @brief Function initializes SiWx Wi-Fi interface
  *
  * TODO: This function is specific to the SiWx platform and should not be present in the WiseconnectWifiInterface.
  *       Once the SoC and NCP init sequence are harmonised, remove this API.


### PR DESCRIPTION
### Description
The goal of the PR is to continue the clean up of the WifiInterface header files aiming for a clean interface. The main focus was finishing the first version of the WiseconnectWifiInterface header. 

- Move code duplicated implementations from the rs9116 and SiWx wifi interface implementations to the WiseconnectWifiInterface
- Clean up function names and documentation to be inline with the Silabs Matter standard
- Remove Wf200 paltform duplicated platform state checks that were split between the `wifi_extra` member and the `sl_wfx_context` state.

PR adds several TODOs that will be addressed in a follow since they require the class inheritance structure and to avoid growing this PR out of hand.

### Testing
- Built al the NCP (wf200, rs9116, SiWx) combos and the SoC ( BRD4338A )
- Commissioned the wf200, rs9116 and SoC (BRD4338A) and sent a few commands 
- Tested power cycle reconnection
