### PR TITLE
Support --storage-space for config dir

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -401,6 +401,9 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     SuccessOrExit(err);
 
     sSecondaryNetworkCommissioningEndpoint = secondaryNetworkCommissioningEndpoint;
+    if (LinuxDeviceOptions::GetInstance().StorageSpace != nullptr) {
+        ConfigurationMgr().SetStorageSpace(LinuxDeviceOptions::GetInstance().StorageSpace);
+    }
 
 #ifdef CHIP_CONFIG_KVS_PATH
     if (LinuxDeviceOptions::GetInstance().KVS == nullptr)

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -108,6 +108,7 @@ enum
     kDeviceOption_TestEventTriggerEnableKey,
     kTraceTo,
     kOptionSimulateNoInternalTime,
+    kDeviceOption_StorageSpace
 #if defined(PW_RPC_ENABLED)
     kOptionRpcServerPort,
 #endif
@@ -170,6 +171,7 @@ OptionDef sDeviceOptionDefs[] = {
 #endif
     { "command", kArgumentRequired, kDeviceOption_Command },
     { "PICS", kArgumentRequired, kDeviceOption_PICS },
+    { "storage-space", kArgumentRequired, kDeviceOption_StorageSpace },
     { "KVS", kArgumentRequired, kDeviceOption_KVS },
     { "interface-id", kArgumentRequired, kDeviceOption_InterfaceId },
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
@@ -300,6 +302,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --PICS <filepath>\n"
     "       A file containing PICS items.\n"
+    "\n"
+    "  --storage-space <dirpath>\n"
+    "       A folder to store factory data, configs, counters\n"
     "\n"
     "  --KVS <filepath>\n"
     "       A file to store Key Value Store items.\n"
@@ -600,6 +605,10 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_PICS:
         LinuxDeviceOptions::GetInstance().PICS = aValue;
+        break;
+
+    case kDeviceOption_StorageSpace:
+        LinuxDeviceOptions::GetInstance().StorageSpace = aValue;
         break;
 
     case kDeviceOption_KVS:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -70,6 +70,7 @@ struct LinuxDeviceOptions
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     const char * command                = nullptr;
     const char * PICS                   = nullptr;
+    const char * StorageSpace           = nullptr;
     const char * KVS                    = nullptr;
     chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::Null();
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -161,6 +161,9 @@ public:
 
     virtual CHIP_ERROR GetLocationCapability(uint8_t & location);
 
+    // Set storage path for all configs/data
+    virtual CHIP_ERROR SetStorageSpace(const char *path) {return CHIP_NO_ERROR;};
+
 protected:
     // ===== Members for internal use by the following friends.
 
@@ -172,7 +175,6 @@ protected:
     // Parentheses used to fix clang parsing issue with these declarations
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Read)(::chip::Platform::PersistedStorage::Key key, uint32_t & value);
     friend CHIP_ERROR(::chip::Platform::PersistedStorage::Write)(::chip::Platform::PersistedStorage::Key key, uint32_t value);
-
     virtual CHIP_ERROR Init()                                                                                   = 0;
     virtual bool CanFactoryReset()                                                                              = 0;
     virtual CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) = 0;

--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -49,15 +49,27 @@
 #define LOCALSTATEDIR "/tmp"
 #endif
 
+#ifndef FATCONFFILE
+#define FATCONFFILE "/chip_factory.ini"
+#endif
+
+#ifndef SYSCONFFILE
+#define SYSCONFFILE "/chip_config.ini"
+#endif
+
+#ifndef LOCALSTATEFILE
+#define LOCALSTATEFILE "/chip_counters.ini"
+#endif
+
 #define CHIP_DEFAULT_FACTORY_PATH                                                                                                  \
-    FATCONFDIR "/"                                                                                                                 \
-               "chip_factory.ini"
+    FATCONFDIR                                                                                                                     \
+    FATCONFFILE
 #define CHIP_DEFAULT_CONFIG_PATH                                                                                                   \
-    SYSCONFDIR "/"                                                                                                                 \
-               "chip_config.ini"
+    SYSCONFDIR                                                                                                                     \
+    SYSCONFFILE
 #define CHIP_DEFAULT_DATA_PATH                                                                                                     \
-    LOCALSTATEDIR "/"                                                                                                              \
-                  "chip_counters.ini"
+    LOCALSTATEDIR                                                                                                                  \
+    LOCALSTATEFILE
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -48,6 +48,16 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::SetStorageSpace(const char *path)
+{
+    CHIP_ERROR err;
+
+    err = PosixConfig::SetStorageSpace(path);
+
+    return err;
+}
+
+
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -53,6 +53,7 @@ public:
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
+    CHIP_ERROR SetStorageSpace(const char *path) override;
     CHIP_ERROR Init() override;
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset() override;

--- a/src/platform/Linux/PosixConfig.h
+++ b/src/platform/Linux/PosixConfig.h
@@ -83,6 +83,7 @@ public:
     static const Key kCounterKey_TotalOperationalHours;
     static const Key kCounterKey_BootReason;
 
+    static CHIP_ERROR SetStorageSpace(const char * path);
     static CHIP_ERROR Init();
 
     // Config value accessors.


### PR DESCRIPTION
This change allows users to reassign configuration, counters, data, and the key-value store to a directory other than "/tmp/" using the `--KVS=<kvs file>` and `--storage-space=<dir path>` flags.
