### PR TITLE
Fix regular expression for variable splitting.

### DIFF
--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -1225,7 +1225,7 @@ class TestStep:
             # But some other tests were relying on the fact that the expression was put 'as if' in
             # the generated code and was resolved before being sent over the wire. For such
             # expressions (e.g 'myVar + 1') we need to compute it before sending it over the wire.
-            tokens = re.split("[- ()|+*/%]", value)
+            tokens = re.split("([- ()|+*/%])", value)
             if len(tokens) == 0:
                 return value
 

--- a/scripts/py_matter_yamltests/matter_yamltests/parser.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/parser.py
@@ -1225,8 +1225,7 @@ class TestStep:
             # But some other tests were relying on the fact that the expression was put 'as if' in
             # the generated code and was resolved before being sent over the wire. For such
             # expressions (e.g 'myVar + 1') we need to compute it before sending it over the wire.
-            delimiter_regex = "(\ |\(|\)|\+|\-|\*|\/|\%)"
-            tokens = re.split(delimiter_regex, value)
+            tokens = re.split("[- ()|+*/%]", value)
             if len(tokens) == 0:
                 return value
 


### PR DESCRIPTION
Previous code tried to escape every character, however python linters complained about illegal escapes. The expression also seemed a bit complex, so a character set seems clearer.

#### Testing

CI will run, however I manually tested over an expression as well:

```
>>> re.split("(\ |\(|\)|\+|\-|\*|/|%)", "var + 1 | 2 ( - ) + 3")
<stdin>:1: SyntaxWarning: invalid escape sequence '\ '
['var', ' ', '', '+', '', ' ', '1', ' ', '|', ' ', '2', ' ', '', '(', '', ' ', '', '-', '', ' ', '', ')', '', ' ', '', '+', '', ' ', '3']

>>> re.split("([- ()|+*/%])", "var + 1 | 2 ( - ) + 3")
['var', ' ', '', '+', '', ' ', '1', ' ', '', '|', '', ' ', '2', ' ', '', '(', '', ' ', '', '-', '', ' ', '', ')', '', ' ', '', '+', '', ' ', '3']

```

Note that the values are not exactly identical as a few more empty strings are added, however it does seem equivalent from a "merge by tokens" perspective.