### PR TITLE
[Android] Reset Android icd storage before init

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -159,6 +159,9 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
         chip::Credentials::SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
     }
 
+    // Because garbage collection may delay the removal of old controller instances, two instances could temporarily exist.
+    // To avoid issues with the shared ICD client storage, reset the storage before creating a new controller.
+    getICDClientStorage()->Shutdown();
     *errInfoOnFailure = getICDClientStorage()->Init(wrapperStorage, &wrapper->mSessionKeystore);
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
Because garbage collection may delay the removal of old controller instances, two instances could temporarily exist.
To avoid issues with the shared ICD client storage, reset the storage before creating a new controller.

fixes: https://github.com/project-chip/connectedhomeip/issues/36346
#### Testing
Manual run

