### PR TITLE
Add missing commissioning steps to TC.MCORE tests

### DIFF
--- a/src/python_testing/TC_MCORE_FS_1_1.py
+++ b/src/python_testing/TC_MCORE_FS_1_1.py
@@ -126,13 +126,14 @@ class TC_MCORE_FS_1_1(MatterBaseTest):
         super().teardown_class()
 
     def steps_TC_MCORE_FS_1_1(self) -> list[TestStep]:
-        steps = [TestStep(1, "Enable Fabric Synchronization on DUT_FSA using the manufacturer specified mechanism.", is_commissioning=True),
-                 TestStep(2, "Commission DUT_FSA onto TH_FSA fabric."),
-                 TestStep(3, "Reverse Commission TH_FSAs onto DUT_FSA fabric."),
-                 TestStep("3a", "TH_FSA sends RequestCommissioningApproval"),
-                 TestStep("3b", "TH_FSA sends CommissionNode"),
-                 TestStep("3c", "DUT_FSA commissions TH_FSA")]
-        return steps
+        return [
+            TestStep(1, "Enable Fabric Synchronization on DUT_FSA using the manufacturer specified mechanism.", is_commissioning=True),
+            TestStep(2, "Commission DUT_FSA onto TH_FSA fabric."),
+            TestStep(3, "Reverse Commission TH_FSAs onto DUT_FSA fabric."),
+            TestStep("3a", "TH_FSA sends RequestCommissioningApproval"),
+            TestStep("3b", "TH_FSA sends CommissionNode"),
+            TestStep("3c", "DUT_FSA commissions TH_FSA"),
+        ]
 
     # This test has some manual steps and one sleep for up to 30 seconds. Test typically
     # runs under 1 mins, so 3 minutes is more than enough.

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -152,14 +152,16 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
             f">>> pairing onnetwork 111 {setup_params.passcode}")
 
     def steps_TC_MCORE_FS_1_2(self) -> list[TestStep]:
-        steps = [TestStep(1, "TH subscribes to PartsList attribute of the Descriptor cluster of DUT_FSA endpoint 0."),
-                 TestStep(2, "Follow manufacturer provided instructions to have DUT_FSA commission TH_SERVER"),
-                 TestStep(3, "TH waits up to 30 seconds for subscription report from the PartsList attribute of the Descriptor to contain new endpoint"),
-                 TestStep(4, "TH uses DUT to open commissioning window to TH_SERVER"),
-                 TestStep(5, "TH commissions TH_SERVER"),
-                 TestStep(6, "TH reads all attributes in Basic Information cluster from TH_SERVER directly"),
-                 TestStep(7, "TH reads all attributes in the Bridged Device Basic Information cluster on new endpoint identified in step 3 from the DUT_FSA")]
-        return steps
+        return [
+            TestStep(0, "Commission DUT if not done", is_commissioning=True),
+            TestStep(1, "TH subscribes to PartsList attribute of the Descriptor cluster of DUT_FSA endpoint 0."),
+            TestStep(2, "Follow manufacturer provided instructions to have DUT_FSA commission TH_SERVER"),
+            TestStep(3, "TH waits up to 30 seconds for subscription report from the PartsList attribute of the Descriptor to contain new endpoint"),
+            TestStep(4, "TH uses DUT to open commissioning window to TH_SERVER"),
+            TestStep(5, "TH commissions TH_SERVER"),
+            TestStep(6, "TH reads all attributes in Basic Information cluster from TH_SERVER directly"),
+            TestStep(7, "TH reads all attributes in the Bridged Device Basic Information cluster on new endpoint identified in step 3 from the DUT_FSA"),
+        ]
 
     # This test has some manual steps, so we need a longer timeout. Test typically runs under 1 mins so 3 mins should
     # be enough time for test to run
@@ -169,6 +171,9 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_MCORE_FS_1_2(self):
+
+        # Commissioning - done
+        self.step(0)
 
         min_report_interval_sec = self.user_params.get("min_report_interval_sec", 0)
         max_report_interval_sec = self.user_params.get("max_report_interval_sec", 30)

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -157,6 +157,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
 
     def steps_TC_MCORE_FS_1_5(self) -> list[TestStep]:
         return [
+            TestStep(0, "Commission DUT if not done", is_commissioning=True),
             TestStep(1, "TH subscribes to PartsList attribute of the Descriptor cluster of DUT_FSA endpoint 0."),
             TestStep(2, "Follow manufacturer provided instructions to have DUT_FSA commission TH_SERVER"),
             TestStep(3, "TH waits up to 30 seconds for subscription report from the PartsList attribute of the Descriptor to contain new endpoint"),
@@ -177,6 +178,9 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
 
     @async_test_body
     async def test_TC_MCORE_FS_1_5(self):
+
+        # Commissioning - done
+        self.step(0)
 
         min_report_interval_sec = 0
         max_report_interval_sec = 30


### PR DESCRIPTION
#### Problem

There is no commissioning step in test steps.
See issue: https://github.com/project-chip/matter-test-scripts/issues/506

#### Testing

There should be no change in test behavior. CI will verify.