### PR TITLE
[Docker Image] Add zstd to chip-build

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -105,6 +105,7 @@ RUN set -x \
     unzip \
     wget \
     zlib1g-dev \
+    zstd \
     && rm -rf /var/lib/apt/lists/ \
     && git lfs install \
     && : # last line

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-109 : [Tizen] Fix race when storing cert credentials
+110 : [Tizen] Add zstd to base image


### PR DESCRIPTION
When running workflow locally using `act`, `Save bootstrap cache` step takes significant amount of time. This is caused by missing `zstd`.

Fixes #37449

#### Testing
Tested by running workflows locally using `act`.
