### PR TITLE
[1.4 branch] Fix command handling logic for invalid endpoint commands.

### DIFF
--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -14,7 +14,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "protocols/interaction_model/StatusCode.h"
 #include <app/codegen-data-model-provider/CodegenDataModelProvider.h>
 
 #include <access/AccessControl.h>
@@ -32,6 +31,7 @@
 #include <app/util/endpoint-config-api.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
+#include <protocols/interaction_model/StatusCode.h>
 
 // separated out for code-reuse
 #include <app/ember_coupling/EventPathValidity.mixin.h>

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -419,7 +419,7 @@ std::optional<DataModel::ActionReturnStatus> CodegenDataModelProvider::Invoke(co
                                                                               CommandHandler * handler)
 {
     // As some CommandHandlerInterface commands are registered on wildcard interfaces,
-    // the valid endpoint/cluster check is done BEFORE attemptiong command handler interface handling
+    // the valid endpoint/cluster check is done BEFORE attempting command handler interface handling
     const EmberAfCluster * cluster = FindServerCluster(request.path);
     if (cluster == nullptr)
     {

--- a/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
+++ b/src/app/codegen-data-model-provider/CodegenDataModelProvider.cpp
@@ -797,7 +797,6 @@ ConcreteCommandPath CodegenDataModelProvider::NextGeneratedCommand(const Concret
                                               : ConcreteCommandPath(before.mEndpointId, before.mClusterId, *nextId);
     }
 
-
     std::optional<CommandId> commandId = mGeneratedCommandsIterator.Next(cluster->generatedCommandList, before.mCommandId);
     VerifyOrReturnValue(commandId.has_value(), kInvalidCommandPath);
 

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1412,9 +1412,9 @@ TEST(TestCodegenModelViaMocks, AcceptedGeneratedCommandsOnInvalidEndpoints)
 
     // invalid endpoint
     EXPECT_FALSE(model.FirstAcceptedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).IsValid());
-    EXPECT_FALSE(model.NextAcceptedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 1234)).IsValid());
+    EXPECT_FALSE(model.NextAcceptedCommand(ConcreteCommandPath(kEndpointIdThatIsMissing, MockClusterId(1), 1234)).IsValid());
     EXPECT_FALSE(model.FirstGeneratedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).HasValidIds());
-    EXPECT_FALSE(model.NextGeneratedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 33)).HasValidIds());
+    EXPECT_FALSE(model.NextGeneratedCommand(ConcreteCommandPath(kEndpointIdThatIsMissing, MockClusterId(1), 33)).HasValidIds());
 }
 
 TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceAcceptedCommands)

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1401,14 +1401,20 @@ TEST(TestCodegenModelViaMocks, AcceptedGeneratedCommandsOnInvalidEndpoints)
 
     // Make the lists non-empty som something is returned.
     handler.AcceptedVec().push_back(1234);
+    handler.AcceptedVec().push_back(2345);
     handler.GeneratedVec().push_back(33);
+    handler.GeneratedVec().push_back(44);
 
     EXPECT_TRUE(model.FirstAcceptedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).IsValid());
+    EXPECT_TRUE(model.NextAcceptedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 1234)).IsValid());
     EXPECT_TRUE(model.FirstGeneratedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).HasValidIds());
+    EXPECT_TRUE(model.NextGeneratedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 33)).HasValidIds());
 
     // invalid endpoint
     EXPECT_FALSE(model.FirstAcceptedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).IsValid());
+    EXPECT_FALSE(model.NextAcceptedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 1234)).IsValid());
     EXPECT_FALSE(model.FirstGeneratedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).HasValidIds());
+    EXPECT_FALSE(model.NextGeneratedCommand(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 33)).HasValidIds());
 }
 
 TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceAcceptedCommands)

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1330,7 +1330,6 @@ TEST(TestCodegenModelViaMocks, AcceptedCommandValidity)
 
     handler.SetOverrideAccepted(true);
     handler.AcceptedVec().push_back(1234);
-    handler.AcceptedVec().push_back(999);
 
     // Command succeeds on a valid endpoint
     EXPECT_TRUE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 1234)).has_value());
@@ -1372,6 +1371,16 @@ TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceValidity)
 
         ASSERT_EQ(model.Invoke(kInvokeRequest, tlvReader, /* handler = */ &commandHandler),
                   Protocols::InteractionModel::Status::UnsupportedEndpoint);
+    }
+
+    // Command fails on an invalid cluster
+    {
+        const ConcreteCommandPath kCommandPath(kMockEndpoint1, MockClusterId(0x1123), kMockCommandId1);
+        const InvokeRequest kInvokeRequest{ .path = kCommandPath };
+        chip::TLV::TLVReader tlvReader;
+
+        ASSERT_EQ(model.Invoke(kInvokeRequest, tlvReader, /* handler = */ &commandHandler),
+                  Protocols::InteractionModel::Status::UnsupportedCluster);
     }
 }
 

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1384,6 +1384,33 @@ TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceValidity)
     }
 }
 
+TEST(TestCodegenModelViaMocks, AcceptedGeneratedCommandsOnInvalidEndpoints)
+{
+    UseMockNodeConfig config(gTestNodeConfig);
+    CodegenDataModelProviderWithContext model;
+
+    // register a CHI on ALL endpoints
+    CustomListCommandHandler handler(chip::NullOptional, MockClusterId(1));
+
+    // check a valid endpoint (no override)
+    EXPECT_FALSE(model.FirstAcceptedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).IsValid());
+    EXPECT_FALSE(model.FirstGeneratedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).HasValidIds());
+
+    handler.SetOverrideAccepted(true);
+    handler.SetOverrideGenerated(true);
+
+    // Make the lists non-empty som something is returned.
+    handler.AcceptedVec().push_back(1234);
+    handler.GeneratedVec().push_back(33);
+
+    EXPECT_TRUE(model.FirstAcceptedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).IsValid());
+    EXPECT_TRUE(model.FirstGeneratedCommand(ConcreteClusterPath(kMockEndpoint1, MockClusterId(1))).HasValidIds());
+
+    // invalid endpoint
+    EXPECT_FALSE(model.FirstAcceptedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).IsValid());
+    EXPECT_FALSE(model.FirstGeneratedCommand(ConcreteClusterPath(kEndpointIdThatIsMissing, MockClusterId(1))).HasValidIds());
+}
+
 TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceAcceptedCommands)
 {
 

--- a/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
+++ b/src/app/codegen-data-model-provider/tests/TestCodegenModelViaMocks.cpp
@@ -1319,6 +1319,30 @@ TEST(TestCodegenModelViaMocks, IterateOverGeneratedCommands)
     }
 }
 
+TEST(TestCodegenModelViaMocks, AcceptedCommandValidity)
+{
+    UseMockNodeConfig config(gTestNodeConfig);
+    CodegenDataModelProviderWithContext model;
+
+    // register a CHI on ALL endpoints
+    CustomListCommandHandler handler(chip::NullOptional, MockClusterId(1));
+    handler.SetHandleCommands(true);
+
+    handler.SetOverrideAccepted(true);
+    handler.AcceptedVec().push_back(1234);
+    handler.AcceptedVec().push_back(999);
+
+    // Command succeeds on a valid endpoint
+    EXPECT_TRUE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 1234)).has_value());
+
+    // but not if the command is invalid
+    EXPECT_FALSE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kMockEndpoint1, MockClusterId(1), 0x1122)).has_value());
+
+    // Fails on an invalid endpoint (even if the handler is on wildcard endpoint)
+    EXPECT_FALSE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kEndpointIdThatIsMissing, MockClusterId(1), 1234)).has_value());
+    EXPECT_FALSE(model.GetAcceptedCommandInfo(ConcreteCommandPath(kEndpointIdThatIsMissing, MockClusterId(1), 0x1122)).has_value());
+}
+
 TEST(TestCodegenModelViaMocks, CommandHandlerInterfaceValidity)
 {
     UseMockNodeConfig config(gTestNodeConfig);


### PR DESCRIPTION
This is the fix for #37184 in the 1.4 branch. Since the logic in 1.4 is a bit different, this was written new rather than cherrypicking #37207 


#### Testing

Manually tested `SoftwareDiagnostics::ResetWatermarks` on an invalid endpoint and got an error rather than crash.
Added unit-tests:
   - backported Invoke unit test from 37207
   - added unit test for GetAcceptedCommandInfo (that is in 1.4 but not present in master anymore)