### PR TITLE
Change for NFC Commissioning feature: Add libpcsclite-dev package

### DIFF
--- a/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
@@ -117,6 +117,7 @@ packages:
   - libdbus-1-dev
   - libgirepository1.0-dev
   - libglib2.0-dev
+  - libpcsclite-dev
   - libreadline-dev
   - libsdl2-dev
   - libssl-dev


### PR DESCRIPTION
Change for NFC Commissioning feature:
Added package libpcsclite-dev to start-sysroot-vm.sh. This package is needed for the cross compilation of chip-tool for arm64.


### Testing

Ran `start-sysroot-vm.sh` (which took a long time and install happens even after console appears, however it eventually installed). Checked some paths based on what https://packages.debian.org/sid/arm64/libpcsclite-dev/filelist reports.

![image](https://github.com/user-attachments/assets/cf4cf72a-7f05-4e3b-995c-50dea855699d)

