### PR TITLE
Python testing: Handle provisional aliased clusters

### DIFF
--- a/src/python_testing/TestSpecParsingSupport.py
+++ b/src/python_testing/TestSpecParsingSupport.py
@@ -213,7 +213,9 @@ ALIASED_CLUSTERS = (
     '  </revisionHistory>'
     '  <clusterIds>'
     '    <clusterId id="0xFFFE" name="Test Alias1"/>'
-    '    <clusterId id="0xFFFD" name="Test Alias2"/>'
+    '    <clusterId id="0xFFFD" name="Test Alias2">'
+    '      <provisionalConform/>'
+    '    </clusterId>'
     '  </clusterIds>'
     '  <classification hierarchy="base" role="application" picsCode="BASE" scope="Endpoint"/>'
     '  <commands>'
@@ -395,6 +397,10 @@ class TestSpecParsingSupport(MatterBaseTest):
         ids = [(id, c.name) for id, c in clusters.items()]
         asserts.assert_true((0xFFFE, 'Test Alias1') in ids, "Unable to find Test Alias1 cluster in parsed clusters")
         asserts.assert_true((0xFFFD, 'Test Alias2') in ids, "Unable to find Test Alias2 cluster in parsed clusters")
+
+        # Test Alias2 is marked as provisional, and TestAlias1 is not
+        asserts.assert_false(clusters[0xFFFE].is_provisional, "Test Alias1 is marked as provisional and should not be")
+        asserts.assert_true(clusters[0xFFFD].is_provisional, "Test Alias2 is not marked as provisional and should be")
 
     def test_known_aliased_clusters(self):
         known_aliased_clusters = set([(0x040C, 'Carbon Monoxide Concentration Measurement', 'CMOCONC'),

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -228,9 +228,10 @@ class ClusterParser:
         except (KeyError, StopIteration):
             self._derived = None
 
-        for id in cluster.iter('clusterIds'):
-            if list(id.iter('provisionalConform')):
-                self._is_provisional = True
+        for ids in cluster.iter('clusterIds'):
+            for id in ids.iter('clusterId'):
+                if id.attrib['name'] == name and list(id.iter('provisionalConform')):
+                    self._is_provisional = True
 
         self._pics: Optional[str] = None
         try:


### PR DESCRIPTION
Handle the case where there are cluster aliases, and only some of the aliased clusters are provisional. This is a weird case that only happens in the 1.3 spec, which was before we handled provisional in the automated testing.

#### Testing
See attached unit tests. Level control is now correctly marked in 1.3.