### PR TITLE
Fix up docker

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-101: [Silabs] Update Silabs docker to support MG26 Modules.
+101 : [Silabs] Update Silabs docker to support MG26 Modules.

--- a/integrations/docker/images/stage-2/chip-build-nuttx/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nuttx/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
 # Download and build g++-13
 RUN set -x \
     && ! test -d /opt/nuttx/gcc-13 \
-    && wget -P gcc_build https://ftp.tsukuba.wide.ad.jp/software/gcc/releases/gcc-13.1.0/gcc-13.1.0.tar.gz \
+    && wget -P gcc_build https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-13.1.0/gcc-13.1.0.tar.gz \
     && cd gcc_build \
     && tar xzf gcc-13.1.0.tar.gz \
     && cd gcc-13.1.0 \


### PR DESCRIPTION
- Apparently space after version was important (because otherwise we get a build error)
- If I am changing things, I also fixed up the mirror for NuttX (previous mirror was giving out expired certificate errors)

I did not bump the version since the previous `101` could not be built at all, so this is the "only 101" we will have.


#### Testing

N/A. Will test once we build it.