### PR TITLE
[Darwin] Add logging for sync storage duration over a threshold

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -27,7 +27,7 @@
 #include <lib/support/SafeInt.h>
 
 // Log error each time sync storage takes longer than this threshold
-#define SYNC_OPERATION_DURATION_LOG_THRESHOLD (2.0)
+#define SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS (2.0)
 
 // FIXME: Are these good key strings? https://github.com/project-chip/connectedhomeip/issues/28973
 static NSString * sResumptionNodeListKey = @"caseResumptionNodeList";
@@ -151,7 +151,7 @@ static bool IsValidCATNumber(id _Nullable value)
         }
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore init took %0.6lf seconds to read from storage", syncDuration);
     }
     if (resumptionNodeList != nil) {
@@ -192,7 +192,7 @@ static bool IsValidCATNumber(id _Nullable value)
         }
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore fetchAttributeDataForAllDevices took %0.6lf seconds to read from storage", syncDuration);
     }
 
@@ -256,7 +256,7 @@ static bool IsValidCATNumber(id _Nullable value)
                          sharingType:MTRStorageSharingTypeNotShared];
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore storeResumptionInfo took %0.6lf seconds to store to storage", syncDuration);
     }
 }
@@ -304,7 +304,7 @@ static bool IsValidCATNumber(id _Nullable value)
                              sharingType:MTRStorageSharingTypeNotShared];
         });
         NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-        if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
             MTR_LOG_ERROR("MTRDeviceControllerDataStore _clearResumptionInfoForNodeID took %0.6lf seconds to remove from storage", syncDuration);
         }
     }
@@ -325,7 +325,7 @@ static bool IsValidCATNumber(id _Nullable value)
                               sharingType:MTRStorageSharingTypeNotShared];
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore storeLastLocallyUsedNOC took %0.6lf seconds to store to storage", syncDuration);
     }
     return ok ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
@@ -347,7 +347,7 @@ static bool IsValidCATNumber(id _Nullable value)
         }
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore fetchLastLocallyUsedNOC took %0.6lf seconds to read from storage", syncDuration);
     }
 
@@ -383,7 +383,7 @@ static bool IsValidCATNumber(id _Nullable value)
         }
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore _findResumptionInfoWithKey took %0.6lf seconds to read from storage", syncDuration);
     }
 
@@ -964,7 +964,7 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
         }
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredClusterDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
     }
 
@@ -982,7 +982,7 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
         clusterDataToReturn = [self _fetchClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredClusterDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
     }
     return clusterDataToReturn;
@@ -1254,7 +1254,7 @@ static NSString * sDeviceDataKeyPrefix = @"deviceData";
         deviceData = dictionary;
     });
     NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
-    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD_SECONDS) {
         MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredDeviceDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
     }
     return deviceData;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -26,6 +26,9 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 
+// Log error each time sync storage takes longer than this threshold
+#define SYNC_OPERATION_DURATION_LOG_THRESHOLD   (2.0)
+
 // FIXME: Are these good key strings? https://github.com/project-chip/connectedhomeip/issues/28973
 static NSString * sResumptionNodeListKey = @"caseResumptionNodeList";
 static NSString * sLastLocallyUsedNOCKey = @"lastLocallyUsedControllerNOC";
@@ -134,6 +137,7 @@ static bool IsValidCATNumber(id _Nullable value)
 
     __block id resumptionNodeList;
     __block NSArray<NSNumber *> * nodesWithAttributeInfo;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             // NOTE: controller, not our weak ref, since we know it's still
@@ -146,6 +150,10 @@ static bool IsValidCATNumber(id _Nullable value)
             nodesWithAttributeInfo = [self _fetchNodeIndex];
         }
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore init took %0.6lf seconds to read from storage", syncDuration);
+    }
     if (resumptionNodeList != nil) {
         if (![resumptionNodeList isKindOfClass:[NSArray class]]) {
             MTR_LOG_ERROR("List of CASE resumption node IDs is not an array");
@@ -177,11 +185,16 @@ static bool IsValidCATNumber(id _Nullable value)
     MTRDeviceController * controller = _controller;
     VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         if ([self->_storageDelegate respondsToSelector:@selector(valuesForController:securityLevel:sharingType:)]) {
             dataStoreSecureLocalValues = [self->_storageDelegate valuesForController:controller securityLevel:MTRStorageSecurityLevelSecure sharingType:MTRStorageSharingTypeNotShared];
         }
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore fetchAttributeDataForAllDevices took %0.6lf seconds to read from storage", syncDuration);
+    }
 
     if (dataStoreSecureLocalValues.count) {
         clusterDataHandler([self _getClusterDataFromSecureLocalValues:dataStoreSecureLocalValues]);
@@ -204,6 +217,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
     auto * oldInfo = [self findResumptionInfoByNodeID:resumptionInfo.nodeID];
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         if (oldInfo != nil) {
             // Remove old resumption id key.  No need to do that for the
@@ -241,6 +255,10 @@ static bool IsValidCATNumber(id _Nullable value)
                        securityLevel:MTRStorageSecurityLevelSecure
                          sharingType:MTRStorageSharingTypeNotShared];
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore storeResumptionInfo took %0.6lf seconds to store to storage", syncDuration);
+    }
 }
 
 - (void)clearAllResumptionInfo
@@ -274,6 +292,7 @@ static bool IsValidCATNumber(id _Nullable value)
 {
     auto * oldInfo = [self findResumptionInfoByNodeID:nodeID];
     if (oldInfo != nil) {
+        NSDate *startTime = [NSDate now];
         dispatch_sync(_storageDelegateQueue, ^{
             [_storageDelegate controller:controller
                        removeValueForKey:ResumptionByResumptionIDKey(oldInfo.resumptionID)
@@ -284,7 +303,11 @@ static bool IsValidCATNumber(id _Nullable value)
                            securityLevel:MTRStorageSecurityLevelSecure
                              sharingType:MTRStorageSharingTypeNotShared];
         });
-    }
+        NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+        if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+            MTR_LOG_ERROR("MTRDeviceControllerDataStore _clearResumptionInfoForNodeID took %0.6lf seconds to remove from storage", syncDuration);
+        }
+   }
 }
 
 - (CHIP_ERROR)storeLastLocallyUsedNOC:(MTRCertificateTLVBytes)noc
@@ -293,6 +316,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturnError(controller != nil, CHIP_ERROR_PERSISTED_STORAGE_FAILED); // No way to call delegate without controller.
 
     __block BOOL ok;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         ok = [_storageDelegate controller:controller
                                storeValue:noc
@@ -300,6 +324,10 @@ static bool IsValidCATNumber(id _Nullable value)
                             securityLevel:MTRStorageSecurityLevelSecure
                               sharingType:MTRStorageSharingTypeNotShared];
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore storeLastLocallyUsedNOC took %0.6lf seconds to store to storage", syncDuration);
+    }
     return ok ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
 }
 
@@ -309,6 +337,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturnValue(controller != nil, nil); // No way to call delegate without controller.
 
     __block id data;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             data = [_storageDelegate controller:controller
@@ -317,6 +346,10 @@ static bool IsValidCATNumber(id _Nullable value)
                                     sharingType:MTRStorageSharingTypeNotShared];
         }
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore fetchLastLocallyUsedNOC took %0.6lf seconds to read from storage", syncDuration);
+    }
 
     if (data == nil) {
         return nil;
@@ -340,6 +373,7 @@ static bool IsValidCATNumber(id _Nullable value)
     }
 
     __block id resumptionInfo;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             resumptionInfo = [_storageDelegate controller:controller
@@ -348,6 +382,10 @@ static bool IsValidCATNumber(id _Nullable value)
                                               sharingType:MTRStorageSharingTypeNotShared];
         }
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore _findResumptionInfoWithKey took %0.6lf seconds to read from storage", syncDuration);
+    }
 
     if (resumptionInfo == nil) {
         return nil;
@@ -866,6 +904,7 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
     }
 
     __block NSMutableDictionary<MTRClusterPath *, MTRDeviceClusterData *> * clusterDataToReturn = nil;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         std::lock_guard lock(self->_nodeArrayLock);
 
@@ -924,6 +963,10 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
             }
         }
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredClusterDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
+    }
 
     return clusterDataToReturn;
 }
@@ -934,9 +977,14 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
     // when the consumer knows that we're supposed to have data for this cluster
     // path.
     __block MTRDeviceClusterData * clusterDataToReturn = nil;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         clusterDataToReturn = [self _fetchClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredClusterDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
+    }
     return clusterDataToReturn;
 }
 
@@ -1173,6 +1221,7 @@ static NSString * sDeviceDataKeyPrefix = @"deviceData";
 - (nullable NSDictionary<NSString *, id> *)getStoredDeviceDataForNodeID:(NSNumber *)nodeID
 {
     __block NSDictionary<NSString *, id> * deviceData = nil;
+    NSDate *startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         MTRDeviceController * controller = self->_controller;
         VerifyOrReturn(controller != nil); // No way to call delegate without controller.
@@ -1204,6 +1253,10 @@ static NSString * sDeviceDataKeyPrefix = @"deviceData";
         // to do that.
         deviceData = dictionary;
     });
+    NSTimeInterval syncDuration = -[startTime timeIntervalSinceNow];
+    if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
+        MTR_LOG_ERROR("MTRDeviceControllerDataStore getStoredDeviceDataForNodeID took %0.6lf seconds to read from storage", syncDuration);
+    }
     return deviceData;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDataStore.mm
@@ -27,7 +27,7 @@
 #include <lib/support/SafeInt.h>
 
 // Log error each time sync storage takes longer than this threshold
-#define SYNC_OPERATION_DURATION_LOG_THRESHOLD   (2.0)
+#define SYNC_OPERATION_DURATION_LOG_THRESHOLD (2.0)
 
 // FIXME: Are these good key strings? https://github.com/project-chip/connectedhomeip/issues/28973
 static NSString * sResumptionNodeListKey = @"caseResumptionNodeList";
@@ -137,7 +137,7 @@ static bool IsValidCATNumber(id _Nullable value)
 
     __block id resumptionNodeList;
     __block NSArray<NSNumber *> * nodesWithAttributeInfo;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             // NOTE: controller, not our weak ref, since we know it's still
@@ -185,7 +185,7 @@ static bool IsValidCATNumber(id _Nullable value)
     MTRDeviceController * controller = _controller;
     VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         if ([self->_storageDelegate respondsToSelector:@selector(valuesForController:securityLevel:sharingType:)]) {
             dataStoreSecureLocalValues = [self->_storageDelegate valuesForController:controller securityLevel:MTRStorageSecurityLevelSecure sharingType:MTRStorageSharingTypeNotShared];
@@ -217,7 +217,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturn(controller != nil); // No way to call delegate without controller.
 
     auto * oldInfo = [self findResumptionInfoByNodeID:resumptionInfo.nodeID];
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         if (oldInfo != nil) {
             // Remove old resumption id key.  No need to do that for the
@@ -292,7 +292,7 @@ static bool IsValidCATNumber(id _Nullable value)
 {
     auto * oldInfo = [self findResumptionInfoByNodeID:nodeID];
     if (oldInfo != nil) {
-        NSDate *startTime = [NSDate now];
+        NSDate * startTime = [NSDate now];
         dispatch_sync(_storageDelegateQueue, ^{
             [_storageDelegate controller:controller
                        removeValueForKey:ResumptionByResumptionIDKey(oldInfo.resumptionID)
@@ -307,7 +307,7 @@ static bool IsValidCATNumber(id _Nullable value)
         if (syncDuration > SYNC_OPERATION_DURATION_LOG_THRESHOLD) {
             MTR_LOG_ERROR("MTRDeviceControllerDataStore _clearResumptionInfoForNodeID took %0.6lf seconds to remove from storage", syncDuration);
         }
-   }
+    }
 }
 
 - (CHIP_ERROR)storeLastLocallyUsedNOC:(MTRCertificateTLVBytes)noc
@@ -316,7 +316,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturnError(controller != nil, CHIP_ERROR_PERSISTED_STORAGE_FAILED); // No way to call delegate without controller.
 
     __block BOOL ok;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         ok = [_storageDelegate controller:controller
                                storeValue:noc
@@ -337,7 +337,7 @@ static bool IsValidCATNumber(id _Nullable value)
     VerifyOrReturnValue(controller != nil, nil); // No way to call delegate without controller.
 
     __block id data;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             data = [_storageDelegate controller:controller
@@ -373,7 +373,7 @@ static bool IsValidCATNumber(id _Nullable value)
     }
 
     __block id resumptionInfo;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         @autoreleasepool {
             resumptionInfo = [_storageDelegate controller:controller
@@ -904,7 +904,7 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
     }
 
     __block NSMutableDictionary<MTRClusterPath *, MTRDeviceClusterData *> * clusterDataToReturn = nil;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         std::lock_guard lock(self->_nodeArrayLock);
 
@@ -977,7 +977,7 @@ static NSString * sAttributeCacheClusterDataKeyPrefix = @"attrCacheClusterData";
     // when the consumer knows that we're supposed to have data for this cluster
     // path.
     __block MTRDeviceClusterData * clusterDataToReturn = nil;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         clusterDataToReturn = [self _fetchClusterDataForNodeID:nodeID endpointID:endpointID clusterID:clusterID];
     });
@@ -1221,7 +1221,7 @@ static NSString * sDeviceDataKeyPrefix = @"deviceData";
 - (nullable NSDictionary<NSString *, id> *)getStoredDeviceDataForNodeID:(NSNumber *)nodeID
 {
     __block NSDictionary<NSString *, id> * deviceData = nil;
-    NSDate *startTime = [NSDate now];
+    NSDate * startTime = [NSDate now];
     dispatch_sync(_storageDelegateQueue, ^{
         MTRDeviceController * controller = self->_controller;
         VerifyOrReturn(controller != nil); // No way to call delegate without controller.


### PR DESCRIPTION
This PR adds logging for when storage operation takes over a threshold number of seconds.

### Testing
Tested by manually slow down storage operations and see that the logs did appear.