### PR TITLE
Fix Android cmdline-tools paths in VSCode docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -54,9 +54,9 @@ RUN curl https://raw.githubusercontent.com/restyled-io/restyler/master/bin/resty
     && chmod +x /usr/local/bin/restyle-path \
     && :
 
-RUN mkdir -p /opt/sdk/sdks/ \
+RUN mkdir -p /opt/android/sdk \
     && chown -R $USERNAME:$USERNAME \
-    /opt/sdk/sdks/ `# NXP uses a patch_sdk script to change SDK files` \
+    /opt/android/sdk `# NXP uses a patch_sdk script to change SDK files` \
     $ANDROID_HOME \
     $IDF_TOOLS_PATH \
     && find $AMEBA_PATH -name "inc_lp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
@@ -64,14 +64,14 @@ RUN mkdir -p /opt/sdk/sdks/ \
     && find $AMEBA_PATH -name "project_lp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
     && find $AMEBA_PATH -name "project_hp" -print0 | xargs -0 chown -R $USERNAME:$USERNAME \
     && chmod -R +x \
-    $ANDROID_HOME/tools/bin `# sdkmanager for accepting licenses`\
+    $ANDROID_HOME/cmdline-tools/10.0/bin `# sdkmanager for accepting licenses`\
     && chmod -R +w \
     $IDF_TOOLS_PATH \
     && find $AMEBA_PATH -name "inc_lp" -print0 | xargs -0 chmod -R +w \
     && find $AMEBA_PATH -name "inc_hp" -print0 | xargs -0 chmod -R +w \
     && find $AMEBA_PATH -name "project_lp" -print0 | xargs -0 chmod -R +w \
     && find $AMEBA_PATH -name "project_hp" -print0 | xargs -0 chmod -R +w \
-    # Safe directory is preffered over chown.
+    # Safe directory is preferred over chown.
     && git config --global --add safe.directory "*" \
     && :
 


### PR DESCRIPTION
### Problem

On trying to open the docker container using VSCode, we were seeing the following error:

```
=> ERROR [5/6] RUN mkdir -p /opt/sdk/sdks/     && chown -R vscode:vscod  28.7s
------
 > [5/6] RUN mkdir -p /opt/sdk/sdks/     && chown -R vscode:vscode     /opt/sdk/sdks/ `# NXP uses a patch_sdk script to change SDK files`     /opt/android/sdk     /opt/espressif/tools     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "inc_lp" -print0 | xargs -0 chown -R vscode:vscode     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "inc_hp" -print0 | xargs -0 chown -R vscode:vscode     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "project_lp" -print0 | xargs -0 chown -R vscode:vscode     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "project_hp" -print0 | xargs -0 chown -R vscode:vscode     && chmod -R +x     /opt/android/sdk/tools/bin `# sdkmanager for accepting licenses`    && chmod -R +w     /opt/espressif/tools     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "inc_lp" -print0 | xargs -0 chmod -R +w     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "inc_hp" -print0 | xargs -0 chmod -R +w     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "project_lp" -print0 | xargs -0 chmod -R +w     && find /opt/ameba/ambd_sdk_with_chip_non_NDA -name "project_hp" -print0 | xargs -0 chmod -R +w     && git config --global --add safe.directory "*"     && ::
28.64 chmod: cannot access '/opt/android/sdk/tools/bin': No such file or directory
```

### Change description
Android cmdline-tools path seem to have shifted. See https://github.com/project-chip/connectedhomeip/pull/37341/files 
This change updates the paths to match these: https://github.com/project-chip/connectedhomeip/blob/5065dd99e83e7b8838c8105ffdd88539fc46b0fb/integrations/docker/images/stage-3/chip-build-android/Dockerfile#L26-L38

#### Testing

Opened the docker container in VSCode successfully after the change to the Dockerfile