### PR TITLE
Modification of Python ChipDevice controller for NFC Commissioning

### DIFF
--- a/examples/chip-tool/commands/pairing/Commands.h
+++ b/examples/chip-tool/commands/pairing/Commands.h
@@ -173,6 +173,14 @@ public:
     {}
 };
 
+class PairNfcThread : public PairingCommand
+{
+public:
+    PairNfcThread(CredentialIssuerCommands * credsIssuerConfig) :
+        PairingCommand("nfc-thread", PairingMode::Nfc, PairingNetworkType::Thread, credsIssuerConfig)
+    {}
+};
+
 class PairSoftAP : public PairingCommand
 {
 public:

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -42,6 +42,7 @@ enum class PairingMode
     AlreadyDiscoveredByIndex,
     AlreadyDiscoveredByIndexWithCode,
     OnNetwork,
+    Nfc,
 };
 
 enum class PairingNetworkType

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -145,6 +145,8 @@ PyChipError pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissio
                                                bool isShortDiscriminator, uint32_t setupPINCode, chip::NodeId nodeid);
 PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
                                               uint32_t setupPINCode, chip::NodeId nodeid);
+PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl,
+                                               uint32_t setupPINCode, chip::NodeId nodeid);
 PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceCommissioner * devCtrl, const char * onboardingPayload,
                                                     chip::NodeId nodeid, uint8_t discoveryType);
 PyChipError pychip_DeviceController_UnpairDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId remoteDeviceId,
@@ -431,6 +433,13 @@ PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceComm
 {
     return ToPyChipError(devCtrl->PairDevice(nodeid, onboardingPayload, sCommissioningParameters,
                                              static_cast<chip::Controller::DiscoveryType>(discoveryType)));
+}
+
+PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl,
+                                               uint32_t setupPINCode, chip::NodeId nodeid)
+{
+    // Not implemented yet
+    return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);
 }
 
 namespace {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -145,8 +145,8 @@ PyChipError pychip_DeviceController_ConnectBLE(chip::Controller::DeviceCommissio
                                                bool isShortDiscriminator, uint32_t setupPINCode, chip::NodeId nodeid);
 PyChipError pychip_DeviceController_ConnectIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
                                               uint32_t setupPINCode, chip::NodeId nodeid);
-PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl,
-                                               uint32_t setupPINCode, chip::NodeId nodeid);
+PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
+                                               chip::NodeId nodeid);
 PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceCommissioner * devCtrl, const char * onboardingPayload,
                                                     chip::NodeId nodeid, uint8_t discoveryType);
 PyChipError pychip_DeviceController_UnpairDevice(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId remoteDeviceId,
@@ -435,8 +435,8 @@ PyChipError pychip_DeviceController_ConnectWithCode(chip::Controller::DeviceComm
                                              static_cast<chip::Controller::DiscoveryType>(discoveryType)));
 }
 
-PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl,
-                                               uint32_t setupPINCode, chip::NodeId nodeid)
+PyChipError pychip_DeviceController_ConnectNFC(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
+                                               chip::NodeId nodeid)
 {
     // Not implemented yet
     return ToPyChipError(CHIP_ERROR_NOT_IMPLEMENTED);

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
@@ -165,6 +165,17 @@ async def commission_device(
         except ChipStackError as e:
             logging.error("Commissioning failed: %s" % e)
             return False
+    elif commissioning_info.commissioning_method == "nfc-thread":
+        try:
+            await dev_ctrl.CommissionNfcThread(
+                info.passcode,
+                node_id,
+                commissioning_info.thread_operational_dataset,
+            )
+            return True
+        except ChipStackError as e:
+            logging.error("Commissioning failed: %s" % e)
+            return False
     elif commissioning_info.commissioning_method == "on-network-ip":
         try:
             logging.warning("==== USING A DIRECT IP COMMISSIONING METHOD NOT SUPPORTED IN THE LONG TERM ====")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1827,6 +1827,11 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread!")
             return False
         config.thread_operational_dataset = args.thread_dataset_hex
+    elif config.commissioning_method == "nfc-thread":
+        if args.thread_dataset_hex is None:
+            print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method nfc-thread!")
+            return False
+        config.thread_operational_dataset = args.thread_dataset_hex
     elif config.commissioning_method == "on-network-ip":
         if args.ip_addr is None:
             print("error: missing --ip-addr <IP_ADDRESS> for --commissioning-method on-network-ip")
@@ -1923,11 +1928,11 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
 
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip", "nfc-thread"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
+                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip", "nfc-thread"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',
@@ -1952,7 +1957,7 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
 
     commission_group.add_argument('--thread-dataset-hex', type=byte_string_from_hex,
                                   metavar='OPERATIONAL_DATASET_HEX',
-                                  help='Thread operational dataset as a hex string for ble-thread commissioning')
+                                  help='Thread operational dataset as a hex string for ble-thread or nfc-thread commissioning')
 
     commission_group.add_argument('--admin-vendor-id', action="store", type=int_decimal_or_hex, default=_DEFAULT_ADMIN_VENDOR_ID,
                                   metavar="VENDOR_ID",

--- a/src/test_driver/mbed/integration_tests/common/utils.py
+++ b/src/test_driver/mbed/integration_tests/common/utils.py
@@ -227,6 +227,24 @@ def connect_device_over_ble(devCtrl, discriminator, pinCode, nodeId=None):
 
     return nodeId
 
+def connect_device_over_nfc(devCtrl, pinCode, nodeId=None):
+    """
+    Connect to Matter accessory device over NFC
+    :param devCtrl: device controller instance
+    :param pinCode: CHIP device pin code
+    :param nodeId: default value of node ID
+    :return: node ID is provisioning successful, otherwise None
+    """
+    if nodeId is None:
+        nodeId = random.randint(1, 1000000)
+
+    try:
+        devCtrl.ConnectNFC(int(pinCode), int(nodeId))
+    except exceptions.ChipStackException as ex:
+        log.error("Connect device over NFC failed: {}".format(str(ex)))
+        return None
+
+    return nodeId
 
 def close_connection(devCtrl, nodeId):
     """

--- a/src/test_driver/mbed/integration_tests/common/utils.py
+++ b/src/test_driver/mbed/integration_tests/common/utils.py
@@ -227,6 +227,7 @@ def connect_device_over_ble(devCtrl, discriminator, pinCode, nodeId=None):
 
     return nodeId
 
+
 def connect_device_over_nfc(devCtrl, pinCode, nodeId=None):
     """
     Connect to Matter accessory device over NFC
@@ -245,6 +246,7 @@ def connect_device_over_nfc(devCtrl, pinCode, nodeId=None):
         return None
 
     return nodeId
+
 
 def close_connection(devCtrl, nodeId):
     """


### PR DESCRIPTION
Modification of Python ChipDevice controller to be able to launch NFC Commissioning.
pychip_DeviceController_ConnectNFC() will be implemented in another PR. The current PR is needed for the modification of Test Harness environment to add some new NFC commissioning tests. Thanks to this change "nfc-thread"
 choice will be accepted by Test Harness interface.
It will help to move forward with the actual implementation of those "nfc-thread" tests.


#### Testing
I'm not able to test this change. I took the example of BLE interface and I did the same for NFC (without the discriminator parameter).