### PR TITLE
Decouple ember functions from ethernet diagnostics cluster

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
@@ -445,47 +445,6 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace DishwasherAlarm
 
-namespace EthernetNetworkDiagnostics {
-
-Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
-                                                          TLV::TLVReader & aDataTlv)
-{
-    CHIP_ERROR TLVError = CHIP_NO_ERROR;
-    bool wasHandled     = false;
-    {
-        switch (aCommandPath.mCommandId)
-        {
-        case Commands::ResetCounts::Id: {
-            Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData);
-            if (TLVError == CHIP_NO_ERROR)
-            {
-                wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);
-            }
-            break;
-        }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI,
-                         ChipLogValueMEI(aCommandPath.mCommandId), ChipLogValueMEI(aCommandPath.mClusterId));
-            return Protocols::InteractionModel::Status::UnsupportedCommand;
-        }
-        }
-    }
-
-    if (CHIP_NO_ERROR != TLVError || !wasHandled)
-    {
-        ChipLogProgress(Zcl, "Failed to dispatch command, TLVError=%" CHIP_ERROR_FORMAT, TLVError.Format());
-        return Protocols::InteractionModel::Status::InvalidCommand;
-    }
-
-    // We use success as a marker that no special handling is required
-    // This is to avoid having a std::optional which uses slightly more code.
-    return Protocols::InteractionModel::Status::Success;
-}
-
-} // namespace EthernetNetworkDiagnostics
-
 namespace FanControl {
 
 Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
@@ -1865,9 +1824,6 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         break;
     case Clusters::DishwasherAlarm::Id:
         errorStatus = Clusters::DishwasherAlarm::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
-        break;
-    case Clusters::EthernetNetworkDiagnostics::Id:
-        errorStatus = Clusters::EthernetNetworkDiagnostics::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     case Clusters::FanControl::Id:
         errorStatus = Clusters::FanControl::DispatchServerCommand(apCommandObj, aCommandPath, aReader);

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
@@ -344,47 +344,6 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace DiagnosticLogs
 
-namespace EthernetNetworkDiagnostics {
-
-Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
-                                                          TLV::TLVReader & aDataTlv)
-{
-    CHIP_ERROR TLVError = CHIP_NO_ERROR;
-    bool wasHandled     = false;
-    {
-        switch (aCommandPath.mCommandId)
-        {
-        case Commands::ResetCounts::Id: {
-            Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData);
-            if (TLVError == CHIP_NO_ERROR)
-            {
-                wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);
-            }
-            break;
-        }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI,
-                         ChipLogValueMEI(aCommandPath.mCommandId), ChipLogValueMEI(aCommandPath.mClusterId));
-            return Protocols::InteractionModel::Status::UnsupportedCommand;
-        }
-        }
-    }
-
-    if (CHIP_NO_ERROR != TLVError || !wasHandled)
-    {
-        ChipLogProgress(Zcl, "Failed to dispatch command, TLVError=%" CHIP_ERROR_FORMAT, TLVError.Format());
-        return Protocols::InteractionModel::Status::InvalidCommand;
-    }
-
-    // We use success as a marker that no special handling is required
-    // This is to avoid having a std::optional which uses slightly more code.
-    return Protocols::InteractionModel::Status::Success;
-}
-
-} // namespace EthernetNetworkDiagnostics
-
 namespace GroupKeyManagement {
 
 Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
@@ -985,9 +944,6 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         break;
     case Clusters::DiagnosticLogs::Id:
         errorStatus = Clusters::DiagnosticLogs::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
-        break;
-    case Clusters::EthernetNetworkDiagnostics::Id:
-        errorStatus = Clusters::EthernetNetworkDiagnostics::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     case Clusters::GroupKeyManagement::Id:
         errorStatus = Clusters::GroupKeyManagement::DispatchServerCommand(apCommandObj, aCommandPath, aReader);

--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -73,7 +73,7 @@ CHIP_ERROR EthernetDiagosticsGlobalInstance::ReadIfSupported(CHIP_ERROR (Diagnos
                                                              AttributeValueEncoder & aEncoder)
 {
     T data;
-    CHIP_ERROR err = (DeviceLayer::GetDiagnosticDataProvider().*getter)(data);
+    CHIP_ERROR err = (mDiagnosticProvider.*getter)(data);
     if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
     {
         data = 0;
@@ -91,7 +91,7 @@ CHIP_ERROR EthernetDiagosticsGlobalInstance::ReadPHYRate(AttributeValueEncoder &
     Attributes::PHYRate::TypeInfo::Type pHYRate;
     auto value = app::Clusters::EthernetNetworkDiagnostics::PHYRateEnum::kRate10M;
 
-    if (DeviceLayer::GetDiagnosticDataProvider().GetEthPHYRate(value) == CHIP_NO_ERROR)
+    if (mDiagnosticProvider.GetEthPHYRate(value) == CHIP_NO_ERROR)
     {
         pHYRate.SetNonNull(value);
         ChipLogProgress(Zcl, "The current nominal, usable speed at the top of the physical layer of the Node: %d",
@@ -110,7 +110,7 @@ CHIP_ERROR EthernetDiagosticsGlobalInstance::ReadFullDuplex(AttributeValueEncode
     Attributes::FullDuplex::TypeInfo::Type fullDuplex;
     bool value = false;
 
-    if (DeviceLayer::GetDiagnosticDataProvider().GetEthFullDuplex(value) == CHIP_NO_ERROR)
+    if (mDiagnosticProvider.GetEthFullDuplex(value) == CHIP_NO_ERROR)
     {
         fullDuplex.SetNonNull(value);
         ChipLogProgress(Zcl, "The full-duplex operating status of Node: %d", value);
@@ -128,7 +128,7 @@ CHIP_ERROR EthernetDiagosticsGlobalInstance::ReadCarrierDetect(AttributeValueEnc
     Attributes::CarrierDetect::TypeInfo::Type carrierDetect;
     bool value = false;
 
-    if (DeviceLayer::GetDiagnosticDataProvider().GetEthCarrierDetect(value) == CHIP_NO_ERROR)
+    if (mDiagnosticProvider.GetEthCarrierDetect(value) == CHIP_NO_ERROR)
     {
         carrierDetect.SetNonNull(value);
         ChipLogProgress(Zcl, "The status of the Carrier Detect control signal present on the ethernet network interface: %d",

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -53,6 +53,7 @@ CommandHandlerInterfaceOnlyClusters:
     - General Diagnostics
     - Software Diagnostics
     - Wi-Fi Network Diagnostics
+    - Ethernet Network Diagnostics
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -5965,12 +5965,6 @@ bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::ThreadNetworkDiagnostics::Commands::ResetCounts::DecodableType & commandData);
 /**
- * @brief Ethernet Network Diagnostics Cluster ResetCounts Command callback (from client)
- */
-bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::EthernetNetworkDiagnostics::Commands::ResetCounts::DecodableType & commandData);
-/**
  * @brief Time Synchronization Cluster SetUTCTime Command callback (from client)
  */
 bool emberAfTimeSynchronizationClusterSetUTCTimeCallback(


### PR DESCRIPTION
Decouple Ethernet Diagnostics Cluster from ember and migrate to use CHI (CommandHandlerInterface) instead

Fix: https://github.com/project-chip/connectedhomeip/issues/37279

#### Testing
Validated by CI
