### PR TITLE
fix: Update test_dcl_server.py for Python 3.x compatibility

### DIFF
--- a/examples/chip-tool/commands/dcl/test_dcl_server.py
+++ b/examples/chip-tool/commands/dcl/test_dcl_server.py
@@ -214,12 +214,14 @@ def run_https_server(cert_file="cert.pem", key_file="key.pem"):
     httpd = http.server.HTTPServer(
         (DEFAULT_HOSTNAME, DEFAULT_PORT), RESTRequestHandler)
 
-    httpd.socket = ssl.wrap_socket(
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile="server.crt", keyfile="server.key")
+    httpd.socket = context.wrap_socket(
         httpd.socket,
         server_side=True,
-        certfile=cert_file,
-        keyfile=key_file,
-        ssl_version=ssl.PROTOCOL_TLS,
+        # certfile=cert_file,
+        # keyfile=key_file,
+        # ssl_version=ssl.PROTOCOL_TLS,
     )
 
     print(f"Serving on https://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}")


### PR DESCRIPTION
Update the DCL server script to support newer Python versions for
TC-CGEN-2.12 manual test case execution. The script provides terms
and conditions functionality required for testing the DCL flow.

Testing:

1. Start the DCL server in terminal 1:

   ```bash
   python3 ./examples/chip-tool/commands/dcl/test_dcl_server.py
   ```

2. Launch terms and conditions app in terminal 2:

   ```bash
   rm /tmp/chip* ; ./out/linux-x64-terms-and-conditions/chip-terms-and-conditions-app \
   --version 0 --custom-flow 2 --capabilities 6 --discriminator 3840 \
   --passcode 20202021 --KVS /tmp/chip_kvs.bin --trace_file /tmp/chip_trace.log \
   --trace_log 1 --trace_decode 1
   ```

3. Execute pairing command in terminal 3:

   ```bash
   yes | ./out/linux-x64-chip-tool/chip-tool pairing code 0x12344321 \
   MT:-24J029Q00KA0648G00 --use-dcl true --dcl-hostname localhost --dcl-port 4443
   ```
