### PR TITLE
[Java] Delete finalize method in java

### DIFF
--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
@@ -105,6 +105,7 @@ import chip.devicecontroller.model.NodeState;
 import chip.devicecontroller.model.Status;
 
 import javax.annotation.Nullable;
+import java.lang.ref.Cleaner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -169,10 +170,19 @@ public class ChipClusters {
 
     private Optional<Long> timeoutMillis = Optional.empty();
 
+    private final Cleaner.Cleanable cleanable;
+
     public BaseChipCluster(long devicePtr, int endpointId, long clusterId) {
       this.devicePtr = devicePtr;
       this.endpointId = endpointId;
       this.clusterId = clusterId;
+
+      this.cleanable = Cleaner.create().register(this, () -> {
+         if (chipClusterPtr != 0) {
+           deleteCluster(chipClusterPtr);
+           chipClusterPtr = 0;
+         }
+      });
     }
 
     /**
@@ -241,15 +251,6 @@ public class ChipClusters {
 
     @Deprecated
     public void deleteCluster(long chipClusterPtr) {}
-    @SuppressWarnings("deprecation")
-    protected void finalize() throws Throwable {
-      super.finalize();
-
-      if (chipClusterPtr != 0) {
-        deleteCluster(chipClusterPtr);
-        chipClusterPtr = 0;
-      }
-    }
   }
 
   abstract static class ReportCallbackImpl implements ReportCallback, SubscriptionEstablishedCallback, ResubscriptionAttemptCallback {

--- a/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
+++ b/scripts/py_matter_idl/matter_idl/generators/java/ChipClusters_java.jinja
@@ -177,12 +177,16 @@ public class ChipClusters {
       this.endpointId = endpointId;
       this.clusterId = clusterId;
 
-      this.cleanable = Cleaner.create().register(this, () -> {
-         if (chipClusterPtr != 0) {
-           deleteCluster(chipClusterPtr);
-           chipClusterPtr = 0;
-         }
-      });
+      this.cleanable =
+        Cleaner.create()
+          .register(
+            this,
+            () -> {
+              if (chipClusterPtr != 0) {
+                deleteCluster(chipClusterPtr);
+                chipClusterPtr = 0;
+              }
+            });
     }
 
     /**

--- a/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
+++ b/scripts/py_matter_idl/matter_idl/tests/outputs/several_clusters/java/ChipClusters.java
@@ -100,12 +100,16 @@ public class ChipClusters {
       this.endpointId = endpointId;
       this.clusterId = clusterId;
 
-      this.cleanable = Cleaner.create().register(this, () -> {
-         if (chipClusterPtr != 0) {
-           deleteCluster(chipClusterPtr);
-           chipClusterPtr = 0;
-         }
-      });
+      this.cleanable =
+        Cleaner.create()
+          .register(
+            this,
+            () -> {
+              if (chipClusterPtr != 0) {
+                deleteCluster(chipClusterPtr);
+                chipClusterPtr = 0;
+              }
+            });
     }
 
     /**

--- a/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/generated/java/chip/devicecontroller/ChipClusters.java
@@ -100,12 +100,16 @@ public class ChipClusters {
       this.endpointId = endpointId;
       this.clusterId = clusterId;
 
-      this.cleanable = Cleaner.create().register(this, () -> {
-         if (chipClusterPtr != 0) {
-           deleteCluster(chipClusterPtr);
-           chipClusterPtr = 0;
-         }
-      });
+      this.cleanable =
+        Cleaner.create()
+          .register(
+            this,
+            () -> {
+              if (chipClusterPtr != 0) {
+                deleteCluster(chipClusterPtr);
+                chipClusterPtr = 0;
+              }
+            });
     }
 
     /**

--- a/src/controller/java/src/chip/devicecontroller/BatchInvokeCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/BatchInvokeCallbackJni.java
@@ -34,12 +34,16 @@ public final class BatchInvokeCallbackJni {
     this.wrappedBatchInvokeCallback = wrappedBatchInvokeCallback;
     this.callbackHandle = newCallback();
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (chipClusterPtr != 0) {
-        deleteCluster(chipClusterPtr);
-        chipClusterPtr = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (chipClusterPtr != 0) {
+                    deleteCluster(chipClusterPtr);
+                    chipClusterPtr = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -26,6 +26,7 @@ import chip.devicecontroller.model.ChipAttributePath;
 import chip.devicecontroller.model.ChipEventPath;
 import chip.devicecontroller.model.DataVersionFilter;
 import chip.devicecontroller.model.InvokeElement;
+import java.lang.ref.Cleaner;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -43,6 +44,8 @@ public class ChipDeviceController {
   private CompletionListener completionListener;
   private ScanNetworksListener scanNetworksListener;
   private NOCChainIssuer nocChainIssuer;
+
+  private final Cleaner.Cleanable cleanable;
 
   /**
    * To load class and jni, we need to new AndroidChipPlatform after jni load but before new
@@ -67,6 +70,13 @@ public class ChipDeviceController {
       throw new NullPointerException("params cannot be null");
     }
     deviceControllerPtr = newDeviceController(params);
+
+    this.cleanable = Cleaner.create().register(this, () -> {
+      if (deviceControllerPtr != 0) {
+        deleteDeviceController(deviceControllerPtr);
+        deviceControllerPtr = 0;
+      }
+    });
   }
 
   public void setCompletionListener(CompletionListener listener) {
@@ -1771,16 +1781,6 @@ public class ChipDeviceController {
 
   static {
     System.loadLibrary("CHIPController");
-  }
-
-  @SuppressWarnings("deprecation")
-  protected void finalize() throws Throwable {
-    super.finalize();
-
-    if (deviceControllerPtr != 0) {
-      deleteDeviceController(deviceControllerPtr);
-      deviceControllerPtr = 0;
-    }
   }
 
   /** Interface to implement custom operational credentials issuer (NOC chain generation). */

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -71,12 +71,16 @@ public class ChipDeviceController {
     }
     deviceControllerPtr = newDeviceController(params);
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (deviceControllerPtr != 0) {
-        deleteDeviceController(deviceControllerPtr);
-        deviceControllerPtr = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (deviceControllerPtr != 0) {
+                    deleteDeviceController(deviceControllerPtr);
+                    deviceControllerPtr = 0;
+                  }
+                });
   }
 
   public void setCompletionListener(CompletionListener listener) {

--- a/src/controller/java/src/chip/devicecontroller/ExtendableInvokeCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/ExtendableInvokeCallbackJni.java
@@ -34,12 +34,16 @@ public final class ExtendableInvokeCallbackJni {
     this.wrappedExtendableInvokeCallback = wrappedExtendableInvokeCallback;
     this.callbackHandle = newCallback();
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (callbackHandle != 0) {
-        deleteCallback(callbackHandle);
-        callbackHandle = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (callbackHandle != 0) {
+                    deleteCallback(callbackHandle);
+                    callbackHandle = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {

--- a/src/controller/java/src/chip/devicecontroller/ExtendableInvokeCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/ExtendableInvokeCallbackJni.java
@@ -19,6 +19,7 @@ package chip.devicecontroller;
 
 import chip.devicecontroller.model.InvokeResponseData;
 import chip.devicecontroller.model.NoInvokeResponseData;
+import java.lang.ref.Cleaner;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -27,9 +28,18 @@ public final class ExtendableInvokeCallbackJni {
   private final ExtendableInvokeCallback wrappedExtendableInvokeCallback;
   private long callbackHandle;
 
+  private final Cleaner.Cleanable cleanable;
+
   public ExtendableInvokeCallbackJni(ExtendableInvokeCallback wrappedExtendableInvokeCallback) {
     this.wrappedExtendableInvokeCallback = wrappedExtendableInvokeCallback;
     this.callbackHandle = newCallback();
+
+    this.cleanable = Cleaner.create().register(this, () -> {
+      if (callbackHandle != 0) {
+        deleteCallback(callbackHandle);
+        callbackHandle = 0;
+      }
+    });
   }
 
   long getCallbackHandle() {
@@ -79,16 +89,5 @@ public final class ExtendableInvokeCallbackJni {
 
   private void onDone() {
     wrappedExtendableInvokeCallback.onDone();
-  }
-
-  // TODO(#8578): Replace finalizer with PhantomReference.
-  @SuppressWarnings("deprecation")
-  protected void finalize() throws Throwable {
-    super.finalize();
-
-    if (callbackHandle != 0) {
-      deleteCallback(callbackHandle);
-      callbackHandle = 0;
-    }
   }
 }

--- a/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java
@@ -17,14 +17,25 @@
  */
 package chip.devicecontroller;
 
+import java.lang.ref.Cleaner;
+
 /** JNI wrapper callback class for getting a connected device. */
 public class GetConnectedDeviceCallbackJni {
   private final GetConnectedDeviceCallback wrappedCallback;
   private long callbackHandle;
 
+  private final Cleaner.Cleanable cleanable;
+
   public GetConnectedDeviceCallbackJni(GetConnectedDeviceCallback wrappedCallback) {
     this.wrappedCallback = wrappedCallback;
     this.callbackHandle = newCallback(wrappedCallback);
+
+    this.cleanable = Cleaner.create().register(this, () -> {
+      if (callbackHandle != 0) {
+        deleteCallback(callbackHandle);
+        callbackHandle = 0;
+      }
+    });
   }
 
   long getCallbackHandle() {
@@ -34,17 +45,6 @@ public class GetConnectedDeviceCallbackJni {
   private native long newCallback(GetConnectedDeviceCallback wrappedCallback);
 
   private native void deleteCallback(long callbackHandle);
-
-  // TODO(#8578): Replace finalizer with PhantomReference.
-  @SuppressWarnings("deprecation")
-  protected void finalize() throws Throwable {
-    super.finalize();
-
-    if (callbackHandle != 0) {
-      deleteCallback(callbackHandle);
-      callbackHandle = 0;
-    }
-  }
 
   /** Callbacks for getting a device connected with PASE or CASE, depending on the context. */
   public interface GetConnectedDeviceCallback {

--- a/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java
@@ -30,12 +30,16 @@ public class GetConnectedDeviceCallbackJni {
     this.wrappedCallback = wrappedCallback;
     this.callbackHandle = newCallback(wrappedCallback);
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (callbackHandle != 0) {
-        deleteCallback(callbackHandle);
-        callbackHandle = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (callbackHandle != 0) {
+                    deleteCallback(callbackHandle);
+                    callbackHandle = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {

--- a/src/controller/java/src/chip/devicecontroller/InvokeCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/InvokeCallbackJni.java
@@ -17,8 +17,8 @@
  */
 package chip.devicecontroller;
 
-import java.lang.ref.Cleaner;
 import chip.devicecontroller.model.InvokeElement;
+import java.lang.ref.Cleaner;
 
 /** JNI wrapper callback class for {@link InvokeCallback}. */
 public final class InvokeCallbackJni {
@@ -31,12 +31,16 @@ public final class InvokeCallbackJni {
     this.wrappedInvokeCallback = wrappedInvokeCallback;
     this.callbackHandle = newCallback();
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (callbackHandle != 0) {
-        deleteCallback(callbackHandle);
-        callbackHandle = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (callbackHandle != 0) {
+                    deleteCallback(callbackHandle);
+                    callbackHandle = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {

--- a/src/controller/java/src/chip/devicecontroller/ReportCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/ReportCallbackJni.java
@@ -43,12 +43,16 @@ public class ReportCallbackJni {
     this.callbackHandle =
         newCallback(subscriptionEstablishedCallback, resubscriptionAttemptCallback);
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (callbackHandle != 0) {
-        deleteCallback(callbackHandle);
-        callbackHandle = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (callbackHandle != 0) {
+                    deleteCallback(callbackHandle);
+                    callbackHandle = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {

--- a/src/controller/java/src/chip/devicecontroller/WriteAttributesCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/WriteAttributesCallbackJni.java
@@ -33,12 +33,16 @@ public final class WriteAttributesCallbackJni {
     this.wrappedWriteAttributesCallback = wrappedWriteAttributesCallback;
     this.callbackHandle = newCallback();
 
-    this.cleanable = Cleaner.create().register(this, () -> {
-      if (callbackHandle != 0) {
-        deleteCallback(callbackHandle);
-        callbackHandle = 0;
-      }
-    });
+    this.cleanable =
+        Cleaner.create()
+            .register(
+                this,
+                () -> {
+                  if (callbackHandle != 0) {
+                    deleteCallback(callbackHandle);
+                    callbackHandle = 0;
+                  }
+                });
   }
 
   long getCallbackHandle() {


### PR DESCRIPTION
Fix #37399 
Replace finalize method to closer class.

#### Testing
 Don't need testing
 - Only replace finalize method to closer class.

