### PR TITLE
Tv casting app stop connect when user navigates back before confirming passcode in commission

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -262,6 +262,22 @@ public class ConnectionExampleFragment extends Fragment {
             });
   }
 
+  @Override
+  public void onDestroy() {
+    super.onDestroy();
+
+    // Only stop connection if we are pending passcode confirmation
+    // We cannot stop connection once continueConnecting() is called
+    if (targetCastingPlayer.isPendingPasscodeFromUser()) {
+      MatterError err = targetCastingPlayer.stopConnecting();
+      if (err.hasError()) {
+        Log.e(
+            TAG,
+            "Going back before connection finishes but stopConnecting() failed due to: " + err);
+      }
+    }
+  }
+
   private void displayPasscodeInputDialog(Context context) {
     AlertDialog.Builder builder = new AlertDialog.Builder(context);
 

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -353,10 +353,7 @@ public class ConnectionExampleFragment extends Fragment {
                                 + finalErr
                                 + ". Route back to disconnect & try again. \n\n");
                       });
-              Log.e(
-                  TAG,
-                  "displayPasscodeInputDialog() continueConnecting() failed due to: "
-                      + err);
+              Log.e(TAG, "displayPasscodeInputDialog() continueConnecting() failed due to: " + err);
             }
           }
         });

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -152,4 +152,10 @@ public interface CastingPlayer {
 
   /** @brief Sets the internal connection state of this CastingPlayer to "disconnected" */
   void disconnect();
+
+  /**
+   * @return true if this CastingPlayer is still pending pass code from user and therefore is not
+   *     ready
+   */
+  boolean isPendingPasscodeFromUser();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -29,6 +29,13 @@ import java.util.List;
  * about the service discovered/resolved.
  */
 public interface CastingPlayer {
+
+  public enum ConnectionState {
+    NOT_CONNECTED,
+    CONNECTING,
+    CONNECTED,
+  }
+
   boolean isConnected();
 
   String getDeviceId();
@@ -157,5 +164,7 @@ public interface CastingPlayer {
    * @return true if this CastingPlayer is still pending pass code from user and therefore is not
    *     ready
    */
-  boolean isPendingPasscodeFromUser();
+  ConnectionState getConnectionState();
+
+  String getConnectionStateNative();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingPlayer.java
@@ -30,9 +30,15 @@ import java.util.List;
  */
 public interface CastingPlayer {
 
+  /** @brief CastingPlayer's Conenction State */
   public enum ConnectionState {
+    /** State when CastingPlayer is not connected */
     NOT_CONNECTED,
+
+    /** State when CastingPlayer is attempting to connect */
     CONNECTING,
+
+    /** State when CastingPlayer is connnected */
     CONNECTED,
   }
 
@@ -161,10 +167,14 @@ public interface CastingPlayer {
   void disconnect();
 
   /**
-   * @return true if this CastingPlayer is still pending pass code from user and therefore is not
-   *     ready
+   * @brief Get CastingPlayer's current ConnectionState.
+   * @return Current ConnectionState.
    */
   ConnectionState getConnectionState();
 
+  /**
+   * @brief Get the Current ConnectionState of a CastingPlayer from the native layer.
+   * @returns A String representation of the CastingPlayer's current connectation.
+   */
   String getConnectionStateNative();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -32,6 +32,7 @@ import java.util.Objects;
  */
 public class MatterCastingPlayer implements CastingPlayer {
   private static final String TAG = MatterCastingPlayer.class.getSimpleName();
+
   /**
    * Time (in sec) to keep the commissioning window open, if commissioning is required. Must be >= 3
    * minutes.
@@ -269,5 +270,9 @@ public class MatterCastingPlayer implements CastingPlayer {
   public native void disconnect();
 
   @Override
-  public native boolean isPendingPasscodeFromUser();
+  public ConnectionState getConnectionState() {
+      return ConnectionState.valueOf(getConnectionStateNative());
+  }
+
+  public native String getConnectionStateNative();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -271,7 +271,7 @@ public class MatterCastingPlayer implements CastingPlayer {
 
   @Override
   public ConnectionState getConnectionState() {
-      return ConnectionState.valueOf(getConnectionStateNative());
+    return ConnectionState.valueOf(getConnectionStateNative());
   }
 
   public native String getConnectionStateNative();

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -269,10 +269,27 @@ public class MatterCastingPlayer implements CastingPlayer {
   @Override
   public native void disconnect();
 
+  /**
+   * @brief Get CastingPlayer's current ConnectionState.
+   * @throws IllegalArgumentException or NullPointerException when native layer returns invalid
+   *     state.
+   * @return Current ConnectionState.
+   */
   @Override
   public ConnectionState getConnectionState() {
     return ConnectionState.valueOf(getConnectionStateNative());
   }
 
+  /*
+   * @brief Get the Current ConnectionState of a CastingPlayer from the native layer.
+   *
+   * @returns A String representation of the CastingPlayer's current connectation.
+   *          Possible return values are
+   *            - "NOT_CONNECTED"
+   *            - "CONNECTING"
+   *            - "CONNECTED"
+   *            - Error message or NULL on error
+   */
+  @Override
   public native String getConnectionStateNative();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java
@@ -267,4 +267,7 @@ public class MatterCastingPlayer implements CastingPlayer {
 
   @Override
   public native void disconnect();
+
+  @Override
+  public native boolean isPendingPasscodeFromUser();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -165,6 +165,18 @@ JNI_METHOD(void, disconnect)
     castingPlayer->Disconnect();
 }
 
+JNI_METHOD(bool, isPendingPasscodeFromUser)
+(JNIEnv * env, jobject thiz)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::isPendingPasscodeFromUser()");
+
+    CastingPlayer * castingPlayer = support::convertCastingPlayerFromJavaToCpp(thiz);
+    VerifyOrReturnValue(castingPlayer != nullptr, support::convertMatterErrorFromCppToJava(CHIP_ERROR_INVALID_ARGUMENT));
+
+    return castingPlayer->IsPendingPasscodeFromUser();
+}
+
 JNI_METHOD(jobject, getEndpoints)
 (JNIEnv * env, jobject thiz)
 {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -168,6 +168,14 @@ JNI_METHOD(void, disconnect)
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {
+    if (NULL == env)
+    {
+        jobject err_jstr = nullptr;
+        LogErrorOnFailure(
+            chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("JNIEnv interface is NULL"), err_jstr));
+        return static_cast<jstring>(err_jstr);
+    }
+
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "MatterCastingPlayer-JNI::getConnectionState()");
 
@@ -186,7 +194,10 @@ JNI_METHOD(jstring, getConnectionStateNative)
     default: {
         char error_str[50];
         snprintf(error_str, sizeof(error_str), "Unsupported Connection State: %d", state);
-        return env->NewStringUTF(error_str);
+
+        jobject err_jstr = nullptr;
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(error_str), err_jstr));
+        return static_cast<jstring>(err_jstr);
     }
     }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/MatterCastingPlayer-JNI.cpp
@@ -168,12 +168,14 @@ JNI_METHOD(void, disconnect)
 JNI_METHOD(jstring, getConnectionStateNative)
 (JNIEnv * env, jobject thiz)
 {
+    char error_str[50];
+    jobject jstr_obj = nullptr;
+
     if (NULL == env)
     {
-        jobject err_jstr = nullptr;
         LogErrorOnFailure(
-            chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("JNIEnv interface is NULL"), err_jstr));
-        return static_cast<jstring>(err_jstr);
+            chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("JNIEnv interface is NULL"), jstr_obj));
+        return static_cast<jstring>(jstr_obj);
     }
 
     chip::DeviceLayer::StackLock lock;
@@ -186,20 +188,20 @@ JNI_METHOD(jstring, getConnectionStateNative)
     switch (state)
     {
     case matter::casting::core::ConnectionState::CASTING_PLAYER_NOT_CONNECTED:
-        return env->NewStringUTF("NOT_CONNECTED");
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("NOT_CONNECTED"), jstr_obj));
+        break;
     case matter::casting::core::ConnectionState::CASTING_PLAYER_CONNECTING:
-        return env->NewStringUTF("CONNECTING");
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("CONNECTING"), jstr_obj));
+        break;
     case matter::casting::core::ConnectionState::CASTING_PLAYER_CONNECTED:
-        return env->NewStringUTF("CONNECTED");
-    default: {
-        char error_str[50];
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString("CONNECTED"), jstr_obj));
+        break;
+    default:
         snprintf(error_str, sizeof(error_str), "Unsupported Connection State: %d", state);
-
-        jobject err_jstr = nullptr;
-        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(error_str), err_jstr));
-        return static_cast<jstring>(err_jstr);
+        LogErrorOnFailure(chip::JniReferences::GetInstance().CharToStringUTF(CharSpan::fromCharString(error_str), jstr_obj));
+        break;
     }
-    }
+    return static_cast<jstring>(jstr_obj);
 }
 
 JNI_METHOD(jobject, getEndpoints)

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -27,6 +27,16 @@
 @class MCEndpoint;
 
 /**
+ * @brief Represents CastingPlayer ConnectionState.
+ * @note Should be kept up to date with matter::casting::core::ConnectionState.
+ */
+typedef enum {
+    MC_CASTING_PLAYER_NOT_CONNECTED,
+    MC_CASTING_PLAYER_CONNECTING,
+    MC_CASTING_PLAYER_CONNECTED,
+} MCCastingPlayerConnectionState;
+
+/**
  * @brief MCCastingPlayer represents a Matter commissioner that is able to play media to a physical
  * output or to a display screen which is part of the device.
  */
@@ -149,9 +159,11 @@
 - (void)disconnect;
 
 /**
- * @return true if this CastingPlayer is still pending pass code from user and therefore is not ready
+ * @brief Get the CastingPlayer's connection state
+ * @param state The current connection state that will be return.
+ * @return nil if request submitted successfully, otherwise a NSError object corresponding to the error.
  */
-- (bool)isPendingPasscodeFromUser;
+- (NSError * _Nullable)getConnectionState:(MCCastingPlayerConnectionState * _Nonnull)state;
 
 - (NSString * _Nonnull)identifier;
 - (NSString * _Nonnull)deviceName;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.h
@@ -148,6 +148,11 @@
  */
 - (void)disconnect;
 
+/**
+ * @return true if this CastingPlayer is still pending pass code from user and therefore is not ready
+ */
+- (bool)isPendingPasscodeFromUser;
+
 - (NSString * _Nonnull)identifier;
 - (NSString * _Nonnull)deviceName;
 - (uint16_t)vendorId;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/MCCastingPlayer.mm
@@ -190,6 +190,20 @@ static const NSInteger kMinCommissioningWindowTimeoutSec = matter::casting::core
     });
 }
 
+- (bool)isPendingPasscodeFromUser
+{
+    ChipLogProgress(AppServer, "MCCastingPlayer.isPendingPasscodeFromUser() called");
+    VerifyOrReturnValue([[MCCastingApp getSharedInstance] isRunning], false, ChipLogError(AppServer, "MCCastingPlayer.isPendingPasscodeFromUser() MCCastingApp NOT running"));
+
+    dispatch_queue_t workQueue = [[MCCastingApp getSharedInstance] getWorkQueue];
+    
+    __block bool isPending = false;
+    dispatch_sync(workQueue, ^{
+        isPending = _cppCastingPlayer->IsPendingPasscodeFromUser();
+    });
+    return isPending;
+}
+
 - (instancetype _Nonnull)initWithCppCastingPlayer:(matter::casting::memory::Strong<matter::casting::core::CastingPlayer>)cppCastingPlayer
 {
     if (self = [super init]) {

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleView.swift
@@ -88,6 +88,9 @@ struct MCConnectionExampleView: View {
                 viewModel.connect(selectedCastingPlayer: self.selectedCastingPlayer, useCommissionerGeneratedPasscode: self.useCommissionerGeneratedPasscode)
             }
         })
+        .onDisappear(perform: {
+            viewModel.cancelConnectionAttempt(selectedCastingPlayer: self.selectedCastingPlayer)
+        })
     }
 }
 

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
@@ -42,6 +42,23 @@ class MCConnectionExampleViewModel: ObservableObject {
 
     @Published var errorCodeDescription: String?
 
+    func cancelConnectionAttempt(selectedCastingPlayer: MCCastingPlayer?) {
+        DispatchQueue.main.async {
+            // Only stop connection if we are pending passcode confirmation
+            if selectedCastingPlayer?.isPendingPasscodeFromUser() == true {
+                self.Log.info("MCConnectionExampleViewModel cancelConnect(). User navigating back from ConnectionView")
+                let err = selectedCastingPlayer?.stopConnecting()
+                if err == nil {
+                    self.connectionStatus = "User cancelled the connection attempt with CastingPlayer.stopConnecting()."
+                    self.Log.info("MCConnectionExampleViewModel cancelConnect() MCCastingPlayer.stopConnecting() succeeded.")
+                } else {
+                    self.connectionStatus = "Cancel connection failed due to: \(String(describing: err))."
+                    self.Log.error("MCConnectionExampleViewModel cancelConnect() MCCastingPlayer.stopConnecting() failed due to: \(err)")
+                }
+            }
+        }
+    }
+
     func connect(selectedCastingPlayer: MCCastingPlayer?, useCommissionerGeneratedPasscode: Bool) {
         self.Log.info("MCConnectionExampleViewModel.connect() useCommissionerGeneratedPasscode: \(String(describing: useCommissionerGeneratedPasscode))")
 

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
@@ -45,7 +45,13 @@ class MCConnectionExampleViewModel: ObservableObject {
     func cancelConnectionAttempt(selectedCastingPlayer: MCCastingPlayer?) {
         DispatchQueue.main.async {
             // Only stop connection if we are pending passcode confirmation
-            if selectedCastingPlayer?.isPendingPasscodeFromUser() == true {
+            var connectionState = MC_CASTING_PLAYER_NOT_CONNECTED;
+            let err = selectedCastingPlayer?.getConnectionState(&connectionState)
+            if err != nil {
+                self.Log.error("MCConnectionExampleViewModel cancelConnect() MCCastingPlayer.getConnectionState() failed due to: \(err)")
+            }
+
+            if connectionState == MC_CASTING_PLAYER_CONNECTING {
                 self.Log.info("MCConnectionExampleViewModel cancelConnect(). User navigating back from ConnectionView")
                 let err = selectedCastingPlayer?.stopConnecting()
                 if err == nil {
@@ -125,17 +131,9 @@ class MCConnectionExampleViewModel: ObservableObject {
                                 dataSource.update(newCommissionableData)
                                 self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Updated MCAppParametersDataSource instance with new MCCommissionableData.")
                             } else {
-                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, calling stopConnecting()")
-                                self.connectionStatus = "Failed to update the MCAppParametersDataSource with the user entered passcode: \n\nRoute back and try again."
+                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed")
+                                self.connectionStatus = "Failed to update the MCAppParametersDataSource with the user entered passcode: \n\nRoute back to disconnect and try again."
                                 self.connectionSuccess = false
-                                // Since we failed to update the passcode, Attempt to cancel the connection attempt with
-                                // the CastingPlayer/Commissioner.
-                                let err = selectedCastingPlayer?.stopConnecting()
-                                if err == nil {
-                                    self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, then stopConnecting() succeeded")
-                                } else {
-                                    self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, InitializationExample.getAppParametersDataSource() failed, then stopConnecting() failed due to: \(err)")
-                                }
                                 return
                             }
 
@@ -144,28 +142,13 @@ class MCConnectionExampleViewModel: ObservableObject {
                             if errContinue == nil {
                                 self.connectionStatus = "Continuing to connect with user entered passcode: \(userEnteredPasscode)"
                             } else {
-                                self.connectionStatus = "Continue Connecting to Casting Player failed with: \(String(describing: errContinue)) \n\nRoute back and try again."
+                                self.connectionStatus = "Continue Connecting to Casting Player failed with: \(String(describing: errContinue)) \n\nRoute back to disconnect and try again."
                                 self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed due to: \(errContinue)")
-                                // Since continueConnecting() failed, Attempt to cancel the connection attempt with
-                                // the CastingPlayer/Commissioner.
-                                let err = selectedCastingPlayer?.stopConnecting()
-                                if err == nil {
-                                    self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed, then stopConnecting() succeeded")
-                                } else {
-                                    self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.continueConnecting() failed, then stopConnecting() failed due to: \(err)")
-                                }
                             }
                         }, cancelConnecting: {
-                            self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Connection attempt cancelled by the user, calling MCCastingPlayer.stopConnecting()")
-                            let err = selectedCastingPlayer?.stopConnecting()
+                            self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, Connection attempt cancelled by the user")
                             self.connectionSuccess = false
-                            if err == nil {
-                                self.connectionStatus = "User cancelled the connection attempt with CastingPlayer. \n\nRoute back to exit."
-                                self.Log.info("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, User cancelled the connection attempt with MCCastingPlayer, MCCastingPlayer.stopConnecting() succeeded.")
-                            } else {
-                                self.connectionStatus = "Cancel connection failed due to: \(String(describing: err)) \n\nRoute back to exit."
-                                self.Log.error("MCConnectionExampleViewModel connect() commissionerDeclarationCallback, MCCastingPlayer.stopConnecting() failed due to: \(err)")
-                            }
+                            self.connectionStatus = "User cancelled the connection attempt with CastingPlayer. \n\nRoute back to disconnect & exit."
                         })
                     }
                 }

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -228,11 +228,6 @@ exit:
 
 CHIP_ERROR CastingPlayer::StopConnecting()
 {
-    VerifyOrReturnValue(
-        mIdOptions.mCommissionerPasscode, CHIP_ERROR_INCORRECT_STATE,
-        ChipLogError(AppServer,
-                     "CastingPlayer::StopConnecting() mIdOptions.mCommissionerPasscode == false, ContinueConnecting() should only "
-                     "be called when the CastingPlayer/Commissioner-Generated passcode commissioning flow is in progress."););
     // Calling the internal StopConnecting() API with the shouldSendIdentificationDeclarationMessage set to true to notify the
     // CastingPlayer/Commissioner that the commissioning session was cancelled by the Casting Client/Commissionee user. This will
     // result in the Casting Client/Commissionee sending a CancelPasscode IdentificationDeclaration message to the CastingPlayer.

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -143,14 +143,6 @@ public:
     bool IsConnected() const { return mConnectionState == CASTING_PLAYER_CONNECTED; }
 
     /**
-     * @return true if this CastingPlayer is still pending pass code from user and therefore is not ready
-     */
-    bool IsPendingPasscodeFromUser() const
-    {
-        return mConnectionState == CASTING_PLAYER_CONNECTING && !mIdOptions.mCommissionerPasscodeReady;
-    }
-
-    /**
      * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new commissioning session request. If the
      * CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk, this will execute the User Directed
      * Commissioning (UDC) process by sending an IdentificationDeclaration message to the CastingPlayer/Commissioner. For certain

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -218,11 +218,15 @@ public:
      * otherwise. StopConnecting() can only be called by the client during the CastingPlayer/Commissioner-Generated passcode
      * commissioning flow. Calling StopConnecting() during the Client/Commissionee-Generated commissioning flow will return a
      * CHIP_ERROR_INCORRECT_STATE error.
+     *
+     * @note This method will free the calling object as a side effect.
      */
     CHIP_ERROR StopConnecting();
 
     /**
      * @brief Sets the internal connection state of this CastingPlayer to "disconnected"
+     *
+     * @note This method will free the calling object as a side effect.
      */
     void Disconnect();
 
@@ -286,7 +290,11 @@ public:
     /**
      * @brief Return the current state of the CastingPlayer
      */
-    ConnectionState GetConnectionState() const { return mConnectionState; }
+    ConnectionState GetConnectionState() const
+    {
+        ChipLogError(AppServer, "CastingPlayer::GetConnectionState() state: %d", mConnectionState);
+        return mConnectionState;
+    }
 
 private:
     std::vector<memory::Strong<Endpoint>> mEndpoints;
@@ -326,6 +334,8 @@ private:
     /**
      * @brief resets this CastingPlayer's state and calls mOnCompleted with the CHIP_ERROR. Also, after calling mOnCompleted, it
      * clears mOnCompleted by setting it to a nullptr.
+     *
+     * @note This method will free the calling object as a side effect.
      */
     void resetState(CHIP_ERROR err);
 

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.h
@@ -143,6 +143,14 @@ public:
     bool IsConnected() const { return mConnectionState == CASTING_PLAYER_CONNECTED; }
 
     /**
+     * @return true if this CastingPlayer is still pending pass code from user and therefore is not ready
+     */
+    bool IsPendingPasscodeFromUser() const
+    {
+        return mConnectionState == CASTING_PLAYER_CONNECTING && !mIdOptions.mCommissionerPasscodeReady;
+    }
+
+    /**
      * @brief Verifies that a connection exists with this CastingPlayer, or triggers a new commissioning session request. If the
      * CastingApp does not have the nodeId and fabricIndex of this CastingPlayer cached on disk, this will execute the User Directed
      * Commissioning (UDC) process by sending an IdentificationDeclaration message to the CastingPlayer/Commissioner. For certain

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayerDiscovery.h
@@ -108,6 +108,7 @@ public:
     static CastingPlayerDiscovery * GetInstance();
     ~CastingPlayerDiscovery()
     {
+        ChipLogError(AppServer, "CastingPlayerDiscovery destructor() called");
         mCastingPlayers.clear();
         mCastingPlayersInternal.clear();
     }

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -37,6 +37,18 @@ void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * e
 {
     ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() called");
 
+    // Make sure we have not disconnected from the TargetCastingPlayer when handling incoming messages.
+    // Sometimes the tv-app will still send messages after we clean up the TargetCastingPlayer.
+    // Exmaple: Call stopConnecting() after immediately after calling continueConnectiong()
+    //
+    // A proper fix would be to either not let user navigate back when running post commission or update commissioner, commissionee
+    // communication protocal to better handle asynchronous disconnects
+    if (CastingPlayer::GetTargetCastingPlayer() == nullptr)
+    {
+        ChipLogError(AppServer, "ChipDeviceEventHandler::Handler() TargetCastingPlayer is null for event: %u", event->Type);
+        return;
+    }
+
     bool runPostCommissioning           = false;
     chip::NodeId targetNodeId           = 0;
     chip::FabricIndex targetFabricIndex = 0;


### PR DESCRIPTION
## Updated Android tv-casting-app to send stopConnect command when user exits UDC before confirming passcode

### Changes
1. Added IsPendingPasscodeFromUser() to CastingPlayer. This function
   will return true if we are still connecting and pending user action
   for passcode
2. ConnectionExampleFragment.java onDestroy() calls stopConnect() if user
   has not confirmed passcode
4. MCConnectionExampleView ConnectingView dissapear calls stopConnect()
   if user has not confirmed passcode

### Testing
1. Manually verified UDC attempt is successful both Android iOS for following
   1. Attempt UDC attempt (both commissionee & commissioner generated passcode)
   2. Navigate back to discovery page
   3. Start new UDC attempt (both commissionee & commissioner generated passcode)

2. Manually verified UDC attempt is successful both Android iOS for following. UDC will finish in the background.
   1. Attempt UDC attempt (both commissionee & commissioner generated passcode)
   2. Confirm passcode on TV app or casting app depending on who
      generated passcode
   3. Navigate back before commission fnishes.

3. Manual regression test following
   * UDC attempt happy path (no navigate back) for both commissinee &
     commissioner generated passcode