### PR TITLE
[Darwin] MTRDeviceController_XPC _updateRegistrationInfo double lock fix

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -72,24 +72,26 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 
 - (void)_updateRegistrationInfo
 {
-    NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
+    dispatch_async(self.workQueue, ^{
+        NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
-    NSMutableDictionary * controllerContext = [NSMutableDictionary dictionary];
-    NSMutableArray * nodeIDs = [NSMutableArray array];
+        NSMutableDictionary * controllerContext = [NSMutableDictionary dictionary];
+        NSMutableArray * nodeIDs = [NSMutableArray array];
 
-    for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-        MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];
-        if ([device delegateExists]) {
-            NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
-            MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
+        for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
+            MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];
+            if ([device delegateExists]) {
+                NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
+                MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
 
-            [nodeIDs addObject:nodeDictionary];
+                [nodeIDs addObject:nodeDictionary];
+            }
         }
-    }
-    MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDsKey, nodeIDs, registrationInfo)
-    MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
+        MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDsKey, nodeIDs, registrationInfo)
+        MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
 
-    [self updateControllerConfiguration:registrationInfo];
+        [self updateControllerConfiguration:registrationInfo];
+    });
 }
 
 - (void)_registerNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -73,13 +73,15 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 - (void)_updateRegistrationInfo
 {
     dispatch_async(self.workQueue, ^{
+        std::lock_guard lock(*self.deviceMapLock);
+
         NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
         NSMutableDictionary * controllerContext = [NSMutableDictionary dictionary];
         NSMutableArray * nodeIDs = [NSMutableArray array];
 
         for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-            MTRDevice * device = [self _deviceForNodeID:nodeID createIfNeeded:NO];
+            MTRDevice * device = self.nodeIDToDeviceMap[nodeID];
             if ([device delegateExists]) {
                 NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
                 MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)


### PR DESCRIPTION
Found that the PR https://github.com/project-chip/connectedhomeip/pull/37662 introduced a potential double-lock bug.

#### Testing

Ran standard unit tests to verify no regressions.