### PR TITLE
Treat a Nullable attribute as raw type if it is not NullValue

### DIFF
--- a/src/python_testing/TC_DGWIFI_2_1.py
+++ b/src/python_testing/TC_DGWIFI_2_1.py
@@ -131,20 +131,17 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         # If not NULL, we expect an integer in the SecurityType enum range.
         # Just do a minimal check here; you can refine or extend based on the spec.
         if security_type is not NullValue:
-            security_type_value = security_type.Value
-            matter_asserts.assert_valid_uint8(security_type_value, "SecurityType")
+            matter_asserts.assert_valid_uint8(security_type, "SecurityType")
 
             # Check if the security_type is a valid SecurityTypeEnum member
-            self.assert_true(
-                security_type_value in [item.value for item in Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum],
-                f"SecurityType {security_type_value} is not a valid SecurityTypeEnum value"
-            )
+            matter_asserts.assert_valid_enum(security_type, "SecurityType",
+                                             Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum)
 
             # Additional check that it's not kUnknownEnumValue:
             self.assert_true(
-                security_type_value != Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue.value,
+                security_type != Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue,
                 f"SecurityType should not be kUnknownEnumValue "
-                f"({Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue.value})"
+                f"({Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue})"
             )
 
         #
@@ -154,16 +151,15 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         wifi_version = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.WiFiVersion)
         # WiFiVersion is an enum. If not configured or operational, might be NULL.
         if wifi_version is not NullValue:
-            wifi_version_value = wifi_version.Value
-            matter_asserts.assert_valid_uint8(wifi_version_value, "WiFiVersion")
+            matter_asserts.assert_valid_uint8(wifi_version, "WiFiVersion")
 
             # Check if the wifi_version is a valid WiFiVersionEnum member
-            self.assert_true(wifi_version_value in [item.value for item in Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum],
-                             f"WiFiVersion {wifi_version_value} is not a valid WiFiVersionEnum value")
+            matter_asserts.assert_valid_enum(wifi_version, "WiFiVersion",
+                                             Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum)
 
             # Additional check that it's not kUnknownEnumValue:
-            self.assert_true(wifi_version_value != Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue.value,
-                             f"WiFiVersion should not be kUnknownEnumValue ({Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue.value})")
+            self.assert_true(wifi_version != Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue,
+                             f"WiFiVersion should not be kUnknownEnumValue ({Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue})")
 
         #
         # STEP 5: TH reads ChannelNumber attribute
@@ -172,7 +168,7 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         channel_number = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.ChannelNumber)
         # If not operational, might be NULL. Else we expect an unsigned integer channel.
         if channel_number is not NullValue:
-            matter_asserts.assert_valid_uint16(channel_number.Value, "ChannelNumber")
+            matter_asserts.assert_valid_uint16(channel_number, "ChannelNumber")
 
         #
         # STEP 6: TH reads RSSI attribute
@@ -181,8 +177,7 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         rssi = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.Rssi)
         # RSSI is typically a signed integer (dB). If not operational, might be NULL.
         if rssi is not NullValue:
-            rssi_value = rssi.Value
-            asserts.assert_true(isinstance(rssi_value, int) and -120 <= rssi_value <= 0,
+            asserts.assert_true(isinstance(rssi, int) and -120 <= rssi <= 0,
                                 "rssi_value is not within valid range.")
 
         #
@@ -196,7 +191,7 @@ class TC_DGWIFI_2_1(MatterBaseTest):
                                 "BeaconLostCount must be of type 'Nullable' when not None.")
 
             if beacon_lost_count is not NullValue:
-                matter_asserts.assert_valid_uint32(beacon_lost_count.Value, "BeaconLostCount")
+                matter_asserts.assert_valid_uint32(beacon_lost_count, "BeaconLostCount")
 
         #
         # STEP 8: TH reads BeaconRxCount attribute
@@ -204,11 +199,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         self.step(8)
         beacon_rx_count = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.BeaconRxCount)
         if beacon_rx_count is not None:
-            asserts.assert_true(isinstance(beacon_rx_count, Nullable),
-                                "BeaconRxCount must be of type 'Nullable' when not None.")
-
             if beacon_rx_count is not NullValue:
-                matter_asserts.assert_valid_uint32(beacon_rx_count.Value, "BeaconRxCount")
+                matter_asserts.assert_valid_uint32(beacon_rx_count, "BeaconRxCount")
 
         #
         # STEP 9: TH reads PacketMulticastRxCount attribute
@@ -216,11 +208,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         self.step(9)
         pkt_multi_rx = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.PacketMulticastRxCount)
         if pkt_multi_rx is not None:
-            asserts.assert_true(isinstance(pkt_multi_rx, Nullable),
-                                "PacketMulticastRxCount must be of type 'Nullable' when not None.")
-
             if pkt_multi_rx is not NullValue:
-                matter_asserts.assert_valid_uint32(pkt_multi_rx.Value, "PacketMulticastRxCount")
+                matter_asserts.assert_valid_uint32(pkt_multi_rx, "PacketMulticastRxCount")
 
         #
         # STEP 10: TH reads PacketMulticastTxCount attribute
@@ -228,11 +217,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         self.step(10)
         pkt_multi_tx = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.PacketMulticastTxCount)
         if pkt_multi_tx is not None:
-            asserts.assert_true(isinstance(pkt_multi_tx, Nullable),
-                                "PacketMulticastTxCount must be of type 'Nullable' when not None.")
-
             if pkt_multi_tx is not NullValue:
-                matter_asserts.assert_valid_uint32(pkt_multi_tx.Value, "PacketMulticastTxCount")
+                matter_asserts.assert_valid_uint32(pkt_multi_tx, "PacketMulticastTxCount")
 
         #
         # STEP 11: TH reads PacketUnicastRxCount attribute
@@ -240,11 +226,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         self.step(11)
         pkt_uni_rx = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.PacketUnicastRxCount)
         if pkt_uni_rx is not None:
-            asserts.assert_true(isinstance(pkt_uni_rx, Nullable),
-                                "PacketUnicastRxCount must be of type 'Nullable' when not None.")
-
             if pkt_uni_rx is not NullValue:
-                matter_asserts.assert_valid_uint32(pkt_uni_rx.Value, "PacketUnicastRxCount")
+                matter_asserts.assert_valid_uint32(pkt_uni_rx, "PacketUnicastRxCount")
 
         #
         # STEP 12: TH reads PacketUnicastTxCount attribute
@@ -252,11 +235,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         self.step(12)
         pkt_uni_tx = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.PacketUnicastTxCount)
         if pkt_uni_tx is not None:
-            asserts.assert_true(isinstance(pkt_uni_tx, Nullable),
-                                "PacketUnicastTxCount must be of type 'Nullable' when not None.")
-
             if pkt_uni_tx is not NullValue:
-                matter_asserts.assert_valid_uint32(pkt_uni_tx.Value, "PacketUnicastTxCount")
+                matter_asserts.assert_valid_uint32(pkt_uni_tx, "PacketUnicastTxCount")
 
         #
         # STEP 13: TH reads CurrentMaxRate attribute
@@ -265,11 +245,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         current_max_rate = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.CurrentMaxRate)
         # According to the spec, this is bytes per second (uint).
         if current_max_rate is not None:
-            asserts.assert_true(isinstance(current_max_rate, Nullable),
-                                "CurrentMaxRate must be of type 'Nullable' when not None.")
-
             if current_max_rate is not NullValue:
-                matter_asserts.assert_valid_uint64(current_max_rate.Value, "CurrentMaxRate")
+                matter_asserts.assert_valid_uint64(current_max_rate, "CurrentMaxRate")
 
         #
         # STEP 14: TH reads OverrunCount attribute
@@ -278,11 +255,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
         overrun_count = await self.read_dgwifi_attribute_expect_success(endpoint=endpoint, attribute=attributes.OverrunCount)
         # This is a uint and may reset to 0 after node reboot.
         if overrun_count is not None:
-            asserts.assert_true(isinstance(overrun_count, Nullable),
-                                "OverrunCount must be of type 'Nullable' when not None.")
-
             if overrun_count is not NullValue:
-                matter_asserts.assert_valid_uint64(overrun_count.Value, "OverrunCount")
+                matter_asserts.assert_valid_uint64(overrun_count, "OverrunCount")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DGWIFI_2_3.py
+++ b/src/python_testing/TC_DGWIFI_2_3.py
@@ -33,7 +33,7 @@
 #
 
 import chip.clusters as Clusters
-from chip.clusters.Types import Nullable, NullValue
+from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -60,10 +60,9 @@ class TC_DGWIFI_2_3(MatterBaseTest):
         value = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.Objects.WiFiNetworkDiagnostics, attribute=attribute)
         if value is None:
             return
-        asserts.assert_true(isinstance(value, Nullable), f"{field_name} must be of type 'Nullable' when not None.")
         if value == NullValue:
             return
-        asserts.assert_true(validation_func(value.Value), f"{field_name} has an invalid value: {value.Value}")
+        asserts.assert_true(validation_func(value), f"{field_name} has an invalid value: {value}")
 
     def desc_TC_DGWIFI_2_3(self) -> str:
         """Returns a description of this test."""


### PR DESCRIPTION
In the Python bindings, when reading a Nullable attribute, if its value isn’t NullValue, the raw type is returned directly. For example:

```
bssid: typing.Union[Nullable, bytes] = NullValue
securityType: typing.Union[Nullable, WiFiNetworkDiagnostics.Enums.SecurityTypeEnum] = NullValue
wiFiVersion: typing.Union[Nullable, WiFiNetworkDiagnostics.Enums.WiFiVersionEnum] = NullValue
```

As a result, there is no need to explicitly unwrap these values when they are non-null.

#### Testing
Validate by CI
