### PR TITLE
[Zephyr] Save total operational hours on Read

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -270,19 +270,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetUpTime(uint64_t & upTime)
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    uint64_t upTimeS;
-
-    ReturnErrorOnFailure(GetUpTime(upTimeS));
-
-    uint64_t totalHours      = 0;
-    const uint32_t upTimeH   = upTimeS / 3600 < UINT32_MAX ? static_cast<uint32_t>(upTimeS / 3600) : UINT32_MAX;
-    const uint64_t deltaTime = upTimeH - PlatformMgrImpl().GetSavedOperationalHoursSinceBoot();
-
-    ReturnErrorOnFailure(ConfigurationMgr().GetTotalOperationalHours(reinterpret_cast<uint32_t &>(totalHours)));
-
-    totalOperationalHours = static_cast<uint32_t>(totalHours + deltaTime < UINT32_MAX ? totalHours + deltaTime : UINT32_MAX);
-
-    return CHIP_NO_ERROR;
+    // Update the total operational hours and get the most recent value.
+    return PlatformMgrImpl().UpdateOperationalHours(&totalOperationalHours);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -76,33 +76,41 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 
 void PlatformManagerImpl::OperationalHoursSavingTimerEventHandler(k_timer * timer)
 {
-    PlatformMgr().ScheduleWork(UpdateOperationalHours);
+    PlatformMgr().ScheduleWork([](intptr_t arg) {
+        CHIP_ERROR error = sInstance.UpdateOperationalHours(nullptr);
+        if (error != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Failed to update operational hours: %" CHIP_ERROR_FORMAT, error.Format());
+        }
+    });
 }
 
-void PlatformManagerImpl::UpdateOperationalHours(intptr_t arg)
+CHIP_ERROR PlatformManagerImpl::UpdateOperationalHours(uint32_t * totalOperationalHours)
 {
     uint64_t upTimeS;
 
-    if (GetDiagnosticDataProvider().GetUpTime(upTimeS) != CHIP_NO_ERROR)
+    ReturnErrorOnFailure(GetDiagnosticDataProvider().GetUpTime(upTimeS));
+
+    uint32_t totalTime       = 0;
+    const uint32_t upTimeH   = upTimeS / 3600 < UINT32_MAX ? static_cast<uint32_t>(upTimeS / 3600) : UINT32_MAX;
+    const uint64_t deltaTime = upTimeH - mSavedOperationalHoursSinceBoot;
+
+    ReturnErrorOnFailure(ConfigurationMgr().GetTotalOperationalHours(totalTime));
+
+    totalTime = totalTime + deltaTime < UINT32_MAX ? static_cast<uint32_t>(totalTime + deltaTime) : UINT32_MAX;
+
+    if (deltaTime > 0)
     {
-        ChipLogError(DeviceLayer, "Failed to get up time of the node");
-        return;
+        ConfigurationMgr().StoreTotalOperationalHours(totalTime);
+        mSavedOperationalHoursSinceBoot = upTimeH;
     }
 
-    uint64_t totalOperationalHours = 0;
-    const uint32_t upTimeH         = upTimeS / 3600 < UINT32_MAX ? static_cast<uint32_t>(upTimeS / 3600) : UINT32_MAX;
-    const uint64_t deltaTime       = upTimeH - sInstance.mSavedOperationalHoursSinceBoot;
+    if (totalOperationalHours != nullptr)
+    {
+        *totalOperationalHours = totalTime;
+    }
 
-    if (ConfigurationMgr().GetTotalOperationalHours(reinterpret_cast<uint32_t &>(totalOperationalHours)) == CHIP_NO_ERROR)
-    {
-        ConfigurationMgr().StoreTotalOperationalHours(
-            static_cast<uint32_t>(totalOperationalHours + deltaTime < UINT32_MAX ? totalOperationalHours + deltaTime : UINT32_MAX));
-        sInstance.mSavedOperationalHoursSinceBoot = upTimeH;
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "Failed to get total operational hours of the node");
-    }
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)

--- a/src/platform/Zephyr/PlatformManagerImpl.h
+++ b/src/platform/Zephyr/PlatformManagerImpl.h
@@ -47,7 +47,7 @@ public:
     // ===== Platform-specific members that may be accessed directly by the application.
 
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
-    uint32_t GetSavedOperationalHoursSinceBoot() { return mSavedOperationalHoursSinceBoot; }
+    CHIP_ERROR UpdateOperationalHours(uint32_t * totalOperationalHours);
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
@@ -55,7 +55,6 @@ private:
     CHIP_ERROR _InitChipStack(void);
 
     static void OperationalHoursSavingTimerEventHandler(k_timer * timer);
-    static void UpdateOperationalHours(intptr_t arg);
 
     // ===== Members for internal use by the following friends.
 


### PR DESCRIPTION
Currently total operational hours are saved to NVM with `CONFIG_CHIP_OPERATIONAL_TIME_SAVE_INTERVAL`.
Certification test `TC-DGGEN-2.1` requires checking the value after 1 hour, restarting the DUT, and checking if the value has not changed, causing failures if given config is higher than 1.

This commit additionaly saves total operational hours to NVM everytime it is being read by `GetTotalOperationalHours` (writing only if currently stored value should be updated). This way value is stored with minimum frequency of 1 hour (if read request is sent frequently) and maximum frequency of `CONFIG_CHIP_OPERATIONAL_TIME_SAVE_INTERVAL`.


#### Testing

Tested on NCS build with patch applied by reading value after 1hr, restarting and reading again (val=1), waiting for 10hr, restarting and reading (val=11).