### PR TITLE
[NXP] Add ota gn file & minor fixes

### DIFF
--- a/src/platform/nxp/common/ota/ota.gni
+++ b/src/platform/nxp/common/ota/ota.gni
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import("//build_overrides/nxp_sdk.gni")
+import("${nxp_sdk_build_root}/nxp_sdk.gni")
+
+ota_root = get_path_info(".", "abspath")
+
+ota_sources = [
+    "${ota_root}/OTAImageProcessorImpl.cpp",
+    "${ota_root}/OTAImageProcessorImpl.h",
+    "${ota_root}/OTATlvProcessor.cpp",
+    "${ota_root}/OTATlvProcessor.h",
+    "${ota_root}/OTAFirmwareProcessor.cpp",
+    "${ota_root}/OTAFirmwareProcessor.h",
+    "${ota_root}/OTAHooks.cpp",
+]
+
+if (nxp_use_factory_data && nxp_enable_ota_factory_data_processor) {
+    ota_sources += [
+        "${ota_root}/OTAFactoryDataProcessor.cpp",
+        "${ota_root}/OTAFactoryDataProcessor.h",
+    ]
+}

--- a/src/platform/nxp/common/ota/ota.gni
+++ b/src/platform/nxp/common/ota/ota.gni
@@ -12,25 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import("//build_overrides/nxp_sdk.gni")
 import("${nxp_sdk_build_root}/nxp_sdk.gni")
 
 ota_root = get_path_info(".", "abspath")
 
 ota_sources = [
-    "${ota_root}/OTAImageProcessorImpl.cpp",
-    "${ota_root}/OTAImageProcessorImpl.h",
-    "${ota_root}/OTATlvProcessor.cpp",
-    "${ota_root}/OTATlvProcessor.h",
-    "${ota_root}/OTAFirmwareProcessor.cpp",
-    "${ota_root}/OTAFirmwareProcessor.h",
-    "${ota_root}/OTAHooks.cpp",
+  "${ota_root}/OTAFirmwareProcessor.cpp",
+  "${ota_root}/OTAFirmwareProcessor.h",
+  "${ota_root}/OTAHooks.cpp",
+  "${ota_root}/OTAImageProcessorImpl.cpp",
+  "${ota_root}/OTAImageProcessorImpl.h",
+  "${ota_root}/OTATlvProcessor.cpp",
+  "${ota_root}/OTATlvProcessor.h",
 ]
 
 if (nxp_use_factory_data && nxp_enable_ota_factory_data_processor) {
-    ota_sources += [
-        "${ota_root}/OTAFactoryDataProcessor.cpp",
-        "${ota_root}/OTAFactoryDataProcessor.h",
-    ]
+  ota_sources += [
+    "${ota_root}/OTAFactoryDataProcessor.cpp",
+    "${ota_root}/OTAFactoryDataProcessor.h",
+  ]
 }

--- a/src/platform/nxp/mcxw71_k32w1/BUILD.gn
+++ b/src/platform/nxp/mcxw71_k32w1/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/openthread.gni")
 
 import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${chip_root}/src/platform/nxp/common/ota/ota.gni")
 
 import("${nxp_sdk_build_root}/nxp_sdk.gni")
 
@@ -53,22 +54,7 @@ source_set("nxp_factory_data") {
 source_set("nxp_ota") {
   public = [ "../common/ota/OTAImageProcessorImpl.h" ]
 
-  sources = [
-    "../common/ota/OTAFirmwareProcessor.cpp",
-    "../common/ota/OTAFirmwareProcessor.h",
-    "../common/ota/OTAHooks.cpp",
-    "../common/ota/OTAImageProcessorImpl.cpp",
-    "../common/ota/OTAImageProcessorImpl.h",
-    "../common/ota/OTATlvProcessor.cpp",
-    "../common/ota/OTATlvProcessor.h",
-  ]
-
-  if (nxp_use_factory_data && nxp_enable_ota_factory_data_processor) {
-    sources += [
-      "../common/ota/OTAFactoryDataProcessor.cpp",
-      "../common/ota/OTAFactoryDataProcessor.h",
-    ]
-  }
+  sources = ota_sources
 
   deps = [
     ":nxp_platform",
@@ -148,6 +134,12 @@ static_library("nxp_platform") {
       "../common/NXPConfig.h",
       "../common/NXPConfigNVS.cpp",
     ]
+  }
+
+  # When the app is built using cmake, we must ensure the OTA platform files are also compiled.
+  # When the app is built using gn, the app selects the nxp_ota target through its build file.
+  if (nxp_external_sdk && chip_enable_ota_requestor) {
+    sources += ota_sources
   }
 
   if (nxp_use_plain_dac_key) {

--- a/src/platform/nxp/mcxw71_k32w1/k32w1-chip-mbedtls-config.h
+++ b/src/platform/nxp/mcxw71_k32w1/k32w1-chip-mbedtls-config.h
@@ -19,14 +19,8 @@
 #ifndef MBEDTLS_CONFIG_H
 #define MBEDTLS_CONFIG_H
 
-#include "openthread-core-config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
-
-#include <openthread/config.h>
-#include <openthread/platform/logging.h>
-#include <openthread/platform/memory.h>
 
 #undef MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
@@ -67,16 +61,6 @@
 #define MBEDTLS_SSL_PROTO_DTLS
 #define MBEDTLS_SSL_TLS_C
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE || OPENTHREAD_CONFIG_COMMISSIONER_ENABLE || OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-#define MBEDTLS_SSL_COOKIE_C
-#define MBEDTLS_SSL_SRV_C
-#endif
-
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-#define MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-#define MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-#endif
-
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 #define MBEDTLS_BASE64_C
 #define MBEDTLS_ECDH_C
@@ -87,15 +71,6 @@
 #define MBEDTLS_X509_CRT_PARSE_C
 #endif
 
-#if OPENTHREAD_CONFIG_ECDSA_ENABLE
-#define MBEDTLS_BASE64_C
-#define MBEDTLS_ECDH_C
-#define MBEDTLS_ECDSA_C
-#define MBEDTLS_ECDSA_DETERMINISTIC
-#define MBEDTLS_OID_C
-#define MBEDTLS_PEM_PARSE_C
-#define MBEDTLS_PK_WRITE_C
-#endif
 
 #define MBEDTLS_MPI_WINDOW_SIZE 1       /**< Maximum windows size used. */
 #define MBEDTLS_MPI_MAX_SIZE 32         /**< Maximum number of bytes for usable MPIs. */
@@ -104,19 +79,9 @@
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM 0 /**< Enable fixed-point speed-up */
 #define MBEDTLS_ENTROPY_MAX_SOURCES 2   /**< Maximum number of sources supported */
 
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-#define MBEDTLS_PLATFORM_STD_CALLOC otPlatCAlloc /**< Default allocator to use, can be undefined */
-#define MBEDTLS_PLATFORM_STD_FREE otPlatFree     /**< Default free to use, can be undefined */
-#else
 #define MBEDTLS_MEMORY_BUFFER_ALLOC_C
-#endif
 
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-#define MBEDTLS_SSL_MAX_CONTENT_LEN 900 /**< Maxium fragment length in bytes */
-#else
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 768 /**< Maxium fragment length in bytes */
-#endif
-
 #define MBEDTLS_SSL_IN_CONTENT_LEN MBEDTLS_SSL_MAX_CONTENT_LEN
 #define MBEDTLS_SSL_OUT_CONTENT_LEN MBEDTLS_SSL_MAX_CONTENT_LEN
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8

--- a/src/platform/nxp/mcxw71_k32w1/k32w1-chip-mbedtls-config.h
+++ b/src/platform/nxp/mcxw71_k32w1/k32w1-chip-mbedtls-config.h
@@ -71,7 +71,6 @@
 #define MBEDTLS_X509_CRT_PARSE_C
 #endif
 
-
 #define MBEDTLS_MPI_WINDOW_SIZE 1       /**< Maximum windows size used. */
 #define MBEDTLS_MPI_MAX_SIZE 32         /**< Maximum number of bytes for usable MPIs. */
 #define MBEDTLS_ECP_MAX_BITS 256        /**< Maximum bit size of groups */

--- a/third_party/openthread/platforms/nxp/mcxw71_k32w1/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/mcxw71_k32w1/BUILD.gn
@@ -24,7 +24,10 @@ import("${nxp_sdk_build_root}/nxp_sdk.gni")
 openthread_nxp_root = "${chip_root}/third_party/openthread/ot-nxp"
 
 config("openthread_k32w1_config") {
-  include_dirs = [ "${openthread_nxp_root}/src/k32w1" ]
+  include_dirs = [
+    "${openthread_nxp_root}/src/k32w1",
+    "${openthread_nxp_root}/src/mcxw71"
+  ]
 
   defines = [
     "OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1",
@@ -111,10 +114,13 @@ source_set("libopenthread-k32w1") {
     "../..:libopenthread-platform-utils",
   ]
 
+  public_deps += [
+    "${nxp_sdk_build_root}:nxp_mbedtls"
+  ]
+
   if (!nxp_external_sdk) {
     public_deps += [
-      "${nxp_sdk_build_root}:nxp_mbedtls",
-      nxp_sdk_target,
+      nxp_sdk_target
     ]
   }
 }

--- a/third_party/openthread/platforms/nxp/mcxw71_k32w1/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/mcxw71_k32w1/BUILD.gn
@@ -26,7 +26,7 @@ openthread_nxp_root = "${chip_root}/third_party/openthread/ot-nxp"
 config("openthread_k32w1_config") {
   include_dirs = [
     "${openthread_nxp_root}/src/k32w1",
-    "${openthread_nxp_root}/src/mcxw71"
+    "${openthread_nxp_root}/src/mcxw71",
   ]
 
   defines = [
@@ -114,13 +114,9 @@ source_set("libopenthread-k32w1") {
     "../..:libopenthread-platform-utils",
   ]
 
-  public_deps += [
-    "${nxp_sdk_build_root}:nxp_mbedtls"
-  ]
+  public_deps += [ "${nxp_sdk_build_root}:nxp_mbedtls" ]
 
   if (!nxp_external_sdk) {
-    public_deps += [
-      nxp_sdk_target
-    ]
+    public_deps += [ nxp_sdk_target ]
   }
 }


### PR DESCRIPTION
Changelog

- add `ota.gni` file to set a list of sources for the NXP OTA component.
- update device layer to use `ota.gni`.
- minor fix in openthread gn files for `mcxw71`.
- remove unused openthread dep in mbedtls config file.

### Testing
Built a reference app successfully.