### PR TITLE
[ICD] Re-activate subscription when receiving check-in message if subscription fails and resub is scheduled

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -493,14 +493,7 @@ void ReadClient::OnActiveModeNotification()
         return;
     }
 
-    if (mIsResubscriptionScheduled)
-    {
-        // If a subscription fails and resubscription is scheduled, a check-in message should cancel
-        // the pending resubscription and initiate a new subscription immediately."
-        mNumRetries = 0;
-        CancelResubscribeTimer();
-        TriggerResubscriptionForLivenessTimeout(CHIP_ERROR_TIMEOUT);
-    }
+    TriggerResubscribeIfScheduled("check-in message");
     return;
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -495,7 +495,7 @@ void ReadClient::OnActiveModeNotification()
 
     if (mIsResubscriptionScheduled)
     {
-        // If a subscription fails and resubscription is scheduled, a check-in message should cancel 
+        // If a subscription fails and resubscription is scheduled, a check-in message should cancel
         // the pending resubscription and initiate a new subscription immediately."
         mNumRetries = 0;
         CancelResubscribeTimer();

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -494,7 +494,6 @@ void ReadClient::OnActiveModeNotification()
     }
 
     TriggerResubscribeIfScheduled("check-in message");
-    return;
 }
 
 void ReadClient::OnPeerTypeChange(PeerType aType)

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2354,6 +2354,69 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
+TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
+
+    {
+        TestResubscriptionCallback callback;
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
+
+        callback.mScheduleLITResubscribeImmediately = false;
+        callback.SetReadClient(&readClient);
+
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+
+        AttributePathParams attributePathParams[1];
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = MATTER_ARRAY_SIZE(attributePathParams);
+        attributePathParams[0].mEndpointId             = kTestEndpointId;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
+
+        constexpr uint16_t maxIntervalCeilingSeconds = 1;
+
+        readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
+        readPrepareParams.mIsPeerLIT                 = true;
+
+        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(6000),
+                                    [&]() { return callback.mOnResubscriptionsAttempted == 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 0);
+
+        GetLoopback().mNumMessagesToDrop = 0;
+        callback.ClearCounters();
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount == 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+
+        //
+        // With re-sub enabled, we shouldn't have encountered any errors
+        //
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnDone, 0);
+
+        GetLoopback().mNumMessagesToDrop = 0;
+        callback.ClearCounters();
+    }
+
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
+
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
 /**
  * When the liveness timeout of a subscription to ICD is reached, the subscription will enter "InactiveICDSubscription" state, the
  * client should call "OnActiveModeNotification" to re-activate it again when the check-in message is received from the ICD.


### PR DESCRIPTION
Assume read client fails for subscription because of various timeout via SendAutoResubscribeRequest API with ScopedNodeId and goes to resubscribe with back-off algorithm, once the device becomes active, controller receives the corresponding check-in message,  client's scheduled subscription cannot be re-activated immediately. Intuitively, it is better that a resubscription can be triggered immediately


Proposed Resolution:
Re-activate subscription when receiving check-in message if subscription fails and resub is scheduled 

#### Testing
Add unit test
