### PR TITLE
Add Mounted Dimmable load device type (1.4)

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -574,6 +574,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
@@ -706,6 +708,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
@@ -799,6 +803,8 @@ limitations under the License.
                 <requireCommand>RecallScene</requireCommand>
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
+                <requireCommand>CopyScene</requireCommand>
+                <requireCommand>CopySceneResponse</requireCommand>
             </include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
                 <features>
@@ -869,6 +875,36 @@ limitations under the License.
                 </features>
             </include>
             <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
+                <requireCommand>CopyScene</requireCommand>
+            </include>
+        </clusters>
+    </deviceType>
+    <deviceType>
+        <name>MA-mounted-dimmable-load-control</name>
+        <domain>CHIP</domain>
+        <typeName>Mounted Dimmable Load Control</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0110</deviceId>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireCommand>TriggerEffect</requireCommand>
+            </include>
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                    <feature code="OO" name="OnOff"></feature>
+                </features>
+            </include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                </features>
+            </include>
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="false">
                 <requireCommand>CopyScene</requireCommand>
             </include>
         </clusters>
@@ -973,10 +1009,10 @@ limitations under the License.
                 <requireAttribute>Capacity</requireAttribute>
                 <requireAttribute>OperationMode</requireAttribute>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Flow Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
             <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true" />
         </clusters>
     </deviceType>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -7702,6 +7702,7 @@ typedef NS_ENUM(uint32_t, MTRDeviceTypeIDType) {
     MTRDeviceTypeIDTypeColorTemperatureLightID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000010C,
     MTRDeviceTypeIDTypeExtendedColorLightID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x0000010D,
     MTRDeviceTypeIDTypeMountedOnOffControlID MTR_PROVISIONALLY_AVAILABLE = 0x0000010F,
+    MTRDeviceTypeIDTypeMountedDimmableLoadControlID MTR_PROVISIONALLY_AVAILABLE = 0x00000110,
     MTRDeviceTypeIDTypeCameraID MTR_PROVISIONALLY_AVAILABLE = 0x00000142,
     MTRDeviceTypeIDTypeWindowCoveringID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000202,
     MTRDeviceTypeIDTypeWindowCoveringControllerID MTR_AVAILABLE(ios(18.2), macos(15.2), watchos(11.2), tvos(18.2)) = 0x00000203,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -78,6 +78,7 @@ static /* constexpr */ const MTRDeviceTypeData knownDeviceTypes[] = {
     { 0x0000010C, MTRDeviceTypeClass::Simple, @"Color Temperature Light" },
     { 0x0000010D, MTRDeviceTypeClass::Simple, @"Extended Color Light" },
     { 0x0000010F, MTRDeviceTypeClass::Simple, @"Mounted On/Off Control" },
+    { 0x00000110, MTRDeviceTypeClass::Simple, @"Mounted Dimmable Load Control" },
     { 0x00000142, MTRDeviceTypeClass::Simple, @"Camera" },
     { 0x00000202, MTRDeviceTypeClass::Simple, @"Window Covering" },
     { 0x00000203, MTRDeviceTypeClass::Simple, @"Window Covering Controller" },

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6699,6 +6699,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Extended Color Light";
     case 0x0000010F:
         return "Mounted On/Off Control";
+    case 0x00000110:
+        return "Mounted Dimmable Load Control";
     case 0x00000142:
         return "Camera";
     case 0x00000202:


### PR DESCRIPTION
**Description**
The 1.4 Matter version brings new device types with it. This PR adds the **Mounted Dimmable Load Control** device type.

This PR also comes with a few fixes based on the actual 1.4 Device Specification:

1. Commands required in certain device types for the Scenes Management cluster and
2. Cluster locked as Server even though there are optional

This Pull Request will come with a new pull request in the [chip-cert-test](https://github.com/CHIP-Specifications/chip-test-plans/tree/master/tools/device_type_requirements) project to add the corresponding .json files required for testing.

This device type was generated using alchemy and compared with the 1.4 device type specification.
`alchemy zap --attribute="in-progress" --sdkRoot=. --specRoot=../connectedhomeip-spec ../connectedhomeip-spec/src/device_types/MountedDimmableLoadControl.adoc`

#### Testing
The testing consisted of using the Zap tool to generate the example with a new device type.
