### PR TITLE
[Tizen] Add ifdef for version-dependent Thread API

### DIFF
--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -521,12 +521,15 @@ CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
 
+    #if defined(TIZEN_NETWORK_THREAD_VERSION) && TIZEN_NETWORK_THREAD_VERSION >= 0x000900
     int threadErr = thread_get_version(mThreadInstance, &version);
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, TizenToChipError(threadErr),
                         ChipLogError(DeviceLayer, "FAIL: Get thread version: %s", get_error_message(threadErr)));
-
     ChipLogProgress(DeviceLayer, "Thread version [%u]", version);
     return CHIP_NO_ERROR;
+    #else
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+    #endif
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -521,15 +521,15 @@ CHIP_ERROR ThreadStackManagerImpl::_GetThreadVersion(uint16_t & version)
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_UNINITIALIZED);
 
-    #if defined(TIZEN_NETWORK_THREAD_VERSION) && TIZEN_NETWORK_THREAD_VERSION >= 0x000900
+#if defined(TIZEN_NETWORK_THREAD_VERSION) && TIZEN_NETWORK_THREAD_VERSION >= 0x000900
     int threadErr = thread_get_version(mThreadInstance, &version);
     VerifyOrReturnError(threadErr == THREAD_ERROR_NONE, TizenToChipError(threadErr),
                         ChipLogError(DeviceLayer, "FAIL: Get thread version: %s", get_error_message(threadErr)));
     ChipLogProgress(DeviceLayer, "Thread version [%u]", version);
     return CHIP_NO_ERROR;
-    #else
+#else
     return CHIP_ERROR_NOT_IMPLEMENTED;
-    #endif
+#endif
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_GetPollPeriod(uint32_t & buf)


### PR DESCRIPTION
### Problem
`thread_get_version` exists only for the Thread package version >=0.9.0.

### Changes
Add ifdef to inspect the version of said package and return `CHIP_ERROR_NOT_IMPLEMENTED` when the the version is invalid. Currently `TIZEN_NETWORK_THREAD_VERSION` is not defined, but new release of Thread package will have it.

### Testing
Examples dependent on Thread like `lightning-app` are building successfully.