### PR TITLE
Improve logging around persistent browse in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.mm
@@ -1133,8 +1133,6 @@ MTR_DIRECT_MEMBERS
     for (MTRDeviceController_Concrete * controller in controllersCopy) {
         auto * compressedFabricId = controller.compressedFabricID;
         if (compressedFabricId != nil && compressedFabricId.unsignedLongLongValue == operationalID.GetCompressedFabricId()) {
-            ChipLogProgress(Controller, "Notifying controller at fabric index %u about new operational node 0x" ChipLogFormatX64,
-                controller.fabricIndex, ChipLogValueX64(operationalID.GetNodeId()));
             [controller operationalInstanceAdded:@(operationalID.GetNodeId())];
         }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1666,6 +1666,9 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
 - (void)operationalInstanceAdded:(NSNumber *)nodeID
 {
+    MTR_LOG("%@ at fabric index %u notified about new operational node 0x%016llx (%llu)", self, self.fabricIndex,
+        nodeID.unsignedLongLongValue, nodeID.unsignedLongLongValue);
+
     // If we don't have an existing MTRDevice for this node ID, that's fine;
     // nothing to do.
     MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];


### PR DESCRIPTION
Log the state of a controller that gets notified about browse results (so we can tell whether it's suspended or not, for example).

#### Testing

Logging changes only.