### PR TITLE
ESP32: Fix the menuconfig option description for LwIP thread safety

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -228,14 +228,15 @@ menu "CHIP Core"
             help
                 Enable this option to start a UDP Endpoint queue filter for mDNS Broadcast packets
 
-        config ENABLE_LWIP_THREAD_SAFETY
-            bool "Enable LwIP Thread safety options"
+        config USE_TCPIP_CORE_LOCK_FOR_THREAD_SAFETY
+            bool "Use TCPIP core locking for LwIP thread safety"
             default y
             select LWIP_TCPIP_CORE_LOCKING
             select LWIP_CHECK_THREAD_SAFETY
             help
                 CHIP SDK performs LwIP core locking before calling an LwIP API.
                 To make the calls thread safe we have to enable LWIP_TCPIP_CORE_LOCKING.
+                Otherwise CHIP SDK will post LwIP APIs to TCPIP task to ensure thread safety.
                 Here, we are also enabling LWIP_CHECK_THREAD_SAFETY which will assert when
                 LwIP code gets called from any other context or without holding the LwIP lock.
 


### PR DESCRIPTION
The menuconfig option `ENABLE_LWIP_THREAD_SAFETY` was created when we can only use TCPIP core locking to ensure Matter calling LwIP API with thread safety. But now we can also ensure thread safety even if disabling TCPIP core locking. We need to change the name and description for this option.

#### Testing
Only document change, no test is required.
