### PR TITLE
Improve logging around sending XPC messages.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDefines_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDefines_Internal.h
@@ -86,13 +86,14 @@ typedef struct {} variable_hidden_by_mtr_hide;
                                                                                                        \
         @try {                                                                                         \
             [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) { \
-                MTR_LOG_ERROR("Error: %@", error);                                                     \
+                MTR_LOG_ERROR("%@ Error in %@ getter: %@", self, NSStringFromSelector(_cmd), error);   \
             }] PREFIX                                                                                  \
                 GETTER_NAME:^(TYPE returnValue) {                                                      \
                     outValue = returnValue;                                                            \
                 }];                                                                                    \
         } @catch (NSException * exception) {                                                           \
-            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                            \
+            MTR_LOG_ERROR("%@ Exception sending XPC messsage for %@ getter: %@", self,                 \
+                NSStringFromSelector(_cmd), exception);                                                \
             outValue = DEFAULT_VALUE;                                                                  \
         }                                                                                              \
         return outValue;                                                                               \
@@ -106,10 +107,11 @@ typedef struct {} variable_hidden_by_mtr_hide;
                                                                                                       \
         @try {                                                                                        \
             [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {           \
-                MTR_LOG_ERROR("Error: %@", error);                                                    \
+                MTR_LOG_ERROR("%@ Error in %@: %@", self, NSStringFromSelector(_cmd), error);         \
             }] PREFIX ADDITIONAL_ARGUMENTS];                                                          \
         } @catch (NSException * exception) {                                                          \
-            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                           \
+            MTR_LOG_ERROR("%@ Exception sending XPC messsage for %@: %@", self,                       \
+                NSStringFromSelector(_cmd), exception);                                               \
         }                                                                                             \
     }
 
@@ -122,12 +124,13 @@ typedef struct {} variable_hidden_by_mtr_hide;
                                                                                                                     \
         @try {                                                                                                      \
             [[xpcConnection synchronousRemoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {              \
-                MTR_LOG_ERROR("Error: %@", error);                                                                  \
+                MTR_LOG_ERROR("%@ Error in %@: %@", self, NSStringFromSelector(_cmd), error);                       \
             }] PREFIX ADDITIONAL_ARGUMENTS:^(TYPE returnValue) {                                                    \
                 outValue = returnValue;                                                                             \
             }];                                                                                                     \
         } @catch (NSException * exception) {                                                                        \
-            MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);                                         \
+            MTR_LOG_ERROR("%@ Exception sending XPC messsage for %@: %@", self, NSStringFromSelector(_cmd),         \
+                exception);                                                                                         \
             outValue = DEFAULT_VALUE;                                                                               \
         }                                                                                                           \
                                                                                                                     \

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -467,7 +467,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 
     @try {
         [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-            MTR_LOG_ERROR("Error: %@", error);
+            MTR_LOG_ERROR("%@ Error in %@: %@", self, NSStringFromSelector(_cmd), error);
             dispatch_async(queue, ^{
                 completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             });
@@ -505,7 +505,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
                      });
                  }];
     } @catch (NSException * exception) {
-        MTR_LOG_ERROR("Exception sending XPC message: %@", exception);
+        MTR_LOG_ERROR("%@ Exception sending XPC message for %@: %@", self, NSStringFromSelector(_cmd), exception);
         dispatch_async(queue, ^{
             completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
         });
@@ -521,7 +521,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
 
     @try {
         [[xpcConnection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
-            MTR_LOG_ERROR("Error: %@", error);
+            MTR_LOG_ERROR("%@ Error in %@: %@", self, NSStringFromSelector(_cmd), error);
             dispatch_async(queue, ^{
                 completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             });
@@ -538,7 +538,7 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
                        });
                    }];
     } @catch (NSException * exception) {
-        MTR_LOG_ERROR("Exception sending XPC messsage: %@", exception);
+        MTR_LOG_ERROR("%@ Exception sending XPC messsage for %@: %@", self, NSStringFromSelector(_cmd), exception);
         dispatch_async(queue, ^{
             completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
         });


### PR DESCRIPTION
Log self and the method involved, so we know what's failing on what objects.

#### Testing

Logging changes only.