### PR TITLE
Fix thread race in test008_pairingAfterCancellation_DeviceAttestationVerification

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -444,14 +444,15 @@ static MTRTestKeys * sTestKeys = nil;
 - (void)test008_pairingAfterCancellation_DeviceAttestationVerification
 {
     // Cancel pairing while we are waiting for our client to decide what to do
-    // with the attestation information we got.
-    __block BOOL delegateCalled = NO;
-    __auto_type * attestationDelegate = [[NoOpAttestationDelegate alloc] initWithCallback:^{
-        delegateCalled = YES;
-    } blockCommissioning:YES];
+    // with the attestation information we got.  Note that the delegate is
+    // called on some arbitrary queue, so we need to make sure we wait for it to
+    // actually be called; we can't just have it set a boolean that we then
+    // check, because that can race.
+    XCTestExpectation * expectation = [self expectationWithDescription:@"Attestation delegate called"];
+    __auto_type * attestationDelegate = [[NoOpAttestationDelegate alloc] initWithExpectation:expectation blockCommissioning:YES];
 
     [self doPairingTestAfterCancellationAtProgress:@"Successfully extended fail-safe timer to handle DA failure" attestationDelegate:attestationDelegate];
-    XCTAssertTrue(delegateCalled);
+    [self waitForExpectations:@[ expectation ] timeout:kPairingTimeoutInSeconds];
 }
 
 @end


### PR DESCRIPTION
The attestation delegate is called on some random framework-internal queue, so it setting the boolean could race with the test main body reading the boolean, which could cause TSan failures, as well as outright failures in some cases. Adding a sleep(5) into the delegate callback before setting the boolean made the test fail reliably.

The fix is to just use an expectation to track the "has the delegate been called?" state, since that will handle synchronization for us.

Fixes https://github.com/project-chip/connectedhomeip/issues/37189

#### Testing

Ran the test locally.