### PR TITLE
[Silabs] Refactor RCP WiFi initialization to remove platform-specific dependencies and unify initialization function

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -31,6 +31,16 @@
 #ifdef WF200_WIFI
 #include <platform/silabs/wifi/wf200/ncp/sl_wfx_task.h>
 #endif // WF200_WIFI
+
+// TODO: We shouldn't need any platform specific includes in this file
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+#include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 )
+
+#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
+#include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>
+#endif // ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
+
 #endif // SL_WIFI
 
 #if PW_RPC_ENABLED
@@ -44,15 +54,6 @@
 #ifdef HEAP_MONITORING
 #include "MemMonitoring.h"
 #endif
-
-// TODO: We shouldn't need any platform specific includes in this file
-#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
-#include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
-#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 )
-
-#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
-#include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>
-#endif // ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
 
 #include <crypto/CHIPCryptoPAL.h>
 // If building with the EFR32-provided crypto backend, we can use the

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -27,20 +27,6 @@
 #ifdef SL_WIFI
 #include <platform/silabs/wifi/WifiInterface.h>
 
-// TODO: We shouldn't need any platform specific includes in this file
-#ifdef WF200_WIFI
-#include <platform/silabs/wifi/wf200/ncp/sl_wfx_task.h>
-#endif // WF200_WIFI
-
-// TODO: We shouldn't need any platform specific includes in this file
-#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
-#include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
-#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 )
-
-#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
-#include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>
-#endif // ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
-
 #endif // SL_WIFI
 
 #if PW_RPC_ENABLED
@@ -318,17 +304,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #ifdef SL_WIFI
 CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 {
-    // TODO: Platform specific init should not be required here
-#ifdef WF200_WIFI
-    // Start wfx bus communication task.
-    wfx_bus_start();
-#endif // WF200_WIFI
-
-    // TODO: Platform specific init should not be required here
-#if RS911X_WIFI
-    VerifyOrReturnError(InitSiWxWifi() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
-#endif // RS911X_WIFI
-
+    VerifyOrReturnError(InitWiFiStack() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
     return CHIP_NO_ERROR;
 }
 #endif // SL_WIFI

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -27,6 +27,10 @@
 #ifdef SL_WIFI
 #include <platform/silabs/wifi/WifiInterface.h>
 
+// TODO: We shouldn't need any platform specific includes in this file
+#if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
+#include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
+#endif // (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 #endif // SL_WIFI
 
 #if PW_RPC_ENABLED
@@ -304,8 +308,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #ifdef SL_WIFI
 CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 {
-    VerifyOrReturnError(InitWiFiStack() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
-    return CHIP_NO_ERROR;
+    return InitWiFiStack();
 }
 #endif // SL_WIFI
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -324,9 +324,9 @@ CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 #endif // WF200_WIFI
 
     // TODO: Platform specific init should not be required here
-#if ((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1) || defined(EXP_BOARD))
+#if RS911X_WIFI
     VerifyOrReturnError(InitSiWxWifi() == SL_STATUS_OK, CHIP_ERROR_INTERNAL);
-#endif //((defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1 ) || defined(EXP_BOARD))
+#endif // RS911X_WIFI
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -52,8 +52,6 @@ extern "C" {
 #define BLE_TIMEOUT_MS 400
 #define BLE_SEND_INDICATION_TIMER_PERIOD_MS (5000)
 
-osSemaphoreId_t sl_rs_ble_init_sem;
-
 using namespace ::chip;
 using namespace ::chip::Ble;
 using namespace ::chip::DeviceLayer::Internal;
@@ -234,9 +232,6 @@ void BLEManagerImpl::sl_ble_event_handling_task(void * args)
     sl_status_t status;
     SilabsBleWrapper::BleEvent_t bleEvent;
 
-    //! This semaphore is waiting for wifi module initialization.
-    osSemaphoreAcquire(sl_rs_ble_init_sem, osWaitForever);
-
     // This function initialize BLE and start BLE advertisement.
     sInstance.sl_ble_init();
 
@@ -287,8 +282,6 @@ void BLEManagerImpl::sl_ble_init()
 CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err;
-
-    sl_rs_ble_init_sem = osSemaphoreNew(1, 0, NULL);
 
     sBleThread = osThreadNew(sInstance.sl_ble_event_handling_task, NULL, &kBleTaskAttr);
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -86,7 +86,6 @@ extern "C" {
 #endif
 
 WfxRsi_t wfx_rsi;
-extern osSemaphoreId_t sl_rs_ble_init_sem;
 
 namespace {
 
@@ -310,7 +309,6 @@ sl_status_t sl_wifi_siwx917_init(void)
 #endif // SL_MBEDTLS_USE_TINYCRYPT
 
     wfx_rsi.dev_state.Set(WifiState::kStationInit);
-    osSemaphoreRelease(sl_rs_ble_init_sem);
     return status;
 }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -553,7 +553,7 @@ CHIP_ERROR ResetCounters()
     return CHIP_NO_ERROR;
 }
 
-sl_status_t InitSiWxWifi(void)
+sl_status_t InitWiFiStack(void)
 {
     sl_status_t status = SL_STATUS_OK;
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -553,29 +553,31 @@ CHIP_ERROR ResetCounters()
     return CHIP_NO_ERROR;
 }
 
-sl_status_t InitWiFiStack(void)
+CHIP_ERROR InitWiFiStack(void)
 {
     sl_status_t status = SL_STATUS_OK;
 
     status = sl_net_init((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, &config, &wifi_client_context, nullptr);
-    VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_init failed: %lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_UNINITIALIZED,
+                        ChipLogError(DeviceLayer, "sl_net_init failed: %lx", status));
 
     // Create Sempaphore for scan completion
     sScanCompleteSemaphore = osSemaphoreNew(1, 0, nullptr);
-    VerifyOrReturnError(sScanCompleteSemaphore != nullptr, SL_STATUS_ALLOCATION_FAILED);
+    VerifyOrReturnError(sScanCompleteSemaphore != nullptr, CHIP_ERROR_NO_MEMORY);
 
     // Create Semaphore for scan in-progress protection
     sScanInProgressSemaphore = osSemaphoreNew(1, 1, nullptr);
-    VerifyOrReturnError(sScanCompleteSemaphore != nullptr, SL_STATUS_ALLOCATION_FAILED);
+    VerifyOrReturnError(sScanCompleteSemaphore != nullptr, CHIP_ERROR_NO_MEMORY);
 
     // Create the message queue
     sWifiEventQueue = osMessageQueueNew(kWfxQueueSize, sizeof(WifiPlatformEvent), nullptr);
-    VerifyOrReturnError(sWifiEventQueue != nullptr, SL_STATUS_ALLOCATION_FAILED);
+    VerifyOrReturnError(sWifiEventQueue != nullptr, CHIP_ERROR_NO_MEMORY);
 
     status = CreateDHCPTimer();
-    VerifyOrReturnError(status == SL_STATUS_OK, status);
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_UNINITIALIZED,
+                        ChipLogError(DeviceLayer, "CreateDHCPTimer failed: %lx", status));
 
-    return status;
+    return CHIP_NO_ERROR;
 }
 
 void HandleDHCPPolling(void)

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -558,8 +558,7 @@ CHIP_ERROR InitWiFiStack(void)
     sl_status_t status = SL_STATUS_OK;
 
     status = sl_net_init((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, &config, &wifi_client_context, nullptr);
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_UNINITIALIZED,
-                        ChipLogError(DeviceLayer, "sl_net_init failed: %lx", status));
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_INTERNAL, ChipLogError(DeviceLayer, "sl_net_init failed: %lx", status));
 
     // Create Sempaphore for scan completion
     sScanCompleteSemaphore = osSemaphoreNew(1, 0, nullptr);
@@ -574,7 +573,7 @@ CHIP_ERROR InitWiFiStack(void)
     VerifyOrReturnError(sWifiEventQueue != nullptr, CHIP_ERROR_NO_MEMORY);
 
     status = CreateDHCPTimer();
-    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_UNINITIALIZED,
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_NO_MEMORY,
                         ChipLogError(DeviceLayer, "CreateDHCPTimer failed: %lx", status));
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -178,6 +178,16 @@ extern WfxRsi_t wfx_rsi;
 /* Updated functions */
 
 /**
+ * @brief Function initalize the WiFi module before starting WiFi task.
+ *
+ * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
+ *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
+ *                     SL_STATUS_FAILURE, otherwise
+ */
+
+sl_status_t InitWiFiStack(void);
+
+/**
  * @brief Function notifies the PlatformManager that an IPv6 event occured on the WiFi interface.
  *
  * @param gotIPv6Addr true, got an IPv6 address

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -181,6 +181,8 @@ extern WfxRsi_t wfx_rsi;
  * @brief Function initalizes the WiFi module before starting WiFi task.
  *
  * @return CHIP_ERROR CHIP_NO_ERROR, if the initialization succeeded
+ *                    CHIP_ERROR_INTERNAL, if sequence failed due to internal API
+ *                    CHIP_ERROR_NO_MEMORY, if sequence failed due to unavaliablility of memory
  */
 
 CHIP_ERROR InitWiFiStack(void);

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -180,12 +180,10 @@ extern WfxRsi_t wfx_rsi;
 /**
  * @brief Function initalize the WiFi module before starting WiFi task.
  *
- * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
- *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
- *                     SL_STATUS_FAILURE, otherwise
+ * @return CHIP_ERROR CHIP_NO_ERROR, if the initialization succeeded
  */
 
-sl_status_t InitWiFiStack(void);
+CHIP_ERROR InitWiFiStack(void);
 
 /**
  * @brief Function notifies the PlatformManager that an IPv6 event occured on the WiFi interface.

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -181,7 +181,7 @@ extern WfxRsi_t wfx_rsi;
  * @brief Function initalizes the WiFi module before starting WiFi task.
  *
  * @return CHIP_ERROR CHIP_NO_ERROR, if the initialization succeeded
- *                    CHIP_ERROR_INTERNAL, if sequence failed due to internal API
+ *                    CHIP_ERROR_INTERNAL, if sequence failed due to internal API error
  *                    CHIP_ERROR_NO_MEMORY, if sequence failed due to unavaliablility of memory
  */
 

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -178,7 +178,7 @@ extern WfxRsi_t wfx_rsi;
 /* Updated functions */
 
 /**
- * @brief Function initalize the WiFi module before starting WiFi task.
+ * @brief Function initalizes the WiFi module before starting WiFi task.
  *
  * @return CHIP_ERROR CHIP_NO_ERROR, if the initialization succeeded
  */

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -641,7 +641,7 @@ void ProcessEvent(WifiPlatformEvent event)
 CHIP_ERROR InitWiFiStack(void)
 {
     int32_t status = sl_matter_wifi_init();
-    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_UNINITIALIZED,
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
                         ChipLogError(DeviceLayer, "sl_matter_wifi_init failed: %lx", status));
     return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -638,15 +638,12 @@ void ProcessEvent(WifiPlatformEvent event)
     }
 }
 
-sl_status_t InitWiFiStack(void)
+CHIP_ERROR InitWiFiStack(void)
 {
     int32_t status = sl_matter_wifi_init();
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "sl_matter_wifi_init: failed: %ld", status);
-        return SL_STATUS_FAIL;
-    }
-    return SL_STATUS_OK;
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_UNINITIALIZED,
+                        ChipLogError(DeviceLayer, "sl_matter_wifi_init failed: %lx", status));
+    return CHIP_NO_ERROR;
 }
 
 void MatterWifiTask(void * arg)

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -638,7 +638,7 @@ void ProcessEvent(WifiPlatformEvent event)
     }
 }
 
-sl_status_t sl_matter_wifi_platform_init(void)
+sl_status_t InitSiWxWifi(void)
 {
     VerifyOrReturnError(sl_matter_wifi_init() == RSI_SUCCESS, SL_STATUS_FAIL);
     return SL_STATUS_OK;

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -640,7 +640,12 @@ void ProcessEvent(WifiPlatformEvent event)
 
 sl_status_t InitSiWxWifi(void)
 {
-    VerifyOrReturnError(sl_matter_wifi_init() == RSI_SUCCESS, SL_STATUS_FAIL);
+    int32_t status = sl_matter_wifi_init();
+    if (status != RSI_SUCCESS)
+    {
+        ChipLogError(DeviceLayer, "sl_matter_wifi_init: failed: %ld", status);
+        return SL_STATUS_FAIL;
+    }
     return SL_STATUS_OK;
 }
 

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -638,7 +638,7 @@ void ProcessEvent(WifiPlatformEvent event)
     }
 }
 
-sl_status_t InitSiWxWifi(void)
+sl_status_t InitWiFiStack(void)
 {
     int32_t status = sl_matter_wifi_init();
     if (status != RSI_SUCCESS)

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -1185,3 +1185,11 @@ void wfx_cancel_scan(void)
     }
     scan_cb = nullptr;
 }
+
+sl_status_t InitWiFiStack(void)
+{
+    // TODO: This function should include sl_wfx_hw_init() and sl_wfx_init() functions. Only done now to make MatterConfig platform
+    // agnostic.
+    // Start wfx bus communication task.
+    return wfx_bus_start();
+}

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -1186,10 +1186,13 @@ void wfx_cancel_scan(void)
     scan_cb = nullptr;
 }
 
-sl_status_t InitWiFiStack(void)
+CHIP_ERROR InitWiFiStack(void)
 {
     // TODO: This function should include sl_wfx_hw_init() and sl_wfx_init() functions. Only done now to make MatterConfig platform
-    // agnostic.
+    // agnostic. (MATTER-4680)
     // Start wfx bus communication task.
-    return wfx_bus_start();
+    sl_status_t status = wfx_bus_start();
+    VerifyOrReturnError(status == SL_STATUS_OK, CHIP_ERROR_NO_MEMORY,
+                        ChipLogError(DeviceLayer, "wfx_bus_start failed: %lx", status));
+    return CHIP_NO_ERROR;
 }

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.c
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.c
@@ -116,7 +116,6 @@ sl_status_t wfx_bus_start(void)
         xTaskCreateStatic(wfx_bus_task, "wfxbus", BUS_TASK_STACK_SIZE, NULL, WFX_BUS_TASK_PRIORITY, busStack, &busTaskStruct);
     if (wfx_bus_task_handle == NULL)
     {
-        SILABS_LOG("*ERR*WFX BusTask");
         return SL_STATUS_ALLOCATION_FAILED;
     }
     return SL_STATUS_OK;

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.c
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.c
@@ -110,19 +110,14 @@ static void wfx_bus_task(void * p_arg)
     }
 }
 
-/***************************************************************************
- * @fn  void wfx_bus_start()
- * @brief
- * Creates WFX bus communication task.
- * @param[in] None
- * @return None
- ******************************************************************************/
-void wfx_bus_start()
+sl_status_t wfx_bus_start(void)
 {
     wfx_bus_task_handle =
         xTaskCreateStatic(wfx_bus_task, "wfxbus", BUS_TASK_STACK_SIZE, NULL, WFX_BUS_TASK_PRIORITY, busStack, &busTaskStruct);
     if (wfx_bus_task_handle == NULL)
     {
         SILABS_LOG("*ERR*WFX BusTask");
+        return SL_STATUS_ALLOCATION_FAILED;
     }
+    return SL_STATUS_OK;
 }

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
@@ -38,15 +38,14 @@ extern TaskHandle_t wfx_bus_task_handle;
 extern "C" {
 #endif
 
-/***************************************************************************
- * @fn  sl_status_t wfx_bus_start()
- * @brief
- * Start WFX bus communication task.
+/**
+ * @brief Start WFX bus communication task.
+ *
  * @param[in] None
  * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
  *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
  *                     SL_STATUS_FAILURE, otherwise
- ******************************************************************************/
+ */
 sl_status_t wfx_bus_start(void);
 
 /****************************************************************************

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
@@ -43,8 +43,7 @@ extern "C" {
  *
  * @param[in] None
  * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
- *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
- *                     SL_STATUS_FAILURE, otherwise
+ *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure.
  */
 sl_status_t wfx_bus_start(void);
 

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
@@ -38,12 +38,16 @@ extern TaskHandle_t wfx_bus_task_handle;
 extern "C" {
 #endif
 
-/****************************************************************************
- * @fn void wfx_bus_start(void)
+/***************************************************************************
+ * @fn  sl_status_t wfx_bus_start()
  * @brief
- * Start wfx bus communication task.
- *****************************************************************************/
-void wfx_bus_start(void);
+ * Start WFX bus communication task.
+ * @param[in] None
+ * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
+ *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
+ *                     SL_STATUS_FAILURE, otherwise
+ ******************************************************************************/
+sl_status_t wfx_bus_start(void);
 
 /****************************************************************************
  * @fn  bool wfx_bus_is_receive_processing(void)

--- a/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
+++ b/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h
@@ -41,7 +41,6 @@ extern "C" {
 /**
  * @brief Start WFX bus communication task.
  *
- * @param[in] None
  * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
  *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure.
  */

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -112,15 +112,3 @@ void PostWifiPlatformEvent(WifiPlatformEvent event);
  * @param[in] arg context pointer
  */
 void MatterWifiTask(void * arg);
-
-/**
- * @brief Function initializes SiWx Wi-Fi interface
- *
- * TODO: This function is specific to the SiWx platform and should not be present in the WiseconnectWifiInterface.
- *       Once the SoC and NCP init sequence are harmonised, remove this API.
- *
- * @return sl_status_t SL_STATUS_OK, if the initialization succeeded
- *                     SL_STATUS_ALLOCATION_FAILED, if there are a memory allocation failure,
- *                     SL_STATUS_FAILURE, otherwise
- */
-sl_status_t InitSiWxWifi();


### PR DESCRIPTION
### Changelog
Refactor WiFi initialization to remove platform-specific dependencies and unify initialization function
### Testing
Manually build the RCP combinations for RS9116, RCP 917, RCP WF200 with EFR32MG24.
Tested commissioning flow with RCP 917, RCP WF200 with EFR32MG24.