### PR TITLE
Adjust documentation script name and images.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ external_content_contents = [
     (MATTER_BASE, "examples/**/*.JPG"),
     (MATTER_BASE, "src/tools/**/*.md"),
     (MATTER_BASE, "scripts/tools/**/*.md"),
+    (MATTER_BASE, "scripts/tools/**/*.png"),
 ]
 external_content_link_prefixes = [
     "src/",

--- a/scripts/tools/ELF_SIZE_TOOLING.md
+++ b/scripts/tools/ELF_SIZE_TOOLING.md
@@ -26,7 +26,7 @@ you can build the master branch of a binary and save it somewhere like
 Example runs:
 
 ```
-> ~/devel/chip-scripts/bindiff.py \
+> ./scripts/tools/binary_elf_size_diff.py \
   ./out/qpg-qpg6105-light/chip-qpg6105-lighting-example.out \
   ./out/qpg-master.out
 
@@ -46,7 +46,7 @@ TOTAL       -34
 ```
 
 ```
-> ~/devel/chip-scripts/bindiff.py \
+> ./scripts/tools/binary_elf_size_diff.py \
   --output csv --skip-total       \
   ./out/qpg-qpg6105-light/chip-qpg6105-lighting-example.out ./out/qpg-master.out
 


### PR DESCRIPTION
This fixes some copy & paste typos from temporary development of size scripts. Also fixes the display of images for the tool examples (the gh pages upload did not have the corresponding png).


#### Testing

Trivial change. CI will validate that docs build, however will check https://project-chip.github.io/connectedhomeip-doc/scripts/tools/ELF_SIZE_TOOLING.html afterwards (right now the image is broken).