### PR TITLE
[Thermostat] Remove obsolete references to CommitPresetsSchedulesRequest

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-delegate.h
+++ b/src/app/clusters/thermostat-server/thermostat-delegate.h
@@ -120,7 +120,7 @@ public:
      * matches i.e. has the same presetHandle as an existing entry in the Presets attribute, the thermostat will update the entry
      * with the new preset values, otherwise it will add a new preset to the Presets attribute. For new presets that get added,
      * it is the responsibility of this API to allocate unique preset handles to the presets before saving the preset. This will be
-     * called when the Thermostat receives a CommitPresetsSchedulesRequest command to commit the pending preset changes.
+     * called when the Thermostat receives a AtomicRequest command of type CommitWrite to commit the pending preset changes.
      *
      * @return CHIP_NO_ERROR if the updates to the presets attribute has been committed successfully.
      * @return CHIP_ERROR if the updates to the presets attribute failed to commit for some reason.

--- a/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server-presets.cpp
@@ -464,7 +464,7 @@ Status ThermostatAttrAccess::PrecommitPresets(EndpointId endpoint)
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl,
-                         "emberAfThermostatClusterCommitPresetsSchedulesRequestCallback: GetPresetAtIndex failed with error "
+                         "PrecommitPresets: GetPresetAtIndex failed with error "
                          "%" CHIP_ERROR_FORMAT,
                          err.Format());
             return Status::InvalidInState;
@@ -516,7 +516,7 @@ Status ThermostatAttrAccess::PrecommitPresets(EndpointId endpoint)
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Zcl,
-                         "emberAfThermostatClusterCommitPresetsSchedulesRequestCallback: GetPendingPresetAtIndex failed with error "
+                         "PrecommitPresets: GetPendingPresetAtIndex failed with error "
                          "%" CHIP_ERROR_FORMAT,
                          err.Format());
             return Status::InvalidInState;


### PR DESCRIPTION
Change two minor references to the obsolete CommitPresetsSchedulesRequest command

#### Testing

Comment and log text update only.