### PR TITLE
Fix CodeQL warning related to comparing uint8_t loop index with size_t

### DIFF
--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -407,7 +407,7 @@ protected:
                                                                     mTimedInteractionTimeoutMs, mSuppressResponse.ValueOr(false));
             VerifyOrReturnError(mWriteClient != nullptr, CHIP_ERROR_NO_MEMORY);
 
-            for (uint8_t i = 0; i < pathsConfig.count; i++)
+            for (size_t i = 0; i < pathsConfig.count; i++)
             {
                 auto & path        = pathsConfig.attributePathParams[i];
                 auto & dataVersion = pathsConfig.dataVersionFilter[i].mDataVersion;


### PR DESCRIPTION
Fix CodeQL warning related to comparing uint8_t for loop index with a size_t `pathsConfig.count`

in reality `pathsConfig.count` will never exceed 255 but since this is TestCode simplest is to make the loop condition index a size_t

- the Warning: https://github.com/project-chip/connectedhomeip/security/code-scanning/7190

#### Testing

This is itself testcode, and the change is minor