### PR TITLE
V1.4 Cherry-pick #37522: TC_CGEN_2_8, TC_CGEN_2_9

### DIFF
--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -119,6 +119,9 @@ class TC_CGEN_2_8(MatterBaseTest):
             "First CommissioningComplete failed",
         )
 
+        # Close the commissioner session with the device to clean up resources
+        commissioner.CloseSession(nodeid=self.dut_node_id)
+
         # Step 5: Factory reset is handled by test operator
         self.step(5)
         if not self.check_pics('PICS_USER_PROMPT'):

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -147,6 +147,9 @@ class TC_CGEN_2_9(MatterBaseTest):
         self.step(5)
         await self.remove_commissioner_fabric()
 
+        # Close the commissioner session with the device to clean up resources
+        commissioner.CloseSession(nodeid=self.dut_node_id)
+
         # Step 6: Put device in commissioning mode (requiring user input, so skip in CI)
         self.step(6)
         if not self.check_pics('PICS_USER_PROMPT'):


### PR DESCRIPTION
Fixes #37490 
Cherry-picks #37522

Add explicit CloseSession calls in TC_CGEN_2_8 and TC_CGEN_2_9 to ensure proper cleanup of commissioner library resources. This fixes an issue where subsequent commissioner sessions could not be established due to lingering resources from previous test runs.

Bug: Commissioner session establishment failures in subsequent test runs
Fix: Add explicit session cleanup after commissioning operations

Testing:
- Set PICS_USER_PROMPT=1 for manual intervention testing
- Verified with terms-and-conditions-app test harness
- Confirmed proper cleanup by:
  1. Running initial commissioning
  2. Performing factory reset (process kill + KVS cleanup)
  3. Successfully re-establishing commissioner session
- Test passes with manual intervention at factory reset and commissioning prompts


#### Testing Details

##### Environment Setup

- Set `PICS_USER_PROMPT=1` to enable interactive command-line prompts during test execution
- This configuration prevents automatic step skipping and allows manual intervention

##### Test Execution Steps

1. Initial DUT Launch:

   ```bash
   rm /tmp/chip* 
   ./out/linux-x64-terms-and-conditions/chip-terms-and-conditions-app \
       --version 0 \
       --custom-flow 2 \
       --capabilities 6 \
       --discriminator 3840 \
       --passcode 20202021 \
       --KVS /tmp/chip_kvs.bin \
       --trace_file /tmp/chip_trace.log \
       --trace_log 1 \
       --trace_decode 1 \
       --vendor-id 0xfff1 \
       --product-id 0x8012

2. Test Script Execution

    ```bash
    python3 src/python_testing/TC_CGEN_2_8.py \
        --storage-path admin_storage.json \
        --int-arg PIXIT.CGEN.FailsafeExpiryLengthSeconds:900 \
        PIXIT.CGEN.RequiredTCAcknowledgements:1 \
        PIXIT.CGEN.TCRevision:1 \
        --qr-code MT:-24J08M.00KA0648G00 \
        --PICS src/app/tests/suites/certification/ci-pics-values \
        --in-test-commissioning-method on-network
    ```

3. Factory Reset Simulation:

   - Terminated the test app process
   - Removed KVS binary and chip-related temporary files
   - Restarted the test app with identical parameters
   - Acknowledged the factory reset prompt
   - Confirmed DUT entering commissioning mode

##### Results

- Test completed successfully with PASS status
- Manual intervention points were properly handled
- Device state was successfully reset and recovered
