### PR TITLE
More crosscompile docker image fixing: fix paths and tar

### DIFF
--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -19,18 +19,17 @@ RUN set -x \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
   && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.01.28' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
-  && tar xfvJ ubuntu-24.04.1-aarch64-sysroot.tar.xz \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/usr/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/usr/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/usr/lib/modules \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/lib/firmware \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/lib/git-core \
-  && rm -rf /opt/ubuntu-24.04.1-aarch64-sysroot/lib/modules \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/modules \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/firmware \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/git-core \
+  && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/lib/modules \
   && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}
 LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
 
-COPY --from=build /opt/ubuntu-24.04.1-aarch64-sysroot/ /opt/ubuntu-24.04.1-aarch64-sysroot/
+COPY --from=build /opt/ubuntu-24.04-aarch64-sysroot/ /opt/ubuntu-24.04-aarch64-sysroot/
 
-ENV SYSROOT_AARCH64=/opt/ubuntu-24.04.1-aarch64-sysroot
+ENV SYSROOT_AARCH64=/opt/ubuntu-24.04-aarch64-sysroot


### PR DESCRIPTION
One more update: new cipd upload is not a tar.gz but instead it is the full layout.

#### Testing

Executed the cipd instruction, noted no tar.gz and corrected the paths (no .01 version)