### PR TITLE
Rename expectedResult to requiredResponse in the invokeCommands API.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.h
+++ b/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.h
@@ -20,11 +20,11 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * An object representing a single command to be invoked and the expected
- * result of invoking it.
+ * An object representing a single command to be invoked and the response
+ * required for the invoke to be considered successful.
  */
 MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
-@interface MTRCommandWithExpectedResult : NSObject <NSCopying, NSSecureCoding>
+@interface MTRCommandWithRequiredResponse : NSObject <NSCopying, NSSecureCoding>
 
 /**
  * The path of the command being invoked.
@@ -39,22 +39,22 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
 @property (nonatomic, retain, nullable) NSDictionary<NSString *, id> * commandFields;
 
 /**
- * The expected result of invoking the command.
+ * The response that represents this command succeeding.
  *
  * If this is nil, that indicates that the invoke is considered successful if it
  * does not result in an error status response.
  *
- * If this is is not nil, then invoke is considered successful if
- * it results in a data response and for each entry in the provided
- * expectedResult the field whose field ID matches the key of the entry has a
+ * If this is is not nil, then the invoke is considered successful if
+ * the response is a data response and for each entry in the provided
+ * requiredResponse the field whose field ID matches the key of the entry has a
  * value that equals the value of the entry.  Values of entries are data-value
  * dictionaries.
  */
-@property (nonatomic, copy, nullable) NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> * expectedResult;
+@property (nonatomic, copy, nullable) NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> * requiredResponse;
 
 - (instancetype)initWithPath:(MTRCommandPath *)path
                commandFields:(nullable NSDictionary<NSString *, id> *)commandFields
-              expectedResult:(nullable NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> *)expectedResult;
+            requiredResponse:(nullable NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> *)requiredResponse;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
+++ b/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
@@ -18,15 +18,15 @@
 #import "MTRLogging_Internal.h"
 #import <Matter/Matter.h>
 
-@implementation MTRCommandWithExpectedResult
+@implementation MTRCommandWithRequiredResponse
 - (instancetype)initWithPath:(MTRCommandPath *)path
                commandFields:(nullable NSDictionary<NSString *, id> *)commandFields
-              expectedResult:(nullable NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> *)expectedResult
+            requiredResponse:(nullable NSDictionary<NSNumber *, NSDictionary<NSString *, id> *> *)requiredResponse
 {
     if (self = [super init]) {
         self.path = path;
         self.commandFields = commandFields;
-        self.expectedResult = expectedResult;
+        self.requiredResponse = requiredResponse;
     }
 
     return self;
@@ -34,19 +34,19 @@
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [[MTRCommandWithExpectedResult alloc] initWithPath:self.path commandFields:self.commandFields expectedResult:self.expectedResult];
+    return [[MTRCommandWithRequiredResponse alloc] initWithPath:self.path commandFields:self.commandFields requiredResponse:self.requiredResponse];
 }
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p, path: %@, fields: %@, expectedResult: %@", NSStringFromClass(self.class), self, self.path, self.commandFields, self.expectedResult];
+    return [NSString stringWithFormat:@"<%@: %p, path: %@, fields: %@, requiredResponse: %@", NSStringFromClass(self.class), self, self.path, self.commandFields, self.requiredResponse];
 }
 
-#pragma mark - MTRCommandWithExpectedResult NSSecureCoding implementation
+#pragma mark - MTRCommandWithRequiredResponse NSSecureCoding implementation
 
 static NSString * const sPathKey = @"pathKey";
 static NSString * const sFieldsKey = @"fieldsKey";
-static NSString * const sExpectedResultKey = @"expectedResultKey";
+static NSString * const sExpectedResultKey = @"requiredResponseKey";
 
 + (BOOL)supportsSecureCoding
 {
@@ -62,38 +62,38 @@ static NSString * const sExpectedResultKey = @"expectedResultKey";
 
     _path = [decoder decodeObjectOfClass:MTRCommandPath.class forKey:sPathKey];
     if (!_path || ![_path isKindOfClass:MTRCommandPath.class]) {
-        MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded %@ for endpoint, not MTRCommandPath.", _path);
+        MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for endpoint, not MTRCommandPath.", _path);
         return nil;
     }
 
     _commandFields = [decoder decodeObjectOfClass:NSDictionary.class forKey:sFieldsKey];
     if (_commandFields) {
         if (![_commandFields isKindOfClass:NSDictionary.class]) {
-            MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded %@ for commandFields, not NSDictionary.", _commandFields);
+            MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for commandFields, not NSDictionary.", _commandFields);
             return nil;
         }
 
         if (!MTRDataValueDictionaryIsWellFormed(_commandFields) || ![MTRStructureValueType isEqual:_commandFields[MTRTypeKey]]) {
-            MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded %@ for commandFields, not a structure-typed data-value dictionary.", _commandFields);
+            MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for commandFields, not a structure-typed data-value dictionary.", _commandFields);
             return nil;
         }
     }
 
-    _expectedResult = [decoder decodeObjectOfClass:NSDictionary.class forKey:sExpectedResultKey];
-    if (_expectedResult) {
-        if (![_expectedResult isKindOfClass:NSDictionary.class]) {
-            MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded %@ for expectedResult, not NSDictionary.", _expectedResult);
+    _requiredResponse = [decoder decodeObjectOfClass:NSDictionary.class forKey:sExpectedResultKey];
+    if (_requiredResponse) {
+        if (![_requiredResponse isKindOfClass:NSDictionary.class]) {
+            MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for requiredResponse, not NSDictionary.", _requiredResponse);
             return nil;
         }
 
-        for (id key in _expectedResult) {
+        for (id key in _requiredResponse) {
             if (![key isKindOfClass:NSNumber.class]) {
-                MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded key %@ in expectedResult", key);
+                MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded key %@ in requiredResponse", key);
                 return nil;
             }
 
-            if (![_expectedResult[key] isKindOfClass:NSDictionary.class] || !MTRDataValueDictionaryIsWellFormed(_expectedResult[key])) {
-                MTR_LOG_ERROR("MTRCommandWithExpectedResult decoded value %@ for key %@ in expectedResult", _expectedResult[key], key);
+            if (![_requiredResponse[key] isKindOfClass:NSDictionary.class] || !MTRDataValueDictionaryIsWellFormed(_requiredResponse[key])) {
+                MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded value %@ for key %@ in requiredResponse", _requiredResponse[key], key);
                 return nil;
             }
         }
@@ -111,8 +111,8 @@ static NSString * const sExpectedResultKey = @"expectedResultKey";
     if (self.commandFields) {
         [coder encodeObject:self.commandFields forKey:sFieldsKey];
     }
-    if (self.expectedResult) {
-        [coder encodeObject:self.expectedResult forKey:sExpectedResultKey];
+    if (self.requiredResponse) {
+        [coder encodeObject:self.requiredResponse forKey:sExpectedResultKey];
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -19,7 +19,7 @@
 #import <Matter/MTRAttributeValueWaiter.h>
 #import <Matter/MTRBaseClusters.h>
 #import <Matter/MTRBaseDevice.h>
-#import <Matter/MTRCommandWithExpectedResult.h>
+#import <Matter/MTRCommandWithRequiredResponse.h>
 #import <Matter/MTRDefines.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -316,7 +316,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  *    response.  In this case the data-value representing the response will be
  *    the value of this field.
  */
-- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithExpectedResult *> *> *)commands
+- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithRequiredResponse *> *> *)commands
                  queue:(dispatch_queue_t)queue
             completion:(MTRDeviceResponseHandler)completion MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -523,7 +523,7 @@ MTR_DIRECT_MEMBERS
                             completion:responseHandler];
 }
 
-- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithExpectedResult *> *> *)commands
+- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithRequiredResponse *> *> *)commands
                  queue:(dispatch_queue_t)queue
             completion:(MTRDeviceResponseHandler)completion
 {

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -150,10 +150,10 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
             argumentIndex:0
                   ofReply:YES];
 
-    // invokeCommands gets handed MTRCommandWithExpectedResult (which includes
+    // invokeCommands gets handed MTRCommandWithRequiredResponse (which includes
     // MTRCommandPath, which is already in allowedClasses).
     [allowedClasses addObjectsFromArray:@[
-        [MTRCommandWithExpectedResult class],
+        [MTRCommandWithRequiredResponse class],
     ]];
     [interface setClasses:allowedClasses
               forSelector:@selector(deviceController:nodeID:invokeCommands:completion:)

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -459,7 +459,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
     }
 }
 
-- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithExpectedResult *> *> *)commands
+- (void)invokeCommands:(NSArray<NSArray<MTRCommandWithRequiredResponse *> *> *)commands
                  queue:(dispatch_queue_t)queue
             completion:(MTRDeviceResponseHandler)completion
 {

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -34,7 +34,7 @@
 #import <Matter/MTRClusterStateCacheContainer.h>
 #import <Matter/MTRClusters.h>
 #import <Matter/MTRCommandPayloadsObjc.h>
-#import <Matter/MTRCommandWithExpectedResult.h>
+#import <Matter/MTRCommandWithRequiredResponse.h>
 #import <Matter/MTRCommissionableBrowserDelegate.h>
 #import <Matter/MTRCommissionableBrowserResult.h>
 #import <Matter/MTRCommissioneeInfo.h>

--- a/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
+++ b/src/darwin/Framework/CHIP/XPC Protocol/MTRXPCServerProtocol.h
@@ -52,7 +52,7 @@ MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2))
  */
 - (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID downloadLogOfType:(MTRDiagnosticLogType)type timeout:(NSTimeInterval)timeout completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
-- (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID invokeCommands:(NSArray<NSArray<MTRCommandWithExpectedResult *> *> *)commands completion:(MTRDeviceResponseHandler)completion MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
+- (oneway void)deviceController:(NSUUID *)controller nodeID:(NSNumber *)nodeID invokeCommands:(NSArray<NSArray<MTRCommandWithRequiredResponse *> *> *)commands completion:(MTRDeviceResponseHandler)completion MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -5742,9 +5742,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                                             clusterID:@(MTRClusterIDTypeOnOffID)
                                                             commandID:@(MTRCommandIDTypeClusterOnOffCommandOffID)];
 
-    __auto_type * onCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:onPath commandFields:nil expectedResult:nil];
-    __auto_type * toggleCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:togglePath commandFields:nil expectedResult:nil];
-    __auto_type * offCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:offPath commandFields:nil expectedResult:nil];
+    __auto_type * onCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:onPath commandFields:nil requiredResponse:nil];
+    __auto_type * toggleCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:togglePath commandFields:nil requiredResponse:nil];
+    __auto_type * offCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:offPath commandFields:nil requiredResponse:nil];
 
     XCTestExpectation * simpleInvokeDone = [self expectationWithDescription:@"Invoke of a single 3-command group done"];
     [device invokeCommands:@[ @[ onCommand, toggleCommand, offCommand ] ]
@@ -5773,7 +5773,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     __auto_type * failingTogglePath = [MTRCommandPath commandPathWithEndpointID:@(1000) // No such endpoint
                                                                       clusterID:@(MTRClusterIDTypeOnOffID)
                                                                       commandID:@(MTRCommandIDTypeClusterOnOffCommandToggleID)];
-    __auto_type * failingToggleCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:failingTogglePath commandFields:nil expectedResult:nil];
+    __auto_type * failingToggleCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:failingTogglePath commandFields:nil requiredResponse:nil];
 
     XCTestExpectation * failingWithStatusInvokeDone = [self expectationWithDescription:@"Invoke of commands where one fails with a status done"];
     [device invokeCommands:@[ @[ failingToggleCommand, offCommand ], @[ onCommand, toggleCommand ], @[ failingToggleCommand ] ]
@@ -5801,7 +5801,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Third test: Do an invoke with three groups.  One of the commands in the
     // first group expects a data response but gets a status, which should be
     // treated as a failure.
-    __auto_type * onCommandExpectingData = [[MTRCommandWithExpectedResult alloc] initWithPath:onPath commandFields:nil expectedResult:@{
+    __auto_type * onCommandExpectingData = [[MTRCommandWithRequiredResponse alloc] initWithPath:onPath commandFields:nil requiredResponse:@{
         @(0) : @ {
             MTRTypeKey : MTRUnsignedIntegerValueType,
             MTRValueKey : @(0),
@@ -5850,7 +5850,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
             },
         ]
     };
-    __auto_type * updateFabricLabelNotExpectingFailureCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields expectedResult:nil];
+    __auto_type * updateFabricLabelNotExpectingFailureCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields requiredResponse:nil];
 
     XCTestExpectation * updateFabricLabelNotExpectingFailureExpectation = [self expectationWithDescription:@"Invoke of commands where no failure is expected and data response is received done"];
     [device invokeCommands:@[ @[ updateFabricLabelNotExpectingFailureCommand, onCommand ], @[ offCommand ] ]
@@ -5889,7 +5889,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Fifth test: do an invoke with two groups.  One of the commands in the
     // first group expects to get a data response and gets it, which should be
     // treated as success.
-    __auto_type * updateFabricLabelExpectingOKCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields expectedResult:@{
+    __auto_type * updateFabricLabelExpectingOKCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields requiredResponse:@{
         @(0) : @ {
             MTRTypeKey : MTRUnsignedIntegerValueType,
             MTRValueKey : @(MTROperationalCredentialsNodeOperationalCertStatusOK),
@@ -5933,7 +5933,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Sixth test: do an invoke with two groups.  One of the commands in the
     // first group expects to get a data response with a field that it does not get, which should be
     // treated as failure.
-    __auto_type * updateFabricLabelExpectingNonexistentFieldCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields expectedResult:@{
+    __auto_type * updateFabricLabelExpectingNonexistentFieldCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields requiredResponse:@{
         @(20) : @ {
             MTRTypeKey : MTRUnsignedIntegerValueType,
             MTRValueKey : @(MTROperationalCredentialsNodeOperationalCertStatusOK),
@@ -5975,7 +5975,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Seventh test: do an invoke with two groups.  One of the commands in the    // first group expects to get a data response with a field value that does
     // not match what it gets, which should be treated as a failure.
-    __auto_type * updateFabricLabelExpectingWrongValueCommand = [[MTRCommandWithExpectedResult alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields expectedResult:@{
+    __auto_type * updateFabricLabelExpectingWrongValueCommand = [[MTRCommandWithRequiredResponse alloc] initWithPath:updateFabricLabelPath commandFields:updateFabricLabelFields requiredResponse:@{
         @(0) : @ {
             MTRTypeKey : MTRUnsignedIntegerValueType,
             MTRValueKey : @(MTROperationalCredentialsNodeOperationalCertStatusFabricConflict),

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -159,8 +159,8 @@
 		512431282BA0C8BF000BC136 /* SetMRPParametersCommand.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5124311C2BA0C09A000BC136 /* SetMRPParametersCommand.mm */; };
 		512431292BA0C8BF000BC136 /* ResetMRPParametersCommand.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5124311A2BA0C09A000BC136 /* ResetMRPParametersCommand.mm */; };
 		5129BCFD26A9EE3300122DDF /* MTRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* MTRError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		512E8E7A2D52F7B6009407E3 /* MTRCommandWithExpectedResult.mm in Sources */ = {isa = PBXBuildFile; fileRef = 512E8E792D52F7B6009407E3 /* MTRCommandWithExpectedResult.mm */; };
-		512E8E7B2D52F7B6009407E3 /* MTRCommandWithExpectedResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 512E8E782D52F7B6009407E3 /* MTRCommandWithExpectedResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		512E8E7A2D52F7B6009407E3 /* MTRCommandWithRequiredResponse.mm in Sources */ = {isa = PBXBuildFile; fileRef = 512E8E792D52F7B6009407E3 /* MTRCommandWithRequiredResponse.mm */; };
+		512E8E7B2D52F7B6009407E3 /* MTRCommandWithRequiredResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 512E8E782D52F7B6009407E3 /* MTRCommandWithRequiredResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5131BF662BE2E1B000D5D6BC /* MTRTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */; };
 		51339B1F2A0DA64D00C798C1 /* MTRCertificateValidityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51339B1E2A0DA64D00C798C1 /* MTRCertificateValidityTests.m */; };
 		5136661328067D550025EDAE /* MTRDeviceController_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */; };
@@ -674,8 +674,8 @@
 		5124311B2BA0C09A000BC136 /* SetMRPParametersCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SetMRPParametersCommand.h; sourceTree = "<group>"; };
 		5124311C2BA0C09A000BC136 /* SetMRPParametersCommand.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SetMRPParametersCommand.mm; sourceTree = "<group>"; };
 		5129BCFC26A9EE3300122DDF /* MTRError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRError.h; sourceTree = "<group>"; };
-		512E8E782D52F7B6009407E3 /* MTRCommandWithExpectedResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommandWithExpectedResult.h; sourceTree = "<group>"; };
-		512E8E792D52F7B6009407E3 /* MTRCommandWithExpectedResult.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommandWithExpectedResult.mm; sourceTree = "<group>"; };
+		512E8E782D52F7B6009407E3 /* MTRCommandWithRequiredResponse.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommandWithRequiredResponse.h; sourceTree = "<group>"; };
+		512E8E792D52F7B6009407E3 /* MTRCommandWithRequiredResponse.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommandWithRequiredResponse.mm; sourceTree = "<group>"; };
 		5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRTestCase.mm; sourceTree = "<group>"; };
 		5131BF652BE2E1B000D5D6BC /* MTRTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTestCase.h; sourceTree = "<group>"; };
 		51339B1E2A0DA64D00C798C1 /* MTRCertificateValidityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRCertificateValidityTests.m; sourceTree = "<group>"; };
@@ -1518,8 +1518,8 @@
 				5178E67F2AE098510069DF72 /* MTRCommandTimedCheck.h */,
 				51FE723E2ACDEF3E00437032 /* MTRCommandPayloadExtensions_Internal.h */,
 				5178E6802AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h */,
-				512E8E782D52F7B6009407E3 /* MTRCommandWithExpectedResult.h */,
-				512E8E792D52F7B6009407E3 /* MTRCommandWithExpectedResult.mm */,
+				512E8E782D52F7B6009407E3 /* MTRCommandWithRequiredResponse.h */,
+				512E8E792D52F7B6009407E3 /* MTRCommandWithRequiredResponse.mm */,
 				3D010DCD2D408FA300CFFA02 /* MTRCommissioneeInfo.h */,
 				3D010DD12D4091C800CFFA02 /* MTRCommissioneeInfo_Internal.h */,
 				3D010DCE2D408FA300CFFA02 /* MTRCommissioneeInfo.mm */,
@@ -1953,7 +1953,7 @@
 				AF1CB86E2874B03B00865A96 /* MTROTAProviderDelegate.h in Headers */,
 				51D0B1402B61B3A4006E3511 /* MTRServerCluster.h in Headers */,
 				754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */,
-				512E8E7B2D52F7B6009407E3 /* MTRCommandWithExpectedResult.h in Headers */,
+				512E8E7B2D52F7B6009407E3 /* MTRCommandWithRequiredResponse.h in Headers */,
 				3CF134AF289D90FF0017A19E /* MTROperationalCertificateIssuer.h in Headers */,
 				5178E6822AE098520069DF72 /* MTRCommissionableBrowserResult_Internal.h in Headers */,
 				516415FD2B6ACA8300D5CE11 /* MTRServerAccessControl.h in Headers */,
@@ -2393,7 +2393,7 @@
 				514C79F02B62ADDA00DD6D7B /* descriptor.cpp in Sources */,
 				5109E9B42CB8B5DF0006884B /* MTRDeviceType.mm in Sources */,
 				3D843757294AD25A0070D20A /* MTRCertificateInfo.mm in Sources */,
-				512E8E7A2D52F7B6009407E3 /* MTRCommandWithExpectedResult.mm in Sources */,
+				512E8E7A2D52F7B6009407E3 /* MTRCommandWithRequiredResponse.mm in Sources */,
 				3D9F2FCE2D112295003CA2BB /* MTRAttributeTLVValueDecoder_Internal.mm in Sources */,
 				5A7947E427C0129600434CF2 /* MTRDeviceController+XPC.mm in Sources */,
 				7592BD0B2CC6BCC300EB74A0 /* EmberAttributeDataBuffer.cpp in Sources */,


### PR DESCRIPTION
The old naming was too confusing, and this more accurately represents what is actually going on.

#### Testing

Rename includes unit tests for the new name