### PR TITLE
devcontainer: Modernize devcontainer, bump version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,20 +1,26 @@
 {
     "name": "CHIP Ubuntu Development Environment",
     "runArgs": [
-        "--cap-add=SYS_PTRACE",
-        "--security-opt",
-        "seccomp=unconfined",
         "--network=host",
-        "--privileged",
-        "-v",
-        "/dev/bus/usb:/dev/bus/usb:ro",
         "--device-cgroup-rule=a 189:* rmw",
         "--add-host=host.docker.internal:host-gateway"
     ],
+    "privileged": true,
+    "capAdd": ["SYS_PTRACE"],
+    "securityOpt": ["seccomp=unconfined"],
     "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+        {
+            "source": "/var/run/docker.sock",
+            "target": "/var/run/docker.sock",
+            "type": "bind"
+        },
+        {
+            "source": "/dev/bus/usb",
+            "target": "/dev/bus/usb",
+            "type": "bind"
+        }
     ],
-    "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 74",
+    "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 97",
     "image": "matter-dev-environment:local",
     "remoteUser": "vscode",
     "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,6 @@
             "source": "/dev/bus/usb",
             "target": "/dev/bus/usb",
             "type": "bind"
-        },
-        {
-            "source": "/run/dbus/system_bus_socket",
-            "target": "/run/dbus/system_bus_socket",
-            "type": "bind"
         }
     ],
     "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 97",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,6 +18,11 @@
             "source": "/dev/bus/usb",
             "target": "/dev/bus/usb",
             "type": "bind"
+        },
+        {
+            "source": "/run/dbus/system_bus_socket",
+            "target": "/run/dbus/system_bus_socket",
+            "type": "bind"
         }
     ],
     "initializeCommand": "bash .devcontainer/build.sh --tag matter-dev-environment:local --version 97",


### PR DESCRIPTION
- bump base image versions to 97 to match CI
- convert some of the runCmd docker options into dedicated properties

#### Testing

Manual rebuild of container and verification using docker inspect that the properties are still set correctly.
