### PR TITLE
[Crypto] Stop compiling legacy SPAKE2P if PSA is available

### DIFF
--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -788,6 +788,9 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     return CHIP_NO_ERROR;
 }
 
+// We should compile this SPAKE2P implementation only if the PSA implementation is not in use.
+#if !CHIP_CRYPTO_PSA_SPAKE2P
+
 typedef struct Spake2p_Context
 {
     mbedtls_ecp_group curve;
@@ -1092,6 +1095,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 
     return CHIP_NO_ERROR;
 }
+
+#endif // !CHIP_CRYPTO_PSA_SPAKE2P
 
 } // namespace Crypto
 } // namespace chip


### PR DESCRIPTION
If the CHIP_CRYPTO_PSA_SPAKE2P is enabled the build system should not compile Legacy Spake2p implementation, because the PSA one is available in the PSASpake2p.cpp file.


#### Testing
Tested by existing automated tests.