### PR TITLE
[chip-tool] Fix missing include <algorithm> in DCL code

### DIFF
--- a/examples/chip-tool/commands/dcl/DisplayTermsAndConditions.cpp
+++ b/examples/chip-tool/commands/dcl/DisplayTermsAndConditions.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
+#include <algorithm>
 #include <iostream>
 #include <regex>
 #include <unordered_map>


### PR DESCRIPTION
[chip-tool] Fix missing include <algorithm> in DCL code

```
[chip_tool/commands/dcl/DisplayTermsAndConditions.cpp:82](/connectedhomeip/next/examples/chip_tool/commands/dcl/DisplayTermsAndConditions.cpp?l=82):10: error: missing '#include <__algorithm/transform.h>'; 'transform' must be declared before it is used
   82 |     std::transform(output.begin(), output.end(), output.begin(), [](unsigned char c) { return std::toupper(c); });
      |          ^
```

#### Testing
* App builds and error is gone
