### PR TITLE
Make DataModel::Provider return a `Complete attribute metadata` as its public interface

### DIFF
--- a/src/app/GlobalAttributes.cpp
+++ b/src/app/GlobalAttributes.cpp
@@ -97,14 +97,6 @@ DataModel::ActionReturnStatus ReadGlobalAttributeFromMetadata(DataModel::Provide
                 //       and this reduces template variants for Encode, saving flash.
                 ReturnErrorOnFailure(listEncodeHelper.Encode(static_cast<uint64_t>(entry.attributeId)));
             }
-
-            for (auto id : GlobalAttributesNotInMetadata)
-            {
-                // NOTE: cast to u64 because TLV encodes all numbers the same (no TLV sideffects)
-                //       and this reduces template variants for Encode, saving flash.
-                ReturnErrorOnFailure(listEncodeHelper.Encode(static_cast<uint64_t>(id)));
-            }
-
             return CHIP_NO_ERROR;
         });
     }

--- a/src/app/data-model-provider/ProviderMetadataTree.h
+++ b/src/app/data-model-provider/ProviderMetadataTree.h
@@ -61,7 +61,7 @@ public:
     virtual CHIP_ERROR ServerClusters(EndpointId endpointId, ListBuilder<ServerClusterEntry> & builder) = 0;
 
     /// Attribute lists contain all attributes. This MUST include all global
-    /// attributes (See SPEC 7.13 Global Elements / Global Attributes Table). 
+    /// attributes (See SPEC 7.13 Global Elements / Global Attributes Table).
     /// In particular this MUST contain:
     ///    - AcceptedCommandList::Id
     ///    - AttributeList::Id

--- a/src/app/data-model-provider/ProviderMetadataTree.h
+++ b/src/app/data-model-provider/ProviderMetadataTree.h
@@ -60,14 +60,14 @@ public:
     virtual CHIP_ERROR ClientClusters(EndpointId endpointId, ListBuilder<ClusterId> & builder)          = 0;
     virtual CHIP_ERROR ServerClusters(EndpointId endpointId, ListBuilder<ServerClusterEntry> & builder) = 0;
 
-    /// Attribute lists contain all attributes EXCEPT the list attributes that
-    /// are part of metadata. The output from this method MUST NOT contain:
-    ///    - AttributeList::Id
+    /// Attribute lists contain all attributes. This MUST include all global
+    /// attributes (See SPEC 7.13 Global Elements / Global Attributes Table). 
+    /// In particular this MUST contain:
     ///    - AcceptedCommandList::Id
-    ///    - GeneratedCommandList::Id
-    /// However it MUST ALWAYS contain:
+    ///    - AttributeList::Id
     ///    - ClusterRevision::Id
     ///    - FeatureMap::Id
+    ///    - GeneratedCommandList::Id
     virtual CHIP_ERROR Attributes(const ConcreteClusterPath & path, ListBuilder<AttributeEntry> & builder)             = 0;
     virtual CHIP_ERROR GeneratedCommands(const ConcreteClusterPath & path, ListBuilder<CommandId> & builder)           = 0;
     virtual CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path, ListBuilder<AcceptedCommandEntry> & builder) = 0;

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -14,10 +14,10 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include "access/Privilege.h"
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 #include <access/AccessControl.h>
+#include <access/Privilege.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/CommandHandlerInterfaceRegistry.h>

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -275,7 +275,7 @@ CHIP_ERROR CodegenDataModelProvider::Attributes(const ConcreteClusterPath & path
     // We have Attributes from ember + global attributes that are NOT in ember metadata.
     // We have to report them all
     constexpr size_t kGlobalAttributeNotInMetadataCount =
-        sizeof(GlobalAttributesNotInMetadata) / sizeof(GlobalAttributesNotInMetadata[0]);
+        ArraySize(GlobalAttributesNotInMetadata);
 
     ReturnErrorOnFailure(builder.EnsureAppendCapacity(cluster->attributeCount + kGlobalAttributeNotInMetadataCount));
 

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -285,11 +285,18 @@ CHIP_ERROR CodegenDataModelProvider::Attributes(const ConcreteClusterPath & path
         ReturnErrorOnFailure(builder.Append(AttributeEntryFrom(path, attribute)));
     }
 
+
+    // This "GlobalListEntry" is specific for metadata that ember does not include
+    // in its attribute list metadata.
+    //
+    // By spec these Attribute/AcceptedCommands/GeneratedCommants lists are:
+    //   - lists of elements
+    //   - read-only, with read privilege view
+    //   - fixed value (no such flag exists, so this is not a quality flag we set/track)
     DataModel::AttributeEntry globalListEntry;
 
     globalListEntry.readPrivilege = Access::Privilege::kView;
     globalListEntry.flags.Set(DataModel::AttributeQualityFlags::kListAttribute);
-    // these entries should also be `Fixed` however no such flag is propagated (we do not track)
 
     for (auto & attribute : GlobalAttributesNotInMetadata)
     {

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -285,7 +285,6 @@ CHIP_ERROR CodegenDataModelProvider::Attributes(const ConcreteClusterPath & path
         ReturnErrorOnFailure(builder.Append(AttributeEntryFrom(path, attribute)));
     }
 
-
     // This "GlobalListEntry" is specific for metadata that ember does not include
     // in its attribute list metadata.
     //

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -274,8 +274,7 @@ CHIP_ERROR CodegenDataModelProvider::Attributes(const ConcreteClusterPath & path
     //
     // We have Attributes from ember + global attributes that are NOT in ember metadata.
     // We have to report them all
-    constexpr size_t kGlobalAttributeNotInMetadataCount =
-        ArraySize(GlobalAttributesNotInMetadata);
+    constexpr size_t kGlobalAttributeNotInMetadataCount = ArraySize(GlobalAttributesNotInMetadata);
 
     ReturnErrorOnFailure(builder.EnsureAppendCapacity(cluster->attributeCount + kGlobalAttributeNotInMetadataCount));
 

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -1153,7 +1153,8 @@ TEST_F(TestCodegenModelViaMocks, GlobalAttributeInfo)
     info = finder.Find(ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id));
     ASSERT_TRUE(info.has_value());
 
-    info = finder.Find(ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id));
+    info = finder.Find(
+        ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id));
     ASSERT_TRUE(info.has_value());
 }
 

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -1073,7 +1073,7 @@ TEST_F(TestCodegenModelViaMocks, IterateOverAttributes)
 
     EXPECT_EQ(model.Attributes(ConcreteClusterPath(kMockEndpoint2, MockClusterId(2)), builder), CHIP_NO_ERROR);
     auto attributes = builder.TakeBuffer();
-    ASSERT_EQ(attributes.size(), 4u);
+    ASSERT_EQ(attributes.size(), 7u);
 
     ASSERT_EQ(attributes[0].attributeId, ClusterRevision::Id);
     ASSERT_FALSE(attributes[0].flags.Has(AttributeQualityFlags::kListAttribute));
@@ -1086,6 +1086,16 @@ TEST_F(TestCodegenModelViaMocks, IterateOverAttributes)
 
     ASSERT_EQ(attributes[3].attributeId, MockAttributeId(2));
     ASSERT_TRUE(attributes[3].flags.Has(AttributeQualityFlags::kListAttribute));
+
+    // Ends with global list attributes
+    ASSERT_EQ(attributes[4].attributeId, GeneratedCommandList::Id);
+    ASSERT_TRUE(attributes[4].flags.Has(AttributeQualityFlags::kListAttribute));
+
+    ASSERT_EQ(attributes[5].attributeId, AcceptedCommandList::Id);
+    ASSERT_TRUE(attributes[5].flags.Has(AttributeQualityFlags::kListAttribute));
+
+    ASSERT_EQ(attributes[6].attributeId, AttributeList::Id);
+    ASSERT_TRUE(attributes[6].flags.Has(AttributeQualityFlags::kListAttribute));
 }
 
 TEST_F(TestCodegenModelViaMocks, FindAttribute)
@@ -1127,7 +1137,7 @@ TEST_F(TestCodegenModelViaMocks, FindAttribute)
     EXPECT_FALSE(info->writePrivilege.has_value());                       // NOLINT(bugprone-unchecked-optional-access)
 }
 
-// global attributes are EXPLICITLY not supported
+// global attributes are EXPLICITLY supported
 TEST_F(TestCodegenModelViaMocks, GlobalAttributeInfo)
 {
     UseMockNodeConfig config(gTestNodeConfig);
@@ -1138,10 +1148,13 @@ TEST_F(TestCodegenModelViaMocks, GlobalAttributeInfo)
     std::optional<AttributeEntry> info = finder.Find(
         ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::GeneratedCommandList::Id));
 
-    ASSERT_FALSE(info.has_value());
+    ASSERT_TRUE(info.has_value());
 
     info = finder.Find(ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AttributeList::Id));
-    ASSERT_FALSE(info.has_value());
+    ASSERT_TRUE(info.has_value());
+
+    info = finder.Find(ConcreteAttributePath(kMockEndpoint1, MockClusterId(1), Clusters::Globals::Attributes::AcceptedCommandList::Id));
+    ASSERT_TRUE(info.has_value());
 }
 
 TEST_F(TestCodegenModelViaMocks, IterateOverAcceptedCommands)


### PR DESCRIPTION
Having a split of "list attributes not reported" is an ember implementation detail. If we allow full list return, we could use optimizations for having the entire list in flash and not consume RAM to build the list.

Previous API guidance of `MUST include these 2 global attributes and MUST NOT include these 3 global attributes` seemed leaky in terms of implementation details. Requiring all allows us better paths to choose optimizations (pure flash const list, vs in-ram building).

Moved the "add global list attributes" logic to the codegen implementation rather than it being part of global attribute handling.

#### Testing

Unit tests updated and pass.
