### PR TITLE
[Silabs] [WiFi] Not allowing the DUT to go to sleep during commissioning

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -182,9 +182,6 @@ void BaseApplicationDelegate::OnCommissioningSessionStarted()
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
-    // Setting the device to high power mode during commissioning
-    // TODO: remove this once the packet drop issue is resolved
-    WifiSleepManager::GetInstance().RequestHighPerformance();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -194,9 +191,6 @@ void BaseApplicationDelegate::OnCommissioningSessionStopped()
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-    // Removing the high power mode request on session stopped
-    // TODO: remove this once the packet drop issue is resolved
-    WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -206,9 +200,6 @@ void BaseApplicationDelegate::OnCommissioningSessionEstablishmentError(CHIP_ERRO
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
-    // Removing the high power mode request on failed commissioning
-    // TODO: remove this once the packet drop issue is resolved
-    WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -925,9 +916,6 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
-        // DUT is commissioned, removing the High Performance request
-        // TODO: remove this once the packet drop issue is resolved
-        WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
         WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kCommissioningComplete);
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     }

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -182,6 +182,9 @@ void BaseApplicationDelegate::OnCommissioningSessionStarted()
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStarted();
+    // Setting the device to high power mode during commissioning
+    // TODO: remove this once the packet drop issue is resolved
+    WifiSleepManager::GetInstance().RequestHighPerformance();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -191,6 +194,9 @@ void BaseApplicationDelegate::OnCommissioningSessionStopped()
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
+    // Removing the high power mode request on session stopped
+    // TODO: remove this once the packet drop issue is resolved
+    WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -200,6 +206,9 @@ void BaseApplicationDelegate::OnCommissioningSessionEstablishmentError(CHIP_ERRO
 
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     WifiSleepManager::GetInstance().HandleCommissioningSessionStopped();
+    // Removing the high power mode request on failed commissioning
+    // TODO: remove this once the packet drop issue is resolved
+    WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
 }
 
@@ -916,6 +925,9 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
 
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
+        // DUT is commissioned, removing the High Performance request
+        // TODO: remove this once the packet drop issue is resolved
+        WifiSleepManager::GetInstance().RemoveHighPerformanceRequest();
         WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kCommissioningComplete);
 #endif // SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
     }

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.h
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.h
@@ -59,7 +59,7 @@ public:
         mIsCommissioningInProgress = true;
 
         // TODO: Remove High Performance Req during commissioning when sleep issues are resolved
-        // WifiSleepManager::GetInstance().RequestHighPerformance();
+        WifiSleepManager::GetInstance().RequestHighPerformance();
     }
 
     inline void HandleCommissioningSessionStopped()


### PR DESCRIPTION
#### Testing

Noticed some stability issues when the device was sleepy during commissioning in high traffic environment. 
Keeping the device TA(Radio) in High performance mode during commissioning, while rootcausing the reason for the random packet drop during the discovery step.

Tested on 917 SoC
