### PR TITLE
Decouple ember functions from diagnostic logs cluster

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
@@ -354,47 +354,6 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace ColorControl
 
-namespace DiagnosticLogs {
-
-Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
-                                                          TLV::TLVReader & aDataTlv)
-{
-    CHIP_ERROR TLVError = CHIP_NO_ERROR;
-    bool wasHandled     = false;
-    {
-        switch (aCommandPath.mCommandId)
-        {
-        case Commands::RetrieveLogsRequest::Id: {
-            Commands::RetrieveLogsRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData);
-            if (TLVError == CHIP_NO_ERROR)
-            {
-                wasHandled = emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(apCommandObj, aCommandPath, commandData);
-            }
-            break;
-        }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI,
-                         ChipLogValueMEI(aCommandPath.mCommandId), ChipLogValueMEI(aCommandPath.mClusterId));
-            return Protocols::InteractionModel::Status::UnsupportedCommand;
-        }
-        }
-    }
-
-    if (CHIP_NO_ERROR != TLVError || !wasHandled)
-    {
-        ChipLogProgress(Zcl, "Failed to dispatch command, TLVError=%" CHIP_ERROR_FORMAT, TLVError.Format());
-        return Protocols::InteractionModel::Status::InvalidCommand;
-    }
-
-    // We use success as a marker that no special handling is required
-    // This is to avoid having a std::optional which uses slightly more code.
-    return Protocols::InteractionModel::Status::Success;
-}
-
-} // namespace DiagnosticLogs
-
 namespace DishwasherAlarm {
 
 Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
@@ -1859,9 +1818,6 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         break;
     case Clusters::ColorControl::Id:
         errorStatus = Clusters::ColorControl::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
-        break;
-    case Clusters::DiagnosticLogs::Id:
-        errorStatus = Clusters::DiagnosticLogs::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     case Clusters::DishwasherAlarm::Id:
         errorStatus = Clusters::DishwasherAlarm::DispatchServerCommand(apCommandObj, aCommandPath, aReader);

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
@@ -303,47 +303,6 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
 
 } // namespace ColorControl
 
-namespace DiagnosticLogs {
-
-Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
-                                                          TLV::TLVReader & aDataTlv)
-{
-    CHIP_ERROR TLVError = CHIP_NO_ERROR;
-    bool wasHandled     = false;
-    {
-        switch (aCommandPath.mCommandId)
-        {
-        case Commands::RetrieveLogsRequest::Id: {
-            Commands::RetrieveLogsRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData);
-            if (TLVError == CHIP_NO_ERROR)
-            {
-                wasHandled = emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(apCommandObj, aCommandPath, commandData);
-            }
-            break;
-        }
-        default: {
-            // Unrecognized command ID, error status will apply.
-            ChipLogError(Zcl, "Unknown command " ChipLogFormatMEI " for cluster " ChipLogFormatMEI,
-                         ChipLogValueMEI(aCommandPath.mCommandId), ChipLogValueMEI(aCommandPath.mClusterId));
-            return Protocols::InteractionModel::Status::UnsupportedCommand;
-        }
-        }
-    }
-
-    if (CHIP_NO_ERROR != TLVError || !wasHandled)
-    {
-        ChipLogProgress(Zcl, "Failed to dispatch command, TLVError=%" CHIP_ERROR_FORMAT, TLVError.Format());
-        return Protocols::InteractionModel::Status::InvalidCommand;
-    }
-
-    // We use success as a marker that no special handling is required
-    // This is to avoid having a std::optional which uses slightly more code.
-    return Protocols::InteractionModel::Status::Success;
-}
-
-} // namespace DiagnosticLogs
-
 namespace EthernetNetworkDiagnostics {
 
 Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandPath & aCommandPath,
@@ -982,9 +941,6 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, TLV:
         break;
     case Clusters::ColorControl::Id:
         errorStatus = Clusters::ColorControl::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
-        break;
-    case Clusters::DiagnosticLogs::Id:
-        errorStatus = Clusters::DiagnosticLogs::DispatchServerCommand(apCommandObj, aCommandPath, aReader);
         break;
     case Clusters::EthernetNetworkDiagnostics::Id:
         errorStatus = Clusters::EthernetNetworkDiagnostics::DispatchServerCommand(apCommandObj, aCommandPath, aReader);

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -166,14 +166,20 @@ void DiagnosticLogsServer::InvokeCommand(HandlerContext & handlerContext)
 {
     switch (handlerContext.mRequestPath.mCommandId)
     {
+#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
     case Commands::RetrieveLogsRequest::Id:
         CommandHandlerInterface::HandleCommand<Commands::RetrieveLogsRequest::DecodableType>(
             handlerContext,
             [this](HandlerContext & ctx, const auto & commandData) { HandleRetrieveLogsRequest(ctx, commandData); });
         break;
+#endif
+    default:
+        break; // Make the switch statement syntactically correct if MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT is not
+               // defined.
     }
 }
 
+#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
 void DiagnosticLogsServer::HandleRetrieveLogsRequest(HandlerContext & ctx,
                                                      const Commands::RetrieveLogsRequest::DecodableType & commandData)
 {
@@ -197,6 +203,7 @@ void DiagnosticLogsServer::HandleRetrieveLogsRequest(HandlerContext & ctx,
         instance.HandleLogRequestForBdx(&ctx.mCommandHandler, ctx.mRequestPath, intent, commandData.transferFileDesignator);
     }
 }
+#endif
 
 } // namespace DiagnosticLogs
 } // namespace Clusters

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -166,7 +166,7 @@ void DiagnosticLogsServer::InvokeCommand(HandlerContext & handlerContext)
 {
     switch (handlerContext.mRequestPath.mCommandId)
     {
-#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
+#ifdef DIAGNOSTIC_LOGS_ENABLE_RETRIEVE_LOGS_REQUEST_CMD
     case Commands::RetrieveLogsRequest::Id:
         CommandHandlerInterface::HandleCommand<Commands::RetrieveLogsRequest::DecodableType>(
             handlerContext,
@@ -179,7 +179,7 @@ void DiagnosticLogsServer::InvokeCommand(HandlerContext & handlerContext)
     }
 }
 
-#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
+#ifdef DIAGNOSTIC_LOGS_ENABLE_RETRIEVE_LOGS_REQUEST_CMD
 void DiagnosticLogsServer::HandleRetrieveLogsRequest(HandlerContext & ctx,
                                                      const Commands::RetrieveLogsRequest::DecodableType & commandData)
 {
@@ -203,7 +203,7 @@ void DiagnosticLogsServer::HandleRetrieveLogsRequest(HandlerContext & ctx,
         instance.HandleLogRequestForBdx(&ctx.mCommandHandler, ctx.mRequestPath, intent, commandData.transferFileDesignator);
     }
 }
-#endif
+#endif // #ifdef DIAGNOSTIC_LOGS_ENABLE_RETRIEVE_LOGS_REQUEST_CMD
 
 } // namespace DiagnosticLogs
 } // namespace Clusters

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
@@ -28,10 +28,12 @@ namespace Clusters {
 namespace DiagnosticLogs {
 
 /// A reference implementation for DiagnosticLogs source.
-class DiagnosticLogsServer
+class DiagnosticLogsServer : public CommandHandlerInterface
 {
 public:
     static DiagnosticLogsServer & Instance();
+
+    DiagnosticLogsServer() : CommandHandlerInterface(Optional<EndpointId>::Missing(), DiagnosticLogs::Id) {}
 
     /**
      * Set the default delegate of the diagnostic logs cluster for the specified endpoint
@@ -60,6 +62,9 @@ public:
 
 private:
     static DiagnosticLogsServer sInstance;
+
+    void InvokeCommand(HandlerContext & ctx) override;
+    void HandleRetrieveLogsRequest(HandlerContext & ctx, const Commands::RetrieveLogsRequest::DecodableType & commandData);
 };
 
 } // namespace DiagnosticLogs

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
@@ -66,7 +66,7 @@ private:
 
     void InvokeCommand(HandlerContext & ctx) override;
 
-#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
+#ifdef DIAGNOSTIC_LOGS_ENABLE_RETRIEVE_LOGS_REQUEST_CMD
     void HandleRetrieveLogsRequest(HandlerContext & ctx, const Commands::RetrieveLogsRequest::DecodableType & commandData);
 #endif
 };

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.h
@@ -21,6 +21,7 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/clusters/diagnostic-logs-server/DiagnosticLogsProviderDelegate.h>
+#include <zap-generated/gen_config.h>
 
 namespace chip {
 namespace app {
@@ -64,7 +65,10 @@ private:
     static DiagnosticLogsServer sInstance;
 
     void InvokeCommand(HandlerContext & ctx) override;
+
+#ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_CLIENT_ENDPOINT_COUNT
     void HandleRetrieveLogsRequest(HandlerContext & ctx, const Commands::RetrieveLogsRequest::DecodableType & commandData);
+#endif
 };
 
 } // namespace DiagnosticLogs

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -53,6 +53,7 @@ CommandHandlerInterfaceOnlyClusters:
     - General Diagnostics
     - Software Diagnostics
     - Wi-Fi Network Diagnostics
+    - Diagnostic Logs
 
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -5953,12 +5953,6 @@ bool emberAfOtaSoftwareUpdateRequestorClusterAnnounceOTAProviderCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOTAProvider::DecodableType & commandData);
 /**
- * @brief Diagnostic Logs Cluster RetrieveLogsRequest Command callback (from client)
- */
-bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::DecodableType & commandData);
-/**
  * @brief Thread Network Diagnostics Cluster ResetCounts Command callback (from client)
  */
 bool emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(


### PR DESCRIPTION
Decouple Diagnostic Logs Cluster from ember and migrate to use CHI (CommandHandlerInterface) instead

Fix: https://github.com/project-chip/connectedhomeip/issues/37281

#### Testing

Validated by CI