### PR TITLE
Clear Thread Network after last fabric is removed

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -87,6 +87,8 @@ public:
         connectNetworkTimeout     = connectTimeoutSec;
     }
 
+    void ClearNetwork() { mStagingNetwork.Clear(); }
+
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback) override;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -87,6 +87,13 @@ void initNetworkCommissioningThreadDriver()
 #endif
 }
 
+void resetGenericThreadDriver()
+{
+#ifndef _NO_GENERIC_THREAD_NETWORK_COMMISSIONING_DRIVER_
+    sGenericThreadDriver.ClearNetwork();
+#endif
+}
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 CHIP_ERROR ReadDomainNameComponent(const char *& in, char * out, size_t outSize)
 {
@@ -1257,6 +1264,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo()
     otThreadSetEnabled(mOTInst, false);
     otIp6SetEnabled(mOTInst, false);
     otInstanceErasePersistentInfo(mOTInst);
+    resetGenericThreadDriver();
     Impl()->UnlockThreadStack();
 }
 


### PR DESCRIPTION
Dataset has to be cleared to allow commissioning to different network when device is not performing a full factory reset after last fabric is removed, e.g. when CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY is enabled on nrfconnect platform.


#### Testing
Tested manually.
