### PR TITLE
Reset backoff on successful subscription in MTRDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -139,8 +139,6 @@ private:
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override;
 
-    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId) override;
-
     CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
     void OnUnsolicitedMessageFromPublisher(chip::app::ReadClient * apReadClient) override;
@@ -152,6 +150,8 @@ protected:
     NSMutableArray * _Nullable mEventReports = nil;
 
     void CallResubscriptionScheduledHandler(NSError * error, NSNumber * resubscriptionDelay);
+
+    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId) override;
 
 private:
     DataReportCallback _Nullable mAttributeReportCallback = nil;

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -118,6 +118,8 @@ public:
     void ResetResubscriptionBackoff() { mResubscriptionNumRetries = 0; }
 
 private:
+    void OnSubscriptionEstablished(chip::SubscriptionId aSubscriptionId) override;
+
     void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) override;
 
     void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) override;
@@ -4770,6 +4772,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
 #pragma mark - SubscriptionCallback
 namespace {
+void SubscriptionCallback::OnSubscriptionEstablished(SubscriptionId aSubscriptionId)
+{
+    // The next time we need to do a resubscribe, we should start a new backoff
+    // sequence.
+    ResetResubscriptionBackoff();
+    MTRBaseSubscriptionCallback::OnSubscriptionEstablished(aSubscriptionId);
+}
+
 void SubscriptionCallback::OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus)
 {
     if (mEventReports == nil) {


### PR DESCRIPTION
ReadClient does this, but we are not using its backoff logic.

#### Testing

Manual testing for now.