### PR TITLE
ESP32: remove the nogncheck in platform source

### DIFF
--- a/src/platform/ESP32/BUILD.gn
+++ b/src/platform/ESP32/BUILD.gn
@@ -124,13 +124,6 @@ static_library("ESP32") {
       "NetworkCommissioningDriver.cpp",
       "NetworkCommissioningDriver.h",
     ]
-
-    # TODO: this is NOT ok, however we added a layering dependecy
-    # in NetworkCommissioningDriver accessing app/InteractionModelEngine.h
-    #
-    # Should be removed after https://github.com/project-chip/connectedhomeip/issues/37126
-    # is fixed
-    deps += [ "${chip_root}/src/access:access_config" ]
   }
 
   if (chip_mdns == "platform") {

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -15,7 +15,6 @@
  *    limitations under the License.
  */
 
-#include <app/InteractionModelEngine.h> // nogncheck
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -459,9 +458,6 @@ void ESPWiFiDriver::OnScanWiFiNetworkDone()
 
 void ESPWiFiDriver::OnNetworkStatusChange()
 {
-    // This function reports the status to the data model provider, so skip it if the provider is not ready.
-    VerifyOrReturn(app::InteractionModelEngine::GetInstance() &&
-                   app::InteractionModelEngine::GetInstance()->GetDataModelProvider());
     Network configuredNetwork;
     bool staEnabled = false, staConnected = false;
     VerifyOrReturn(ESP32Utils::IsStationEnabled(staEnabled) == CHIP_NO_ERROR);


### PR DESCRIPTION
Remove the nogncheck in ESP32 platform source mentioned in #37126

The original change in #36939 was to fix crash when the esp32 reboots with wifi connected. it crashed at MatterReportAttributeChange, and the data model provider check was already added at https://github.com/project-chip/connectedhomeip/blob/master/src/app/reporting/reporting.cpp#L36.

#### Testing

- CI should pass.
- Tested on ESP32C3, there is no crash after reboot the device when the device is commissioned
