### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-103 : Changed sysroot for crosscompile image (new ubuntu version and includes NFC libs)
+104 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=c05c461b1119782cc839cf436fa04ec5e1fb2c8c
+ARG ZEPHYR_REVISION=52c23bb5bfa7b08fb2499fda8c34cbd3418e0c1d
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- telink: samples: FactoryData verifier for Telink
- telink: B92: add exit latency mechanism
- telink: tl721x: update hal_telink
- telink: tl721x: fix tercel retention mode
- drivers: ieee802154: b9x/tlx: avoid duplicate encryption during retx
- telink: tl321x: fix potential ram crash
- telink: tlsr9258a: remove b95

**Changes of N22 binary:**

- None (latest hash 7771c2fd73347f217919cb9fcf458b0fc6568a0c)

#### Testing
Tested manually.

Steps:
- Build image
- Run docker
- Check if Telink examples able to be built successfully