### PR TITLE
Return InvalidCommand instead of UnsupportedCluster if the command is not handled in CHI

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
@@ -1845,7 +1845,8 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace Clusters
 
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj,
+                                  bool aClusterIsValid)
 {
     Protocols::InteractionModel::Status errorStatus = Protocols::InteractionModel::Status::Success;
 
@@ -1927,8 +1928,17 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         errorStatus = Clusters::WindowCovering::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     default:
-        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
-        errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;
+        // If we already validated that the cluster does indeed exist in our CHI,
+        if (aClusterIsValid)
+        {
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;
+        }
+        else
+        {
+            ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;
+        }
+
         break;
     }
 

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
@@ -1928,7 +1928,8 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         errorStatus = Clusters::WindowCovering::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     default:
-        // If we already validated that the cluster does indeed exist in our CHI,
+        // If we already validated that the cluster does indeed exist (e.g. when dispatching to CommandHandlerInterface for that
+        // cluster).
         if (aClusterIsValid)
         {
             errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
@@ -971,7 +971,8 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace Clusters
 
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj,
+                                  bool aClusterIsValid)
 {
     Protocols::InteractionModel::Status errorStatus = Protocols::InteractionModel::Status::Success;
 
@@ -1014,8 +1015,17 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         errorStatus = Clusters::ThreadNetworkDiagnostics::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     default:
-        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
-        errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;
+        // If we already validated that the cluster does indeed exist in our CHI,
+        if (aClusterIsValid)
+        {
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;
+        }
+        else
+        {
+            ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;
+        }
+
         break;
     }
 

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
@@ -1015,7 +1015,8 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         errorStatus = Clusters::ThreadNetworkDiagnostics::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     default:
-        // If we already validated that the cluster does indeed exist in our CHI,
+        // If we already validated that the cluster does indeed exist (e.g. when dispatching to CommandHandlerInterface for that
+        // cluster).
         if (aClusterIsValid)
         {
             errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;

--- a/src/app/dynamic_server/DynamicDispatcher.cpp
+++ b/src/app/dynamic_server/DynamicDispatcher.cpp
@@ -67,7 +67,8 @@ namespace app {
 using Access::SubjectDescriptor;
 using Protocols::InteractionModel::Status;
 
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj)
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj,
+                                  bool aClusterIsValid)
 {
     // This command passed ServerClusterCommandExists so we know it's one of our
     // supported commands.

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -215,7 +215,7 @@ static Protocols::InteractionModel::Status ServerClusterCommandExists(const Conc
 }
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
+                                  CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     ChipLogDetail(Controller, "Received Cluster Command: Endpoint=%x Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
                   aRequestCommandPath.mEndpointId, ChipLogValueMEI(aRequestCommandPath.mClusterId),

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -619,7 +619,7 @@ namespace chip {
 namespace app {
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
+                                  CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     // Nothing todo.
 }

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -79,7 +79,7 @@ public:
 //   every data version compare is the same etc.".
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
+                                  CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     static bool statusCodeFlipper = false;
 

--- a/src/app/tests/test-interaction-model-api.cpp
+++ b/src/app/tests/test-interaction-model-api.cpp
@@ -62,7 +62,8 @@ private:
 
 // strong defintion in TestCommandInteraction.cpp
 __attribute__((weak)) void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath,
-                                                        chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+                                                        chip::TLV::TLVReader & aReader, CommandHandler * apCommandObj,
+                                                        bool aClusterIsValid)
 {}
 
 // Used by the code in TestReadInteraction.cpp (and generally tests that interact with the Reporting Engine may need this).

--- a/src/app/tests/test-interaction-model-api.h
+++ b/src/app/tests/test-interaction-model-api.h
@@ -85,7 +85,7 @@ namespace app {
 bool IsClusterDataVersionEqual(const ConcreteClusterPath & aConcreteClusterPath, DataVersion aRequiredVersion);
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj);
+                                  CommandHandler * apCommandObj, bool aClusterIsValid = false);
 
 /// A customized class for read/write/invoke that matches functionality
 /// with the ember-compatibility-functions functionality here.

--- a/src/app/util/IMClusterCommandHandler.h
+++ b/src/app/util/IMClusterCommandHandler.h
@@ -34,5 +34,17 @@ namespace app {
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
                                   CommandHandler * apCommandObj);
 
+/**
+ * Dispatch is generally implemented in code-generated code in ember within
+ * IMClusterCommandHandler.cpp
+ *
+ * aCommandPath - the path that is invoked
+ * aReader      - the input TLV data for this command
+ * apCommandObj - how to send back the reply
+ * aClusterIsValid - boolean that tracks if a CHI handler exists for this cluster
+ */
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
+                                  CommandHandler * apCommandObj, bool aClusterIsValid);
+
 } // namespace app
 } // namespace chip

--- a/src/app/util/IMClusterCommandHandler.h
+++ b/src/app/util/IMClusterCommandHandler.h
@@ -30,21 +30,10 @@ namespace app {
  * aCommandPath - the path that is invoked
  * aReader      - the input TLV data for this command
  * apCommandObj - how to send back the reply
- */
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj);
-
-/**
- * Dispatch is generally implemented in code-generated code in ember within
- * IMClusterCommandHandler.cpp
- *
- * aCommandPath - the path that is invoked
- * aReader      - the input TLV data for this command
- * apCommandObj - how to send back the reply
  * aClusterIsValid - boolean that tracks if a CHI handler exists for this cluster
  */
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj, bool aClusterIsValid);
+                                  CommandHandler * apCommandObj, bool aClusterIsValid = false);
 
 } // namespace app
 } // namespace chip

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -91,7 +91,7 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
     {{/unless}}
     {{/all_user_clusters_with_incoming_commands}}
     default:
-        // If we already validated that the cluster does indeed exist in our CHI,
+        // If we already validated that the cluster does indeed exist (e.g. when dispatching to CommandHandlerInterface for that cluster).
         if (aClusterIsValid)
         {
             errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -75,7 +75,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace Clusters
 
-void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj)
+void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV::TLVReader & aReader, CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     Protocols::InteractionModel::Status errorStatus = Protocols::InteractionModel::Status::Success;
 
@@ -91,8 +91,17 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
     {{/unless}}
     {{/all_user_clusters_with_incoming_commands}}
     default:
-        ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
-        errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;
+        // If we already validated that the cluster does indeed exist in our CHI,
+        if (aClusterIsValid)
+        {
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCommand;
+        }
+        else
+        {
+            ChipLogError(Zcl, "Unknown cluster " ChipLogFormatMEI, ChipLogValueMEI(aCommandPath.mClusterId));
+            errorStatus = Protocols::InteractionModel::Status::UnsupportedCluster;            
+        }
+
         break;
     }
 

--- a/src/controller/tests/data_model/DataModelFixtures.cpp
+++ b/src/controller/tests/data_model/DataModelFixtures.cpp
@@ -228,7 +228,7 @@ static CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubje
 }
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
+                                  CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     ChipLogDetail(Controller, "Received Cluster Command: Endpoint=%x Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
                   aCommandPath.mEndpointId, ChipLogValueMEI(aCommandPath.mClusterId), ChipLogValueMEI(aCommandPath.mCommandId));
@@ -473,7 +473,7 @@ ActionReturnStatus CustomDataModel::WriteAttribute(const WriteAttributeRequest &
 std::optional<ActionReturnStatus> CustomDataModel::Invoke(const InvokeRequest & request, chip::TLV::TLVReader & input_arguments,
                                                           CommandHandler * handler)
 {
-    DispatchSingleClusterCommand(request.path, input_arguments, handler);
+    DispatchSingleClusterCommand(request.path, input_arguments, handler, false);
     return std::nullopt; // handler status is set by the dispatch
 }
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm
@@ -62,7 +62,7 @@ Protocols::InteractionModel::Status emberAfWriteAttribute(const ConcreteAttribut
 namespace chip {
 namespace app {
 
-    void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj)
+    void DispatchSingleClusterCommand(const ConcreteCommandPath & aPath, TLV::TLVReader & aReader, CommandHandler * aCommandObj, bool aClusterIsValid)
     {
         // TODO: Consider having MTRServerCluster register a
         // CommandHandlerInterface for command dispatch.  But OTA would need

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -164,7 +164,12 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
     CommandHandlerInterface * handler_interface =
         CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(request.path.mEndpointId, request.path.mClusterId);
 
-    if (handler_interface)
+    // Some CommandHandlerInterface instances are registered of ALL endpoints, so make sure first that
+    // the cluster actually exists on this endpoint before asking the CommandHandlerInterface whether it
+    // supports the command.
+    const bool clusterIsPresent = (FindServerCluster(request.path) != nullptr);
+
+    if (clusterIsPresent && handler_interface)
     {
         clusterRecognizedByCHI = true;
         CommandHandlerInterface::HandlerContext context(*handler, request.path, input_arguments);

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -172,13 +172,11 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
         {
             return std::nullopt;
         }
-        else
-        {
-            // If we reach here, it means this particular CommandHandlerInterface recognized the cluster but the command is invalid
-            // or cannot be processed.
-            handler->AddStatus(request.path, Protocols::InteractionModel::Status::InvalidCommand);
-            return std::nullopt;
-        }
+
+        // If we reach here, it means this particular CommandHandlerInterface recognized the cluster but the command is invalid
+        // or cannot be processed.
+        handler->AddStatus(request.path, Protocols::InteractionModel::Status::InvalidCommand);
+        return std::nullopt;
     }
 
     // Ember always sets the return in the handler

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -172,6 +172,13 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
         {
             return std::nullopt;
         }
+        else
+        {
+            // If we reach here, it means this particular CommandHandlerInterface recognized the cluster but the command is invalid
+            // or cannot be processed.
+            handler->AddStatus(request.path, Protocols::InteractionModel::Status::InvalidCommand);
+            return std::nullopt;
+        }
     }
 
     // Ember always sets the return in the handler

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -159,11 +159,13 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
                                                                               TLV::TLVReader & input_arguments,
                                                                               CommandHandler * handler)
 {
+    bool clusterRecognizedByCHI = false;
     CommandHandlerInterface * handler_interface =
         CommandHandlerInterfaceRegistry::Instance().GetCommandHandler(request.path.mEndpointId, request.path.mClusterId);
 
     if (handler_interface)
     {
+        clusterRecognizedByCHI = true;
         CommandHandlerInterface::HandlerContext context(*handler, request.path, input_arguments);
         handler_interface->InvokeCommand(context);
 
@@ -172,15 +174,10 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
         {
             return std::nullopt;
         }
-
-        // If we reach here, it means this particular CommandHandlerInterface recognized the cluster but the command is invalid
-        // or cannot be processed.
-        handler->AddStatus(request.path, Protocols::InteractionModel::Status::InvalidCommand);
-        return std::nullopt;
     }
 
     // Ember always sets the return in the handler
-    DispatchSingleClusterCommand(request.path, input_arguments, handler);
+    DispatchSingleClusterCommand(request.path, input_arguments, handler, clusterRecognizedByCHI);
     return std::nullopt;
 }
 

--- a/src/data-model-providers/codegen/tests/EmberInvokeOverride.cpp
+++ b/src/data-model-providers/codegen/tests/EmberInvokeOverride.cpp
@@ -45,7 +45,7 @@ namespace chip {
 namespace app {
 
 void DispatchSingleClusterCommand(const ConcreteCommandPath & aRequestCommandPath, chip::TLV::TLVReader & aReader,
-                                  CommandHandler * apCommandObj)
+                                  CommandHandler * apCommandObj, bool aClusterIsValid)
 {
     gLastDispatchPath = aRequestCommandPath;
     gDispatchCount++;


### PR DESCRIPTION
Currently, after switching to CHI, any unhandled command is returning Protocols::InteractionModel::Status::UnsupportedCluster. Previously, when Ember handled these commands, we would return Protocols::InteractionModel::Status::InvalidCommand. We should preserve that behavior and continue returning InvalidCommand for runhandled commands in CHI.


#### Testing

Verified by manually disable command Commands::ResetCounts in WiFiDiagnosticsServer

```
1737591036.077317][170120:170120] CHIP:EM: Rxd Ack; Removing MessageCounter:189047319 from Retrans Table on exchange 6982r
[1737591036.077854][170120:170120] CHIP:EM: >>> [E:6983r S:15406 M:134670837] (S) Msg RX from 1:000000000001B669 [C8E0] to 0000000012344321 --- Type 0001:08 (IM:InvokeCommandRequest) (B:59)
[1737591036.077865][170120:170120] CHIP:EM: Handling via exchange: 6983r, Delegate: 0x555556e35508
[1737591036.077906][170120:170120] CHIP:DMG: InvokeRequestMessage =
[1737591036.077911][170120:170120] CHIP:DMG: {
[1737591036.077915][170120:170120] CHIP:DMG: 	suppressResponse = false, 
[1737591036.077918][170120:170120] CHIP:DMG: 	timedRequest = false, 
[1737591036.077921][170120:170120] CHIP:DMG: 	InvokeRequests =
[1737591036.077936][170120:170120] CHIP:DMG: 	[
[1737591036.077940][170120:170120] CHIP:DMG: 		CommandDataIB =
[1737591036.077946][170120:170120] CHIP:DMG: 		{
[1737591036.077949][170120:170120] CHIP:DMG: 			CommandPathIB =
[1737591036.077955][170120:170120] CHIP:DMG: 			{
[1737591036.077960][170120:170120] CHIP:DMG: 				EndpointId = 0x0,
[1737591036.077965][170120:170120] CHIP:DMG: 				ClusterId = 0x36,
[1737591036.077970][170120:170120] CHIP:DMG: 				CommandId = 0x0,
[1737591036.077973][170120:170120] CHIP:DMG: 			},
[1737591036.077981][170120:170120] CHIP:DMG: 			
[1737591036.077985][170120:170120] CHIP:DMG: 			CommandFields = 
[1737591036.077990][170120:170120] CHIP:DMG: 			{
[1737591036.077995][170120:170120] CHIP:DMG: 			},
[1737591036.077998][170120:170120] CHIP:DMG: 		},
[1737591036.078009][170120:170120] CHIP:DMG: 		
[1737591036.078013][170120:170120] CHIP:DMG: 	],
[1737591036.078027][170120:170120] CHIP:DMG: 	
[1737591036.078031][170120:170120] CHIP:DMG: 	InteractionModelRevision = 11
[1737591036.078034][170120:170120] CHIP:DMG: },
[1737591036.078133][170120:170120] CHIP:DMG: AccessControl: checking f=1 a=c s=0x000000000001B669 t=0x00010001 c=0x0000_0036 e=0 p=o r=i
[1737591036.078141][170120:170120] CHIP:DMG: AccessControl: allowed
[1737591036.078150][170120:170120] CHIP:DMG: Received command for Endpoint=0 Cluster=0x0000_0036 Command=0x0000_0000
[1737591036.078168][170120:170120] CHIP:DMG: Endpoint=0 Cluster=0x0000_0036 Command=0x0000_0000 status 0x85 (INVALID_COMMAND) (no additional context)
[1737591036.078183][170120:170120] CHIP:DMG: Command handler moving to [NewRespons]
[1737591036.078187][170120:170120] CHIP:DMG: Command handler moving to [ Preparing]
[1737591036.078198][170120:170120] CHIP:DMG: Command handler moving to [AddingComm]
[1737591036.078206][170120:170120] CHIP:DMG: Command handler moving to [AddedComma]

```