### PR TITLE
Don't log kNone events in BdxTransferDiagnosticLog::HandleTransferSessionOutput.

### DIFF
--- a/src/protocols/bdx/BdxTransferDiagnosticLog.cpp
+++ b/src/protocols/bdx/BdxTransferDiagnosticLog.cpp
@@ -42,6 +42,16 @@ void BdxTransferDiagnosticLog::HandleTransferSessionOutput(TransferSession::Outp
 {
     assertChipStackLockedByCurrentThread();
 
+    if (event.EventType == TransferSession::OutputEventType::kNone)
+    {
+        // Because we are polling for output every 50ms on our transfer session,
+        // we will get a lot of kNone events coming through here: one for every
+        // time we poll but the other side has not sent anything new yet.  Just
+        // ignore those here, for now, and make sure not to log them, because
+        // that bloats the logs pretty quickly.
+        return;
+    }
+
     ChipLogDetail(BDX, "Got an event %s", event.ToString(event.EventType));
 
     switch (event.EventType)
@@ -71,7 +81,7 @@ void BdxTransferDiagnosticLog::HandleTransferSessionOutput(TransferSession::Outp
         }
         break;
     case TransferSession::OutputEventType::kAckEOFReceived:
-    case TransferSession::OutputEventType::kNone:
+    // case TransferSession::OutputEventType::kNone: handled above.
     case TransferSession::OutputEventType::kQueryWithSkipReceived:
     case TransferSession::OutputEventType::kQueryReceived:
     case TransferSession::OutputEventType::kAckReceived:


### PR DESCRIPTION
We get a lot of them because of the polling setup, and all they mean is "we have not gotten the next thing from the other side yet".

#### Testing

No behavior changes, just logging change.