### PR TITLE
Optimize flash cost for optional command in wifi diagnostic cluster

### DIFF
--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -66,7 +66,9 @@ private:
 
     void InvokeCommand(HandlerContext & ctx) override;
 
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD   
     void HandleResetCounts(HandlerContext & ctx, const Commands::ResetCounts::DecodableType & commandData);
+#endif    
 
     DiagnosticDataProvider & mDiagnosticProvider;
 };
@@ -254,18 +256,22 @@ void WiFiDiagosticsGlobalInstance::InvokeCommand(HandlerContext & handlerContext
 {
     switch (handlerContext.mRequestPath.mCommandId)
     {
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD        
     case Commands::ResetCounts::Id:
         CommandHandlerInterface::HandleCommand<Commands::ResetCounts::DecodableType>(
             handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleResetCounts(ctx, commandData); });
         break;
+#endif        
     }
 }
 
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD   
 void WiFiDiagosticsGlobalInstance::HandleResetCounts(HandlerContext & ctx, const Commands::ResetCounts::DecodableType & commandData)
 {
     mDiagnosticProvider.ResetWiFiNetworkDiagnosticsCounts();
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::Success);
 }
+#endif
 
 WiFiDiagosticsGlobalInstance gWiFiDiagosticsInstance(DeviceLayer::GetDiagnosticDataProvider());
 

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -66,9 +66,9 @@ private:
 
     void InvokeCommand(HandlerContext & ctx) override;
 
-#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD   
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD
     void HandleResetCounts(HandlerContext & ctx, const Commands::ResetCounts::DecodableType & commandData);
-#endif    
+#endif
 
     DiagnosticDataProvider & mDiagnosticProvider;
 };
@@ -256,16 +256,16 @@ void WiFiDiagosticsGlobalInstance::InvokeCommand(HandlerContext & handlerContext
 {
     switch (handlerContext.mRequestPath.mCommandId)
     {
-#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD        
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD
     case Commands::ResetCounts::Id:
         CommandHandlerInterface::HandleCommand<Commands::ResetCounts::DecodableType>(
             handlerContext, [this](HandlerContext & ctx, const auto & commandData) { HandleResetCounts(ctx, commandData); });
         break;
-#endif        
+#endif
     }
 }
 
-#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD   
+#ifdef WI_FI_NETWORK_DIAGNOSTICS_ENABLE_RESET_COUNTS_CMD
 void WiFiDiagosticsGlobalInstance::HandleResetCounts(HandlerContext & ctx, const Commands::ResetCounts::DecodableType & commandData)
 {
     mDiagnosticProvider.ResetWiFiNetworkDiagnosticsCounts();


### PR DESCRIPTION
If command ResetCounts of wifi diagnostic cluster is not enabled in the ZAP config, we should not pay the flash cost for handling this command.

#### Testing
Validated by CI