### PR TITLE
[Linux] Optimize generated glib D-Bus integration stubs

### DIFF
--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -100,7 +100,8 @@ public:
 
     ScannerDelegateImpl(PyObject * context, DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback,
                         ScanErrorCallback errorCallback) :
-        mContext(context), mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
+        mContext(context),
+        mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
     {}
 
     CHIP_ERROR ScannerInit(BluezAdapter1 * adapter)

--- a/src/controller/python/chip/ble/LinuxImpl.cpp
+++ b/src/controller/python/chip/ble/LinuxImpl.cpp
@@ -27,7 +27,7 @@
 #include <platform/Linux/bluez/AdapterIterator.h>
 #include <platform/Linux/bluez/BluezObjectManager.h>
 #include <platform/Linux/bluez/ChipDeviceScanner.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <platform/PlatformManager.h>
 #include <system/SystemClock.h>
 #include <system/SystemLayer.h>
@@ -100,8 +100,7 @@ public:
 
     ScannerDelegateImpl(PyObject * context, DeviceScannedCallback scanCallback, ScanCompleteCallback completeCallback,
                         ScanErrorCallback errorCallback) :
-        mContext(context),
-        mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
+        mContext(context), mScanCallback(scanCallback), mCompleteCallback(completeCallback), mErrorCallback(errorCallback)
     {}
 
     CHIP_ERROR ScannerInit(BluezAdapter1 * adapter)

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -86,13 +86,13 @@ struct GDBusWpaSupplicant
         SCANNING,
     };
 
-    WpaState state                          = WpaState::INIT;
-    WpaScanningState scanState              = WpaScanningState::IDLE;
-    WpaFiW1Wpa_supplicant1 * proxy          = nullptr;
-    WpaFiW1Wpa_supplicant1Interface * iface = nullptr;
-    WpaFiW1Wpa_supplicant1BSS * bss         = nullptr;
-    gchar * interfacePath                   = nullptr;
-    gchar * networkPath                     = nullptr;
+    WpaState state                  = WpaState::INIT;
+    WpaScanningState scanState      = WpaScanningState::IDLE;
+    WpaSupplicant1 * proxy          = nullptr;
+    WpaSupplicant1Interface * iface = nullptr;
+    WpaSupplicant1BSS * bss         = nullptr;
+    gchar * interfacePath           = nullptr;
+    gchar * networkPath             = nullptr;
 };
 #endif
 
@@ -222,10 +222,10 @@ private:
     CHIP_ERROR StopAutoScan();
 
     void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaInterfaceRemoved(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
-    void _OnWpaInterfaceAdded(WpaFiW1Wpa_supplicant1 * proxy, const char * path, GVariant * properties);
-    void _OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Interface * proxy, GVariant * properties);
-    void _OnWpaInterfaceScanDone(WpaFiW1Wpa_supplicant1Interface * proxy, gboolean success);
+    void _OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaPropertiesChanged(WpaSupplicant1Interface * proxy, GVariant * properties);
+    void _OnWpaInterfaceScanDone(WpaSupplicant1Interface * proxy, gboolean success);
     void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -23,7 +23,7 @@
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/openthread/introspect.h>
+#include <platform/Linux/dbus/openthread/DBusOpenthread.h>
 #include <platform/NetworkCommissioning.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -31,7 +31,7 @@
 namespace chip {
 
 template <>
-struct GAutoPtrDeleter<OpenthreadIoOpenthreadBorderRouter>
+struct GAutoPtrDeleter<OpenthreadBorderRouter>
 {
     using deleter = GObjectDeleter;
 };
@@ -149,12 +149,12 @@ private:
         uint8_t lqi;
     };
 
-    GAutoPtr<OpenthreadIoOpenthreadBorderRouter> mProxy;
+    GAutoPtr<OpenthreadBorderRouter> mProxy;
 
     static CHIP_ERROR GLibMatterContextInitThreadStack(ThreadStackManagerImpl * self);
     static CHIP_ERROR GLibMatterContextCallAttach(ThreadStackManagerImpl * self);
     static CHIP_ERROR GLibMatterContextCallScan(ThreadStackManagerImpl * self);
-    static void OnDbusPropertiesChanged(OpenthreadIoOpenthreadBorderRouter * proxy, GVariant * changed_properties,
+    static void OnDbusPropertiesChanged(OpenthreadBorderRouter * proxy, GVariant * changed_properties,
                                         const gchar * const * invalidated_properties, gpointer user_data);
     void ThreadDeviceRoleChangedHandler(const gchar * role);
 

--- a/src/platform/Linux/bluez/AdapterIterator.cpp
+++ b/src/platform/Linux/bluez/AdapterIterator.cpp
@@ -25,7 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 #include "BluezObjectIterator.h"
 #include "BluezObjectList.h"

--- a/src/platform/Linux/bluez/AdapterIterator.h
+++ b/src/platform/Linux/bluez/AdapterIterator.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 #include "BluezObjectIterator.h"
 #include "BluezObjectManager.h"

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -131,8 +131,8 @@ CHIP_ERROR BluezAdvertisement::Init(BluezAdapter1 * apAdapter, const char * aAdv
         g_snprintf(mAdvName, sizeof(mAdvName), "%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
     }
 
-    CHIP_ERROR err =
-        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
+    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Init() on CHIPoBluez thread"));
 
@@ -269,7 +269,8 @@ CHIP_ERROR BluezAdvertisement::Start()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnValue(!mIsAdvertising, CHIP_NO_ERROR, ChipLogDetail(DeviceLayer, "BLE advertising already started"));
-    return PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
 }
 
 void BluezAdvertisement::StopDone(GObject * aObject, GAsyncResult * aResult)
@@ -319,7 +320,8 @@ CHIP_ERROR BluezAdvertisement::Stop()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnValue(mIsAdvertising, CHIP_NO_ERROR, ChipLogDetail(DeviceLayer, "BLE advertising already stopped"));
-    return PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/BluezAdvertisement.cpp
+++ b/src/platform/Linux/bluez/BluezAdvertisement.cpp
@@ -29,7 +29,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <platform/PlatformManager.h>
 
 #include "BluezEndpoint.h"
@@ -131,8 +131,8 @@ CHIP_ERROR BluezAdvertisement::Init(BluezAdapter1 * apAdapter, const char * aAdv
         g_snprintf(mAdvName, sizeof(mAdvName), "%s%04x", CHIP_DEVICE_CONFIG_BLE_DEVICE_NAME_PREFIX, getpid() & 0xffff);
     }
 
-    CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
+    CHIP_ERROR err =
+        PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->InitImpl(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(Ble, "Failed to schedule BLE advertisement Init() on CHIPoBluez thread"));
 
@@ -269,8 +269,7 @@ CHIP_ERROR BluezAdvertisement::Start()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnValue(!mIsAdvertising, CHIP_NO_ERROR, ChipLogDetail(DeviceLayer, "BLE advertising already started"));
-    return PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StartImpl(); }, this);
 }
 
 void BluezAdvertisement::StopDone(GObject * aObject, GAsyncResult * aResult)
@@ -320,8 +319,7 @@ CHIP_ERROR BluezAdvertisement::Stop()
 {
     VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnValue(mIsAdvertising, CHIP_NO_ERROR, ChipLogDetail(DeviceLayer, "BLE advertising already stopped"));
-    return PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
+    return PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezAdvertisement * self) { return self->StopImpl(); }, this);
 }
 
 } // namespace Internal

--- a/src/platform/Linux/bluez/BluezAdvertisement.h
+++ b/src/platform/Linux/bluez/BluezAdvertisement.h
@@ -27,7 +27,7 @@
 #include <ble/Ble.h>
 #include <lib/core/CHIPError.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 #include "BluezEndpoint.h"
 #include "Types.h"

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -77,7 +77,8 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn),
+    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -29,7 +29,7 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/ConnectivityManager.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/BLEManager.h>
 #include <system/SystemPacketBuffer.h>
@@ -77,8 +77,7 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn),
-    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.h
+++ b/src/platform/Linux/bluez/BluezConnection.h
@@ -25,7 +25,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <system/SystemPacketBuffer.h>
 
 #include "Types.h"

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -66,7 +66,7 @@
 #include <platform/ConnectivityManager.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/BLEManager.h>
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
@@ -554,8 +554,7 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -554,7 +554,8 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -55,7 +55,7 @@
 #include <ble/Ble.h>
 #include <lib/core/CHIPError.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 #include "BluezConnection.h"
 #include "BluezObjectManager.h"

--- a/src/platform/Linux/bluez/BluezObjectIterator.h
+++ b/src/platform/Linux/bluez/BluezObjectIterator.h
@@ -22,7 +22,7 @@
 #include <glib.h>
 
 #include <platform/CHIPDeviceConfig.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/bluez/BluezObjectList.h
+++ b/src/platform/Linux/bluez/BluezObjectList.h
@@ -21,7 +21,7 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceConfig.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 #include "BluezObjectIterator.h"
 

--- a/src/platform/Linux/bluez/BluezObjectManager.cpp
+++ b/src/platform/Linux/bluez/BluezObjectManager.cpp
@@ -31,7 +31,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <platform/PlatformManager.h>
 
 #include "Types.h"

--- a/src/platform/Linux/bluez/ChipDeviceScanner.h
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.h
@@ -24,7 +24,7 @@
 #include <ble/Ble.h>
 #include <lib/core/CHIPError.h>
 #include <platform/GLibTypeDeleter.h>
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 #include <system/SystemLayer.h>
 
 #include "BluezObjectManager.h"

--- a/src/platform/Linux/bluez/Types.h
+++ b/src/platform/Linux/bluez/Types.h
@@ -50,7 +50,7 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
-#include <platform/Linux/dbus/bluez/DbusBluez.h>
+#include <platform/Linux/dbus/bluez/DBusBluez.h>
 
 namespace chip {
 

--- a/src/platform/Linux/dbus/bluez/BUILD.gn
+++ b/src/platform/Linux/dbus/bluez/BUILD.gn
@@ -17,7 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/linux/gdbus_library.gni")
 
 gdbus_library("bluez") {
-  sources = [ "DbusBluez.xml" ]
+  sources = [ "DBusBluez.xml" ]
 
   c_namespace = "Bluez"
   interface_prefix = "org.bluez"

--- a/src/platform/Linux/dbus/bluez/DBusBluez.xml
+++ b/src/platform/Linux/dbus/bluez/DBusBluez.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 # Copyright (c) 2020 Project CHIP Authors
 #
@@ -21,8 +20,10 @@
 # relevant for the Matter GATT service and advertisement management. Also,
 # some properties and methods not used by Matter are omitted in order to
 # decrease the size of Matter SDK library.
-#
 -->
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 
 <node>
 
@@ -158,9 +159,9 @@
     <property name="Discoverable" type="b" access="read"/>
     <!--
     Do not expose discoverable timeout property, so BlueZ will set it
-    internally to zero, effectively disabling the timeout. Becase of BlueZ
+    internally to zero, effectively disabling the timeout. Because of BlueZ
     bug, which is not fixed until BlueZ 5.73, exposing discoverable timeout
-    as zero will timout the advertisement immediately.
+    as zero will timeout the advertisement immediately.
 
     <property name="DiscoverableTimeout" type="q" access="read"/>
     -->

--- a/src/platform/Linux/dbus/openthread/BUILD.gn
+++ b/src/platform/Linux/dbus/openthread/BUILD.gn
@@ -17,9 +17,10 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/linux/gdbus_library.gni")
 
 gdbus_library("openthread") {
-  sources = [ "introspect.xml" ]
+  sources = [ "DBusOpenthread.xml" ]
 
   c_namespace = "Openthread"
+  interface_prefix = "io.openthread"
   c_generate_object_manager = false
   dbus_out_dir = "platform/Linux/dbus/openthread"
 }

--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
@@ -13,12 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+<!--
+This file is constructed based on the OpenThread D-Bus API exposed by the
+OpenThread Border Router. The list of methods and properties is available
+at: https://github.com/openthread/ot-br-posix/blob/main/src/dbus/common/constants.hpp
+
+Please note that this file is not a complete representation of the OpenThread
+D-Bus API, but only includes the methods and properties that are relevant for
+the OpenThread integration with the Matter SDK.
+-->
+
 <!DOCTYPE node PUBLIC
   "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
   "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 
 <node>
   <interface name="io.openthread.BorderRouter">
+
     <!-- Scan: Perform a Thread network scan.
       @scan_result: array of scan results.
 
@@ -44,434 +56,76 @@ limitations under the License.
       <arg name="scan_result" type="a(tstayqqynyybb)" direction="out"/>
     </method>
 
-    <!-- Attach: Attach the current device to the Thread network using the current active network dataset. -->
+    <!--
+    Attach the current device to the Thread network using
+    the current active network dataset.
+    -->
     <method name="Attach" />
 
-    <!-- PermitUnsecureJoin: Allow joining the network via unsecure traffic temporarily.
-      @port: The port of the unsecure traffic.
-      @timeout: The timeout for the permission.
+    <!--
+    Perform a reset, will try to resume the network after reset.
     -->
-    <method name="PermitUnsecureJoin">
-      <arg name="port" type="q"/>
-      <arg name="timeout" type="u"/>
-    </method>
+    <method name="Reset" />
 
-    <!-- JoinerStart: Start Thread joining.
-      @pskd: The pre-shared key for the device.
-      @provision_url: The url for further provision.
-      @vendor vendor_name: The current device vendor name.
-      @vendor vendor_model: The current device model.
-      @vendor vendor_sw_version: The current device software version.
-      @vendor vendor_data: The additional vendor data.
-    -->
-    <method name="JoinerStart">
-      <arg name="pskd" type="s"/>
-      <arg name="provision_url" type="s"/>
-      <arg name="vendor_name" type="s"/>
-      <arg name="vendor_model" type="s"/>
-      <arg name="vendor_sw_version" type="s"/>
-      <arg name="vendor_data" type="s"/>
-    </method>
+    <!--
+    The current link mode.
 
-    <!-- JoinerStop: Stop Thread joining. -->
-    <method name="JoinerStop">
-    </method>
-
-    <!-- FactoryReset: Perform a factory reset, will wipe all Thread persistent data. -->
-    <method name="FactoryReset">
-    </method>
-
-    <!-- Reset: Perform a reset, will try to resume the network after reset. -->
-    <method name="Reset">
-    </method>
-
-    <!-- AddExternalRoute: Add an external border routing rule to the network.
-      @prefix: The prefix for border routing.
-
-      This will make the current device act as the border router for the prefix.
-      The prefix structure is:
-      <literallayout>
-        struct {
-          struct {
-            uint8[] prefix_bytes
-            uint8 prefix_length
-          }
-          uint16 rloc // Not used
-          uint8 preference
-          bool stable
-          bool next_hop_is_self // Not used
-        }
-      </literallayout>
-    -->
-    <method name="AddExternalRoute">
-      <arg name="prefix" type="((ayy)qybb)"/>
-    </method>
-
-    <!-- RemoveExternalRoute: Remove an external border routing rule from the network.
-      @prefix: The prefix for border routing.
-
-      The prefix structure is:
-      <literallayout>
-        struct {
-          uint8[] prefix_bytes
-          uint8 prefix_length
-        }
-      </literallayout>
-    -->
-    <method name="RemoveExternalRoute">
-      <arg name="prefix" type="(ayy)"/>
-    </method>
-
-    <!-- AddOnMeshPrefix: Add an on-mesh prefix to the network.
-      @prefix: The on-mesh prefix.
-
-      The on-mesh prefix structure is:
-      <literallayout>
-        struct {
-          struct {
-            uint8[] prefix_bytes
-            uint8 prefix_length
-          }
-          byte preference
-          struct {
-            boolean preferred
-            boolean slaac
-            boolean dhcp
-            boolean configure
-            boolean default_route
-            boolean on_mesh
-            boolean stable
-          }
-        }
-      </literallayout>
-    -->
-    <method name="AddOnMeshPrefix">
-      <arg name="prefix" type="((ayy)y(bbbbbbb))"/>
-    </method>
-
-    <!-- RemoveOnMeshPrefix: Remove an on-mesh prefix from the network.
-      @prefix: The on-mesh prefix.
-
-      The prefix structure is:
-      <literallayout>
-        struct {
-          uint8[] prefix_bytes
-          uint8 prefix_length
-        }
-      </literallayout>
-    -->
-    <method name="RemoveOnMeshPrefix">
-      <arg name="prefix" type="(ayy)"/>
-    </method>
-
-    <!-- MeshLocalPrefix: The /64 mesh-local prefix.  -->
-    <property name="MeshLocalPrefix" type="ay" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- LegacyULAPrefix: The /64 legacy prefix.  -->
-    <property name="LegacyULAPrefix" type="ay" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- LinkMode: The current link mode.
-      <literallayout>
-      struct {
-        bool rx_on_when_idle    //whether the radio receiving is on when idle
-        bool device_type        //ftd or mtd
-        bool network_data       //full or stable
-      }
-      </literallayout>
+    This property is a struct with the following fields:
+      bool rx_on_when_idle    // whether the radio receiving is on when idle
+      bool device_type        // ftd or mtd
+      bool network_data       // full or stable
     -->
     <property name="LinkMode" type="(bbb)" access="readwrite">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
-    <!-- DeviceRole: The current device role.
-      Possible values are:
-      <literallayout>
-        0: Disabled
-        1: Detached
-        2: Child
-        3: Router
-        4: Leader
-      </literallayout>
+    <!--
+    The current device role.
+
+    Possible values are:
+      - disabled
+      - detached
+      - child
+      - router
+      - leader
     -->
     <property name="DeviceRole" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
     </property>
 
-    <!-- NetworkName: The network name. -->
-    <property name="NetworkName" type="s" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- PanId: The pan ID. -->
-    <property name="PanId" type="q" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ExtPanId: The extended pan ID. -->
-    <property name="ExtPanId" type="t" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- Channel: The current network channel, from 11 to 26 -->
-    <property name="Channel" type="q" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- CcaFailureRate: The Clear Channel Assessment failure rate. -->
-    <property name="CcaFailureRate" type="q" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- MacCounters: The mac layer statistic counters.
-      The counter structure definition:
-      <literallayout>
-        struct {
-          uint32 tx_total;
-          uint32 tx_unicast;
-          uint32 tx_broadcast;
-          uint32 tx_ack_requested;
-          uint32 tx_acked;
-          uint32 tx_no_ack_requested;
-          uint32 tx_data;
-          uint32 tx_data_poll;
-          uint32 tx_beacon;
-          uint32 tx_beacon_request;
-          uint32 tx_other;
-          uint32 tx_retry;
-          uint32 tx_err_cca;
-          uint32 tx_err_abort;
-          uint32 tx_busy_channel;
-          uint32 rx_total;
-          uint32 rx_unicast;
-          uint32 rx_broadcast;
-          uint32 rx_data;
-          uint32 rx_data_poll;
-          uint32 rx_beacon;
-          uint32 rx_beacon_request;
-          uint32 rx_other;
-          uint32 rx_address_filtered;
-          uint32 rx_dest_address_filtered;
-          uint32 rx_duplicated;
-          uint32 rx_err_no_frame;
-          uint32 rx_err_unknown_neighbor;
-          uint32 rx_err_invalid_src_addr;
-          uint32 rx_err_sec;
-          uint32 rx_err_fcs;
-          uint32 rx_err_other;
-        }
-      </literallayout>
+    <!--
+    The 64-bit extended address.
     -->
-    <property name="MacCounters" type="(uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- LinkCounters: The link statistic counters.
-      The counter structure definition:
-      <literallayout>
-        struct {
-          uint32 ip_tx_success;
-          uint32 ip_rx_success;
-          uint32 ip_tx_failure;
-          uint32 ip_rx_failure;
-        }
-      </literallayout>
-    -->
-    <property name="LinkCounters" type="(uuuu)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- LinkSupportedChannelMask: The bitwise link supported channel mask -->
-    <property name="LinkSupportedChannelMask" type="u" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- Rloc16: The 16-bit routing locator -->
-    <property name="Rloc16" type="q" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ExtendedAddress: The 64-bit extended address -->
     <property name="ExtendedAddress" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
-    <!-- RouterID: The current router ID -->
-    <property name="RouterID" type="y" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
+    <!--
+    The list of current external route rules.
 
-    <!-- LeaderData: The network leader data.
-      The structure definition:
-      <literallayout>
+    The structure definition for a single route rule:
+      struct {
         struct {
-          uint32_t mPartitionId;       // Partition ID
-          uint8_t  mWeighting;         // Leader Weight
-          uint8_t  mDataVersion;       // Full Network Data Version
-          uint8_t  mStableDataVersion; // Stable Network Data Version
-          uint8_t  mLeaderRouterId;    // Leader Router ID
+          uint8[] prefix_bytes
+          uint8 prefix_length
         }
-      </literallayout>
-    -->
-    <property name="LeaderData" type="(uyyyy)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- NetworkData: The network data. -->
-    <property name="NetworkData" type="ay" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- StableNetworkData: The stable network data. -->
-    <property name="StableNetworkData" type="ay" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- LocalLeaderWeight: The leader weight of the current node. -->
-    <property name="LocalLeaderWeight" type="y" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ChannelMonitorSampleCount: The number of the collected samples from the channel monitor -->
-    <property name="ChannelMonitorSampleCount" type="u" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ChannelMonitorChannelQualityMap: The channel monitor statistics data.
-      The structure definition:
-      <literallayout>
-        struct {
-          uint8_t  mChannel;
-          uint16_t mOccupancy;
-        }
-      </literallayout>
-    -->
-    <property name="ChannelMonitorChannelQualityMap" type="a(yq)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ChildTable: The node's child table as an array of child entry structure.
-      The child entry structure definition:
-      <literallayout>
-        struct {
-          uint64_t mExtAddress;         // IEEE 802.15.4 Extended Address
-          uint32_t mTimeout;            // Timeout
-          uint32_t mAge;                // Time last heard
-          uint16_t mRloc16;             // RLOC16
-          uint16_t mChildId;            // Child ID
-          uint8_t  mNetworkDataVersion; // Network Data Version
-          uint8_t  mLinkQualityIn;      // Link Quality In
-          int8_t   mAverageRssi;        // Average RSSI
-          int8_t   mLastRssi;           // Last observed RSSI
-          uint16_t mFrameErrorRate;     // Frame error rate (0xffff->100%). Requires error tracking feature.
-          uint16_t mMessageErrorRate;   // (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
-          bool     mRxOnWhenIdle;       // rx-on-when-idle
-          bool     mFullThreadDevice;   // Full Thread Device
-          bool     mFullNetworkData;    // Full Network Data
-          bool     mIsStateRestoring;   // Is in restoring state
-        }
-      </literallayout>
-    -->
-    <property name="ChildTable" type="a(tuuqqyyyyqqbbbb)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- NeighborTable: The node's neighbor table as an array of neighbor entry structure.
-      The neighbor entry structure definition:
-      <literallayout>
-        struct {
-          uint64_t mExtAddress;        // IEEE 802.15.4 Extended Address
-          uint32_t mAge;               // Time last heard
-          uint16_t mRloc16;            // RLOC16
-          uint32_t mLinkFrameCounter;  // Link Frame Counter
-          uint32_t mMleFrameCounter;   // MLE Frame Counter
-          uint8_t  mLinkQualityIn;     // Link Quality In
-          int8_t   mAverageRssi;       // Average RSSI
-          int8_t   mLastRssi;          // Last observed RSSI
-          uint16_t mFrameErrorRate;    // Frame error rate (0xffff->100%). Requires error tracking feature.
-          uint16_t mMessageErrorRate;  // (IPv6) msg error rate (0xffff->100%). Requires error tracking feature.
-          bool     mRxOnWhenIdle;      // rx-on-when-idle
-          bool     mFullThreadDevice;  // Full Thread Device
-          bool     mFullNetworkData;   // Full Network Data
-          bool     mIsChild;           // Is the neighbor a child
-        }
-      </literallayout>
-    -->
-    <property name="NeighborTable" type="a(tuquuyyyqqbbbb)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- PartitionId: The network partition ID. -->
-    <property name="PartitionId" type="u" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- InstantRssi: The RSSI of the last received packet. -->
-    <property name="InstantRssi" type="y" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- RadioTxPower: The radio transmit power. -->
-    <property name="RadioTxPower" type="y" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!-- ExternalRoutes: The list of current external route rules.
-      External route rule structure definition:
-      <literallayout>
-        struct {
-          struct {
-            uint8[] prefix_bytes
-            uint8 prefix_length
-          }
-          uint16 rloc
-          uint8 preference
-          bool stable
-          bool next_hop_is_self
-        }
-      </literallayout>
+        uint16 rloc
+        uint8 preference
+        bool stable
+        bool next_hop_is_self
+      }
     -->
     <property name="ExternalRoutes" type="a((ayy)qybb)" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
-    <!-- ActiveDatasetTlvs: The Thread active dataset tlv in binary form. -->
+    <!--
+    The Thread active dataset TLV in binary form.
+    -->
     <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
       <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
-    <!-- RadioRegion: The radio region code in ISO 3166-1. -->
-    <property name="RadioRegion" type="s" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-  </interface>
-
-  <interface name="org.freedesktop.DBus.Properties">
-    <method name="Get">
-      <arg name="interface" direction="in" type="s"/>
-      <arg name="property" direction="in" type="s"/>
-      <arg name="value" direction="out" type="v"/>
-    </method>
-
-    <method name="GetAll">
-      <arg name="interface" direction="in" type="s"/>
-      <arg name="properties" direction="out" type="a{sv}"/>
-    </method>
-
-    <method name="Set">
-      <arg name="interface" direction="in" type="s"/>
-      <arg name="property" direction="in" type="s"/>
-      <arg name="value" direction="in" type="v"/>
-    </method>
-
-    <signal name="PropertiesChanged">
-      <arg type="s" name="interface"/>
-      <arg type="a{sv}" name="changed_properties"/>
-      <arg type="as" name="invalidated_properties"/>
-    </signal>
   </interface>
 </node>

--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <!--
 Copyright (c) 2021 Project CHIP Authors
 
@@ -14,14 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
 <node>
   <interface name="io.openthread.BorderRouter">
     <!-- Scan: Perform a Thread network scan.
       @scan_result: array of scan results.
 
-      The result struture definition is:
+      The result structure definition is:
       <literallayout>
         struct {
           uint64 ext_address
@@ -40,7 +41,7 @@ limitations under the License.
       </literallayout>
     -->
     <method name="Scan">
-      <arg name="scan_result" type="a(tstayqqynyybb)" direction="out"/> 
+      <arg name="scan_result" type="a(tstayqqynyybb)" direction="out"/>
     </method>
 
     <!-- Attach: Attach the current device to the Thread network using the current active network dataset. -->
@@ -134,12 +135,12 @@ limitations under the License.
           byte preference
           struct {
             boolean preferred
-            boolean slaac 
-            boolean dhcp 
-            boolean configure 
-            boolean default_route   
+            boolean slaac
+            boolean dhcp
+            boolean configure
+            boolean default_route
             boolean on_mesh
-            boolean stable 
+            boolean stable
           }
         }
       </literallayout>
@@ -147,7 +148,7 @@ limitations under the License.
     <method name="AddOnMeshPrefix">
       <arg name="prefix" type="((ayy)y(bbbbbbb))"/>
     </method>
-    
+
     <!-- RemoveOnMeshPrefix: Remove an on-mesh prefix from the network.
       @prefix: The on-mesh prefix.
 

--- a/src/platform/Linux/dbus/wpa/BUILD.gn
+++ b/src/platform/Linux/dbus/wpa/BUILD.gn
@@ -24,7 +24,8 @@ gdbus_library("wpa") {
     "DBusWpaNetwork.xml",
   ]
 
-  c_namespace = "Wpa"
+  c_namespace = "WpaSupplicant"
+  interface_prefix = "fi.w1.wpa_supplicant"
   c_generate_object_manager = false
   dbus_out_dir = "platform/Linux/dbus/wpa"
 }

--- a/src/platform/Linux/dbus/wpa/DBusWpa.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpa.xml
@@ -1,36 +1,42 @@
-<?xml version="1.0" ?>
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<!--
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed based on the wpa_supplicant D-Bus API exposed by the
+wpa_supplicant daemon. The list of methods and properties is available at:
+https://w1.fi/wpa_supplicant/devel/dbus.html
+
+Please note that this file is not a complete representation of the
+wpa_supplicant D-Bus API, but only includes the methods that are relevant for
+the wpa_supplicant integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
 <node>
     <interface name="fi.w1.wpa_supplicant1">
         <method name="CreateInterface">
             <arg name="args" type="a{sv}" direction="in" />
             <arg name="path" type="o" direction="out" />
         </method>
-        <method name="RemoveInterface">
-            <arg name="path" type="o" direction="in" />
-        </method>
         <method name="GetInterface">
             <arg name="ifname" type="s" direction="in" />
             <arg name="path" type="o" direction="out" />
         </method>
-        <method name="ExpectDisconnect" />
-        <signal name="InterfaceAdded">
-            <arg name="path" type="o" />
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <signal name="InterfaceRemoved">
-            <arg name="path" type="o" />
-        </signal>
-        <signal name="PropertiesChanged">
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <property name="DebugLevel" type="s" access="readwrite" />
-        <property name="DebugTimestamp" type="b" access="readwrite" />
-        <property name="DebugShowKeys" type="b" access="readwrite" />
-        <property name="Interfaces" type="ao" access="read" />
-        <property name="EapMethods" type="as" access="read" />
-        <property name="Capabilities" type="as" access="read" />
-        <property name="WFDIEs" type="ay" access="readwrite" />
     </interface>
-    <node name="Interfaces" />
 </node>

--- a/src/platform/Linux/dbus/wpa/DBusWpaBss.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaBss.xml
@@ -1,19 +1,25 @@
-<?xml version="1.0" ?>
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<!--
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
 <node>
     <interface name="fi.w1.wpa_supplicant1.BSS">
-        <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
-        <signal name="PropertiesChanged">
-            <arg name="properties" type="a{sv}" />
-        </signal>
-
-        <property name="SSID" type="ay" access="read">
-            <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
-        </property>
-        <property name="BSSID" type="ay" access="read">
-            <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
-        </property>
-        <property name="WPA" type="a{sv}" access="read" />
         <property name="Signal" type="n" access="read" />
         <property name="Frequency" type="q" access="read" />
     </interface>

--- a/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
@@ -1,33 +1,57 @@
-<?xml version="1.0" ?>
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<!--
+Copyright (c) 2020 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+This file is constructed based on the wpa_supplicant D-Bus API exposed by the
+wpa_supplicant daemon. The list of methods and properties is available at:
+https://w1.fi/wpa_supplicant/devel/dbus.html
+
+Please note that this file is not a complete representation of the
+wpa_supplicant D-Bus API, but only includes the methods that are relevant for
+the wpa_supplicant integration with the Matter SDK.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
 <node>
     <interface name="fi.w1.wpa_supplicant1.Interface">
+
         <method name="Scan">
             <arg name="args" type="a{sv}" direction="in" />
         </method>
-        <method name="SignalPoll">
-            <arg name="args" type="a{sv}" direction="out" />
-        </method>
+
         <method name="Disconnect" />
+
         <method name="AddNetwork">
             <arg name="args" type="a{sv}" direction="in" />
             <arg name="path" type="o" direction="out" />
         </method>
-        <method name="Reassociate" />
-        <method name="Reattach" />
-        <method name="Reconnect" />
+
         <method name="RemoveNetwork">
             <arg name="path" type="o" direction="in" />
         </method>
+
         <method name="RemoveAllNetworks" />
+
         <method name="SelectNetwork">
             <arg name="path" type="o" direction="in" />
         </method>
-        <method name="NetworkReply">
-            <arg name="path" type="o" direction="in" />
-            <arg name="field" type="s" direction="in" />
-            <arg name="value" type="s" direction="in" />
-        </method>
+
         <method name="AddBlob">
             <arg name="name" type="s" direction="in" />
             <arg name="data" type="ay" direction="in">
@@ -35,266 +59,47 @@
                 <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
             </arg>
         </method>
-        <method name="GetBlob">
-            <arg name="name" type="s" direction="in" />
-            <arg name="data" type="ay" direction="out" />
-        </method>
+
         <method name="RemoveBlob">
             <arg name="name" type="s" direction="in" />
         </method>
-        <method name="SetPKCS11EngineAndModulePath">
-            <arg name="pkcs11_engine_path" type="s" direction="in" />
-            <arg name="pkcs11_module_path" type="s" direction="in" />
-        </method>
-        <method name="FlushBSS">
-            <arg name="age" type="u" direction="in" />
-        </method>
-        <method name="SubscribeProbeReq" />
-        <method name="UnsubscribeProbeReq" />
-        <method name="EAPLogoff" />
-        <method name="EAPLogon" />
+
         <method name="AutoScan">
             <arg name="arg" type="s" direction="in" />
         </method>
+
         <method name="NANPublish">
             <arg name="nan_args" type="s" direction="in" />
             <arg name="publish_id" type="i" direction="out" />
         </method>
+
         <method name="NANCancelPublish">
             <arg name="nan_args" type="s" direction="in" />
         </method>
+
         <method name="NANSubscribe">
             <arg name="nan_args" type="s" direction="in" />
             <arg name="subscribe_id" type="i" direction="out" />
         </method>
+
         <method name="NANCancelSubscribe">
             <arg name="nan_args" type="s" direction="in" />
         </method>
+
         <method name="NANTransmit">
             <arg name="nan_args" type="s" direction="in" />
         </method>
-        <method name="TDLSDiscover">
-            <arg name="peer_address" type="s" direction="in" />
-        </method>
-        <method name="TDLSSetup">
-            <arg name="peer_address" type="s" direction="in" />
-        </method>
-        <method name="TDLSStatus">
-            <arg name="peer_address" type="s" direction="in" />
-            <arg name="status" type="s" direction="out" />
-        </method>
-        <method name="TDLSTeardown">
-            <arg name="peer_address" type="s" direction="in" />
-        </method>
-        <method name="TDLSChannelSwitch">
-            <arg name="args" type="a{sv}" direction="in" />
-        </method>
-        <method name="TDLSCancelChannelSwitch">
-            <arg name="peer_address" type="s" direction="in" />
-        </method>
-        <method name="VendorElemAdd">
-            <arg name="frame_id" type="i" direction="in" />
-            <arg name="ielems" type="ay" direction="in" />
-        </method>
-        <method name="VendorElemGet">
-            <arg name="frame_id" type="i" direction="in" />
-            <arg name="ielems" type="ay" direction="out" />
-        </method>
-        <method name="VendorElemRem">
-            <arg name="frame_id" type="i" direction="in" />
-            <arg name="ielems" type="ay" direction="in" />
-        </method>
+
         <method name="SaveConfig" />
-        <method name="AbortScan" />
-        <signal name="ScanDone">
-            <arg name="success" type="b" />
-        </signal>
-        <signal name="NanDiscoveryresult">
-            <arg name="result" type="b" />
-            <arg name="discov_info" type="a{sv}" />
-        </signal>
-        <signal name="NanReceive">
-            <arg name="nanrx" type="a{sv}" />
-        </signal>
-        <signal name="NanPublishterminated">
-            <arg name="publish_id" type="i" />
-            <arg name="reason" type="i" />
-        </signal>
-        <signal name="NanSubscribeterminated">
-            <arg name="term_subscribe_id" type="i" />
-            <arg name="reason" type="i" />
-        </signal>
-        <signal name="BSSAdded">
-            <arg name="path" type="o" />
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <signal name="BSSRemoved">
-            <arg name="path" type="o" />
-        </signal>
-        <signal name="BlobAdded">
-            <arg name="name" type="s" />
-        </signal>
-        <signal name="BlobRemoved">
-            <arg name="name" type="s" />
-        </signal>
-        <signal name="NetworkAdded">
-            <arg name="path" type="o" />
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <signal name="NetworkRemoved">
-            <arg name="path" type="o" />
-        </signal>
-        <signal name="NetworkSelected">
-            <arg name="path" type="o" />
-        </signal>
-        <signal name="PropertiesChanged">
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <signal name="ProbeRequest">
-            <arg name="args" type="a{sv}" />
-        </signal>
-        <signal name="Certification">
-            <arg name="certification" type="a{sv}" />
-        </signal>
-        <signal name="EAP">
-            <arg name="status" type="s" />
-            <arg name="parameter" type="s" />
-        </signal>
-        <signal name="StaAuthorized">
-            <arg name="name" type="s" />
-        </signal>
-        <signal name="StaDeauthorized">
-            <arg name="name" type="s" />
-        </signal>
-        <signal name="StationAdded">
-            <arg name="path" type="o" />
-            <arg name="properties" type="a{sv}" />
-        </signal>
-        <signal name="StationRemoved">
-            <arg name="path" type="o" />
-        </signal>
-        <signal name="NetworkRequest">
-            <arg name="path" type="o" />
-            <arg name="field" type="s" />
-            <arg name="text" type="s" />
-        </signal>
-        <property name="Capabilities" type="a{sv}" access="read" />
+
         <property name="State" type="s" access="read" />
-        <property name="Scanning" type="b" access="read" />
-        <property name="ApScan" type="u" access="readwrite" />
-        <property name="BSSExpireAge" type="u" access="readwrite" />
-        <property name="BSSExpireCount" type="u" access="readwrite" />
-        <property name="Country" type="s" access="readwrite" />
-        <property name="Ifname" type="s" access="read" />
-        <property name="Driver" type="s" access="read" />
-        <property name="BridgeIfname" type="s" access="read" />
-        <property name="ConfigFile" type="s" access="read" />
         <property name="CurrentBSS" type="o" access="read" />
         <property name="CurrentNetwork" type="o" access="read" />
         <property name="CurrentAuthMode" type="s" access="read" />
-        <property name="Blobs" type="a{say}" access="read" />
         <property name="BSSs" type="ao" access="read" />
-        <property name="Networks" type="ao" access="read" />
-        <property name="FastReauth" type="b" access="readwrite" />
-        <property name="ScanInterval" type="i" access="readwrite" />
-        <property name="PKCS11EnginePath" type="s" access="read" />
-        <property name="PKCS11ModulePath" type="s" access="read" />
         <property name="DisconnectReason" type="i" access="read" />
         <property name="AuthStatusCode" type="i" access="read" />
         <property name="AssocStatusCode" type="i" access="read" />
-        <property name="RoamTime" type="u" access="read" />
-        <property name="RoamComplete" type="b" access="read" />
-        <property name="SessionLength" type="u" access="read" />
-        <property name="BSSTMStatus" type="u" access="read" />
-        <property name="Stations" type="ao" access="read" />
-        <property name="MACAddressRandomizationMask" type="a{say}" access="readwrite" />
-        <property name="CtrlInterface" type="s" access="readwrite" />
-        <property name="CtrlInterfaceGroup" type="s" access="readwrite" />
-        <property name="EapolVersion" type="s" access="readwrite" />
-        <property name="Bgscan" type="s" access="readwrite" />
-        <property name="DisableScanOffload" type="s" access="readwrite" />
-        <property name="OpenscEnginePath" type="s" access="readwrite" />
-        <property name="OpensslCiphers" type="s" access="readwrite" />
-        <property name="PcscReader" type="s" access="readwrite" />
-        <property name="PcscPin" type="s" access="readwrite" />
-        <property name="ExternalSim" type="s" access="readwrite" />
-        <property name="DriverParam" type="s" access="readwrite" />
-        <property name="Dot11RSNAConfigPMKLifetime" type="s" access="readwrite" />
-        <property name="Dot11RSNAConfigPMKReauthThreshold" type="s" access="readwrite" />
-        <property name="Dot11RSNAConfigSATimeout" type="s" access="readwrite" />
-        <property name="UpdateConfig" type="s" access="readwrite" />
-        <property name="Uuid" type="s" access="readwrite" />
-        <property name="AutoUuid" type="s" access="readwrite" />
-        <property name="DeviceName" type="s" access="readwrite" />
-        <property name="Manufacturer" type="s" access="readwrite" />
-        <property name="ModelName" type="s" access="readwrite" />
-        <property name="ModelNumber" type="s" access="readwrite" />
-        <property name="SerialNumber" type="s" access="readwrite" />
-        <property name="DeviceType" type="s" access="readwrite" />
-        <property name="OsVersion" type="s" access="readwrite" />
-        <property name="ConfigMethods" type="s" access="readwrite" />
-        <property name="SecDeviceType" type="s" access="readwrite" />
-        <property name="IpAddrGo" type="s" access="readwrite" />
-        <property name="IpAddrMask" type="s" access="readwrite" />
-        <property name="IpAddrStart" type="s" access="readwrite" />
-        <property name="IpAddrEnd" type="s" access="readwrite" />
-        <property name="BssMaxCount" type="s" access="readwrite" />
-        <property name="FilterSsids" type="s" access="readwrite" />
-        <property name="FilterRssi" type="s" access="readwrite" />
-        <property name="MaxNumSta" type="s" access="readwrite" />
-        <property name="ApIsolate" type="s" access="readwrite" />
-        <property name="DisassocLowAck" type="s" access="readwrite" />
-        <property name="Hs20" type="s" access="readwrite" />
-        <property name="Interworking" type="s" access="readwrite" />
-        <property name="Hessid" type="s" access="readwrite" />
-        <property name="AccessNetworkType" type="s" access="readwrite" />
-        <property name="GoInterworking" type="s" access="readwrite" />
-        <property name="GoAccessNetworkType" type="s" access="readwrite" />
-        <property name="GoInternet" type="s" access="readwrite" />
-        <property name="GoVenueGroup" type="s" access="readwrite" />
-        <property name="GoVenueType" type="s" access="readwrite" />
-        <property name="PbcInM1" type="s" access="readwrite" />
-        <property name="Autoscan" type="s" access="readwrite" />
-        <property name="ExtPasswordBackend" type="s" access="readwrite" />
-        <property name="AutoInterworking" type="s" access="readwrite" />
-        <property name="Okc" type="s" access="readwrite" />
-        <property name="Pmf" type="s" access="readwrite" />
-        <property name="SaeGroups" type="s" access="readwrite" />
-        <property name="SaePwe" type="s" access="readwrite" />
-        <property name="SaePmkidInAssoc" type="s" access="readwrite" />
-        <property name="DtimPeriod" type="s" access="readwrite" />
-        <property name="BeaconInt" type="s" access="readwrite" />
-        <property name="ApVendorElements" type="s" access="readwrite" />
-        <property name="IgnoreOldScanRes" type="s" access="readwrite" />
-        <property name="FreqList" type="s" access="readwrite" />
-        <property name="ScanCurFreq" type="s" access="readwrite" />
-        <property name="SchedScanInterval" type="s" access="readwrite" />
-        <property name="SchedScanStartDelay" type="s" access="readwrite" />
-        <property name="TdlsExternalControl" type="s" access="readwrite" />
-        <property name="OsuDir" type="s" access="readwrite" />
-        <property name="WowlanTriggers" type="s" access="readwrite" />
-        <property name="MacAddr" type="s" access="readwrite" />
-        <property name="RandAddrLifetime" type="s" access="readwrite" />
-        <property name="PreassocMacAddr" type="s" access="readwrite" />
-        <property name="KeyMgmtOffload" type="s" access="readwrite" />
-        <property name="PassiveScan" type="s" access="readwrite" />
-        <property name="ReassocSameBssOptim" type="s" access="readwrite" />
-        <property name="FstGroupId" type="s" access="readwrite" />
-        <property name="FstPriority" type="s" access="readwrite" />
-        <property name="FstLlt" type="s" access="readwrite" />
-        <property name="CertInCb" type="s" access="readwrite" />
-        <property name="WpaRscRelaxation" type="s" access="readwrite" />
-        <property name="SchedScanPlans" type="s" access="readwrite" />
-        <property name="GasAddress3" type="s" access="readwrite" />
-        <property name="FtmResponder" type="s" access="readwrite" />
-        <property name="FtmInitiator" type="s" access="readwrite" />
-        <property name="GasRandAddrLifetime" type="s" access="readwrite" />
-        <property name="GasRandMacAddr" type="s" access="readwrite" />
-        <property name="DppConfigProcessing" type="s" access="readwrite" />
-        <property name="DppName" type="s" access="readwrite" />
-        <property name="DppMudUrl" type="s" access="readwrite" />
-        <property name="ColocIntfReporting" type="s" access="readwrite" />
+
     </interface>
-    <node name="BSSs" />
-    <node name="Networks" />
 </node>

--- a/src/platform/Linux/dbus/wpa/DBusWpaNetwork.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaNetwork.xml
@@ -1,10 +1,25 @@
-<?xml version="1.0" ?>
-<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN" "https://raw.githubusercontent.com/freedesktop/dbus/master/doc/introspect.dtd">
+<!--
+Copyright (c) 2021 Project CHIP Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!DOCTYPE node PUBLIC
+  "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+
 <node>
     <interface name="fi.w1.wpa_supplicant1.Network">
-        <signal name="PropertiesChanged">
-            <arg name="properties" type="a{sv}" />
-        </signal>
         <property name="Properties" type="a{sv}" access="readwrite" />
         <property name="Enabled" type="b" access="readwrite" />
     </interface>

--- a/src/platform/NuttX/ThreadStackManagerImpl.h
+++ b/src/platform/NuttX/ThreadStackManagerImpl.h
@@ -25,7 +25,7 @@
 #include <lib/support/ThreadOperationalDataset.h>
 #include <platform/GLibTypeDeleter.h>
 #include <platform/NetworkCommissioning.h>
-#include <platform/NuttX/dbus/openthread/introspect.h>
+#include <platform/NuttX/dbus/openthread/DBusOpenthread.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -25,7 +25,7 @@
 #include <platform/NetworkCommissioning.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/DeviceNetworkInfo.h>
-#include <platform/webos/dbus/openthread/introspect.h>
+#include <platform/webos/dbus/openthread/DBusOpenthread.h>
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
#### Problem

The OpenThread and wpa_supplicant auto-generated D-Bus stubs contain not used methods and properties which bloat final exec.

#### Changes

- Simplify namespace for OpenThread and wpa_supplicant D-Bus codegen API
- Strip unused methods and props

#### Testing

Tested locally:

OpenThread optimization saves:
.text -> 16980 bytes
.data -> 4720 bytes

wpa_supplicant optimization saves:
.text -> 69969 bytes
.data -> 16384 bytes

CI should also verify that, and check for potential breaks.