### PR TITLE
Move common validation methods to base class

### DIFF
--- a/src/python_testing/TC_DGSW_2_1.py
+++ b/src/python_testing/TC_DGSW_2_1.py
@@ -37,34 +37,9 @@
 
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 
 
 class TC_DGSW_2_1(MatterBaseTest):
-
-    @staticmethod
-    def is_valid_uint64_value(value):
-        return isinstance(value, int) and 0 <= value <= 0xFFFFFFFFFFFFFFFF
-
-    @staticmethod
-    def is_valid_uint32_value(value):
-        return isinstance(value, int) and 0 <= value <= 0xFFFFFFFF
-
-    @staticmethod
-    def is_valid_str_value(value):
-        return isinstance(value, str) and len(value) > 0
-
-    def assert_valid_uint64(self, value, field_name):
-        """Asserts that the value is a valid uint64."""
-        asserts.assert_true(self.is_valid_uint64_value(value), f"{field_name} field should be a uint64 type")
-
-    def assert_valid_uint32(self, value, field_name):
-        """Asserts that the value is a valid uint32."""
-        asserts.assert_true(self.is_valid_uint32_value(value), f"{field_name} field should be a uint32 type")
-
-    def assert_valid_str(self, value, field_name):
-        """Asserts that the value is a non-empty string."""
-        asserts.assert_true(self.is_valid_str_value(value), f"{field_name} field should be a non-empty string")
 
     async def read_dgsw_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.SoftwareDiagnostics

--- a/src/python_testing/TC_DGSW_2_2.py
+++ b/src/python_testing/TC_DGSW_2_2.py
@@ -49,10 +49,6 @@ from mobly import asserts
 class TC_DGSW_2_2(MatterBaseTest):
 
     @staticmethod
-    def is_valid_uint64_value(value):
-        return isinstance(value, int) and 0 <= value <= 0xFFFFFFFFFFFFFFFF
-
-    @staticmethod
     def is_valid_octet_string(value):
         return isinstance(value, (bytes, bytearray))
 
@@ -71,7 +67,7 @@ class TC_DGSW_2_2(MatterBaseTest):
 
         # Validate 'Id' field: Ensure it is a uint64 type
         asserts.assert_true(
-            self.is_valid_uint64_value(event_data.id),
+            self.is_valid_uint_value(event_data.id, bit_count=64),
             "The 'Id' field must be a uint64 type"
         )
 

--- a/src/python_testing/TC_DGSW_2_3.py
+++ b/src/python_testing/TC_DGSW_2_3.py
@@ -44,30 +44,6 @@ from mobly import asserts
 
 class TC_DGSW_2_3(MatterBaseTest):
 
-    @staticmethod
-    def is_valid_uint64_value(value):
-        return isinstance(value, int) and 0 <= value <= 0xFFFFFFFFFFFFFFFF
-
-    @staticmethod
-    def is_valid_uint32_value(value):
-        return isinstance(value, int) and 0 <= value <= 0xFFFFFFFF
-
-    @staticmethod
-    def is_valid_str_value(value):
-        return isinstance(value, str) and len(value) > 0
-
-    def assert_valid_uint64(self, value, field_name):
-        """Asserts that the value is a valid uint64."""
-        asserts.assert_true(self.is_valid_uint64_value(value), f"{field_name} field should be a uint64 type")
-
-    def assert_valid_uint32(self, value, field_name):
-        """Asserts that the value is a valid uint32."""
-        asserts.assert_true(self.is_valid_uint32_value(value), f"{field_name} field should be a uint32 type")
-
-    def assert_valid_str(self, value, field_name):
-        """Asserts that the value is a non-empty string."""
-        asserts.assert_true(self.is_valid_str_value(value), f"{field_name} field should be a non-empty string")
-
     async def read_dgsw_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.SoftwareDiagnostics
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)

--- a/src/python_testing/TC_DGWIFI_2_1.py
+++ b/src/python_testing/TC_DGWIFI_2_1.py
@@ -63,18 +63,6 @@ class TC_DGWIFI_2_1(MatterBaseTest):
 
         return False
 
-    @staticmethod
-    def is_valid_uint_value(value, bit_count=64):
-        """
-        Checks if 'value' is a non-negative integer fitting into 'bit_count' bits.
-        For example, bit_count=32 => must fit within 0 <= value <= 0xFFFFFFFF
-        """
-        if not isinstance(value, int):
-            return False
-        if value < 0:
-            return False
-        return value < 2**bit_count
-
     def assert_valid_bssid(self, value, field_name):
         """Asserts that the value is a valid BSSID (MAC address), None, or NullValue."""
         if isinstance(value, Nullable):
@@ -85,26 +73,6 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         if value is not None:
             asserts.assert_true(self.is_valid_bssid(value),
                                 f"{field_name} should be a valid BSSID string (e.g., '00:11:22:33:44:55') or None/NullValue.")
-
-    def assert_valid_uint64(self, value, field_name):
-        """Asserts that the value is a valid uint64 or None (if attribute can return NULL)."""
-        asserts.assert_true(value is None or self.is_valid_uint_value(value, bit_count=64),
-                            f"{field_name} should be a uint64 or NULL.")
-
-    def assert_valid_uint32(self, value, field_name):
-        """Asserts that the value is a valid uint32 or None (if attribute can return NULL)."""
-        asserts.assert_true(value is None or self.is_valid_uint_value(value, bit_count=32),
-                            f"{field_name} should be a uint32 or NULL.")
-
-    def assert_valid_uint16(self, value, field_name):
-        """Asserts that the value is a valid uint16 or None (if attribute can return NULL)."""
-        asserts.assert_true(value is None or self.is_valid_uint_value(value, bit_count=16),
-                            f"{field_name} should be a uint16 or NULL.")
-
-    def assert_valid_uint8(self, value, field_name):
-        """Asserts that the value is a valid uint16 or None (if attribute can return NULL)."""
-        asserts.assert_true(value is None or self.is_valid_uint_value(value, bit_count=8),
-                            f"{field_name} should be a uint8 or NULL.")
 
     async def read_dgwifi_attribute_expect_success(self, endpoint, attribute):
         cluster = Clusters.Objects.WiFiNetworkDiagnostics

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -972,6 +972,46 @@ class MatterBaseTest(base_test.BaseTestClass):
         # The named pipe name must be set in the derived classes
         self.app_pipe = None
 
+    @staticmethod
+    def is_valid_uint_value(value, bit_count=64):
+        """
+        Checks if 'value' is a non-negative integer fitting into 'bit_count' bits.
+        For example, bit_count=32 => must fit within 0 <= value <= 0xFFFFFFFF
+        """
+        if not isinstance(value, int):
+            return False
+        if value < 0:
+            return False
+        return value < 2**bit_count
+
+    @staticmethod
+    def is_valid_str_value(value):
+        return isinstance(value, str) and len(value) > 0
+
+    def assert_valid_uint64(self, value, field_name):
+        """Asserts that the value is a valid uint64."""
+        asserts.assert_true(self.is_valid_uint_value(value, bit_count=64),
+                            f"{field_name} should be a uint64 or NULL.")
+
+    def assert_valid_uint32(self, value, field_name):
+        """Asserts that the value is a valid uint32."""
+        asserts.assert_true(self.is_valid_uint_value(value, bit_count=32),
+                            f"{field_name} should be a uint32 or NULL.")
+
+    def assert_valid_uint16(self, value, field_name):
+        """Asserts that the value is a valid uint16."""
+        asserts.assert_true(self.is_valid_uint_value(value, bit_count=16),
+                            f"{field_name} should be a uint16 or NULL.")
+
+    def assert_valid_uint8(self, value, field_name):
+        """Asserts that the value is a valid uint16."""
+        asserts.assert_true(self.is_valid_uint_value(value, bit_count=8),
+                            f"{field_name} should be a uint8 or NULL.")
+
+    def assert_valid_str(self, value, field_name):
+        """Asserts that the value is a non-empty string."""
+        asserts.assert_true(self.is_valid_str_value(value), f"{field_name} field should be a non-empty string")
+
     def get_test_steps(self, test: str) -> list[TestStep]:
         ''' Retrieves the test step list for the given test
 


### PR DESCRIPTION
#### Testing

1. Move common validation methods to base class
2. Remove the None check in common validation methods since None is only valid when the attribute explicitly marked with 'optional="true"' in the xml definition, if the attribute is not optional, then None should not be assumed as validation success.