### PR TITLE
Fix typo in CC13x4_26x4 Lighting App README

### DIFF
--- a/examples/lighting-app/cc13x4_26x4/README.md
+++ b/examples/lighting-app/cc13x4_26x4/README.md
@@ -264,7 +264,7 @@ On
 
 ```
 ./chip-tool onoff on <nodeID> 1
-./chip-tool onoff toggee <nodeID> 1 (assuming the light is off)
+./chip-tool onoff toggle <nodeID> 1 (assuming the light is off)
 
 ```
 


### PR DESCRIPTION
Correct spelling of "toggle" in README.
