### PR TITLE
Remove zzz generated and a few more useless directories from clang coverage

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -654,6 +654,7 @@ class HostBuilder(GnBuilder):
                 + f' | xargs -I @ echo -object {shlex.quote(os.path.join(self.output_dir, "tests", "@"))}'
                 + f' | xargs -n 10240 llvm-cov export -format=lcov --instr-profile {_indexed_instrumentation} '
                 + ' --ignore-filename-regex "/third_party/"'
+                    + ' --ignore-filename-regex "/zzz_generated/"'  # NOTE: about 75K lines with almost 0% coverage ...
                 + ' --ignore-filename-regex "/tests/"'
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -653,12 +653,17 @@ class HostBuilder(GnBuilder):
                 + ' | xargs -n1 basename | sed "s/\\.profraw//" '
                 + f' | xargs -I @ echo -object {shlex.quote(os.path.join(self.output_dir, "tests", "@"))}'
                 + f' | xargs -n 10240 llvm-cov export -format=lcov --instr-profile {_indexed_instrumentation} '
+                # only care about SDK code. third_party is not considered sdk
                 + ' --ignore-filename-regex "/third_party/"'
-                + ' --ignore-filename-regex "/zzz_generated/"'      # about 75K lines with almost 0% coverage ...
-                + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'  # generated interface files. about 8K lines with little coverage
+                # about 75K lines with almost 0% coverage
+                + ' --ignore-filename-regex "/zzz_generated/"'
+                # generated interface files. about 8K lines with little coverage
+                + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'
                 # 100% coverage for 1K lines, but not relevant (test code)
                 + ' --ignore-filename-regex "/out/.*/clang_static_coverage_config/"'
+                # Tests are likely 100% or close to, want to see only "functionality tested"
                 + ' --ignore-filename-regex "/tests/"'
+                # Ignore system includes
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'
                 + f' | cat >{shlex.quote(_lcov_data)}'

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -656,7 +656,7 @@ class HostBuilder(GnBuilder):
                 + ' --ignore-filename-regex "/third_party/"'
                 + ' --ignore-filename-regex "/zzz_generated/"'      # about 75K lines with almost 0% coverage ...
                 + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'  # generated interface files. about 8K lines with little coverage
-                + ' --ignore-filename-regex "/out/clang_static_coverage_config/"'  # 100% coverage for 1K lines, but not relevant (test code)
+                + ' --ignore-filename-regex "/out/.*/clang_static_coverage_config/"'  # 100% coverage for 1K lines, but not relevant (test code)
                 + ' --ignore-filename-regex "/tests/"'
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -654,7 +654,8 @@ class HostBuilder(GnBuilder):
                 + f' | xargs -I @ echo -object {shlex.quote(os.path.join(self.output_dir, "tests", "@"))}'
                 + f' | xargs -n 10240 llvm-cov export -format=lcov --instr-profile {_indexed_instrumentation} '
                 + ' --ignore-filename-regex "/third_party/"'
-                    + ' --ignore-filename-regex "/zzz_generated/"'  # NOTE: about 75K lines with almost 0% coverage ...
+                + ' --ignore-filename-regex "/zzz_generated/"'      # about 75K lines with almost 0% coverage ...
+                + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'  # generated interface files. about 8K lines with little coverage
                 + ' --ignore-filename-regex "/tests/"'
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -656,7 +656,8 @@ class HostBuilder(GnBuilder):
                 + ' --ignore-filename-regex "/third_party/"'
                 + ' --ignore-filename-regex "/zzz_generated/"'      # about 75K lines with almost 0% coverage ...
                 + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'  # generated interface files. about 8K lines with little coverage
-                + ' --ignore-filename-regex "/out/.*/clang_static_coverage_config/"'  # 100% coverage for 1K lines, but not relevant (test code)
+                # 100% coverage for 1K lines, but not relevant (test code)
+                + ' --ignore-filename-regex "/out/.*/clang_static_coverage_config/"'
                 + ' --ignore-filename-regex "/tests/"'
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -656,6 +656,7 @@ class HostBuilder(GnBuilder):
                 + ' --ignore-filename-regex "/third_party/"'
                 + ' --ignore-filename-regex "/zzz_generated/"'      # about 75K lines with almost 0% coverage ...
                 + ' --ignore-filename-regex "/out/.*/Linux/dbus/"'  # generated interface files. about 8K lines with little coverage
+                + ' --ignore-filename-regex "/out/clang_static_coverage_config/"'  # 100% coverage for 1K lines, but not relevant (test code)
                 + ' --ignore-filename-regex "/tests/"'
                 + ' --ignore-filename-regex "/usr/include/"'
                 + ' --ignore-filename-regex "/usr/lib/"'


### PR DESCRIPTION
zzz_generated is 75K non-tested lines:

![bad_coverage](https://github.com/user-attachments/assets/b6c00107-a0c2-4a44-985a-91c3264fcb12)

Out also contains dbus (not tested and meaningless) and clang-coverage support files (100% covered, but skews results to be meaningless).

#### Testing

Ran clang coverage report, it looks reasonable now:

![image](https://github.com/user-attachments/assets/6f111668-434f-443c-bcfd-70a0f298957b)


