### PR TITLE
[Silabs] Move LwIP specific functions out of the WifiInterface

### DIFF
--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -149,6 +149,7 @@ source_set("wifi-platform") {
       "${silabs_platform_dir}/wifi/lwip-support/ethernetif.cpp",
       "${silabs_platform_dir}/wifi/lwip-support/ethernetif.h",
       "${silabs_platform_dir}/wifi/lwip-support/lwip_netif.cpp",
+      "${silabs_platform_dir}/wifi/lwip-support/lwip_netif.h",
     ]
   }
 

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -616,8 +616,7 @@ void HandleDHCPPolling(void)
     uint8_t dhcp_state = dhcpclient_poll(sta_netif);
     if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !HasNotifiedIPv4Change())
     {
-        wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
-        NotifyIPv4Change(true);
+        GotIPv4Address((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
         event = WifiPlatformEvent::kStationDhcpDone;
         PostWifiPlatformEvent(event);
         NotifyConnectivity();
@@ -845,29 +844,3 @@ CHIP_ERROR ConfigureBroadcastFilter(bool enableBroadcastFilter)
     return CHIP_NO_ERROR;
 }
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
-
-#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
-/********************************************************************************************
- * @fn   void wfx_dhcp_got_ipv4(uint32_t ip)
- * @brief
- *        Acquire the new ip address
- * @param[in] ip: internet protocol
- * @return
- *        None
- **********************************************************************************************/
-void wfx_dhcp_got_ipv4(uint32_t ip)
-{
-    /*
-     * Acquire the new IP address
-     */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
-    wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
-    wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
-    wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;
-    ChipLogDetail(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
-                  wfx_rsi.ip4_addr[3]);
-    /* Notify the Connectivity Manager - via the app */
-    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone).Set(WifiState::kStationReady);
-    NotifyIPv4Change(true);
-}
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */

--- a/src/platform/silabs/wifi/WifiInterface.cpp
+++ b/src/platform/silabs/wifi/WifiInterface.cpp
@@ -31,6 +31,9 @@ using namespace chip::DeviceLayer;
 
 #define CONVERT_SEC_TO_MS(TimeInS) (TimeInS * 1000)
 
+// TODO: We shouldn't need to have access to a global variable in the interface here
+extern WfxRsi_t wfx_rsi;
+
 // TODO: This is a workaround because we depend on the platform lib which depends on the platform implementation.
 //       As such we can't depend on the platform here as well
 extern void HandleWFXSystemEvent(sl_wfx_generic_message_t * eventData);

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -166,9 +166,6 @@ typedef struct wfx_rsi_s
     uint8_t ip4_addr[4]; /* Not sure if this is enough */
 } WfxRsi_t;
 
-// TODO: We shouldn't need to have access to a global variable in the interface here
-extern WfxRsi_t wfx_rsi;
-
 /* Updated functions */
 
 /**
@@ -393,7 +390,4 @@ void wfx_cancel_scan(void);
  */
 void sl_matter_wifi_task_started(void);
 
-#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
-void wfx_dhcp_got_ipv4(uint32_t);
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 void wfx_retry_connection(uint16_t retryAttempt);

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -26,12 +26,6 @@
 #include "sl_status.h"
 #include <stdbool.h>
 
-/* LwIP includes. */
-#include "lwip/ip_addr.h"
-#include "lwip/netif.h"
-#include "lwip/netifapi.h"
-#include "lwip/tcpip.h"
-
 #if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
 #include "rsi_common_apis.h"
 #include "sl_si91x_types.h"
@@ -399,34 +393,7 @@ void wfx_cancel_scan(void);
  */
 void sl_matter_wifi_task_started(void);
 
-/* Implemented for LWIP */
-void wfx_lwip_set_sta_link_up(void);
-void wfx_lwip_set_sta_link_down(void);
-void sl_matter_lwip_start(void);
-struct netif * wfx_get_netif(sl_wfx_interface_t interface);
-
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
 void wfx_dhcp_got_ipv4(uint32_t);
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 void wfx_retry_connection(uint16_t retryAttempt);
-
-#ifdef RS911X_WIFI
-#if !(EXP_BOARD) // for RS9116
-void * wfx_rsi_alloc_pkt(void);
-/* RSI for LWIP */
-void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off);
-int32_t wfx_rsi_send_data(void * p, uint16_t len);
-#endif //!(EXP_BOARD)
-#endif // RS911X_WIFI
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#ifdef WF200_WIFI
-void sl_wfx_host_gpio_init(void);
-#endif /* WF200_WIFI */
-
-#ifdef __cplusplus
-}
-#endif

--- a/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
+++ b/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
@@ -21,40 +21,26 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef WF200_WIFI
-#include "FreeRTOS.h"
-#include "event_groups.h"
-#include "task.h"
-#if (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-#ifdef __cplusplus
-extern "C" {
-#endif
-#include "cmsis_os2.h"
-#include "sl_net.h"
-#include "sl_si91x_driver.h"
-#include "sl_si91x_host_interface.h"
-#include "sl_si91x_types.h"
-#include "sl_wifi.h"
-#include "sl_wifi_callback_framework.h"
-#include "sl_wifi_constants.h"
-#include "sl_wifi_types.h"
-#ifdef __cplusplus
-}
-#endif
-#endif // (SLI_SI91X_MCU_INTERFACE | EXP_BOARD)
-#endif // WF200_WIFI
-
-#include <platform/silabs/wifi/WifiInterface.h>
-#ifdef WF200_WIFI
-#include "sl_wfx.h"
-#endif
-/* LwIP includes. */
-#include "ethernetif.h"
+// LwIP includes - Includes must be before the rsi headers due to redefination errors
 #include "lwip/ethip6.h"
 #include "lwip/timeouts.h"
 #include "netif/etharp.h"
 
+#ifdef RS911X_WIFI
+extern "C" {
+#include "rsi_driver.h"
+#include "rsi_pkt_mgmt.h"
+}
+#endif // RS911X_WIFI
+
+#ifdef WF200_WIFI
+#include "sl_wfx.h"
+#endif
+
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/silabs/wifi/WifiInterface.h>
+#include <platform/silabs/wifi/lwip-support/ethernetif.h>
+#include <platform/silabs/wifi/lwip-support/lwip_netif.h>
 
 StaticSemaphore_t xEthernetIfSemaBuffer;
 
@@ -286,7 +272,7 @@ void sl_wfx_host_received_frame_callback(sl_wfx_received_ind_t * rx_buffer)
     {
 
         /* Send received frame to station interface */
-        if ((netif = wfx_get_netif(SL_WFX_STA_INTERFACE)) != NULL)
+        if ((netif = chip::DeviceLayer::Silabs::Lwip::GetNetworkInterface(SL_WFX_STA_INTERFACE)) != NULL)
         {
             uint8_t * buffer;
             uint16_t len;
@@ -316,7 +302,92 @@ void sl_wfx_host_received_frame_callback(sl_wfx_received_ind_t * rx_buffer)
 }
 
 #else /* For RS911x - using LWIP */
+
 static SemaphoreHandle_t ethout_sem;
+
+/**
+ * @brief Allocates packets for the data bout to be sent
+ *
+ * TODO: Validate if this warning still applied and fix the associated code
+ * WARNING - Taken from RSI and broken up
+ * This is my own RSI stuff for not copying code and allocating an extra
+ * level of indirection - when using LWIP buffers
+ * see also: int32_t rsi_wlan_send_data_xx(uint8_t *buffer, uint32_t length)
+ *
+ * @return void* pointer to the allocated packet buffer
+ */
+static void * wfx_rsi_alloc_pkt(void)
+{
+    rsi_pkt_t * pkt;
+
+    // Allocate packet to send data
+    if ((pkt = rsi_pkt_alloc(&rsi_driver_cb->wlan_cb->wlan_tx_pool)) == NULL)
+    {
+        return (void *) 0;
+    }
+
+    return (void *) pkt;
+}
+
+/**
+ * @brief Adds the buffer data to the allocated packet.
+ *        the packet must be allocated before adding data to it.
+ *
+ * @param[in,out] p pointer to the allocated packet
+ * @param[in] buf pointer to the data buffer to copy to the packet
+ * @param[in] len length of the data buffer
+ * @param[in] off the offset at which to put the data in the packet
+ */
+void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off)
+{
+    rsi_pkt_t * pkt;
+
+    pkt = (rsi_pkt_t *) p;
+    memcpy(((char *) pkt->data) + off, buf, len);
+}
+
+/**
+ * @brief Triggers the packet to sent on the wire
+ *
+ * @param p pointer to the packet to send
+ * @param len length of the packet to send
+ *
+ * @return int32_t RSI_ERROR_NONE, if the packet was succesfully sent out
+ *                 RSI_ERROR_RESPONSE_TIMEOUT, if we are unable to acquire the semaphore of the status
+ *                 other error (< 0) if we were unable to send out the the packet
+ */
+int32_t wfx_rsi_send_data(void * p, uint16_t len)
+{
+    int32_t status;
+    uint8_t * host_desc;
+    rsi_pkt_t * pkt;
+
+    pkt       = (rsi_pkt_t *) p;
+    host_desc = pkt->desc;
+    memset(host_desc, 0, RSI_HOST_DESC_LENGTH);
+    rsi_uint16_to_2bytes(host_desc, (len & 0xFFF));
+
+    // Fill packet type
+    host_desc[1] |= (RSI_WLAN_DATA_Q << 4);
+    host_desc[2] |= 0x01;
+
+    rsi_enqueue_pkt(&rsi_driver_cb->wlan_tx_q, pkt);
+
+#ifndef RSI_SEND_SEM_BITMAP
+    rsi_driver_cb_non_rom->send_wait_bitmap |= BIT(0);
+#endif
+    // Set TX packet pending event
+    rsi_set_event(RSI_TX_EVENT);
+
+    if (rsi_wait_on_wlan_semaphore(&rsi_driver_cb_non_rom->send_data_sem, RSI_SEND_DATA_RESPONSE_WAIT_TIME) != RSI_ERROR_NONE)
+    {
+        return RSI_ERROR_RESPONSE_TIMEOUT;
+    }
+    status = rsi_wlan_get_status();
+
+    return status;
+}
+
 /*****************************************************************************
  *  @fn  static err_t low_level_output(struct netif *netif, struct pbuf *p)
  *  @brief
@@ -441,7 +512,7 @@ sl_status_t sl_si91x_host_process_data_frame(sl_wifi_interface_t interface, sl_w
     /* get the network interface for STATION interface,
      * and forward the received frame buffer to LWIP
      */
-    if ((ifp = wfx_get_netif(SL_WFX_STA_INTERFACE)) != (struct netif *) 0)
+    if ((ifp = GetNetworkInterface(SL_WFX_STA_INTERFACE)) != (struct netif *) 0)
     {
         low_level_input(ifp, rsi_pkt->data, rsi_pkt->length);
     }
@@ -465,7 +536,7 @@ void wfx_host_received_sta_frame_cb(uint8_t * buf, int len)
     /* get the network interface for STATION interface,
      * and forward the received frame buffer to LWIP
      */
-    if ((ifp = wfx_get_netif(SL_WFX_STA_INTERFACE)) != (struct netif *) 0)
+    if ((ifp = chip::DeviceLayer::Silabs::Lwip::GetNetworkInterface(SL_WFX_STA_INTERFACE)) != (struct netif *) 0)
     {
         low_level_input(ifp, buf, len);
     }

--- a/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
+++ b/src/platform/silabs/wifi/lwip-support/ethernetif.cpp
@@ -306,7 +306,7 @@ void sl_wfx_host_received_frame_callback(sl_wfx_received_ind_t * rx_buffer)
 static SemaphoreHandle_t ethout_sem;
 
 /**
- * @brief Allocates packets for the data bout to be sent
+ * @brief Allocates packets for the data about to be sent
  *
  * TODO: Validate if this warning still applied and fix the associated code
  * WARNING - Taken from RSI and broken up

--- a/src/platform/silabs/wifi/lwip-support/lwip_netif.cpp
+++ b/src/platform/silabs/wifi/lwip-support/lwip_netif.cpp
@@ -19,132 +19,104 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <platform/silabs/wifi/WifiInterface.h>
+#include "lwip/netifapi.h"
+#include "lwip/tcpip.h"
 
-#include "dhcp_client.h"
-#include "ethernetif.h"
+#include <platform/silabs/wifi/lwip-support/dhcp_client.h>
+#include <platform/silabs/wifi/lwip-support/ethernetif.h>
+#include <platform/silabs/wifi/lwip-support/lwip_netif.h>
 
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/silabs/wifi/WifiInterface.h>
 
-using namespace ::chip;
-using namespace ::chip::DeviceLayer;
+namespace {
 
-static struct netif sta_netif;
+constexpr uint8_t kLinkUp      = 1;
+constexpr uint8_t kLinkDown    = 0;
+constexpr uint8_t kMac48BitSet = 1;
 
-#ifdef SL_WFX_CONFIG_SOFTAP
-static struct netif ap_netif;
-#endif
+struct netif sStationNetworkInterface;
 
-#define LINK_UP (1)
-#define LINK_DOWN (0)
-#define MAC_48_BIT_SET (1)
-
-/****************************************************************************
- * @fn   static void netif_config(struct netif *sta_if, struct netif *ap_if)
- * @brief
- *      netif configuration
- * @param[in]  sta_if:
- * @param[in]  ap_if:
- * @return None
- *****************************************************************************/
-static void netif_config(struct netif * sta_if, struct netif * ap_if)
+/**
+ * @brief Configures the provided network interface
+ *
+ * @param[in] interface interface to be configured
+ */
+void ConfigureNetworkInterface(struct netif & interface)
 {
-    if (sta_if != NULL)
-    {
-#if LWIP_IPV4
-        ip_addr_t sta_ipaddr;
-        ip_addr_t sta_netmask;
-        ip_addr_t sta_gw;
 
-        /* Initialize the Station information */
-        ip_addr_set_zero_ip4(&sta_ipaddr);
-        ip_addr_set_zero_ip4(&sta_netmask);
-        ip_addr_set_zero_ip4(&sta_gw);
+#if LWIP_IPV4
+    ip_addr_t sta_ipaddr;
+    ip_addr_t sta_netmask;
+    ip_addr_t sta_gw;
+
+    /* Initialize the Station information */
+    ip_addr_set_zero_ip4(&sta_ipaddr);
+    ip_addr_set_zero_ip4(&sta_netmask);
+    ip_addr_set_zero_ip4(&sta_gw);
 #endif /* LWIP_IPV4 */
 
-        /* Add station interfaces */
-        netif_add(sta_if,
+    /* Add station interfaces */
+    netif_add(&interface,
 #if LWIP_IPV4
-                  (const ip4_addr_t *) &sta_ipaddr, (const ip4_addr_t *) &sta_netmask, (const ip4_addr_t *) &sta_gw,
+              (const ip4_addr_t *) &sta_ipaddr, (const ip4_addr_t *) &sta_netmask, (const ip4_addr_t *) &sta_gw,
 #endif /* LWIP_IPV4 */
-                  NULL, &sta_ethernetif_init, &tcpip_input);
+              NULL, &sta_ethernetif_init, &tcpip_input);
 
-        /* Registers the default network interface */
-        netif_set_default(sta_if);
-    }
+    /* Registers the default network interface */
+    netif_set_default(&interface);
 }
 
-/****************************************************************************
- * @fn  void wfx_lwip_set_sta_link_up(void)
- * @brief
- * Set station link status to up.
- * @param[in]  None
- * @return None
- *****************************************************************************/
-void wfx_lwip_set_sta_link_up(void)
+} // namespace
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+namespace Lwip {
+
+void SetLwipStationLinkUp(void)
 {
-    netifapi_netif_set_up(&sta_netif);
-    netifapi_netif_set_link_up(&sta_netif);
+    netifapi_netif_set_up(&sStationNetworkInterface);
+    netifapi_netif_set_link_up(&sStationNetworkInterface);
 #if LWIP_IPV4 && LWIP_DHCP
-    dhcpclient_set_link_state(LINK_UP);
+    dhcpclient_set_link_state(kLinkUp);
 #endif /* LWIP_IPV4 && LWIP_DHCP */
     /*
      * Enable IPV6
      */
 
 #if LWIP_IPV6_AUTOCONFIG
-    sta_netif.ip6_autoconfig_enabled = 1;
+    sStationNetworkInterface.ip6_autoconfig_enabled = 1;
 #endif /* LWIP_IPV6_AUTOCONFIG */
-    netif_create_ip6_linklocal_address(&sta_netif, MAC_48_BIT_SET);
+    netif_create_ip6_linklocal_address(&sStationNetworkInterface, kMac48BitSet);
 }
 
-/***************************************************************************
- * @fn  void wfx_lwip_set_sta_link_down(void)
- * @brief
- * Set station link status to down.
- * @param[in] None
- * @return None
- *****************************************************************************/
-void wfx_lwip_set_sta_link_down(void)
+void SetLwipStationLinkDown(void)
 {
 #if LWIP_IPV4 && LWIP_DHCP
-    dhcpclient_set_link_state(LINK_DOWN);
+    dhcpclient_set_link_state(kLinkDown);
 #endif /* LWIP_IPV4 && LWIP_DHCP */
-    netifapi_netif_set_link_down(&sta_netif);
-    netifapi_netif_set_down(&sta_netif);
+    netifapi_netif_set_link_down(&sStationNetworkInterface);
+    netifapi_netif_set_down(&sStationNetworkInterface);
 }
 
-/***************************************************************************
- * @fn  void sl_matter_lwip_start(void)
- * @brief
- * Initialize the LwIP stack
- * @param[in] None
- * @return None
- *****************************************************************************/
-void sl_matter_lwip_start(void)
+void InitializeLwip(void)
 {
     /* Initialize the LwIP stack */
-    netif_config(&sta_netif, NULL);
+    ConfigureNetworkInterface(sStationNetworkInterface);
 }
 
-/***************************************************************************
- * @fn   struct netif *wfx_get_netif(sl_wfx_interface_t interface)
- * @brief
- * get the netif
- * @param[in] interface:
- * @return None
- *****************************************************************************/
-struct netif * wfx_get_netif(sl_wfx_interface_t interface)
+struct netif * GetNetworkInterface(sl_wfx_interface_t interface)
 {
     if (interface == SL_WFX_STA_INTERFACE)
     {
-        return &sta_netif;
+        return &sStationNetworkInterface;
     }
-#ifdef SL_WFX_CONFIG_SOFTAP
-    else if (interface == SL_WFX_SOFTAP_INTERFACE)
-    {
-        return &ap_netif;
-    }
-#endif
-    return (struct netif *) 0;
+
+    return nullptr;
 }
+
+} // namespace Lwip
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/wifi/lwip-support/lwip_netif.h
+++ b/src/platform/silabs/wifi/lwip-support/lwip_netif.h
@@ -1,0 +1,55 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <platform/silabs/wifi/WifiInterface.h>
+
+namespace chip {
+namespace DeviceLayer {
+namespace Silabs {
+namespace Lwip {
+
+/**
+ * @brief Set station link status to up
+ */
+void SetLwipStationLinkUp(void);
+
+/**
+ * @brief Set station link status to down
+ *
+ */
+void SetLwipStationLinkDown(void);
+
+/**
+ * @brief Initialize the LwIP stack
+ *
+ */
+void InitializeLwip(void);
+
+/**
+ * @brief Returns the requested network interface
+ *
+ * @param interface requested network interface
+ *
+ * @return struct netif* if the requested interface is not supported, returns nullptr
+ */
+struct netif * GetNetworkInterface(sl_wfx_interface_t interface);
+
+} // namespace Lwip
+} // namespace Silabs
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -506,8 +506,7 @@ void HandleDHCPPolling(void)
     uint8_t dhcp_state = dhcpclient_poll(sta_netif);
     if (dhcp_state == DHCP_ADDRESS_ASSIGNED && !HasNotifiedIPv4Change())
     {
-        wfx_dhcp_got_ipv4((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
-        NotifyIPv4Change(true);
+        GotIPv4Address((uint32_t) sta_netif->ip_addr.u_addr.ip4.addr);
         NotifyConnectivity();
     }
     else if (dhcp_state == DHCP_OFF)
@@ -692,29 +691,3 @@ void MatterWifiTask(void * arg)
         }
     }
 }
-
-#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
-/********************************************************************************************
- * @fn   void wfx_dhcp_got_ipv4(uint32_t ip)
- * @brief
- *        Acquire the new ip address
- * @param[in] ip: internet protocol
- * @return
- *        None
- **********************************************************************************************/
-void wfx_dhcp_got_ipv4(uint32_t ip)
-{
-    /*
-     * Acquire the new IP address
-     */
-    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
-    wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
-    wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
-    wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;
-    ChipLogProgress(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
-                    wfx_rsi.ip4_addr[3]);
-    /* Notify the Connectivity Manager - via the app */
-    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone, WifiState::kStationReady);
-    NotifyIPv4Change(true);
-}
-#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -27,6 +27,7 @@
 #include <platform/silabs/wifi/WifiInterface.h>
 #include <platform/silabs/wifi/lwip-support/dhcp_client.h>
 #include <platform/silabs/wifi/lwip-support/ethernetif.h>
+#include <platform/silabs/wifi/lwip-support/lwip_netif.h>
 #include <platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h>
 
 extern "C" {
@@ -493,7 +494,7 @@ void HandleDHCPPolling(void)
 {
     struct netif * sta_netif;
 
-    sta_netif = wfx_get_netif(SL_WFX_STA_INTERFACE);
+    sta_netif = chip::DeviceLayer::Silabs::Lwip::GetNetworkInterface(SL_WFX_STA_INTERFACE);
     if (sta_netif == NULL)
     {
         // TODO: Notify the application that the interface is not set up or Chipdie here because we
@@ -558,7 +559,7 @@ void ProcessEvent(WifiPlatformEvent event)
         ChipLogDetail(DeviceLayer, "WifiPlatformEvent::kStationConnect");
         wfx_rsi.dev_state.Set(WifiState::kStationConnected);
         ResetDHCPNotificationFlags();
-        wfx_lwip_set_sta_link_up();
+        chip::DeviceLayer::Silabs::Lwip::SetLwipStationLinkUp();
     }
     break;
     case WifiPlatformEvent::kStationDisconnect: {
@@ -569,7 +570,7 @@ void ProcessEvent(WifiPlatformEvent event)
         wfx_rsi.dev_state.Clear(flagsToClear);
         /* TODO: Implement disconnect notify */
         ResetDHCPNotificationFlags();
-        wfx_lwip_set_sta_link_down();
+        chip::DeviceLayer::Silabs::Lwip::SetLwipStationLinkDown();
 
 #if (CHIP_DEVICE_CONFIG_ENABLE_IPV4)
         NotifyIPv4Change(false);
@@ -611,8 +612,8 @@ void ProcessEvent(WifiPlatformEvent event)
             ap.security = static_cast<wfx_sec_t>(scan.security_mode);
             ap.rssi     = (-1) * scan.rssi_val;
 
-            configASSERT(sizeof(ap.bssid) == kWifiMacAddressLength);
-            configASSERT(sizeof(scan.bssid) == kWifiMacAddressLength);
+            VerifyOrDie(sizeof(ap.bssid) == kWifiMacAddressLength);
+            VerifyOrDie(sizeof(scan.bssid) == kWifiMacAddressLength);
 
             chip::MutableByteSpan bssidSpan(ap.bssid, kWifiMacAddressLength);
             chip::ByteSpan scanBssidSpan(scan.bssid, kWifiMacAddressLength);
@@ -674,7 +675,7 @@ void MatterWifiTask(void * arg)
 {
     (void) arg;
     WifiPlatformEvent event;
-    sl_matter_lwip_start();
+    chip::DeviceLayer::Silabs::Lwip::InitializeLwip();
     sl_matter_wifi_task_started();
 
     ChipLogProgress(DeviceLayer, "MatterWifiTask: starting event loop");
@@ -706,7 +707,7 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     /*
      * Acquire the new IP address
      */
-    wfx_rsi.ip4_addr[0] = (ip) &0xFF;
+    wfx_rsi.ip4_addr[0] = (ip) & 0xFF;
     wfx_rsi.ip4_addr[1] = (ip >> 8) & 0xFF;
     wfx_rsi.ip4_addr[2] = (ip >> 16) & 0xFF;
     wfx_rsi.ip4_addr[3] = (ip >> 24) & 0xFF;
@@ -717,90 +718,3 @@ void wfx_dhcp_got_ipv4(uint32_t ip)
     NotifyIPv4Change(true);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
-
-/*
- * WARNING - Taken from RSI and broken up
- * This is my own RSI stuff for not copying code and allocating an extra
- * level of indirection - when using LWIP buffers
- * see also: int32_t rsi_wlan_send_data_xx(uint8_t *buffer, uint32_t length)
- */
-/********************************************************************************************
- * @fn   void *wfx_rsi_alloc_pkt(void)
- * @brief
- *       Allocate packet to send data
- * @param[in] None
- * @return
- *        None
- **********************************************************************************************/
-void * wfx_rsi_alloc_pkt(void)
-{
-    rsi_pkt_t * pkt;
-
-    // Allocate packet to send data
-    if ((pkt = rsi_pkt_alloc(&rsi_driver_cb->wlan_cb->wlan_tx_pool)) == NULL)
-    {
-        return (void *) 0;
-    }
-
-    return (void *) pkt;
-}
-
-/********************************************************************************************
- * @fn   void wfx_rsi_pkt_add_data(void *p, uint8_t *buf, uint16_t len, uint16_t off)
- * @brief
- *       add the data into packet
- * @param[in]  p:
- * @param[in]  buf:
- * @param[in]  len:
- * @param[in]  off:
- * @return
- *        None
- **********************************************************************************************/
-void wfx_rsi_pkt_add_data(void * p, uint8_t * buf, uint16_t len, uint16_t off)
-{
-    rsi_pkt_t * pkt;
-
-    pkt = (rsi_pkt_t *) p;
-    memcpy(((char *) pkt->data) + off, buf, len);
-}
-
-/********************************************************************************************
- * @fn   int32_t wfx_rsi_send_data(void *p, uint16_t len)
- * @brief
- *       Driver send a data
- * @param[in]  p:
- * @param[in]  len:
- * @return
- *        None
- **********************************************************************************************/
-int32_t wfx_rsi_send_data(void * p, uint16_t len)
-{
-    int32_t status;
-    uint8_t * host_desc;
-    rsi_pkt_t * pkt;
-
-    pkt       = (rsi_pkt_t *) p;
-    host_desc = pkt->desc;
-    memset(host_desc, 0, RSI_HOST_DESC_LENGTH);
-    rsi_uint16_to_2bytes(host_desc, (len & 0xFFF));
-
-    // Fill packet type
-    host_desc[1] |= (RSI_WLAN_DATA_Q << 4);
-    host_desc[2] |= 0x01;
-
-    rsi_enqueue_pkt(&rsi_driver_cb->wlan_tx_q, pkt);
-
-#ifndef RSI_SEND_SEM_BITMAP
-    rsi_driver_cb_non_rom->send_wait_bitmap |= BIT(0);
-#endif
-    // Set TX packet pending event
-    rsi_set_event(RSI_TX_EVENT);
-
-    if (rsi_wait_on_wlan_semaphore(&rsi_driver_cb_non_rom->send_data_sem, RSI_SEND_DATA_RESPONSE_WAIT_TIME) != RSI_ERROR_NONE)
-    {
-        return RSI_ERROR_RESPONSE_TIMEOUT;
-    }
-    status = rsi_wlan_get_status();
-
-    return status;
-}

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -33,6 +33,8 @@
 #include <platform/silabs/wifi/WifiInterface.h>
 #include <platform/silabs/wifi/lwip-support/dhcp_client.h>
 #include <platform/silabs/wifi/lwip-support/ethernetif.h>
+#include <platform/silabs/wifi/lwip-support/lwip_netif.h>
+#include <platform/silabs/wifi/wf200/ncp/efr_spi.h>
 #include <platform/silabs/wifi/wf200/ncp/sl_wfx_board.h>
 #include <platform/silabs/wifi/wf200/ncp/sl_wfx_host.h>
 #include <platform/silabs/wifi/wf200/ncp/sl_wfx_task.h>
@@ -828,7 +830,7 @@ static void wfx_events_task(void * p_arg)
     EventBits_t flags;
     (void) p_arg;
 
-    sta_netif      = wfx_get_netif(SL_WFX_STA_INTERFACE);
+    sta_netif      = chip::DeviceLayer::Silabs::Lwip::GetNetworkInterface(SL_WFX_STA_INTERFACE);
     last_dhcp_poll = xTaskGetTickCount();
     while (true)
     {
@@ -891,7 +893,7 @@ static void wfx_events_task(void * p_arg)
             ChipLogProgress(DeviceLayer, "connected to AP");
             wifi_extra.Set(WifiState::kStationConnected);
             retryJoin = 0;
-            wfx_lwip_set_sta_link_up();
+            chip::DeviceLayer::Silabs::Lwip::SetLwipStationLinkUp();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
             if (!(wifi_extra.Has(WifiState::kAPReady)))
             {
@@ -912,7 +914,7 @@ static void wfx_events_task(void * p_arg)
             NotifyIPv6Change(false);
             hasNotifiedWifiConnectivity = false;
             wifi_extra.Clear(WifiState::kStationConnected);
-            wfx_lwip_set_sta_link_down();
+            chip::DeviceLayer::Silabs::Lwip::SetLwipStationLinkDown();
         }
 
         if (flags & SL_WFX_SCAN_START)
@@ -1046,7 +1048,7 @@ static sl_status_t wfx_wifi_hw_start(void)
 
     /* Initialize the LwIP stack */
     ChipLogDetail(DeviceLayer, "WF200:Start LWIP");
-    sl_matter_lwip_start();
+    chip::DeviceLayer::Silabs::Lwip::InitializeLwip();
     sl_matter_wifi_task_started();
 
     ChipLogDetail(DeviceLayer, "WF200:ready.");

--- a/src/platform/silabs/wifi/wf200/ncp/efr_spi.c
+++ b/src/platform/silabs/wifi/wf200/ncp/efr_spi.c
@@ -33,6 +33,7 @@
 #include "sl_wfx_task.h"
 #include "spidrv.h"
 #include <platform/silabs/wifi/ncp/spi_multiplex.h>
+#include <platform/silabs/wifi/wf200/ncp/efr_spi.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -324,9 +325,6 @@ static void sl_wfx_spi_wakeup_irq_callback(uint8_t irqNumber)
     portYIELD_FROM_ISR(bus_task_woken);
 }
 
-/****************************************************************************
- * Init some actions pins to the WF-200 expansion board
- *****************************************************************************/
 void sl_wfx_host_gpio_init(void)
 {
     // Enable GPIO clock.
@@ -354,6 +352,7 @@ void sl_wfx_host_gpio_init(void)
     NVIC_SetPriority(GPIO_EVEN_IRQn, 5);
     NVIC_SetPriority(GPIO_ODD_IRQn, 5);
 }
+
 #if SL_SPICTRL_MUX
 void SPIDRV_SetBaudrate(uint32_t baudrate)
 {

--- a/src/platform/silabs/wifi/wf200/ncp/efr_spi.h
+++ b/src/platform/silabs/wifi/wf200/ncp/efr_spi.h
@@ -1,0 +1,29 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Init some actions pins to the WF-200 expansion board
+ */
+void sl_wfx_host_gpio_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/platform/silabs/wifi/wf200/wf200.gni
+++ b/src/platform/silabs/wifi/wf200/wf200.gni
@@ -21,6 +21,7 @@ wf200_plat_src = [
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.c",
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/wf200_init.c",
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/efr_spi.c",
+  "${chip_root}/src/platform/silabs/wifi/wf200/ncp/efr_spi.h",
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/sl_wfx_board.h",
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/sl_wfx_host.h",
   "${chip_root}/src/platform/silabs/wifi/wf200/ncp/sl_wfx_task.h",

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -181,6 +181,24 @@ void ResetDHCPNotificationFlags(void)
     PostWifiPlatformEvent(event);
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_IPV4
+void GotIPv4Address(uint32_t ip)
+{
+    // Acquire the new IP address
+    for (int i = 0; i < 4; ++i)
+    {
+        wfx_rsi.ip4_addr[i] = (ip >> (i * 8)) & 0xFF;
+    }
+
+    ChipLogDetail(DeviceLayer, "DHCP OK: IP=%d.%d.%d.%d", wfx_rsi.ip4_addr[0], wfx_rsi.ip4_addr[1], wfx_rsi.ip4_addr[2],
+                  wfx_rsi.ip4_addr[3]);
+
+    // Notify the Connectivity Manager - via the app
+    wfx_rsi.dev_state.Set(WifiState::kStationDhcpDone).Set(WifiState::kStationReady);
+    NotifyIPv4Change(true);
+}
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
+
 /*********************************************************************
  * @fn  void wfx_set_wifi_provision(wfx_wifi_provision_t *cfg)
  * @brief

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -112,3 +112,10 @@ void PostWifiPlatformEvent(WifiPlatformEvent event);
  * @param[in] arg context pointer
  */
 void MatterWifiTask(void * arg);
+
+/**
+ * @brief Updates the IPv4 address in the Wi-Fi interface and notifies the application layer about the new IP address.
+ *
+ * @param[in] ip New IPv4 address
+ */
+void GotIPv4Address(uint32_t ip)

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.h
@@ -118,4 +118,4 @@ void MatterWifiTask(void * arg);
  *
  * @param[in] ip New IPv4 address
  */
-void GotIPv4Address(uint32_t ip)
+void GotIPv4Address(uint32_t ip);


### PR DESCRIPTION
#### Description
PR continues the on-going Wi-Fi interface refactor. PR moves out all LwIP specific functions out of the WifiInterface and to the LwIP specific sources.

PR has no functional changes other than cleanin up certain functions and constants.

#### Testing
To validate LwIP function still worked, commissioned the WF200 and sent commands since this Wi-Fi platform uses the LwIP sources.
