### PR TITLE
Stop logging the Wi-Fi SSID in MTRCommissioningParameters.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -47,14 +47,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description
 {
-    // SSID is not required to be UTF-8, but almost always is.
-    NSString * ssidString;
-    if (self.wifiSSID) {
-        ssidString = [[NSString alloc] initWithData:self.wifiSSID encoding:NSUTF8StringEncoding];
-    } else {
-        ssidString = nil;
-    }
-    return [NSString stringWithFormat:@"<MTRCommissioningParameters: %p ssid: %@>", self, ssidString];
+    return [NSString stringWithFormat:@"<MTRCommissioningParameters: %p, has ssid: %d, has thread dataset: %d>", self,
+                     self.wifiSSID != nil, self.threadOperationalDataset != nil];
 }
 
 @end


### PR DESCRIPTION
Just log whether we have one at all.

#### Testing

Logging only.