### PR TITLE
[ESP32]: Fixed the crash due to bypassing the ble_hs_is_enabled check.

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -227,6 +227,7 @@ private:
         kUseCustomDeviceName      = 0x0400, /**< The application has configured a custom BLE device name. */
         kAdvertisingRefreshNeeded = 0x0800, /**< The advertising configuration/state in ESP BLE layer needs to be updated. */
         kExtAdvertisingEnabled    = 0x1000, /**< The application has enabled Extended BLE announcement. */
+        kBleDeinitAndMemReleased  = 0x2000, /**< The ble is deinitialized and memory is reclaimed. */
     };
 
     enum


### PR DESCRIPTION
**Problem**
- Intermittent crashes were observed in pair unpair stress tests for `esp32` and `esp32c2 `due to accessing the `ble_hs_enabled_state` variable which is already cleared after reclaiming the memory in ble_hs_is_enabled check.

**Change Overview**
-  Added the `kBleDeinitializedMemReleased` flag in the state machine to return if the ble is already deinitialized.

#### Testing
- [x]  Conduct pair unpair stress tests on esp32 and esp32c2 for crash behaviour.
