### PR TITLE
[third-party] Add third_party/libdatachannel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,7 @@ updates:
       - dependency-name: "third_party/java_deps/repo"
       - dependency-name: "third_party/jlink/repo"
       - dependency-name: "third_party/jsoncpp/repo"
+      - dependency-name: "third_party/libdatachannel/repo"
       - dependency-name: "third_party/libwebsockets/repo"
       - dependency-name: "third_party/lwip/repo"
       - dependency-name: "third_party/mbed-mcu-boot/repo"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -215,11 +215,12 @@ jobs:
                 # Exclude all files under "third_party/"
                 files-ignore: |
                   third_party/
+
             - name: Clang-tidy validation
               # NOTE: clang-tidy crashes on CodegenDataModel_Write due to Nullable/std::optional check.
               #       See https://github.com/llvm/llvm-project/issues/97426
               env:
-                  ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+                  ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
               run: |
                   touch out/changed_files.txt
                   for file in ${ALL_CHANGED_FILES}; do

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,7 +226,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/sanitizers/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone|libdatachannel)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
                        --file-list-file out/changed_files.txt \
                        check \
                     "

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -218,7 +218,13 @@ jobs:
                   ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
               run: |
                   touch out/changed_files.txt
+
+                  # Loop over all changed files and filter out any that contain "third_party"
                   for file in ${ALL_CHANGED_FILES}; do
+                      if [[ "$file" == *"third_party"* ]]; then
+                          continue
+                      fi
+
                       echo "$file changed and will be considered for tidy"
                       echo "$file" >>out/changed_files.txt
                   done
@@ -226,7 +232,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/sanitizers/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write|QuieterReporting' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
                        --file-list-file out/changed_files.txt \
                        check \
                     "

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -211,6 +211,10 @@ jobs:
             - name: Find changed files
               id: changed-files
               uses: tj-actions/changed-files@v45
+              with:
+                # Exclude all files under "third_party/"
+                files-ignore: |
+                  third_party/**              
             - name: Clang-tidy validation
               # NOTE: clang-tidy crashes on CodegenDataModel_Write due to Nullable/std::optional check.
               #       See https://github.com/llvm/llvm-project/issues/97426
@@ -218,13 +222,7 @@ jobs:
                   ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
               run: |
                   touch out/changed_files.txt
-
-                  # Loop over all changed files and filter out any that contain "third_party"
                   for file in ${ALL_CHANGED_FILES}; do
-                      if [[ "$file" == *"third_party"* ]]; then
-                          continue
-                      fi
-
                       echo "$file changed and will be considered for tidy"
                       echo "$file" >>out/changed_files.txt
                   done

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
               with:
                 # Exclude all files under "third_party/"
                 files-ignore: |
-                  third_party/**              
+                  third_party/**
             - name: Clang-tidy validation
               # NOTE: clang-tidy crashes on CodegenDataModel_Write due to Nullable/std::optional check.
               #       See https://github.com/llvm/llvm-project/issues/97426

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -226,7 +226,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/sanitizers/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone|libdatachannel)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write|QuieterReporting' \
                        --file-list-file out/changed_files.txt \
                        check \
                     "

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
               with:
                 # Exclude all files under "third_party/"
                 files-ignore: |
-                  third_party/**
+                  third_party/
             - name: Clang-tidy validation
               # NOTE: clang-tidy crashes on CodegenDataModel_Write due to Nullable/std::optional check.
               #       See https://github.com/llvm/llvm-project/issues/97426

--- a/.gitmodules
+++ b/.gitmodules
@@ -349,3 +349,8 @@
 	path = third_party/re2/src
 	url = https://github.com/google/re2.git
 	platforms = linux,darwin
+[submodule "third_party/libdatachannel/repo"]
+	path = third_party/libdatachannel/repo
+	url = https://github.com/paullouisageneau/libdatachannel.git
+	platforms = linux
+	recursive = true

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -1,0 +1,155 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("libdatachannel_config") {
+  include_dirs = [
+    "repo/include",
+    "repo/include/rtc",
+  ]
+}
+
+config("libdatachannel_config_disable_warnings") {
+  cflags_cc = [
+    "-Wno-shadow",
+    "-Wno-unreachable-code",
+    "-Wno-non-virtual-dtor",
+    "-Wno-implicit-fallthrough",
+  ]
+}
+
+config("libdatachannel_config_enable_features") {
+  cflags_cc = [
+    "-fexceptions",
+    "-frtti",
+  ]
+}
+
+source_set("libdatachannel") {
+  include_dirs = [
+    "repo/src",
+    "repo/include/rtc",
+    "repo/deps/plog/include",
+    "repo/deps/usrsctp/usrsctplib",
+    "repo/deps/libjuice/include",
+    "repo/deps/libsrtp/include",
+  ]
+
+  # ---------------------------------------------------------------------------
+  # Source files from repo/src/*.cpp
+  # ---------------------------------------------------------------------------
+  sources = [
+    "repo/src/av1rtppacketizer.cpp",
+    "repo/src/candidate.cpp",
+    "repo/src/capi.cpp",
+    "repo/src/channel.cpp",
+    "repo/src/configuration.cpp",
+    "repo/src/datachannel.cpp",
+    "repo/src/description.cpp",
+    "repo/src/global.cpp",
+    "repo/src/h264rtpdepacketizer.cpp",
+    "repo/src/h264rtppacketizer.cpp",
+    "repo/src/h265nalunit.cpp",
+    "repo/src/h265rtpdepacketizer.cpp",
+    "repo/src/h265rtppacketizer.cpp",
+    "repo/src/mediahandler.cpp",
+    "repo/src/message.cpp",
+    "repo/src/nalunit.cpp",
+    "repo/src/pacinghandler.cpp",
+    "repo/src/peerconnection.cpp",
+    "repo/src/plihandler.cpp",
+    "repo/src/rembhandler.cpp",
+    "repo/src/rtcpnackresponder.cpp",
+    "repo/src/rtcpreceivingsession.cpp",
+    "repo/src/rtcpsrreporter.cpp",
+    "repo/src/rtp.cpp",
+    "repo/src/rtpdepacketizer.cpp",
+    "repo/src/rtppacketizationconfig.cpp",
+    "repo/src/rtppacketizer.cpp",
+    "repo/src/track.cpp",
+    "repo/src/websocket.cpp",
+    "repo/src/websocketserver.cpp",
+  ]
+
+  # ---------------------------------------------------------------------------
+  # Source files from repo/src/impl/*.cpp
+  # ---------------------------------------------------------------------------
+  sources += [
+    "repo/src/impl/certificate.cpp",
+    "repo/src/impl/channel.cpp",
+    "repo/src/impl/datachannel.cpp",
+    "repo/src/impl/dtlssrtptransport.cpp",
+    "repo/src/impl/dtlstransport.cpp",
+    "repo/src/impl/http.cpp",
+    "repo/src/impl/httpproxytransport.cpp",
+    "repo/src/impl/icetransport.cpp",
+    "repo/src/impl/init.cpp",
+    "repo/src/impl/logcounter.cpp",
+    "repo/src/impl/peerconnection.cpp",
+    "repo/src/impl/pollinterrupter.cpp",
+    "repo/src/impl/pollservice.cpp",
+    "repo/src/impl/processor.cpp",
+    "repo/src/impl/sctptransport.cpp",
+    "repo/src/impl/sha.cpp",
+    "repo/src/impl/tcpserver.cpp",
+    "repo/src/impl/tcptransport.cpp",
+    "repo/src/impl/threadpool.cpp",
+    "repo/src/impl/tls.cpp",
+    "repo/src/impl/tlstransport.cpp",
+    "repo/src/impl/track.cpp",
+    "repo/src/impl/transport.cpp",
+    "repo/src/impl/utils.cpp",
+    "repo/src/impl/verifiedtlstransport.cpp",
+    "repo/src/impl/websocket.cpp",
+    "repo/src/impl/websocketserver.cpp",
+    "repo/src/impl/wshandshake.cpp",
+    "repo/src/impl/wstransport.cpp",
+  ]
+
+  public_configs = [ ":libdatachannel_config" ]
+  configs += [
+    ":libdatachannel_config_disable_warnings",
+    ":libdatachannel_config_enable_features",
+  ]
+
+  defines = [
+    "BUILD_SHARED_LIBS=1",  # default ON in the CMake
+    "BUILD_SHARED_DEPS_LIBS=0",  # default OFF
+    "USE_GNUTLS=0",  # default OFF => no GnuTLS
+    "USE_MBEDTLS=0",  # default OFF => no MbedTLS
+    "USE_NICE=0",  # default OFF => no libnice
+    "PREFER_SYSTEM_LIB=0",  # default OFF
+    "USE_SYSTEM_SRTP=0",  # default from PREFER_SYSTEM_LIB
+    "USE_SYSTEM_JUICE=0",
+    "USE_SYSTEM_USRSCTP=0",
+    "USE_SYSTEM_PLOG=0",
+    "USE_SYSTEM_JSON=0",
+    "NO_WEBSOCKET=0",  # default OFF => websockets on
+    "NO_MEDIA=0",  # default OFF => media on
+    "NO_EXAMPLES=0",  # default OFF
+    "NO_TESTS=0",  # default OFF
+    "WARNINGS_AS_ERRORS=0",  # default OFF
+    "CAPI_STDCALL=0",  # default OFF
+    "SCTP_DEBUG=0",  # default OFF
+    "RTC_UPDATE_VERSION_HEADER=0",  # default OFF
+
+    # Because NO_WEBSOCKET=0 => RTC_ENABLE_WEBSOCKET=1
+    "RTC_ENABLE_WEBSOCKET=1",
+
+    # Because NO_MEDIA=0 => RTC_ENABLE_MEDIA=1
+    "RTC_ENABLE_MEDIA=1",
+
+    # Because USE_SYSTEM_SRTP=0 => RTC_SYSTEM_SRTP=0
+    "RTC_SYSTEM_SRTP=0",
+  ]
+}


### PR DESCRIPTION
####  Change overview

We plan to use libdatachannel as the WebRTC lib for camera feature, add third_party/libdatachannel, passed the legal review.
- Add third_party/libdatachannel
- Add GN build file

#### Testing

The camera example app is still in progress, tested with chip-tool by adding libdatachannel as the public dependency
