### PR TITLE
[IM]Fix leaked readClient in onFabricRemoved call

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1969,6 +1969,8 @@ void InteractionModelEngine::OnFabricRemoved(const FabricTable & fabricTable, Fa
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr;)
     {
+        // ReadClient::Close may delete the read client so that readClient->GetNextClient() will be use-after-free.
+        // We need save readClient as nextReadClient before closing.
         if (readClient->GetFabricIndex() == fabricIndex)
         {
             ChipLogProgress(InteractionModel, "Fabric removed, deleting obsolete read client with FabricIndex: %u", fabricIndex);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1980,7 +1980,6 @@ void InteractionModelEngine::OnFabricRemoved(const FabricTable & fabricTable, Fa
         {
             readClient = readClient->GetNextClient();
         }
-
     }
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1967,13 +1967,20 @@ void InteractionModelEngine::OnFabricRemoved(const FabricTable & fabricTable, Fa
     });
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-    for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
+    for (auto * readClient = mpActiveReadClientList; readClient != nullptr;)
     {
         if (readClient->GetFabricIndex() == fabricIndex)
         {
             ChipLogProgress(InteractionModel, "Fabric removed, deleting obsolete read client with FabricIndex: %u", fabricIndex);
+            auto * nextReadClient = readClient->GetNextClient();
             readClient->Close(CHIP_ERROR_IM_FABRIC_DELETED, false);
+            readClient = nextReadClient;
         }
+        else
+        {
+            readClient = readClient->GetNextClient();
+        }
+
     }
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -336,7 +336,6 @@ public:
     //
     FabricTable * GetFabricTable() { return mpFabricTable; }
 
-
     //
     // Get direct access to the underlying read handler pool
     //

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -324,12 +324,19 @@ public:
     /**
      * @brief Function decrements the number of subscriptions to resume counter - mNumOfSubscriptionsToResume.
      *        This should be called after we have completed a re-subscribe attempt on a persisted subscription wether the attempt
-     *        was succesful or not.
+     *        was successful or not.
      */
     void DecrementNumSubscriptionsToResume();
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+    //
+    // Get fabric table
+    //
+    FabricTable * GetFabricTable() { return mpFabricTable; }
+
+
     //
     // Get direct access to the underlying read handler pool
     //
@@ -714,7 +721,7 @@ private:
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
-    FabricTable * mpFabricTable;
+    FabricTable * mpFabricTable = nullptr;
 
     CASESessionManager * mpCASESessionMgr = nullptr;
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -330,12 +330,6 @@ public:
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-
-    //
-    // Get fabric table
-    //
-    FabricTable * GetFabricTable() { return mpFabricTable; }
-
     //
     // Get direct access to the underlying read handler pool
     //

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -113,6 +113,9 @@ ReadClient::~ReadClient()
             mpImEngine->RemoveReadClient(this);
         }
     }
+    mpExchangeMgr = nullptr;
+    mpNext        = nullptr;
+    mpImEngine    = nullptr;
 }
 
 uint32_t ReadClient::ComputeTimeTillNextSubscription()

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -113,9 +113,6 @@ ReadClient::~ReadClient()
             mpImEngine->RemoveReadClient(this);
         }
     }
-    mpExchangeMgr = nullptr;
-    mpNext        = nullptr;
-    mpImEngine    = nullptr;
 }
 
 uint32_t ReadClient::ComputeTimeTillNextSubscription()

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4526,8 +4526,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions_OnFabricRemoved)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
-    };
+    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {};
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -3053,9 +3053,8 @@ void EstablishReadOrSubscriptions(const SessionHandle & sessionHandle, size_t nu
 
     for (uint32_t i = 0; i < numSubs; i++)
     {
-        std::unique_ptr<ReadClient> readClient =
-            std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
-                                              InteractionModelEngine::GetInstance()->GetExchangeManager(), *callback, type);
+        std::unique_ptr<ReadClient> readClient = std::make_unique<ReadClient>(
+            InteractionModelEngine::GetInstance(), InteractionModelEngine::GetInstance()->GetExchangeManager(), *callback, type);
         EXPECT_EQ(readClient->SendRequest(readParams), CHIP_NO_ERROR);
         readClients.push_back(std::move(readClient));
     }
@@ -3241,7 +3240,7 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
     // Part 2: Testing per fabric minimas.
     // Validate we have more than kMinSupportedSubscriptionsPerFabric subscriptions for testing per fabric minimas.
     EXPECT_GT(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
-                                                                                   GetAliceFabricIndex()),
+                                                                              GetAliceFabricIndex()),
               InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
 
     // The following check will trigger the logic in im to kill the read handlers that use more paths than the limit per fabric.
@@ -3291,10 +3290,10 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
               InteractionModelEngine::kMinSupportedPathsPerSubscription *
                   InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
     EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
-                                                                                   GetAliceFabricIndex()),
+                                                                              GetAliceFabricIndex()),
               InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
     EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
-                                                                                   GetBobFabricIndex()),
+                                                                              GetBobFabricIndex()),
               InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
 
     // Ensure our read transactions are still alive.
@@ -3368,8 +3367,7 @@ TEST_F(TestRead, TestReadHandler_KillOldestSubscriptions)
         // This read handler should evict some existing subscriptions for enough space
         EXPECT_EQ(readCallback.mOnSubscriptionEstablishedCount, 1u);
         EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerSubscription);
-        EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(),
-                  static_cast<size_t>(kExpectedParallelSubs));
+        EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), static_cast<size_t>(kExpectedParallelSubs));
     }
 
     {
@@ -3911,10 +3909,10 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict one read request from Bob fabric for enough resources.
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetAliceFabricIndex()),
+                                                                                      GetAliceFabricIndex()),
                       1u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetBobFabricIndex()),
+                                                                                      GetBobFabricIndex()),
                       1u);
         });
 
@@ -3962,10 +3960,10 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict one read request from Bob fabric for enough resources.
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetAliceFabricIndex()),
+                                                                                      GetAliceFabricIndex()),
                       1u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetBobFabricIndex()),
+                                                                                      GetBobFabricIndex()),
                       1u);
         });
 
@@ -4013,10 +4011,10 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mLastError, CHIP_IM_GLOBAL_STATUS(Busy));
             // Should evict one read request from Bob fabric for enough resources.
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetAliceFabricIndex()),
+                                                                                      GetAliceFabricIndex()),
                       2u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetBobFabricIndex()),
+                                                                                      GetBobFabricIndex()),
                       1u);
         });
 
@@ -4059,10 +4057,10 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // No read transactions should be evicted.
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetAliceFabricIndex()),
+                                                                                      GetAliceFabricIndex()),
                       1u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           GetBobFabricIndex()),
+                                                                                      GetBobFabricIndex()),
                       1u);
         });
 
@@ -4101,10 +4099,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mOnDone, 1u);
             EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict the read request on PASE session for enough resources.
-            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
-                      1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 1u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       0u);
         });
 
@@ -4145,10 +4142,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mOnDone, 1u);
             EXPECT_EQ(readCallback.mAttributeCount, 1u);
             // Should evict the read request on PASE session for enough resources.
-            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
-                      1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 1u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       0u);
         });
 
@@ -4194,10 +4190,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             // The read handler on PASE session should not be evicted since the resources used by all PASE sessions are not
             // exceeding the resources guaranteed to a normal fabric.
-            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
-                      2u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 2u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       1u);
         });
 
@@ -4228,7 +4223,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
                 return InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read) == 6;
             });
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       3u);
 
             // We have to evict one read transaction on PASE session and one read transaction on Alice's fabric.
@@ -4246,10 +4241,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             // No more than one read handler on PASE session should be evicted exceeding the resources guaranteed to a normal
             // fabric. Note: We are using ">=" here since it is also acceptable if we choose to evict one read transaction from
             // Alice fabric.
-            EXPECT_GE(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
-                      4u);
+            EXPECT_GE(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 4u);
             EXPECT_GE(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       2u);
         });
 
@@ -4303,10 +4297,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             // The read handler on PASE session should be evicted, and the read transactions on a normal fabric should be untouched
             // although it is oversized.
-            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
-                      2u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 2u);
             EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
-                                                                                           kUndefinedFabricIndex),
+                                                                                      kUndefinedFabricIndex),
                       0u);
         });
 
@@ -4607,8 +4600,8 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
 
     readParam.mAttributePathParamsListSize = 0;
     readClient                             = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
-                                                   InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                   ReadClient::InteractionType::Subscribe);
+                                              InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                              ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4557,7 +4557,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions_OnFabricRemoved)
     EXPECT_EQ(numSubscriptionEstablishedCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
     EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
 
-    app::InteractionModelEngine::GetInstance()->GetFabricTable()->DeleteAllFabrics();
+    chip::Test::MessagingContext::GetFabricTable().DeleteAllFabrics();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
     size_t numActiveReadClients = app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -4557,7 +4557,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions_OnFabricRemoved)
     EXPECT_EQ(numSubscriptionEstablishedCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
     EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
 
-    chip::Test::MessagingContext::GetFabricTable().DeleteAllFabrics();
+    GetFabricTable().DeleteAllFabrics();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
     size_t numActiveReadClients = app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -109,7 +109,7 @@ const MockNodeConfig & TestMockNodeConfig()
     return config;
 }
 
-class TestRead : public chip::Test::AppContext, public app::ReadHandler::ApplicationCallback
+class TestRead : public AppContext, public ReadHandler::ApplicationCallback
 {
 protected:
     static uint16_t mMaxInterval;
@@ -117,24 +117,24 @@ protected:
     // Performs setup for each individual test in the test suite
     void SetUp() override
     {
-        chip::Test::AppContext::SetUp();
+        AppContext::SetUp();
         // Register app callback, so we can test it as well to ensure we get the right
         // number of SubscriptionEstablishment/Termination callbacks.
         InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(this);
         mOldProvider = InteractionModelEngine::GetInstance()->SetDataModelProvider(&CustomDataModel::Instance());
-        chip::Test::SetMockNodeConfig(TestMockNodeConfig());
+        SetMockNodeConfig(TestMockNodeConfig());
     }
 
     // Performs teardown for each individual test in the test suite
     void TearDown() override
     {
-        chip::Test::ResetMockNodeConfig();
+        ResetMockNodeConfig();
         InteractionModelEngine::GetInstance()->SetDataModelProvider(mOldProvider);
         InteractionModelEngine::GetInstance()->UnregisterReadHandlerAppCallback();
-        chip::Test::AppContext::TearDown();
+        AppContext::TearDown();
     }
 
-    CHIP_ERROR OnSubscriptionRequested(app::ReadHandler & aReadHandler, Transport::SecureSession & aSecureSession) override
+    CHIP_ERROR OnSubscriptionRequested(ReadHandler & aReadHandler, Transport::SecureSession & aSecureSession) override
     {
         VerifyOrReturnError(!mEmitSubscriptionError, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -145,9 +145,9 @@ protected:
         return CHIP_NO_ERROR;
     }
 
-    void OnSubscriptionEstablished(app::ReadHandler & aReadHandler) override { mNumActiveSubscriptions++; }
+    void OnSubscriptionEstablished(ReadHandler & aReadHandler) override { mNumActiveSubscriptions++; }
 
-    void OnSubscriptionTerminated(app::ReadHandler & aReadHandler) override { mNumActiveSubscriptions--; }
+    void OnSubscriptionTerminated(ReadHandler & aReadHandler) override { mNumActiveSubscriptions--; }
 
     // Issue the given number of reads in parallel and wait for them all to
     // succeed.
@@ -165,23 +165,20 @@ protected:
     // max-interval to time out.
     static System::Clock::Timeout ComputeSubscriptionTimeout(System::Clock::Seconds16 aMaxInterval);
 
-    bool mEmitSubscriptionError                   = false;
-    int32_t mNumActiveSubscriptions               = 0;
-    bool mAlterSubscriptionIntervals              = false;
-    chip::app::DataModel::Provider * mOldProvider = nullptr;
+    bool mEmitSubscriptionError        = false;
+    int32_t mNumActiveSubscriptions    = 0;
+    bool mAlterSubscriptionIntervals   = false;
+    DataModel::Provider * mOldProvider = nullptr;
 };
 
 uint16_t TestRead::mMaxInterval = 66;
 
-class MockInteractionModelApp : public chip::app::ClusterStateCache::Callback
+class MockInteractionModelApp : public ClusterStateCache::Callback
 {
 public:
-    void OnEventData(const chip::app::EventHeader & aEventHeader, chip::TLV::TLVReader * apData,
-                     const chip::app::StatusIB * apStatus) override
-    {}
+    void OnEventData(const EventHeader & aEventHeader, chip::TLV::TLVReader * apData, const StatusIB * apStatus) override {}
 
-    void OnAttributeData(const chip::app::ConcreteDataAttributePath & aPath, chip::TLV::TLVReader * apData,
-                         const chip::app::StatusIB & status) override
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, chip::TLV::TLVReader * apData, const StatusIB & status) override
     {
         if (status.mStatus == chip::Protocols::InteractionModel::Status::Success)
         {
@@ -197,9 +194,9 @@ public:
         mReadError = true;
     }
 
-    void OnDone(app::ReadClient *) override {}
+    void OnDone(ReadClient *) override {}
 
-    void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
+    void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) override
     {
         if (aReadPrepareParams.mpAttributePathParamsList != nullptr)
         {
@@ -231,7 +228,7 @@ TEST_F(TestRead, TestReadAttributeResponse)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         uint8_t i = 0;
         EXPECT_TRUE(attributePath.mDataVersion.HasValue() && attributePath.mDataVersion.Value() == kDataVersion);
         auto iter = dataResponse.begin();
@@ -248,7 +245,7 @@ TEST_F(TestRead, TestReadAttributeResponse)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&onFailureCbInvoked](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         onFailureCbInvoked = true;
     };
 
@@ -258,8 +255,8 @@ TEST_F(TestRead, TestReadAttributeResponse)
     DrainAndServiceIO();
 
     EXPECT_TRUE(onSuccessCbInvoked && !onFailureCbInvoked);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -271,22 +268,22 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithVersionOnlyCache)
     ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     MockInteractionModelApp delegate;
-    chip::app::ClusterStateCache cache(delegate, Optional<EventNumber>::Missing(), false /*cachedData*/);
+    ClusterStateCache cache(delegate, Optional<EventNumber>::Missing(), false /*cachedData*/);
 
-    chip::app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+    ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
     // read of E2C2A* and E3C2A2. Expect cache E2C2 version
     {
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams2[2];
-        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = MockClusterId(3);
         attributePathParams2[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
-        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
-        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        attributePathParams2[1].mEndpointId            = kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = MockAttributeId(2);
         readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams.mAttributePathParamsListSize = 2;
         err                                            = readClient.SendRequest(readPrepareParams);
@@ -297,38 +294,35 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithVersionOnlyCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 0));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_NE(cache.Get(attributePath, reader), CHIP_NO_ERROR);
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_NE(cache.Get(attributePath, reader), CHIP_NO_ERROR);
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_NE(cache.Get(attributePath, reader), CHIP_NO_ERROR);
         }
         delegate.mNumAttributeResponse = 0;
     }
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -338,17 +332,17 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
 
     MockInteractionModelApp delegate;
-    chip::app::ClusterStateCache cache(delegate);
+    ClusterStateCache cache(delegate);
 
-    chip::app::EventPathParams eventPathParams[100];
+    EventPathParams eventPathParams[100];
     for (auto & eventPathParam : eventPathParams)
     {
-        eventPathParam.mEndpointId = chip::Test::kMockEndpoint3;
-        eventPathParam.mClusterId  = chip::Test::MockClusterId(2);
+        eventPathParam.mEndpointId = kMockEndpoint3;
+        eventPathParam.mClusterId  = MockClusterId(2);
         eventPathParam.mEventId    = 0;
     }
 
-    chip::app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+    ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 4;
 
@@ -359,19 +353,19 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
-        attributePathParams1[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(1);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = MockClusterId(3);
+        attributePathParams1[0].mAttributeId = MockAttributeId(1);
 
         attributePathParams1[1].mEndpointId  = kInvalidEndpointId;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(1);
+        attributePathParams1[1].mClusterId   = MockClusterId(3);
+        attributePathParams1[1].mAttributeId = MockAttributeId(1);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(3);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[2].mClusterId   = MockClusterId(3);
         attributePathParams1[2].mAttributeId = kInvalidAttributeId;
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
@@ -383,7 +377,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_FALSE(version1.HasValue());
         delegate.mNumAttributeResponse = 0;
@@ -394,20 +388,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
-        attributePathParams1[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(1);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = MockClusterId(3);
+        attributePathParams1[0].mAttributeId = MockAttributeId(1);
 
-        attributePathParams1[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[1].mClusterId   = MockClusterId(3);
+        attributePathParams1[1].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint3;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[2].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint3;
+        attributePathParams1[2].mClusterId   = MockClusterId(2);
+        attributePathParams1[2].mAttributeId = MockAttributeId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -418,17 +412,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 3);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_FALSE(version1.HasValue());
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -437,8 +430,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -447,8 +439,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -465,20 +456,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
         attributePathParams1[0].mEndpointId  = kInvalidEndpointId;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[0].mClusterId   = MockClusterId(2);
+        attributePathParams1[0].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[1].mClusterId   = MockClusterId(2);
+        attributePathParams1[1].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint3;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[2].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint3;
+        attributePathParams1[2].mClusterId   = MockClusterId(2);
+        attributePathParams1[2].mAttributeId = MockAttributeId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -489,24 +480,22 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 2);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_FALSE(version1.HasValue());
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint1, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint1, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_NE(cache.Get(attributePath, reader), CHIP_NO_ERROR);
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -515,8 +504,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -531,16 +519,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams2[2];
-        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = MockClusterId(3);
         attributePathParams2[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
-        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
-        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        attributePathParams2[1].mEndpointId            = kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = MockAttributeId(2);
         readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams.mAttributePathParamsListSize = 2;
         err                                            = readClient.SendRequest(readPrepareParams);
@@ -551,17 +539,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 0));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -570,8 +557,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -580,8 +566,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -590,8 +575,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -606,20 +590,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
-        attributePathParams1[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(1);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = MockClusterId(3);
+        attributePathParams1[0].mAttributeId = MockAttributeId(1);
 
-        attributePathParams1[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[1].mClusterId   = MockClusterId(3);
+        attributePathParams1[1].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint3;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[2].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint3;
+        attributePathParams1[2].mClusterId   = MockClusterId(2);
+        attributePathParams1[2].mAttributeId = MockAttributeId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -630,17 +614,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 1);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 0));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -649,8 +632,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -659,8 +641,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -675,16 +656,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams2[2];
-        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = MockClusterId(3);
         attributePathParams2[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
-        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
-        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        attributePathParams2[1].mEndpointId            = kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = MockAttributeId(2);
         readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams.mAttributePathParamsListSize = 2;
         err                                            = readClient.SendRequest(readPrepareParams);
@@ -694,17 +675,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 1);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 0));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -713,8 +693,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -723,8 +702,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -733,8 +711,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -744,7 +721,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         delegate.mNumAttributeResponse = 0;
     }
 
-    chip::Test::BumpVersion();
+    BumpVersion();
 
     // Read of E2C3A1, E2C3A2 and E3C2A2. It would use the stored data versions in the cache since our subsequent read's C1A*
     // path intersects with previous cached data version, server's version is changed. Expect E2C3A1, E2C3A2 and E3C2A2 attribute in
@@ -752,20 +729,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
-        attributePathParams1[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(1);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = MockClusterId(3);
+        attributePathParams1[0].mAttributeId = MockAttributeId(1);
 
-        attributePathParams1[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[1].mClusterId   = MockClusterId(3);
+        attributePathParams1[1].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint3;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[2].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint3;
+        attributePathParams1[2].mClusterId   = MockClusterId(2);
+        attributePathParams1[2].mAttributeId = MockAttributeId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -776,17 +753,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 3);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_FALSE(version1.HasValue());
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -795,8 +771,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -805,8 +780,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -821,20 +795,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[3];
-        attributePathParams1[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[0].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[0].mAttributeId = chip::Test::MockAttributeId(1);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = MockClusterId(3);
+        attributePathParams1[0].mAttributeId = MockAttributeId(1);
 
-        attributePathParams1[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams1[1].mClusterId   = chip::Test::MockClusterId(3);
-        attributePathParams1[1].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams1[1].mClusterId   = MockClusterId(3);
+        attributePathParams1[1].mAttributeId = MockAttributeId(2);
 
-        attributePathParams1[2].mEndpointId  = chip::Test::kMockEndpoint3;
-        attributePathParams1[2].mClusterId   = chip::Test::MockClusterId(2);
-        attributePathParams1[2].mAttributeId = chip::Test::MockAttributeId(2);
+        attributePathParams1[2].mEndpointId  = kMockEndpoint3;
+        attributePathParams1[2].mClusterId   = MockClusterId(2);
+        attributePathParams1[2].mAttributeId = MockAttributeId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -845,17 +819,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 3);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_FALSE(version1.HasValue());
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -864,8 +837,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -874,8 +846,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -890,16 +861,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams2[2];
-        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = MockClusterId(3);
         attributePathParams2[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
-        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
-        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        attributePathParams2[1].mEndpointId            = kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = MockAttributeId(2);
         readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams.mAttributePathParamsListSize = 2;
         err                                            = readClient.SendRequest(readPrepareParams);
@@ -909,17 +880,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 1));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -928,8 +898,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -938,8 +907,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -948,8 +916,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -965,16 +932,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams2[2];
-        attributePathParams2[0].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams2[0].mClusterId   = chip::Test::MockClusterId(3);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams2[2];
+        attributePathParams2[0].mEndpointId  = kMockEndpoint2;
+        attributePathParams2[0].mClusterId   = MockClusterId(3);
         attributePathParams2[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams2[1].mEndpointId            = chip::Test::kMockEndpoint3;
-        attributePathParams2[1].mClusterId             = chip::Test::MockClusterId(2);
-        attributePathParams2[1].mAttributeId           = chip::Test::MockAttributeId(2);
+        attributePathParams2[1].mEndpointId            = kMockEndpoint3;
+        attributePathParams2[1].mClusterId             = MockClusterId(2);
+        attributePathParams2[1].mAttributeId           = MockAttributeId(2);
         readPrepareParams.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams.mAttributePathParamsListSize = 2;
 
@@ -992,17 +959,16 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 1));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint3, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_FALSE(version2.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1011,8 +977,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1021,8 +986,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -1031,8 +995,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1044,27 +1007,27 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         readPrepareParams.mEventPathParamsListSize = 0;
     }
 
-    chip::Test::BumpVersion();
+    BumpVersion();
 
     // Read of E1C2A* and E2C3A* and E2C2A*, it would use C1 cached version to construct DataVersionFilter, but version has
     // changed in server. Expect E1C2A* and C2C3A* and E2C2A* attributes in report, and cache their versions
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
 
-        chip::app::AttributePathParams attributePathParams3[3];
-        attributePathParams3[0].mEndpointId  = chip::Test::kMockEndpoint1;
-        attributePathParams3[0].mClusterId   = chip::Test::MockClusterId(2);
+        AttributePathParams attributePathParams3[3];
+        attributePathParams3[0].mEndpointId  = kMockEndpoint1;
+        attributePathParams3[0].mClusterId   = MockClusterId(2);
         attributePathParams3[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams3[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams3[1].mClusterId   = chip::Test::MockClusterId(3);
+        attributePathParams3[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams3[1].mClusterId   = MockClusterId(3);
         attributePathParams3[1].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams3[2].mEndpointId            = chip::Test::kMockEndpoint2;
-        attributePathParams3[2].mClusterId             = chip::Test::MockClusterId(2);
+        attributePathParams3[2].mEndpointId            = kMockEndpoint2;
+        attributePathParams3[2].mClusterId             = MockClusterId(2);
         attributePathParams3[2].mAttributeId           = kInvalidAttributeId;
         readPrepareParams.mpAttributePathParamsList    = attributePathParams3;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -1077,21 +1040,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 12);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 2));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint2, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_TRUE(version2.HasValue() && (version2.Value() == 2));
         Optional<DataVersion> version3;
-        app::ConcreteClusterPath clusterPath3(chip::Test::kMockEndpoint1, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath3(kMockEndpoint1, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath3, version3), CHIP_NO_ERROR);
         EXPECT_TRUE(version3.HasValue() && (version3.Value() == 2));
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint1, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint1, MockClusterId(2), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1100,8 +1062,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1110,8 +1071,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1120,8 +1080,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -1130,8 +1089,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1139,8 +1097,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
             EXPECT_EQ(receivedAttribute1, mockAttribute1);
         }
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1158,20 +1115,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
 
-        chip::app::AttributePathParams attributePathParams3[3];
-        attributePathParams3[0].mEndpointId  = chip::Test::kMockEndpoint1;
-        attributePathParams3[0].mClusterId   = chip::Test::MockClusterId(2);
+        AttributePathParams attributePathParams3[3];
+        attributePathParams3[0].mEndpointId  = kMockEndpoint1;
+        attributePathParams3[0].mClusterId   = MockClusterId(2);
         attributePathParams3[0].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams3[1].mEndpointId  = chip::Test::kMockEndpoint2;
-        attributePathParams3[1].mClusterId   = chip::Test::MockClusterId(3);
+        attributePathParams3[1].mEndpointId  = kMockEndpoint2;
+        attributePathParams3[1].mClusterId   = MockClusterId(3);
         attributePathParams3[1].mAttributeId = kInvalidAttributeId;
 
-        attributePathParams3[2].mEndpointId            = chip::Test::kMockEndpoint2;
-        attributePathParams3[2].mClusterId             = chip::Test::MockClusterId(2);
+        attributePathParams3[2].mEndpointId            = kMockEndpoint2;
+        attributePathParams3[2].mClusterId             = MockClusterId(2);
         attributePathParams3[2].mAttributeId           = kInvalidAttributeId;
         readPrepareParams.mpAttributePathParamsList    = attributePathParams3;
         readPrepareParams.mAttributePathParamsListSize = 3;
@@ -1188,21 +1145,20 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 7);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath1(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3));
+        ConcreteClusterPath clusterPath1(kMockEndpoint2, MockClusterId(3));
         EXPECT_EQ(cache.GetVersion(clusterPath1, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue() && (version1.Value() == 2));
         Optional<DataVersion> version2;
-        app::ConcreteClusterPath clusterPath2(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath2(kMockEndpoint2, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath2, version2), CHIP_NO_ERROR);
         EXPECT_TRUE(version2.HasValue() && (version2.Value() == 2));
         Optional<DataVersion> version3;
-        app::ConcreteClusterPath clusterPath3(chip::Test::kMockEndpoint1, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath3(kMockEndpoint1, MockClusterId(2));
         EXPECT_EQ(cache.GetVersion(clusterPath3, version3), CHIP_NO_ERROR);
         EXPECT_TRUE(version3.HasValue() && (version3.Value() == 2));
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint1, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint1, MockClusterId(2), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1211,8 +1167,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1221,8 +1176,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1231,8 +1185,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(3),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(3), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -1241,8 +1194,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1251,8 +1203,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint2, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint2, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1269,11 +1220,11 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
     {
         testId++;
         ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &GetExchangeManager(),
-                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
-        chip::app::AttributePathParams attributePathParams1[1];
-        attributePathParams1[0].mEndpointId = chip::Test::kMockEndpoint3;
-        attributePathParams1[0].mClusterId  = chip::Test::MockClusterId(2);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), cache.GetBufferedCallback(),
+                              ReadClient::InteractionType::Read);
+        AttributePathParams attributePathParams1[1];
+        attributePathParams1[0].mEndpointId = kMockEndpoint3;
+        attributePathParams1[0].mClusterId  = MockClusterId(2);
 
         readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams.mAttributePathParamsListSize = 1;
@@ -1284,14 +1235,13 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         EXPECT_EQ(delegate.mNumAttributeResponse, 6);
         EXPECT_FALSE(delegate.mReadError);
         Optional<DataVersion> version1;
-        app::ConcreteClusterPath clusterPath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2));
+        ConcreteClusterPath clusterPath(kMockEndpoint3, MockClusterId(2));
 
         EXPECT_EQ(cache.GetVersion(clusterPath, version1), CHIP_NO_ERROR);
         EXPECT_TRUE(version1.HasValue());
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(1));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(1));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             bool receivedAttribute1;
@@ -1300,8 +1250,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(2));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(2));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             int16_t receivedAttribute2;
@@ -1310,8 +1259,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(3));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(3));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint64_t receivedAttribute3;
@@ -1320,8 +1268,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         }
 
         {
-            app::ConcreteAttributePath attributePath(chip::Test::kMockEndpoint3, chip::Test::MockClusterId(2),
-                                                     chip::Test::MockAttributeId(4));
+            ConcreteAttributePath attributePath(kMockEndpoint3, MockClusterId(2), MockAttributeId(4));
             TLV::TLVReader reader;
             EXPECT_EQ(cache.Get(attributePath, reader), CHIP_NO_ERROR);
             uint8_t receivedAttribute4[256];
@@ -1331,7 +1278,7 @@ TEST_F(TestRead, TestReadSubscribeAttributeResponseWithCache)
         delegate.mNumAttributeResponse = 0;
     }
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -1342,18 +1289,16 @@ TEST_F(TestRead, TestReadEventResponse)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::EventHeader & eventHeader, const auto & EventResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const EventHeader & eventHeader, const auto & EventResponse) {
         // TODO: Need to add check when IM event server integration completes
         onSuccessCbInvoked = true;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::EventHeader * eventHeader, CHIP_ERROR aError) {
-        onFailureCbInvoked = true;
-    };
+    auto onFailureCb = [&onFailureCbInvoked](const EventHeader * eventHeader, CHIP_ERROR aError) { onFailureCbInvoked = true; };
 
-    auto onDoneCb = [&onDoneCbInvoked](app::ReadClient * apReadClient) { onDoneCbInvoked = true; };
+    auto onDoneCb = [&onDoneCbInvoked](ReadClient * apReadClient) { onDoneCbInvoked = true; };
 
     Controller::ReadEvent<Clusters::UnitTesting::Events::TestEvent::DecodableType>(
         &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, onDoneCb);
@@ -1363,8 +1308,8 @@ TEST_F(TestRead, TestReadEventResponse)
     EXPECT_FALSE(onFailureCbInvoked);
     EXPECT_TRUE(onDoneCbInvoked);
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -1377,14 +1322,14 @@ TEST_F(TestRead, TestReadAttributeError)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         onSuccessCbInvoked = true;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
-        EXPECT_TRUE(aError.IsIMStatus() && app::StatusIB(aError).mStatus == Protocols::InteractionModel::Status::Busy);
+    auto onFailureCb = [&onFailureCbInvoked](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+        EXPECT_TRUE(aError.IsIMStatus() && StatusIB(aError).mStatus == Protocols::InteractionModel::Status::Busy);
         onFailureCbInvoked = true;
     };
 
@@ -1394,8 +1339,8 @@ TEST_F(TestRead, TestReadAttributeError)
     DrainAndServiceIO();
 
     EXPECT_TRUE(!onSuccessCbInvoked && onFailureCbInvoked);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -1408,13 +1353,13 @@ TEST_F(TestRead, TestReadAttributeTimeout)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         onSuccessCbInvoked = true;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&onFailureCbInvoked](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         EXPECT_EQ(aError, CHIP_ERROR_TIMEOUT);
         onFailureCbInvoked = true;
     };
@@ -1436,7 +1381,7 @@ TEST_F(TestRead, TestReadAttributeTimeout)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
 
     //
     // Let's put back the sessions so that the next tests (which assume a valid initialized set of sessions)
@@ -1448,14 +1393,14 @@ TEST_F(TestRead, TestReadAttributeTimeout)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
-class TestResubscriptionCallback : public app::ReadClient::Callback
+class TestResubscriptionCallback : public ReadClient::Callback
 {
 public:
     TestResubscriptionCallback() {}
 
-    void SetReadClient(app::ReadClient * apReadClient) { mpReadClient = apReadClient; }
+    void SetReadClient(ReadClient * apReadClient) { mpReadClient = apReadClient; }
 
-    void OnDone(app::ReadClient *) override { mOnDone++; }
+    void OnDone(ReadClient *) override { mOnDone++; }
 
     void OnError(CHIP_ERROR aError) override
     {
@@ -1465,7 +1410,7 @@ public:
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablishedCount++; }
 
-    CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
+    CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
         mOnResubscriptionsAttempted++;
         mLastError = aTerminationCause;
@@ -1493,7 +1438,7 @@ public:
     int32_t mOnError                        = 0;
     CHIP_ERROR mLastError                   = CHIP_NO_ERROR;
     bool mScheduleLITResubscribeImmediately = false;
-    app::ReadClient * mpReadClient          = nullptr;
+    ReadClient * mpReadClient               = nullptr;
 };
 
 //
@@ -1508,24 +1453,24 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
 
     {
         TestResubscriptionCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
         callback.SetReadClient(&readClient);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
         // Read full wildcard paths, repeat twice to ensure chunking.
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kTestEndpointId;
-        attributePathParams[0].mClusterId              = app::Clusters::UnitTesting::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::UnitTesting::Attributes::Boolean::Id;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
 
         constexpr uint16_t maxIntervalCeilingSeconds = 1;
 
@@ -1543,7 +1488,7 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
         EXPECT_EQ(callback.mOnError, 0);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
 
-        chip::app::ReadHandler * readHandler = app::InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -1553,7 +1498,7 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
         // Disable packet transmission, and drive IO till we have reported a re-subscription attempt.
         //
         //
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)),
                                     [&]() { return callback.mOnResubscriptionsAttempted > 0; });
 
@@ -1577,9 +1522,9 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
         EXPECT_EQ(callback.mOnDone, 0);
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -1591,23 +1536,23 @@ TEST_F(TestRead, TestSubscribeAttributeTimeout)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
 
     {
         TestResubscriptionCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
         callback.SetReadClient(&readClient);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kTestEndpointId;
-        attributePathParams[0].mClusterId              = app::Clusters::UnitTesting::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::UnitTesting::Attributes::Boolean::Id;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
 
         //
         // Request a max interval that's very small to reduce time to discovering a liveness failure.
@@ -1628,9 +1573,9 @@ TEST_F(TestRead, TestSubscribeAttributeTimeout)
         //
         // Request we drop all further messages.
         //
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
 
-        chip::app::ReadHandler * readHandler = app::InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -1650,9 +1595,9 @@ TEST_F(TestRead, TestSubscribeAttributeTimeout)
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
     GetLoopback().mNumMessagesToDrop = 0;
 }
@@ -1667,30 +1612,30 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         //
         // We shouldn't be encountering any failures in this test.
         //
         EXPECT_TRUE(false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
     //
-    // Try to issue parallel subscriptions that will exceed the value for app::InteractionModelEngine::kReadHandlerPoolSize.
+    // Try to issue parallel subscriptions that will exceed the value for InteractionModelEngine::kReadHandlerPoolSize.
     // If heap allocation is correctly setup, this should result in it successfully servicing more than the number
     // present in that define.
     //
-    for (size_t i = 0; i < (app::InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
+    for (size_t i = 0; i < (InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
     {
         EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                       &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 0, 20,
@@ -1701,20 +1646,20 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions)
     // There are too many messages and the test (gcc_debug, which includes many sanity checks) will be quite slow. Note: report
     // engine is using ScheduleWork which cannot be handled by DrainAndServiceIO correctly.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(60), [&]() {
-        return numSuccessCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1) &&
-            numSubscriptionEstablishedCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1);
+        return numSuccessCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1) &&
+            numSubscriptionEstablishedCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1);
     });
 
-    EXPECT_EQ(numSuccessCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    EXPECT_EQ(numSubscriptionEstablishedCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(numSuccessCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(numSubscriptionEstablishedCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(InteractionModelEngine::kReadHandlerPoolSize + 1));
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 }
 
 TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
@@ -1728,17 +1673,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
@@ -1765,7 +1710,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionAppRejection)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 0u);
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
@@ -1787,17 +1732,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -1827,7 +1772,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest1)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -1848,17 +1793,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -1888,7 +1833,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest2)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -1909,17 +1854,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -1954,7 +1899,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest3)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -1977,17 +1922,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
@@ -2012,7 +1957,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest4)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 0u);
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2035,17 +1980,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -2075,7 +2020,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest5)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2096,17 +2041,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -2141,7 +2086,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest6)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2162,17 +2107,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         uint16_t minInterval = 0, maxInterval = 0;
 
@@ -2207,7 +2152,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest7)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 1u);
     EXPECT_EQ(mNumActiveSubscriptions, 1);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2230,17 +2175,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
@@ -2265,7 +2210,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest8)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 0u);
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2285,17 +2230,17 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
@@ -2313,7 +2258,7 @@ TEST_F(TestRead, TestReadHandler_SubscriptionReportingIntervalsTest9)
     EXPECT_EQ(numSubscriptionEstablishedCalls, 0u);
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
 
@@ -2328,25 +2273,25 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
 
     {
         TestResubscriptionCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
         callback.mScheduleLITResubscribeImmediately = false;
         callback.SetReadClient(&readClient);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
         // Read full wildcard paths, repeat twice to ensure chunking.
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kTestEndpointId;
-        attributePathParams[0].mClusterId              = app::Clusters::UnitTesting::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::UnitTesting::Attributes::Boolean::Id;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
 
         constexpr uint16_t maxIntervalCeilingSeconds = 1;
 
@@ -2364,7 +2309,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
         EXPECT_EQ(callback.mOnError, 0);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
-        chip::app::ReadHandler * readHandler = app::InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -2376,14 +2321,14 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         // WakeUp() is called.
         //
         //
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)), [&]() { return false; });
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT);
 
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
-        app::InteractionModelEngine::GetInstance()->OnActiveModeNotification(
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(
             ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
@@ -2402,9 +2347,9 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         EXPECT_EQ(callback.mOnDone, 0);
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -2416,27 +2361,27 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
     ScopedChange directive(gReadResponseDirective, ReadResponseDirective::kSendDataResponse);
     ScopedChange isLitIcd(gIsLitIcd, false);
 
     {
         TestResubscriptionCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
         callback.mScheduleLITResubscribeImmediately = false;
         callback.SetReadClient(&readClient);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
         // Read full wildcard paths, repeat twice to ensure chunking.
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kRootEndpointId;
-        attributePathParams[0].mClusterId              = app::Clusters::IcdManagement::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::IcdManagement::Attributes::OperatingMode::Id;
+        attributePathParams[0].mClusterId              = Clusters::IcdManagement::Id;
+        attributePathParams[0].mAttributeId            = Clusters::IcdManagement::Attributes::OperatingMode::Id;
 
         constexpr uint16_t maxIntervalCeilingSeconds = 1;
 
@@ -2454,7 +2399,7 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
         EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
         EXPECT_EQ(callback.mOnError, 0);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
-        chip::app::ReadHandler * readHandler = app::InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -2469,7 +2414,7 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
         //
         // Even if we set the peer type to LIT before, the report indicates that the peer is a SIT now, it will just bahve as
         // normal, non-LIT subscriptions.
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)),
                                     [&]() { return callback.mOnResubscriptionsAttempted != 0; });
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
@@ -2495,18 +2440,18 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 
         isLitIcd = true;
         {
-            app::AttributePathParams path;
+            AttributePathParams path;
             path.mEndpointId  = kRootEndpointId;
             path.mClusterId   = Clusters::IcdManagement::Id;
             path.mAttributeId = Clusters::IcdManagement::Attributes::OperatingMode::Id;
-            app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+            InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
         }
         callback.ClearCounters();
         GetIOContext().DriveIOUntil(System::Clock::Seconds16(60),
-                                    [&]() { return app::InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
+                                    [&]() { return InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
 
         // When we received the update that OperatingMode becomes LIT, we automatically set the inner peer type to LIT ICD.
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)), [&]() { return false; });
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT);
@@ -2515,9 +2460,9 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
         callback.ClearCounters();
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -2529,25 +2474,25 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
 
     {
         TestResubscriptionCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
         callback.mScheduleLITResubscribeImmediately = true;
         callback.SetReadClient(&readClient);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
         // Read full wildcard paths, repeat twice to ensure chunking.
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kTestEndpointId;
-        attributePathParams[0].mClusterId              = app::Clusters::UnitTesting::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::UnitTesting::Attributes::Boolean::Id;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
 
         constexpr uint16_t maxIntervalCeilingSeconds = 1;
 
@@ -2565,7 +2510,7 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
         EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
         EXPECT_EQ(callback.mOnError, 0);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
-        chip::app::ReadHandler * readHandler = app::InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -2577,7 +2522,7 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
         // WakeUp() is called.
         //
         //
-        GetLoopback().mNumMessagesToDrop = chip::Test::LoopbackTransport::kUnlimitedMessageCount;
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)),
                                     [&]() { return callback.mLastError == CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT; });
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
@@ -2600,27 +2545,27 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
         EXPECT_EQ(callback.mOnDone, 0);
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
 TEST_F(TestRead, TestReadHandler_MultipleReads)
 {
-    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= app::InteractionModelEngine::kReadHandlerPoolSize,
+    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= InteractionModelEngine::kReadHandlerPoolSize,
                   "How can we have more reports in flight than read handlers?");
 
     MultipleReadHelper(CHIP_IM_MAX_REPORTS_IN_FLIGHT);
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 }
 
 TEST_F(TestRead, TestReadHandler_OneSubscribeMultipleReads)
 {
-    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= app::InteractionModelEngine::kReadHandlerPoolSize,
+    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= InteractionModelEngine::kReadHandlerPoolSize,
                   "How can we have more reports in flight than read handlers?");
     static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT > 1, "We won't do any reads");
 
@@ -2628,12 +2573,12 @@ TEST_F(TestRead, TestReadHandler_OneSubscribeMultipleReads)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 }
 
 TEST_F(TestRead, TestReadHandler_TwoSubscribesMultipleReads)
 {
-    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= app::InteractionModelEngine::kReadHandlerPoolSize,
+    static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT <= InteractionModelEngine::kReadHandlerPoolSize,
                   "How can we have more reports in flight than read handlers?");
     static_assert(CHIP_IM_MAX_REPORTS_IN_FLIGHT > 2, "We won't do any reads");
 
@@ -2641,7 +2586,7 @@ TEST_F(TestRead, TestReadHandler_TwoSubscribesMultipleReads)
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 }
 
 void TestRead::SubscribeThenReadHelper(size_t aSubscribeCount, size_t aReadCount)
@@ -2657,13 +2602,13 @@ void TestRead::SubscribeThenReadHelper(size_t aSubscribeCount, size_t aReadCount
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         //
         // We shouldn't be encountering any failures in this test.
         //
@@ -2671,8 +2616,7 @@ void TestRead::SubscribeThenReadHelper(size_t aSubscribeCount, size_t aReadCount
     };
 
     auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, this, aSubscribeCount, aReadCount, &numReadSuccessCalls,
-                                        &numReadFailureCalls](const app::ReadClient & readClient,
-                                                              chip::SubscriptionId aSubscriptionId) {
+                                        &numReadFailureCalls](const ReadClient & readClient, chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
         if (numSubscriptionEstablishedCalls == aSubscribeCount)
         {
@@ -2709,7 +2653,7 @@ void TestRead::MultipleReadHelperInternal(size_t aReadCount, uint32_t & aNumSucc
 
     uint16_t firstExpectedResponse = gInt16uTotalReadCount + 1;
 
-    auto onFailureCb = [&aNumFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&aNumFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         aNumFailureCalls++;
 
         EXPECT_EQ(attributePath, nullptr);
@@ -2717,7 +2661,7 @@ void TestRead::MultipleReadHelperInternal(size_t aReadCount, uint32_t & aNumSucc
 
     for (size_t i = 0; i < aReadCount; ++i)
     {
-        auto onSuccessCb = [&aNumSuccessCalls, firstExpectedResponse, i](const app::ConcreteDataAttributePath & attributePath,
+        auto onSuccessCb = [&aNumSuccessCalls, firstExpectedResponse, i](const ConcreteDataAttributePath & attributePath,
                                                                          const auto & dataResponse) {
             EXPECT_EQ(dataResponse, firstExpectedResponse + i);
             aNumSuccessCalls++;
@@ -2752,32 +2696,32 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptionsWithDataVersionFilter)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         EXPECT_TRUE(attributePath.mDataVersion.HasValue() && attributePath.mDataVersion.Value() == kDataVersion);
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         //
         // We shouldn't be encountering any failures in this test.
         //
         EXPECT_TRUE(false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
     //
-    // Try to issue parallel subscriptions that will exceed the value for app::InteractionModelEngine::kReadHandlerPoolSize.
+    // Try to issue parallel subscriptions that will exceed the value for InteractionModelEngine::kReadHandlerPoolSize.
     // If heap allocation is correctly setup, this should result in it successfully servicing more than the number
     // present in that define.
     //
     chip::Optional<chip::DataVersion> dataVersion(1);
-    for (size_t i = 0; i < (app::InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
+    for (size_t i = 0; i < (InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
     {
         EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                       &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 0, 10,
@@ -2788,17 +2732,17 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptionsWithDataVersionFilter)
     // There are too many messages and the test (gcc_debug, which includes many sanity checks) will be quite slow. Note: report
     // engine is using ScheduleWork which cannot be handled by DrainAndServiceIO correctly.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(30), [&]() {
-        return numSubscriptionEstablishedCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1) &&
-            numSuccessCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1);
+        return numSubscriptionEstablishedCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1) &&
+            numSuccessCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1);
     });
 
     ChipLogError(Zcl, "Success call cnt: %" PRIu32 " (expect %" PRIu32 ") subscription cnt: %" PRIu32 " (expect %" PRIu32 ")",
-                 numSuccessCalls, uint32_t(app::InteractionModelEngine::kReadHandlerPoolSize + 1), numSubscriptionEstablishedCalls,
-                 uint32_t(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
+                 numSuccessCalls, uint32_t(InteractionModelEngine::kReadHandlerPoolSize + 1), numSubscriptionEstablishedCalls,
+                 uint32_t(InteractionModelEngine::kReadHandlerPoolSize + 1));
 
-    EXPECT_EQ(numSuccessCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    EXPECT_EQ(numSubscriptionEstablishedCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    EXPECT_EQ(numSuccessCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(numSubscriptionEstablishedCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
@@ -2806,7 +2750,7 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptionsWithDataVersionFilter)
 TEST_F(TestRead, TestReadHandler_DataVersionFiltersTruncated)
 {
     static TestRead * pContext = this;
-    struct : public chip::Test::LoopbackTransportDelegate
+    struct : public LoopbackTransportDelegate
     {
         size_t requestSize = 0;
         void WillSendMessage(const Transport::PeerAddress & peer, const System::PacketBufferHandle & message) override
@@ -2856,7 +2800,7 @@ TEST_F(TestRead, TestReadHandler_DataVersionFiltersTruncated)
 
         } readCallback;
 
-        ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), readCallback,
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), readCallback,
                               ReadClient::InteractionType::Read);
 
         EXPECT_EQ(readClient.SendRequest(read), CHIP_NO_ERROR);
@@ -2894,21 +2838,21 @@ TEST_F(TestRead, TestReadHandlerResourceExhaustion_MultipleReads)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&numFailureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         numFailureCalls++;
 
         EXPECT_EQ(aError, CHIP_IM_GLOBAL_STATUS(Busy));
         EXPECT_EQ(attributePath, nullptr);
     };
 
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(0);
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(0);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
 
     EXPECT_EQ(Controller::ReadAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                   &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb),
@@ -2916,9 +2860,9 @@ TEST_F(TestRead, TestReadHandlerResourceExhaustion_MultipleReads)
 
     DrainAndServiceIO();
 
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
 
     EXPECT_EQ(numSuccessCalls, 0u);
     EXPECT_EQ(numFailureCalls, 1u);
@@ -2945,7 +2889,7 @@ TEST_F(TestRead, TestReadFabricScopedWithoutFabricFilter)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         size_t len = 0;
 
         EXPECT_EQ(dataResponse.ComputeSize(&len), CHIP_NO_ERROR);
@@ -2956,7 +2900,7 @@ TEST_F(TestRead, TestReadFabricScopedWithoutFabricFilter)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&onFailureCbInvoked](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         onFailureCbInvoked = true;
     };
 
@@ -2966,8 +2910,8 @@ TEST_F(TestRead, TestReadFabricScopedWithoutFabricFilter)
     DrainAndServiceIO();
 
     EXPECT_TRUE(onSuccessCbInvoked && !onFailureCbInvoked);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -2990,7 +2934,7 @@ TEST_F(TestRead, TestReadFabricScopedWithFabricFilter)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&onSuccessCbInvoked](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&onSuccessCbInvoked](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         size_t len = 0;
 
         EXPECT_EQ(dataResponse.ComputeSize(&len), CHIP_NO_ERROR);
@@ -3010,7 +2954,7 @@ TEST_F(TestRead, TestReadFabricScopedWithFabricFilter)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&onFailureCbInvoked](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+    auto onFailureCb = [&onFailureCbInvoked](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
         onFailureCbInvoked = true;
     };
 
@@ -3020,18 +2964,17 @@ TEST_F(TestRead, TestReadFabricScopedWithFabricFilter)
     DrainAndServiceIO();
 
     EXPECT_TRUE(onSuccessCbInvoked && !onFailureCbInvoked);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
 namespace SubscriptionPathQuotaHelpers {
-class TestReadCallback : public app::ReadClient::Callback
+class TestReadCallback : public ReadClient::Callback
 {
 public:
     TestReadCallback() {}
-    void OnAttributeData(const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const app::StatusIB & aStatus) override
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override
     {
         if (apData != nullptr)
         {
@@ -3039,7 +2982,7 @@ public:
         }
     }
 
-    void OnDone(app::ReadClient *) override { mOnDone++; }
+    void OnDone(ReadClient *) override { mOnDone++; }
 
     void OnReportEnd() override { mOnReportEnd++; }
 
@@ -3069,41 +3012,40 @@ public:
     CHIP_ERROR mLastError                    = CHIP_NO_ERROR;
 };
 
-class TestPerpetualListReadCallback : public app::ReadClient::Callback
+class TestPerpetualListReadCallback : public ReadClient::Callback
 {
 public:
     TestPerpetualListReadCallback() {}
-    void OnAttributeData(const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
-                         const app::StatusIB & aStatus) override
+    void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override
     {
         if (apData != nullptr)
         {
             reportsReceived++;
-            app::AttributePathParams path;
+            AttributePathParams path;
             path.mEndpointId  = aPath.mEndpointId;
             path.mClusterId   = aPath.mClusterId;
             path.mAttributeId = aPath.mAttributeId;
-            app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+            InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
         }
     }
 
-    void OnDone(chip::app::ReadClient *) override {}
+    void OnDone(ReadClient *) override {}
 
     void ClearCounter() { reportsReceived = 0; }
 
     int32_t reportsReceived = 0;
 };
 
-void EstablishReadOrSubscriptions(const SessionHandle & sessionHandle, size_t numSubs, size_t pathPerSub,
-                                  app::AttributePathParams path, app::ReadClient::InteractionType type,
-                                  app::ReadClient::Callback * callback, std::vector<std::unique_ptr<app::ReadClient>> & readClients)
+void EstablishReadOrSubscriptions(const SessionHandle & sessionHandle, size_t numSubs, size_t pathPerSub, AttributePathParams path,
+                                  ReadClient::InteractionType type, ReadClient::Callback * callback,
+                                  std::vector<std::unique_ptr<ReadClient>> & readClients)
 {
-    std::vector<app::AttributePathParams> attributePaths(pathPerSub, path);
+    std::vector<AttributePathParams> attributePaths(pathPerSub, path);
 
-    app::ReadPrepareParams readParams(sessionHandle);
+    ReadPrepareParams readParams(sessionHandle);
     readParams.mpAttributePathParamsList    = attributePaths.data();
     readParams.mAttributePathParamsListSize = pathPerSub;
-    if (type == app::ReadClient::InteractionType::Subscribe)
+    if (type == ReadClient::InteractionType::Subscribe)
     {
         readParams.mMaxIntervalCeilingSeconds = 1;
         readParams.mKeepSubscriptions         = true;
@@ -3111,9 +3053,9 @@ void EstablishReadOrSubscriptions(const SessionHandle & sessionHandle, size_t nu
 
     for (uint32_t i = 0; i < numSubs; i++)
     {
-        std::unique_ptr<app::ReadClient> readClient =
-            std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                              app::InteractionModelEngine::GetInstance()->GetExchangeManager(), *callback, type);
+        std::unique_ptr<ReadClient> readClient =
+            std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
+                                              InteractionModelEngine::GetInstance()->GetExchangeManager(), *callback, type);
         EXPECT_EQ(readClient->SendRequest(readParams), CHIP_NO_ERROR);
         readClients.push_back(std::move(readClient));
     }
@@ -3125,21 +3067,21 @@ TEST_F(TestRead, TestSubscribeAttributeDeniedNotExistPath)
 {
     auto sessionHandle = GetSessionBobToAlice();
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kResponsive);
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
 
     {
         SubscriptionPathQuotaHelpers::TestReadCallback callback;
-        app::ReadClient readClient(app::InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
-                                   app::ReadClient::InteractionType::Subscribe);
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
 
-        app::ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
 
-        app::AttributePathParams attributePathParams[1];
+        AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
         attributePathParams[0].mEndpointId             = kRootEndpointId; // this cluster does NOT exist on the root endpoint
-        attributePathParams[0].mClusterId              = app::Clusters::UnitTesting::Id;
-        attributePathParams[0].mAttributeId            = app::Clusters::UnitTesting::Attributes::ListStructOctetString::Id;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::ListStructOctetString::Id;
 
         //
         // Request a max interval that's very small to reduce time to discovering a liveness failure.
@@ -3156,9 +3098,9 @@ TEST_F(TestRead, TestSubscribeAttributeDeniedNotExistPath)
         EXPECT_EQ(callback.mOnDone, 1u);
     }
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -3168,31 +3110,30 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
     using namespace SubscriptionPathQuotaHelpers;
     auto sessionHandle = GetSessionBobToAlice();
 
-    const auto kExpectedParallelSubs =
-        app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
-    const auto kExpectedParallelPaths = kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription;
+    const auto kExpectedParallelSubs = InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
+    const auto kExpectedParallelPaths = kExpectedParallelSubs * InteractionModelEngine::kMinSupportedPathsPerSubscription;
 
     // Here, we set up two background perpetual read requests to simulate parallel Read + Subscriptions.
     // We don't care about the data read, we only care about the existence of such read transactions.
     TestReadCallback readCallback;
     TestReadCallback readCallbackFabric2;
     TestPerpetualListReadCallback perpetualReadCallback;
-    std::vector<std::unique_ptr<app::ReadClient>> readClients;
+    std::vector<std::unique_ptr<ReadClient>> readClients;
 
     EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                 app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, kPerpetualAttributeid),
-                                 app::ReadClient::InteractionType::Read, &perpetualReadCallback, readClients);
+                                 AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, kPerpetualAttributeid),
+                                 ReadClient::InteractionType::Read, &perpetualReadCallback, readClients);
     EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                 app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, kPerpetualAttributeid),
-                                 app::ReadClient::InteractionType::Read, &perpetualReadCallback, readClients);
+                                 AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, kPerpetualAttributeid),
+                                 ReadClient::InteractionType::Read, &perpetualReadCallback, readClients);
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
-        return app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read) == 2;
+        return InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read) == 2;
     });
     // Ensure our read transactions are established.
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read), 2u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 2u);
 
     // Intentially establish subscriptions using exceeded resources.
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
     //
     // We establish 1 subscription that exceeds the minimum supported paths (but is still established since the
     // target has sufficient resources), and kExpectedParallelSubs subscriptions that conform to the minimum
@@ -3201,46 +3142,46 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
     //
     // Subscription A
     EstablishReadOrSubscriptions(
-        GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
-        app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-        app::ReadClient::InteractionType::Subscribe, &readCallback, readClients);
+        GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
+        AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+        ReadClient::InteractionType::Subscribe, &readCallback, readClients);
     // Subscription B
     EstablishReadOrSubscriptions(
-        GetSessionBobToAlice(), kExpectedParallelSubs, app::InteractionModelEngine::kMinSupportedPathsPerSubscription,
-        app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-        app::ReadClient::InteractionType::Subscribe, &readCallback, readClients);
+        GetSessionBobToAlice(), kExpectedParallelSubs, InteractionModelEngine::kMinSupportedPathsPerSubscription,
+        AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+        ReadClient::InteractionType::Subscribe, &readCallback, readClients);
 
     // There are too many messages and the test (gcc_debug, which includes many sanity checks) will be quite slow. Note: report
     // engine is using ScheduleWork which cannot be handled by DrainAndServiceIO correctly.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
         return readCallback.mOnSubscriptionEstablishedCount == kExpectedParallelSubs + 1 &&
             readCallback.mAttributeCount ==
-            kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription +
-                app::InteractionModelEngine::kMinSupportedPathsPerSubscription + 1;
+            kExpectedParallelSubs * InteractionModelEngine::kMinSupportedPathsPerSubscription +
+                InteractionModelEngine::kMinSupportedPathsPerSubscription + 1;
     });
 
     EXPECT_EQ(readCallback.mAttributeCount,
-              kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription +
-                  app::InteractionModelEngine::kMinSupportedPathsPerSubscription + 1);
+              kExpectedParallelSubs * InteractionModelEngine::kMinSupportedPathsPerSubscription +
+                  InteractionModelEngine::kMinSupportedPathsPerSubscription + 1);
     EXPECT_EQ(readCallback.mOnSubscriptionEstablishedCount, kExpectedParallelSubs + 1);
 
     // We have set up the environment for testing the evicting logic.
     // We now have a full stable of subscriptions setup AND we've artificially limited the capacity, creation of further
     // subscriptions will require the eviction of existing subscriptions, OR potential rejection of the subscription if it exceeds
     // minimas.
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelSubs));
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelPaths));
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelSubs));
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelPaths));
 
     // Part 1: Test per subscription minimas.
     // Rejection of the subscription that exceeds minimas.
     {
         TestReadCallback callback;
-        std::vector<std::unique_ptr<app::ReadClient>> outReadClient;
+        std::vector<std::unique_ptr<ReadClient>> outReadClient;
         EstablishReadOrSubscriptions(
-            GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
-            app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-            app::ReadClient::InteractionType::Subscribe, &callback, outReadClient);
+            GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
+            AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+            ReadClient::InteractionType::Subscribe, &callback, outReadClient);
 
         GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return callback.mOnError == 1; });
 
@@ -3253,39 +3194,39 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
     // was previously established with more paths than the limit per fabric)
     {
         EstablishReadOrSubscriptions(
-            GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerSubscription,
-            app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-            app::ReadClient::InteractionType::Subscribe, &readCallback, readClients);
+            GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerSubscription,
+            AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+            ReadClient::InteractionType::Subscribe, &readCallback, readClients);
 
         readCallback.ClearCounters();
         // Run until the new subscription got setup fully as viewed by the client.
         GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
             return readCallback.mOnSubscriptionEstablishedCount == 1 &&
-                readCallback.mAttributeCount == app::InteractionModelEngine::kMinSupportedPathsPerSubscription;
+                readCallback.mAttributeCount == InteractionModelEngine::kMinSupportedPathsPerSubscription;
         });
 
         // This read handler should evict some existing subscriptions for enough space.
         // Validate that the new subscription got setup fully as viewed by the client. And we will validate we handled this
         // subscription by evicting the correct subscriptions later.
         EXPECT_EQ(readCallback.mOnSubscriptionEstablishedCount, 1u);
-        EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerSubscription);
+        EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerSubscription);
     }
 
     // Validate we evicted the right subscription for handling the new subscription above.
     // We should used **exactly** all resources for subscriptions if we have evicted the correct subscription, and we validate the
     // number of used paths by mark all subscriptions as dirty, and count the number of received reports.
     {
-        app::AttributePathParams path;
+        AttributePathParams path;
         path.mEndpointId  = kTestEndpointId;
         path.mClusterId   = Clusters::UnitTesting::Id;
         path.mAttributeId = Clusters::UnitTesting::Attributes::Int16u::Id;
-        app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+        InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
     }
     readCallback.ClearCounters();
 
     // Run until all subscriptions are clean.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(60),
-                                [&]() { return app::InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
+                                [&]() { return InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
 
     // Before the above subscription, we have one subscription with kMinSupportedPathsPerSubscription + 1 paths, we should evict
     // that subscription before evicting any other subscriptions, which will result we used exactly kExpectedParallelPaths and have
@@ -3294,82 +3235,81 @@ TEST_F(TestRead, TestReadHandler_KillOverQuotaSubscriptions)
     // will have exactly kExpectedParallelPaths only when that subscription have been evicted. We use this indirect method to verify
     // the subscriptions since the read client won't shutdown until the timeout fired.
     EXPECT_EQ(readCallback.mAttributeCount, kExpectedParallelPaths);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Subscribe),
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe),
               static_cast<uint32_t>(kExpectedParallelSubs));
 
     // Part 2: Testing per fabric minimas.
     // Validate we have more than kMinSupportedSubscriptionsPerFabric subscriptions for testing per fabric minimas.
-    EXPECT_GT(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Subscribe,
+    EXPECT_GT(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
                                                                                    GetAliceFabricIndex()),
-              app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+              InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
 
     // The following check will trigger the logic in im to kill the read handlers that use more paths than the limit per fabric.
     {
         EstablishReadOrSubscriptions(
-            GetSessionAliceToBob(), app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric,
-            app::InteractionModelEngine::kMinSupportedPathsPerSubscription,
-            app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-            app::ReadClient::InteractionType::Subscribe, &readCallbackFabric2, readClients);
+            GetSessionAliceToBob(), InteractionModelEngine::kMinSupportedSubscriptionsPerFabric,
+            InteractionModelEngine::kMinSupportedPathsPerSubscription,
+            AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+            ReadClient::InteractionType::Subscribe, &readCallbackFabric2, readClients);
 
         // Run until we have established the subscriptions.
         GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
             return readCallbackFabric2.mOnSubscriptionEstablishedCount ==
-                app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric &&
+                InteractionModelEngine::kMinSupportedSubscriptionsPerFabric &&
                 readCallbackFabric2.mAttributeCount ==
-                app::InteractionModelEngine::kMinSupportedPathsPerSubscription *
-                    app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric;
+                InteractionModelEngine::kMinSupportedPathsPerSubscription *
+                    InteractionModelEngine::kMinSupportedSubscriptionsPerFabric;
         });
 
         // Verify the subscriptions are established successfully. We will check if we evicted the expected subscriptions later.
-        EXPECT_EQ(readCallbackFabric2.mOnSubscriptionEstablishedCount,
-                  app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+        EXPECT_EQ(readCallbackFabric2.mOnSubscriptionEstablishedCount, InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
         EXPECT_EQ(readCallbackFabric2.mAttributeCount,
-                  app::InteractionModelEngine::kMinSupportedPathsPerSubscription *
-                      app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+                  InteractionModelEngine::kMinSupportedPathsPerSubscription *
+                      InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
     }
 
     // Validate the subscriptions are handled by evicting one or more subscriptions from Fabric A.
     {
-        app::AttributePathParams path;
+        AttributePathParams path;
         path.mEndpointId  = kTestEndpointId;
         path.mClusterId   = Clusters::UnitTesting::Id;
         path.mAttributeId = Clusters::UnitTesting::Attributes::Int16u::Id;
-        app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+        InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
     }
     readCallback.ClearCounters();
     readCallbackFabric2.ClearCounters();
 
     // Run until all subscriptions are clean.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(60),
-                                [&]() { return app::InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
+                                [&]() { return InteractionModelEngine::GetInstance()->GetNumDirtySubscriptions() == 0; });
 
     // Some subscriptions on fabric 1 should be evicted since fabric 1 is using more resources than the limits.
     EXPECT_EQ(readCallback.mAttributeCount,
-              app::InteractionModelEngine::kMinSupportedPathsPerSubscription *
-                  app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+              InteractionModelEngine::kMinSupportedPathsPerSubscription *
+                  InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
     EXPECT_EQ(readCallbackFabric2.mAttributeCount,
-              app::InteractionModelEngine::kMinSupportedPathsPerSubscription *
-                  app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Subscribe,
+              InteractionModelEngine::kMinSupportedPathsPerSubscription *
+                  InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
                                                                                    GetAliceFabricIndex()),
-              app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Subscribe,
+              InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe,
                                                                                    GetBobFabricIndex()),
-              app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
+              InteractionModelEngine::kMinSupportedSubscriptionsPerFabric);
 
     // Ensure our read transactions are still alive.
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read), 2u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read), 2u);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     DrainAndServiceIO();
 
     // Shutdown all clients
     readClients.clear();
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(-1);
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(-1);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(-1);
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(-1);
 }
 
 TEST_F(TestRead, TestReadHandler_KillOldestSubscriptions)
@@ -3377,37 +3317,36 @@ TEST_F(TestRead, TestReadHandler_KillOldestSubscriptions)
     using namespace SubscriptionPathQuotaHelpers;
     auto sessionHandle = GetSessionBobToAlice();
 
-    const auto kExpectedParallelSubs =
-        app::InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
-    const auto kExpectedParallelPaths = kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription;
+    const auto kExpectedParallelSubs = InteractionModelEngine::kMinSupportedSubscriptionsPerFabric * GetFabricTable().FabricCount();
+    const auto kExpectedParallelPaths = kExpectedParallelSubs * InteractionModelEngine::kMinSupportedPathsPerSubscription;
 
     TestReadCallback readCallback;
-    std::vector<std::unique_ptr<app::ReadClient>> readClients;
+    std::vector<std::unique_ptr<ReadClient>> readClients;
 
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelSubs));
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelPaths));
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelSubs));
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(static_cast<int32_t>(kExpectedParallelPaths));
 
     // This should just use all availbale resources.
     EstablishReadOrSubscriptions(
-        GetSessionBobToAlice(), kExpectedParallelSubs, app::InteractionModelEngine::kMinSupportedPathsPerSubscription,
-        app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-        app::ReadClient::InteractionType::Subscribe, &readCallback, readClients);
+        GetSessionBobToAlice(), kExpectedParallelSubs, InteractionModelEngine::kMinSupportedPathsPerSubscription,
+        AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+        ReadClient::InteractionType::Subscribe, &readCallback, readClients);
 
     DrainAndServiceIO();
 
-    EXPECT_EQ(readCallback.mAttributeCount, kExpectedParallelSubs * app::InteractionModelEngine::kMinSupportedPathsPerSubscription);
+    EXPECT_EQ(readCallback.mAttributeCount, kExpectedParallelSubs * InteractionModelEngine::kMinSupportedPathsPerSubscription);
     EXPECT_EQ(readCallback.mOnSubscriptionEstablishedCount, kExpectedParallelSubs);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), kExpectedParallelSubs);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), kExpectedParallelSubs);
 
     // The following check will trigger the logic in im to kill the read handlers that uses more paths than the limit per fabric.
     {
         TestReadCallback callback;
-        std::vector<std::unique_ptr<app::ReadClient>> outReadClient;
+        std::vector<std::unique_ptr<ReadClient>> outReadClient;
         EstablishReadOrSubscriptions(
-            GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
-            app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-            app::ReadClient::InteractionType::Subscribe, &callback, outReadClient);
+            GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerSubscription + 1,
+            AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+            ReadClient::InteractionType::Subscribe, &callback, outReadClient);
 
         DrainAndServiceIO();
 
@@ -3419,42 +3358,42 @@ TEST_F(TestRead, TestReadHandler_KillOldestSubscriptions)
     // The following check will trigger the logic in im to kill the read handlers that uses more paths than the limit per fabric.
     {
         EstablishReadOrSubscriptions(
-            GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerSubscription,
-            app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-            app::ReadClient::InteractionType::Subscribe, &readCallback, readClients);
+            GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerSubscription,
+            AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+            ReadClient::InteractionType::Subscribe, &readCallback, readClients);
         readCallback.ClearCounters();
 
         DrainAndServiceIO();
 
         // This read handler should evict some existing subscriptions for enough space
         EXPECT_EQ(readCallback.mOnSubscriptionEstablishedCount, 1u);
-        EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerSubscription);
-        EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(),
+        EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerSubscription);
+        EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(),
                   static_cast<size_t>(kExpectedParallelSubs));
     }
 
     {
-        app::AttributePathParams path;
+        AttributePathParams path;
         path.mEndpointId  = kTestEndpointId;
         path.mClusterId   = Clusters::UnitTesting::Id;
         path.mAttributeId = Clusters::UnitTesting::Attributes::Int16u::Id;
-        app::InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
+        InteractionModelEngine::GetInstance()->GetReportingEngine().SetDirty(path);
     }
     readCallback.ClearCounters();
     DrainAndServiceIO();
 
     EXPECT_LE(readCallback.mAttributeCount, kExpectedParallelPaths);
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     DrainAndServiceIO();
 
     // Shutdown all clients
     readClients.clear();
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(-1);
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(-1);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForSubscriptions(-1);
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForSubscriptions(-1);
 }
 
 struct TestReadHandler_ParallelReads_TestCase_Parameters
@@ -3468,24 +3407,24 @@ static void TestReadHandler_ParallelReads_TestCase(TestRead * apContext,
                                                    const TestReadHandler_ParallelReads_TestCase_Parameters & params,
                                                    std::function<void()> body)
 {
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(params.ReadHandlerCapacity);
-    app::InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(params.MaxFabrics);
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(params.PathPoolCapacity);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(true);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(params.ReadHandlerCapacity);
+    InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(params.MaxFabrics);
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(params.PathPoolCapacity);
 
     body();
 
     // Clean up
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     apContext->DrainAndServiceIO();
 
     // Sanity check
     EXPECT_EQ(apContext->GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
-    app::InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(-1);
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(-1);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
+    InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(-1);
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(-1);
 }
 
 TEST_F(TestRead, TestReadHandler_ParallelReads)
@@ -3507,21 +3446,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
@@ -3532,9 +3471,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             backgroundReadCallback2.ClearCounter();
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
@@ -3550,21 +3489,19 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
@@ -3575,9 +3512,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             backgroundReadCallback2.ClearCounter();
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
@@ -3592,21 +3529,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
@@ -3614,14 +3551,14 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_TRUE(backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1);
             EXPECT_EQ(readCallback.mOnError, 0u);
 
             // The two subscriptions should still alive
@@ -3637,21 +3574,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
@@ -3663,8 +3600,8 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             EstablishReadOrSubscriptions(
                 GetSessionAliceToBob(), 1, 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
@@ -3686,43 +3623,41 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback readCallbackForOversizedRead;
             TestPerpetualListReadCallback backgroundReadCallback;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5),
                                         [&]() { return readCallbackForOversizedRead.reportsReceived > 0; });
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback.reportsReceived > 0; });
 
             EXPECT_TRUE(readCallbackForOversizedRead.reportsReceived > 0 && backgroundReadCallback.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // The oversized read handler should be evicted -> We should have one active read handler.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
 
             backgroundReadCallback.ClearCounter();
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback.reportsReceived > 0; });
@@ -3740,43 +3675,41 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback readCallbackForOversizedRead;
             TestPerpetualListReadCallback backgroundReadCallback;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback.reportsReceived > 0; });
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5),
                                         [&]() { return readCallbackForOversizedRead.reportsReceived > 0; });
 
             EXPECT_TRUE(readCallbackForOversizedRead.reportsReceived > 0 && backgroundReadCallback.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // The oversized read handler should be evicted -> We should have one active read handler.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
 
             backgroundReadCallback.ClearCounter();
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback.reportsReceived > 0; });
@@ -3796,22 +3729,20 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback readCallbackForOversizedRead;
             TestPerpetualListReadCallback backgroundReadCallback;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &readCallbackForOversizedRead, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback.reportsReceived > 0 && readCallbackForOversizedRead.reportsReceived > 0;
             });
@@ -3819,9 +3750,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_TRUE(readCallbackForOversizedRead.reportsReceived > 0 && backgroundReadCallback.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
@@ -3844,23 +3775,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback1.reportsReceived > 0; });
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback2.reportsReceived > 0; });
             EXPECT_TRUE(backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0);
 
@@ -3868,21 +3797,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             backgroundReadCallback2.ClearCounter();
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be rejected.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // One of the read requests from Bob to Alice should be evicted.
             // We should have only one 1 active read handler, since the transaction from Alice to Bob has finished already, and one
             // of two Bob to Alice transactions has been evicted.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
 
             // Note: Younger read handler will be evicted.
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback1.reportsReceived > 0; });
@@ -3894,24 +3823,22 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback1.reportsReceived > 0; });
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback2.reportsReceived > 0; });
             EXPECT_TRUE(backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0);
 
@@ -3919,21 +3846,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             backgroundReadCallback2.ClearCounter();
 
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be rejected.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // One of the read requests from Bob to Alice should be evicted.
             // We should have only one 1 active read handler, since the transaction from Alice to Bob has finished already, and one
             // of two Bob to Alice transactions has been evicted.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
 
             // Note: Larger read handler will be evicted before evicting the younger one.
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return backgroundReadCallback2.reportsReceived > 0; });
@@ -3947,7 +3874,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 3,
         },
         [&]() {
@@ -3955,17 +3882,14 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
             TestPerpetualListReadCallback backgroundReadCallback3;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0 &&
@@ -3975,21 +3899,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
                         backgroundReadCallback3.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionCharlieToDavid(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict one read request from Bob fabric for enough resources.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetAliceFabricIndex()),
                       1u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetBobFabricIndex()),
                       1u);
         });
@@ -4001,7 +3925,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 3,
         },
         [&]() {
@@ -4009,17 +3933,14 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
             TestPerpetualListReadCallback backgroundReadCallback3;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0 &&
@@ -4029,21 +3950,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
                         backgroundReadCallback3.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionCharlieToDavid(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict one read request from Bob fabric for enough resources.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetAliceFabricIndex()),
                       1u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetBobFabricIndex()),
                       1u);
         });
@@ -4053,7 +3974,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
@@ -4061,17 +3982,17 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
             TestPerpetualListReadCallback backgroundReadCallback3;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback3, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0 &&
@@ -4081,9 +4002,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
                         backgroundReadCallback3.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionCharlieToDavid(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
@@ -4091,10 +4012,10 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mOnError, 1u);
             EXPECT_EQ(readCallback.mLastError, CHIP_IM_GLOBAL_STATUS(Busy));
             // Should evict one read request from Bob fabric for enough resources.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetAliceFabricIndex()),
                       2u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetBobFabricIndex()),
                       1u);
         });
@@ -4104,21 +4025,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
@@ -4126,21 +4047,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_TRUE(backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionCharlieToDavid(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
 
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // No read transactions should be evicted.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetAliceFabricIndex()),
                       1u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            GetBobFabricIndex()),
                       1u);
         });
@@ -4150,40 +4071,39 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
             EstablishReadOrSubscriptions(GetSessionCharlieToDavid(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
             });
             EXPECT_TRUE(backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0);
 
             EstablishReadOrSubscriptions(
-                GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
             // Should evict the read request on PASE session for enough resources.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read),
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
                       1u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       0u);
         });
@@ -4194,22 +4114,21 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 2,
-            .PathPoolCapacity    = 2 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 2 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
             TestReadCallback readCallback;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
             EstablishReadOrSubscriptions(GetSessionCharlieToDavid(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallback1.reportsReceived > 0 && backgroundReadCallback2.reportsReceived > 0;
             });
@@ -4217,8 +4136,8 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             EstablishReadOrSubscriptions(
                 GetSessionBobToAlice(), 1, 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
@@ -4226,9 +4145,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             EXPECT_EQ(readCallback.mOnDone, 1u);
             EXPECT_EQ(readCallback.mAttributeCount, 1u);
             // Should evict the read request on PASE session for enough resources.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read),
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
                       1u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       0u);
         });
@@ -4238,7 +4157,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 3,
-            .PathPoolCapacity    = 3 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 3 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 3,
         },
         [&]() {
@@ -4246,17 +4165,15 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallbackForPASESession;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 1, 1, app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                app::ReadClient::InteractionType::Read, &backgroundReadCallbackForPASESession, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionCharlieToDavid(), 1, 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallbackForPASESession, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, 1, AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallbackForPASESession.reportsReceived > 0 && backgroundReadCallback1.reportsReceived > 0 &&
                     backgroundReadCallback2.reportsReceived > 0;
@@ -4266,8 +4183,8 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             EstablishReadOrSubscriptions(
                 GetSessionBobToAlice(), 1, 1,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
@@ -4277,9 +4194,9 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
 
             // The read handler on PASE session should not be evicted since the resources used by all PASE sessions are not
             // exceeding the resources guaranteed to a normal fabric.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read),
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
                       2u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       1u);
         });
@@ -4290,7 +4207,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 6,
-            .PathPoolCapacity    = 6 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 6 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 3,
         },
         [&]() {
@@ -4298,42 +4215,40 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallbackForPASESession;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 3, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest - 1,
-                app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1), app::ReadClient::InteractionType::Read,
-                &backgroundReadCallbackForPASESession, readClients);
-            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 3,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionCharlieToDavid(), 3,
+                                         InteractionModelEngine::kMinSupportedPathsPerReadRequest - 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallbackForPASESession, readClients);
+            EstablishReadOrSubscriptions(GetSessionBobToAlice(), 3, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
-                return app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(
-                           app::ReadHandler::InteractionType::Read) == 6;
+                return InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read) == 6;
             });
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       3u);
 
             // We have to evict one read transaction on PASE session and one read transaction on Alice's fabric.
             EstablishReadOrSubscriptions(
-                GetSessionAliceToBob(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // No more than one read handler on PASE session should be evicted exceeding the resources guaranteed to a normal
             // fabric. Note: We are using ">=" here since it is also acceptable if we choose to evict one read transaction from
             // Alice fabric.
-            EXPECT_GE(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read),
+            EXPECT_GE(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
                       4u);
-            EXPECT_GE(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_GE(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       2u);
         });
@@ -4343,7 +4258,7 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
     TestCase(
         Params{
             .ReadHandlerCapacity = 4,
-            .PathPoolCapacity    = 4 * app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+            .PathPoolCapacity    = 4 * InteractionModelEngine::kMinSupportedPathsPerReadRequest,
             .MaxFabrics          = 2,
         },
         [&]() {
@@ -4351,60 +4266,58 @@ TEST_F(TestRead, TestReadHandler_ParallelReads)
             TestPerpetualListReadCallback backgroundReadCallbackForPASESession;
             TestPerpetualListReadCallback backgroundReadCallback1;
             TestPerpetualListReadCallback backgroundReadCallback2;
-            std::vector<std::unique_ptr<app::ReadClient>> readClients;
+            std::vector<std::unique_ptr<ReadClient>> readClients;
 
-            EstablishReadOrSubscriptions(
-                GetSessionCharlieToDavid(), 2, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest - 1,
-                app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1), app::ReadClient::InteractionType::Read,
-                &backgroundReadCallbackForPASESession, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
-            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1,
-                                         app::InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
-                                         app::AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
-                                         app::ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
+            EstablishReadOrSubscriptions(GetSessionCharlieToDavid(), 2,
+                                         InteractionModelEngine::kMinSupportedPathsPerReadRequest - 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallbackForPASESession, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback1, readClients);
+            EstablishReadOrSubscriptions(GetSessionAliceToBob(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest + 1,
+                                         AttributePathParams(kTestEndpointId, kPerpetualClusterId, 1),
+                                         ReadClient::InteractionType::Read, &backgroundReadCallback2, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() {
                 return backgroundReadCallbackForPASESession.reportsReceived > 0 && backgroundReadCallback1.reportsReceived > 0 &&
                     backgroundReadCallback2.reportsReceived > 0 &&
-                    app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
-                                                                                         kUndefinedFabricIndex) == 2;
+                    InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
+                                                                                    kUndefinedFabricIndex) == 2;
             });
             EXPECT_TRUE(backgroundReadCallbackForPASESession.reportsReceived > 0 && backgroundReadCallback1.reportsReceived > 0 &&
                         backgroundReadCallback2.reportsReceived > 0 &&
-                        app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(
-                            app::ReadHandler::InteractionType::Read, kUndefinedFabricIndex) == 2);
+                        InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
+                                                                                        kUndefinedFabricIndex) == 2);
 
             // To handle this read request, we must evict both read transactions from the PASE session.
             EstablishReadOrSubscriptions(
-                GetSessionBobToAlice(), 1, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest,
-                app::AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
-                app::ReadClient::InteractionType::Read, &readCallback, readClients);
+                GetSessionBobToAlice(), 1, InteractionModelEngine::kMinSupportedPathsPerReadRequest,
+                AttributePathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id),
+                ReadClient::InteractionType::Read, &readCallback, readClients);
             GetIOContext().DriveIOUntil(System::Clock::Seconds16(5), [&]() { return readCallback.mOnDone != 0; });
 
             // The new read request should be accepted.
             EXPECT_EQ(readCallback.mOnError, 0u);
             EXPECT_EQ(readCallback.mOnDone, 1u);
-            EXPECT_EQ(readCallback.mAttributeCount, app::InteractionModelEngine::kMinSupportedPathsPerReadRequest);
+            EXPECT_EQ(readCallback.mAttributeCount, InteractionModelEngine::kMinSupportedPathsPerReadRequest);
 
             // The read handler on PASE session should be evicted, and the read transactions on a normal fabric should be untouched
             // although it is oversized.
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read),
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read),
                       2u);
-            EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(app::ReadHandler::InteractionType::Read,
+            EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(ReadHandler::InteractionType::Read,
                                                                                            kUndefinedFabricIndex),
                       0u);
         });
 
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     DrainAndServiceIO();
 
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
-    app::InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
-    app::InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(-1);
-    app::InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
-    app::InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(-1);
+    InteractionModelEngine::GetInstance()->SetForceHandlerQuota(false);
+    InteractionModelEngine::GetInstance()->SetConfigMaxFabrics(-1);
+    InteractionModelEngine::GetInstance()->SetHandlerCapacityForReads(-1);
+    InteractionModelEngine::GetInstance()->SetPathPoolCapacityForReads(-1);
 }
 
 // Needs to be larger than our plausible path pool.
@@ -4412,8 +4325,6 @@ constexpr size_t sTooLargePathCount = 200;
 
 TEST_F(TestRead, TestReadHandler_TooManyPaths)
 {
-    using namespace chip::app;
-
     chip::Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
     // Shouldn't have anything in the retransmit table when starting the test.
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
@@ -4423,7 +4334,7 @@ TEST_F(TestRead, TestReadHandler_TooManyPaths)
 
     ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
     // Needs to be larger than our plausible path pool.
-    chip::app::AttributePathParams attributePathParams[sTooLargePathCount];
+    AttributePathParams attributePathParams[sTooLargePathCount];
     readPrepareParams.mpAttributePathParamsList    = attributePathParams;
     readPrepareParams.mAttributePathParamsListSize = ArraySize(attributePathParams);
 
@@ -4453,8 +4364,6 @@ TEST_F(TestRead, TestReadHandler_TooManyPaths)
 
 TEST_F(TestRead, TestReadHandler_TwoParallelReadsSecondTooManyPaths)
 {
-    using namespace chip::app;
-
     chip::Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
     // Shouldn't have anything in the retransmit table when starting the test.
     EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
@@ -4477,7 +4386,7 @@ TEST_F(TestRead, TestReadHandler_TwoParallelReadsSecondTooManyPaths)
 
         ReadPrepareParams readPrepareParams1(GetSessionBobToAlice());
         // Read full wildcard paths, repeat twice to ensure chunking.
-        chip::app::AttributePathParams attributePathParams1[2];
+        AttributePathParams attributePathParams1[2];
         readPrepareParams1.mpAttributePathParamsList    = attributePathParams1;
         readPrepareParams1.mAttributePathParamsListSize = ArraySize(attributePathParams1);
 
@@ -4486,7 +4395,7 @@ TEST_F(TestRead, TestReadHandler_TwoParallelReadsSecondTooManyPaths)
 
         ReadPrepareParams readPrepareParams2(GetSessionBobToAlice());
         // Read full wildcard paths, repeat twice to ensure chunking.
-        chip::app::AttributePathParams attributePathParams2[sTooLargePathCount];
+        AttributePathParams attributePathParams2[sTooLargePathCount];
         readPrepareParams2.mpAttributePathParamsList    = attributePathParams2;
         readPrepareParams2.mAttributePathParamsListSize = ArraySize(attributePathParams2);
 
@@ -4520,25 +4429,25 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions_OnFabricRemoved)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&numSuccessCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&numSuccessCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         numSuccessCalls++;
     };
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {};
+    auto onFailureCb = [](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {};
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const app::ReadClient & readClient,
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls](const ReadClient & readClient,
                                                                           chip::SubscriptionId aSubscriptionId) {
         numSubscriptionEstablishedCalls++;
     };
 
     //
-    // Try to issue parallel subscriptions that will exceed the value for app::InteractionModelEngine::kReadHandlerPoolSize.
+    // Try to issue parallel subscriptions that will exceed the value for InteractionModelEngine::kReadHandlerPoolSize.
     // If heap allocation is correctly setup, this should result in it successfully servicing more than the number
     // present in that define.
     //
-    for (size_t i = 0; i < (app::InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
+    for (size_t i = 0; i < (InteractionModelEngine::kReadHandlerPoolSize + 1); i++)
     {
         EXPECT_EQ(Controller::SubscribeAttribute<Clusters::UnitTesting::Attributes::ListStructOctetString::TypeInfo>(
                       &GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb, 0, 20,
@@ -4549,22 +4458,22 @@ TEST_F(TestRead, TestReadHandler_MultipleSubscriptions_OnFabricRemoved)
     // There are too many messages and the test (gcc_debug, which includes many sanity checks) will be quite slow. Note: report
     // engine is using ScheduleWork which cannot be handled by DrainAndServiceIO correctly.
     GetIOContext().DriveIOUntil(System::Clock::Seconds16(60), [&]() {
-        return numSuccessCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1) &&
-            numSubscriptionEstablishedCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1);
+        return numSuccessCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1) &&
+            numSubscriptionEstablishedCalls == (InteractionModelEngine::kReadHandlerPoolSize + 1);
     });
 
-    EXPECT_EQ(numSuccessCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    EXPECT_EQ(numSubscriptionEstablishedCalls, (app::InteractionModelEngine::kReadHandlerPoolSize + 1));
-    EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(numSuccessCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(numSubscriptionEstablishedCalls, (InteractionModelEngine::kReadHandlerPoolSize + 1));
+    EXPECT_EQ(mNumActiveSubscriptions, static_cast<int32_t>(InteractionModelEngine::kReadHandlerPoolSize + 1));
 
     GetFabricTable().DeleteAllFabrics();
 
     EXPECT_EQ(mNumActiveSubscriptions, 0);
-    size_t numActiveReadClients = app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients();
+    size_t numActiveReadClients = InteractionModelEngine::GetInstance()->GetNumActiveReadClients();
     EXPECT_EQ(numActiveReadClients, 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
-    SetMRPMode(chip::Test::MessagingContext::MRPMode::kDefault);
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
 }
 
 TEST_F(TestRead, TestReadAttribute_ManyDataValues)
@@ -4577,7 +4486,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValues)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&successCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&successCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         EXPECT_TRUE(attributePath.mDataVersion.HasValue() && attributePath.mDataVersion.Value() == kDataVersion);
 
         EXPECT_TRUE(dataResponse);
@@ -4586,7 +4495,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValues)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&failureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
+    auto onFailureCb = [&failureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
 
     Controller::ReadAttribute<Clusters::UnitTesting::Attributes::Boolean::TypeInfo>(&GetExchangeManager(), sessionHandle,
                                                                                     kTestEndpointId, onSuccessCb, onFailureCb);
@@ -4595,8 +4504,8 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValues)
 
     EXPECT_EQ(successCalls, 1u);
     EXPECT_EQ(failureCalls, 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -4610,7 +4519,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValuesWrongPath)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&successCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&successCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         EXPECT_TRUE(attributePath.mDataVersion.HasValue() && attributePath.mDataVersion.Value() == kDataVersion);
 
         EXPECT_TRUE(dataResponse);
@@ -4619,7 +4528,7 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValuesWrongPath)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&failureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
+    auto onFailureCb = [&failureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
 
     Controller::ReadAttribute<Clusters::UnitTesting::Attributes::Boolean::TypeInfo>(&GetExchangeManager(), sessionHandle,
                                                                                     kTestEndpointId, onSuccessCb, onFailureCb);
@@ -4628,8 +4537,8 @@ TEST_F(TestRead, TestReadAttribute_ManyDataValuesWrongPath)
 
     EXPECT_EQ(successCalls, 0u);
     EXPECT_EQ(failureCalls, 1u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -4643,7 +4552,7 @@ TEST_F(TestRead, TestReadAttribute_ManyErrors)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onSuccessCb = [&successCalls](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
+    auto onSuccessCb = [&successCalls](const ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
         EXPECT_TRUE(attributePath.mDataVersion.HasValue() && attributePath.mDataVersion.Value() == kDataVersion);
 
         EXPECT_TRUE(dataResponse);
@@ -4652,7 +4561,7 @@ TEST_F(TestRead, TestReadAttribute_ManyErrors)
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
     // not safe to do so.
-    auto onFailureCb = [&failureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
+    auto onFailureCb = [&failureCalls](const ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
 
     Controller::ReadAttribute<Clusters::UnitTesting::Attributes::Boolean::TypeInfo>(&GetExchangeManager(), sessionHandle,
                                                                                     kTestEndpointId, onSuccessCb, onFailureCb);
@@ -4661,8 +4570,8 @@ TEST_F(TestRead, TestReadAttribute_ManyErrors)
 
     EXPECT_EQ(successCalls, 0u);
     EXPECT_EQ(failureCalls, 1u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadClients(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
@@ -4677,36 +4586,36 @@ TEST_F(TestRead, TestReadHandler_KeepSubscriptionTest)
     using namespace SubscriptionPathQuotaHelpers;
 
     TestReadCallback readCallback;
-    app::AttributePathParams pathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id);
+    AttributePathParams pathParams(kTestEndpointId, Clusters::UnitTesting::Id, Clusters::UnitTesting::Attributes::Int16u::Id);
 
-    app::ReadPrepareParams readParam(GetSessionAliceToBob());
+    ReadPrepareParams readParam(GetSessionAliceToBob());
     readParam.mpAttributePathParamsList    = &pathParams;
     readParam.mAttributePathParamsListSize = 1;
     readParam.mMaxIntervalCeilingSeconds   = 1;
     readParam.mKeepSubscriptions           = false;
 
-    std::unique_ptr<app::ReadClient> readClient = std::make_unique<app::ReadClient>(
-        app::InteractionModelEngine::GetInstance(), app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-        app::ReadClient::InteractionType::Subscribe);
+    std::unique_ptr<ReadClient> readClient = std::make_unique<ReadClient>(
+        InteractionModelEngine::GetInstance(), InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+        ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 1u);
 
     ChipLogProgress(DataManagement, "Issue another subscription that will evict the first sub...");
 
     readParam.mAttributePathParamsListSize = 0;
-    readClient                             = std::make_unique<app::ReadClient>(app::InteractionModelEngine::GetInstance(),
-                                                   app::InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
-                                                   app::ReadClient::InteractionType::Subscribe);
+    readClient                             = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(),
+                                                   InteractionModelEngine::GetInstance()->GetExchangeManager(), readCallback,
+                                                   ReadClient::InteractionType::Subscribe);
     EXPECT_EQ(readClient->SendRequest(readParam), CHIP_NO_ERROR);
 
     DrainAndServiceIO();
 
-    EXPECT_EQ(app::InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
+    EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveReadHandlers(), 0u);
     EXPECT_NE(readCallback.mOnError, 0u);
-    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     DrainAndServiceIO();
 }
 


### PR DESCRIPTION
#### Summary

When ReadClient::Close is called from onFabricRemove in InteractionModel Engine, readClient is destoryed and becomes not valid so that readClient->GetNextClient() will be use-after-free.

Fixes https://github.com/project-chip/connectedhomeip/issues/36920

#### Testing
Add unit test to cover this, where we create multiple subscriptions, then we remove fabric,
Without this change, the unit test would fail since the problematic loop code in onFabricRemoved cannot continue and numActiveReadClient cannot decrease to 0 after removing fabric, with this change, the numActiveReadClient can decrease to 0.

