### PR TITLE
[Silabs] Raise TimerTask to the highest prio

### DIFF
--- a/examples/platform/silabs/FreeRTOSConfig.h
+++ b/examples/platform/silabs/FreeRTOSConfig.h
@@ -174,11 +174,8 @@ extern uint32_t SystemCoreClock;
 
 /* Software timer related definitions. */
 #define configUSE_TIMERS (1)
-#ifdef SLI_SI917
+// Keep the timerTask at the highest prio as some of our stacks tasks leverage eventing with timers.
 #define configTIMER_TASK_PRIORITY (55) /* Highest priority */
-#else
-#define configTIMER_TASK_PRIORITY (40) /* Highest priority */
-#endif                                 // SLI_SI917
 #define configTIMER_QUEUE_LENGTH (10)
 #define configTIMER_TASK_STACK_DEPTH (1024)
 
@@ -313,7 +310,7 @@ standard names. */
 /* Thread local storage pointers used by the SDK */
 
 #ifndef configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS
-#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 2
+#define configNUM_USER_THREAD_LOCAL_STORAGE_POINTERS 0
 #endif
 
 #ifndef configNUM_SDK_THREAD_LOCAL_STORAGE_POINTERS


### PR DESCRIPTION
Keep the timer task at the highest priority as some of our stacks tasks leverage eventing with timers.

#### Testing
Manual Sanity check on efr32.
