### PR TITLE
[Silabs] Explicitly specify the notifier dependency that ICDShellCommands needs

### DIFF
--- a/examples/platform/silabs/shell/BUILD.gn
+++ b/examples/platform/silabs/shell/BUILD.gn
@@ -35,5 +35,8 @@ source_set("icd") {
 
   public_configs = [ ":icd-shell-config" ]
 
-  deps = [ "${shell_dependency_path}:matter-shell" ]
+  deps = [
+    "${chip_root}/src/app/icd/server:notifier",
+    "${shell_dependency_path}:matter-shell",
+  ]
 }


### PR DESCRIPTION
Ours shell/icd source set requires the ICDNotifier for some shell commands in ICDShellCommands.cpp, but it didn't explicitly add the dependency.

It was working as all our sample apps making use of the `ICDShellCommands.cpp` were ICD apps already pulling ICD dependency publicly 

#### Testing
Validate the source_set builds without an external source providing it the `icd/server:notifier`