### PR TITLE
update docker for android

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-104 : [Telink] Update Docker image (Zephyr update)
+105 : Upgrade android docker with new kotlin/gradle

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -28,11 +28,11 @@ RUN set -x \
 
 # Download and install android command line tool (for installing `sdkmanager`)
 RUN set -x \
-    && wget -O /tmp/android-tools.zip https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip \
+    && wget -O /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
     && cd /opt/android/sdk \
-    && unzip /tmp/android-tools.zip \
-    && rm -f /tmp/android-tools.zip \
-    && test -d /opt/android/sdk/tools \
+    && unzip /tmp/cmdline-tools.zip \
+    && rm -f /tmp/cmdline-tools.zip \
+    && test -d /opt/android/sdk/cmdline-tools \
     && : # last line
 
 # Download and install android NDK


### PR DESCRIPTION
port change from https://github.com/project-chip/connectedhomeip/pull/33837/files to unblock android ci build

#### Testing

Docker update only, will be validated by docker if needed.
Checked URL mentioned in docker is valid.
