### PR TITLE
Log attempts to commission a device in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -45,6 +45,18 @@ NS_ASSUME_NONNULL_BEGIN
     self.failSafeTimeout = failSafeExpiryTimeoutSecs;
 }
 
+- (NSString *)description
+{
+    // SSID is not required to be UTF-8, but almost always is.
+    NSString * ssidString;
+    if (self.wifiSSID) {
+        ssidString = [[NSString alloc] initWithData:self.wifiSSID encoding:NSUTF8StringEncoding];
+    } else {
+        ssidString = nil;
+    }
+    return [NSString stringWithFormat:@"<MTRCommissioningParameters: %p ssid: %@>", self, ssidString];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -950,6 +950,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
          commissioningParams:(MTRCommissioningParameters *)commissioningParams
                        error:(NSError * __autoreleasing *)error
 {
+    MTR_LOG("%@ trying to commission node with ID 0x%016llX parameters %@", self, nodeID.unsignedLongLongValue, commissioningParams);
+
     if (self.suspended) {
         MTR_LOG_ERROR("%@ suspended: can't commission device ID 0x%016llX with parameters %@", self, nodeID.unsignedLongLongValue, commissioningParams);
         // TODO: Can we do a better error here?


### PR DESCRIPTION
Also logs the SSID when doing commmissioning onto a Wi-Fi network.

#### Testing

Just adds logging.