### PR TITLE
Map "chip" Python imports as first-party

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -1162,6 +1162,7 @@ PyFunction
 pylint
 PyObject
 pypi
+pyproject
 PyRun
 pytest
 QEMU

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-line_length = 132

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -228,8 +228,6 @@ restylers:
       command:
           - autopep8
           - "--in-place"
-          - "--max-line-length"
-          - "132"
       arguments: []
       include:
           - "**/*.py"

--- a/docs/style/CODING_STYLE_GUIDE.md
+++ b/docs/style/CODING_STYLE_GUIDE.md
@@ -60,22 +60,20 @@ be removed.
 
 We use the following auto-formatters on code:
 
-| Language    | Formatter          | Style File                                                                                 |
-| ----------- | ------------------ | ------------------------------------------------------------------------------------------ |
-| C++         | clang-format       | [.clang-format](https://github.com/project-chip/connectedhomeip/blob/master/.clang-format) |
-| Objective-C | clang-format       | [.clang-format](https://github.com/project-chip/connectedhomeip/blob/master/.clang-format) |
-| java        | google-java-format | N/A                                                                                        |
-| Python      | pep8, isort, ruff  | [.restyled.yaml][restyle_link] (command line), [isort][isort_link], [ruff][ruff_link]      |
-| YAML        | prettier           | None                                                                                       |
-| JSON        | prettier           | None                                                                                       |
-| markdown    | prettier           | None                                                                                       |
+| Language    | Formatter          | Style File                         |
+| ----------- | ------------------ | -----------------------------------|
+| C++         | clang-format       | [.clang-format][clang_format_link] |
+| Objective-C | clang-format       | [.clang-format][clang_format_link] |
+| java        | google-java-format | N/A                                |
+| Python      | pep8, isort, ruff  | [pyproject.toml][pyproject_link]   |
+| YAML        | prettier           | None                               |
+| JSON        | prettier           | None                               |
+| markdown    | prettier           | None                               |
 
-[restyle_link]:
-    https://github.com/project-chip/connectedhomeip/blob/master/.restyled.yaml
-[isort_link]:
-    https://github.com/project-chip/connectedhomeip/blob/master/.isort.cfg
-[ruff_link]:
-    https://github.com/project-chip/connectedhomeip/blob/master/ruff.toml
+[clang_format_link]:
+    https://github.com/project-chip/connectedhomeip/blob/master/.clang-format
+[pyproject_link]:
+    https://github.com/project-chip/connectedhomeip/blob/master/pyproject.toml
 
 All pull requests run formatting checks using these tools before merge is
 allowed. Generated code is not run through restyle.

--- a/docs/style/CODING_STYLE_GUIDE.md
+++ b/docs/style/CODING_STYLE_GUIDE.md
@@ -61,7 +61,7 @@ be removed.
 We use the following auto-formatters on code:
 
 | Language    | Formatter          | Style File                         |
-| ----------- | ------------------ | -----------------------------------|
+| ----------- | ------------------ | ---------------------------------- |
 | C++         | clang-format       | [.clang-format][clang_format_link] |
 | Objective-C | clang-format       | [.clang-format][clang_format_link] |
 | java        | google-java-format | N/A                                |

--- a/examples/common/pigweed/rpc_console/py/chip_rpc/plugins/device_toolbar.py
+++ b/examples/common/pigweed/rpc_console/py/chip_rpc/plugins/device_toolbar.py
@@ -21,7 +21,6 @@ in the toolbar whenever the 'Refresh' button is pressed.
 """
 
 from prompt_toolkit.layout import WindowAlign
-
 from pw_console.plugin_mixin import PluginMixin
 from pw_console.widgets import ToolbarButton, WindowPaneToolbar
 

--- a/examples/lighting-app/python/lighting.py
+++ b/examples/lighting-app/python/lighting.py
@@ -22,10 +22,11 @@ import textwrap
 import threading
 from cmd import Cmd
 
-from chip.server import GetLibraryHandle, PostAttributeChangeCallback
 from dali.address import Broadcast
 from dali.driver.hid import tridonic
 from dali.gear.general import DAPC, Off, RecallMaxLevel
+
+from chip.server import GetLibraryHandle, PostAttributeChangeCallback
 
 dali_loop = None
 dev = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[tool.autopep8]
+max_line_length = 132
+
+[tool.isort]
+line_length = 132
+
+[tool.ruff]
+line-length = 132
+target-version = "py310"
 exclude = [
     ".environment",
     ".git",
@@ -8,12 +17,9 @@ exclude = [
     "third_party",
     "examples/common/QRCode/",
 ]
-target-version = "py310"
 
-line-length = 132
-
-[lint]
+[tool.ruff.lint]
 select = ["E4", "E7", "E9", "F"]
 ignore = [
-    "E721" # We use it for good reasons
+    "E721", # We use it for good reasons
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ max_line_length = 132
 
 [tool.isort]
 line_length = 132
+known_first_party = "chip"
 
 [tool.ruff]
 line-length = 132

--- a/scripts/py_matter_idl/matter_idl/zapxml/handlers/__init__.py
+++ b/scripts/py_matter_idl/matter_idl/zapxml/handlers/__init__.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from matter_idl.matter_idl_types import Idl
+
 from .base import BaseHandler
 from .context import Context
 from .handlers import ConfiguratorHandler
-
-from matter_idl.matter_idl_types import Idl
 
 
 class ZapXmlHandler(BaseHandler):

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -23,8 +23,9 @@ import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 
 import click
-from chip.testing.spec_parsing import build_xml_clusters
 from paths import get_chip_root, get_documentation_file_path, get_in_progress_defines
+
+from chip.testing.spec_parsing import build_xml_clusters
 
 # Use the get_in_progress_defines() function to fetch the in-progress defines
 CURRENT_IN_PROGRESS_DEFINES = get_in_progress_defines()

--- a/scripts/spec_xml/spec_revision_diff_summary.py
+++ b/scripts/spec_xml/spec_revision_diff_summary.py
@@ -21,6 +21,7 @@
 # spec expectations before the 1.4 release and we should continue to do so going forward.
 
 import click
+
 from chip.testing.conformance import ConformanceDecision
 from chip.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 

--- a/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
+++ b/scripts/tests/chiptest/yamltest_with_chip_repl_tester.py
@@ -46,13 +46,14 @@ except ImportError:
     __ALL__ = (matter_idl_types)
 
 
-import chip.CertificateAuthority
-import chip.native
 import click
-from chip.ChipStack import ChipStack
-from chip.yaml.runner import ReplTestRunner
 from matter_yamltests.definitions import SpecDefinitionsFromPaths
 from matter_yamltests.parser import PostProcessCheckStatus, TestParser, TestParserConfig
+
+import chip.CertificateAuthority
+import chip.native
+from chip.ChipStack import ChipStack
+from chip.yaml.runner import ReplTestRunner
 
 _DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", ".."))

--- a/scripts/tests/run_python_test.py
+++ b/scripts/tests/run_python_test.py
@@ -32,9 +32,10 @@ import typing
 
 import click
 import coloredlogs
+from colorama import Fore, Style
+
 from chip.testing.metadata import Metadata, MetadataReader
 from chip.testing.tasks import Subprocess
-from colorama import Fore, Style
 
 DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..'))

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -5,14 +5,15 @@ import logging
 import os
 import pathlib
 
+import coloredlogs
+from rich import inspect, pretty
+from rich.console import Console
+
 import chip.CertificateAuthority
 import chip.FabricAdmin
 import chip.logging
 import chip.native
-import coloredlogs
 from chip.ChipStack import ChipStack
-from rich import inspect, pretty
-from rich.console import Console
 
 _fabricAdmins = None
 

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -29,14 +29,15 @@ from dataclasses import dataclass, field
 from enum import Enum, unique
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
+import construct  # type: ignore
+from rich.pretty import pprint  # type: ignore
+
 import chip
 import chip.exceptions
 import chip.interaction_model
 import chip.tlv
-import construct  # type: ignore
 from chip.interaction_model import PyWriteAttributeData
 from chip.native import ErrorSDKPart, PyChipError
-from rich.pretty import pprint  # type: ignore
 
 from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
 

--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -20,9 +20,10 @@ import typing
 from dataclasses import asdict, dataclass, field, make_dataclass
 from typing import Any, ClassVar, Dict, List, Mapping, Union
 
+from dacite import from_dict  # type: ignore
+
 from chip import ChipUtility, tlv
 from chip.clusters.Types import Nullable, NullValue
-from dacite import from_dict  # type: ignore
 
 
 def GetUnionUnderlyingType(typeToCheck, matchingType=None):

--- a/src/controller/python/chip/commissioning/commissioning_flow_blocks.py
+++ b/src/controller/python/chip/commissioning/commissioning_flow_blocks.py
@@ -18,13 +18,14 @@
 import base64
 import logging
 
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
 import chip.credentials.cert
 import chip.crypto.fabric
 from chip import ChipDeviceCtrl
 from chip import clusters as Clusters
 from chip import commissioning
-from cryptography import x509
-from cryptography.hazmat.primitives import serialization
 
 
 class CommissioningFlowBlocks:

--- a/src/controller/python/chip/crypto/p256keypair.py
+++ b/src/controller/python/chip/crypto/p256keypair.py
@@ -21,8 +21,9 @@ from ctypes import (CFUNCTYPE, POINTER, _Pointer, c_bool, c_char, c_size_t, c_ui
                     string_at)
 from typing import TYPE_CHECKING
 
-from chip import native
 from ecdsa import ECDH, NIST256p, SigningKey  # type: ignore
+
+from chip import native
 
 # WORKAROUND: Create a subscriptable pointer type (with square brackets) to ensure compliance of type hinting with ctypes
 if not TYPE_CHECKING:

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -20,10 +20,11 @@ from ctypes import CFUNCTYPE, POINTER, c_uint8, c_uint32, c_uint64, c_void_p
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from construct import Int8ul, Int16ul, Int32ul, Int64ul, Struct  # type: ignore
+
 import chip.exceptions
 import chip.native
 import chip.tlv
-from construct import Int8ul, Int16ul, Int32ul, Int64ul, Struct  # type: ignore
 
 # The type should match CommandStatus in interaction_model/Delegate.h
 # CommandStatus should not contain padding

--- a/src/controller/python/chip/native/__init__.py
+++ b/src/controller/python/chip/native/__init__.py
@@ -23,8 +23,9 @@ import platform
 import typing
 from dataclasses import dataclass
 
-import chip.exceptions
 import construct  # type: ignore
+
+import chip.exceptions
 
 
 class Library(enum.Enum):

--- a/src/controller/python/chip/yaml/format_converter.py
+++ b/src/controller/python/chip/yaml/format_converter.py
@@ -18,11 +18,12 @@
 import typing
 from dataclasses import dataclass
 
+from matter_idl import matter_idl_types
+
 from chip.clusters.enum import MatterIntEnum
 from chip.clusters.Types import Nullable, NullValue
 from chip.tlv import float32, uint
 from chip.yaml.errors import ValidationError
-from matter_idl import matter_idl_types
 
 
 @dataclass

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -22,6 +22,9 @@ from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from typing import Any, Optional, Tuple
 
+from matter_idl.generators.filters import to_pascal_case, to_snake_case
+from matter_yamltests.pseudo_clusters.pseudo_clusters import get_default_pseudo_clusters
+
 import chip.interaction_model
 import chip.yaml.format_converter as Converter
 from chip.ChipDeviceCtrl import ChipDeviceController, discovery
@@ -31,8 +34,6 @@ from chip.clusters.Attribute import (AttributeStatus, EventReadResult, Subscript
 from chip.exceptions import ChipStackError
 from chip.yaml.data_model_lookup import DataModelLookup
 from chip.yaml.errors import ActionCreationError, UnexpectedActionCreationError
-from matter_idl.generators.filters import to_pascal_case, to_snake_case
-from matter_yamltests.pseudo_clusters.pseudo_clusters import get_default_pseudo_clusters
 
 from .data_model_lookup import PreDefinedDataModelLookup
 

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/adapter.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from chip.yaml.runner import ReplTestRunner
 from matter_yamltests.adapter import TestAdapter
+
+from chip.yaml.runner import ReplTestRunner
 
 
 class Adapter(TestAdapter):

--- a/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
+++ b/src/controller/python/py_matter_yamltest_repl_adapter/matter_yamltest_repl_adapter/runner.py
@@ -19,12 +19,13 @@ import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 
 # isort: on
 
+from matter_yamltests.runner import TestRunner
+
 import chip.CertificateAuthority
 import chip.logging
 import chip.native
 from chip.ChipStack import ChipStack
 from chip.yaml.runner import ReplTestRunner
-from matter_yamltests.runner import TestRunner
 
 
 class Runner(TestRunner):

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -31,6 +31,9 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from cirque_restart_remote_device import restartRemoteDevice
+from ecdsa import NIST256p
+
 import chip.CertificateAuthority
 import chip.clusters as Clusters
 import chip.clusters.Attribute as Attribute
@@ -43,8 +46,6 @@ from chip.ChipStack import ChipStack
 from chip.crypto import p256keypair
 from chip.exceptions import ChipStackException
 from chip.utils import CommissioningBuildingBlocks
-from cirque_restart_remote_device import restartRemoteDevice
-from ecdsa import NIST256p
 
 logger = logging.getLogger('PythonMatterControllerTEST')
 logger.setLevel(logging.INFO)

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -20,6 +20,7 @@ import logging
 import pprint
 
 import base
+
 import chip.clusters as Clusters
 import chip.exceptions
 import chip.interaction_model

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -41,13 +41,14 @@ import asyncio
 import os
 
 import base
-import chip.logging
 import click
 import coloredlogs
 from base import BaseTestHelper, FailIfNot, SetTestSet, TestFail, TestTimeout, logger
-from chip.tracing import TracingContext
 from cluster_objects import ClusterObjectTests
 from network_commissioning import NetworkCommissioningTests
+
+import chip.logging
+from chip.tracing import TracingContext
 
 # The thread network dataset tlv for testing, splitted into T-L-V.
 

--- a/src/controller/python/test/test_scripts/network_commissioning.py
+++ b/src/controller/python/test/test_scripts/network_commissioning.py
@@ -20,6 +20,7 @@ import logging
 import random
 
 import base
+
 import chip.clusters as Clusters
 import chip.interaction_model
 from chip.clusters.Types import NullValue

--- a/src/controller/python/test/test_scripts/python_commissioning_flow_test.py
+++ b/src/controller/python/test/test_scripts/python_commissioning_flow_test.py
@@ -26,6 +26,7 @@ from optparse import OptionParser
 
 import example_python_commissioning_flow
 from base import BaseTestHelper, TestFail, TestTimeout, logger
+
 from chip import ChipDeviceCtrl
 from chip import clusters as Clusters
 from chip import commissioning

--- a/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
+++ b/src/controller/python/test/test_scripts/subscription_resumption_timeout_test.py
@@ -25,6 +25,7 @@ import sys
 from optparse import OptionParser
 
 from base import BaseTestHelper, FailIfNot, TestFail, TestTimeout, logger
+
 from chip import clusters as Clusters
 
 TEST_DISCRIMINATOR = 3840

--- a/src/controller/python/test/unit_tests/test_generated_clusterobjects.py
+++ b/src/controller/python/test/unit_tests/test_generated_clusterobjects.py
@@ -1,8 +1,9 @@
 import unittest
 
+from rich.pretty import pprint
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
-from rich.pretty import pprint
 
 '''
 This file contains tests for validating the generated cluster objects by running encoding and decoding

--- a/src/python_testing/MinimalRepresentation.py
+++ b/src/python_testing/MinimalRepresentation.py
@@ -17,11 +17,12 @@
 
 from dataclasses import dataclass, field
 
+from TC_DeviceConformance import DeviceConformanceTests
+
 from chip.testing.conformance import ConformanceDecision
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from chip.tlv import uint
-from TC_DeviceConformance import DeviceConformanceTests
 
 
 @dataclass

--- a/src/python_testing/TCP_Tests.py
+++ b/src/python_testing/TCP_Tests.py
@@ -29,12 +29,13 @@
 #     factory-reset: true
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
-#
+
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TCP_Tests(MatterBaseTest):

--- a/src/python_testing/TC_ACE_1_2.py
+++ b/src/python_testing/TC_ACE_1_2.py
@@ -37,13 +37,14 @@
 import logging
 import queue
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import EventReadResult, SubscriptionTransaction, TypedAttributePath
 from chip.exceptions import ChipStackError
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class AttributeChangeCallback:

--- a/src/python_testing/TC_ACE_1_3.py
+++ b/src/python_testing/TC_ACE_1_3.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 def acl_subject(cat: int) -> int:

--- a/src/python_testing/TC_ACE_1_4.py
+++ b/src/python_testing/TC_ACE_1_4.py
@@ -40,10 +40,11 @@
 
 import sys
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_ACE_1_5.py
+++ b/src/python_testing/TC_ACE_1_5.py
@@ -37,11 +37,12 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_ACE_1_5(MatterBaseTest):

--- a/src/python_testing/TC_ACL_2_11.py
+++ b/src/python_testing/TC_ACL_2_11.py
@@ -41,8 +41,10 @@
 import logging
 import queue
 
-import chip.clusters as Clusters
 import matter_testing_infrastructure.chip.testing.global_attribute_ids as global_attribute_ids
+from mobly import asserts
+
+import chip.clusters as Clusters
 from chip.clusters.Attribute import EventReadResult, SubscriptionTransaction, ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ACCEPTED_COMMANDS, ALL_ATTRIBUTES, ALL_CLUSTERS, ClusterEvent
 from chip.clusters.Objects import AccessControl
@@ -50,7 +52,6 @@ from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.basic_composition import arls_populated
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class EventChangeCallback:

--- a/src/python_testing/TC_ACL_2_2.py
+++ b/src/python_testing/TC_ACL_2_2.py
@@ -31,9 +31,10 @@
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_ACL_2_2(MatterBaseTest):

--- a/src/python_testing/TC_BOOLCFG_2_1.py
+++ b/src/python_testing/TC_BOOLCFG_2_1.py
@@ -35,9 +35,10 @@ import functools
 import logging
 from operator import ior
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_BOOLCFG_2_1(MatterBaseTest):

--- a/src/python_testing/TC_BOOLCFG_3_1.py
+++ b/src/python_testing/TC_BOOLCFG_3_1.py
@@ -34,10 +34,11 @@
 import logging
 from random import choice
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_BOOLCFG_3_1(MatterBaseTest):

--- a/src/python_testing/TC_BOOLCFG_4_1.py
+++ b/src/python_testing/TC_BOOLCFG_4_1.py
@@ -33,9 +33,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_BOOLCFG_4_1(MatterBaseTest):

--- a/src/python_testing/TC_BOOLCFG_4_2.py
+++ b/src/python_testing/TC_BOOLCFG_4_2.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 sensorTrigger = 0x0080_0000_0000_0000
 sensorUntrigger = 0x0080_0000_0000_0001

--- a/src/python_testing/TC_BOOLCFG_4_3.py
+++ b/src/python_testing/TC_BOOLCFG_4_3.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 sensorTrigger = 0x0080_0000_0000_0000
 sensorUntrigger = 0x0080_0000_0000_0001

--- a/src/python_testing/TC_BOOLCFG_4_4.py
+++ b/src/python_testing/TC_BOOLCFG_4_4.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 sensorTrigger = 0x0080_0000_0000_0000
 sensorUntrigger = 0x0080_0000_0000_0001

--- a/src/python_testing/TC_BOOLCFG_5_1.py
+++ b/src/python_testing/TC_BOOLCFG_5_1.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 sensorTrigger = 0x0080_0000_0000_0000
 sensorUntrigger = 0x0080_0000_0000_0001

--- a/src/python_testing/TC_BOOLCFG_5_2.py
+++ b/src/python_testing/TC_BOOLCFG_5_2.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 sensorTrigger = 0x0080_0000_0000_0000
 sensorUntrigger = 0x0080_0000_0000_0001

--- a/src/python_testing/TC_BRBINFO_4_1.py
+++ b/src/python_testing/TC_BRBINFO_4_1.py
@@ -50,12 +50,13 @@ import queue
 import random
 import tempfile
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.apps import IcdAppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, SimpleEventCallback, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 _ROOT_ENDPOINT_ID = 0

--- a/src/python_testing/TC_CADMIN_1_11.py
+++ b/src/python_testing/TC_CADMIN_1_11.py
@@ -37,14 +37,15 @@ import random
 from time import sleep
 from typing import Optional
 
+from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
+                                                                       default_matter_test_main)
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
 from chip.native import PyChipError
-from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
-                                                                       default_matter_test_main)
-from mobly import asserts
 
 
 class TC_CADMIN_1_11(MatterBaseTest):

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -33,11 +33,12 @@
 
 import random
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.exceptions import ChipStackError
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_CADMIN_1_19(MatterBaseTest):

--- a/src/python_testing/TC_CADMIN_1_22_24.py
+++ b/src/python_testing/TC_CADMIN_1_22_24.py
@@ -36,11 +36,12 @@ import logging
 import random
 from time import sleep
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_CADMIN_1_22_24(MatterBaseTest):

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -35,13 +35,14 @@ import logging
 import random
 from time import sleep
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
 from chip.native import PyChipError
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_CADMIN_1_9(MatterBaseTest):

--- a/src/python_testing/TC_CCTRL_2_1.py
+++ b/src/python_testing/TC_CCTRL_2_1.py
@@ -53,9 +53,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
-from mobly import asserts
 
 
 class TC_CCTRL_2_1(MatterBaseTest):

--- a/src/python_testing/TC_CCTRL_2_2.py
+++ b/src/python_testing/TC_CCTRL_2_2.py
@@ -63,13 +63,14 @@ import random
 import tempfile
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
                                          run_if_endpoint_matches)
-from mobly import asserts
 
 
 class TC_CCTRL_2_2(MatterBaseTest):

--- a/src/python_testing/TC_CCTRL_2_3.py
+++ b/src/python_testing/TC_CCTRL_2_3.py
@@ -63,13 +63,14 @@ import random
 import tempfile
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_cluster,
                                          run_if_endpoint_matches)
-from mobly import asserts
 
 
 class TC_CCTRL_2_3(MatterBaseTest):

--- a/src/python_testing/TC_CC_10_1.py
+++ b/src/python_testing/TC_CC_10_1.py
@@ -39,10 +39,11 @@
 import asyncio
 from typing import List
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 kCCAttributeValueIDs = [0x0001, 0x0003, 0x0004, 0x0007, 0x4000, 0x4001, 0x4002, 0x4003, 0x4004]
 

--- a/src/python_testing/TC_CC_2_2.py
+++ b/src/python_testing/TC_CC_2_2.py
@@ -39,12 +39,13 @@
 import logging
 import time
 
+from mobly import asserts
+from test_plan_support import commission_if_required, read_attribute, verify_success
+
 import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, default_matter_test_main,
                                          has_cluster, run_if_endpoint_matches)
-from mobly import asserts
-from test_plan_support import commission_if_required, read_attribute, verify_success
 
 
 class TC_CC_2_3(MatterBaseTest):

--- a/src/python_testing/TC_CGEN_2_4.py
+++ b/src/python_testing/TC_CGEN_2_4.py
@@ -38,6 +38,8 @@ import logging
 import random
 import time
 
+from mobly import asserts
+
 import chip.CertificateAuthority
 import chip.clusters as Clusters
 import chip.clusters.enum
@@ -47,7 +49,6 @@ from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
 from chip.native import PyChipError
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # Commissioning stage numbers - we should find a better way to match these to the C++ code
 # TODO: https://github.com/project-chip/connectedhomeip/issues/36629

--- a/src/python_testing/TC_CNET_1_4.py
+++ b/src/python_testing/TC_CNET_1_4.py
@@ -37,9 +37,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 kRootEndpointId = 0
 kSecondaryNetworkInterfaceDeviceTypeId = 0x0019

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -20,10 +20,11 @@ import random
 import string
 from typing import Optional
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 class TC_CNET_4_4(MatterBaseTest):

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -40,12 +40,6 @@ import os
 import random
 import re
 
-import chip.clusters as Clusters
-from chip.interaction_model import InteractionModelError, Status
-from chip.testing.basic_composition import BasicCompositionTests
-from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, hex_from_bytes,
-                                         type_matches)
-from chip.tlv import TLVReader
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat._oid import ExtensionOID
@@ -57,6 +51,13 @@ from pyasn1.codec.der.decoder import decode as der_decoder
 from pyasn1.error import PyAsn1Error
 from pyasn1.type import univ
 from pyasn1_modules import rfc5652
+
+import chip.clusters as Clusters
+from chip.interaction_model import InteractionModelError, Status
+from chip.testing.basic_composition import BasicCompositionTests
+from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main, hex_from_bytes,
+                                         type_matches)
+from chip.tlv import TLVReader
 
 
 def get_value_for_oid(oid_dotted_str: str, cert: x509.Certificate) -> str:

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -37,11 +37,6 @@
 
 import random
 
-import chip.clusters as Clusters
-from chip import ChipDeviceCtrl
-from chip.interaction_model import InteractionModelError, Status
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, hex_from_bytes, type_matches
-from chip.tlv import TLVReader
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, utils
@@ -50,6 +45,12 @@ from mobly import asserts
 from pyasn1.codec.der.decoder import decode as der_decoder
 from pyasn1.error import PyAsn1Error
 from pyasn1_modules import rfc2986, rfc3279, rfc5480
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.interaction_model import InteractionModelError, Status
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, hex_from_bytes, type_matches
+from chip.tlv import TLVReader
 
 
 class TC_DA_1_5(MatterBaseTest):

--- a/src/python_testing/TC_DA_1_7.py
+++ b/src/python_testing/TC_DA_1_7.py
@@ -40,15 +40,16 @@ from glob import glob
 from pathlib import Path
 from typing import List, Optional
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, bytes_from_hex, default_matter_test_main,
-                                         hex_from_bytes)
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.x509 import AuthorityKeyIdentifier, Certificate, SubjectKeyIdentifier, load_der_x509_certificate
 from mobly import asserts
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, bytes_from_hex, default_matter_test_main,
+                                         hex_from_bytes)
 
 # Those are SDK samples that are known to be non-production.
 FORBIDDEN_AKID = [

--- a/src/python_testing/TC_DEMTestBase.py
+++ b/src/python_testing/TC_DEMTestBase.py
@@ -17,10 +17,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import utc_time_in_matter_epoch
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_1.py
+++ b/src/python_testing/TC_DEM_2_1.py
@@ -47,11 +47,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_10.py
+++ b/src/python_testing/TC_DEM_2_10.py
@@ -48,12 +48,13 @@ import logging
 import sys
 import time
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, async_test_body,
                                          default_matter_test_main)
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_2.py
+++ b/src/python_testing/TC_DEM_2_2.py
@@ -50,11 +50,12 @@ import logging
 import sys
 import time
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_3.py
+++ b/src/python_testing/TC_DEM_2_3.py
@@ -43,12 +43,13 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_4.py
+++ b/src/python_testing/TC_DEM_2_4.py
@@ -44,12 +44,13 @@
 import logging
 import time
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import Status
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_5.py
+++ b/src/python_testing/TC_DEM_2_5.py
@@ -47,11 +47,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_6.py
+++ b/src/python_testing/TC_DEM_2_6.py
@@ -47,11 +47,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_7.py
+++ b/src/python_testing/TC_DEM_2_7.py
@@ -47,11 +47,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_8.py
+++ b/src/python_testing/TC_DEM_2_8.py
@@ -47,11 +47,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_DEMTestBase import DEMTestBase
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_DEMTestBase import DEMTestBase
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DEM_2_9.py
+++ b/src/python_testing/TC_DEM_2_9.py
@@ -47,10 +47,11 @@
 
 import logging
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_DEMTestBase import DEMTestBase
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DGGEN_2_4.py
+++ b/src/python_testing/TC_DGGEN_2_4.py
@@ -37,13 +37,14 @@
 import asyncio
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main,
                                          matter_epoch_us_from_utc_datetime, utc_datetime_from_matter_epoch_us,
                                          utc_datetime_from_posix_time_ms)
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DGGEN_3_2.py
+++ b/src/python_testing/TC_DGGEN_3_2.py
@@ -15,9 +15,10 @@
 #    limitations under the License.
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGGEN_3_2(MatterBaseTest):

--- a/src/python_testing/TC_DGSW_2_1.py
+++ b/src/python_testing/TC_DGSW_2_1.py
@@ -35,8 +35,6 @@
 # === END CI TEST ARGUMENTS ===
 #
 
-from mobly import asserts
-
 import chip.clusters as Clusters
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DGSW_2_1.py
+++ b/src/python_testing/TC_DGSW_2_1.py
@@ -35,6 +35,8 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DGSW_2_2.py
+++ b/src/python_testing/TC_DGSW_2_2.py
@@ -41,6 +41,8 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DGSW_2_2.py
+++ b/src/python_testing/TC_DGSW_2_2.py
@@ -41,8 +41,6 @@
 # === END CI TEST ARGUMENTS ===
 #
 
-from mobly import asserts
-
 import chip.clusters as Clusters
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_DGSW_2_3.py
+++ b/src/python_testing/TC_DGSW_2_3.py
@@ -37,10 +37,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGSW_2_3(MatterBaseTest):

--- a/src/python_testing/TC_DGTHREAD_2_4.py
+++ b/src/python_testing/TC_DGTHREAD_2_4.py
@@ -32,9 +32,10 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_THREADND_2_4(MatterBaseTest):

--- a/src/python_testing/TC_DGWIFI_2_1.py
+++ b/src/python_testing/TC_DGWIFI_2_1.py
@@ -32,11 +32,12 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import Nullable, NullValue
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGWIFI_2_1(MatterBaseTest):

--- a/src/python_testing/TC_DGWIFI_2_2.py
+++ b/src/python_testing/TC_DGWIFI_2_2.py
@@ -41,9 +41,10 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGWIFI_2_2(MatterBaseTest):

--- a/src/python_testing/TC_DGWIFI_2_3.py
+++ b/src/python_testing/TC_DGWIFI_2_3.py
@@ -32,10 +32,11 @@
 # === END CI TEST ARGUMENTS ===
 #
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGWIFI_2_3(MatterBaseTest):

--- a/src/python_testing/TC_DRLK_2_12.py
+++ b/src/python_testing/TC_DRLK_2_12.py
@@ -35,8 +35,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from drlk_2_x_common import DRLK_COMMON
+
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
 # - userIndex: userIndex to use when creating a user on the DUT for testing purposes

--- a/src/python_testing/TC_DRLK_2_13.py
+++ b/src/python_testing/TC_DRLK_2_13.py
@@ -39,12 +39,13 @@ import logging
 import random
 from dataclasses import dataclass
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Attribute import EventPriority
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DRLK_2_2.py
+++ b/src/python_testing/TC_DRLK_2_2.py
@@ -35,8 +35,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from drlk_2_x_common import DRLK_COMMON
+
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
 # - userIndex: userIndex to use when creating a user on the DUT for testing purposes

--- a/src/python_testing/TC_DRLK_2_3.py
+++ b/src/python_testing/TC_DRLK_2_3.py
@@ -35,8 +35,9 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from drlk_2_x_common import DRLK_COMMON
+
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 
 # Configurable parameters:
 # - userIndex: userIndex to use when creating a user on the DUT for testing purposes

--- a/src/python_testing/TC_DRLK_2_5.py
+++ b/src/python_testing/TC_DRLK_2_5.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -38,12 +38,13 @@ import logging
 import random
 import string
 
+from drlk_2_x_common import DRLK_COMMON
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from drlk_2_x_common import DRLK_COMMON
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -62,6 +62,8 @@ import os
 import random
 import tempfile
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import Status
@@ -69,7 +71,6 @@ from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import (MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main,
                                          type_matches)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_ECOINFO_2_1(MatterBaseTest):

--- a/src/python_testing/TC_ECOINFO_2_2.py
+++ b/src/python_testing/TC_ECOINFO_2_2.py
@@ -62,11 +62,12 @@ import os
 import random
 import tempfile
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 _DEVICE_TYPE_AGGREGATOR = 0x000E
 

--- a/src/python_testing/TC_EEM_2_1.py
+++ b/src/python_testing/TC_EEM_2_1.py
@@ -41,11 +41,12 @@
 
 import logging
 
+from mobly import asserts
+from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEM_2_2.py
+++ b/src/python_testing/TC_EEM_2_2.py
@@ -41,9 +41,10 @@
 
 import time
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 
 class TC_EEM_2_2(MatterBaseTest, EnergyReportingBaseTestHelper):

--- a/src/python_testing/TC_EEM_2_3.py
+++ b/src/python_testing/TC_EEM_2_3.py
@@ -41,9 +41,10 @@
 
 import time
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 
 class TC_EEM_2_3(MatterBaseTest, EnergyReportingBaseTestHelper):

--- a/src/python_testing/TC_EEM_2_4.py
+++ b/src/python_testing/TC_EEM_2_4.py
@@ -41,9 +41,10 @@
 
 import time
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 
 class TC_EEM_2_4(MatterBaseTest, EnergyReportingBaseTestHelper):

--- a/src/python_testing/TC_EEM_2_5.py
+++ b/src/python_testing/TC_EEM_2_5.py
@@ -41,9 +41,10 @@
 
 import time
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 
 class TC_EEM_2_5(MatterBaseTest, EnergyReportingBaseTestHelper):

--- a/src/python_testing/TC_EEVSE_2_2.py
+++ b/src/python_testing/TC_EEVSE_2_2.py
@@ -44,11 +44,12 @@ import logging
 import time
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+from TC_EEVSE_Utils import EEVSEBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEVSE_2_3.py
+++ b/src/python_testing/TC_EEVSE_2_3.py
@@ -43,12 +43,13 @@
 import logging
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+from TC_EEVSE_Utils import EEVSEBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import Status
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEVSE_2_4.py
+++ b/src/python_testing/TC_EEVSE_2_4.py
@@ -43,10 +43,11 @@
 import logging
 import time
 
+from TC_EEVSE_Utils import EEVSEBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEVSE_2_5.py
+++ b/src/python_testing/TC_EEVSE_2_5.py
@@ -42,11 +42,12 @@
 
 import logging
 
+from TC_EEVSE_Utils import EEVSEBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import Status
 from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEVSE_2_6.py
+++ b/src/python_testing/TC_EEVSE_2_6.py
@@ -43,12 +43,13 @@
 import logging
 import time
 
+from mobly import asserts
+from TC_EEVSE_Utils import EEVSEBaseTestHelper
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, EventChangeCallback, MatterBaseTest, TestStep,
                                          async_test_body, default_matter_test_main)
-from mobly import asserts
-from TC_EEVSE_Utils import EEVSEBaseTestHelper
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EEVSE_Utils.py
+++ b/src/python_testing/TC_EEVSE_Utils.py
@@ -18,10 +18,11 @@
 import logging
 import typing
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EPM_2_1.py
+++ b/src/python_testing/TC_EPM_2_1.py
@@ -41,10 +41,11 @@
 
 import logging
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EPM_2_2.py
+++ b/src/python_testing/TC_EPM_2_2.py
@@ -42,9 +42,10 @@
 import logging
 import time
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EnergyReporting_Utils import EnergyReportingBaseTestHelper
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EWATERHTRBase.py
+++ b/src/python_testing/TC_EWATERHTRBase.py
@@ -18,9 +18,10 @@
 import logging
 import typing
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EWATERHTR_2_1.py
+++ b/src/python_testing/TC_EWATERHTR_2_1.py
@@ -44,10 +44,11 @@
 
 import logging
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EWATERHTRBase import EWATERHTRBase
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EWATERHTR_2_2.py
+++ b/src/python_testing/TC_EWATERHTR_2_2.py
@@ -46,10 +46,11 @@
 import logging
 import time
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EWATERHTRBase import EWATERHTRBase
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EWATERHTR_2_3.py
+++ b/src/python_testing/TC_EWATERHTR_2_3.py
@@ -44,10 +44,11 @@
 
 import logging
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 from TC_EWATERHTRBase import EWATERHTRBase
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import EventChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_EnergyReporting_Utils.py
+++ b/src/python_testing/TC_EnergyReporting_Utils.py
@@ -17,9 +17,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_FAN_3_1.py
+++ b/src/python_testing/TC_FAN_3_1.py
@@ -37,10 +37,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_FAN_3_2.py
+++ b/src/python_testing/TC_FAN_3_2.py
@@ -37,10 +37,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_FAN_3_3.py
+++ b/src/python_testing/TC_FAN_3_3.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_FAN_3_4.py
+++ b/src/python_testing/TC_FAN_3_4.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # import time
 

--- a/src/python_testing/TC_FAN_3_5.py
+++ b/src/python_testing/TC_FAN_3_5.py
@@ -37,10 +37,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_2_1.py
+++ b/src/python_testing/TC_ICDM_2_1.py
@@ -38,9 +38,10 @@
 import logging
 import re
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_3_1.py
+++ b/src/python_testing/TC_ICDM_3_1.py
@@ -39,10 +39,11 @@
 import logging
 import os
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_3_2.py
+++ b/src/python_testing/TC_ICDM_3_2.py
@@ -40,10 +40,11 @@ import logging
 import time
 from dataclasses import dataclass
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_3_3.py
+++ b/src/python_testing/TC_ICDM_3_3.py
@@ -39,10 +39,11 @@
 import logging
 from dataclasses import dataclass
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_3_4.py
+++ b/src/python_testing/TC_ICDM_3_4.py
@@ -39,10 +39,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                          default_matter_test_main)
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_ICDM_5_1.py
+++ b/src/python_testing/TC_ICDM_5_1.py
@@ -38,11 +38,12 @@
 import logging
 from dataclasses import dataclass
 
+from mdns_discovery import mdns_discovery
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mdns_discovery import mdns_discovery
-from mobly import asserts
 
 Cluster = Clusters.Objects.IcdManagement
 Commands = Cluster.Commands

--- a/src/python_testing/TC_ICDManagementCluster.py
+++ b/src/python_testing/TC_ICDManagementCluster.py
@@ -41,9 +41,10 @@
 import ctypes
 from enum import IntEnum
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # Assumes `--enable-key 000102030405060708090a0b0c0d0e0f` on Linux app command line, or a DUT
 # that has that Enable Key

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -39,13 +39,14 @@ import logging
 import random
 from dataclasses import dataclass
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 import chip.discovery as Discovery
 from chip import ChipUtility
 from chip.exceptions import ChipStackError
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 def get_all_cmds_for_cluster_id(cid: int) -> list[Clusters.ClusterObjects.ClusterCommand]:

--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -41,11 +41,12 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.exceptions import ChipStackError
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 # If DUT supports `MaxPathsPerInvoke > 1`, additional command line argument
 # run with

--- a/src/python_testing/TC_IDM_4_2.py
+++ b/src/python_testing/TC_IDM_4_2.py
@@ -38,6 +38,8 @@ import copy
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.ChipDeviceCtrl import ChipDeviceController
 from chip.clusters import ClusterObjects as ClusterObjects
@@ -45,7 +47,6 @@ from chip.clusters.Attribute import AttributePath, TypedAttributePath
 from chip.exceptions import ChipStackError
 from chip.interaction_model import Status
 from chip.testing.matter_testing import AttributeChangeCallback, MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 '''
 Category:

--- a/src/python_testing/TC_LVL_2_3.py
+++ b/src/python_testing/TC_LVL_2_3.py
@@ -40,11 +40,12 @@
 import logging
 import time
 
-import chip.clusters as Clusters
 import test_plan_support
+from mobly import asserts
+
+import chip.clusters as Clusters
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, default_matter_test_main,
                                          has_cluster, run_if_endpoint_matches)
-from mobly import asserts
 
 
 class TC_LVL_2_3(MatterBaseTest):

--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -61,11 +61,12 @@ import random
 import tempfile
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 _DEVICE_TYPE_AGGREGATOR = 0x000E
 

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -66,14 +66,15 @@ import struct
 import tempfile
 import time
 
+from ecdsa.curves import NIST256p
+from mobly import asserts
+from TC_SC_3_6 import AttributeChangeAccumulator
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import (MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main,
                                          type_matches)
-from ecdsa.curves import NIST256p
-from mobly import asserts
-from TC_SC_3_6 import AttributeChangeAccumulator
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -65,12 +65,13 @@ import os
 import random
 import tempfile
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import Status
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 _DEVICE_TYPE_AGGREGATOR = 0x000E
 

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -66,13 +66,14 @@ import os
 import random
 import tempfile
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import Status
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
 from chip.testing.tasks import Subprocess
-from mobly import asserts
 
 
 class FabricSyncApp(Subprocess):

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -66,14 +66,15 @@ import struct
 import tempfile
 import time
 
+from ecdsa.curves import NIST256p
+from mobly import asserts
+from TC_SC_3_6 import AttributeChangeAccumulator
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import (MatterBaseTest, SetupParameters, TestStep, async_test_body, default_matter_test_main,
                                          type_matches)
-from ecdsa.curves import NIST256p
-from mobly import asserts
-from TC_SC_3_6 import AttributeChangeAccumulator
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8

--- a/src/python_testing/TC_MWOCTRL_2_1.py
+++ b/src/python_testing/TC_MWOCTRL_2_1.py
@@ -35,10 +35,11 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_MWOCTRL_2_2.py
+++ b/src/python_testing/TC_MWOCTRL_2_2.py
@@ -37,10 +37,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_MWOCTRL_2_4.py
+++ b/src/python_testing/TC_MWOCTRL_2_4.py
@@ -37,10 +37,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_MWOM_1_2.py
+++ b/src/python_testing/TC_MWOM_1_2.py
@@ -36,9 +36,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_MWOM_1_2(MatterBaseTest):

--- a/src/python_testing/TC_OCC_2_1.py
+++ b/src/python_testing/TC_OCC_2_1.py
@@ -42,9 +42,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_OCC_2_1(MatterBaseTest):

--- a/src/python_testing/TC_OCC_2_2.py
+++ b/src/python_testing/TC_OCC_2_2.py
@@ -36,9 +36,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_OCC_2_2(MatterBaseTest):

--- a/src/python_testing/TC_OCC_2_3.py
+++ b/src/python_testing/TC_OCC_2_3.py
@@ -38,9 +38,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_OCC_2_3(MatterBaseTest):

--- a/src/python_testing/TC_OCC_3_1.py
+++ b/src/python_testing/TC_OCC_3_1.py
@@ -41,11 +41,12 @@ import logging
 import time
 from typing import Any, Optional
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, EventChangeCallback, MatterBaseTest, TestStep,
                                          async_test_body, await_sequence_of_reports, default_matter_test_main)
-from mobly import asserts
 
 
 class TC_OCC_3_1(MatterBaseTest):

--- a/src/python_testing/TC_OCC_3_2.py
+++ b/src/python_testing/TC_OCC_3_2.py
@@ -43,10 +43,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep,
                                          async_test_body, await_sequence_of_reports, default_matter_test_main)
-from mobly import asserts
 
 
 class TC_OCC_3_2(MatterBaseTest):

--- a/src/python_testing/TC_OPCREDS_3_1.py
+++ b/src/python_testing/TC_OPCREDS_3_1.py
@@ -37,6 +37,8 @@ import copy
 import logging
 import random
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 import chip.discovery as Discovery
 from chip import ChipDeviceCtrl
@@ -44,7 +46,6 @@ from chip.exceptions import ChipStackError
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from chip.tlv import TLVReader, TLVWriter
-from mobly import asserts
 
 
 class TC_OPCREDS_3_1(MatterBaseTest):

--- a/src/python_testing/TC_OPCREDS_3_2.py
+++ b/src/python_testing/TC_OPCREDS_3_2.py
@@ -35,13 +35,14 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+from test_plan_support import (commission_from_existing, commission_if_required, read_attribute, remove_fabric,
+                               verify_commissioning_successful, verify_success)
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.tlv import TLVReader
 from chip.utils import CommissioningBuildingBlocks
-from mobly import asserts
-from test_plan_support import (commission_from_existing, commission_if_required, read_attribute, remove_fabric,
-                               verify_commissioning_successful, verify_success)
 
 
 def verify_fabric(controller: str) -> str:

--- a/src/python_testing/TC_OPCREDS_3_4.py
+++ b/src/python_testing/TC_OPCREDS_3_4.py
@@ -37,11 +37,12 @@
 
 import random
 
+from mobly import asserts
+from test_plan_support import commission_if_required, read_attribute, send_command
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
-from test_plan_support import commission_if_required, read_attribute, send_command
 
 
 def verify_noc() -> str:

--- a/src/python_testing/TC_OPCREDS_3_5.py
+++ b/src/python_testing/TC_OPCREDS_3_5.py
@@ -38,10 +38,11 @@
 import random
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.utils import CommissioningBuildingBlocks
-from mobly import asserts
 
 
 class TC_OPCREDS_3_5(MatterBaseTest):

--- a/src/python_testing/TC_OPSTATE_2_1.py
+++ b/src/python_testing/TC_OPSTATE_2_1.py
@@ -36,9 +36,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_1(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OPSTATE_2_2.py
+++ b/src/python_testing/TC_OPSTATE_2_2.py
@@ -37,9 +37,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_2(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OPSTATE_2_3.py
+++ b/src/python_testing/TC_OPSTATE_2_3.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_3(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OPSTATE_2_4.py
+++ b/src/python_testing/TC_OPSTATE_2_4.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_4(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OPSTATE_2_5.py
+++ b/src/python_testing/TC_OPSTATE_2_5.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_5(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OPSTATE_2_6.py
+++ b/src/python_testing/TC_OPSTATE_2_6.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OPSTATE_2_6(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_1.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_1.py
@@ -37,9 +37,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_1(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_2.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_2.py
@@ -37,9 +37,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_2(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_3.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_3.py
@@ -37,9 +37,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_3(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_4.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_4.py
@@ -37,9 +37,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_4(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_5.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_5.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_5(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OVENOPSTATE_2_6.py
+++ b/src/python_testing/TC_OVENOPSTATE_2_6.py
@@ -38,9 +38,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from TC_OpstateCommon import TC_OPSTATE_BASE, TestInfo
 
 
 class TC_OVENOPSTATE_2_6(MatterBaseTest, TC_OPSTATE_BASE):

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -21,14 +21,15 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import chip.clusters as Clusters
 import psutil
+from mobly import asserts
+
+import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import EventReadResult, SubscriptionTransaction
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import ClusterAttributeChangeAccumulator, EventChangeCallback, TestStep
-from mobly import asserts
 
 
 def get_pid(name):

--- a/src/python_testing/TC_PS_2_3.py
+++ b/src/python_testing/TC_PS_2_3.py
@@ -37,10 +37,11 @@
 import logging
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import (ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, async_test_body,
                                          default_matter_test_main)
-from mobly import asserts
 
 
 class TC_PS_2_3(MatterBaseTest):

--- a/src/python_testing/TC_PWRTL_2_1.py
+++ b/src/python_testing/TC_PWRTL_2_1.py
@@ -36,9 +36,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_PWRTL_2_1(MatterBaseTest):

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -43,12 +43,13 @@ import string
 import time
 from typing import Any, Dict, List, Set
 
+from mobly import asserts
+from TC_SC_3_6 import AttributeChangeAccumulator, ResubscriptionCatcher
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status as StatusEnum
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from chip.utils import CommissioningBuildingBlocks
-from mobly import asserts
-from TC_SC_3_6 import AttributeChangeAccumulator, ResubscriptionCatcher
 
 # TODO: Overall, we need to add validation that session IDs have not changed throughout to be agnostic
 #       to some internal behavior assumptions of the SDK we are making relative to the write to

--- a/src/python_testing/TC_RVCCLEANM_1_2.py
+++ b/src/python_testing/TC_RVCCLEANM_1_2.py
@@ -38,9 +38,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_RVCCLEANM_1_2(MatterBaseTest):

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -40,9 +40,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -38,9 +38,10 @@
 
 import enum
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 class RvcStatusEnum(enum.IntEnum):

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_RVCOPSTATE_2_1(MatterBaseTest):

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -39,10 +39,11 @@
 import logging
 from time import sleep
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 # Takes an OpState or RvcOpState state enum and returns a string representation

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -38,9 +38,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 # Takes an OpState or RvcOpState state enum and returns a string representation

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -38,9 +38,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_RVCRUNM_1_2(MatterBaseTest):

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -40,9 +40,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 # This test requires several additional command line arguments
 # run with

--- a/src/python_testing/TC_RVCRUNM_2_2.py
+++ b/src/python_testing/TC_RVCRUNM_2_2.py
@@ -40,9 +40,10 @@
 
 import enum
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # This test requires several additional command line arguments.
 # Run the test with

--- a/src/python_testing/TC_SC_3_6.py
+++ b/src/python_testing/TC_SC_3_6.py
@@ -42,12 +42,13 @@ import time
 from threading import Event
 from typing import List
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClustersObjects
 from chip.clusters.Attribute import SubscriptionTransaction, TypedAttributePath
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from chip.utils import CommissioningBuildingBlocks
-from mobly import asserts
 
 # TODO: Overall, we need to add validation that session IDs have not changed throughout to be agnostic
 #       to some internal behavior assumptions of the SDK we are making relative to the write to

--- a/src/python_testing/TC_SC_4_3.py
+++ b/src/python_testing/TC_SC_4_3.py
@@ -38,11 +38,12 @@ import ipaddress
 import logging
 import re
 
-import chip.clusters as Clusters
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mdns_discovery.mdns_discovery import DNSRecordType, MdnsDiscovery, MdnsServiceType
 from mobly import asserts
 from zeroconf.const import _TYPE_AAAA, _TYPES
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 
 '''
 Purpose

--- a/src/python_testing/TC_SC_7_1.py
+++ b/src/python_testing/TC_SC_7_1.py
@@ -37,9 +37,10 @@
 # This should still be fine as this test has unit tests for other conditions. See test_TC_SC_7_1.py
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 def _trusted_root_test_step(dut_num: int) -> TestStep:

--- a/src/python_testing/TC_SEAR_1_2.py
+++ b/src/python_testing/TC_SEAR_1_2.py
@@ -39,10 +39,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_SEAR_1_2(MatterBaseTest):

--- a/src/python_testing/TC_SEAR_1_3.py
+++ b/src/python_testing/TC_SEAR_1_3.py
@@ -40,9 +40,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_SEAR_1_3(MatterBaseTest):

--- a/src/python_testing/TC_SEAR_1_4.py
+++ b/src/python_testing/TC_SEAR_1_4.py
@@ -39,9 +39,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_SEAR_1_4(MatterBaseTest):

--- a/src/python_testing/TC_SEAR_1_5.py
+++ b/src/python_testing/TC_SEAR_1_5.py
@@ -39,10 +39,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_SEAR_1_5(MatterBaseTest):

--- a/src/python_testing/TC_SEAR_1_6.py
+++ b/src/python_testing/TC_SEAR_1_6.py
@@ -39,10 +39,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_SEAR_1_6(MatterBaseTest):

--- a/src/python_testing/TC_SWTCH.py
+++ b/src/python_testing/TC_SWTCH.py
@@ -81,15 +81,16 @@ import time
 from datetime import datetime, timedelta
 from typing import Any
 
-import chip.clusters as Clusters
 import test_plan_support
+from mobly import asserts
+
+import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import EventReadResult
 from chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, EventChangeCallback, MatterBaseTest,
                                          TestStep, await_sequence_of_reports, default_matter_test_main, has_feature,
                                          run_if_endpoint_matches)
 from chip.tlv import uint
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_TCCM_1_2.py
+++ b/src/python_testing/TC_TCCM_1_2.py
@@ -36,9 +36,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
+from modebase_cluster_check import ModeBaseClusterChecks
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from modebase_cluster_check import ModeBaseClusterChecks
 
 CLUSTER = Clusters.RefrigeratorAndTemperatureControlledCabinetMode
 

--- a/src/python_testing/TC_TCTL_2_3.py
+++ b/src/python_testing/TC_TCTL_2_3.py
@@ -32,9 +32,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
-from mobly import asserts
 
 
 class TC_TCTL_2_3(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -39,11 +39,12 @@
 import ipaddress
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import (MatterBaseTest, default_matter_test_main, has_attribute, has_cluster,
                                          run_if_endpoint_matches, utc_time_in_matter_epoch)
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_1(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -40,13 +40,14 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, SimpleEventCallback, async_test_body, default_matter_test_main,
                                          utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 def get_wait_seconds_from_set_time(set_time_matter_us: int, wait_seconds: int):

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -40,13 +40,14 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, SimpleEventCallback, async_test_body, default_matter_test_main,
                                          get_wait_seconds_from_set_time, type_matches, utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_11(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -40,13 +40,14 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, SimpleEventCallback, async_test_body, default_matter_test_main,
                                          get_wait_seconds_from_set_time, type_matches, utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_12(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -38,11 +38,12 @@
 import queue
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, SimpleEventCallback, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_13(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -37,12 +37,13 @@
 
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main,
                                          utc_time_in_matter_epoch)
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_2(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -38,11 +38,12 @@
 import typing
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, type_matches,
                                          utc_time_in_matter_epoch)
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_4(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_5.py
+++ b/src/python_testing/TC_TIMESYNC_2_5.py
@@ -37,11 +37,12 @@
 
 import typing
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, utc_time_in_matter_epoch
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_5(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_6.py
+++ b/src/python_testing/TC_TIMESYNC_2_6.py
@@ -37,11 +37,12 @@
 
 import typing
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import Nullable, NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_6(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -39,13 +39,14 @@ import time
 import typing
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main, type_matches,
                                          utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_7(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -39,13 +39,14 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main, type_matches,
                                          utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_8(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -38,13 +38,14 @@
 import typing
 from datetime import timedelta
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main, type_matches,
                                          utc_time_in_matter_epoch)
 from chip.tlv import uint
-from mobly import asserts
 
 
 class TC_TIMESYNC_2_9(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_3_1.py
+++ b/src/python_testing/TC_TIMESYNC_3_1.py
@@ -34,9 +34,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_TIMESYNC_3_1(MatterBaseTest):

--- a/src/python_testing/TC_TMP_2_1.py
+++ b/src/python_testing/TC_TMP_2_1.py
@@ -14,10 +14,11 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_TMP_2_1(MatterBaseTest):

--- a/src/python_testing/TC_TSTAT_4_2.py
+++ b/src/python_testing/TC_TSTAT_4_2.py
@@ -39,13 +39,14 @@ import logging
 import random
 from collections import namedtuple
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
 from chip.clusters import Globals
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_TestAttrAvail.py
+++ b/src/python_testing/TC_TestAttrAvail.py
@@ -61,9 +61,10 @@
 
 import asyncio
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_TestAttrAvail(MatterBaseTest):

--- a/src/python_testing/TC_TestEventTrigger.py
+++ b/src/python_testing/TC_TestEventTrigger.py
@@ -41,10 +41,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # Assumes `--enable-key 000102030405060708090a0b0c0d0e0f` on Linux app command line, or a DUT
 # that has that Enable Key

--- a/src/python_testing/TC_VALCC_2_1.py
+++ b/src/python_testing/TC_VALCC_2_1.py
@@ -34,10 +34,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_2_1(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_3_1.py
+++ b/src/python_testing/TC_VALCC_3_1.py
@@ -32,11 +32,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep,
                                          async_test_body, default_matter_test_main)
-from mobly import asserts
 
 
 class TC_VALCC_3_1(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_3_2.py
+++ b/src/python_testing/TC_VALCC_3_2.py
@@ -33,12 +33,13 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep,
                                          async_test_body, default_matter_test_main)
-from mobly import asserts
 
 
 class TC_VALCC_3_2(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_3_3.py
+++ b/src/python_testing/TC_VALCC_3_3.py
@@ -32,11 +32,12 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep,
                                          async_test_body, default_matter_test_main)
-from mobly import asserts
 
 
 class TC_VALCC_3_3(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_3_4.py
+++ b/src/python_testing/TC_VALCC_3_4.py
@@ -34,10 +34,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_3_4(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_4_1.py
+++ b/src/python_testing/TC_VALCC_4_1.py
@@ -34,11 +34,12 @@
 
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_4_1(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_4_2.py
+++ b/src/python_testing/TC_VALCC_4_2.py
@@ -34,11 +34,12 @@
 
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_4_2(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_4_3.py
+++ b/src/python_testing/TC_VALCC_4_3.py
@@ -34,11 +34,12 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_4_3(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -34,12 +34,13 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body, default_matter_test_main,
                                          utc_time_in_matter_epoch)
-from mobly import asserts
 
 
 class TC_VALCC_4_4(MatterBaseTest):

--- a/src/python_testing/TC_VALCC_4_5.py
+++ b/src/python_testing/TC_VALCC_4_5.py
@@ -34,11 +34,12 @@
 
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_VALCC_4_5(MatterBaseTest):

--- a/src/python_testing/TC_WASHERCTRL_2_1.py
+++ b/src/python_testing/TC_WASHERCTRL_2_1.py
@@ -38,10 +38,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
-from mobly import asserts
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/TC_WHM_1_2.py
+++ b/src/python_testing/TC_WHM_1_2.py
@@ -40,9 +40,10 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_WHM_1_2(MatterBaseTest):

--- a/src/python_testing/TC_WHM_2_1.py
+++ b/src/python_testing/TC_WHM_2_1.py
@@ -41,10 +41,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 
 class TC_WHM_2_1(MatterBaseTest):

--- a/src/python_testing/TC_pics_checker.py
+++ b/src/python_testing/TC_pics_checker.py
@@ -16,6 +16,8 @@
 #
 import math
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.testing.basic_composition import BasicCompositionTests
 from chip.testing.global_attribute_ids import GlobalAttributeIds
@@ -23,7 +25,6 @@ from chip.testing.matter_testing import (AttributePathLocation, ClusterPathLocat
                                          MatterBaseTest, ProblemLocation, TestStep, async_test_body, default_matter_test_main)
 from chip.testing.pics import accepted_cmd_pics_str, attribute_pics_str, feature_pics_str, generated_cmd_pics_str
 from chip.testing.spec_parsing import build_xml_clusters
-from mobly import asserts
 
 
 class TC_PICS_Checker(MatterBaseTest, BasicCompositionTests):

--- a/src/python_testing/TestBatchInvoke.py
+++ b/src/python_testing/TestBatchInvoke.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
-from mobly import asserts
 
 ''' Integration test of batch commands using UnitTesting Cluster
 

--- a/src/python_testing/TestBdxTransfer.py
+++ b/src/python_testing/TestBdxTransfer.py
@@ -38,10 +38,11 @@
 import asyncio
 import random
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.bdx import BdxProtocol, BdxTransfer
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TestBdxTransfer(MatterBaseTest):

--- a/src/python_testing/TestChoiceConformanceSupport.py
+++ b/src/python_testing/TestChoiceConformanceSupport.py
@@ -19,11 +19,12 @@ import itertools
 import xml.etree.ElementTree as ElementTree
 
 import jinja2
+from mobly import asserts
+
 from chip.testing.choice_conformance import (evaluate_attribute_choice_conformance, evaluate_command_choice_conformance,
                                              evaluate_feature_choice_conformance)
 from chip.testing.matter_testing import MatterBaseTest, ProblemNotice, default_matter_test_main
 from chip.testing.spec_parsing import XmlCluster, add_cluster_data_from_xml
-from mobly import asserts
 
 FEATURE_TEMPLATE = '''\
     <feature bit="{{ id }}" code="{{ name }}" name="{{ name }}" summary="summary">

--- a/src/python_testing/TestCommissioningTimeSync.py
+++ b/src/python_testing/TestCommissioningTimeSync.py
@@ -16,12 +16,13 @@
 #
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, utc_time_in_matter_epoch
-from mobly import asserts
 
 # We don't have a good pipe between the c++ enums in CommissioningDelegate and python
 # so this is hardcoded.

--- a/src/python_testing/TestConformanceSupport.py
+++ b/src/python_testing/TestConformanceSupport.py
@@ -18,12 +18,13 @@
 import xml.etree.ElementTree as ElementTree
 from typing import Callable
 
+from mobly import asserts
+
 from chip.testing.conformance import (Choice, Conformance, ConformanceDecision, ConformanceException, ConformanceParseParameters,
                                       deprecated, disallowed, mandatory, optional, parse_basic_callable_from_xml,
                                       parse_callable_from_xml, parse_device_type_callable_from_xml, provisional, zigbee)
 from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from chip.tlv import uint
-from mobly import asserts
 
 
 def basic_test(xml: str, cls: Callable) -> None:

--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -17,14 +17,15 @@
 
 from typing import Any
 
+from mobly import asserts
+from TC_DeviceConformance import DeviceConformanceTests
+
 import chip.clusters as Clusters
 from chip.testing.basic_composition import arls_populated
 from chip.testing.conformance import ConformanceDecision
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from chip.testing.spec_parsing import build_xml_clusters, build_xml_device_types
-from mobly import asserts
-from TC_DeviceConformance import DeviceConformanceTests
 
 
 def create_onoff_endpoint(endpoint: int) -> dict[int, dict[int, dict[int, Any]]]:

--- a/src/python_testing/TestGroupTableReports.py
+++ b/src/python_testing/TestGroupTableReports.py
@@ -38,12 +38,13 @@ import logging
 import queue
 from typing import List
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import SubscriptionTransaction, TypedAttributePath
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class AttributeChangeCallback:

--- a/src/python_testing/TestIdChecks.py
+++ b/src/python_testing/TestIdChecks.py
@@ -15,13 +15,14 @@
 #    limitations under the License.
 #
 
+from mobly import asserts
+
 from chip.testing.global_attribute_ids import (AttributeIdType, ClusterIdType, CommandIdType, DeviceTypeIdType, attribute_id_type,
                                                cluster_id_type, command_id_type, device_type_id_type, is_standard_attribute_id,
                                                is_standard_cluster_id, is_standard_command_id, is_standard_device_type_id,
                                                is_valid_attribute_id, is_valid_cluster_id, is_valid_command_id,
                                                is_valid_device_type_id)
 from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
-from mobly import asserts
 
 
 class TestIdChecks(MatterBaseTest):

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -20,6 +20,8 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+from mobly import asserts, signals
+
 import chip.clusters as Clusters
 from chip.clusters.Types import Nullable, NullValue
 from chip.testing.matter_testing import (MatterBaseTest, async_test_body, compare_time, default_matter_test_main,
@@ -30,7 +32,6 @@ from chip.testing.taglist_and_topology_test import (TagProblem, create_device_ty
                                                     find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
                                                     get_direct_children_of_root, parts_list_cycles, separate_endpoint_types)
 from chip.tlv import uint
-from mobly import asserts, signals
 
 
 def get_raw_type_list():

--- a/src/python_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/TestSpecParsingDeviceType.py
@@ -16,15 +16,16 @@
 #
 import xml.etree.ElementTree as ElementTree
 
+from jinja2 import Template
+from mobly import asserts
+from TC_DeviceConformance import DeviceConformanceTests
+
 import chip.clusters as Clusters
 from chip.clusters import Attribute
 from chip.testing.conformance import conformance_allowed
 from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
 from chip.testing.spec_parsing import build_xml_clusters, build_xml_device_types, parse_single_device_type
 from chip.tlv import uint
-from jinja2 import Template
-from mobly import asserts
-from TC_DeviceConformance import DeviceConformanceTests
 
 
 class TestSpecParsingDeviceType(MatterBaseTest):

--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -17,14 +17,15 @@
 
 import xml.etree.ElementTree as ElementTree
 
-import chip.clusters as Clusters
 import jinja2
+from mobly import asserts
+
+import chip.clusters as Clusters
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.matter_testing import MatterBaseTest, ProblemNotice, default_matter_test_main
 from chip.testing.spec_parsing import (ClusterParser, DataModelLevel, PrebuiltDataModelDirectory, XmlCluster,
                                        add_cluster_data_from_xml, build_xml_clusters, check_clusters_for_unknown_commands,
                                        combine_derived_clusters_with_base, get_data_model_directory)
-from mobly import asserts
 
 # TODO: improve the test coverage here
 # https://github.com/project-chip/connectedhomeip/issues/30958

--- a/src/python_testing/TestTimeSyncTrustedTimeSource.py
+++ b/src/python_testing/TestTimeSyncTrustedTimeSource.py
@@ -16,10 +16,11 @@
 #
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 # We don't have a good pipe between the c++ enums in CommissioningDelegate and python
 # so this is hardcoded.

--- a/src/python_testing/TestUnitTestingErrorPath.py
+++ b/src/python_testing/TestUnitTestingErrorPath.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
-from mobly import asserts
 
 """ Integration test for error path returns via the UnitTesting cluster.
 """

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -20,11 +20,12 @@ import random
 import string
 import time
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import type_matches
-from mobly import asserts
 
 
 class DRLK_COMMON:

--- a/src/python_testing/hello_external_runner.py
+++ b/src/python_testing/hello_external_runner.py
@@ -23,8 +23,9 @@ import sys
 from multiprocessing import Process
 from multiprocessing.managers import BaseManager
 
-from chip.testing.matter_testing import MatterTestConfig, get_test_info, run_tests
 from hello_test import HelloTest
+
+from chip.testing.matter_testing import MatterTestConfig, get_test_info, run_tests
 
 try:
     from matter_yamltests.hooks import TestRunnerHooks

--- a/src/python_testing/hello_test.py
+++ b/src/python_testing/hello_test.py
@@ -36,10 +36,11 @@
 
 import logging
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class HelloTest(MatterBaseTest):

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/basic_composition.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/basic_composition.py
@@ -27,11 +27,12 @@ from dataclasses import dataclass
 from pprint import pformat, pprint
 from typing import Any, Optional
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 import chip.clusters.ClusterObjects
 import chip.tlv
 from chip.clusters.Attribute import ValueDecodeFailure
-from mobly import asserts
 
 
 @dataclass

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -41,22 +41,18 @@ from functools import partial
 from itertools import chain
 from typing import Any, Iterable, List, Optional, Tuple
 
-from chip.tlv import float32, uint
+from mobly import asserts, base_test, signals, utils
+from mobly.config_parser import ENV_MOBLY_LOGPATH, TestRunConfig
+from mobly.test_runner import TestRunner
 
-# isort: off
-
-from chip import ChipDeviceCtrl  # Needed before chip.FabricAdmin
-import chip.FabricAdmin  # Needed before chip.CertificateAuthority
 import chip.CertificateAuthority
-from chip.ChipDeviceCtrl import CommissioningParameters
-
-# isort: on
-from time import sleep
-
 import chip.clusters as Clusters
+import chip.FabricAdmin
 import chip.logging
 import chip.native
+from chip import ChipDeviceCtrl
 from chip import discovery
+from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.ChipStack import ChipStack
 from chip.clusters import Attribute
 from chip.clusters import ClusterObjects as ClusterObjects
@@ -67,10 +63,8 @@ from chip.setup_payload import SetupPayload
 from chip.storage import PersistentStorage
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.pics import read_pics_from_file
+from chip.tlv import float32, uint
 from chip.tracing import TracingContext
-from mobly import asserts, base_test, signals, utils
-from mobly.config_parser import ENV_MOBLY_LOGPATH, TestRunConfig
-from mobly.test_runner import TestRunner
 
 try:
     from matter_yamltests.hooks import TestRunnerHooks
@@ -1075,7 +1069,7 @@ class MatterBaseTest(base_test.BaseTestClass):
             with open(app_pipe_name, "w") as app_pipe:
                 app_pipe.write(command + "\n")
             # TODO(#31239): remove the need for sleep
-            sleep(0.001)
+            time.sleep(0.001)
         else:
             logging.info(f"Using DUT IP address: {dut_ip}")
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -50,8 +50,7 @@ import chip.clusters as Clusters
 import chip.FabricAdmin
 import chip.logging
 import chip.native
-from chip import ChipDeviceCtrl
-from chip import discovery
+from chip import ChipDeviceCtrl, discovery
 from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.ChipStack import ChipStack
 from chip.clusters import Attribute

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
@@ -3,8 +3,9 @@
 import enum
 import unittest
 
-from chip.testing import matter_asserts
 from mobly import signals
+
+from chip.testing import matter_asserts
 
 
 class MyTestEnum(enum.Enum):

--- a/src/python_testing/modebase_cluster_check.py
+++ b/src/python_testing/modebase_cluster_check.py
@@ -17,8 +17,9 @@
 
 import logging
 
-from chip.clusters.Types import NullValue
 from mobly import asserts
+
+from chip.clusters.Types import NullValue
 
 logger = logging.getLogger(__name__)
 

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -51,10 +51,11 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 
-import chip.clusters as Clusters
 import cv2
 import requests
 from mobly import asserts
+
+import chip.clusters as Clusters
 
 DEFAULT_CHIP_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), '..', '..', '..'))

--- a/src/python_testing/test_plan_table_generator.py
+++ b/src/python_testing/test_plan_table_generator.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 import click
+
 from chip.testing.matter_testing import MatterTestConfig, generate_mobly_test_config
 
 

--- a/src/python_testing/test_testing/TestDecorators.py
+++ b/src/python_testing/test_testing/TestDecorators.py
@@ -29,12 +29,13 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from mobly import asserts
+
 import chip.clusters as Clusters
 from chip.clusters import Attribute
 from chip.testing.matter_testing import (MatterBaseTest, MatterTestConfig, async_test_body, has_attribute, has_cluster, has_feature,
                                          run_if_endpoint_matches, run_on_singleton_matching_endpoint, should_run_test_on_endpoint)
 from chip.testing.runner import MockTestRunner
-from mobly import asserts
 
 
 def get_clusters(endpoints: list[int]) -> Attribute.AsyncReadTransaction.ReadResponse:

--- a/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
+++ b/src/python_testing/test_testing/test_TC_CCNTL_2_2.py
@@ -23,8 +23,9 @@ import sys
 import typing
 from pathlib import Path
 
-import chip.clusters as Clusters
 import click
+
+import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.clusters import Attribute
 from chip.interaction_model import InteractionModelError, Status

--- a/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
+++ b/src/python_testing/test_testing/test_TC_MCORE_FS_1_1.py
@@ -23,8 +23,9 @@ import sys
 import typing
 from pathlib import Path
 
-import chip.clusters as Clusters
 import click
+
+import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.clusters import Attribute
 from chip.interaction_model import InteractionModelError, Status

--- a/src/test_driver/mbed/integration_tests/lighting-app/test_app.py
+++ b/src/test_driver/mbed/integration_tests/lighting-app/test_app.py
@@ -18,13 +18,14 @@ from time import sleep
 
 import pytest
 from button_service import button_service_pb2
-from chip import ChipDeviceCtrl
 from common.pigweed_client import PigweedClient
 from common.utils import (check_chip_ble_devices_advertising, close_ble, close_connection, commissioning_wifi,
                           connect_device_over_ble, get_device_details, resolve_device, send_zcl_command)
 from device_service import device_service_pb2
 from lighting_service import lighting_service_pb2
 from pw_status import Status
+
+from chip import ChipDeviceCtrl
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/mbed/integration_tests/lock-app/test_app.py
+++ b/src/test_driver/mbed/integration_tests/lock-app/test_app.py
@@ -18,13 +18,14 @@ from time import sleep
 
 import pytest
 from button_service import button_service_pb2
-from chip import ChipDeviceCtrl
 from common.pigweed_client import PigweedClient
 from common.utils import (check_chip_ble_devices_advertising, close_ble, close_connection, commissioning_wifi,
                           connect_device_over_ble, get_device_details, resolve_device, send_zcl_command)
 from device_service import device_service_pb2
 from locking_service import locking_service_pb2
 from pw_status import Status
+
+from chip import ChipDeviceCtrl
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/mbed/integration_tests/shell/test_app.py
+++ b/src/test_driver/mbed/integration_tests/shell/test_app.py
@@ -17,10 +17,11 @@ import logging
 from time import sleep
 
 import pytest
-from chip import ChipDeviceCtrl, exceptions
-from chip.setup_payload import SetupPayload
 from common.utils import check_chip_ble_devices_advertising
 from packaging import version
+
+from chip import ChipDeviceCtrl, exceptions
+from chip.setup_payload import SetupPayload
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/openiotsdk/integration-tests/all-clusters-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/all-clusters-app/test_app.py
@@ -19,12 +19,13 @@ import logging
 import os
 import re
 
-import chip.interaction_model
 import pytest
-from chip.clusters.Objects import AccessControl
-from chip.clusters.Types import NullValue
 from common.utils import (connect_device, disconnect_device, discover_device, get_setup_payload, read_zcl_attribute,
                           write_zcl_attribute)
+
+import chip.interaction_model
+from chip.clusters.Objects import AccessControl
+from chip.clusters.Types import NullValue
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/openiotsdk/integration-tests/common/fixtures.py
+++ b/src/test_driver/openiotsdk/integration-tests/common/fixtures.py
@@ -20,9 +20,10 @@ import os
 import pathlib
 import shutil
 
+import pytest
+
 import chip.CertificateAuthority
 import chip.native
-import pytest
 from chip import exceptions
 
 from .fvp_device import FvpDevice

--- a/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/lock-app/test_app.py
@@ -19,9 +19,10 @@ import logging
 import os
 
 import pytest
+from common.utils import connect_device, disconnect_device, discover_device, get_setup_payload, read_zcl_attribute, send_zcl_command
+
 from chip.clusters.Objects import DoorLock
 from chip.clusters.Types import NullValue
-from common.utils import connect_device, disconnect_device, discover_device, get_setup_payload, read_zcl_attribute, send_zcl_command
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/openiotsdk/integration-tests/ota-requestor-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/ota-requestor-app/test_app.py
@@ -19,12 +19,13 @@ import logging
 import os
 import re
 
-import chip.interaction_model
 import pytest
-from chip.clusters.Objects import OtaSoftwareUpdateRequestor
-from chip.clusters.Types import NullValue
 from common.utils import (connect_device, disconnect_device, discover_device, get_setup_payload, send_zcl_command,
                           write_zcl_attribute)
+
+import chip.interaction_model
+from chip.clusters.Objects import OtaSoftwareUpdateRequestor
+from chip.clusters.Types import NullValue
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/shell/test_app.py
@@ -18,12 +18,13 @@
 import logging
 import os
 
-import chip.native
 import pytest
-from chip import exceptions
-from chip.setup_payload import SetupPayload
 from common.utils import get_shell_commands_from_help_response
 from packaging import version
+
+import chip.native
+from chip import exceptions
+from chip.setup_payload import SetupPayload
 
 log = logging.getLogger(__name__)
 

--- a/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
+++ b/src/test_driver/openiotsdk/integration-tests/tv-app/test_app.py
@@ -19,12 +19,13 @@ import logging
 import os
 import re
 
-import chip.native
 import pytest
-from chip import exceptions
-from chip.clusters.Objects import ApplicationLauncher, Channel, ContentLauncher, KeypadInput, MediaPlayback, TargetNavigator
 from common.utils import (connect_device, disconnect_device, discover_device, get_log_messages_from_response, get_setup_payload,
                           get_shell_commands_from_help_response, read_zcl_attribute, send_zcl_command)
+
+import chip.native
+from chip import exceptions
+from chip.clusters.Objects import ApplicationLauncher, Channel, ContentLauncher, KeypadInput, MediaPlayback, TargetNavigator
 
 cecKeyCode = KeypadInput.Enums.CecKeyCode
 log = logging.getLogger(__name__)

--- a/src/tools/PICS-generator/PICSGenerator.py
+++ b/src/tools/PICS-generator/PICSGenerator.py
@@ -21,9 +21,10 @@ import pathlib
 import sys
 import xml.etree.ElementTree as ET
 
-import chip.clusters as Clusters
 from pics_generator_support import map_cluster_name_to_pics_xml, pics_xml_file_list_loader
 from rich.console import Console
+
+import chip.clusters as Clusters
 
 # Add the path to python_testing folder, in order to be able to import from chip.testing.matter_testing
 sys.path.append(os.path.abspath(sys.path[0] + "/../../python_testing"))

--- a/src/tools/device-graph/matter-device-graph.py
+++ b/src/tools/device-graph/matter-device-graph.py
@@ -19,9 +19,10 @@ import os
 import pprint
 import sys
 
-import chip.clusters as Clusters
 import graphviz
 from rich.console import Console
+
+import chip.clusters as Clusters
 
 # Add the path to python_testing folder, in order to be able to import from chip.testing.matter_testing
 sys.path.append(os.path.abspath(sys.path[0] + "/../../python_testing"))


### PR DESCRIPTION
#### Problem

CHIP imports are intermixed with 3rd party imports. Since, `chip` is "reserved" namespace for CHIP project, we can mark it as first-party from our point of view. This should improve imports readability.

Commit  0d3c003049ac5cbcf8935abd89888afa0d1e42a5 was created by running `isort` on entire codebase.

#### Changes

- Keep Python formatters/checkers configuration in one place
- Map "chip" Python imports as first-party

#### Testing

CI should catch any issues with this PR