### PR TITLE
[Darwin] MTRDevice resub logic should reset backoff as needed

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1069,7 +1069,8 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         } errorHandler:nil /* not much we can do */];
     }
 
-    // Reattempt subscription after the above ReleaseSession call to avoid churn
+    // The subscription reattempt here eventually asyncs onto the matter queue for session,
+    // and should be called after the above ReleaseSession call, to avoid churn.
     if (shouldReattemptSubscription) {
         [self _reattemptSubscriptionNowIfNeededWithReason:reason];
     }


### PR DESCRIPTION
This change includes:
- Added a backoff timer reset for when `nodeLikelyReachable` is true and we are doing / in the middle of a MTRDevice resubscription (as opposed to the ReadClient resubscription)
- Moved the subscription reattempt below the `ReleaseSession` call, so that CASE establishment isn't potentially interrupted.

#### Testing

Tested with unit tests
Sanity testing locally with actual Matter device