### PR TITLE
Enable python tests during coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,14 +81,6 @@ jobs:
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Run Tests
               run: scripts/tests/gn_tests.sh
-            # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
-            # TODO https://github.com/project-chip/connectedhomeip/issues/1512
-            # - name: Run Code Coverage
-            #   if: ${{ contains('main', env.BUILD_TYPE) }}
-            #   run: scripts/tools/codecoverage.sh
-            # - name: Upload Code Coverage
-            #   if: ${{ contains('main', env.BUILD_TYPE) }}
-            #   run: bash <(curl -s https://codecov.io/bash)
             - name: Set up Build Without Detail Logging
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
             - name: Run Build Without Detail Logging

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -172,8 +172,13 @@ if [ "$skip_gn" == false ]; then
     # 3) Run Python tests if requested
     #
     if [ "$ENABLE_PYTHON" == true ]; then
+        echo "Building python and applications ..."
+        scripts/run_in_build_env.sh \
+            "./scripts/tests/local.py build"
+
         echo "Running Python tests ..."
-        # TODO: run python tests.
+        scripts/run_in_build_env.sh \
+            "./scripts/tests/local.py python-tests"
     fi
 
     # ----------------------------------------------------------------------------


### PR DESCRIPTION
Add Python Integration Tests into Test Coverage
Fixes #37220

#### Testing

```
yufengw@yufengw-MX70:~/connectedhomeip$ ./scripts/build_coverage.sh --python

Running tests |████⚠︎                                   | (!) 18/181 [10%] in 8:50.2 (0.03/s) 
Script                   Duration(sec)  Status
---------------------  ---------------  --------
TC_BOOLCFG_4_1.py              1.9036   PASS
TC_BOOLCFG_4_2.py              1.91895  PASS
TC_BOOLCFG_2_1.py              1.93373  PASS
TC_BOOLCFG_3_1.py              1.99153  PASS
TC_BOOLCFG_4_4.py              2.01287  PASS
TC_BOOLCFG_5_2.py              2.02724  PASS
TC_BOOLCFG_5_1.py              2.04001  PASS
TC_ACL_2_2.py                  2.0491   PASS
TC_BOOLCFG_4_3.py              2.06557  PASS
TC_ACL_2_11.py                 2.09135  PASS
TC_ACE_1_4.py                  2.56405  PASS
TC_ACE_1_5.py                  2.7441   PASS
TC_ACE_1_3.py                  3.57819  PASS
TCP_Tests.py                   5.43298  PASS
TC_ACE_1_2.py                  9.39551  PASS
TC_BRBINFO_4_1.py            136.957    PASS
TC_AccessChecker.py          148.482    PASS
mobile-device-test.py        188.17     PASS

```
