### PR TITLE
Changed needed for NFC Commissioning: Added libpcsclite-dev package.

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -69,6 +69,7 @@ RUN set -x \
     libnl-route-3-dev \
     libnspr4-dev \
     libpango1.0-dev \
+    libpcsclite-dev \
     libpixman-1-dev \
     libreadline-dev \
     libsdl2-dev \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-98 : [nrfconnect] Update nRF Connect SDK version.
+99 : [ST] Added libpcsclite-dev package for NFC Commissioning on Linux platforms.


### PR DESCRIPTION
Changed needed for NFC Commissioning:
Added libpcsclite-dev which is needed to build linux platforms. This package contains the files needed for compiling and linking an application that communicates with an available PC/SC reader.

This change is needed for https://github.com/project-chip/connectedhomeip/pull/37060

#### Testing
I'm not able to test that it does what is expected but we will quickly see if the wanted package is added or not.