### PR TITLE
Change config headers include order

### DIFF
--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -28,8 +28,6 @@
 #include <platform/CHIPDeviceBuildConfig.h>
 #endif
 
-#include <lib/core/CHIPConfig.h>
-
 /* Include a project-specific configuration file, if defined.
  *
  * An application or module that incorporates the chip Device Layer can define a project
@@ -40,6 +38,8 @@
 #ifdef CHIP_DEVICE_PROJECT_CONFIG_INCLUDE
 #include CHIP_DEVICE_PROJECT_CONFIG_INCLUDE
 #endif
+
+#include <lib/core/CHIPConfig.h>
 
 /* Include a platform-specific configuration file, if defined.
  *


### PR DESCRIPTION
Move `CHIPConfig.h` after `CHIP_DEVICE_PROJECT_CONFIG_INCLUDE` as it defines default configuration values that may be overriden by project specific config. This may result in macro redefined warning when `CHIP_DEVICE_PROJECT_CONFIG_INCLUDE` is not included before `CHIPDeviceConfig.h`.

Problem was found during development of #37513 in `tv-casting-app` example:
```
In file included from ../../../../../../../../../src/system/SystemStats.cpp:32:
In file included from ../../../../../../../../../src/include/platform/LockTracker.h:20:
In file included from ../../../../../../../../../src/include/platform/CHIPDeviceConfig.h:41:
../../../../../../../../../examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h:61:9: warning: 'CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY' macro redefined [-Wmacro-redefined]
#define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY 20
        ^
../../../../../../../../../src/lib/core/CHIPConfig.h:1157:9: note: previous definition is here
#define CHIP_CONFIG_EXAMPLE_ACCESS_CONTROL_MAX_TARGETS_PER_ENTRY 3
        ^
```
> Build: https://github.com/project-chip/connectedhomeip/actions/runs/13280834267/job/37078701920

#### Testing
Tested by CI.