### PR TITLE
Delay the commissioning window ended check by one second

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
@@ -420,8 +420,9 @@ tests:
       command: "WaitForMs"
       arguments:
           values:
+              # Wait one second longer to make sure the DUT had time to end the commissioning window
               - name: "ms"
-                value: PIXIT.CADMIN.CwDuration * 1000
+                value: (PIXIT.CADMIN.CwDuration + 1 ) * 1000
 
     - label:
           "Step 11: TH_CR2 reads the window status to verify the DUT_CE window


### PR DESCRIPTION
The test plan states that the test should wait till the time is over. The current test waits exactly as long as the window is. If there are cases where on the DUT the timers are not that accurate this "very exact check" could lead to false positives.

We had such cases with matter.js in the CI here and there because Node.js Timers are not 100% accurate and depending on other tasks in the event loop closing the window could be slightly delayed.

One CI example can be seen in https://github.com/project-chip/matter.js/actions/runs/12964616630/job/36163527843#step:4:3695

The analysis of a comparable showed this:

* 10:17:46.984 matter.js enables the timer for 180s
* 10:17:46.987 matter.js send InvokeResponse
* 10:17:46.989 till 10:20:46.989 test-runner wait, so exactly 180s
* 10:20:46.992 we get the read and we are still on "window opened"
* 10:20:46.994 we close the window - 10:20:46.996 trx is unlocked so done

So the test did the read 4ms too early.

This proposal could make this test a bit more false positive secure also for production certifications. The test and the exact timers in the test runner are "too exact" in my eyes and giving the DUT one second more time should not bring any harm but reduce false positives.

### Testing

This is a test itself. It is not executed in CI. I tested it manually locally