### PR TITLE
Fix assert command: self has no assert_true, this in mobly asserts.

### DIFF
--- a/src/python_testing/TC_DGWIFI_2_1.py
+++ b/src/python_testing/TC_DGWIFI_2_1.py
@@ -138,7 +138,7 @@ class TC_DGWIFI_2_1(MatterBaseTest):
                                              Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum)
 
             # Additional check that it's not kUnknownEnumValue:
-            self.assert_true(
+            asserts.assert_true(
                 security_type != Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue,
                 f"SecurityType should not be kUnknownEnumValue "
                 f"({Clusters.Objects.WiFiNetworkDiagnostics.Enums.SecurityTypeEnum.kUnknownEnumValue})"
@@ -158,8 +158,8 @@ class TC_DGWIFI_2_1(MatterBaseTest):
                                              Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum)
 
             # Additional check that it's not kUnknownEnumValue:
-            self.assert_true(wifi_version != Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue,
-                             f"WiFiVersion should not be kUnknownEnumValue ({Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue})")
+            asserts.assert_true(wifi_version != Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue,
+                                f"WiFiVersion should not be kUnknownEnumValue ({Clusters.Objects.WiFiNetworkDiagnostics.Enums.WiFiVersionEnum.kUnknownEnumValue})")
 
         #
         # STEP 5: TH reads ChannelNumber attribute


### PR DESCRIPTION
`self.assert_true` is not a thing, the assert_true is in mobly asserts (and is used in other places in this file too, I assume this was some copy&paste that got us).

#### Testing

Ran DGWIFI test on my laptop. It was erroring out before, after these changes it passed.
