### PR TITLE
[Darwin] MTRDevice _delegateExists cannot be called without holding lock

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -253,6 +253,12 @@ MTR_DIRECT_MEMBERS
     [self _cancelAllAttributeValueWaiters];
 }
 
+- (BOOL)delegateExists
+{
+    std::lock_guard lock(_lock);
+    return [self _delegateExists];
+}
+
 - (BOOL)_delegateExists
 {
     os_unfair_lock_assert_owner(&self->_lock);

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -79,7 +79,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 
     for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
         MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];
-        if ([device _delegateExists]) {
+        if ([device delegateExists]) {
             NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
             MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -146,7 +146,11 @@ MTR_DIRECT_MEMBERS
 // Returns YES if any non-null delegates were found
 - (BOOL)_iterateDelegatesWithBlock:(void(NS_NOESCAPE ^ _Nullable)(MTRDeviceDelegateInfo * delegateInfo))block;
 
+// For subclasses to call while holding lock
 - (BOOL)_delegateExists;
+
+// For device controller or other objects to call
+- (BOOL)delegateExists;
 
 // Must be called by subclasses or MTRDevice implementation only.
 - (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate;


### PR DESCRIPTION
Found a bug where MTRDeviceController is calling the MTRDevice method `_delegateExists` without holding the lock, and the method asserts the lock. This change adds an MTRDevice method `delegateExists` for non-subclass objects to use.

#### Testing

Ran standard unit tests to verify no regressions.