### PR TITLE
[Silabs] Add provisioning root argument

### DIFF
--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -18,6 +18,7 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/examples/platform/silabs/args.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 import("${chip_root}/src/platform/silabs/wifi/args.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
 import("${silabs_sdk_build_root}/SiWx917_sdk.gni")
@@ -67,7 +68,7 @@ source_set("test-event-trigger") {
     "${silabs_common_plat_dir}/SilabsTestEventTriggerDelegate.h",
   ]
 
-  deps = [ "${chip_root}/src/platform/silabs/provision:provision-headers" ]
+  deps = [ "${sl_provision_root}:provision-headers" ]
   public_configs = [ ":test-event-trigger-config" ]
   public_deps = [
     "${chip_root}/src/app:test-event-trigger",

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -20,6 +20,7 @@ import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
 import("${silabs_sdk_build_root}/efr32_sdk.gni")
 import("${silabs_sdk_build_root}/silabs_board.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 
 declare_args() {
   enable_heap_monitoring = false
@@ -71,7 +72,7 @@ source_set("test-event-trigger") {
     "${silabs_common_plat_dir}/SilabsTestEventTriggerDelegate.h",
   ]
 
-  deps = [ "${chip_root}/src/platform/silabs/provision:provision-headers" ]
+  deps = [ "${sl_provision_root}:provision-headers" ]
   public_configs = [ ":test-event-trigger-config" ]
   public_deps = [
     "${chip_root}/src/app:test-event-trigger",

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -18,9 +18,9 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 import("${silabs_sdk_build_root}/efr32_sdk.gni")
 import("${silabs_sdk_build_root}/silabs_board.gni")
-import("${chip_root}/src/platform/silabs/provision/args.gni")
 
 declare_args() {
   enable_heap_monitoring = false

--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -14,9 +14,8 @@
 
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
-import("${silabs_sdk_build_root}/silabs_board.gni")
 import("${chip_root}/src/platform/silabs/provision/args.gni")
-
+import("${silabs_sdk_build_root}/silabs_board.gni")
 
 if (wifi_soc) {
   import("${silabs_sdk_build_root}/SiWx917_sdk.gni")
@@ -50,8 +49,7 @@ source_set("storage") {
 
   deps = [ "${chip_root}/src/lib" ]
 
-  public_deps =
-      [ "${sl_provision_root}:provision-headers" ]
+  public_deps = [ "${sl_provision_root}:provision-headers" ]
 
   if (sl_enable_test_event_trigger) {
     # Temporary workaround since we have duplicated configurations

--- a/examples/platform/silabs/provision/BUILD.gn
+++ b/examples/platform/silabs/provision/BUILD.gn
@@ -15,6 +15,8 @@
 import("//build_overrides/chip.gni")
 import("//build_overrides/efr32_sdk.gni")
 import("${silabs_sdk_build_root}/silabs_board.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
+
 
 if (wifi_soc) {
   import("${silabs_sdk_build_root}/SiWx917_sdk.gni")
@@ -49,7 +51,7 @@ source_set("storage") {
   deps = [ "${chip_root}/src/lib" ]
 
   public_deps =
-      [ "${chip_root}/src/platform/silabs/provision:provision-headers" ]
+      [ "${sl_provision_root}:provision-headers" ]
 
   if (sl_enable_test_event_trigger) {
     # Temporary workaround since we have duplicated configurations

--- a/src/platform/silabs/SiWx917/BUILD.gn
+++ b/src/platform/silabs/SiWx917/BUILD.gn
@@ -18,6 +18,7 @@ import("${chip_root}/src/platform/device.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 import("${chip_root}/src/platform/silabs/wifi/args.gni")
 import("${chip_root}/third_party/silabs/SiWx917_sdk.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
@@ -87,7 +88,10 @@ static_library("SiWx917") {
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/platform:platform_base",
   ]
-  deps = [ "${chip_root}/src/platform/logging:headers" ]
+  deps = [
+    "${chip_root}/src/platform/logging:headers",
+    "${sl_provision_root}:provision-headers",
+  ]
 
   # Add platform crypto implementation
   if (chip_crypto == "platform") {

--- a/src/platform/silabs/efr32/BUILD.gn
+++ b/src/platform/silabs/efr32/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/buildconfig_header.gni")
 import("${chip_root}/src/crypto/crypto.gni")
 import("${chip_root}/src/platform/device.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 import("${chip_root}/third_party/silabs/efr32_sdk.gni")
 import("${chip_root}/third_party/silabs/silabs_board.gni")
 
@@ -114,7 +115,7 @@ static_library("efr32") {
     "${chip_root}/src/platform:platform_base",
     "${chip_root}/src/platform/logging:headers",
   ]
-  deps = [ "${silabs_platform_dir}/provision:provision-headers" ]
+  deps = [ "${sl_provision_root}:provision-headers" ]
   public_configs = []
 
   # Add platform crypto implementation

--- a/src/platform/silabs/provision/args.gni
+++ b/src/platform/silabs/provision/args.gni
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+declare_args() {
+  sl_provision_root = "${chip_root}/src/platform/silabs/provision"
+}

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -19,6 +19,7 @@ import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
 import("${silabs_sdk_build_root}/efr32_sdk.gni")
+import("${chip_root}/src/platform/silabs/provision/args.gni")
 
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/platform/device.gni")
@@ -94,7 +95,7 @@ source_set("efr32_test_main") {
     "${chip_root}/examples/common/pigweed:system_rpc_server",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/support:pw_tests_wrapper",
-    "${chip_root}/src/platform/silabs/provision:provision-headers",
+    "${sl_provision_root}:provision-headers",
     "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
   ]
 

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -18,8 +18,8 @@ import("//build_overrides/efr32_sdk.gni")
 import("//build_overrides/pigweed.gni")
 
 import("${build_root}/config/defaults.gni")
-import("${silabs_sdk_build_root}/efr32_sdk.gni")
 import("${chip_root}/src/platform/silabs/provision/args.gni")
+import("${silabs_sdk_build_root}/efr32_sdk.gni")
 
 import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/platform/device.gni")
@@ -95,8 +95,8 @@ source_set("efr32_test_main") {
     "${chip_root}/examples/common/pigweed:system_rpc_server",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/support:pw_tests_wrapper",
-    "${sl_provision_root}:provision-headers",
     "${examples_common_plat_dir}/pw_sys_io:pw_sys_io_silabs",
+    "${sl_provision_root}:provision-headers",
   ]
 
   # OpenThread Settings


### PR DESCRIPTION
### Description
PR adds a gn build argument that allows us to change where to get the provisioning headers

### Testing
CI to validate the builds are sill working
