### PR TITLE
Set up an `kInternalDeviceAccess` Auth mode to be used by internal requests when building subject descriptors

### DIFF
--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -192,7 +192,7 @@ public:
             return ::pw::Status::NotFound();
         }
 
-        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kPase };
+        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternal };
         app::DataModel::WriteAttributeRequest write_request;
         write_request.path = path;
         write_request.operationFlags.Set(app::DataModel::OperationFlags::kInternal);
@@ -343,7 +343,7 @@ private:
 
     ::pw::Status ReadAttributeIntoTlvBuffer(const app::ConcreteAttributePath & path, MutableByteSpan & tlvBuffer)
     {
-        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kPase };
+        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternal };
         app::AttributeReportIBs::Builder attributeReports;
         TLV::TLVWriter writer;
         TLV::TLVType outer;

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -192,7 +192,7 @@ public:
             return ::pw::Status::NotFound();
         }
 
-        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternal };
+        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternalDeviceAccess };
         app::DataModel::WriteAttributeRequest write_request;
         write_request.path = path;
         write_request.operationFlags.Set(app::DataModel::OperationFlags::kInternal);
@@ -343,7 +343,7 @@ private:
 
     ::pw::Status ReadAttributeIntoTlvBuffer(const app::ConcreteAttributePath & path, MutableByteSpan & tlvBuffer)
     {
-        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternal };
+        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kInternalDeviceAccess };
         app::AttributeReportIBs::Builder attributeReports;
         TLV::TLVWriter writer;
         TLV::TLVType outer;

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -98,7 +98,7 @@ char GetAuthModeStringForLogging(AuthMode authMode)
     {
     case AuthMode::kNone:
         return 'n';
-    case AuthMode::kInternal:
+    case AuthMode::kInternalDeviceAccess:
         return 'i';
     case AuthMode::kPase:
         return 'p';

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -98,6 +98,8 @@ char GetAuthModeStringForLogging(AuthMode authMode)
     {
     case AuthMode::kNone:
         return 'n';
+    case AuthMode::kInternal:
+        return 'i';
     case AuthMode::kPase:
         return 'p';
     case AuthMode::kCase:

--- a/src/access/AuthMode.h
+++ b/src/access/AuthMode.h
@@ -27,11 +27,11 @@ namespace Access {
 // Auth mode should have only one value expressed, which should not be None.
 enum class AuthMode : uint8_t
 {
-    kNone     = 0,
-    kInternal = 1 << 4, // Not part of an external interaction
-    kPase     = 1 << 5,
-    kCase     = 1 << 6,
-    kGroup    = 1 << 7
+    kNone                 = 0,
+    kInternalDeviceAccess = 1 << 4, // Not part of an external interaction
+    kPase                 = 1 << 5,
+    kCase                 = 1 << 6,
+    kGroup                = 1 << 7
 };
 
 } // namespace Access

--- a/src/access/AuthMode.h
+++ b/src/access/AuthMode.h
@@ -27,11 +27,11 @@ namespace Access {
 // Auth mode should have only one value expressed, which should not be None.
 enum class AuthMode : uint8_t
 {
-    kNone  = 0,
+    kNone     = 0,
     kInternal = 1 << 4, // Not part of an external interaction
-    kPase  = 1 << 5,
-    kCase  = 1 << 6,
-    kGroup = 1 << 7
+    kPase     = 1 << 5,
+    kCase     = 1 << 6,
+    kGroup    = 1 << 7
 };
 
 } // namespace Access

--- a/src/access/AuthMode.h
+++ b/src/access/AuthMode.h
@@ -28,6 +28,7 @@ namespace Access {
 enum class AuthMode : uint8_t
 {
     kNone  = 0,
+    kInternal = 1 << 4, // Not part of an external interaction
     kPase  = 1 << 5,
     kCase  = 1 << 6,
     kGroup = 1 << 7

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -63,7 +63,8 @@ class AccessControlDelegate : public Access::AccessControl::Delegate
             return CHIP_ERROR_ACCESS_DENIED;
         }
 
-        if (subjectDescriptor.authMode != AuthMode::kCase && subjectDescriptor.authMode != AuthMode::kPase)
+        if (subjectDescriptor.authMode != AuthMode::kCase && subjectDescriptor.authMode != AuthMode::kPase &&
+            subjectDescriptor.authMode != AuthMode::kInternal)
         {
             // No idea who is asking; deny for now.
             return CHIP_ERROR_ACCESS_DENIED;

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -64,7 +64,7 @@ class AccessControlDelegate : public Access::AccessControl::Delegate
         }
 
         if (subjectDescriptor.authMode != AuthMode::kCase && subjectDescriptor.authMode != AuthMode::kPase &&
-            subjectDescriptor.authMode != AuthMode::kInternal)
+            subjectDescriptor.authMode != AuthMode::kInternalDeviceAccess)
         {
             // No idea who is asking; deny for now.
             return CHIP_ERROR_ACCESS_DENIED;


### PR DESCRIPTION
This is to allow `SubjectDescriptor` settings to trickle down marked as internal requests rather than pretending PASE or CASE without a real remote node requesting interactions.

Updated the PR-RPC implementation to use this flag for its reads/writes of attributes (this is on top of setting the kInternal flag for the read/write requests).

#### Testing

Letting CI to validate this, as the intent is "no regressions"
