### PR TITLE
Change Thread OTA throttling algorithm in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -77,7 +77,7 @@ private:
 
     bool mIsPeerNodeAKnownThreadDevice = NO;
 
-    chip::System::Clock::Milliseconds32 mBDXThrottleIntervalForThreadDevicesInMSecs;
+    chip::System::Clock::Milliseconds32 mBDXThrottleIntervalForThreadDevices;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/platform/Darwin/UserDefaults.h
+++ b/src/platform/Darwin/UserDefaults.h
@@ -18,13 +18,14 @@
 
 #include <cstdint>
 #include <optional>
+#include <system/SystemClock.h>
 
 namespace chip {
 namespace Platform {
 
 std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs();
 
-std::optional<uint16_t> GetUserDefaultBDXThrottleIntervalForThreadInMSecs();
+std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread();
 
 } // namespace Platform
 } // namespace chip

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -40,7 +40,7 @@ namespace Platform {
         return std::nullopt;
     }
 
-    std::optional<uint16_t> GetUserDefaultBDXThrottleIntervalForThreadInMSecs()
+    std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread()
     {
         NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
         NSInteger bdxThrottleIntervalInMsecs = [defaults integerForKey:kBDXThrottleIntervalInMsecsUserDefaultKey];
@@ -48,7 +48,7 @@ namespace Platform {
         if (bdxThrottleIntervalInMsecs > 0 && CanCastTo<uint16_t>(bdxThrottleIntervalInMsecs)) {
             uint16_t intervalInMsecs = static_cast<uint16_t>(bdxThrottleIntervalInMsecs);
             ChipLogProgress(BDX, "Got a user default value for BDX Throttle Interval for Thread devices - %d msecs", intervalInMsecs);
-            return std::make_optional(intervalInMsecs);
+            return std::make_optional(System::Clock::Milliseconds16(intervalInMsecs));
         }
 
         // For now return NullOptional if value returned in bdxThrottleIntervalInMsecs is 0, since that either means the key was not found or value was zero.


### PR DESCRIPTION
Throttle by rounding up to the nearest multiple of our throttle interval, not by just comparing to that interval.  This matches the old "poll at 50ms" behavior we had.

#### Testing

Manual testing.