### PR TITLE
For thread devices throttle the response to BlockQuery by an interval…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -224,9 +224,9 @@ NS_ASSUME_NONNULL_BEGIN
                        completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 /**
- * Returns YES if the MTRDevice corrresponding to the given node ID is a thread device, NO otherwise.
+ * Returns YES if the MTRDevice corrresponding to the given node ID is known to be a thread device, NO otherwise.
  */
-- (BOOL)usesThreadForDevice:(chip::NodeId)nodeID;
+- (BOOL)definitelyUsesThreadForDevice:(chip::NodeId)nodeID;
 
 /**
  * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -224,6 +224,11 @@ NS_ASSUME_NONNULL_BEGIN
                        completion:(void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
 
 /**
+ * Returns YES if the MTRDevice corrresponding to the given node ID is a thread device, NO otherwise.
+ */
+- (BOOL)usesThreadForDevice:(chip::NodeId)nodeID;
+
+/**
  * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.
  */
 @property (readonly) chip::FabricIndex fabricIndex;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1429,9 +1429,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return NO;
 }
 
-- (BOOL)usesThreadForDevice:(chip::NodeId)nodeID
+- (BOOL)definitelyUsesThreadForDevice:(chip::NodeId)nodeID
 {
-    if (nodeID == chip::kUndefinedNodeId) {
+    if (!chip::IsOperationalNodeId(nodeID)) {
         return NO;
     }
 
@@ -1464,7 +1464,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
     // In the case that this device is known to use thread, queue this with subscription attempts as well, to
     // help with throttling Thread traffic.
-    if ([self usesThreadForDevice:nodeID]) {
+    if ([self definitelyUsesThreadForDevice:nodeID]) {
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull workItemCompletion) {
             MTRInternalDeviceConnectionCallback completionWrapper = ^(chip::Messaging::ExchangeManager * _Nullable exchangeManager,

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1429,6 +1429,29 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return NO;
 }
 
+- (BOOL)usesThreadForDevice:(chip::NodeId)nodeID
+{
+    if (nodeID == chip::kUndefinedNodeId)
+    {
+        return NO;
+    }
+
+    // Get the corresponding MTRDevice object for the node id
+    MTRDevice * device = [self deviceForNodeID:@(nodeID)];
+
+    // TODO: Can we not just assume this isKindOfClass test is true?  Would be
+    // really nice if we had compile-time checking for this somehow...
+    if (![device isKindOfClass:MTRDevice_Concrete.class]) {
+        MTR_LOG_ERROR("%@ somehow has %@ instead of MTRDevice_Concrete for node ID 0x%016llX (%llu)", self, device, nodeID, nodeID);
+        return NO;
+    }
+
+    auto * concreteDevice = static_cast<MTRDevice_Concrete *>(device);
+
+    BOOL usesThread = [concreteDevice deviceUsesThread];
+    return usesThread;
+}
+
 - (void)getSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion
 {
     // TODO: Figure out whether the synchronization here makes sense.  What
@@ -1440,22 +1463,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         return;
     }
 
-    // Get the corresponding MTRDevice object to determine if the case/subscription pool is to be used
-    MTRDevice * device = [self deviceForNodeID:@(nodeID)];
-
-    // TODO: Can we not just assume this isKindOfClass test is true?  Would be
-    // really nice if we had compile-time checking for this somehow...
-    if (![device isKindOfClass:MTRDevice_Concrete.class]) {
-        MTR_LOG_ERROR("%@ somehow has %@ instead of MTRDevice_Concrete for node ID 0x%016llX (%llu)", self, device, nodeID, nodeID);
-        completion(nullptr, chip::NullOptional, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE], nil);
-        return;
-    }
-
-    auto * concreteDevice = static_cast<MTRDevice_Concrete *>(device);
-
     // In the case that this device is known to use thread, queue this with subscription attempts as well, to
     // help with throttling Thread traffic.
-    if ([concreteDevice deviceUsesThread]) {
+    if ([self usesThreadForDevice:nodeID]) {
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull workItemCompletion) {
             MTRInternalDeviceConnectionCallback completionWrapper = ^(chip::Messaging::ExchangeManager * _Nullable exchangeManager,

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1431,8 +1431,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (BOOL)usesThreadForDevice:(chip::NodeId)nodeID
 {
-    if (nodeID == chip::kUndefinedNodeId)
-    {
+    if (nodeID == chip::kUndefinedNodeId) {
         return NO;
     }
 

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -76,6 +76,8 @@ private:
     bool mNeedToCallTransferSessionEnd = false;
 
     bool mIsPeerNodeAKnownThreadDevice = NO;
+
+    chip::System::Clock::Milliseconds32 mBDXThrottleIntervalForThreadDevicesInMSecs;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -75,7 +75,7 @@ private:
 
     bool mNeedToCallTransferSessionEnd = false;
 
-    bool mIsPeerNodeAThreadDevice = NO;
+    bool mIsPeerNodeAKnownThreadDevice = NO;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -74,6 +74,8 @@ private:
     MTROTAImageTransferHandlerWrapper * mOTAImageTransferHandlerWrapper;
 
     bool mNeedToCallTransferSessionEnd = false;
+
+    bool mIsPeerNodeAThreadDevice = NO;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -33,10 +33,10 @@ constexpr double kMilliSecondsInSecond = 1000.0;
 // Timeout for the BDX transfer session. The OTA Spec mandates this should be >= 5 minutes.
 constexpr System::Clock::Timeout kBdxTimeout = System::Clock::Seconds16(5 * 60);
 
-// For thread devices, we need to throttle sending Blocks in response to BlockQuery messages
-// to avoid spamming the network with too many BDX messages. We are going to match the polling
-// interval of 50 ms as the time to wait before sending a Block in response to a BlockQuery.
-constexpr System::Clock::Timeout kBdxThrottleIntervalInMsecs = System::Clock::Milliseconds32(50);
+// For thread devices, we may want to throttle sending Blocks in response to BlockQuery messages
+// to avoid spamming the network with too many BDX messages.  For now, match the old 50ms
+// polling interval we used to have.
+constexpr auto kBdxThrottleInterval = System::Clock::Milliseconds32(50);
 
 constexpr bdx::TransferRole kBdxRole = bdx::TransferRole::kSender;
 
@@ -245,7 +245,7 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
     // For thread devices, we need to throttle sending the response to BlockQuery, if the query is processed, before kBdxThrottleIntervalInMsecs
     // has elapsed to prevent the BDX messages spamming up the network. Get the timestamp at which we start processing the BlockQuery message.
 
-    __block uint64_t startBlockQueryHandlingTimestamp = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+    auto startBlockQueryHandlingTimestamp = System::SystemClock().GetMonotonicTimestamp()
 
     auto blockSize = @(mTransfer.GetTransferBlockSize());
     auto blockIndex = @(mTransfer.GetNextBlockNum());
@@ -294,12 +294,12 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
 
     if (mIsPeerNodeAThreadDevice) {
         completionHandler = ^(NSData * _Nullable data, BOOL isEOF) {
-            uint64_t timeElapsed = chip::System::SystemClock().GetMonotonicMilliseconds64().count() - startBlockQueryHandlingTimestamp;
-            if (timeElapsed >= kBdxThrottleIntervalInMsecs.count()) {
+            auto timeElapsed = System::SystemClock().GetMonotonicTimestamp - startBlockQueryHandlingTimestamp;
+            if (timeElapsed >= kBdxThrottleIntervalInMsecs) {
                 completionHandler = respondWithBlock;
             } else {
-                double timeRemainingInSecs = (kBdxThrottleIntervalInMsecs.count() - timeElapsed) / kMilliSecondsInSecond;
-                dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t) (timeRemainingInSecs * NSEC_PER_SEC));
+                auto timeRemaining = std::chrono::duration_cast<std::chrono::nanoseconds>(kBdxThrottleIntervalInMsecs - timeElapsed);
+                dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, timeRemaining.count());
                 dispatch_after(time, dispatch_get_main_queue(), ^{
                     respondWithBlock(data, isEOF);
                 });

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -28,8 +28,15 @@ using namespace chip::app;
 
 constexpr uint32_t kMaxBdxBlockSize = 1024;
 
+constexpr double kMilliSecondsInSecond = 1000.0;
+
 // Timeout for the BDX transfer session. The OTA Spec mandates this should be >= 5 minutes.
 constexpr System::Clock::Timeout kBdxTimeout = System::Clock::Seconds16(5 * 60);
+
+// For thread devices, we need to throttle sending Blocks in response to BlockQuery messages
+// to avoid spamming the network with too many BDX messages. We are going to match the polling
+// interval of 50 ms as the time to wait before sending a Block in response to a BlockQuery.
+constexpr System::Clock::Timeout kBdxThrottleIntervalInMsecs = System::Clock::Milliseconds32(50);
 
 constexpr bdx::TransferRole kBdxRole = bdx::TransferRole::kSender;
 
@@ -77,6 +84,8 @@ CHIP_ERROR MTROTAImageTransferHandler::Init(Messaging::ExchangeContext * exchang
     // We should have already checked that this controller supports OTA.
     VerifyOrReturnError(mDelegate != nil, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mDelegateNotificationQueue != nil, CHIP_ERROR_INCORRECT_STATE);
+
+    mIsPeerNodeAThreadDevice = [controller usesThreadForDevice:mPeer.GetNodeId()];
 
     BitFlags<bdx::TransferControlFlags> flags(bdx::TransferControlFlags::kReceiverDrive);
 
@@ -233,6 +242,11 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
 {
     assertChipStackLockedByCurrentThread();
 
+    // For thread devices, we need to throttle sending the response to BlockQuery, if the query is processed, before kBdxThrottleIntervalInMsecs
+    // has elapsed to prevent the BDX messages spamming up the network. Get the timestamp at which we start processing the BlockQuery message.
+
+    __block uint64_t startBlockQueryHandlingTimestamp = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
+
     auto blockSize = @(mTransfer.GetTransferBlockSize());
     auto blockIndex = @(mTransfer.GetNextBlockNum());
 
@@ -241,7 +255,7 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
 
     MTROTAImageTransferHandlerWrapper * __weak weakWrapper = mOTAImageTransferHandlerWrapper;
 
-    auto completionHandler = ^(NSData * _Nullable data, BOOL isEOF) {
+    auto respondWithBlock = ^(NSData * _Nullable data, BOOL isEOF) {
         [controller
             asyncDispatchToMatterQueue:^() {
                 assertChipStackLockedByCurrentThread();
@@ -271,6 +285,35 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
                               // should already have been destroyed anyway.
                           }];
     };
+
+    __block void (^completionHandler)(NSData * _Nullable data, BOOL isEOF) = nil;
+
+    // If the peer node is a Thread device, check how much time has elapsed since we started processing the BlockQuery.
+    // If the time elapsed is greater than kBdxThrottleIntervalInMsecs, call the completion handler to respond with a Block right away.
+    // If time elapsed is less than kBdxThrottleIntervalInMsecs, dispatch the completion handler to respond with a Block after kBdxThrottleIntervalInMsecs has elapsed.
+
+    if (mIsPeerNodeAThreadDevice)
+    {
+        completionHandler = ^(NSData * _Nullable data, BOOL isEOF) {
+            uint64_t timeElapsed = chip::System::SystemClock().GetMonotonicMilliseconds64().count() - startBlockQueryHandlingTimestamp;
+            if (timeElapsed >= kBdxThrottleIntervalInMsecs.count())
+            {
+                completionHandler = respondWithBlock;
+            }
+            else
+            {
+                double timeRemainingInSecs = (kBdxThrottleIntervalInMsecs.count() - timeElapsed) / kMilliSecondsInSecond;
+                dispatch_time_t time =  dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeRemainingInSecs * NSEC_PER_SEC));
+                dispatch_after(time, dispatch_get_main_queue(), ^{
+                    respondWithBlock(data, isEOF);
+                });
+            }
+        };
+    }
+    else
+    {
+        completionHandler = respondWithBlock;
+    }
 
     // TODO Handle MaxLength
 

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -292,26 +292,20 @@ CHIP_ERROR MTROTAImageTransferHandler::OnBlockQuery(const TransferSession::Outpu
     // If the time elapsed is greater than kBdxThrottleIntervalInMsecs, call the completion handler to respond with a Block right away.
     // If time elapsed is less than kBdxThrottleIntervalInMsecs, dispatch the completion handler to respond with a Block after kBdxThrottleIntervalInMsecs has elapsed.
 
-    if (mIsPeerNodeAThreadDevice)
-    {
+    if (mIsPeerNodeAThreadDevice) {
         completionHandler = ^(NSData * _Nullable data, BOOL isEOF) {
             uint64_t timeElapsed = chip::System::SystemClock().GetMonotonicMilliseconds64().count() - startBlockQueryHandlingTimestamp;
-            if (timeElapsed >= kBdxThrottleIntervalInMsecs.count())
-            {
+            if (timeElapsed >= kBdxThrottleIntervalInMsecs.count()) {
                 completionHandler = respondWithBlock;
-            }
-            else
-            {
+            } else {
                 double timeRemainingInSecs = (kBdxThrottleIntervalInMsecs.count() - timeElapsed) / kMilliSecondsInSecond;
-                dispatch_time_t time =  dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeRemainingInSecs * NSEC_PER_SEC));
+                dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t) (timeRemainingInSecs * NSEC_PER_SEC));
                 dispatch_after(time, dispatch_get_main_queue(), ^{
                     respondWithBlock(data, isEOF);
                 });
             }
         };
-    }
-    else
-    {
+    } else {
         completionHandler = respondWithBlock;
     }
 

--- a/src/platform/Darwin/UserDefaults.h
+++ b/src/platform/Darwin/UserDefaults.h
@@ -24,5 +24,7 @@ namespace Platform {
 
 std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs();
 
+std::optional<uint16_t> GetUserDefaultBDXThrottleIntervalForThreadInMSecs();
+
 } // namespace Platform
 } // namespace chip

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -23,6 +23,8 @@
 
 static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
 
+static NSString * const kBDXThrottleIntervalInMsecsUserDefaultKey = @"BDXThrottleIntervalForThreadDevicesInMSecs";
+
 namespace chip {
 namespace Platform {
 
@@ -35,6 +37,22 @@ namespace Platform {
             ChipLogProgress(Discovery, "Got a user default value for Dnssd SRP timeout - %d msecs", timeoutinMsecs);
             return std::make_optional(timeoutinMsecs);
         }
+        return std::nullopt;
+    }
+
+    std::optional<uint16_t> GetUserDefaultBDXThrottleIntervalForThreadInMSecs()
+    {
+        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+        NSInteger bdxThrottleIntervalInMsecs = [defaults integerForKey:kBDXThrottleIntervalInMsecsUserDefaultKey];
+
+        if (bdxThrottleIntervalInMsecs > 0 && CanCastTo<uint16_t>(bdxThrottleIntervalInMsecs)) {
+            uint16_t intervalInMsecs = static_cast<uint16_t>(bdxThrottleIntervalInMsecs);
+            ChipLogProgress(BDX, "Got a user default value for BDX Throttle Interval for Thread devices - %d msecs", intervalInMsecs);
+            return std::make_optional(intervalInMsecs);
+        }
+
+        // For now return NullOptional if value returned in bdxThrottleIntervalInMsecs is 0, since that either means the key was not found or value was zero.
+        // Since 0 is not a feasible value for this interval for now, we will treat that as not being set.
         return std::nullopt;
     }
 


### PR DESCRIPTION
… specified in kBdxThrottleIntervalInMsecs so that we don't overload the network with frequent BDX messages

Fixes: #37532 

#### Testing

Ran OTAProviderTests.m to verify
