### PR TITLE
Add Thermostat Controller Device Type

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2805,4 +2805,28 @@ limitations under the License.
             </include>
         </clusters>
     </deviceType>
+    <deviceType>
+        <name>MA-thermostatcontroller</name>
+        <domain>CHIP</domain>
+        <typeName>Matter Thermostat Controller</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x030A</deviceId>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters lockOthers="true">
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
+                <requireAttribute>SERVER_LIST</requireAttribute>
+                <requireAttribute>CLIENT_LIST</requireAttribute>
+                <requireAttribute>PARTS_LIST</requireAttribute>
+            </include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>BINDING</requireAttribute>
+            </include>
+            <include cluster="Thermostat" client="true" server="false" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="Scenes Management" client="true" server="false" clientLocked="false" serverLocked="true"></include>
+        </clusters>
+    </deviceType>
 </configurator>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2814,15 +2814,8 @@ limitations under the License.
         <class>Simple</class>
         <scope>Endpoint</scope>
         <clusters lockOthers="true">
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
-                <requireAttribute>SERVER_LIST</requireAttribute>
-                <requireAttribute>CLIENT_LIST</requireAttribute>
-                <requireAttribute>PARTS_LIST</requireAttribute>
-            </include>
-            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>BINDING</requireAttribute>
-            </include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Binding" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Thermostat" client="true" server="false" clientLocked="true" serverLocked="true"></include>
             <include cluster="Identify" client="true" server="false" clientLocked="false" serverLocked="true"></include>
             <include cluster="Groups" client="true" server="false" clientLocked="false" serverLocked="true"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2808,7 +2808,7 @@ limitations under the License.
     <deviceType>
         <name>MA-thermostatcontroller</name>
         <domain>CHIP</domain>
-        <typeName>Matter Thermostat Controller</typeName>
+        <typeName>Thermostat Controller</typeName>
         <profileId editable="false">0x0103</profileId>
         <deviceId editable="false">0x030A</deviceId>
         <class>Simple</class>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7687,6 +7687,7 @@ typedef NS_ENUM(uint32_t, MTRDeviceTypeIDType) {
     MTRDeviceTypeIDTypeFlowSensorID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000306,
     MTRDeviceTypeIDTypeHumiditySensorID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000307,
     MTRDeviceTypeIDTypeHeatPumpID MTR_PROVISIONALLY_AVAILABLE = 0x00000309,
+    MTRDeviceTypeIDTypeThermostatControllerID MTR_PROVISIONALLY_AVAILABLE = 0x0000030A,
     MTRDeviceTypeIDTypeEVSEID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000050C,
     MTRDeviceTypeIDTypeDeviceEnergyManagementID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000050D,
     MTRDeviceTypeIDTypeWaterHeaterID MTR_PROVISIONALLY_AVAILABLE = 0x0000050F,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -88,6 +88,7 @@ static /* constexpr */ const MTRDeviceTypeData knownDeviceTypes[] = {
     { 0x00000306, MTRDeviceTypeClass::Simple, @"Flow Sensor" },
     { 0x00000307, MTRDeviceTypeClass::Simple, @"Humidity Sensor" },
     { 0x00000309, MTRDeviceTypeClass::Simple, @"Heat Pump" },
+    { 0x0000030A, MTRDeviceTypeClass::Simple, @"Thermostat Controller" },
     { 0x0000050C, MTRDeviceTypeClass::Simple, @"EVSE" },
     { 0x0000050D, MTRDeviceTypeClass::Utility, @"Device Energy Management" },
     { 0x0000050F, MTRDeviceTypeClass::Simple, @"Water Heater" },

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6663,6 +6663,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Humidity Sensor";
     case 0x00000309:
         return "Heat Pump";
+    case 0x0000030A:
+        return "Thermostat Controller";
     case 0x0000050C:
         return "EVSE";
     case 0x0000050D:


### PR DESCRIPTION
This PR adds Thermostat Controller device type to matter-devices.xml
https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10417

#### Testing
Opened the zap tool and confirmed the new device type shows up.
