### PR TITLE
Move GenericEventManagementTestEventTriggerHandler to separate source set

### DIFF
--- a/examples/platform/infineon/cyw30739/BUILD.gn
+++ b/examples/platform/infineon/cyw30739/BUILD.gn
@@ -29,7 +29,10 @@ static_library("platform") {
 
   public_configs = [ ":${target_name}-config" ]
 
-  deps = [ app_data_model ]
+  deps = [
+    "${chip_root}/src/app:generic-test-event-trigger-handler",
+    app_data_model,
+  ]
 }
 
 config("platform-config") {

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -449,6 +449,18 @@ source_set("attribute-persistence") {
   ]
 }
 
+source_set("generic-test-event-trigger-handler") {
+  sources = [
+    "GenericEventManagementTestEventTriggerHandler.cpp",
+    "GenericEventManagementTestEventTriggerHandler.h",
+  ]
+
+  public_deps = [
+    ":test-event-trigger",
+    "${chip_root}/src/platform",
+  ]
+}
+
 # Note to developpers, instead of continuously adding files in the app librabry, it is recommand to create smaller source_sets that app can depend on.
 # This way, we can have a better understanding of dependencies and other componenets can depend on the different source_sets without needing to depend on the entire app library.
 static_library("app") {
@@ -464,8 +476,6 @@ static_library("app") {
     "EventManagement.h",
     "FailSafeContext.cpp",
     "FailSafeContext.h",
-    "GenericEventManagementTestEventTriggerHandler.cpp",
-    "GenericEventManagementTestEventTriggerHandler.h",
     "OTAUserConsentCommon.h",
     "ReadHandler.cpp",
     "TimerDelegates.cpp",
@@ -488,7 +498,6 @@ static_library("app") {
     ":global-attributes",
     ":interaction-model",
     ":path-expansion",
-    ":test-event-trigger",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/icd/server:icd-server-config",

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -472,6 +472,7 @@ if (chip_device_platform != "none") {
       "../include/platform/ConnectivityManager.h",
       "../include/platform/DeviceControlServer.h",
       "../include/platform/DeviceInstanceInfoProvider.h",
+      "../include/platform/GeneralFaults.h",
       "../include/platform/GeneralUtils.h",
       "../include/platform/KeyValueStoreManager.h",
       "../include/platform/KvsPersistentStorageDelegate.h",


### PR DESCRIPTION
#### Changes
Move `GenericEventManagementTestEventTriggerHandler` to separate source set, as it's not used in most of the examples.

#### Testing
Tested by CI.
