### PR TITLE
[Docker] Add terms and conditions app to chip-cert-bins image

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -502,6 +502,7 @@ jobs:
                       --target linux-x64-fabric-bridge-rpc-ipv6only-no-ble-no-wifi-clang \
                       --target linux-x64-fabric-sync-ipv6only-no-ble-no-wifi-clang \
                       --target linux-x64-light-data-model-no-unique-id-ipv6only-no-ble-no-wifi-clang \
+                      --target linux-x64-terms-and-conditions \
                       --target linux-x64-python-bindings \
                       build \
                       --copy-artifacts-to objdir-clone \
@@ -520,6 +521,7 @@ jobs:
                   echo "FABRIC_BRIDGE_APP: out/linux-x64-fabric-bridge-rpc-ipv6only-no-ble-no-wifi-clang/fabric-bridge-app" >> /tmp/test_env.yaml
                   echo "FABRIC_SYNC_APP: out/linux-x64-fabric-sync-ipv6only-no-ble-no-wifi-clang/fabric-sync" >> /tmp/test_env.yaml
                   echo "LIGHTING_APP_NO_UNIQUE_ID: out/linux-x64-light-data-model-no-unique-id-ipv6only-no-ble-no-wifi-clang/chip-lighting-app" >> /tmp/test_env.yaml
+                  echo "TERMS_AND_CONDITIONS_APP: out/linux-x64-terms-and-conditions/chip-terms-and-conditions-app" >> /tmp/test_env.yaml
                   echo "TRACE_APP: out/trace_data/app-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml
                   echo "TRACE_TEST_JSON: out/trace_data/test-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml
                   echo "TRACE_TEST_PERFETTO: out/trace_data/test-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -168,6 +168,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-fabric-admin-rpc-ipv6only \
     --target linux-x64-light-data-model-no-unique-id-ipv6only \
     --target linux-x64-network-manager-ipv6only \
+    --target linux-x64-terms-and-conditions \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -192,6 +193,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
     && mv out/linux-x64-light-data-model-no-unique-id-ipv6only/chip-lighting-app out/chip-lighting-data-model-no-unique-id-app \
     && mv out/linux-x64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
+    && mv out/linux-x64-terms-and-conditions/chip-terms-and-conditions-app out/chip-terms-and-conditions-app \
     ;; \
     "linux/arm64")\
     set -x \
@@ -220,6 +222,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-fabric-admin-rpc-ipv6only \
     --target linux-arm64-light-data-model-no-unique-id-ipv6only \
     --target linux-arm64-network-manager-ipv6only \
+    --target linux-arm64-terms-and-conditions \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -244,6 +247,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-fabric-admin-rpc-ipv6only/fabric-admin out/fabric-admin \
     && mv out/linux-arm64-light-data-model-no-unique-id-ipv6only/chip-lighting-app out/chip-lighting-data-model-no-unique-id-app \
     && mv out/linux-arm64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
+    && mv out/linux-arm64-terms-and-conditions/chip-terms-and-conditions-app out/chip-terms-and-conditions-app \
     ;; \
     *) ;; \
     esac
@@ -283,6 +287,7 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-bridge-app app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/fabric-admin apps/fabric-admin
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-lighting-data-model-no-unique-id-app apps/chip-lighting-data-model-no-unique-id-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/matter-network-manager-app apps/matter-network-manager-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-terms-and-conditions-app apps/chip-terms-and-conditions-app
 
 # Create symbolic links for now since this allows users to use existing configurations
 # for running just `app-name` instead of `apps/app-name`

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -282,8 +282,8 @@ class HostApp(Enum):
             yield 'water-leak-detector-app'
             yield 'water-leak-detector-app.map'
         elif self == HostApp.TERMS_AND_CONDITIONS:
-            yield 'terms-and-conditions-app'
-            yield 'terms-and-conditions-app.map'
+            yield 'chip-terms-and-conditions-app'
+            yield 'chip-terms-and-conditions-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -387,6 +387,7 @@ def python_tests(
             FABRIC_SYNC_APP: {
                 as_runner(f'out/{target_prefix}-fabric-sync-no-ble-no-wifi-ipv6only-clang-boringssl/fabric-sync')}
             LIGHTING_APP_NO_UNIQUE_ID: {as_runner(f'out/{target_prefix}-light-data-model-no-unique-id-ipv6only-no-ble-no-wifi-clang/chip-lighting-app')}
+            TERMS_AND_CONDITIONS_APP: {as_runner(f'out/{target_prefix}-terms-and-conditions/chip-terms-and-conditions-app')}
             TRACE_APP: out/trace_data/app-{{SCRIPT_BASE_NAME}}
             TRACE_TEST_JSON: out/trace_data/test-{{SCRIPT_BASE_NAME}}
             TRACE_TEST_PERFETTO: out/trace_data/test-{{SCRIPT_BASE_NAME}}


### PR DESCRIPTION
Add the terms and conditions application binary to the chip-cert-bins Docker image build for both x64 and arm64 architectures. This change includes:

- Adding build target for terms-and-conditions app
- Copying the built binary to the final image
- Adding environment variable reference in CI test configuration

This addition will support upcoming CI test requirements for the terms and conditions functionality.


#### Testing

The CI build will be used to validate the correctness of the change.