### PR TITLE
[bouffalo lab] open commission window when last fabric is removed

### DIFF
--- a/examples/platform/bouffalolab/common/plat/platform.cpp
+++ b/examples/platform/bouffalolab/common/plat/platform.cpp
@@ -178,6 +178,35 @@ void UnlockOpenThreadTask(void)
 }
 #endif
 
+class AppFabricTableDelegate : public FabricTable::Delegate
+{
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex)
+    {
+        if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            ChipLogProgress(DeviceLayer, "Performing erasing of settings partition");
+            PlatformMgr().ScheduleWork([](intptr_t) {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+                ConfigurationManagerImpl::GetDefaultInstance().ClearThreadStack();
+                ThreadStackMgrImpl().FactoryResetThreadStack();
+                ThreadStackMgr().InitThreadStack();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+                ChipLogProgress(DeviceLayer, "Clearing WiFi provision");
+                chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
+
+                CHIP_ERROR err = Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
+                if (err != CHIP_NO_ERROR)
+                {
+                    ChipLogError(AppServer, "Failed to open the Basic Commissioning Window");
+                }
+            });
+        }
+    }
+};
+
 CHIP_ERROR PlatformManagerImpl::PlatformInit(void)
 {
     chip::RendezvousInformationFlags rendezvousMode(chip::RendezvousInformationFlag::kOnNetwork);
@@ -265,6 +294,9 @@ CHIP_ERROR PlatformManagerImpl::PlatformInit(void)
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
 
+    static AppFabricTableDelegate sAppFabricDelegate;
+    chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
+        
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/examples/platform/bouffalolab/common/plat/platform.cpp
+++ b/examples/platform/bouffalolab/common/plat/platform.cpp
@@ -296,7 +296,7 @@ CHIP_ERROR PlatformManagerImpl::PlatformInit(void)
 
     static AppFabricTableDelegate sAppFabricDelegate;
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
-        
+
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/bouffalolab/BL616/ThreadStackManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL616/ThreadStackManagerImpl.cpp
@@ -63,6 +63,12 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
+void ThreadStackManagerImpl::FactoryResetThreadStack(void)
+{
+    VerifyOrReturn(ThreadStackMgrImpl().OTInstance() != NULL);
+    otInstanceFactoryReset(ThreadStackMgrImpl().OTInstance());
+}
+
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/platform/bouffalolab/BL702/ThreadStackManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL702/ThreadStackManagerImpl.cpp
@@ -65,6 +65,12 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
+void ThreadStackManagerImpl::FactoryResetThreadStack(void)
+{
+    VerifyOrReturn(ThreadStackMgrImpl().OTInstance() != NULL);
+    otInstanceFactoryReset(ThreadStackMgrImpl().OTInstance());
+}
+
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/platform/bouffalolab/BL702L/ThreadStackManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL702L/ThreadStackManagerImpl.cpp
@@ -65,6 +65,12 @@ bool ThreadStackManagerImpl::IsInitialized()
     return sInstance.mThreadStackLock != NULL;
 }
 
+void ThreadStackManagerImpl::FactoryResetThreadStack(void)
+{
+    VerifyOrReturn(ThreadStackMgrImpl().OTInstance() != NULL);
+    otInstanceFactoryReset(ThreadStackMgrImpl().OTInstance());
+}
+
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
+++ b/src/platform/bouffalolab/common/BLConfig_littlefs.cpp
@@ -278,7 +278,7 @@ CHIP_ERROR BLConfig::WriteConfigValue(const char * key, uint8_t * val, size_t si
 
     blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
 
-    ret = lfs_file_open(blconfig_lfs, &file, write_key, LFS_O_CREAT | LFS_O_RDWR);
+    ret = lfs_file_open(blconfig_lfs, &file, write_key, LFS_O_CREAT | LFS_O_RDWR | LFS_O_TRUNC);
     VerifyOrExit(ret == LFS_ERR_OK, err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
     lfs_file_write(blconfig_lfs, &file, val, size);
@@ -353,7 +353,7 @@ CHIP_ERROR BLConfig::FactoryResetConfig(void)
 
     blconfig_lfs->cfg->lock(blconfig_lfs->cfg);
 
-    ret = lfs_file_open(blconfig_lfs, &file, reset_key, LFS_O_CREAT | LFS_O_RDWR);
+    ret = lfs_file_open(blconfig_lfs, &file, reset_key, LFS_O_CREAT | LFS_O_RDWR | LFS_O_TRUNC);
     if (ret != LFS_ERR_OK)
     {
         blconfig_lfs->cfg->unlock(blconfig_lfs->cfg);

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
@@ -190,6 +190,17 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
     BLConfig::RunConfigUnitTest();
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+void ConfigurationManagerImpl::ClearThreadStack()
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    ChipLogProgress(DeviceLayer, "Clearing Thread provision");
+    ThreadStackMgr().ErasePersistentInfo();
+}
+#endif
+
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     CHIP_ERROR err;

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
@@ -38,6 +38,10 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
     bool IsFullyProvisioned();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    void ClearThreadStack();
+#endif
+
 private:
     // ===== Members that implement the ConfigurationManager private interface.
 

--- a/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
+++ b/src/platform/bouffalolab/common/ThreadStackManagerImpl.h
@@ -65,6 +65,7 @@ public:
 
     using ThreadStackManager::InitThreadStack;
     CHIP_ERROR InitThreadStack(otInstance * otInst);
+    void FactoryResetThreadStack(void);
 
 private:
     // ===== Methods that implement the ThreadStackManager abstract interface.


### PR DESCRIPTION
- add handle to open commission window when last fabric is removed

#### Testing
- targets
  - bouffalolab-bl602dk-light-wifi-littlefs
  - bouffalolab-bl616dk-light-wifi-littlefs

- tested with chip-tool on pairing, unpairing and pairing
  ```shell
     chip-tool pairing ble-wifi 2 <ssid>  <password>20202021 3840
     chip-tool pairing unpair 2     
     chip-tool pairing ble-wifi 2 <ssid>  <password>20202021 3840
  ```
- tested with chip-tool on pairing, unpairing, reboot then pairing
  ```shell
     chip-tool pairing ble-wifi 2 <ssid>  <password>20202021 3840
     chip-tool pairing unpair 2 
  ```
  Manually reboot the device, then commission it again.
  ``` shell
     chip-tool pairing ble-wifi 2 <ssid>  <password>20202021 3840
  ```