### PR TITLE
[Silabs] Fixed the condition making the code always pick water heater

### DIFF
--- a/examples/energy-management-app/silabs/src/AppTask.cpp
+++ b/examples/energy-management-app/silabs/src/AppTask.cpp
@@ -133,7 +133,7 @@ AppTask AppTask::sAppTask;
 
 EndpointId GetEnergyDeviceEndpointId()
 {
-#if defined(SL_CONFIG_ENABLE_EXAMPLE_WATER_HEATER_DEVICE)
+#if SL_CONFIG_ENABLE_EXAMPLE_WATER_HEATER_DEVICE
     return kWaterHeaterEndpoint;
 #else
     return kEvseEndpoint;


### PR DESCRIPTION
Energy management used to crash at boot since it always assumed it was actually a water heater.

#### Testing

Built and ran the app, now doesn't crash during init.
