### PR TITLE
Enhance assert_list_element_type with optional empty list handling

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_asserts.py
@@ -158,19 +158,24 @@ def assert_list(value: Any, description: str, min_length: Optional[int] = None, 
                                   f"{description} must not exceed {max_length} elements")
 
 
-def assert_list_element_type(value: List[Any], description: str, expected_type: Type[T]) -> None:
+def assert_list_element_type(value: List[Any], expected_type: Type[T], description: str, allow_empty: bool = False) -> None:
     """
     Asserts that all elements in the list are of the expected type.
 
     Args:
         value: The list to validate
-        description: User-defined description for error messages
         expected_type: The type that all elements should match
+        description: User-defined description for error messages
+        allow_empty: If False, raises AssertionError for empty lists (default: False)
 
     Raises:
-        AssertionError: If value is not a list or contains elements of wrong type
+        AssertionError: If value is not a list, contains elements of wrong type,
+                       or is empty when allow_empty=False
+        TypeError: If expected_type is not a valid type
     """
     assert_list(value, description)
+    if not allow_empty and not value:
+        asserts.fail(f"{description} must not be empty")
     for i, item in enumerate(value):
         asserts.assert_true(isinstance(item, expected_type),
                             f"{description}[{i}] must be of type {expected_type.__name__}")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/test_matter_asserts.py
@@ -167,15 +167,17 @@ class TestMatterAsserts(unittest.TestCase):
     def test_assert_list_element_type(self):
         """Test assert_list_element_type with valid and invalid values."""
         # Valid cases
-        matter_asserts.assert_list_element_type([], "test_empty", str)
-        matter_asserts.assert_list_element_type(["a", "b"], "test_strings", str)
-        matter_asserts.assert_list_element_type([1, 2, 3], "test_ints", int)
+        matter_asserts.assert_list_element_type(["a", "b"], str, "test_strings")
+        matter_asserts.assert_list_element_type([1, 2, 3], int, "test_ints")
+        matter_asserts.assert_list_element_type([], str, "test_empty", allow_empty=True)
 
         # Invalid cases
         with self.assertRaises(signals.TestFailure):
-            matter_asserts.assert_list_element_type("not_a_list", "test_not_list", str)
+            matter_asserts.assert_list_element_type("not_a_list", str, "test_not_list")
         with self.assertRaises(signals.TestFailure):
-            matter_asserts.assert_list_element_type([1, "2", 3], "test_mixed", int)
+            matter_asserts.assert_list_element_type([1, "2", 3], int, "test_mixed")
+        with self.assertRaises(signals.TestFailure):
+            matter_asserts.assert_list_element_type([], str, "test_empty")  # empty list should fail by default
 
     # String assertion tests
     def test_assert_is_string(self):


### PR DESCRIPTION
#### Testing: local and in CI

Fixes #37452 

- Add optional `allow_empty` parameter to control empty list validation
- Reorder function parameters for better readability
- Update function docstring to clarify new behavior
- Update test cases