### PR TITLE
Build time optimization

### DIFF
--- a/examples/chef/common/chef-dishwasher-mode-delegate-impl.cpp
+++ b/examples/chef/common/chef-dishwasher-mode-delegate-impl.cpp
@@ -17,6 +17,7 @@
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <chef-dishwasher-mode-delegate-impl.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/examples/chef/common/chef-rvc-mode-delegate.cpp
+++ b/examples/chef/common/chef-rvc-mode-delegate.cpp
@@ -17,6 +17,7 @@
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <chef-rvc-mode-delegate.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 

--- a/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 
 #include "LightingManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 

--- a/examples/lock-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lock-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 
 #include "LockManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Nullable.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/thermostat/infineon/cyw30739/src/TemperatureManager.cpp
+++ b/examples/thermostat/infineon/cyw30739/src/TemperatureManager.cpp
@@ -24,6 +24,7 @@
 #include "AppTask.h"
 #include "hdc2010.h"
 #include "platform/CHIPDeviceLayer.h"
+#include <app-common/zap-generated/cluster-objects.h>
 
 /**********************************************************
  * Defines and Constants

--- a/examples/thermostat/silabs/src/TemperatureManager.cpp
+++ b/examples/thermostat/silabs/src/TemperatureManager.cpp
@@ -25,6 +25,7 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "AppTask.h"
+#include <app-common/zap-generated/cluster-objects.h>
 
 /**********************************************************
  * Defines and Constants

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -129,14 +129,6 @@ function(chip_configure_data_model APP_TARGET)
         set(APP_GEN_FILES)
     endif()
 
-    # This is:
-    #    //src/app/common:cluster-objects
-    #
-    # TODO: ideally we would avoid duplication and would link gn-built items
-    target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-    )
-
     chip_zapgen(${APP_TARGET}-zapgen
         INPUT "${ARG_ZAP_FILE}"
         GENERATOR "app-templates"

--- a/src/app/util/AttributesChangedListener.h
+++ b/src/app/util/AttributesChangedListener.h
@@ -1,0 +1,35 @@
+/**
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/AttributePathParams.h>
+
+namespace chip {
+namespace app {
+
+/// Notification object of a specific path being changed
+class AttributesChangedListener
+{
+public:
+    virtual ~AttributesChangedListener() = default;
+
+    /// Called when the set of attributes identified by AttributePathParams (which may contain wildcards) is to be considered dirty.
+    virtual void MarkDirty(const AttributePathParams & path) = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/util/BUILD.gn
+++ b/src/app/util/BUILD.gn
@@ -53,7 +53,11 @@ source_set("types") {
 
 # This source set also depends on data-model
 source_set("af-types") {
-  sources = [ "af-types.h" ]
+  sources = [
+    "AttributesChangedListener.h",
+    "MarkAttributeDirty.h",
+    "af-types.h",
+  ]
   deps = [
     ":types",
     "${chip_root}/src/app:paths",

--- a/src/app/util/MarkAttributeDirty.h
+++ b/src/app/util/MarkAttributeDirty.h
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+namespace chip {
+namespace app {
+
+enum class MarkAttributeDirty
+{
+    kIfChanged,
+    kNo,
+    // kYes might need to be used if the attribute value was previously changed
+    // without reporting, and now is being set in a situation where we know
+    // reporting needs to be triggered (e.g. because QuieterReportingAttribute
+    // indicated that).
+    kYes,
+};
+}
+} // namespace chip

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -26,6 +26,8 @@
 #include <stdbool.h> // For bool
 #include <stdint.h>  // For various uint*_t types
 
+#include <app/util/AttributesChangedListener.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <app/util/basic-types.h>
 #include <app/util/types_stub.h> // For various types.
 
@@ -280,30 +282,3 @@ typedef chip::Protocols::InteractionModel::Status (*EmberAfClusterPreAttributeCh
 #define MAX_INT16U_VALUE (0xFFFF)
 
 /** @} END addtogroup */
-
-namespace chip {
-namespace app {
-
-enum class MarkAttributeDirty
-{
-    kIfChanged,
-    kNo,
-    // kYes might need to be used if the attribute value was previously changed
-    // without reporting, and now is being set in a situation where we know
-    // reporting needs to be triggered (e.g. because QuieterReportingAttribute
-    // indicated that).
-    kYes,
-};
-
-/// Notification object of a specific path being changed
-class AttributesChangedListener
-{
-public:
-    virtual ~AttributesChangedListener() = default;
-
-    /// Called when the set of attributes identified by AttributePathParams (which may contain wildcards) is to be considered dirty.
-    virtual void MarkDirty(const AttributePathParams & path) = 0;
-};
-
-} // namespace app
-} // namespace chip

--- a/src/app/util/attribute-table.h
+++ b/src/app/util/attribute-table.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include <app/ConcreteAttributePath.h>
-#include <app/util/af-types.h>
+#include <app/util/AttributesChangedListener.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <app/util/attribute-metadata.h>
 #include <lib/core/DataModelTypes.h>
 #include <protocols/interaction_model/StatusCode.h>

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -12,6 +12,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/attribute-table.h>
+#include <app/util/ember-strings.h>
 #include <app/util/odd-sized-integers.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/zap-templates/templates/app/attributes/Accessors.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors.zapt
@@ -7,11 +7,10 @@
 
 #pragma once
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/af-types.h>
-#include <app/util/ember-strings.h>
-#include <app-common/zap-generated/cluster-objects.h>
-#include <lib/support/Span.h>
+#include <app/util/basic-types.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/attribute-table.h>
+#include <app/util/ember-strings.h>
 #include <app/util/odd-sized-integers.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -24,11 +24,10 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/af-types.h>
-#include <app/util/ember-strings.h>
-#include <lib/support/Span.h>
+#include <app/util/MarkAttributeDirty.h>
+#include <app/util/basic-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {


### PR DESCRIPTION
### Changes
* Remove dependency to `cluster-objects.h` in `Accessors.h`
* Remove `cluster-objects.cpp` from `chip_data_model.cmake`

This should improve build times.

### Testing
Tested by building nrfconnect lock-app example. Build time improved by 5.69%. 

|  | Before | After |
|--------|--------|--------|
| Total | 34.95s | 32.96s |
| Accessors.cpp | 6.47s | 5.18s |
| cluster-objects.cpp | 7.40s | 0.00s |
| door-lock-server-callback.cpp | 3.24s | 2.69s |
| ZclCallbacks.cpp | 2.94s | 2.18s | 
> cluster-objects.cpp is now compiled only once

Traces generated with `ninjatracing`:
- [before.json](https://github.com/user-attachments/files/18709107/before.json)
- [after.json](https://github.com/user-attachments/files/18709122/after.json)