### PR TITLE
[Android][Docker]upgrade android sdk from 8 to 11 with java 11 support

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-109 : [Tizen] Fix race when storing cert credentials
+110 : [Android] Update android sdk and java version

--- a/integrations/docker/images/stage-2/chip-build-java/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-java/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    openjdk-17-jdk \
+    openjdk-11-jdk \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
@@ -20,4 +20,4 @@ RUN set -x \
     && : # last line
 
 ENV PATH $PATH:/usr/lib/kotlinc/bin
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -27,14 +27,14 @@ RUN set -x \
     && : # last line
 
 # Download and install android command line tool (for installing `sdkmanager`)
-# We need create latest folder inide cmdline-tools, since latest android commandline tool looks for this latest folder
+# We need create 10.0 folder inide cmdline-tools, since latest android commandline tool looks for this latest folder
 # when running sdkmanager --licenses
 RUN set -x \
     && wget -O /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-9862592_latest.zip \
     && cd /opt/android/sdk \
     && mkdir -p temp \
     && unzip /tmp/cmdline-tools.zip -d temp \
-    && mkdir -p cmdline-tools/latest \
+    && mkdir -p cmdline-tools/10.0 \
     && cp -rf temp/cmdline-tools/* cmdline-tools/10.0 \
     && rm -rf temp \
     && test -d /opt/android/sdk/cmdline-tools \

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -16,26 +16,26 @@ RUN set -x \
 
 # Download and install android SDK
 RUN set -x \
-    && wget -O /tmp/android-26.zip https://dl.google.com/android/repository/platform-26_r02.zip \
+    && wget -O /tmp/android-30.zip https://dl.google.com/android/repository/platform-30_r03.zip \
     && mkdir -p /opt/android/sdk/platforms \
     && cd /opt/android/sdk/platforms \
-    && unzip /tmp/android-26.zip \
-    && mv android-8.0.0 android-26 \
-    && rm -f /tmp/android-26.zip \
+    && unzip /tmp/android-30.zip \
+    && mv android-11 android-30 \
+    && rm -f /tmp/android-30.zip \
     && chmod -R a+rX /opt/android/sdk \
-    && test -d /opt/android/sdk/platforms/android-26 \
+    && test -d /opt/android/sdk/platforms/android-30 \
     && : # last line
 
 # Download and install android command line tool (for installing `sdkmanager`)
 # We need create latest folder inide cmdline-tools, since latest android commandline tool looks for this latest folder
 # when running sdkmanager --licenses
 RUN set -x \
-    && wget -O /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip \
+    && wget -O /tmp/cmdline-tools.zip https://dl.google.com/android/repository/commandlinetools-linux-9862592_latest.zip \
     && cd /opt/android/sdk \
     && mkdir -p temp \
     && unzip /tmp/cmdline-tools.zip -d temp \
     && mkdir -p cmdline-tools/latest \
-    && cp -rf temp/cmdline-tools/* cmdline-tools/latest \
+    && cp -rf temp/cmdline-tools/* cmdline-tools/10.0 \
     && rm -rf temp \
     && test -d /opt/android/sdk/cmdline-tools \
     && : # last line


### PR DESCRIPTION
Android oreo(8) is too old, and deprecated. 
Bump android to 11 where we start to have java 11 support

#### Testing

local testing
