### PR TITLE
Remove unused code from Verhoeff library

### DIFF
--- a/src/lib/support/verhoeff/Verhoeff.cpp
+++ b/src/lib/support/verhoeff/Verhoeff.cpp
@@ -24,27 +24,6 @@
 
 #include "Verhoeff.h"
 
-int Verhoeff::DihedralMultiply(int x, int y, int n)
-{
-    int n2 = n * 2;
-
-    x = x % n2;
-    y = y % n2;
-
-    if (x < n)
-    {
-        if (y < n)
-            return (x + y) % n;
-
-        return ((x + (y - n)) % n) + n;
-    }
-
-    if (y < n)
-        return ((n + (x - n) - y) % n) + n;
-
-    return (n + (x - n) - (y - n)) % n;
-}
-
 int Verhoeff::DihedralInvert(int val, int n)
 {
     if (val > 0 && val < n)

--- a/src/lib/support/verhoeff/Verhoeff.h
+++ b/src/lib/support/verhoeff/Verhoeff.h
@@ -75,7 +75,6 @@ private:
 class Verhoeff
 {
 public:
-    static int DihedralMultiply(int x, int y, int n);
     static int DihedralInvert(int val, int n);
     static int Permute(int val, const uint8_t * permTable, int permTableLen, uint64_t iterCount);
 };

--- a/src/lib/support/verhoeff/Verhoeff10.cpp
+++ b/src/lib/support/verhoeff/Verhoeff10.cpp
@@ -28,15 +28,11 @@
 #include <stdint.h>
 #include <string.h>
 
-#ifndef VERHOEFF10_NO_MULTIPLY_TABLE
-
 const uint8_t Verhoeff10::sMultiplyTable[] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 0, 6, 7, 8, 9, 5, 2, 3, 4, 0, 1, 7, 8, 9, 5, 6, 3, 4, 0, 1,
     2, 8, 9, 5, 6, 7, 4, 0, 1, 2, 3, 9, 5, 6, 7, 8, 5, 9, 8, 7, 6, 0, 4, 3, 2, 1, 6, 5, 9, 8, 7, 1, 0, 4,
     3, 2, 7, 6, 5, 9, 8, 2, 1, 0, 4, 3, 8, 7, 6, 5, 9, 3, 2, 1, 0, 4, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
 };
-
-#endif
 
 const uint8_t Verhoeff10::sPermTable[] = { 1, 5, 7, 6, 2, 8, 3, 0, 9, 4 };
 
@@ -59,11 +55,7 @@ char Verhoeff10::ComputeCheckChar(const char * str, size_t strLen)
 
         int p = Verhoeff::Permute(val, sPermTable, Base, i);
 
-#ifdef VERHOEFF10_NO_MULTIPLY_TABLE
-        c = Verhoeff::DihedralMultiply(c, p, PolygonSize);
-#else
         c = sMultiplyTable[c * Base + p];
-#endif
     }
 
     c = Verhoeff::DihedralInvert(c, PolygonSize);


### PR DESCRIPTION
There is currently code not used in the Verhoeff library, the implementation is compiled conditionally according to a specific define in the code. One of these branches is not used and the proposal is to remove it to keep the implementation clean.

#### Testing

Existing Unit Tests for the current code.
