### PR TITLE
fix: use mSystemState if systemState not passed in params

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -212,7 +212,10 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
     ReturnErrorOnFailure(ConvertX509CertToChipCert(params.controllerNOC, nocSpan));
     ReturnErrorOnFailure(ExtractNodeIdFabricIdFromOpCert(nocSpan, &nodeId, &fabricId));
 
-    auto * fabricTable            = params.systemState->Fabrics();
+    auto * systemState = params.systemState ? params.systemState : mSystemState;
+    VerifyOrReturnError(systemState != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    auto * fabricTable            = systemState->Fabrics();
     const FabricInfo * fabricInfo = nullptr;
 
     //


### PR DESCRIPTION
Use current system state in `InitControllerNOCChain` if systemState not passed via parameters.
`InitControllerNOCChain` can be called after `Init`, and `Init` installs `mSystemState`

#### Testing

Manual testing
