### PR TITLE
TC-DISHM-1_2 python test

### DIFF
--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2025 Project CHIP Authors
+#    Copyright (c) 2024 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,21 +15,19 @@
 #    limitations under the License.
 #
 
-# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
-# for details about the block below.
-#
-# FIXME: https://github.com/project-chip/connectedhomeip/issues/36885
 # === BEGIN CI TEST ARGUMENTS ===
 # test-runner-runs:
 #   run1:
-#     app: ${CHIP_MICROWAVE_OVEN_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: >
+#       --discriminator 1234
+#       --KVS kvs1
+#       --trace-to json:${TRACE_APP}.json
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
-#       --PICS src/app/tests/suites/certification/ci-pics-values
 #       --endpoint 1
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -42,7 +42,7 @@ import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from modebase_cluster_check import ModeBaseClusterChecks
 
-CLUSTER = Clusters.RefrigeratorAndTemperatureControlledCabinetMode
+CLUSTER = Clusters.DishwasherMode
 
 
 class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
@@ -82,10 +82,10 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         self.step(2)
         # Verify common checks for Mode Base as described in the TC-DISHM-1.2
         supported_modes = await self.check_supported_modes_and_labels(endpoint=endpoint)
-        # According to the spec, there should be at least one RapidCool or RapidFreeze tag in
+        # According to the spec, there should be at least one Normal, Heavy, OR Light tag in
         # the ones supported.
-        additional_tags = [CLUSTER.Enums.ModeTag.kRapidCool,
-                           CLUSTER.Enums.ModeTag.kRapidFreeze]
+        additional_tags = [CLUSTER.Enums.ModeTag.kNormal,
+                           CLUSTER.Enums.ModeTag.kHeavy]
         self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)
 
         self.step(3)

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -57,9 +57,7 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         steps = [
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH reads from the DUT the SupportedModes attribute."),
-            TestStep(3, "TH reads from the DUT the CurrentMode attribute."),
-            TestStep(4, "TH reads from the DUT the OnMode attribute."),
-            TestStep(5, "TH reads from the DUT the StartUpMode attribute.")
+            TestStep(3, "TH reads from the DUT the CurrentMode attribute.")
         ]
         return steps
 
@@ -91,18 +89,6 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         # Verify that the CurrentMode attribute has a valid value.
         mode = self.cluster.Attributes.CurrentMode
         await self.read_and_check_mode(endpoint=endpoint, mode=mode, supported_modes=supported_modes)
-
-        self.step(4)
-        # Verify that the OnMode attribute has a valid value or null.
-        mode = self.cluster.Attributes.OnMode
-        await self.read_and_check_mode(endpoint=endpoint, mode=mode,
-                                       supported_modes=supported_modes, is_nullable=True)
-
-        self.step(5)
-        # Verify that the StartUpMode has a valid value or null
-        mode = self.cluster.Attributes.StartUpMode
-        await self.read_and_check_mode(endpoint=endpoint, mode=mode,
-                                       supported_modes=supported_modes, is_nullable=True)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -87,7 +87,7 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
 
         self.step(3)
         # Verify that the CurrentMode attribute has a valid value.
-        mode = cluster_dishm_mode.Attributes.CurrentMode
+        mode = self.cluster.Attributes.CurrentMode
         await self.read_and_check_mode(endpoint=endpoint, mode=mode, supported_modes=supported_modes)
 
 

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -1,0 +1,110 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# FIXME: https://github.com/project-chip/connectedhomeip/issues/36885
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CHIP_MICROWAVE_OVEN_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 1
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+
+import chip.clusters as Clusters
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from modebase_cluster_check import ModeBaseClusterChecks
+
+CLUSTER = Clusters.RefrigeratorAndTemperatureControlledCabinetMode
+
+
+class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
+
+    def __init__(self, *args):
+        MatterBaseTest.__init__(self, *args)
+        ModeBaseClusterChecks.__init__(self,
+                                       modebase_derived_cluster=CLUSTER)
+
+    def desc_TC_DISHM_1_2(self) -> str:
+        return "[TC-DISHM-1.2] Cluster attributes with DUT as Server"
+
+    def steps_TC_DISHM_1_2(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "TH reads from the DUT the SupportedModes attribute."),
+            TestStep(3, "TH reads from the DUT the CurrentMode attribute."),
+            TestStep(4, "TH reads from the DUT the OnMode attribute."),
+            TestStep(5, "TH reads from the DUT the StartUpMode attribute.")
+        ]
+        return steps
+
+    def pics_TC_DISHM_1_2(self) -> list[str]:
+        pics = [
+            "DISHM.S"
+        ]
+        return pics
+
+    @async_test_body
+    async def test_TC_DISHM_1_2(self):
+
+        # Setup common mode check
+        endpoint = self.get_endpoint(default=1)
+
+        self.step(1)
+
+        self.step(2)
+        # Verify common checks for Mode Base as described in the TC-DISHM-1.2
+        supported_modes = await self.check_supported_modes_and_labels(endpoint=endpoint)
+        # According to the spec, there should be at least one RapidCool or RapidFreeze tag in
+        # the ones supported.
+        additional_tags = [CLUSTER.Enums.ModeTag.kRapidCool,
+                           CLUSTER.Enums.ModeTag.kRapidFreeze]
+        self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)
+
+        self.step(3)
+        # Verify that the CurrentMode attribute has a valid value.
+        mode = self.cluster.Attributes.CurrentMode
+        await self.read_and_check_mode(endpoint=endpoint, mode=mode, supported_modes=supported_modes)
+
+        self.step(4)
+        # Verify that the OnMode attribute has a valid value or null.
+        mode = self.cluster.Attributes.OnMode
+        await self.read_and_check_mode(endpoint=endpoint, mode=mode,
+                                       supported_modes=supported_modes, is_nullable=True)
+
+        self.step(5)
+        # Verify that the StartUpMode has a valid value or null
+        mode = self.cluster.Attributes.StartUpMode
+        await self.read_and_check_mode(endpoint=endpoint, mode=mode,
+                                       supported_modes=supported_modes, is_nullable=True)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -82,8 +82,9 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         self.step(2)
         # Verify common checks for Mode Base as described in the TC-DISHM-1.2
         supported_modes = await self.check_supported_modes_and_labels(endpoint=endpoint)
-        # According to the spec, there should be at least one Normal, Heavy, OR Light tag in
-        # the ones supported.
+        # According to the spec, there should be at least one like
+        # Normal, Heavy, or Light
+        # tag in the ones supported.
         additional_tags = [CLUSTER.Enums.ModeTag.kNormal,
                            CLUSTER.Enums.ModeTag.kHeavy]
         self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2025 Project CHIP Authors
 #    All rights reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -40,7 +40,7 @@ import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from modebase_cluster_check import ModeBaseClusterChecks
 
-CLUSTER = Clusters.DishwasherMode
+cluster_dishm_mode = Clusters.DishwasherMode
 
 
 class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
@@ -48,7 +48,7 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
     def __init__(self, *args):
         MatterBaseTest.__init__(self, *args)
         ModeBaseClusterChecks.__init__(self,
-                                       modebase_derived_cluster=CLUSTER)
+                                       modebase_derived_cluster=cluster_dishm_mode)
 
     def desc_TC_DISHM_1_2(self) -> str:
         return "[TC-DISHM-1.2] Cluster attributes with DUT as Server"
@@ -81,13 +81,13 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         # According to the spec, there should be at least one like
         # Normal, Heavy, or Light
         # tag in the ones supported.
-        additional_tags = [CLUSTER.Enums.ModeTag.kNormal,
-                           CLUSTER.Enums.ModeTag.kHeavy]
+        additional_tags = [cluster_dishm_mode.Enums.ModeTag.kNormal,
+                           cluster_dishm_mode.Enums.ModeTag.kHeavy]
         self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)
 
         self.step(3)
         # Verify that the CurrentMode attribute has a valid value.
-        mode = self.cluster.Attributes.CurrentMode
+        mode = cluster_dishm_mode.Attributes.CurrentMode
         await self.read_and_check_mode(endpoint=endpoint, mode=mode, supported_modes=supported_modes)
 
 

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -81,8 +81,7 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         # According to the spec, there should be at least one like
         # Normal, Heavy, or Light
         # tag in the ones supported.
-        additional_tags = [cluster_dishm_mode.Enums.ModeTag.kNormal,
-                           cluster_dishm_mode.Enums.ModeTag.kHeavy]
+        additional_tags = [cluster_dishm_mode.Enums.ModeTag.kNormal]
         self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)
 
         self.step(3)

--- a/src/python_testing/TC_DISHM_1_2.py
+++ b/src/python_testing/TC_DISHM_1_2.py
@@ -78,9 +78,7 @@ class TC_DISHM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         self.step(2)
         # Verify common checks for Mode Base as described in the TC-DISHM-1.2
         supported_modes = await self.check_supported_modes_and_labels(endpoint=endpoint)
-        # According to the spec, there should be at least one like
-        # Normal, Heavy, or Light
-        # tag in the ones supported.
+        # According to the spec, Normal tag should be a supported tag.
         additional_tags = [cluster_dishm_mode.Enums.ModeTag.kNormal]
         self.check_tags_in_lists(supported_modes=supported_modes, required_tags=additional_tags)
 


### PR DESCRIPTION
### Description
This PR is focused on implementing and validating the **TC-DISHM-1.2**
Fixes: https://github.com/project-chip/matter-test-scripts/issues/424
Test plan: From `allclusters` https://github.com//CHIP-Specifications/chip-test-plans/tree/gh-site

### Purpose ###
This test case validates the behavior of the mode checks to ensure that the system operates according to the expected mode configurations.

### Notes ###
N/A

#### Testing
To run the automated **TC-DISHM-1.2** test, follow these steps:
1. Ensure your environment is set up and the necessary dependencies are installed.
2. Run the following command from the command line:

`python3 src/python_testing/TC_DISHM_1_2.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00`    
