### PR TITLE
[Darwin] On resubscribe attempt, if no need to subscribe, clear subsc ription work

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1487,6 +1487,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     os_unfair_lock_assert_owner(&self->_lock);
     if (!self.reattemptingSubscription) {
+        [self _clearSubscriptionPoolWork];
         return;
     }
 


### PR DESCRIPTION
From testing we've found that if a resubscription reattempt is scheduled, and then subscription establishes, then when the resubscription attempt happens, it'll exit early but failed to clear the subscription pool of its work, in the case where the subscription pool is used.

This change adds the call to clear subscription pool work item (if it exists) on this condition.

### Testing

Manually tested, and script verified