### PR TITLE
Fix key error when using TLV dictionary in DeviceConformance test.

### DIFF
--- a/src/python_testing/TC_DeviceConformance.py
+++ b/src/python_testing/TC_DeviceConformance.py
@@ -68,9 +68,9 @@ class DeviceConformanceTests(BasicCompositionTests):
         # Currently this is just NIM. We may later be able to pull this from the device type scrape using the ManagedAclAllowed condition,
         # but these are not currently exposed directly by the device.
         allowed_ids = [self._get_device_type_id('network infrastructure manager')]
-        for endpoint in self.endpoints_tlv.values():
+        for endpoint in self.endpoints.values():
             desc = Clusters.Descriptor
-            device_types = [dt.deviceType for dt in endpoint[desc.id][desc.Attributes.DeviceTypeList.attribute_id]]
+            device_types = [dt.deviceType for dt in endpoint[desc][desc.Attributes.DeviceTypeList]]
             if set(allowed_ids).intersection(set(device_types)):
                 # TODO: it's unclear if this needs to be present on every endpoint. Right now, this assumes one is sufficient.
                 return True

--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -187,27 +187,31 @@ class TestConformanceSupport(MatterBaseTest, DeviceConformanceTests):
             attr.ServerList,
             attr.ClientList,
             attr.PartsList,
-            attr.AttributeList
         ]
 
         attribute_values = [
-            0,  # FeatureMap
-            [],  # AcceptedCommandList
-            [],  # GeneratedCommandList
-            self.xml_clusters[Clusters.Descriptor.id].revision,  # ClusterRevision
-            [Clusters.Descriptor.Structs.DeviceTypeStruct(
-                deviceType=device_type_id, revision=device_type_revision)],  # DeviceTypeList
-            required_servers,  # ServerList
-            required_clients,  # ClientList
-            [],  # PartsList
-            list(attrs.keys())  # AttributeList
+            (0, 0),  # FeatureMap
+            ([], []),  # AcceptedCommandList
+            ([], []),  # GeneratedCommandList
+            (self.xml_clusters[Clusters.Descriptor.id].revision,
+             self.xml_clusters[Clusters.Descriptor.id].revision),  # ClusterRevision
+            ([{0: device_type_id, 1: device_type_revision}],
+             [Clusters.Descriptor.Structs.DeviceTypeStruct(
+                 deviceType=device_type_id, revision=device_type_revision)]),  # DeviceTypeList
+            (required_servers, required_servers),  # ServerList
+            (required_clients, required_clients),  # ClientList
+            ([], []),  # PartsList
         ]
 
         for attribute_name, attribute_value in zip(attributes, attribute_values):
             key = attribute_name.attribute_id if is_tlv_endpoint else attribute_name
-            attrs[key] = attribute_value
+            attrs[key] = attribute_value[0] if is_tlv_endpoint else attribute_value[1]
+
+        # Append the attribute list now that is populated.
+        attrs[attr.AttributeList.attribute_id if is_tlv_endpoint else attr.AttributeList] = list(attrs.keys())
 
         endpoint_tlv[Clusters.Descriptor.id if is_tlv_endpoint else Clusters.Descriptor] = attrs
+
         return endpoint_tlv
 
     def add_macl(self, root_endpoint: dict[int, dict[int, Any]], populate_arl: bool = False, populate_commissioning_arl: bool = False):


### PR DESCRIPTION
Fixes #37267 

There is a "mixture" in the DeviceConformance test when trying to get the device type for the NetworkManager app. Trying to use "named" indexes in the TLV dictionary causes a key error.

#### Testing

Tested using DeviceConformance python script with Network Manager app.
