### PR TITLE
Fix: reset lock owner thread id on stack unlock

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -112,7 +112,8 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_UnlockChipStack()
         chipDie();
 #endif
     }
-    mChipStackIsLocked = false;
+    mChipStackIsLocked        = false;
+    mChipStackLockOwnerThread = pthread_t();
 #endif
 
     int err = pthread_mutex_unlock(&mChipStackLock);


### PR DESCRIPTION
`_IsChipStackLockedByCurrentThread()` can be used in cases when chip stack in fact is not locked. So race condition can be triggered in some cases.

Minimal case:
```cpp
if (!chip::DeviceLayer::PlatformMgr().IsChipStackLockedByCurrentThread()) {
    chip::DeviceLayer::PlatformMgr().LockChipStack();
}

assertChipStackLockedByCurrentThread();
```

This code can lead to crash:
```
[chip] [warning] [DL] Chip stack locking error at 'contrib/libs/connectedhomeip/src/system/SystemLayerImplSelect.cpp:295'. Code is unsafe/racy
[chip] [warning] [-] chipDie chipDie chipDie
```

Scenario:
1. Thread A calls `_LockChipStack`
  - `mChipStackIsLocked` becomes `true`
  - `mChipStackLockOwnerThread` becomes the id of thread A
2. Thread B calls `_LockChipStack`
  - stack is locked, so it waits on mutex
3. Thread A calls `_UnlockChipStack`
  - `mChipStackIsLocked` becomes `false`
  - `mChipStackLockOwnerThread` still contains the id of thread A
4. Thread B is unlocked and starts to perform `_LockChipStack` code
  - `mChipStackIsLocked` becomes `true`
5. Thread A calls the minimal case code
  - `IsChipStackLockedByCurrentThread()` is `true` (because `mChipStackIsLocked` is set to `true` by thread B and `mChipStackLockOwnerThread` still contains the id of thread A), so it doesn't lock the stack
6. Thread B continues to perform the `_LockChipStack` code
  - `mChipStackLockOwnerThread` becomes the id of thread B
7. Thread A continues the minimal case code and goes into `assertChipStackLockedByCurrentThread();` and crashed because now `mChipStackLockOwnerThread` contains the id of thread B

I suggest to reset `mChipStackLockOwnerThread` on chip stack unlock to avoid such race condition.

#### Testing
Manual testing