### PR TITLE
[Silabs]Add conditions to renegotiate ble connection intervals

### DIFF
--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -94,7 +94,7 @@ namespace {
 #define BLE_CONFIG_RF_PATH_GAIN_RX (0)
 
 // Default Connection  parameters
-#define BLE_CONFIG_MIN_INTERVAL (16) // Time = Value x 1.25 ms = 30ms
+#define BLE_CONFIG_MIN_INTERVAL (16) // Time = Value x 1.25 ms = 20ms
 #define BLE_CONFIG_MAX_INTERVAL (80) // Time = Value x 1.25 ms = 100ms
 #define BLE_CONFIG_LATENCY (0)
 #define BLE_CONFIG_TIMEOUT (100)          // Time = Value x 10 ms = 1s
@@ -678,12 +678,17 @@ void BLEManagerImpl::HandleConnectParams(volatile sl_bt_msg_t * evt)
 {
     sl_bt_evt_connection_parameters_t * con_param_evt = (sl_bt_evt_connection_parameters_t *) &(evt->data);
 
-    if (con_param_evt->timeout < BLE_CONFIG_TIMEOUT)
+    uint16_t desiredTimeout = con_param_evt->timeout < BLE_CONFIG_TIMEOUT ? BLE_CONFIG_TIMEOUT : con_param_evt->timeout;
+
+    // For beter stability, renegotiate the connection parameters if the received ones from the central are outside
+    // of our defined constraints
+    if (desiredTimeout != con_param_evt->timeout || con_param_evt->interval < BLE_CONFIG_MIN_INTERVAL ||
+        con_param_evt->interval > BLE_CONFIG_MAX_INTERVAL)
     {
-        ChipLogProgress(DeviceLayer, "Request to increase the connection timeout from %d to %d", con_param_evt->timeout,
-                        BLE_CONFIG_TIMEOUT);
+        ChipLogProgress(DeviceLayer, "Renegotiate BLE connection parameters to minInterval:%d, maxInterval:%d, timeout:%d",
+                        BLE_CONFIG_MIN_INTERVAL, BLE_CONFIG_MAX_INTERVAL, desiredTimeout);
         sl_bt_connection_set_parameters(con_param_evt->connection, BLE_CONFIG_MIN_INTERVAL, BLE_CONFIG_MAX_INTERVAL,
-                                        BLE_CONFIG_LATENCY, BLE_CONFIG_TIMEOUT, BLE_CONFIG_MIN_CE_LENGTH, BLE_CONFIG_MAX_CE_LENGTH);
+                                        BLE_CONFIG_LATENCY, desiredTimeout, BLE_CONFIG_MIN_CE_LENGTH, BLE_CONFIG_MAX_CE_LENGTH);
     }
 
     PlatformMgr().ScheduleWork(DriveBLEState, 0);

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -680,7 +680,7 @@ void BLEManagerImpl::HandleConnectParams(volatile sl_bt_msg_t * evt)
 
     uint16_t desiredTimeout = con_param_evt->timeout < BLE_CONFIG_TIMEOUT ? BLE_CONFIG_TIMEOUT : con_param_evt->timeout;
 
-    // For beter stability, renegotiate the connection parameters if the received ones from the central are outside
+    // For better stability, renegotiate the connection parameters if the received ones from the central are outside
     // of our defined constraints
     if (desiredTimeout != con_param_evt->timeout || con_param_evt->interval < BLE_CONFIG_MIN_INTERVAL ||
         con_param_evt->interval > BLE_CONFIG_MAX_INTERVAL)


### PR DESCRIPTION
Improve BLE connection stability across different central devices with the efr32 platform by renegotiating the connection parameters if the connection interval is outside of our defined constraints


#### Testing
Confirm the renegotiation by establishing a ble connection with Chip-tool 
```
[00:01:05.725][info  ][DL] Connect Event for handle : 1
[00:01:05.725][info  ][DL] Connection parameter ID received - i:39, l:0, t:42, sm:0
[00:01:05.726][info  ][DL] Renegotiate BLE connection parameters to minInterval:16, maxInterval:80, timeout:100
[00:01:05.726][info  ][DL] Connection phy status ID received - phy:1
[00:01:05.730][info  ][DL] _OnPlatformEvent default:  event->Type = 32781
[00:01:05.827][info  ][DL] Connection data length ID received - txL:251, txT:2120, rxL:251, rxL:2120
```
Connection Interval and timeout parameters were updated
`[00:01:06.167][info  ][DL] Connection parameter ID received - i:78, l:0, t:100, sm:0`