### PR TITLE
[Silabs] Check if a duplicated provider is present before loading it into RAM

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
@@ -59,6 +59,25 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocat
                                                static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
+bool DefaultOTARequestorStorage::CheckDuplicateProvider(ProviderLocationList & listProviders, ProviderLocationType provider)
+{
+    auto iterator = listProviders.Begin();
+
+    while (iterator.Next())
+    {
+        ProviderLocationType pl = iterator.GetValue();
+
+        if ((pl.providerNodeID == provider.providerNodeID) &&
+            (pl.fabricIndex == provider.fabricIndex) &&
+            (pl.endpoint == provider.endpoint))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList & providers)
 {
     uint8_t buffer[kProviderListMaxSerializedSize];
@@ -77,7 +96,10 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList
     {
         ProviderLocationType provider;
         ReturnErrorOnFailure(provider.Decode(reader));
-        providers.Add(provider);
+        if (CheckDuplicateProvider(providers, provider) == false)
+        {
+            providers.Add(provider);
+        }
     }
 
     ReturnErrorOnFailure(reader.ExitContainer(outerType));

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.h
@@ -49,6 +49,7 @@ public:
     CHIP_ERROR ClearTargetVersion() override;
 
 private:
+    bool CheckDuplicateProvider(ProviderLocationList & listProviders, ProviderLocationType provider);
     CHIP_ERROR Load(const char * key, MutableByteSpan & buffer);
     PersistentStorageDelegate * mPersistentStorage = nullptr;
 };


### PR DESCRIPTION
### Description
What is happening is that every time IP connectivity is established (i.e. when the device (re)joins the fabric) the **_InitOTARequestorHandler_** callback is invoked which reads the configured providers from NVM into a RAM. And we don't check whether the entry is already present in the RAM.
### Testing
Some unit testing has been added, to test the **_CheckDuplicateProvider_** function. Some tests have been made manually with a BRD4186C with multiple ecosystems.
