### PR TITLE
fix: Remove empty test steps from CGEN test cases

### DIFF
--- a/src/python_testing/TC_CGEN_2_10.py
+++ b/src/python_testing/TC_CGEN_2_10.py
@@ -52,8 +52,7 @@ class TC_CGEN_2_10(MatterBaseTest):
 
     def steps_TC_CGEN_2_10(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH reads from the DUT the attribute TCAcceptedVersion. Store the value as acceptedVersion."),
+            TestStep(1, "TH reads from the DUT the attribute TCAcceptedVersion. Store the value as acceptedVersion.", is_commissioning=False),
             TestStep(2, "TH reads from the DUT the attribute TCAcknowledgements. Store the value as userAcknowledgements."),
             TestStep(3, "TH Sends the SetTCAcknowledgements command to the DUT with the fields set as follows:\n* TCVersion: 0\n* TCUserResponse: 65535"),
             TestStep(4, "TH reads from the DUT the attribute TCAcceptedVersion."),
@@ -67,7 +66,6 @@ class TC_CGEN_2_10(MatterBaseTest):
     async def test_TC_CGEN_2_10(self):
         commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_11.py
+++ b/src/python_testing/TC_CGEN_2_11.py
@@ -53,8 +53,7 @@ class TC_CGEN_2_11(MatterBaseTest):
 
     def steps_TC_CGEN_2_11(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc."),
+            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc.", is_commissioning=False),
             TestStep(2, "TH sends SetTCAcknowledgements to DUT with the following values:\n* TCVersion: PIXIT.CGEN.TCRevision\n* TCUserResponse: PIXIT.CGEN.RequiredTCAcknowledgements"),
             TestStep(3, "TH sends CommissioningComplete to DUT."),
             TestStep(4, "TH Sends the SetTCAcknowledgements command to the DUT with the fields set as follows:\n* TCVersion: PIXIT.CGEN.TCRevision + 1\n* TCUserResponse: PIXIT.CGEN.RequiredTCAcknowledgements"),
@@ -70,7 +69,6 @@ class TC_CGEN_2_11(MatterBaseTest):
         tc_version_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.TCRevision']
         tc_user_response_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.RequiredTCAcknowledgements']
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_5.py
+++ b/src/python_testing/TC_CGEN_2_5.py
@@ -55,8 +55,7 @@ class TC_CGEN_2_5(MatterBaseTest):
 
     def steps_TC_CGEN_2_5(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc."),
+            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc.", is_commissioning=False),
             TestStep(2, "TH reads TCAcknowledgementsRequired attribute from the DUT"),
             TestStep(3, "TH reads TCUpdateDeadline attribute from the DUT"),
             TestStep(4, "TH reads the FeatureMap from the General Commissioning Cluster."),
@@ -78,7 +77,6 @@ class TC_CGEN_2_5(MatterBaseTest):
         tc_version_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.TCRevision']
         tc_user_response_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.RequiredTCAcknowledgements']
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_6.py
+++ b/src/python_testing/TC_CGEN_2_6.py
@@ -50,8 +50,7 @@ class TC_CGEN_2_6(MatterBaseTest):
 
     def steps_TC_CGEN_2_6(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH starts commissioning the DUT. It performs all commissioning steps from 'Device discovery and establish commissioning channel' to 'Security setup using CASE', except for TC configuration with SetTCAcknowledgements."),
+            TestStep(1, "TH starts commissioning the DUT. It performs all commissioning steps from 'Device discovery and establish commissioning channel' to 'Security setup using CASE', except for TC configuration with SetTCAcknowledgements.", is_commissioning=False),
             TestStep(2, "TH sends CommissioningComplete to DUT."),
         ]
 
@@ -59,7 +58,6 @@ class TC_CGEN_2_6(MatterBaseTest):
     async def test_TC_CGEN_2_6(self):
         commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_7.py
+++ b/src/python_testing/TC_CGEN_2_7.py
@@ -53,8 +53,7 @@ class TC_CGEN_2_7(MatterBaseTest):
 
     def steps_TC_CGEN_2_7(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc."),
+            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc.", is_commissioning=False),
             TestStep(2, "TH reads from the DUT the attribute TCMinRequiredVersion. Store the value as minVersion."),
             TestStep(3, "TH sends SetTCAcknowledgements to DUT with the following values:\n* TCVersion: minVersion\n* TCUserResponse: 0"),
             TestStep(4, "TH continues commissioning with the DUT and performs the steps from 'Operation CSR exchange' through 'Security setup using CASE'"),
@@ -70,7 +69,6 @@ class TC_CGEN_2_7(MatterBaseTest):
         tc_version_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.TCRevision']
         tc_user_response_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.RequiredTCAcknowledgements']
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -53,8 +53,7 @@ class TC_CGEN_2_8(MatterBaseTest):
 
     def steps_TC_CGEN_2_8(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc."),
+            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc.", is_commissioning=False),
             TestStep(2, "TH sends SetTCAcknowledgements to DUT with the following values:\n* TCVersion: PIXIT.CGEN.TCRevision\n* TCUserResponse: PIXIT.CGEN.RequiredTCAcknowledgements"),
             TestStep(3, "TH continues commissioning steps with the DUT and performs steps 'Operation CSR exchange' through 'Security setup using CASE'"),
             TestStep(4, "TH sends CommissioningComplete to DUT."),
@@ -74,7 +73,6 @@ class TC_CGEN_2_8(MatterBaseTest):
         tc_version_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.TCRevision']
         tc_user_response_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.RequiredTCAcknowledgements']
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -76,8 +76,7 @@ class TC_CGEN_2_9(MatterBaseTest):
 
     def steps_TC_CGEN_2_9(self) -> list[TestStep]:
         return [
-            TestStep(0, description="", expectation="", is_commissioning=False),
-            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc."),
+            TestStep(1, "TH begins commissioning the DUT and performs the following steps in order:\n* Security setup using PASE\n* Setup fail-safe timer, with ExpiryLengthSeconds field set to PIXIT.CGEN.FailsafeExpiryLengthSeconds and the Breadcrumb value as 1\n* Configure information- UTC time, regulatory, etc.", is_commissioning=False),
             TestStep(2, "TH sends SetTCAcknowledgements to DUT with the following values:\n* TCVersion: PIXIT.CGEN.TCRevision\n* TCUserResponse: PIXIT.CGEN.RequiredTCAcknowledgements"),
             TestStep(3, "TH continues commissioning with the DUT and performs the steps from 'Operation CSR exchange' through 'Security setup using CASE'"),
             TestStep(4, "TH sends CommissioningComplete to DUT."),
@@ -94,7 +93,6 @@ class TC_CGEN_2_9(MatterBaseTest):
         tc_version_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.TCRevision']
         tc_user_response_to_simulate = self.matter_test_config.global_test_params['PIXIT.CGEN.RequiredTCAcknowledgements']
 
-        self.step(0)
         if not self.check_pics("CGEN.S.F00"):
             asserts.skip('Root endpoint does not support the [commissioning] feature under test')
             return


### PR DESCRIPTION
Fixes https://github.com/project-chip/matter-test-scripts/issues/504

This commit fixes the UI hanging issue during commissioning with DUT in test cases TC-CGEN-2.5 through TC-CGEN-2.11 by:
- Removing empty TestStep(0) definitions with no description
- Removing corresponding self.step(0) calls
- Adding is_commissioning=False flag to the first actual test step

This addresses issue [#504](https://github.com/project-chip/matter-test-scripts/issues/504) where the Test Harness UI became unresponsive during commissioning due to empty test step descriptions causing delays between test execution steps.


#### Testing

Locally validated the modified test scripts.

```bash
source out/venv/bin/activate
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_5.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_6.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_7.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_8.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_9.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_10.py
rm /tmp/chip* kvs1; ./scripts/tests/run_python_test.py --load-from-env /workspace/test_env.yaml --script src/python_testing/TC_CGEN_2_11.py
```