### PR TITLE
Fix availability annotations for XPC protocols in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCClientProtocol.h
@@ -38,7 +38,7 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
 //- (oneway void)controller:(NSUUID *)controller commissioningComplete:(NSError * _Nullable)error nodeID:(NSNumber * _Nullable)nodeID metrics:(MTRMetrics * _Nullable)metrics;
 //- (oneway void)controller:(NSUUID *)controller readCommissioningInfo:(MTRProductIdentity *)info;
 @optional
-- (oneway void)controller:(NSUUID *)controller controllerConfigurationUpdated:(NSDictionary *)configuration;
+- (oneway void)controller:(NSUUID *)controller controllerConfigurationUpdated:(NSDictionary *)configuration MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3));
 @end
 
 MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -54,7 +54,7 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
 
 @end
 
-MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
+MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3))
 @protocol MTRXPCServerProtocol_MTRDeviceController <NSObject>
 
 @optional
@@ -75,11 +75,11 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
 
 - (oneway void)deviceController:(NSUUID *)controller registerNodeID:(NSNumber *)nodeID;
 - (oneway void)deviceController:(NSUUID *)controller unregisterNodeID:(NSNumber *)nodeID;
-- (oneway void)deviceController:(NSUUID *)controller updateControllerConfiguration:(NSDictionary *)controllerState;
+- (oneway void)deviceController:(NSUUID *)controller updateControllerConfiguration:(NSDictionary *)controllerState MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3));
 
 @end
 
-MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
+MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3))
 @protocol MTRXPCServerProtocol <NSObject, MTRXPCServerProtocol_MTRDevice, MTRXPCServerProtocol_MTRDeviceController>
 @optional
 - (oneway void)deviceController:(NSUUID *)controller checkInWithContext:(NSDictionary *)context;


### PR DESCRIPTION
There were backwards-incompatible changes to
MTRXPCServerProtocol_MTRDeviceController and MTRXPCServerProtocol, so mark those as not available before those changes, to avoid problems with people trying to use them before the change happened.

controllerConfigurationUpdated and updateControllerConfiguration were added later than the protocol they are part of, and need to be annotated accordingly.

#### Testing

Code inspection.