### PR TITLE
[Darwin] Support MTRCommandWithRequiredResponse being nested in XPC

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
+++ b/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
@@ -66,7 +66,7 @@ static NSString * const sExpectedResultKey = @"requiredResponseKey";
         return nil;
     }
 
-    _commandFields = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class]]] forKey:sFieldsKey];
+    _commandFields = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[ [NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class] ]] forKey:sFieldsKey];
     if (_commandFields) {
         if (![_commandFields isKindOfClass:NSDictionary.class]) {
             MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for commandFields, not NSDictionary.", _commandFields);
@@ -79,7 +79,7 @@ static NSString * const sExpectedResultKey = @"requiredResponseKey";
         }
     }
 
-    _requiredResponse = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class]]] forKey:sExpectedResultKey];
+    _requiredResponse = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[ [NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class] ]] forKey:sExpectedResultKey];
     if (_requiredResponse) {
         if (![_requiredResponse isKindOfClass:NSDictionary.class]) {
             MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for requiredResponse, not NSDictionary.", _requiredResponse);

--- a/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
+++ b/src/darwin/Framework/CHIP/MTRCommandWithRequiredResponse.mm
@@ -66,7 +66,7 @@ static NSString * const sExpectedResultKey = @"requiredResponseKey";
         return nil;
     }
 
-    _commandFields = [decoder decodeObjectOfClass:NSDictionary.class forKey:sFieldsKey];
+    _commandFields = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class]]] forKey:sFieldsKey];
     if (_commandFields) {
         if (![_commandFields isKindOfClass:NSDictionary.class]) {
             MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for commandFields, not NSDictionary.", _commandFields);
@@ -79,7 +79,7 @@ static NSString * const sExpectedResultKey = @"requiredResponseKey";
         }
     }
 
-    _requiredResponse = [decoder decodeObjectOfClass:NSDictionary.class forKey:sExpectedResultKey];
+    _requiredResponse = [decoder decodeObjectOfClasses:[NSSet setWithArray:@[[NSDictionary class], [NSString class], [NSNumber class], [NSArray class], [NSData class]]] forKey:sExpectedResultKey];
     if (_requiredResponse) {
         if (![_requiredResponse isKindOfClass:NSDictionary.class]) {
             MTR_LOG_ERROR("MTRCommandWithRequiredResponse decoded %@ for requiredResponse, not NSDictionary.", _requiredResponse);


### PR DESCRIPTION
When secure decoding MTRCommandWithRequiredResponse as part of [MTRDevice deviceController:nodeID:invokeCommands:completion:], it needs to list all classes that be part of the commandFields and requiredResponse fields. When double nested XPC will only assume to decode NSDictionary of basic type.

### Testing
Tested locally