### PR TITLE
Pass the arg of GetPrimaryOrFallbackMACAddress by reference.

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -170,7 +170,7 @@ void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 }
 #endif
 
-void DnssdServer::GetPrimaryOrFallbackMACAddress(chip::MutableByteSpan mac)
+void DnssdServer::GetPrimaryOrFallbackMACAddress(MutableByteSpan & mac)
 {
     if (ConfigurationMgr().GetPrimaryMACAddress(mac) != CHIP_NO_ERROR)
     {

--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -168,7 +168,7 @@ private:
     // Our randomly-generated fallback "MAC address", in case we don't have a real one.
     uint8_t mFallbackMAC[chip::DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength] = { 0 };
 
-    void GetPrimaryOrFallbackMACAddress(chip::MutableByteSpan mac);
+    void GetPrimaryOrFallbackMACAddress(MutableByteSpan & mac);
 
     //
     // Check if we have any valid operational credentials present in the fabric table and return true

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -94,7 +94,7 @@ public:
     // Copies the primary MAC into a mutable span, which must be of size kPrimaryMACAddressLength.
     // Upon success, the span will be reduced to the size of the MAC address being returned, which
     // can be less than kPrimaryMACAddressLength on a device that supports Thread.
-    virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) = 0;
+    virtual CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) = 0;
 
     // Copies the primary WiFi MAC into a buffer of size kEthernetMACAddressLength
     virtual CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) = 0;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -69,7 +69,7 @@ public:
     CHIP_ERROR GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & buildTime) override;
     CHIP_ERROR SetFirmwareBuildChipEpochTime(System::Clock::Seconds32 buildTime) override;
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override;
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override;
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override;
     CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -369,7 +369,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimaryWiFiMACAddres
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimaryMACAddress(MutableByteSpan buf)
+CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPrimaryMACAddress(MutableByteSpan & buf)
 {
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -312,7 +312,7 @@ CHIP_ERROR ConfigurationManagerImpl::StoreCountryCode(const char * code, size_t 
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
 
-CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan & buf)
 {
     if (GetPrimaryEthernetMACAddress(buf) == CHIP_NO_ERROR)
     {
@@ -322,7 +322,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan buf)
     return CHIP_ERROR_NOT_FOUND;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetPrimaryEthernetMACAddress(MutableByteSpan buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryEthernetMACAddress(MutableByteSpan & buf)
 {
     if (buf.size() < ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_BUFFER_TOO_SMALL;

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -70,8 +70,8 @@ private:
 
     CHIP_ERROR Init(void) override;
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
-    CHIP_ERROR GetPrimaryEthernetMACAddress(MutableByteSpan buf);
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override;
+    CHIP_ERROR GetPrimaryEthernetMACAddress(MutableByteSpan & buf);
 #endif
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override;
     bool CanFactoryReset(void) override;

--- a/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
@@ -38,7 +38,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan buf)
+CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan & buf)
 {
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.h
@@ -70,7 +70,7 @@ private:
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_ETHERNET
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override;
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override;
 #endif
 
     static void DoFactoryReset(intptr_t arg);

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -50,7 +50,7 @@ private:
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSoftwareVersion(uint32_t softwareVer) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreSerialNumber(const char * serialNum, size_t serialNumLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR GetPrimaryMACAddress(MutableByteSpan & buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetPrimaryWiFiMACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetPrimary802154MACAddress(uint8_t * buf) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreManufacturingDate(const char * mfgDate, size_t mfgDateLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/platform/tests/TestConfigurationMgr.cpp
+++ b/src/platform/tests/TestConfigurationMgr.cpp
@@ -389,9 +389,16 @@ TEST_F(TestConfigurationMgr, GetPrimaryMACAddress)
     MutableByteSpan mac6Bytes(macBuffer6Bytes);
 
     err = ConfigurationMgr().GetPrimaryMACAddress(mac8Bytes);
-    if (mac8Bytes.size() != ConfigurationManager::kPrimaryMACAddressLength)
+    if (sizeof(macBuffer8Bytes) != ConfigurationManager::kPrimaryMACAddressLength)
     {
+        // Should have failed input validation
         EXPECT_EQ(err, CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    else if (mac8Bytes.size() != ConfigurationManager::kPrimaryMACAddressLength)
+    {
+        // This can happen if the primary address is Thread but then there is no
+        // Thread address to be had and we fell back to Wi-Fi.
+        EXPECT_EQ(mac8Bytes.size(), ConfigurationManager::kEthernetMACAddressLength);
     }
 
     err = ConfigurationMgr().GetPrimaryMACAddress(mac6Bytes);


### PR DESCRIPTION
Implementations want to resize it to the size of the data they actually put in it.

#### Testing

We have existing unit tests for this, but in practice the sizes on caller and callee are identical in our CI configurations, so hard to exercise this codepath.