### PR TITLE
[Chef] Add semicolon to fix compilation failure on MacOS

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -339,8 +339,8 @@ void ApplicationInit()
     ChipLogProgress(NotSpecified, "Chef Application Init !!!");
 
 #ifdef MATTER_DM_PLUGIN_REFRIGERATOR_ALARM_SERVER
-        // set Parent Endpoint and Composition Type for an Endpoint
-        EndpointId kRefEndpointId       = 1;
+    // set Parent Endpoint and Composition Type for an Endpoint
+    EndpointId kRefEndpointId           = 1;
     EndpointId kColdCabinetEndpointId   = 2;
     EndpointId kFreezeCabinetEndpointId = 3;
     SetTreeCompositionForEndpoint(kRefEndpointId);

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -336,7 +336,7 @@ void emberAfWakeOnLanClusterInitCallback(EndpointId endpoint)
 
 void ApplicationInit()
 {
-    ChipLogProgress(NotSpecified, "Chef Application Init !!!")
+    ChipLogProgress(NotSpecified, "Chef Application Init !!!");
 
 #ifdef MATTER_DM_PLUGIN_REFRIGERATOR_ALARM_SERVER
         // set Parent Endpoint and Composition Type for an Endpoint
@@ -354,7 +354,7 @@ void ApplicationInit()
 
 void ApplicationShutdown()
 {
-    ChipLogProgress(NotSpecified, "Chef Application Down !!!")
+    ChipLogProgress(NotSpecified, "Chef Application Down !!!");
 }
 
 // No-op function, used to force linking this file,


### PR DESCRIPTION
#### Testing

Just run the following commands to compile any Chef devices on MacOS 

```
$ source scripts/bootstrap.sh

$ cd examples/chef

$ ./chef.py -zbr -d rootnode_onofflight_bbs1b7IaOV -t linux 

```
