### PR TITLE
Update specification revision and test

### DIFF
--- a/src/app/SpecificationDefinedRevisions.h
+++ b/src/app/SpecificationDefinedRevisions.h
@@ -31,7 +31,7 @@ namespace Revision {
  * See section 8.1.1. "Revision History" in the "Interaction Model
  * Specification" chapter of the core Matter specification.
  */
-inline constexpr InteractionModelRevision kInteractionModelRevision = 11;
+inline constexpr InteractionModelRevision kInteractionModelRevision = 12;
 inline constexpr uint8_t kInteractionModelRevisionTag               = 0xFF;
 
 /**
@@ -50,7 +50,7 @@ inline constexpr uint16_t kDataModelRevision = 18;
  * See section 11.1.5.22. "SpecificationVersion Attribute" in "Service and
  * Device Management" chapter of the core Matter specification.
  */
-inline constexpr uint32_t kSpecificationVersion = 0x01040000;
+inline constexpr uint32_t kSpecificationVersion = 0x01040100;
 
 } // namespace Revision
 } // namespace chip

--- a/src/app/tests/suites/TestBasicInformation.yaml
+++ b/src/app/tests/suites/TestBasicInformation.yaml
@@ -207,7 +207,7 @@ tests:
       attribute: "SpecificationVersion"
       response:
           # For now all-clusters-app has a version 1.4.
-          value: 0x01040000
+          value: 0x01040100
 
     - label: "Read the Max Paths Per Invoke value"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -717,7 +717,7 @@ tests:
 
     # This list should be expanded as we expand the TH to support more specification revisions
     - label:
-          "Step 62: SpecificationVersion value should be set to an appropriate
+          "Step 62: SpecificationVersion value should be set to a valid
            Major, Minor, and Dot version with the lower 8 bits set to zero."
       command: "readAttribute"
       attribute: "SpecificationVersion"

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -717,8 +717,8 @@ tests:
 
     # This list should be expanded as we expand the TH to support more specification revisions
     - label:
-          "Step 62: SpecificationVersion value should be set to a valid
-           Major, Minor, and Dot version with the lower 8 bits set to zero."
+          "Step 62: SpecificationVersion value should be set to a valid Major,
+          Minor, and Dot version with the lower 8 bits set to zero."
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -715,16 +715,16 @@ tests:
       response:
           value: ProductAppearancevalue
 
+    # This list should be expanded as we expand the TH to support more specification revisions
     - label:
-          "Step 62: SpecificationVersion value should in the inclusive range of
-          (0x01040000 to 0x0104FF00) and the lower 8 bits are set to zero."
+          "Step 62: SpecificationVersion value should be set to an appropriate
+           Major, Minor, and Dot version with the lower 8 bits set to zero."
       command: "readAttribute"
       attribute: "SpecificationVersion"
       response:
           saveAs: SpecificationVersionValue
           constraints:
-              minValue: 0x01040000
-              maxValue: 0x0104FF00
+              anyOf: [0x01040000, 0x01040100]
               hasMasksClear: [0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80]
 
     - label:


### PR DESCRIPTION
- Updates TC-BINFO-2.1 to expect specification revision as specified in https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10867.
- Updates specification revision in the SDK.
- Updates interaction model revision (note - it would appear we don't have tests for this see https://github.com/CHIP-Specifications/chip-test-plans/issues/4945)

test plan update: https://github.com/CHIP-Specifications/chip-test-plans/pull/4946

#### Testing
TC-BINFO-2.1 (updated in this PR and run in the CI)