### PR TITLE
[NXP][examples][mcxw71_k32w1] Remove "LittleFS" based key storage build option

### DIFF
--- a/examples/contact-sensor-app/nxp/k32w1/BUILD.gn
+++ b/examples/contact-sensor-app/nxp/k32w1/BUILD.gn
@@ -86,14 +86,6 @@ mcxw71_k32w1_sdk("sdk") {
   defines += [
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
-
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
 }
 
 mcxw71_k32w1_executable("contact_sensor_app") {

--- a/examples/contact-sensor-app/nxp/k32w1/args.gni
+++ b/examples/contact-sensor-app/nxp/k32w1/args.gni
@@ -42,5 +42,3 @@ chip_openthread_ftd = false
 nxp_enable_ot_cli = false
 
 chip_with_diag_logs_demo = true
-
-nxp_nvm_component = "nvs"

--- a/examples/contact-sensor-app/nxp/mcxw71/BUILD.gn
+++ b/examples/contact-sensor-app/nxp/mcxw71/BUILD.gn
@@ -85,14 +85,6 @@ mcxw71_k32w1_sdk("sdk") {
   defines += [
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
-
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
 }
 
 mcxw71_k32w1_executable("contact_sensor_app") {

--- a/examples/contact-sensor-app/nxp/mcxw71/args.gni
+++ b/examples/contact-sensor-app/nxp/mcxw71/args.gni
@@ -40,5 +40,3 @@ chip_openthread_ftd = false
 nxp_enable_ot_cli = false
 
 chip_with_diag_logs_demo = true
-
-nxp_nvm_component = "nvs"

--- a/examples/lighting-app/nxp/k32w1/BUILD.gn
+++ b/examples/lighting-app/nxp/k32w1/BUILD.gn
@@ -100,14 +100,6 @@ mcxw71_k32w1_sdk("sdk") {
   defines += [
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
-
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
 }
 
 mcxw71_k32w1_executable("light_app") {

--- a/examples/lighting-app/nxp/k32w1/args.gni
+++ b/examples/lighting-app/nxp/k32w1/args.gni
@@ -35,7 +35,5 @@ chip_system_config_provide_statistics = false
 chip_system_config_use_open_thread_inet_endpoints = true
 chip_with_lwip = false
 
-nxp_nvm_component = "nvs"
-
 nxp_use_smu2_static = true
 nxp_use_smu2_dynamic = true

--- a/examples/lighting-app/nxp/mcxw71/BUILD.gn
+++ b/examples/lighting-app/nxp/mcxw71/BUILD.gn
@@ -100,14 +100,6 @@ mcxw71_k32w1_sdk("sdk") {
   defines += [
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
-
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
 }
 
 mcxw71_k32w1_executable("light_app") {

--- a/examples/lighting-app/nxp/mcxw71/args.gni
+++ b/examples/lighting-app/nxp/mcxw71/args.gni
@@ -35,7 +35,5 @@ chip_system_config_provide_statistics = false
 chip_system_config_use_open_thread_inet_endpoints = true
 chip_with_lwip = false
 
-nxp_nvm_component = "nvs"
-
 nxp_use_smu2_static = true
 nxp_use_smu2_dynamic = true

--- a/examples/lock-app/nxp/k32w1/BUILD.gn
+++ b/examples/lock-app/nxp/k32w1/BUILD.gn
@@ -85,14 +85,6 @@ mcxw71_k32w1_sdk("sdk") {
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
 
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
-
   if (nxp_multiple_ble_connections) {
     include_dirs += [ "${example_platform_dir}/app_ble/include" ]
     defines += [

--- a/examples/lock-app/nxp/mcxw71/BUILD.gn
+++ b/examples/lock-app/nxp/mcxw71/BUILD.gn
@@ -85,14 +85,6 @@ mcxw71_k32w1_sdk("sdk") {
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR=${setup_discriminator}",
   ]
 
-  if (nxp_nvm_component == "littlefs") {
-    include_dirs += [ "${example_platform_dir}/board" ]
-    sources += [
-      "${example_platform_dir}/board/peripherals.c",
-      "${example_platform_dir}/board/peripherals.h",
-    ]
-  }
-
   if (nxp_multiple_ble_connections) {
     include_dirs += [ "${example_platform_dir}/app_ble/include" ]
     defines += [

--- a/examples/platform/nxp/mcxw71_k32w1/app/support/BUILD.gn
+++ b/examples/platform/nxp/mcxw71_k32w1/app/support/BUILD.gn
@@ -55,8 +55,6 @@ source_set("freertos_memory_utils") {
 
   if (nxp_nvm_component == "fwk_nvm") {
     defines = [ "CHIP_PLAT_NVM_SUPPORT=1" ]
-  } else if (nxp_nvm_component == "littlefs") {
-    defines = [ "CHIP_PLAT_NVM_SUPPORT=3" ]
   }
 
   public_configs = [

--- a/src/platform/nxp/mcxw71_k32w1/BUILD.gn
+++ b/src/platform/nxp/mcxw71_k32w1/BUILD.gn
@@ -123,18 +123,6 @@ static_library("nxp_platform") {
       "ram_storage.c",
       "ram_storage.h",
     ]
-  } else if (nxp_nvm_component == "littlefs") {
-    defines += [
-      "CHIP_PLAT_NVM_SUPPORT=3",
-      "EXTERNAL_KEYVALUESTOREMANAGERIMPL_HEADER=\"platform/nxp/common/KeyValueStoreManagerImpl.h\"",
-    ]
-
-    sources += [
-      "../common/KeyValueStoreManagerImpl.cpp",
-      "../common/KeyValueStoreManagerImpl.h",
-      "../common/NXPConfig.h",
-      "../common/NXPConfigKS.cpp",
-    ]
   } else if (nxp_nvm_component == "nvs") {
     defines += [
       "gAppNvsExternalFlash_c=0",

--- a/src/platform/nxp/mcxw71_k32w1/args.gni
+++ b/src/platform/nxp/mcxw71_k32w1/args.gni
@@ -21,6 +21,7 @@ openthread_root =
 nxp_platform = "mcxw71_k32w1"
 nxp_sdk_name = "mcxw71_k32w1_sdk"
 nxp_device_layer = "nxp/${nxp_platform}"
+nxp_nvm_component = "nvs"
 nxp_use_lwip = false
 
 # ARM architecture flags will be set based on NXP board.


### PR DESCRIPTION
The components required in order to support LittleFS based key storage in Matter applications are no longer available in NXP SDK 3.0. Moreover, since the migration to the (Zephyr) NVS based key storage is complete, LittleFS based key storage can now be removed from the build options.

### Testing

* Successfully built all supported examples on NXP K32W1 & MCXW71 platform
* Functional tests successfully passed in CI