### PR TITLE
Fix Chef compilation failure on Mac due to #35429

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -884,7 +884,7 @@ def main() -> int:
                         """))
             if options.do_clean:
                 shell.run_cmd("rm -rf out")
-            shell.run_cmd("gn gen --add-export-compile-commands=* out")
+            shell.run_cmd("gn gen --add-export-compile-commands=\"*\" out")
             shell.run_cmd("ninja -C out")
 
     #


### PR DESCRIPTION
#### Issue description

Chef compilation failure on MacOS caused by #35429

```
% ./chef.py -zbr -d rootnode_onofflight_bbs1b7IaOV -t linux
...
Building...
arm64
zsh:1: no matches found: --add-export-compile-commands=*
Traceback (most recent call last):
  File "/Users/erwinpan/matter/erwinpan1/master_20250218_fixing_mvd/examples/chef/./chef.py", line 1027, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/erwinpan/matter/erwinpan1/master_20250218_fixing_mvd/examples/chef/./chef.py", line 887, in main
    shell.run_cmd("gn gen --add-export-compile-commands=* out")
  File "/Users/erwinpan/matter/erwinpan1/master_20250218_fixing_mvd/examples/chef/stateful_shell.py", line 139, in run_cmd
    raise RuntimeError(
RuntimeError: Error. Nonzero return code.
Returncode: 1
Cmd: gn gen --add-export-compile-commands=* out

```

#### Testing

```
% ./chef.py -zbr -d rootnode_onofflight_bbs1b7IaOV -t linux
... (build successfully) ...
```