### PR TITLE
[bouffalo lab] update scripts and documents to support more options t…

### DIFF
--- a/docs/platforms/bouffalolab/getting_started.md
+++ b/docs/platforms/bouffalolab/getting_started.md
@@ -20,14 +20,17 @@ git clone --recurse-submodules https://github.com/project-chip/connectedhomeip.g
 -   Check out necessary submodules
 
     Checkout `BL_IOT_SDK` for `BL602`, `BL702` and `BL702L` platform:
+
     ```
     ./scripts/checkout_submodules.py --shallow --recursive --platform bouffalolab
     ```
 
     Checkout `bouffalo_sdk` for `BL616` platform:
+
     ```
     ./scripts/checkout_submodules.py --shallow --recursive --platform bouffalo_sdk
     ```
+
     > Please contact `Bouffalo Lab` for `BL616` SDK access.
 
     If you want to checkout Matter Linux example and development tools, please

--- a/docs/platforms/bouffalolab/getting_started.md
+++ b/docs/platforms/bouffalolab/getting_started.md
@@ -17,24 +17,31 @@ git clone --recurse-submodules https://github.com/project-chip/connectedhomeip.g
     git clone --depth=1 https://github.com/project-chip/connectedhomeip.git
     ```
 
--   check out `Bouffalo Lab` platform support repos as follows:
+-   Check out necessary submodules
 
+    Checkout `BL_IOT_SDK` for `BL602`, `BL702` and `BL702L` platform:
     ```
-    scripts/checkout_submodules.py --shallow --recursive --platform bouffalolab
+    ./scripts/checkout_submodules.py --shallow --recursive --platform bouffalolab
     ```
+
+    Checkout `bouffalo_sdk` for `BL616` platform:
+    ```
+    ./scripts/checkout_submodules.py --shallow --recursive --platform bouffalo_sdk
+    ```
+    > Please contact `Bouffalo Lab` for `BL616` SDK access.
 
     If you want to checkout Matter Linux example and development tools, please
     try as follows:
 
     ```
-    scripts/checkout_submodules.py --shallow --recursive --platform linux bouffalolab
+    ./scripts/checkout_submodules.py --shallow --recursive --platform linux bouffalolab
     ```
 
     Or if you want to checkout Matter Darwin example and development tools,
     please try as follows:
 
     ```
-    scripts/checkout_submodules.py --shallow --recursive --platform darwin bouffalolab
+    ./scripts/checkout_submodules.py --shallow --recursive --platform darwin bouffalolab
     ```
 
 # Setup build environment

--- a/docs/platforms/bouffalolab/matter_factory_data.md
+++ b/docs/platforms/bouffalolab/matter_factory_data.md
@@ -113,43 +113,45 @@ Please reference to `--help` for more detail.
 
 ## Generate with default configuration
 
-- Default setting uses the following parameters
+-   Default setting uses the following parameters
 
-  - PAI certification: [test PAI certification](../../../credentials/test/attestation/Chip-Test-PAI-FFF1-8000-Key.pem) 
+    -   PAI certification:
+        [test PAI certification](../../../credentials/test/attestation/Chip-Test-PAI-FFF1-8000-Key.pem)
 
-  - Vendor ID for DAC: 0xFFF1; Vendor ID for CD: 0x130d
+    -   Vendor ID for DAC: 0xFFF1; Vendor ID for CD: 0x130d
 
-  - Product ID for DAC: 0x8000, Product ID for CD: 0x1001
+    -   Product ID for DAC: 0x8000, Product ID for CD: 0x1001
 
+*   Run following command to generate all plain text factory data
 
-- Run following command to generate all plain text factory data
-
-  Please create output folder first. Here takes `out/test-cert` as example.
-
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
-  ```
-
-  - Check DAC certificate. Here takes `out_130d_1001_106_dac_cert.pem` as generated test certificate.
+    Please create output folder first. Here takes `out/test-cert` as example.
 
     ```shell
-    openssl x509 -noout -text -in out/test-cert/out_130d_1001_106_dac_cert.pem
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
     ```
 
-  - Check Certification Declare. Here takes `out_130d_1001_cd.der` as generated test certificate.
+    -   Check DAC certificate. Here takes `out_130d_1001_106_dac_cert.pem` as
+        generated test certificate.
+
+        ```shell
+        openssl x509 -noout -text -in out/test-cert/out_130d_1001_106_dac_cert.pem
+        ```
+
+    -   Check Certification Declare. Here takes `out_130d_1001_cd.der` as
+        generated test certificate.
+
+        ```shell
+        ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+        ```
+
+*   Run following command to generate factory data which encrypt private of
+    device attestation data
 
     ```shell
-    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
     ```
 
-- Run following command to generate factory data which encrypt private of
-  device attestation data
-
-  ```shell
-  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
-  ```
-
-  > An example of hex string of 16 bytes: 12345678123456781234567812345678. 
+    > An example of hex string of 16 bytes: 12345678123456781234567812345678.
 
 After command executes successfully, the output folder will has files as below:
 
@@ -174,113 +176,119 @@ After command executes successfully, the output folder will has files as below:
 Self-defined PAA/PAI certificates may use in development and test scenario. But,
 user should know it has limit to work with real ecosystem.
 
-- Export environment variables in terminal for certificates generation
+-   Export environment variables in terminal for certificates generation
 
-  ```
-  export TEST_CERT_VENDOR_ID=130D   # Vendor ID hex string
-  export TEST_CERT_PRODUCT_ID=1001  # Product ID hex string
-  export TEST_CERT_CN=BFLB          # Common Name
-  ```
-
-- Generate PAA certificate and key to `out/cert` folder.
-
-  ```shell
-  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
-  ```
-
-  - Check PAA certificate
-
-    ```shell
-    openssl x509 -noout -text -in out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+    ```
+    export TEST_CERT_VENDOR_ID=130D   # Vendor ID hex string
+    export TEST_CERT_PRODUCT_ID=1001  # Product ID hex string
+    export TEST_CERT_CN=BFLB          # Common Name
     ```
 
-- Convert PAA PEM format file to PAA DER format file
-
-  ```shell
-  ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
-  ```
-
-  > Please save this PAA DER format file which will be used by `chip-tool`
-  > during commissioning.
-
-- Generate PAI certificate and key:
-
-  ```shell
-  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
-  ```
-
-  -   Check PAI certificate
-
-      ```shell
-      openssl x509 -noout -text -in out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
-      ```
-
-- Generate `MFD` in plain text data with same VID/PID in DAC and CD
-
-  - Use same environment variables  `TEST_CERT_VENDOR_ID` and `TEST_CERT_PRODUCT_ID` for CD.
-
-      ```shell
-      ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CERT_VENDOR_ID} --product_id 0x${TEST_CERT_PRODUCT_ID}
-      ```
-
-      > Appending `--key <hex string of 16 bytes>` option to enable encrypt
-      > private key of attestation device data.
-
-  - Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as generated test certification.
+-   Generate PAA certificate and key to `out/cert` folder.
 
     ```shell
-    openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
+    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
     ```
 
-  - Check PAA/PAI/DAC certificate chain.
+    -   Check PAA certificate
+
+        ```shell
+        openssl x509 -noout -text -in out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+        ```
+
+-   Convert PAA PEM format file to PAA DER format file
 
     ```shell
-    ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
-    ```
-    
-  - Check Certification Declare. Here takes `out_130d_1001_cd.der` as generated test certification.
-
-    ```shell
-    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+    ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
     ```
 
-- Generate `MFD` in plain text data with different VID/PID in DAC and CD
+    > Please save this PAA DER format file which will be used by `chip-tool`
+    > during commissioning.
 
-  - Export vendor ID and product ID for CD
-  
-    ```shell
-    export TEST_CD_VENDOR_ID=730D   # Vendor ID hex string
-    export TEST_CD_PRODUCT_ID=7001  # Product ID hex string
-    ```
-  
-  - Run script to generate DAC/CD and MFD.
+-   Generate PAI certificate and key:
 
-      ```shell
-      ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CD_VENDOR_ID} --product_id 0x${TEST_CD_PRODUCT_ID}
-      ```
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+    ```
 
-      > Appending `--key <hex string of 16 bytes>` option to enable encrypt
-      > private key of attestation device data.
-      >
-      > Please use --`vendor_name`  and `--product_name` to change vendor name and product name.
-  
-  - Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as generated test certification.
-  
-    ```shell
-    openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
-    ```
-  
-  - Check PAA/PAI/DAC certificate chain.
-  
-    ```shell
-    ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
-    ```
-    
-  - Check Certification Declare. Here takes `out_730D_7001_cd.der` as generated test certification.
-  
-    ```shell
-    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
-    ```
+    -   Check PAI certificate
+
+        ```shell
+        openssl x509 -noout -text -in out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+        ```
+
+-   Generate `MFD` in plain text data with same VID/PID in DAC and CD
+
+    -   Use same environment variables `TEST_CERT_VENDOR_ID` and
+        `TEST_CERT_PRODUCT_ID` for CD.
+
+        ```shell
+        ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CERT_VENDOR_ID} --product_id 0x${TEST_CERT_PRODUCT_ID}
+        ```
+
+        > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+        > private key of attestation device data.
+
+    -   Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as
+        generated test certification.
+
+        ```shell
+        openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
+        ```
+
+    -   Check PAA/PAI/DAC certificate chain.
+
+        ```shell
+        ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+        ```
+
+    -   Check Certification Declare. Here takes `out_130d_1001_cd.der` as
+        generated test certification.
+
+        ```shell
+        ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+        ```
+
+-   Generate `MFD` in plain text data with different VID/PID in DAC and CD
+
+    -   Export vendor ID and product ID for CD
+
+        ```shell
+        export TEST_CD_VENDOR_ID=730D   # Vendor ID hex string
+        export TEST_CD_PRODUCT_ID=7001  # Product ID hex string
+        ```
+
+    -   Run script to generate DAC/CD and MFD.
+
+        ```shell
+        ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CD_VENDOR_ID} --product_id 0x${TEST_CD_PRODUCT_ID}
+        ```
+
+        > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+        > private key of attestation device data.
+        >
+        > Please use --`vendor_name` and `--product_name` to change vendor name
+        > and product name.
+
+    -   Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as
+        generated test certification.
+
+        ```shell
+        openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
+        ```
+
+    -   Check PAA/PAI/DAC certificate chain.
+
+        ```shell
+        ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+        ```
+
+    -   Check Certification Declare. Here takes `out_730D_7001_cd.der` as
+        generated test certification.
+
+        ```shell
+        ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+        ```
 
 ## Generate with self-defined DAC certificate and key
 

--- a/docs/platforms/bouffalolab/matter_factory_data.md
+++ b/docs/platforms/bouffalolab/matter_factory_data.md
@@ -337,6 +337,5 @@ key.
 > If `MFD` file has cipher text data, please append
 > `--key <hex string of 16 bytes>` option to program to this key to efuse.
 
-
 Please free contact to `Bouffalo Lab` for DAC provider service and higher
 security solution, such as SoC inside certificate requesting.

--- a/docs/platforms/bouffalolab/matter_factory_data.md
+++ b/docs/platforms/bouffalolab/matter_factory_data.md
@@ -71,7 +71,7 @@ Script tool
 call `chip-cert` to generate test certificates and verify certificates.
 
 Please run below command to compile `chip-cert` tool under `connnectedhomeip`
-repo.
+repo for Linux platform.
 
 ```shell
 ./scripts/build/build_examples.py --target linux-x64-chip-cert build
@@ -111,24 +111,45 @@ repo.
 
 Please reference to `--help` for more detail.
 
-## Generate with default test certificates
+## Generate with default configuration
 
--   Run following command to generate all plain text factory data
+- Default setting uses the following parameters
 
-    Please create output folder first. Here takes `out/test-cert` as example.
+  - PAI certification: [test PAI certification](../../../credentials/test/attestation/Chip-Test-PAI-FFF1-8000-Key.pem) 
+
+  - Vendor ID for DAC: 0xFFF1; Vendor ID for CD: 0x130d
+
+  - Product ID for DAC: 0x8000, Product ID for CD: 0x1001
+
+
+- Run following command to generate all plain text factory data
+
+  Please create output folder first. Here takes `out/test-cert` as example.
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
+  ```
+
+  - Check DAC certificate. Here takes `out_130d_1001_106_dac_cert.pem` as generated test certificate.
 
     ```shell
-    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert
+    openssl x509 -noout -text -in out/test-cert/out_130d_1001_106_dac_cert.pem
     ```
 
--   Run following command to generate factory data which encrypt private of
-    device attestation data
+  - Check Certification Declare. Here takes `out_130d_1001_cd.der` as generated test certificate.
 
     ```shell
-    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
+    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
     ```
 
-    > An example of hex string of 16 bytes: 12345678123456781234567812345678
+- Run following command to generate factory data which encrypt private of
+  device attestation data
+
+  ```shell
+  ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --key <hex string of 16 bytes>
+  ```
+
+  > An example of hex string of 16 bytes: 12345678123456781234567812345678. 
 
 After command executes successfully, the output folder will has files as below:
 
@@ -153,43 +174,113 @@ After command executes successfully, the output folder will has files as below:
 Self-defined PAA/PAI certificates may use in development and test scenario. But,
 user should know it has limit to work with real ecosystem.
 
--   Export environment variables in terminal for easy operations
+- Export environment variables in terminal for certificates generation
 
-    ```
-    export TEST_CERT_VENDOR_ID=130D # Vendor ID hex string
-    export TEST_CERT_CN=BFLB        # Common Name
-    ```
+  ```
+  export TEST_CERT_VENDOR_ID=130D   # Vendor ID hex string
+  export TEST_CERT_PRODUCT_ID=1001  # Product ID hex string
+  export TEST_CERT_CN=BFLB          # Common Name
+  ```
 
--   Generate PAA certificate and key to `out/cert` folder.
+- Generate PAA certificate and key to `out/cert` folder.
 
-    ```shell
-    mkdir out/test-cert
-    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
-    ```
+  ```shell
+  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type a --subject-cn "${TEST_CERT_CN} PAA 01" --valid-from "2020-10-15 14:23:43" --lifetime 7305 --out-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --subject-vid ${TEST_CERT_VENDOR_ID}
+  ```
 
--   Convert PAA PEM format file to PAA DER format file
-
-    ```shell
-    ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
-    ```
-
-    > Please save this PAA DER format file which will be used by `chip-tool`
-    > during commissioning.
-
--   Generate PAI certificate and key:
+  - Check PAA certificate
 
     ```shell
-    ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+    openssl x509 -noout -text -in out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
     ```
 
--   Generate `MFD` in plain text data
+- Convert PAA PEM format file to PAA DER format file
+
+  ```shell
+  ./out/linux-x64-chip-cert/chip-cert convert-cert -d out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.der
+  ```
+
+  > Please save this PAA DER format file which will be used by `chip-tool`
+  > during commissioning.
+
+- Generate PAI certificate and key:
+
+  ```shell
+  ./out/linux-x64-chip-cert/chip-cert gen-att-cert --type i --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-15 14:23:43" --lifetime 7305 --ca-key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --out out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+  ```
+
+  -   Check PAI certificate
+
+      ```shell
+      openssl x509 -noout -text -in out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem
+      ```
+
+- Generate `MFD` in plain text data with same VID/PID in DAC and CD
+
+  - Use same environment variables  `TEST_CERT_VENDOR_ID` and `TEST_CERT_PRODUCT_ID` for CD.
+
+      ```shell
+      ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CERT_VENDOR_ID} --product_id 0x${TEST_CERT_PRODUCT_ID}
+      ```
+
+      > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+      > private key of attestation device data.
+
+  - Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as generated test certification.
 
     ```shell
-    ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem
+    openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
     ```
 
-    > Appending `--key <hex string of 16 bytes>` option to enable encrypt
-    > private key of attestation device data.
+  - Check PAA/PAI/DAC certificate chain.
+
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+    ```
+    
+  - Check Certification Declare. Here takes `out_130d_1001_cd.der` as generated test certification.
+
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+    ```
+
+- Generate `MFD` in plain text data with different VID/PID in DAC and CD
+
+  - Export vendor ID and product ID for CD
+  
+    ```shell
+    export TEST_CD_VENDOR_ID=730D   # Vendor ID hex string
+    export TEST_CD_PRODUCT_ID=7001  # Product ID hex string
+    ```
+  
+  - Run script to generate DAC/CD and MFD.
+
+      ```shell
+      ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CD_VENDOR_ID} --product_id 0x${TEST_CD_PRODUCT_ID}
+      ```
+
+      > Appending `--key <hex string of 16 bytes>` option to enable encrypt
+      > private key of attestation device data.
+      >
+      > Please use --`vendor_name`  and `--product_name` to change vendor name and product name.
+  
+  - Check DAC certificate. Here takes `out_130d_1001_1349_dac_cert.pem` as generated test certification.
+  
+    ```shell
+    openssl x509 -noout -text -in out/test-cert/out_130d_1001_1349_dac_cert.pem
+    ```
+  
+  - Check PAA/PAI/DAC certificate chain.
+  
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert validate-att-cert --dac out/test-cert/out_130d_1001_1349_dac_cert.pem --pai out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --paa out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem
+    ```
+    
+  - Check Certification Declare. Here takes `out_730D_7001_cd.der` as generated test certification.
+  
+    ```shell
+    ./out/linux-x64-chip-cert/chip-cert print-cd out/test-cert/out_130d_1001_cd.der
+    ```
 
 ## Generate with self-defined DAC certificate and key
 
@@ -200,14 +291,14 @@ user should know it has limit to work with real ecosystem.
 
     ```
     export TEST_CERT_VENDOR_ID=130D  # Vendor ID hex string
-    export TEST_CERT_PRODUCT_ID=1001 # Vendor ID hex string
+    export TEST_CERT_PRODUCT_ID=1001 # Product ID hex string
     export TEST_CERT_CN=BFLB         # Common Name
     ```
 
 -   Generate DAC certificate and key
 
     ```shell
-    out/linux-x64-chip-cert/chip-cert gen-att-cert --type d --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --subject-pid ${TEST_CERT_VENDOR_ID} --valid-from "2020-10-16 14:23:43" --lifetime 5946 --ca-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --out out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
+    out/linux-x64-chip-cert/chip-cert gen-att-cert --type d --subject-cn "${TEST_CERT_CN} PAI 01" --subject-vid ${TEST_CERT_VENDOR_ID} --subject-pid ${TEST_CERT_PRODUCT_ID} --valid-from "2020-10-16 14:23:43" --lifetime 5946 --ca-key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --ca-cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --out-key out/test-cert/Chip-DAC-Key-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem --out out/test-cert/Chip-DAC-Cert-${TEST_CERT_VENDOR_ID}-${TEST_CERT_PRODUCT_ID}.pem
     ```
 
     > **Note**, `--valid-from` and `--lifetime` should be in `--valid-from` and

--- a/docs/platforms/bouffalolab/matter_factory_data.md
+++ b/docs/platforms/bouffalolab/matter_factory_data.md
@@ -258,7 +258,7 @@ user should know it has limit to work with real ecosystem.
         export TEST_CD_PRODUCT_ID=7001  # Product ID hex string
         ```
 
-    -   Run script to generate DAC/CD and MFD.
+    -   Run script to generate DAC/CD and `MFD`.
 
         ```shell
         ./scripts/tools/bouffalolab/generate_factory_data.py --output out/test-cert --paa_cert out/test-cert/Chip-PAA-Cert-${TEST_CERT_VENDOR_ID}.pem --paa_key out/test-cert/Chip-PAA-Key-${TEST_CERT_VENDOR_ID}.pem --pai_cert out/test-cert/Chip-PAI-Cert-${TEST_CERT_VENDOR_ID}.pem --pai_key out/test-cert/Chip-PAI-Key-${TEST_CERT_VENDOR_ID}.pem --dac_pid 0x${TEST_CERT_PRODUCT_ID} --vendor_id 0x${TEST_CD_VENDOR_ID} --product_id 0x${TEST_CD_PRODUCT_ID}
@@ -337,12 +337,6 @@ key.
 > If `MFD` file has cipher text data, please append
 > `--key <hex string of 16 bytes>` option to program to this key to efuse.
 
--   Limits on BL IOT SDK
-
-    If developer would like to program `MFD` with all plain text data, option
-    `--key <hex string of 16 bytes>` needs pass to script, otherwise, flash tool
-    will raise an error. And SoC BL602, BL702 and BL702L use BL IOT SDK for
-    Matter Application.
 
 Please free contact to `Bouffalo Lab` for DAC provider service and higher
 security solution, such as SoC inside certificate requesting.

--- a/scripts/flashing/bouffalolab_firmware_utils.py
+++ b/scripts/flashing/bouffalolab_firmware_utils.py
@@ -447,7 +447,6 @@ class Flasher(firmware_utils.Flasher):
                 new_name = os.path.join(self.work_dir, "ota_images", fw_name + ota_img_name[len("FW_OTA"):])
                 os.system("mv {} {}".format(img, new_name))
 
-
         def construct_prog_confg():
 
             iot_cfg = {
@@ -507,7 +506,6 @@ class Flasher(firmware_utils.Flasher):
                 toml.dump(iot_cfg, f)
 
             return conf_toml
-
 
         def exe_prog_cmd(flashtool_exe, mfd_addr, flashtool_path):
 

--- a/scripts/flashing/bouffalolab_firmware_utils.py
+++ b/scripts/flashing/bouffalolab_firmware_utils.py
@@ -23,7 +23,6 @@ import re
 import shutil
 import subprocess
 import sys
-import toml
 
 import coloredlogs
 import firmware_utils

--- a/scripts/flashing/bouffalolab_firmware_utils.py
+++ b/scripts/flashing/bouffalolab_firmware_utils.py
@@ -23,6 +23,7 @@ import re
 import shutil
 import subprocess
 import sys
+import toml
 
 import coloredlogs
 import firmware_utils
@@ -446,7 +447,69 @@ class Flasher(firmware_utils.Flasher):
                 new_name = os.path.join(self.work_dir, "ota_images", fw_name + ota_img_name[len("FW_OTA"):])
                 os.system("mv {} {}".format(img, new_name))
 
-        def exe_prog_cmd(flashtool_exe, mfd_addr):
+
+        def construct_prog_confg():
+
+            iot_cfg = {
+                "param": {
+                    "interface_type": "uart",
+                    "comport_uart": self.args["port"],
+                    "speed_uart": self.args["baudrate"],
+                    "speed_jlink": "1000",
+                    "chip_xtal": self.args["xtal"],
+                    "ota": "",
+                    "version": "",
+                    "aes_key": "",
+                    "aes_iv": "",
+                    "addr": "0x0",
+                    "publickey": "",
+                    "privatekey": ""
+                },
+                "check_box": {
+                    "fw_download": True,
+                    "mfg_download": False,
+                    "media_download": False,
+                    "romfs_download": False,
+                    "psm_download": False,
+                    "key_download": False,
+                    "data_download": False,
+                    "factory_download": True if self.args["dts"] else False,
+                    "mfd_download": True if self.args["mfd"] else False,
+                    "boot2_download": True if self.args["boot2"] else False,
+                    "ckb_erase_all": "True" if self.args["erase"] else "False",
+                    "partition_download": True if self.args["pt"] else False,
+                    "encrypt": False,
+                    "sign": False,
+                    "single_download": False,
+                    "auto_efuse_verify": False
+                },
+                "input_path": {
+                    "fw_bin_input": self.args['firmware'],
+                    "mfg_bin_input": "",
+                    "media_bin_input": "",
+                    "romfs_dir_input": "",
+                    "psm_bin_input": "",
+                    "key_bin_input": "",
+                    "data_bin_input": "",
+                    "factory_bin_input": self.args["dts"],
+                    "mfd_bin_input": self.args["mfd"],
+                    "boot2_bin_input": self.args["boot2"],
+                    "img_bin_input": "",
+                    "pt_table_bin_input": self.args["pt"],
+                    "publickey": "",
+                    "privatekey": ""
+                }
+            }
+
+            conf_toml = os.path.splitext(self.args['firmware'])[0] + "_config.toml"
+
+            with open(conf_toml, "w", encoding="utf-8") as f:
+                toml.dump(iot_cfg, f)
+
+            return conf_toml
+
+
+        def exe_prog_cmd(flashtool_exe, mfd_addr, flashtool_path):
 
             if not self.args["port"]:
                 return
@@ -454,33 +517,43 @@ class Flasher(firmware_utils.Flasher):
             if self.args["mfd"] and not mfd_addr:
                 raise Exception("No MFD partition found in partition table.")
 
-            prog_cmd = [
-                flashtool_exe,
-                "--port", self.args["port"],
-                "--baudrate", self.args["baudrate"],
-                "--chipname", self.args["chipname"],
-                "--firmware", self.args["firmware"],
-                "--dts", self.args["dts"],
-                "--pt", self.args["pt"],
-            ]
+            if self.args["mfd"] and not self.args["key"]:
+                conf_toml = construct_prog_confg()
 
-            if self.args["boot2"]:
-                prog_cmd += ["--boot2", self.args["boot2"]]
+                prog_cmd = [
+                    flashtool_exe,
+                    "--chipname", self.args["chipname"],
+                    "--config", conf_toml,
+                ]
 
-            if self.args["sk"]:
-                prog_cmd += ["--sk", self.args["sk"]]
+            else:
+                prog_cmd = [
+                    flashtool_exe,
+                    "--port", self.args["port"],
+                    "--baudrate", self.args["baudrate"],
+                    "--chipname", self.args["chipname"],
+                    "--firmware", self.args["firmware"],
+                    "--dts", self.args["dts"],
+                    "--pt", self.args["pt"],
+                ]
 
-            if mfd_addr and self.args["mfd_str"]:
-                if self.args["key"] and not self.args["iv"]:
-                    logging.warning("mfd file has no iv, do NOT program mfd key.")
-                else:
-                    prog_cmd += ["--dac_key", self.args["key"]]
-                    prog_cmd += ["--dac_iv", self.args["iv"]]
-                    prog_cmd += ["--dac_addr", hex(mfd_addr)]
-                    prog_cmd += ["--dac_value", self.args["mfd_str"]]
+                if self.args["boot2"]:
+                    prog_cmd += ["--boot2", self.args["boot2"]]
 
-            if self.option.erase:
-                prog_cmd += ["--erase"]
+                if self.args["sk"]:
+                    prog_cmd += ["--sk", self.args["sk"]]
+
+                if mfd_addr and self.args["mfd_str"]:
+                    if self.args["key"] and not self.args["iv"]:
+                        logging.warning("mfd file has no iv, do NOT program mfd key.")
+                    else:
+                        prog_cmd += ["--dac_key", self.args["key"]]
+                        prog_cmd += ["--dac_iv", self.args["iv"]]
+                        prog_cmd += ["--dac_addr", hex(mfd_addr)]
+                        prog_cmd += ["--dac_value", self.args["mfd_str"]]
+
+                if self.option.erase:
+                    prog_cmd += ["--erase"]
 
             logging.info("firmware programming: {}".format(" ".join(prog_cmd)))
             process = subprocess.Popen(prog_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -500,7 +573,7 @@ class Flasher(firmware_utils.Flasher):
         os.chdir(self.work_dir)
 
         exe_gen_ota_image_cmd(flashtool_exe)
-        exe_prog_cmd(flashtool_exe, mfd_addr)
+        exe_prog_cmd(flashtool_exe, mfd_addr, flashtool_path)
 
     def bouffalo_sdk_prog(self):
 

--- a/scripts/setup/requirements.bouffalolab.txt
+++ b/scripts/setup/requirements.bouffalolab.txt
@@ -5,3 +5,5 @@ qrcode==7.4.2
 bitarray==2.6.0
 python_stdnum==1.18
 pycryptodome>=3.20.0
+toml>=0.10.2
+construct>=2.10.70

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -507,7 +507,6 @@ def main():
 
     log.basicConfig(format='[%(levelname)s] %(message)s', level=log.INFO)
 
-    print(args.dac_pid)
     check_arg(args)
 
     passcode = gen_test_passcode(args.passcode)

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -258,7 +258,7 @@ def gen_test_certs(chip_cert: str,
                     ]
 
         if paa_cert:
-            cmd += [ "--authorized-paa-cert", paa_cert ]
+            cmd += ["--authorized-paa-cert", paa_cert]
 
         log.info("Generate CD: {}".format(shlex.join(cmd)))
         subprocess.run(cmd)
@@ -507,7 +507,7 @@ def main():
 
     log.basicConfig(format='[%(levelname)s] %(message)s', level=log.INFO)
 
-    print (args.dac_pid)
+    print(args.dac_pid)
     check_arg(args)
 
     passcode = gen_test_passcode(args.passcode)

--- a/scripts/tools/bouffalolab/generate_factory_data.py
+++ b/scripts/tools/bouffalolab/generate_factory_data.py
@@ -133,7 +133,9 @@ def gen_test_certs(chip_cert: str,
                    pai_cert: str = None,
                    pai_key: str = None,
                    dac_cert: str = None,
-                   dac_key: str = None):
+                   dac_key: str = None,
+                   dac_product_id: int = None,
+                   discriminator: int = None):
 
     def parse_cert_file(cert):
 
@@ -189,7 +191,7 @@ def gen_test_certs(chip_cert: str,
                 log.info("Verify Certificate Chain: {}".format(shlex.join(cmd)))
                 subprocess.run(cmd)
 
-    def gen_dac_certificate(chip_cert, device_name, vendor_id, product_id, pai_cert, pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date):
+    def gen_dac_certificate(chip_cert, device_name, dac_vid, dac_pid, pai_cert, pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date, discriminator):
         def gen_valid_times(issue_date, expire_date):
             now = datetime.now() - timedelta(days=1)
 
@@ -206,8 +208,8 @@ def gen_test_certs(chip_cert: str,
             cmd = [chip_cert, "gen-att-cert",
                    "--type", "d",  # device attestation certificate
                    "--subject-cn", device_name + " Test DAC 0",
-                   "--subject-vid", hex(vendor_id),
-                   "--subject-pid", hex(product_id),
+                   "--subject-vid", hex(dac_vid),
+                   "--subject-pid", hex(dac_pid),
                    "--ca-cert", pai_cert,
                    "--ca-key", pai_key,
                    "--out", dac_cert,
@@ -230,7 +232,7 @@ def gen_test_certs(chip_cert: str,
 
         return der
 
-    def gen_cd(chip_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd):
+    def gen_cd(chip_cert, paa_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd):
 
         if os.path.isfile(cd):
             return
@@ -255,15 +257,29 @@ def gen_test_certs(chip_cert: str,
                     "--dac-origin-product-id", hex(dac_product_id),
                     ]
 
+        if paa_cert:
+            cmd += [ "--authorized-paa-cert", paa_cert ]
+
         log.info("Generate CD: {}".format(shlex.join(cmd)))
         subprocess.run(cmd)
 
     pai_vendor_id, pai_product_id, pai_issue_date, pai_expire_date = parse_cert_file(pai_cert)
 
-    dac_vendor_id = pai_vendor_id if pai_vendor_id else vendor_id
-    dac_product_id = pai_product_id if pai_product_id else product_id
+    dac_vendor_id = pai_vendor_id
+
+    if dac_product_id is not None and pai_product_id is not None and dac_product_id != pai_product_id:
+        raise Exception("Specified product id for DAC certificate is not same as product id in PAI certificate.")
+
+    if pai_product_id is not None:
+        dac_product_id = pai_product_id
+
+    if dac_cert is None:
+        dac_disc_vp = "{}_{}_{}".format(hex(dac_vendor_id).split("x")[-1], hex(dac_product_id).split("x")[-1], discriminator)
+        dac_cert = os.path.join(output, "out_{}_dac_cert.pem".format(dac_disc_vp))
+        dac_key = os.path.join(output, "out_{}_dac_key.pem".format(dac_disc_vp))
+
     gen_dac_certificate(chip_cert, device_name, dac_vendor_id, dac_product_id, pai_cert,
-                        pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date)
+                        pai_key, dac_cert, dac_key, pai_issue_date, pai_expire_date, discriminator)
 
     dac_cert_der = convert_pem_to_der(chip_cert, "convert-cert", dac_cert)
     dac_key_der = convert_pem_to_der(chip_cert, "convert-key", dac_key)
@@ -274,7 +290,7 @@ def gen_test_certs(chip_cert: str,
 
     verify_certificates(chip_cert, paa_cert, pai_cert, dac_cert)
 
-    gen_cd(chip_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd)
+    gen_cd(chip_cert, paa_cert, dac_vendor_id, dac_product_id, vendor_id, product_id, cd_cert, cd_key, cd)
 
     return cd, pai_cert_der, dac_cert_der, dac_key_der
 
@@ -447,10 +463,14 @@ def main():
         else:
             return None
 
+    def hex_to_int(hex_string):
+        return int(hex_string, 16)
+
     parser = argparse.ArgumentParser(description="Bouffalo Lab Factory Data generator tool")
 
     parser.add_argument("--dac_cert", type=str, help="DAC certificate file.")
     parser.add_argument("--dac_key", type=str, help="DAC certificate privat key.")
+    parser.add_argument("--dac_pid", type=hex_to_int, help="Product Identification, hex string, used in DAC certificate. ")
     parser.add_argument("--passcode", type=int, help="Setup pincode, optional.")
     parser.add_argument("--pai_cert", type=str, default=TEST_PAI_CERT, help="PAI certificate file.")
     parser.add_argument("--cd", type=str, help="Certificate Declaration file.")
@@ -460,9 +480,9 @@ def main():
     parser.add_argument("--spake2p_it", type=int, default=None, help="Spake2+ iteration count, optional.")
     parser.add_argument("--spake2p_salt", type=base64.b64decode, help="Spake2+ salt in hex string, optional.")
 
-    parser.add_argument("--vendor_id", type=int, default=0x130D, help="Vendor Identification, mandatory.")
+    parser.add_argument("--vendor_id", type=hex_to_int, default=0x130D, help="Vendor Identification, hex string, mandatory.")
     parser.add_argument("--vendor_name", type=str, default="Bouffalo Lab", help="Vendor Name string, optional.")
-    parser.add_argument("--product_id", type=int, default=0x1001, help="Product Identification, mandatory.")
+    parser.add_argument("--product_id", type=hex_to_int, default=0x1001, help="Product Identification, hex string, mandatory.")
     parser.add_argument("--product_name", type=str, default="Test Product", help="Product Name string, optional.")
 
     parser.add_argument("--product_part_no", type=str, help="Product Part number, optional.")
@@ -487,6 +507,7 @@ def main():
 
     log.basicConfig(format='[%(levelname)s] %(message)s', level=log.INFO)
 
+    print (args.dac_pid)
     check_arg(args)
 
     passcode = gen_test_passcode(args.passcode)
@@ -494,11 +515,8 @@ def main():
     unique_id = gen_test_unique_id(args.unique_id)
     spake2p_it, spake2p_salt, spake2p_verifier = gen_test_spake2(passcode, args.spake2p_it, args.spake2p_salt)
 
-    vp_info = "{}_{}".format(hex(args.vendor_id), hex(args.product_id))
-    vp_disc_info = "{}_{}_{}".format(hex(args.vendor_id), hex(args.product_id), discriminator)
-    if args.dac_cert is None:
-        args.dac_cert = os.path.join(args.output, "out_{}_dac_cert.pem".format(vp_disc_info))
-        args.dac_key = os.path.join(args.output, "out_{}_dac_key.pem".format(vp_disc_info))
+    vp_info = "{}_{}".format(hex(args.vendor_id).split('x')[-1], hex(args.product_id).split('x')[-1])
+    vp_disc_info = "{}_{}".format(vp_info, discriminator)
 
     if args.cd is None:
         args.cd = os.path.join(args.output, "out_{}_cd.der".format(vp_info))
@@ -516,7 +534,9 @@ def main():
                                                                  args.pai_cert,
                                                                  args.pai_key,
                                                                  args.dac_cert,
-                                                                 args.dac_key)
+                                                                 args.dac_key,
+                                                                 args.dac_pid,
+                                                                 discriminator)
 
     mfd_output = os.path.join(args.output, "out_{}_mfd.bin".format(vp_disc_info))
     args.dac_cert = dac_cert_der


### PR DESCRIPTION

- Update generate_factory_data.py to support more options for VID/PID configurations in PAA/PAI/DAC and CD
- Update documents to describe more detail for factory data generation
- Update bouffalolab_firmware_utils.py to download plaintext MFD for test and development.

#### Testing
- targets:
  - bouffalolab-bl602dk-light-wifi-littlefs-mfd
  - bouffalolab-bl704ldk-light-thread-littlefs-mfd
  - bouffalolab-bl616dk-light-wifi-littlefs-mfd
- use generate_factory_data.py to generate MFD files with test VID/PID, Bouffalo Lab VID/PID and thirdParty VID/PID to download to DVK board and tested commission with chip-tool