### PR TITLE
Correct PICS feature for TimeSync TSC MissingTrustedTimeSource event

### DIFF
--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -55,7 +55,7 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
             asserts.fail("Did not receive MissingTrustedTimeSouce event")
 
     def pics_TC_TIMESYNC_2_13(self) -> list[str]:
-        return ["TIMESYNC.S.F01"]
+        return ["TIMESYNC.S.F03"]
 
     @async_test_body
     async def test_TC_TIMESYNC_2_13(self):


### PR DESCRIPTION
Fixes PICS feature to match the TSC feature value. See PR with associated fixes in time sync cluster [test plan doc here](https://github.com/CHIP-Specifications/chip-test-plans/pull/4867). 

#### Testing
CI should validate, its a small string change that should correspond to the[ PR linked here](https://github.com/CHIP-Specifications/chip-test-plans/pull/4867)
