### PR TITLE
[Silabs] Implement WifiSleepManager

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -67,6 +67,10 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/silabs/NetworkCommissioningWiFiDriver.h>
 #include <platform/silabs/wifi/WifiInterface.h>
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SL_WIFI
 
 #ifdef DIC_ENABLE
@@ -175,25 +179,32 @@ BaseApplicationDelegate BaseApplication::sAppDelegate = BaseApplicationDelegate(
 void BaseApplicationDelegate::OnCommissioningSessionStarted()
 {
     isComissioningStarted = true;
+
+#if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+    WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
+#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 void BaseApplicationDelegate::OnCommissioningSessionStopped()
 {
     isComissioningStarted = false;
+
+#if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
+#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+}
+
+void BaseApplicationDelegate::OnCommissioningSessionEstablishmentError(CHIP_ERROR err)
+{
+    isComissioningStarted = false;
+
+#if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+    WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
+#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
 void BaseApplicationDelegate::OnCommissioningWindowClosed()
 {
-#if CHIP_CONFIG_ENABLE_ICD_SERVER && (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
-    if (!BaseApplication::GetProvisionStatus() && !isComissioningStarted)
-    {
-        int32_t status = wfx_power_save(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION);
-        if (status != SL_STATUS_OK)
-        {
-            ChipLogError(AppServer, "Failed to enable the TA Deep Sleep");
-        }
-    }
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI917
     if (BaseApplication::GetProvisionStatus())
     {
         // After the device is provisioned and the commissioning passed
@@ -888,6 +899,10 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
         {
 #if SL_WIFI
             chip::app::DnssdServer::Instance().StartServer();
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+            WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kConnectivityChange);
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif // SL_WIFI
 
 #if SILABS_OTA_ENABLED
@@ -895,37 +910,14 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
             chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
                                                         InitOTARequestorHandler, nullptr);
 #endif // SILABS_OTA_ENABLED
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI)
-            // on power cycle, let the device go to sleep after connection is established
-            if (BaseApplication::sAppDelegate.isCommissioningInProgress() == false)
-            {
-#if SLI_SI917
-                sl_status_t err = wfx_power_save(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE);
-#else
-                sl_status_t err = wfx_power_save();
-#endif /* SLI_SI917 */
-                if (err != SL_STATUS_OK)
-                {
-                    ChipLogError(AppServer, "wfx_power_save failed: 0x%lx", err);
-                }
-            }
-#endif /* CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI */
         }
     }
     break;
 
     case DeviceEventType::kCommissioningComplete: {
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI)
-#if SLI_SI917
-        sl_status_t err = wfx_power_save(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE);
-#else
-        sl_status_t err = wfx_power_save();
-#endif /* SLI_SI917 */
-        if (err != SL_STATUS_OK)
-        {
-            ChipLogError(AppServer, "wfx_power_save failed: 0x%lx", err);
-        }
-#endif /* CHIP_CONFIG_ENABLE_ICD_SERVER && RS911X_WIFI */
+#if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+        WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kCommissioningComplete);
+#endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     }
     break;
     default:

--- a/examples/platform/silabs/BaseApplication.h
+++ b/examples/platform/silabs/BaseApplication.h
@@ -73,6 +73,7 @@ private:
     bool isComissioningStarted = false;
     void OnCommissioningSessionStarted() override;
     void OnCommissioningSessionStopped() override;
+    void OnCommissioningSessionEstablishmentError(CHIP_ERROR err) override;
     void OnCommissioningWindowClosed() override;
 
     // FabricTable::Delegate

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -27,6 +27,10 @@
 #ifdef SL_WIFI
 #include <platform/silabs/wifi/WifiInterface.h>
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 // TODO: We shouldn't need any platform specific includes in this file
 #if (defined(SLI_SI91X_MCU_INTERFACE) && SLI_SI91X_MCU_INTERFACE == 1)
 #include <platform/silabs/SiWx917/SiWxPlatformInterface.h>
@@ -228,6 +232,10 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     // See comment above about OpenThread memory allocation as to why this is WIFI only here.
     ReturnErrorOnFailure(chip::Platform::MemoryInit());
     ReturnErrorOnFailure(InitWiFi());
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    ReturnErrorOnFailure(DeviceLayer::Silabs::WifiSleepManager::GetInstance().Init());
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 #endif
 
     ReturnErrorOnFailure(PlatformMgr().InitChipStack());

--- a/src/app/icd/server/BUILD.gn
+++ b/src/app/icd/server/BUILD.gn
@@ -154,6 +154,8 @@ source_set("configuration-data") {
     "ICDConfigurationData.h",
   ]
 
+  public_deps = [ "${chip_root}/src/app/common:enums" ]
+
   deps = [
     ":icd-server-config",
     "${chip_root}/src/lib/core",

--- a/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
@@ -161,7 +161,7 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
     imageProcessor->mHeaderParser.Init();
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    // Setting the device is in high performace - no-sleepy mode during OTA tranfer
+    // Setting the device in high performance - no-sleep mode during OTA tranfer
     DeviceLayer::Silabs::WifiSleepManager::GetInstance().RequestHighPerformance();
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER*/
 

--- a/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
@@ -19,9 +19,13 @@
 #include <app/clusters/ota-requestor/OTADownloader.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <platform/silabs/OTAImageProcessorImpl.h>
-
 #include <platform/silabs/SilabsConfig.h>
 #include <platform/silabs/wifi/WifiInterface.h>
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -156,13 +160,9 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
 
     imageProcessor->mHeaderParser.Init();
 
-    // Setting the device is in high performace - no-sleepy mode while OTA tranfer
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER)
-    status = wfx_power_save(RSI_ACTIVE, HIGH_PERFORMANCE);
-    if (status != SL_STATUS_OK)
-    {
-        ChipLogError(DeviceLayer, "Failed to enable the TA Deep Sleep");
-    }
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    // Setting the device is in high performace - no-sleepy mode during OTA tranfer
+    DeviceLayer::Silabs::WifiSleepManager::GetInstance().RequestHighPerformance();
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER*/
 
     imageProcessor->mDownloader->OnPreparedForDownload(CHIP_NO_ERROR);
@@ -199,13 +199,9 @@ void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
     }
     imageProcessor->ReleaseBlock();
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Setting the device back to power save mode when transfer is completed successfully
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER)
-    sl_status_t err = wfx_power_save(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE);
-    if (err != SL_STATUS_OK)
-    {
-        ChipLogError(DeviceLayer, "Power save config for Wifi failed");
-    }
+    DeviceLayer::Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER*/
 
     ChipLogProgress(SoftwareUpdate, "OTA image downloaded successfully");
@@ -222,13 +218,9 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
 
     ChipLogProgress(SoftwareUpdate, "OTA image downloaded successfully in HandleApply");
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Setting the device is in high performace - no-sleepy mode before soft reset as soft reset is not happening in sleep mode
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER)
-    status = wfx_power_save(RSI_ACTIVE, HIGH_PERFORMANCE);
-    if (status != SL_STATUS_OK)
-    {
-        ChipLogError(DeviceLayer, "Failed to enable the TA Deep Sleep");
-    }
+    DeviceLayer::Silabs::WifiSleepManager::GetInstance().RequestHighPerformance();
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER*/
 
     if (mReset)
@@ -249,13 +241,9 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
         return;
     }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Setting the device back to power save mode when transfer is aborted in the middle
-#if (CHIP_CONFIG_ENABLE_ICD_SERVER)
-    sl_status_t err = wfx_power_save(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE);
-    if (err != SL_STATUS_OK)
-    {
-        ChipLogError(DeviceLayer, "Power save config for Wifi failed");
-    }
+    DeviceLayer::Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif /* CHIP_CONFIG_ENABLE_ICD_SERVER*/
 
     // Not clearing the image storage area as it is done during each write

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -152,7 +152,7 @@ source_set("wifi-platform") {
     ]
   }
 
-  # TODO: Once the WifiInterface refactor is done and becomes a class, we will be inject an interface instead of having them in same source_set
+  # TODO: Once the WifiInterface refactor is done and becomes a class, we will inject an interface instead of having them in same source_set
   if (chip_enable_icd_server) {
     public_deps += [ "${chip_root}/src/app/icd/server:configuration-data" ]
 

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -151,4 +151,14 @@ source_set("wifi-platform") {
       "${silabs_platform_dir}/wifi/lwip-support/lwip_netif.cpp",
     ]
   }
+
+  # TODO: Once the WifiInterface refactor is done and becomes a class, we will be inject an interface instead of having them in same source_set
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd/server:configuration-data" ]
+
+    sources += [
+      "${silabs_platform_dir}/wifi/icd/WifiSleepManager.cpp",
+      "${silabs_platform_dir}/wifi/icd/WifiSleepManager.h",
+    ]
+  }
 }

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -821,7 +821,7 @@ CHIP_ERROR ConfigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, 
     sl_wifi_performance_profile_t wifi_profile = { .profile = sl_si91x_wifi_state,
                                                    // TODO: Performance profile fails if not alligned with DTIM
                                                    .dtim_aligned_type = SL_SI91X_ALIGN_WITH_DTIM_BEACON,
-                                                   // TODO: Different types need to be fixe in the Wi-Fi SDK
+                                                   // TODO: Different types need to be fixed in the Wi-Fi SDK
                                                    .listen_interval = static_cast<uint16_t>(listenInterval) };
 
     sl_status_t status = sl_wifi_set_performance_profile(&wifi_profile);

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -860,7 +860,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -71,7 +71,7 @@ extern "C" {
 #endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-#include <app/icd/server/ICDConfigurationData.h>
+#include <app/icd/server/ICDConfigurationData.h> // nogncheck
 #include <platform/silabs/wifi/icd/WifiSleepManager.h>
 
 #if SLI_SI91X_MCU_INTERFACE // SoC Only
@@ -860,7 +860,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -15,8 +15,6 @@
  *    limitations under the License.
  */
 
-// SL MATTER WI-FI INTERFACE
-
 #include "silabs_utils.h"
 #include <app/icd/server/ICDServerConfig.h>
 #include <lib/support/CHIPMem.h>
@@ -24,10 +22,9 @@
 #include <lib/support/TypeTraits.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/silabs/wifi/WifiInterface.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 using namespace chip;
 using namespace chip::DeviceLayer;
@@ -56,9 +53,6 @@ bool hasNotifiedIPV4 = false;
  */
 void RetryConnectionTimerHandler(void * arg)
 {
-#if CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
-    wfx_power_save(RSI_ACTIVE, HIGH_PERFORMANCE);
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
     if (wfx_connect_to_ap() != SL_STATUS_OK)
     {
         ChipLogError(DeviceLayer, "wfx_connect_to_ap() failed.");
@@ -192,11 +186,18 @@ void wfx_retry_connection(uint16_t retryAttempt)
         {
             ChipLogError(DeviceLayer, "wfx_connect_to_ap() failed.");
         }
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+        //  Remove High performance request before giving up due to a timer start error to save battery life
+        Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
         return;
     }
-#if CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
-    wfx_power_save(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION);
-#endif // CHIP_CONFIG_ENABLE_ICD_SERVER && SLI_SI91X_MCU_INTERFACE
+
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+    Silabs::WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
     ChipLogProgress(DeviceLayer, "wfx_retry_connection : Next attempt after %d Seconds", retryInterval);
     retryInterval += retryInterval;
 }

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -360,7 +360,27 @@ CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info);
  */
 CHIP_ERROR ResetCounters();
 
+/**
+ * @brief Configures the broadcast filter.
+ *
+ * @param[in] enableBroadcastFilter Boolean to enable or disable the broadcast filter.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR, the counters were succesfully reset to 0.
+ *                    CHIP_ERROR_INTERNAL, if there was an error when configuring the broadcast filter
+ */
+CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter);
+
 /* Function to update */
+
+// TODO: Harmonize the Power Save function inputs for all platforms
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+#if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
+CHIP_ERROR ConfigurePowerSave(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state,
+                              uint32_t listenInterval);
+#else
+CHIP_ERROR ConfigurePowerSave();
+#endif /* (SLI_SI91X_MCU_INTERFACE | EXP_BOARD) */
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 void wfx_set_wifi_provision(wfx_wifi_provision_t * wifiConfig);
 bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig);
@@ -398,17 +418,6 @@ void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off);
 int32_t wfx_rsi_send_data(void * p, uint16_t len);
 #endif //!(EXP_BOARD)
 #endif // RS911X_WIFI
-
-#ifdef RS911X_WIFI // for RS9116, 917 NCP and 917 SoC
-/* RSI Power Save */
-#if SL_ICD_ENABLED
-#if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-sl_status_t wfx_power_save(rsi_power_save_profile_mode_t sl_si91x_ble_state, sl_si91x_performance_profile_t sl_si91x_wifi_state);
-#else
-sl_status_t wfx_power_save();
-#endif /* (SLI_SI91X_MCU_INTERFACE | EXP_BOARD) */
-#endif /* SL_ICD_ENABLED */
-#endif /* RS911X_WIFI */
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -87,7 +87,7 @@ CHIP_ERROR WifiSleepManager::RequestHighPerformance()
 
     mHighPerformanceRequestCounter++;
 
-    // We don't do the mHighPerformanceRequestCounter check here; the check is in VerifyAndTransitionToLowPowerMode function
+    // We don't do the mHighPerformanceRequestCounter check here; the check is in the VerifyAndTransitionToLowPowerMode function
     ReturnErrorOnFailure(VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent));
 
     return CHIP_NO_ERROR;
@@ -100,7 +100,7 @@ CHIP_ERROR WifiSleepManager::RemoveHighPerformanceRequest()
 
     mHighPerformanceRequestCounter--;
 
-    // We don't do the mHighPerformanceRequestCounter check here; the check is in VerifyAndTransitionToLowPowerMode function
+    // We don't do the mHighPerformanceRequestCounter check here; the check is in the VerifyAndTransitionToLowPowerMode function
     ReturnErrorOnFailure(VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent));
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -22,7 +22,7 @@
 
 namespace {
 
-// TODO: Once the platform sleep platform calls are unified, we can removed this ifdef
+// TODO: Once the platform sleep calls are unified, we can removed this ifdef
 #if SLI_SI917 // 917 SoC & NCP
 
 /**
@@ -143,8 +143,8 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
 
     if (mIsCommissioningInProgress)
     {
-        // During commissioning, don't let the device to go to sleep
-        // This is needed to interrupt the sleep and retry to join the network
+        // During commissioning, don't let the device go to sleep
+        // This is needed to interrupt the sleep and retry joining the network
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -1,0 +1,170 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/icd/server/ICDConfigurationData.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <platform/silabs/wifi/WifiInterface.h>
+#include <platform/silabs/wifi/icd/WifiSleepManager.h>
+
+namespace {
+
+// TODO: Once the platform sleep platform calls are unified, we can removed this ifdef
+#if SLI_SI917 // 917 SoC & NCP
+
+/**
+ * @brief Configures the Wi-Fi Chip to go to DTIM based sleep.
+ *        Function sets the listen interval to be synced with the DTIM beacon and disables the broadcast filter.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR if the configuration of the Wi-Fi chip was successful; otherwise CHIP_ERROR_INTERNAL
+ */
+CHIP_ERROR ConfigureDTIMBasedSleep()
+{
+    ReturnLogErrorOnFailure(ConfigureBroadcastFilter(false));
+
+    // Allowing the device to go to sleep must be the last actions to avoid configuration failures.
+    ReturnLogErrorOnFailure(ConfigurePowerSave(RSI_SLEEP_MODE_2, ASSOCIATED_POWER_SAVE, 0));
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ * @brief Configures the Wi-Fi chip to go Deep Sleep.
+ *        Function doesn't change the state of the broadcast filter.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR if the configuration of the Wi-Fi chip was successful; otherwise CHIP_ERROR_INTERNAL
+ */
+CHIP_ERROR ConfigureDeepSleep()
+{
+    ReturnLogErrorOnFailure(ConfigurePowerSave(RSI_SLEEP_MODE_8, DEEP_SLEEP_WITH_RAM_RETENTION, 0));
+    return CHIP_NO_ERROR;
+}
+
+/**
+ * @brief Configures the Wi-Fi chip to go to High Performance.
+ *        Function doesn't change the broad cast filter configuration.
+ *
+ * @return CHIP_ERROR CHIP_NO_ERROR if the configuration of the Wi-Fi chip was successful; otherwise CHIP_ERROR_INTERNAL
+ */
+CHIP_ERROR ConfigureHighPerformance()
+{
+    ReturnLogErrorOnFailure(ConfigurePowerSave(RSI_ACTIVE, HIGH_PERFORMANCE, 0));
+    return CHIP_NO_ERROR;
+}
+#endif // SLI_SI917
+
+} // namespace
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+// Initialize the static instance
+WifiSleepManager WifiSleepManager::mInstance;
+
+CHIP_ERROR WifiSleepManager::Init()
+{
+    return VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent);
+}
+
+CHIP_ERROR WifiSleepManager::RequestHighPerformance()
+{
+    VerifyOrReturnError(mHighPerformanceRequestCounter < std::numeric_limits<uint8_t>::max(), CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "High performance request counter overflow"));
+
+    mHighPerformanceRequestCounter++;
+
+    // We don't do the mHighPerformanceRequestCounter check here; the check is in VerifyAndTransitionToLowPowerMode function
+    ReturnErrorOnFailure(VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiSleepManager::RemoveHighPerformanceRequest()
+{
+    VerifyOrReturnError(mHighPerformanceRequestCounter > 0, CHIP_NO_ERROR,
+                        ChipLogError(DeviceLayer, "Wi-Fi configuration already in low power mode"));
+
+    mHighPerformanceRequestCounter--;
+
+    // We don't do the mHighPerformanceRequestCounter check here; the check is in VerifyAndTransitionToLowPowerMode function
+    ReturnErrorOnFailure(VerifyAndTransitionToLowPowerMode(PowerEvent::kGenericEvent));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiSleepManager::HandlePowerEvent(PowerEvent event)
+{
+    switch (event)
+    {
+    case PowerEvent::kCommissioningComplete:
+        ChipLogProgress(AppServer, "WifiSleepManager: Handling Commissioning Complete Event");
+        mIsCommissioningInProgress = false;
+
+        // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
+        WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+        break;
+
+    case PowerEvent::kConnectivityChange:
+    case PowerEvent::kGenericEvent:
+        // No additional processing needed for these events at the moment
+        break;
+
+    default:
+        ChipLogError(AppServer, "Unknown Power Event");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
+{
+    ReturnErrorOnFailure(HandlePowerEvent(event));
+
+#if SLI_SI917 // 917 SoC & NCP
+    if (mHighPerformanceRequestCounter > 0)
+    {
+        return ConfigureHighPerformance();
+    }
+
+    if (mIsCommissioningInProgress)
+    {
+        // During commissioning, don't let the device to go to sleep
+        // This is needed to interrupt the sleep and retry to join the network
+        return CHIP_NO_ERROR;
+    }
+
+    // TODO: Clean this up when the Wi-Fi interface re-work is finished
+    wfx_wifi_provision_t wifiConfig;
+    wfx_get_wifi_provision(&wifiConfig);
+
+    if (!(wifiConfig.ssid[0] != 0))
+    {
+        return ConfigureDeepSleep();
+    }
+
+    return ConfigureDTIMBasedSleep();
+
+#else
+    ReturnErrorOnFailure(ConfigurePowerSave());
+    return CHIP_NO_ERROR;
+#endif
+}
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -26,7 +26,7 @@ namespace Silabs {
 
 /**
  * @brief WifiSleepManager is a singleton class that manages the sleep modes for Wi-Fi devices.
- *        The class contains the buisness logic associated with optimizing the sleep states based on the Matter SDK internal states
+ *        The class contains the business logic associated with optimizing the sleep states based on the Matter SDK internal states
  */
 class WifiSleepManager
 {

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -1,0 +1,137 @@
+
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+
+/**
+ * @brief WifiSleepManager is a singleton class that manages the sleep modes for Wi-Fi devices.
+ *        The class contains the buisness logic associated with optimizing the sleep states based on the Matter SDK internal states
+ */
+class WifiSleepManager
+{
+public:
+    WifiSleepManager(const WifiSleepManager &)             = delete;
+    WifiSleepManager & operator=(const WifiSleepManager &) = delete;
+
+    static WifiSleepManager & GetInstance() { return mInstance; }
+
+    enum class PowerEvent : uint8_t
+    {
+        kGenericEvent          = 0,
+        kCommissioningComplete = 1,
+        kConnectivityChange    = 2,
+    };
+
+    /**
+     * @brief Init function that configure the SleepManager APIs based on the type of ICD.
+     *        Function validates that the SleepManager configuration were correctly set as well.
+     *
+     *        Triggers an initial VerifyAndTransitionToLowPowerMode to set the initial sleep mode.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR if the device was transitionned to low power
+     *                    CHIP_ERROR_INTERNAL if an error occured
+     */
+    CHIP_ERROR Init();
+
+    inline void HandleCommissioningSessionStarted()
+    {
+        mIsCommissioningInProgress = true;
+
+        // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
+        // WifiSleepManager::GetInstance().RequestHighPerformance();
+    }
+
+    inline void HandleCommissioningSessionStopped()
+    {
+        mIsCommissioningInProgress = false;
+
+        // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
+        WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
+    }
+
+    /**
+     * @brief Public API to request the Wi-Fi chip to transition to High Performance.
+     *        Function increases the HighPerformance request counter to prevent the chip from going to sleep
+     *        while the Matter SDK is in a state that requires High Performance
+     *
+     *        It is not necessary to call VerifyAndTransitionToLowPowerMode after calling this function.
+     *        The API does the call after incrementing the HighPerformance request counter.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR if the chip was set to high performance or already in high performance
+     *                    CHIP_ERROR_INTERNAL, if the high performance configuration failed
+     */
+    CHIP_ERROR RequestHighPerformance();
+
+    /**
+     * @brief Public API to remove request to keep the Wi-Fi chip in High Performance.
+     *        If calling this function removes the last High performance request,
+     *        The chip will transition to sleep based on its lowest sleep level allowed
+     *
+     *
+     *        It is not necessary to call VerifyAndTransitionToLowPowerMode after calling this function.
+     *        The API does the call after decreasing the HighPerformance request counter.
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR if the req removal and sleep transition succeed
+     *                    CHIP_ERROR_INTERNAL, if the req removal or the transition to sleep failed
+     */
+    CHIP_ERROR RemoveHighPerformanceRequest();
+
+    /**
+     * @brief Public API to validate what is the lowest power mode the device can got to and transitions the device to the
+     *        determined low power state.
+     *
+     *        State machine logic:
+     *        1. If there are high performance requests, configure high performance mode.
+     *        2. If commissioning is in progress, configure DTIM based sleep.
+     *        3. If no commissioning is in progress and the device is unprovisioned, configure deep sleep.
+     *
+     * @param event PowerEvent triggering the Verify and transition to low power mode processing
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR if the device was transitionned to low power
+     *                    CHIP_ERROR_INTERNAL if an error occured
+     */
+    CHIP_ERROR VerifyAndTransitionToLowPowerMode(PowerEvent event);
+
+private:
+    WifiSleepManager()  = default;
+    ~WifiSleepManager() = default;
+
+    /**
+     * @brief Function to handle the power events before transitionning the device to the appropriate low power mode.
+     *
+     * @param event PowerEvent to handle
+     * @return CHIP_ERROR CHIP_NO_ERROR if the event was handled successfully
+     *                    CHIP_ERROR_INVALID_ARGUMENT if the event is not supported
+     */
+    CHIP_ERROR HandlePowerEvent(PowerEvent event);
+
+    static WifiSleepManager mInstance;
+
+    bool mIsCommissioningInProgress        = false;
+    uint8_t mHighPerformanceRequestCounter = 0;
+};
+
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -139,6 +139,30 @@ CHIP_ERROR ResetCounters()
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+CHIP_ERROR ConfigurePowerSave()
+{
+    int32_t status = RSI_SUCCESS;
+#ifdef RSI_BLE_ENABLE
+    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "BT Powersave Config Failed, Error Code : 0x%lX", status));
+#endif /* RSI_BLE_ENABLE */
+
+    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
+    VerifyOrReturnError(status == RSI_SUCCESS, CHIP_ERROR_INTERNAL,
+                        ChipLogError(DeviceLayer, "WLAN Powersave Config Failed, Error Code : 0x%lX", status));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter)
+{
+    // TODO: Implement Broadcast filtering. We do a silent failure to avoid causing problems in higher layers.
+    return CHIP_NO_ERROR;
+}
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 /******************************************************************
  * @fn   void rsi_wireless_driver_task_wrapper(void * argument)
  * @brief
@@ -780,36 +804,3 @@ int32_t wfx_rsi_send_data(void * p, uint16_t len)
 
     return status;
 }
-
-#if SL_ICD_ENABLED
-/*********************************************************************
- * @fn  sl_status_t wfx_power_save(void)
- * @brief
- *      Implements the power save in sleepy application
- * @param[in]  None
- * @return  SL_STATUS_OK if successful,
- *          SL_STATUS_FAIL otherwise
- ***********************************************************************/
-sl_status_t wfx_power_save(void)
-{
-    int32_t status;
-#ifdef RSI_BLE_ENABLE
-    status = rsi_bt_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "BT Powersave Config Failed, Error Code : 0x%lX", status);
-        return SL_STATUS_FAIL;
-    }
-#endif /* RSI_BLE_ENABLE */
-
-    status = rsi_wlan_power_save_profile(RSI_SLEEP_MODE_2, RSI_MAX_PSP);
-    if (status != RSI_SUCCESS)
-    {
-        ChipLogError(DeviceLayer, "Powersave Config Failed, Error Code : 0x%lX", status);
-        return SL_STATUS_FAIL;
-    }
-
-    ChipLogDetail(DeviceLayer, "Powersave Config Success");
-    return SL_STATUS_OK;
-}
-#endif /* SL_ICD_ENABLED */

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -432,6 +432,20 @@ CHIP_ERROR GetAccessPointExtendedInfo(wfx_wifi_scan_ext_t & info)
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_CONFIG_ENABLE_ICD_SERVER
+CHIP_ERROR ConfigurePowerSave()
+{
+    // TODO: Implement Power save configuration. We do a silent failure to avoid causing problems in higher layers.
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter)
+{
+    // TODO: Implement Broadcast filtering. We do a silent failure to avoid causing problems in higher layers.
+    return CHIP_NO_ERROR;
+}
+#endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
 /***************************************************************************
  * @brief
  * Creates WFX events processing task.


### PR DESCRIPTION
#### Description
PR adds the WifiSleepManager who's responsibility is to determine the lowest power mode the Wi-Fi chip can go to.

- PR centralises all the sleep mode buisness logic into the WifiSleepManager and exposes a set of public APIs consummers can use
- Initial refactor of the Power Save platform configuraiton APIs. Some of the APIs will be implemented the focus of the PR was to support the WifiSleepManager for the SiWx platform.
- Adds a missing dependency in the ICDConfigurationData class that was missed when the feature map was re-structured
https://github.com/project-chip/connectedhomeip/pull/37062

#### Testing

Manual testing with the 917 SoC of the commissioning flow to see the device change power states with the Silabs Energy profiler. Device successfully changed power states trough out the commissioning.
