### PR TITLE
ESP32: Fix ble init and deinit flow.

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -925,7 +925,8 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     SuccessOrExit(err);
 #endif
 
-    nimble_port_init();
+    err = MapBLEError(nimble_port_init());
+    SuccessOrExit(err);
 
     /* Initialize the NimBLE host configuration. */
     ble_hs_cfg.reset_cb          = bleprph_on_reset;
@@ -973,7 +974,9 @@ exit:
 void BLEManagerImpl::DeinitESPBleLayer()
 {
     VerifyOrReturn(DeinitBLE() == CHIP_NO_ERROR);
+#ifdef CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING
     BLEManagerImpl::ClaimBLEMemory(nullptr, nullptr);
+#endif /* CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING */
 }
 
 void BLEManagerImpl::ClaimBLEMemory(System::Layer *, void *)


### PR DESCRIPTION
### Problem
- We should catch the error return by `nimble_port_init`.
- Once ble memory is released, we cannot initialize the BLE in the same cycle.

### Changes
- Use the error returned by the `nibmle_port_init`.
- Guarded ble memory reclaim by `CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING`.

### Testing
Tested esp32 with the `CONFIG_USE_BLE_ONLY_FOR_COMMISSIONING` flag set and unset.