### PR TITLE
Fix TC-SC-4.3: Add is_commissioning variable set to True

### DIFF
--- a/src/python_testing/TC_SC_4_3.py
+++ b/src/python_testing/TC_SC_4_3.py
@@ -57,7 +57,7 @@ https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/securecha
 class TC_SC_4_3(MatterBaseTest):
 
     def steps_TC_SC_4_3(self):
-        return [TestStep(1, "DUT is commissioned on the same fabric as TH."),
+        return [TestStep(1, "DUT is commissioned on the same fabric as TH.", is_commissioning=True),
                 TestStep(2, "TH reads ServerList attribute from the Descriptor cluster on EP0. ",
                          "If the ICD Management cluster ID (70,0x46) is present in the list, set supports_icd to true, otherwise set supports_icd to false."),
                 TestStep(3,


### PR DESCRIPTION
#### Testing
Addresses
[[BUG] In TC-SC-4.3 python script 'is_commissioning="true"' has to be added in test step1. #37551
](https://github.com/project-chip/connectedhomeip/issues/37551)