### PR TITLE
Delete the ChipEventQueue and BackgroundEventQueue after returning from the event loop.

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -422,6 +422,8 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
         mBackgroundEventQueue = NULL;
     }
 #endif
+    vSemaphoreDelete(mChipStackLock);
+    mChipStackLock = NULL;
     GenericPlatformManagerImpl<ImplClass>::_Shutdown();
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -270,9 +270,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::EventLoopTaskMain(void * ar
         static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg);
     platformManager->Impl()->RunEventLoop();
     vTaskDelete(NULL);
-    vQueueDelete(platformManager->mChipEventQueue);
-    platformManager->mChipEventQueue = NULL;
-    platformManager->mEventLoopTask  = NULL;
+    platformManager->mEventLoopTask = NULL;
 }
 
 template <class ImplClass>
@@ -372,8 +370,6 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::BackgroundEventLoopTaskMain
         static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg);
     platformManager->Impl()->RunBackgroundEventLoop();
     vTaskDelete(NULL);
-    vQueueDelete(platformManager->mBackgroundEventQueue);
-    platformManager->mBackgroundEventQueue    = NULL;
     platformManager->mBackgroundEventLoopTask = NULL;
 }
 #endif
@@ -414,6 +410,18 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
 template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 {
+    if (mChipEventQueue)
+    {
+        vQueueDelete(mChipEventQueue);
+        mChipEventQueue = NULL;
+    }
+#if defined(CHIP_DEVICE_CONFIG_ENABLE_BG_EVENT_PROCESSING) && CHIP_DEVICE_CONFIG_ENABLE_BG_EVENT_PROCESSING
+    if (mBackgroundEventQueue)
+    {
+        vQueueDelete(mBackgroundEventQueue);
+        mBackgroundEventQueue = NULL;
+    }
+#endif
     GenericPlatformManagerImpl<ImplClass>::_Shutdown();
 }
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -278,9 +278,9 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::EventLoopTaskMain(void * ar
 {
     ChipLogDetail(DeviceLayer, "CHIP event task running");
     static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->Impl()->RunEventLoop();
-    // TODO: At this point, should we not
-    // vTaskDelete(static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->mEventLoopTask)?
-    // Or somehow get our caller to do it once this thread is joined?
+    vTaskDelete(NULL);
+    vQueueDelete(static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->mChipEventQueue);
+    static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->mChipEventQueue = NULL;
 }
 
 template <class ImplClass>
@@ -377,6 +377,9 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::BackgroundEventLoopTaskMain
 {
     ChipLogDetail(DeviceLayer, "CHIP background task running");
     static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->Impl()->RunBackgroundEventLoop();
+    vTaskDelete(NULL);
+    vQueueDelete(static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->mBackgroundEventQueue);
+    static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg)->mBackgroundEventQueue = NULL;
 }
 #endif
 


### PR DESCRIPTION
### Changes
We should delete the task and event queue after the event loop is stopped, and reset the queue handlers to NULL.

### Testing
Tested the example by stopping the event loop and restarting it.