### PR TITLE
[ESP32] Fix incorrect RTC log format in SystemTimeSupport

### DIFF
--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -94,9 +94,9 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
         const time_t timep = tv.tv_sec;
         struct tm calendar;
         localtime_r(&timep, &calendar);
-        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%04d/%02d/%02d %02d:%02d:%02d UTC)",
-                        static_cast<long long>(tv.tv_sec), calendar.tm_year + 1900, calendar.tm_mon + 1, calendar.tm_mday,
-                        calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
+        char time_str[64];
+        strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S UTC", &calendar);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%s)", static_cast<long long>(tv.tv_sec), time_str);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -95,8 +95,8 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
         struct tm calendar;
         localtime_r(&timep, &calendar);
         ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%04d/%02d/%02d %02d:%02d:%02d UTC)",
-                        static_cast<long long>(tv.tv_sec), calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour,
-                        calendar.tm_min, calendar.tm_sec);
+                        static_cast<long long>(tv.tv_sec), calendar.tm_year + 1900, calendar.tm_mon + 1, calendar.tm_mday,
+                        calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem  
Fixes espressif/esp-matter#1269  

The `tm_year` and `tm_mon` values were being logged incorrectly, resulting in an invalid date format.  

#### Changes  
- Used strftime() for formatting utc time.

#### Testing  
- Verified the fix by setting the RTC time using the Time Synchronization cluster through `chip-tool` and checking the log output.  
- Logs now correctly reflect the expected timestamp format.  
