### PR TITLE
Update Darwin availability annotations for non-generated code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Information read from the commissionee device during commissioning.
  */
 NS_SWIFT_SENDABLE
-MTR_NEWLY_AVAILABLE
+MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @interface MTRCommissioneeInfo : NSObject <NSCopying, NSSecureCoding>
 
 /**

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -100,7 +100,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Read device type information from all endpoints during commissioning.
  * Defaults to NO.
  */
-@property (nonatomic, assign) BOOL readEndpointInformation MTR_NEWLY_AVAILABLE;
+@property (nonatomic, assign) BOOL readEndpointInformation MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -273,7 +273,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Forget any information we have about the device with the given node ID.  That
  * includes clearing any information we have stored about it.
  */
-- (void)forgetDeviceWithNodeID:(NSNumber *)nodeID MTR_NEWLY_AVAILABLE;
+- (void)forgetDeviceWithNodeID:(NSNumber *)nodeID MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 /**
  * Compute a PASE verifier for the desired setup passcode.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
@@ -94,12 +94,11 @@ MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  * so the information delivered by this notification should not be trusted.
  */
 - (void)controller:(MTRDeviceController *)controller
-    readCommissioneeInfo:(MTRCommissioneeInfo *)info MTR_NEWLY_AVAILABLE;
+    readCommissioneeInfo:(MTRCommissioneeInfo *)info MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 - (void)controller:(MTRDeviceController *)controller
     readCommissioningInfo:(MTRProductIdentity *)info
-    MTR_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
-        MTR_NEWLY_DEPRECATED("Use controller:readCommissioneeInfo:");
+    MTR_DEPRECATED("Use controller:readCommissioneeInfo:", ios(17.0, 18.4), macos(14.0, 15.4), watchos(10.0, 11.4), tvos(17.0, 18.4));
 
 /**
  * Notify the delegate when the suspended state changed of the controller, after this happens

--- a/src/darwin/Framework/CHIP/MTRDeviceType.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceType.h
@@ -55,7 +55,7 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
 
 @end
 
-MTR_NEWLY_AVAILABLE
+MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @interface MTRDeviceType () <NSCopying>
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceTypeRevision.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceTypeRevision.h
@@ -44,7 +44,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
 /**
  * Initializes the receiver based on the values in the specified struct.
  */
-- (nullable instancetype)initWithDeviceTypeStruct:(MTRDescriptorClusterDeviceTypeStruct *)deviceTypeStruct MTR_NEWLY_AVAILABLE;
+- (nullable instancetype)initWithDeviceTypeStruct:(MTRDescriptorClusterDeviceTypeStruct *)deviceTypeStruct MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 @property (nonatomic, copy, readonly) NSNumber * deviceTypeID;
 @property (nonatomic, copy, readonly) NSNumber * deviceTypeRevision;
@@ -53,11 +53,11 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  * Returns the MTRDeviceType corresponding to deviceTypeID,
  * or nil if deviceTypeID does not represent a known device type.
  */
-@property (nonatomic, copy, readonly, nullable) MTRDeviceType * typeInformation MTR_NEWLY_AVAILABLE;
+@property (nonatomic, copy, readonly, nullable) MTRDeviceType * typeInformation MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 @end
 
-MTR_NEWLY_AVAILABLE
+MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @interface MTRDeviceTypeRevision () <NSSecureCoding>
 @end
 

--- a/src/darwin/Framework/CHIP/MTREndpointInfo.h
+++ b/src/darwin/Framework/CHIP/MTREndpointInfo.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Meta-data about an endpoint of a Matter node.
  */
 NS_SWIFT_SENDABLE
-MTR_NEWLY_AVAILABLE
+MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @interface MTREndpointInfo : NSObject <NSCopying, NSSecureCoding>
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRProductIdentity.h
+++ b/src/darwin/Framework/CHIP/MTRProductIdentity.h
@@ -35,7 +35,7 @@ MTR_AVAILABLE(ios(17.0), macos(14.0), watchos(10.0), tvos(17.0))
 
 @end
 
-MTR_NEWLY_AVAILABLE
+MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @interface MTRProductIdentity () <NSCopying, NSSecureCoding>
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -175,7 +175,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 /**
  * Generate a random Matter-valid setup PIN.
  */
-+ (NSUInteger)generateRandomPIN MTR_NEWLY_DEPRECATED("Please use generateRandomSetupPasscode");
++ (NSUInteger)generateRandomPIN MTR_DEPRECATED("Please use generateRandomSetupPasscode", ios(16.1, 18.4), macos(13.0, 15.4), watchos(9.1, 11.4), tvos(16.1, 18.4));
 
 /**
  * Generate a random Matter-valid setup passcode.
@@ -218,7 +218,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * Check whether the provided setup passcode (represented as an unsigned
  * integer) is a valid setup passcode.
  */
-+ (BOOL)isValidSetupPasscode:(NSNumber *)setupPasscode MTR_NEWLY_AVAILABLE;
++ (BOOL)isValidSetupPasscode:(NSNumber *)setupPasscode MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 @end
 

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -71,7 +71,7 @@ MTR_AVAILABLE(ios(18.3), macos(15.3), watchos(11.3), tvos(18.3))
 // - (oneway void)deviceController:(NSUUID *)controller addServerEndpoint:(MTRServerEndpoint *)endpoint withReply:(void (^)(BOOL success))reply;
 // - (oneway void)deviceController:(NSUUID *)controller removeServerEndpoint:(MTRServerEndpoint *)endpoint;
 
-- (oneway void)deviceController:(NSUUID *)controller deleteNodeID:(NSNumber *)nodeID MTR_NEWLY_AVAILABLE;
+- (oneway void)deviceController:(NSUUID *)controller deleteNodeID:(NSNumber *)nodeID MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 - (oneway void)deviceController:(NSUUID *)controller registerNodeID:(NSNumber *)nodeID;
 - (oneway void)deviceController:(NSUUID *)controller unregisterNodeID:(NSNumber *)nodeID;


### PR DESCRIPTION
#### Testing

No impact except on system framework consumers.