### PR TITLE
[chip-tool] Add config_enable_https_requests flag to examples/chip-to…

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -47,6 +47,10 @@ config("config") {
     defines += [ "CONFIG_USE_LOCAL_STORAGE" ]
   }
 
+  if (config_enable_https_requests) {
+    defines += [ "CONFIG_ENABLE_HTTPS_REQUESTS" ]
+  }
+
   cflags = [ "-Wconversion" ]
 }
 

--- a/examples/chip-tool/chip-tool.gni
+++ b/examples/chip-tool/chip-tool.gni
@@ -21,4 +21,5 @@ declare_args() {
   config_use_interactive_mode = true
   config_enable_yaml_tests = true
   config_use_local_storage = true
+  config_enable_https_requests = true
 }

--- a/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
@@ -25,6 +25,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <system/SystemError.h>
 
+#ifdef CONFIG_ENABLE_HTTPS_REQUESTS
 #if (CHIP_CRYPTO_OPENSSL || CHIP_CRYPTO_BORINGSSL)
 #include <netdb.h>
 #include <openssl/ssl.h>
@@ -33,6 +34,7 @@
 #define USE_CHIP_CRYPTO 1
 #endif
 #endif //(CHIP_CRYPTO_OPENSSL || CHIP_CRYPTO_BORINGSSL)
+#endif // CONFIG_ENABLE_HTTPS_REQUESTS
 
 namespace {
 constexpr const char * kHttpsPrefix        = "https://";
@@ -68,9 +70,18 @@ public:
 private:
     CHIP_ERROR LogNotImplementedError() const
     {
+#ifndef CONFIG_ENABLE_HTTPS_REQUESTS
+        ChipLogError(chipTool, "HTTPS requests are disabled via build configuration (config_enable_https_requests=false).");
+#elif !(CHIP_CRYPTO_OPENSSL || CHIP_CRYPTO_BORINGSSL)
         ChipLogError(chipTool,
                      "HTTPS requests are not available because neither OpenSSL nor BoringSSL is enabled. Contributions for "
                      "alternative implementations are welcome!");
+#elif !defined(SHA256_DIGEST_LENGTH)
+        ChipLogError(chipTool,
+                     "HTTPS requests are not available because SHA256_DIGEST_LENGTH is not defined, meaning response integrity "
+                     "verification via SHA-256 digest checking cannot be performed.");
+#endif
+
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 };
@@ -83,6 +94,38 @@ constexpr const char * kErrorSSLContextCreate    = "Failed to create SSL context
 constexpr const char * kErrorSSLObjectCreate     = "Failed to create SSL object";
 constexpr const char * kErrorSSLHandshake        = "SSL handshake failed";
 constexpr const char * kErrorDigestMismatch      = "The response digest does not match the expected digest";
+class AddressInfoHolder
+{
+public:
+    AddressInfoHolder(std::string & hostname, uint16_t port)
+    {
+        struct addrinfo hints                       = {};
+        hints.ai_family                             = AF_INET;
+        hints.ai_socktype                           = SOCK_STREAM;
+        int err                                     = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &mRes);
+#if CHIP_ERROR_LOGGING
+        constexpr const char * kErrorGetAddressInfo = "Failed to get address info: ";
+        VerifyOrDo(nullptr != mRes, ChipLogError(chipTool, "%s%s", kErrorGetAddressInfo, gai_strerror(err)));
+#else
+        (void) err;
+#endif
+    }
+
+    ~AddressInfoHolder()
+    {
+        if (mRes != nullptr)
+        {
+            freeaddrinfo(mRes);
+        }
+    }
+
+    bool HasInfo() const { return mRes != nullptr; }
+    struct addrinfo * Get() const { return mRes; }
+
+private:
+    struct addrinfo * mRes = nullptr;
+};
+
 class HTTPSSessionHolder
 {
 public:
@@ -90,10 +133,16 @@ public:
 
     ~HTTPSSessionHolder()
     {
-        VerifyOrReturn(nullptr != mContext);
-        SSL_free(mSSL);
-        SSL_CTX_free(mContext);
-        close(mSock);
+        if (nullptr != mContext)
+        {
+            SSL_free(mSSL);
+            SSL_CTX_free(mContext);
+        }
+
+        if (mSock >= 0)
+        {
+            close(mSock);
+        }
 
 #if !defined(OPENSSL_IS_BORINGSSL)
         EVP_cleanup();
@@ -134,23 +183,30 @@ public:
 private:
     CHIP_ERROR InitSocket(std::string & hostname, uint16_t port, int & sock)
     {
-        auto * server = gethostbyname(hostname.c_str());
-        VerifyOrReturnError(nullptr != server, CHIP_ERROR_NOT_CONNECTED);
+        AddressInfoHolder addressInfoHolder(hostname, port);
+        VerifyOrReturnError(addressInfoHolder.HasInfo(), CHIP_ERROR_NOT_CONNECTED);
 
-        sock = socket(AF_INET, SOCK_STREAM, 0);
-        VerifyOrReturnError(sock >= 0, CHIP_ERROR_NOT_CONNECTED);
+        auto * res = addressInfoHolder.Get();
+        for (struct addrinfo * p = res; p != nullptr; p = p->ai_next)
+        {
+            sock = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+            if (sock < 0)
+            {
+                continue; // Try the next address
+            }
 
-        struct sockaddr_in server_addr;
-        memset(&server_addr, 0, sizeof(server_addr));
-        server_addr.sin_family = AF_INET;
-        server_addr.sin_port   = htons(port);
-        memcpy(&server_addr.sin_addr.s_addr, server->h_addr, (size_t) server->h_length);
+            if (connect(sock, p->ai_addr, p->ai_addrlen) != 0)
+            {
+                close(sock);
+                sock = -1;
+                continue; // Try the next address
+            }
 
-        int rv = connect(sock, (struct sockaddr *) &server_addr, sizeof(server_addr));
-        VerifyOrReturnError(rv >= 0, CHIP_ERROR_POSIX(errno),
-                            ChipLogError(chipTool, "%s%s:%u", kErrorConnection, hostname.c_str(), port));
+            return CHIP_NO_ERROR;
+        }
 
-        return CHIP_NO_ERROR;
+        ChipLogError(chipTool, "%s%s:%u", kErrorConnection, hostname.c_str(), port);
+        return CHIP_ERROR_NOT_CONNECTED;
     }
 
     CHIP_ERROR InitSSL(int sock)


### PR DESCRIPTION
…ol/BUILD.gn and replace gethostbyname by getaddrinfo


#### Problem

This PR is a follow-up to #37049, introducing minor improvements:
 - Replaced `gethostbyname` with the modern `getaddrinfo` for better compatibility and future-proofing.
 - Enhanced logging when HTTPS requests are not enabled, making it clearer why they are unavailable.
 - Added a flag (`config_enabled_https_requests`) to `chip-tool` that allows explicitly disabling HTTPS requests, even when `OpenSSL`/`BoringSSL` is available. This flag is enabled by default but can be overridden to force HTTPS requests off.

#### Testing
 - Manual verification confirmed that the previous behavior is preserved.
 - Verified that logging correctly identifies why HTTPS requests are unavailable.
 - Ensured that the new flag properly disables HTTPS requests when set.
