### PR TITLE
Add ICDConfigurationData to app sources when ICD management server cluster is included

### DIFF
--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -24,6 +24,15 @@ include("${CHIP_ROOT}/src/data-model-providers/codegen/model.cmake")
 function(chip_configure_cluster APP_TARGET CLUSTER)
     file(GLOB CLUSTER_SOURCES "${CHIP_APP_BASE_DIR}/clusters/${CLUSTER}/*.cpp")
     target_sources(${APP_TARGET} PRIVATE ${CLUSTER_SOURCES})
+
+    # Add clusters dependencies
+    if (CLUSTER STREQUAL "icd-management-server")
+      # Add ICDConfigurationData when ICD management server cluster is included,
+      # but ICD support is disabled, e.g. lock-app on some platforms
+      if(NOT CONFIG_CHIP_ENABLE_ICD_SUPPORT)
+        target_sources(${APP_TARGET} PRIVATE ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp)
+      endif()
+    endif()
 endfunction()
 
 #

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -27,6 +27,7 @@ function(chip_configure_cluster APP_TARGET CLUSTER)
 
     # Add clusters dependencies
     if (CLUSTER STREQUAL "icd-management-server")
+      # TODO(#32321): Remove after issue is resolved
       # Add ICDConfigurationData when ICD management server cluster is included,
       # but ICD support is disabled, e.g. lock-app on some platforms
       if(NOT CONFIG_CHIP_ENABLE_ICD_SUPPORT)

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -466,6 +466,7 @@ bool emberAfIcdManagementClusterUnregisterClientCallback(CommandHandler * comman
 bool emberAfIcdManagementClusterStayActiveRequestCallback(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                                           const Commands::StayActiveRequest::DecodableType & commandData)
 {
+// TODO(#32321): Remove #if after issue is resolved
 // Note: We only need this #if statement for platform examples that enable the ICD management server without building the sample
 // as an ICD. Since this is not spec compliant, we should remove this #if statement once we stop compiling the ICD management
 // server in those examples.


### PR DESCRIPTION
Add ICDConfigurationData to app sources when ICD management server
cluster is included in sample, but ICD support is disabled, e.g.
lock-app on some platforms.

Related to: #32321

#### Testing
Verified by building lock-app example on nRF7002.
