### PR TITLE
TC-SC-4.3: Clear cache before sending request

### DIFF
--- a/src/python_testing/mdns_discovery/mdns_discovery.py
+++ b/src/python_testing/mdns_discovery/mdns_discovery.py
@@ -439,8 +439,8 @@ class MdnsDiscovery:
         """
         # Get service info
         service_info = AsyncServiceInfo(service_type, service_name)
-        is_service_discovered = await service_info.async_request(zeroconf, 3000)
         service_info.async_clear_cache()
+        is_service_discovered = await service_info.async_request(zeroconf, 3000)
 
         if is_service_discovered:
             if self._verbose_logging:


### PR DESCRIPTION
I believe this is a fix for the TC-SC-4.3 problem observed by QA. Because this is a race, it's difficult to determine if this is the only problem being observed, but these are flipped in the code.

#### Testing

This test is actually run in the CI already, but because this is a cache problem, this is timing dependent and only seems to show up when running locally on systems where the response comes back before the cache flush. I was able to repro the test failure here before the fix, and haven't seen the problem since (10 runs against LIT)