### PR TITLE
Only register XPC interest when a delegate exists

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -201,10 +201,10 @@ MTR_DIRECT_MEMBERS
     MTR_LOG("%@ added delegate info %@", self, newDelegateInfo);
 
     // Call hook to allow subclasses to act on delegate addition.
-    [self _delegateAdded];
+    [self _delegateAdded: delegate];
 }
 
-- (void)_delegateAdded
+- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
@@ -214,9 +214,9 @@ MTR_DIRECT_MEMBERS
 - (void)removeDelegate:(id<MTRDeviceDelegate>)delegate
 {
     MTR_LOG("%@ removeDelegate %@", self, delegate);
-
+    
     std::lock_guard lock(_lock);
-
+    
     NSMutableSet<MTRDeviceDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
     [self _iterateDelegatesWithBlock:^(MTRDeviceDelegateInfo * delegateInfo) {
         id<MTRDeviceDelegate> strongDelegate = delegateInfo.delegate;
@@ -233,6 +233,16 @@ MTR_DIRECT_MEMBERS
         [_delegates minusSet:delegatesToRemove];
         MTR_LOG("%@ removeDelegate: removed %lu", self, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
     }
+    
+    // Call hook to allow subclasses to act on delegate addition.
+    [self _delegateRemoved: delegate];
+}
+
+- (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    // Nothing to do for now. At the moment this is a hook for subclasses.
 }
 
 - (void)invalidate

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -214,9 +214,9 @@ MTR_DIRECT_MEMBERS
 - (void)removeDelegate:(id<MTRDeviceDelegate>)delegate
 {
     MTR_LOG("%@ removeDelegate %@", self, delegate);
-    
+
     std::lock_guard lock(_lock);
-    
+
     NSMutableSet<MTRDeviceDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
     [self _iterateDelegatesWithBlock:^(MTRDeviceDelegateInfo * delegateInfo) {
         id<MTRDeviceDelegate> strongDelegate = delegateInfo.delegate;
@@ -233,7 +233,7 @@ MTR_DIRECT_MEMBERS
         [_delegates minusSet:delegatesToRemove];
         MTR_LOG("%@ removeDelegate: removed %lu", self, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
     }
-    
+
     // Call hook to allow subclasses to act on delegate addition.
     [self _delegateRemoved: delegate];
 }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -201,7 +201,7 @@ MTR_DIRECT_MEMBERS
     MTR_LOG("%@ added delegate info %@", self, newDelegateInfo);
 
     // Call hook to allow subclasses to act on delegate addition.
-    [self _delegateAdded: delegate];
+    [self _delegateAdded:delegate];
 }
 
 - (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate
@@ -235,7 +235,7 @@ MTR_DIRECT_MEMBERS
     }
 
     // Call hook to allow subclasses to act on delegate addition.
-    [self _delegateRemoved: delegate];
+    [self _delegateRemoved:delegate];
 }
 
 - (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -82,7 +82,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
         if ( [device _delegateExists] ) {
             NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
             MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
-            
+
             [nodeIDs addObject:nodeDictionary];
         }
     }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -78,8 +78,8 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
     NSMutableArray * nodeIDs = [NSMutableArray array];
 
     for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-        MTRDevice * device = [self _deviceForNodeID: nodeID createIfNeeded: NO];
-        if ( [device _delegateExists] ) {
+        MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];
+        if ([device _delegateExists]) {
             NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
             MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC_Internal.h
@@ -19,5 +19,6 @@
 @interface MTRDeviceController_XPC (Internal)
 
 - (id)initWithMachServiceName:(NSString *)machServiceName options:(NSXPCConnectionOptions)options;
+- (void)_updateRegistrationInfo;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -884,11 +884,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     return self.suspended == NO && ![_deviceController isKindOfClass:MTRDeviceControllerOverXPC.class];
 }
 
-- (void)_delegateAdded
+- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
-    [super _delegateAdded];
+    [super _delegateAdded: delegate];
 
     [self _ensureSubscriptionForExistingDelegates:@"delegate is set"];
 }

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -888,7 +888,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
-    [super _delegateAdded: delegate];
+    [super _delegateAdded:delegate];
 
     [self _ensureSubscriptionForExistingDelegates:@"delegate is set"];
 }

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -149,7 +149,8 @@ MTR_DIRECT_MEMBERS
 - (BOOL)_delegateExists;
 
 // Must be called by subclasses or MTRDevice implementation only.
-- (void)_delegateAdded;
+- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate;
+- (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate;
 
 #ifdef DEBUG
 // Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -22,6 +22,7 @@
 #import <Matter/MTRDeviceControllerParameters.h>
 
 #import "MTRDeviceController_Internal.h"
+#import "MTRDeviceController_XPC_Internal.h"
 
 #import "MTRAsyncWorkQueue.h"
 #import "MTRAttestationTrustStoreBridge.h"
@@ -144,6 +145,20 @@
 - (MTRNetworkCommissioningFeature)networkCommissioningFeatures
 {
     return [[self._internalState objectForKey:kMTRDeviceInternalPropertyNetworkFeatures] unsignedIntValue];
+}
+
+#pragma mark - Delegate added/removed callbacks
+
+- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate {
+    [super _delegateAdded: delegate];
+    MTR_LOG("%@ delegate added: %@", self, delegate);
+    [(MTRDeviceController_XPC *)[self deviceController] _updateRegistrationInfo];
+}
+
+- (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate {
+    [super _delegateRemoved: delegate];
+    MTR_LOG("%@ delegate removed: %@", self, delegate);
+    [(MTRDeviceController_XPC *)[self deviceController] _updateRegistrationInfo];
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -149,16 +149,18 @@
 
 #pragma mark - Delegate added/removed callbacks
 
-- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate {
-    [super _delegateAdded: delegate];
+- (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate
+{
+    [super _delegateAdded:delegate];
     MTR_LOG("%@ delegate added: %@", self, delegate);
-    [(MTRDeviceController_XPC *)[self deviceController] _updateRegistrationInfo];
+    [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
 }
 
-- (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate {
-    [super _delegateRemoved: delegate];
+- (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate
+{
+    [super _delegateRemoved:delegate];
     MTR_LOG("%@ delegate removed: %@", self, delegate);
-    [(MTRDeviceController_XPC *)[self deviceController] _updateRegistrationInfo];
+    [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)


### PR DESCRIPTION
Right now when an MTRDevice is created we register it with the XPC server, but we should only do this when someone adds a delegate to reduce noise.

#### Testing

Tested this on a real iOS device to verify the XPC path