### PR TITLE
Allow test event loop dispatch time adjustment for slow VMs

### DIFF
--- a/src/system/tests/TestEventLoopHandler.cpp
+++ b/src/system/tests/TestEventLoopHandler.cpp
@@ -144,7 +144,7 @@ TEST_F(TestEventLoopHandler, EventLoopHandlerWake)
     // adjust it if the test machine is under heavy load, e.g. in CI or on a slow VM.
     // By default, we expect the sleep duration to be close to the requested 400ms.
     unsigned int expectedMaxDuration = 500u; // allow some slack for test machine load
-    const char * maxDurationEnv = std::getenv("CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS");
+    const char * maxDurationEnv      = std::getenv("CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS");
     if (maxDurationEnv != nullptr)
     {
         ChipLogDetail(Test, "CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS=%s", maxDurationEnv);

--- a/src/system/tests/TestEventLoopHandler.cpp
+++ b/src/system/tests/TestEventLoopHandler.cpp
@@ -14,6 +14,10 @@
  *    limitations under the License.
  */
 
+#include <cstdlib>
+#include <functional>
+#include <string>
+
 #include <pw_unit_test/framework.h>
 #include <system/SystemConfig.h>
 
@@ -24,9 +28,6 @@
 
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
-
-#include <functional>
-#include <string>
 
 using namespace chip;
 using namespace chip::System::Clock;
@@ -139,9 +140,20 @@ TEST_F(TestEventLoopHandler, EventLoopHandlerWake)
     SystemLayer().RemoveLoopHandler(loopHandler);
     cancelFallback(); // avoid leaking the fallback timer
 
+    // Get the upper bound of the sleep duration from the environment, so we can
+    // adjust it if the test machine is under heavy load, e.g. in CI or on a slow VM.
+    // By default, we expect the sleep duration to be close to the requested 400ms.
+    unsigned int expectedMaxDuration = 500u; // allow some slack for test machine load
+    const char * maxDurationEnv = std::getenv("CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS");
+    if (maxDurationEnv != nullptr)
+    {
+        ChipLogDetail(Test, "CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS=%s", maxDurationEnv);
+        expectedMaxDuration = static_cast<unsigned int>(std::stoul(maxDurationEnv));
+    }
+
     Timestamp sleepDuration = loopHandler.wakeTimestamp - loopHandler.startTimestamp;
     EXPECT_GE(sleepDuration.count(), 400u); // loopHandler requested wake-up after 400ms
-    EXPECT_LE(sleepDuration.count(), 500u); // allow some slack for test machine load
+    EXPECT_LE(sleepDuration.count(), expectedMaxDuration);
 }
 
 #endif // !CHIP_DEVICE_LAYER_TARGET_FAKE

--- a/src/test_driver/tizen/chip_tests/runner.sh
+++ b/src/test_driver/tizen/chip_tests/runner.sh
@@ -21,6 +21,9 @@ set -e
 # Print CHIP logs on stdout
 dlogutil CHIP &
 
+# Override the default value to account for slower execution on QEMU.
+export CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS=1000
+
 # Set the correct path for .gcda files
 export GCOV_PREFIX=/mnt/chip
 export GCOV_PREFIX_STRIP=5


### PR DESCRIPTION
#### Problem

Due to slower execution on Tizen QEMU, CI sometimes fails on checking time upper bound for events dispatching. In order to "fix" that, allow overriding default upper bound via env `CHIP_TEST_EVENT_LOOP_HANDLER_MAX_DURATION_MS` variable.

#### Testing

CI will verify.