### PR TITLE
[Java]disable warning error for java

### DIFF
--- a/build/chip/java/rules.gni
+++ b/build/chip/java/rules.gni
@@ -104,10 +104,7 @@ template("java_library") {
   # Building from sources - perform Java compilation and JAR creation.
   if (!_is_prebuilt) {
     # Additional flags
-    _javac_flags = [
-      "-Werror",
-      "-Xlint:all",
-    ]
+    _javac_flags = [ "-Xlint:all" ]
     if (defined(invoker.javac_flags)) {
       _javac_flags += invoker.javac_flags
     }


### PR DESCRIPTION
Android/java build system has upgraded to java 11, finalize has been treated as warning since java 9, and further our build system treated warning as error, we would like to maintain finalize usage, we decide to disable werror

#### Testing
Compilation