### PR TITLE
Remove ICD server sources from chip_data_model.cmake

### DIFF
--- a/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
@@ -62,7 +62,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
@@ -57,7 +57,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
@@ -56,7 +56,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -98,7 +98,7 @@
 #include <app/clusters/device-energy-management-server/DeviceEnergyManagementTestEventTriggerHandler.h>
 #endif
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-#include <app/icd/server/ICDManager.h>
+#include <app/icd/server/ICDManager.h> // nogncheck
 #endif
 #include <app/TestEventTriggerDelegate.h>
 

--- a/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
@@ -58,7 +58,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
@@ -53,7 +53,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/tv-casting-app/darwin/args.gni
+++ b/examples/tv-casting-app/darwin/args.gni
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/config/darwin/args.gni")
 
 chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
 
 chip_project_config_include_dirs = [
   "${chip_root}/examples/tv-casting-app/tv-casting-common/include",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -228,7 +228,6 @@ static_library("interaction-model") {
     "${chip_root}/src/app/MessageDef",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/icd/server:icd-server-config",
-    "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:observer",
     "${chip_root}/src/app/util:af-types",
     "${chip_root}/src/app/util:callbacks",
@@ -239,6 +238,10 @@ static_library("interaction-model") {
     "${chip_root}/src/protocols/secure_channel",
     "${chip_root}/src/system",
   ]
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd/server:manager" ]
+  }
 
   public_configs = [ "${chip_root}/src:includes" ]
 
@@ -485,6 +488,7 @@ static_library("app") {
     ":global-attributes",
     ":interaction-model",
     ":path-expansion",
+    ":test-event-trigger",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/icd/server:icd-server-config",

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -119,19 +119,6 @@ function(chip_configure_data_model APP_TARGET)
         set(APP_GEN_FILES)
     endif()
 
-    # These are:
-    #   //src/app/icd/server:notfier
-    #   //src/app/icd/server:monitoring-table
-    #   //src/app/icd/server:configuration-data
-    #
-    # TODO: ideally we would avoid duplication and would link gn-built items. In this case
-    #       it may be slightly harder because these are source_sets rather than libraries.
-    target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDMonitoringTable.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
-    )
-
     # This is:
     #    //src/app/common:cluster-objects
     #

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/chip_codegen.gni")
 import("${chip_root}/src/app/common_flags.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/data-model-providers/codegen/model.gni")
 import("${chip_root}/src/platform/python.gni")
 
@@ -340,9 +341,13 @@ template("chip_data_model") {
         deps += [
           "${chip_root}/src/app/icd/server:configuration-data",
           "${chip_root}/src/app/icd/server:icd-server-config",
-          "${chip_root}/src/app/icd/server:monitoring-table",
-          "${chip_root}/src/app/icd/server:notifier",
         ]
+        if (chip_enable_icd_server) {
+          deps += [ "${chip_root}/src/app/icd/server:notifier" ]
+          if (chip_enable_icd_checkin) {
+            deps += [ "${chip_root}/src/app/icd/server:monitoring-table" ]
+          }
+        }
       } else if (cluster == "resource-monitoring-server") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -25,7 +25,9 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
-#include <app/icd/server/ICDNotifier.h>
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+#include <app/icd/server/ICDNotifier.h> // nogncheck
+#endif
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 

--- a/src/app/clusters/icd-management-server/icd-management-server.h
+++ b/src/app/clusters/icd-management-server/icd-management-server.h
@@ -30,7 +30,7 @@
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
 #include <app/ConcreteAttributePath.h>
-#include <app/icd/server/ICDMonitoringTable.h>
+#include <app/icd/server/ICDMonitoringTable.h> // nogncheck
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -91,12 +91,8 @@ static_library("server") {
   #       be updated if this is not really "testing" even though headers are Test*.h)
   public_deps += [ "${chip_root}/src/lib/support:testing" ]
 
-  if (chip_enable_icd_server) {
-    public_deps += [ "${chip_root}/src/app/icd/server:notifier" ]
-
-    if (chip_enable_icd_checkin) {
-      public_deps +=
-          [ "${chip_root}/src/app/icd/server:default-check-in-back-off" ]
-    }
+  if (chip_enable_icd_checkin) {
+    public_deps +=
+        [ "${chip_root}/src/app/icd/server:default-check-in-back-off" ]
   }
 }


### PR DESCRIPTION
#### Changes
* Remove ICD server sources from `chip_data_model.cmake`. They are built by `gn`, there is no need to compile them twice.
* Don't depend on ICD sources if it's not enabled.

#### Testing
Tested by building samples from nRF Connected SDK.
