### PR TITLE
Avoid always re-generating output file in clang coverage driver

### DIFF
--- a/scripts/build/clang_coverage_wrapper.py
+++ b/scripts/build/clang_coverage_wrapper.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
+import sys
 
 import click
 import coloredlogs
@@ -80,9 +82,17 @@ def main(log_level, no_log_timestamps, output, raw_profile_filename):
         log_fmt = "%(levelname)-7s %(message)s"
     coloredlogs.install(level=__LOG_LEVELS__[log_level], fmt=log_fmt)
 
+    expected_output = jinja2.Template(_CPP_TEMPLATE).render(raw_profile_filename=raw_profile_filename)
+    if os.path.exists(output):
+        with open(output, 'rt') as f:
+            if f.read() == expected_output:
+                logging.info("File %s is already as expected. Will not re-write", output)
+                sys.exit(0)
+
+
     logging.info("Writing output to %s (profile name: %s)", output, raw_profile_filename)
     with open(output, "wt") as f:
-        f.write(jinja2.Template(_CPP_TEMPLATE).render(raw_profile_filename=raw_profile_filename))
+        f.write(expected_output)
 
     logging.debug("Writing completed")
 

--- a/scripts/build/clang_coverage_wrapper.py
+++ b/scripts/build/clang_coverage_wrapper.py
@@ -89,7 +89,6 @@ def main(log_level, no_log_timestamps, output, raw_profile_filename):
                 logging.info("File %s is already as expected. Will not re-write", output)
                 sys.exit(0)
 
-
     logging.info("Writing output to %s (profile name: %s)", output, raw_profile_filename)
     with open(output, "wt") as f:
         f.write(expected_output)


### PR DESCRIPTION
This may avoid some re-builds if our tooling just looks at file timestamps.

#### Testing

Ran build of `linux-x64-tests-clang-coverage` 2 times, observed 2nd time did not re-compile files.