### PR TITLE
Fix comments and naming for Darwin invoke responses validation.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceDataValidation.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceDataValidation.h
@@ -39,9 +39,9 @@ MTR_EXTERN MTR_TESTABLE BOOL MTREventReportIsWellFormed(NSArray<MTRDeviceRespons
 // objects in the right places.
 MTR_EXTERN MTR_TESTABLE BOOL MTRInvokeResponseIsWellFormed(NSArray<MTRDeviceResponseValueDictionary> * response);
 
-// Returns whether the provided invoke reponses actually has the right sorts of
-// objects in the right places.  This differes from
-// MTRInvokeResponseIsWellFormed in not enforcing that there is only one response.
-MTR_EXTERN MTR_TESTABLE BOOL MTRInvokeResponsesAreWellFormed(NSArray<MTRDeviceResponseValueDictionary> * response);
+// Returns whether the provided invoke responses actually have the right sorts of objects in the
+// right places.  This differs from MTRInvokeResponseIsWellFormed in not enforcing that there is
+// only one response.
+MTR_EXTERN MTR_TESTABLE BOOL MTRInvokeResponsesAreWellFormed(NSArray<MTRDeviceResponseValueDictionary> * responses);
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceDataValidation.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceDataValidation.mm
@@ -178,14 +178,14 @@ BOOL MTRInvokeResponseIsWellFormed(NSArray<MTRDeviceResponseValueDictionary> * r
     return YES;
 }
 
-BOOL MTRInvokeResponsesAreWellFormed(NSArray<MTRDeviceResponseValueDictionary> * response)
+BOOL MTRInvokeResponsesAreWellFormed(NSArray<MTRDeviceResponseValueDictionary> * responses)
 {
-    if (!MTR_SAFE_CAST(response, NSArray)) {
-        MTR_LOG_ERROR("Invoke response is not an array: %@", response);
+    if (!MTR_SAFE_CAST(responses, NSArray)) {
+        MTR_LOG_ERROR("Invoke responses are not an array: %@", responses);
         return NO;
     }
 
-    for (MTRDeviceResponseValueDictionary responseValue in response) {
+    for (MTRDeviceResponseValueDictionary responseValue in responses) {
         // Each entry must be a dictionary that has MTRCommandPathKey.
 
         if (!MTR_SAFE_CAST(responseValue, NSDictionary) || !MTR_SAFE_CAST(responseValue[MTRCommandPathKey], MTRCommandPath)) {


### PR DESCRIPTION
Some typos crept in, and the function argument name was sub-optimal.

#### Testing

No behavior changes, just variable naming and comment fixes.  Existing CI should cover this.