### PR TITLE
Update test_dcl_server.py for Python 3.10+ compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Python Debugger: test_dcl_server",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "/workspace/connectedhomeip/examples/chip-tool/commands/dcl/test_dcl_server.py",
+            "args": [],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Attach to running process",
             "type": "lldb",
             "request": "attach",

--- a/examples/chip-tool/commands/dcl/test_dcl_server.py
+++ b/examples/chip-tool/commands/dcl/test_dcl_server.py
@@ -211,21 +211,25 @@ class RESTRequestHandler(http.server.BaseHTTPRequestHandler):
 
 
 def run_https_server(cert_file="cert.pem", key_file="key.pem"):
-    httpd = http.server.HTTPServer(
-        (DEFAULT_HOSTNAME, DEFAULT_PORT), RESTRequestHandler)
+    # Creates a basic HTTP server instance that listens on DEFAULT_HOSTNAME and DEFAULT_PORT
+    # RESTRequestHandler handles incoming HTTP requests
+    httpd = http.server.HTTPServer((DEFAULT_HOSTNAME, DEFAULT_PORT), RESTRequestHandler)
 
+    # Creates an SSL context using TLS protocol for secure communications
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-    context.load_cert_chain(certfile="server.crt", keyfile="server.key")
-    httpd.socket = context.wrap_socket(
-        httpd.socket,
-        server_side=True,
-        # certfile=cert_file,
-        # keyfile=key_file,
-        # ssl_version=ssl.PROTOCOL_TLS,
-    )
 
-    print(f"Serving on https://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}")
-    httpd.serve_forever()
+    # Loads the SSL certificate and private key for the server
+    # cert_file: contains the server's public certificate
+    # key_file: contains the server's private key
+    context.load_cert_chain(certfile=cert_file, keyfile=key_file)
+
+    # Uses a context manager (with statement) to wrap the HTTP server's socket with SSL
+    # server_side=True indicates this is a server socket
+    # The wrapped socket is automatically closed when exiting the with block
+    with context.wrap_socket(httpd.socket, server_side=True) as httpd.socket:
+        print(f"Serving on https://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}")
+        # Starts the server and runs indefinitely, handling incoming HTTPS requests
+        httpd.serve_forever()
 
 
 # Generate self-signed certificates if needed

--- a/examples/chip-tool/commands/dcl/test_dcl_server.py
+++ b/examples/chip-tool/commands/dcl/test_dcl_server.py
@@ -214,12 +214,14 @@ def run_https_server(cert_file="cert.pem", key_file="key.pem"):
     httpd = http.server.HTTPServer(
         (DEFAULT_HOSTNAME, DEFAULT_PORT), RESTRequestHandler)
 
-    httpd.socket = ssl.wrap_socket(
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile="server.crt", keyfile="server.key")
+    httpd.socket = context.wrap_socket(
         httpd.socket,
         server_side=True,
-        certfile=cert_file,
-        keyfile=key_file,
-        ssl_version=ssl.PROTOCOL_TLS,
+        # certfile=cert_file,
+        # keyfile=key_file,
+        # ssl_version=ssl.PROTOCOL_TLS,
     )
 
     print(f"Serving on https://{DEFAULT_HOSTNAME}:{DEFAULT_PORT}")


### PR DESCRIPTION
#### Testing:

1. Start the DCL server in terminal 1:

   ```bash
   python3 ./examples/chip-tool/commands/dcl/test_dcl_server.py
   ```

2. Launch terms and conditions app in terminal 2:

   ```bash
   rm /tmp/chip* ; ./out/linux-x64-terms-and-conditions/chip-terms-and-conditions-app \
   --version 0 --custom-flow 2 --capabilities 6 --discriminator 3840 \
   --passcode 20202021 --KVS /tmp/chip_kvs.bin --trace_file /tmp/chip_trace.log \
   --trace_log 1 --trace_decode 1
   ```

3. Execute pairing command in terminal 3:

   ```bash
   yes | ./out/linux-x64-chip-tool/chip-tool pairing code 0x12344321 \
   MT:-24J029Q00KA0648G00 --use-dcl true --dcl-hostname localhost --dcl-port 4443
   ```
