### PR TITLE
[Darwin] MTRDevice _deviceMayBeReachable should not reset active subscription

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -337,7 +337,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 @property (nonatomic) BOOL throttlingDeviceBecameActiveCallbacks;
 
 // Keep track of the last time we received subscription related communication from the device
-@property (nonatomic) NSDate * lastSubscriptionActiveTime;
+@property (nonatomic, nullable) NSDate * lastSubscriptionActiveTime;
 
 /**
  * If currentReadClient is non-null, that means that we successfully

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -336,6 +336,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 @property (nonatomic) NSDate * lastDeviceBecameActiveCallbackTime;
 @property (nonatomic) BOOL throttlingDeviceBecameActiveCallbacks;
 
+// Keep track of the last time we received subscription related communication from the device
+@property (nonatomic) NSDate * lastSubscriptionActiveTime;
+
 /**
  * If currentReadClient is non-null, that means that we successfully
  * called SendAutoResubscribeRequest on the ReadClient and have not yet gotten
@@ -360,6 +363,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 - (void)unitTestClusterDataPersisted:(MTRDevice *)device;
 - (BOOL)unitTestSuppressTimeBasedReachabilityChanges:(MTRDevice *)device;
 - (void)unitTestSubscriptionCallbackDeleteForDevice:(MTRDevice *)device;
+- (void)unitTestSubscriptionResetForDevice:(MTRDevice *)device;
 @end
 #endif
 
@@ -1697,6 +1701,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     assertChipStackLockedByCurrentThread();
 
     std::lock_guard lock(_lock);
+    self.lastSubscriptionActiveTime = [NSDate now];
 
     _receivingReport = YES;
     if (_state != MTRDeviceStateReachable) {
@@ -2669,6 +2674,14 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     [self.matterCPPObjectsHolder clearReadClientAndDeleteSubscriptionCallback];
 
     [self _doHandleSubscriptionError:nil];
+
+#ifdef DEBUG
+    [self _callFirstDelegateSynchronouslyWithBlock:^(id testDelegate) {
+        if ([testDelegate respondsToSelector:@selector(unitTestSubscriptionResetForDevice:)]) {
+            [testDelegate unitTestSubscriptionResetForDevice:self];
+        }
+    }];
+#endif
 }
 
 #ifdef DEBUG
@@ -2774,6 +2787,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                                ^(NSArray * value) {
                                    mtr_strongify(self);
                                    VerifyOrReturn(self, MTR_LOG_DEBUG("_setupSubscriptionWithReason subscription attribute report called back with nil MTRDevice"));
+                                   {
+                                       std::lock_guard lock(self->_lock);
+                                       self.lastSubscriptionActiveTime = [NSDate now];
+                                   }
 
                                    MTR_LOG("%@ got attribute report (%p) %@", self, value, value);
                                    dispatch_async(self.queue, ^{
@@ -2790,6 +2807,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                                ^(NSArray * value) {
                                    mtr_strongify(self);
                                    VerifyOrReturn(self, MTR_LOG_DEBUG("_setupSubscriptionWithReason subscription event report called back with nil MTRDevice"));
+                                   {
+                                       std::lock_guard lock(self->_lock);
+                                       self.lastSubscriptionActiveTime = [NSDate now];
+                                   }
 
                                    MTR_LOG("%@ got event report %@", self, value);
                                    dispatch_async(self.queue, ^{
@@ -2822,6 +2843,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
                                    MTR_LOG("%@ got subscription established", self);
                                    std::lock_guard lock(self->_lock);
+                                   self.lastSubscriptionActiveTime = [NSDate now];
 
                                    // First synchronously change state
                                    if (HadSubscriptionEstablishedOnce(self->_internalDeviceState)) {
@@ -4723,8 +4745,21 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     return HaveSubscriptionEstablishedRightNow(_internalDeviceState);
 }
 
+// TODO: make this configurable - for now use 500ms or 0.5 seconds
+#define MTRDEVICE_ACTIVE_COMMUNICATION_THRESHOLD_SECONDS (0.5)
+
 - (void)_deviceMayBeReachable
 {
+    // Ignore this call if actively receiving communication from this device
+    {
+        std::lock_guard lock(self->_lock);
+        NSTimeInterval intervalSinceDeviceLastActive = -[self.lastSubscriptionActiveTime timeIntervalSinceNow];
+        if (intervalSinceDeviceLastActive < MTRDEVICE_ACTIVE_COMMUNICATION_THRESHOLD_SECONDS) {
+            MTR_LOG("%@ _deviceMayBeReachable called and ignored, because last received communication from device %.6lf seconds ago", self, intervalSinceDeviceLastActive);
+            return;
+        }
+    }
+
     MTR_LOG("%@ _deviceMayBeReachable called, resetting subscription", self);
     // TODO: This should only be allowed for thread devices
     mtr_weakify(self);

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -37,6 +37,7 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 @property (nonatomic, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
 @property (nonatomic, nullable) dispatch_block_t onClusterDataPersisted;
 @property (nonatomic, nullable) dispatch_block_t onSubscriptionCallbackDelete;
+@property (nonatomic, nullable) dispatch_block_t onSubscriptionReset;
 @end
 
 @interface MTRDeviceTestDelegateWithSubscriptionSetupOverride : MTRDeviceTestDelegate

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
@@ -126,6 +126,13 @@
     }
 }
 
+- (void)unitTestSubscriptionResetForDevice:(MTRDevice *)device
+{
+    if (self.onSubscriptionReset != nil) {
+        self.onSubscriptionReset();
+    }
+}
+
 @end
 
 @implementation MTRDeviceTestDelegateWithSubscriptionSetupOverride

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -51,12 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceController (Test)
 + (void)forceLocalhostAdvertisingOnly;
 - (void)removeDevice:(MTRDevice *)device;
+- (void)syncRunOnWorkQueue:(void (^)(void))block error:(NSError * __autoreleasing *)error;
 @property (nonatomic, readonly, nullable) id<MTRDeviceControllerDataStoreAttributeStoreMethods> controllerDataStore;
 @end
 
 @interface MTRDevice (Test)
 - (NSMutableArray<NSNumber *> *)arrayOfNumbersFromAttributeValue:(MTRDeviceDataValueDictionary)dataDictionary;
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration;
+- (void)_deviceMayBeReachable;
 @end
 
 #pragma mark - Declarations for items compiled only for DEBUG configuration


### PR DESCRIPTION
When `_deviceMayBeReachable` is called to reset and reestablish subscriptions, if we know we are actively receiving communication from the subscription, then ignore the call.

#### Testing

Added unit test to test this very specific scenario.