### PR TITLE
Fix android docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-105 : Upgrade android docker with new kotlin/gradle
+106 : Upgrade android docker with java 17 and adjust the location for android cmdline tool

--- a/integrations/docker/images/stage-2/chip-build-java/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-java/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
@@ -20,4 +20,4 @@ RUN set -x \
     && : # last line
 
 ENV PATH $PATH:/usr/lib/kotlinc/bin
-ENV JAVA_PATH=/usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_PATH=/usr/lib/jvm/java-17-openjdk-amd64

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -27,11 +27,16 @@ RUN set -x \
     && : # last line
 
 # Download and install android command line tool (for installing `sdkmanager`)
+# We need create latest folder inide cmdline-tools, since latest android commandline tool looks for this latest folder
+# when running sdkmanager --licenses
 RUN set -x \
     && wget -O /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
     && cd /opt/android/sdk \
-    && unzip /tmp/cmdline-tools.zip \
-    && rm -f /tmp/cmdline-tools.zip \
+    && mkdir -p temp \
+    && unzip /tmp/cmdline-tools.zip -d temp \
+    && mkdir -p cmdline-tools/latest \
+    && cp -rf temp/cmdline-tools/* cmdline-tools/latest \
+    && rm -rf temp \
     && test -d /opt/android/sdk/cmdline-tools \
     && : # last line
 


### PR DESCRIPTION
-- latest android commandline tool needs java 17, otherwise, the compilation complains the  Unsupported class version for the sdk manager cli 
-- we need create latest folder inide cmdline-tools, since latest android commandline tool looks for this latest folder  when running sdkmanager --licenses

#### Testing
locally validated