### PR TITLE
[TC-DLOG-2.1] Added disabled: true parameter in test step 3

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_DLOG_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DLOG_2_1.yaml
@@ -120,6 +120,7 @@ tests:
           The current SDK implementation stores log files transferred via the BDX protocol in the /tmp folder.
           if {PICS_MCORE_DLOG_S_UTCTIMESTAMP} then verify that UTCTimeStamp is included in the RetrieveLogsResponse command
           if {PICS_MCORE_DLOG_S_TIMESINCEBOOT} then verify that TimeSinceBoot is included in the RetrieveLogsResponse command
+      disabled: true
 
     - label:
           "Step 4: if (SendInitMsgfromDUT = false) TH does not send BDX
@@ -318,7 +319,7 @@ tests:
           If SendInitMsgfromDUT = false  proceed with the following validation:
 
           1. Verification:
-          On TH(chip-tool), verify that the DUT responds by sending RetrieveLogsResponse Command with Exhausted(1) status code to TH and LogContent field of RetrieveLogsResponse contains at most 1024 bytes
+          On TH(chip-tool), verify   that the DUT responds by sending RetrieveLogsResponse Command with Exhausted(1) status code to TH and LogContent field of RetrieveLogsResponse contains at most 1024 bytes
 
           [1725363236.448] [56032:56034] [DMG] Received Command Response Data, Endpoint=0 Cluster=0x0000_0032 Command=0x0000_0001
           [1725363236.449] [56032:56034] [TOO] Endpoint: 0 Cluster: 0x0000_0032 Command 0x0000_0001
@@ -466,7 +467,6 @@ tests:
           [1707967219.637242][10723:10726] CHIP:TOO:     status: 2
           [1707967219.637248][10723:10726] CHIP:TOO:     logContent:
           [1707967219.637253][10723:10726] CHIP:TOO:    }
-
       disabled: true
 
     - label:


### PR DESCRIPTION
#### Testing

**Fix for Issue** : https://github.com/project-chip/matter-test-scripts/issues/502

 **Description:**  For all the manual test steps  "disabled: true" must be set. It was missed in test step 3 for TC-DLOG-2.1 Test case. Now it is added.

These changes has been updated in master with PR https://github.com/project-chip/connectedhomeip/pull/37546. Now syncing up with v1.4 branch.