### PR TITLE
Do not pass cluster ID to CommissionerControlServer

### DIFF
--- a/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
+++ b/examples/fabric-bridge-app/linux/include/CommissionerControlDelegate.h
@@ -31,7 +31,7 @@ inline constexpr EndpointId kAggregatorEndpointId = 1;
 class CommissionerControlDelegate : public Delegate
 {
 public:
-    CommissionerControlDelegate() : mCommissionerControlServer(this, kAggregatorEndpointId, CommissionerControl::Id) {}
+    CommissionerControlDelegate() : mCommissionerControlServer(this, kAggregatorEndpointId) {}
 
     CHIP_ERROR HandleCommissioningApprovalRequest(const CommissioningApprovalRequest & request) override;
     // TODO(#35627) clientNodeId should move towards ScopedNodeId.

--- a/examples/fabric-sync/bridge/include/CommissionerControlDelegate.h
+++ b/examples/fabric-sync/bridge/include/CommissionerControlDelegate.h
@@ -33,7 +33,7 @@ class CommissionerControlDelegate : public Delegate
 {
 public:
     CommissionerControlDelegate(bridge::FabricAdminDelegate * fabricAdmin) :
-        mFabricAdmin(fabricAdmin), mCommissionerControlServer(this, kAggregatorEndpointId, CommissionerControl::Id)
+        mFabricAdmin(fabricAdmin), mCommissionerControlServer(this, kAggregatorEndpointId)
     {}
 
     CHIP_ERROR HandleCommissioningApprovalRequest(const CommissioningApprovalRequest & request) override;

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
@@ -69,8 +69,8 @@ namespace app {
 namespace Clusters {
 namespace CommissionerControl {
 
-CommissionerControlServer::CommissionerControlServer(Delegate * delegate, EndpointId endpointId, ClusterId clusterId) :
-    CommandHandlerInterface(MakeOptional(endpointId), clusterId)
+CommissionerControlServer::CommissionerControlServer(Delegate * delegate, EndpointId endpointId) :
+    CommandHandlerInterface(MakeOptional(endpointId), Id)
 {
     mDelegate = delegate;
 }

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.h
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.h
@@ -110,9 +110,8 @@ public:
      * @param delegate A pointer to the delegate to be used by this server.
      * Note: the caller must ensure that the delegate lives throughout the instance's lifetime.
      * @param endpointId The endpoint on which this cluster exists. This must match the zap configuration.
-     * @param clusterId The ID of the Microwave Oven Control cluster to be instantiated.
      */
-    CommissionerControlServer(Delegate * delegate, EndpointId endpointId, ClusterId clusterId);
+    CommissionerControlServer(Delegate * delegate, EndpointId endpointId);
 
     ~CommissionerControlServer() override;
 


### PR DESCRIPTION
Align with other cluster server implementation, we should not pass cluster Id to CommissionerControlServer, this value is fixed and we should not customize it from the application.

#### Testing

Validated by CI