### PR TITLE
Pin the Restyler version to v0.6.0.2

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -14,13 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Restyler
       - uses: restyled-io/actions/setup@v4
         with:
           # Pin the Restyler version to v0.6.0.2
-          version: v0.6.0.2
+          tag: 'v0.6.0.2'
 
-      - name: Run Restyler      
       - id: restyler
         uses: restyled-io/actions/run@v4
         with:

--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -14,7 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Restyler
       - uses: restyled-io/actions/setup@v4
+        with:
+          # Pin the Restyler version to v0.6.0.2
+          version: v0.6.0.2
+
+      - name: Run Restyler      
       - id: restyler
         uses: restyled-io/actions/run@v4
         with:


### PR DESCRIPTION
Restyle have been updated to the [v1.0.0-rc-semantic-release.1](https://github.com/restyled-io/restyler/releases/tag/v1.0.0-rc-semantic-release.1) artifact, and the install script that they provide ([install script](https://raw.githubusercontent.com/restyled-io/restyler/main/install)) is failing with 404 in CI.

#### Testing
Verified by CI

