### PR TITLE
Fix compilation errors for android-chip-tool and java-matter-commissioner

### DIFF
--- a/src/controller/java/AndroidLogDownloadFromNode.cpp
+++ b/src/controller/java/AndroidLogDownloadFromNode.cpp
@@ -210,7 +210,7 @@ void AndroidLogDownloadFromNode::FinishLogDownloadFromNode(void * context, CHIP_
     JniLocalReferenceScope scope(env);
 
     jobject jCallback   = self->mJavaCallback.ObjectRef();
-    jint jFabricIndex   = self->mController->GetFabricIndex();
+    jint jFabricIndex   = static_cast<jint>(self->mController->GetFabricIndex());
     jlong jremoteNodeId = static_cast<jlong>(self->mRemoteNodeId);
 
     VerifyOrExit(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));

--- a/src/controller/java/AndroidLogDownloadFromNode.cpp
+++ b/src/controller/java/AndroidLogDownloadFromNode.cpp
@@ -152,7 +152,7 @@ void AndroidLogDownloadFromNode::OnResponseRetrieveLogs(void * context,
     using namespace chip::app::Clusters::DiagnosticLogs;
     if (data.status == StatusEnum::kSuccess)
     {
-        ChipLogProgress(Controller, "Success. Will receive log from BDX protocol.")
+        ChipLogProgress(Controller, "Success. Will receive log from BDX protocol.");
     }
     else if (data.status == StatusEnum::kExhausted)
     {
@@ -211,7 +211,7 @@ void AndroidLogDownloadFromNode::FinishLogDownloadFromNode(void * context, CHIP_
 
     jobject jCallback   = self->mJavaCallback.ObjectRef();
     jint jFabricIndex   = self->mController->GetFabricIndex();
-    jlong jremoteNodeId = self->mRemoteNodeId;
+    jlong jremoteNodeId = static_cast<jlong>(self->mRemoteNodeId);
 
     VerifyOrExit(env != nullptr, ChipLogError(Controller, "Could not get JNIEnv for current thread"));
 
@@ -274,7 +274,8 @@ void AndroidLogDownloadFromNode::OnTransferCallback(FabricIndex fabricIndex, Nod
 
     if (ret != JNI_TRUE)
     {
-        ChipLogError(Controller, "Transfer will be rejected.") * errInfoOnFailure = CHIP_ERROR_INTERNAL;
+        ChipLogError(Controller, "Transfer will be rejected.");
+        *errInfoOnFailure = CHIP_ERROR_INTERNAL;
     }
 }
 

--- a/src/controller/java/CHIPP256KeypairBridge.cpp
+++ b/src/controller/java/CHIPP256KeypairBridge.cpp
@@ -108,14 +108,14 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    VerifyOrReturnError(CanCastTo<uint32_t>(msg_length), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<jsize>(msg_length), CHIP_ERROR_INVALID_ARGUMENT);
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     jbyteArray jniMsg;
     jobject signedResult = nullptr;
     JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnError(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
-    err = JniReferences::GetInstance().N2J_ByteArray(env, msg, static_cast<uint32_t>(msg_length), jniMsg);
+    err = JniReferences::GetInstance().N2J_ByteArray(env, msg, static_cast<jsize>(msg_length), jniMsg);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
     VerifyOrReturnError(jniMsg != nullptr, err);
     VerifyOrReturnError(mDelegate.HasValidObjectRef(), CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
- Corrected logging statement syntax in `AndroidLogDownloadFromNode.cpp`
- Fixed type casting issue for `jlong jremoteNodeId`
- Resolved incorrect pointer dereference causing a misplaced operation in `OnTransferCallback`
- Updated type casting for `msg_length` in `CHIPP256KeypairBridge.cpp` to use `jsize` instead of `uint32_t`
- Adjusted JNI function call to use `static_cast<jsize>(msg_length)`

These changes ensure compatibility with JNI and address type inconsistencies that were causing build failures.

#### Testing

```bash
export PATH=$PATH:/opt/kotlin-compiler-1.8.0/bin
export ANDROID_HOME=/opt/Android/sdk/
export ANDROID_NDK_HOME=/opt/Android/sdk/ndk/23.2.8568313
export JAVA_HOME=/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home
export JAVA_PATH=/Library/Java/JavaVirtualMachines/amazon-corretto-11.jdk/Contents/Home

sed 's/ -XX:MaxPermSize=2048m//' examples/android/CHIPTool/gradle.properties > examples/android/CHIPTool/gradle.properties.new && mv examples/android/CHIPTool/gradle.properties.new examples/android/CHIPTool/gradle.properties

source scripts/activate.sh
./scripts/build/build_examples.py --target android-arm64-chip-tool --target darwin-arm64-java-matter-controller build
```

