### PR TITLE
[ESP32] update document for app_main outside of main component

### DIFF
--- a/docs/platforms/esp32/config_options.md
+++ b/docs/platforms/esp32/config_options.md
@@ -15,14 +15,12 @@ CONFIG_LWIP_IPV4=n
 ### Executable component not in "main" component
 
 The ESP-IDF framework allows renaming the main component, which can be useful if
-you want to place the app_main() function in a different component.
+you want to place the `app_main()` function in a different component.
 
 For required changes in the executable component, please refer to the
 [esp-idf documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#renaming-main-component).
 
-If you're building applications that support Matter and want to place app_main()
-in a component other than main, use the following command:
-
-```
-idf.py -DEXECUTABLE_COMPONENT_NAME="your_component" build
-```
+You need to list the required components in `idf_component_register()`.
+If this module contains Matter related code, you may need to include
+`chip, app_update, spi_flash, and nvs_flash` as `PRIV_REQUIRES`, along with any
+other necessary dependencies.

--- a/docs/platforms/esp32/config_options.md
+++ b/docs/platforms/esp32/config_options.md
@@ -20,7 +20,7 @@ you want to place the `app_main()` function in a different component.
 For required changes in the executable component, please refer to the
 [esp-idf documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#renaming-main-component).
 
-You need to list the required components in `idf_component_register()`.
-If this module contains Matter related code, you may need to include
+You need to list the required components in `idf_component_register()`. If this
+module contains Matter related code, you may need to include
 `chip, app_update, spi_flash, and nvs_flash` as `PRIV_REQUIRES`, along with any
 other necessary dependencies.


### PR DESCRIPTION
Earlier, we needed to fetch and link the components separately. In #36883 we started using `add_prebuilt_library()` so there is no need to explicitly specify the executable component.

#### Testing
- manually moved `main` component somewhere else and verified that `idf.py build` works by following the steps in doc.