### PR TITLE
[chip-tool] include crypto/CryptoBuildConfig.h must be guarded by CHIP_HAVE_CONFIG_H

### DIFF
--- a/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
@@ -89,7 +89,7 @@ constexpr const char * kErrorDigestMismatch      = "The response digest does not
 class HTTPSSessionHolder
 {
 public:
-    HTTPSSessionHolder() {};
+    HTTPSSessionHolder(){};
 
     ~HTTPSSessionHolder()
     {

--- a/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
@@ -18,7 +18,10 @@
 
 #include "HTTPSRequest.h"
 
+#if CHIP_HAVE_CONFIG_H
 #include <crypto/CryptoBuildConfig.h>
+#endif // CHIP_HAVE_CONFIG_H
+
 #include <lib/support/Base64.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/ScopedBuffer.h>
@@ -86,7 +89,7 @@ constexpr const char * kErrorDigestMismatch      = "The response digest does not
 class HTTPSSessionHolder
 {
 public:
-    HTTPSSessionHolder(){};
+    HTTPSSessionHolder() {};
 
     ~HTTPSSessionHolder()
     {


### PR DESCRIPTION
`#include crypto/CryptoBuildConfig.h` must be guarded by `CHIP_HAVE_CONFIG_H`

#### Testing
* App builds
* Apps that don't use a config file no longer fail to build 
