### PR TITLE
tv-casting-app/android: Include MatterEndpoint.java in TvCastingApp.jar build sources

### DIFF
--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -103,6 +103,7 @@ android_library("java") {
     "App/app/src/main/jni/com/matter/casting/core/Endpoint.java",
     "App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayer.java",
     "App/app/src/main/jni/com/matter/casting/core/MatterCastingPlayerDiscovery.java",
+    "App/app/src/main/jni/com/matter/casting/core/MatterEndpoint.java",
     "App/app/src/main/jni/com/matter/casting/support/AppParameters.java",
     "App/app/src/main/jni/com/matter/casting/support/CommissionableData.java",
     "App/app/src/main/jni/com/matter/casting/support/CommissionerDeclaration.java",


### PR DESCRIPTION
#### Problem
Seeing an error at runtime when including TvCastingApp.jar in an Android app:
```
E convertEndpointFromCppToJava() could not locate MatterEndpoint Java class
```

#### Change summary
The error is logged at: https://github.com/project-chip/connectedhomeip/blob/33aec35beef7c48e0986b9d947163ebe4859b628/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp#L91-L98

It is happening because the tv-casting-app/android/BUILD.gn did not have the MatterEndpoint.java included in sources. Verified the problem by running `jar tf TvCastingApp.jar` and not finding MatterEndpoint.java there.

This fix includes the required file in the BUILD.gn

#### Testing
Build succeeds, and
`jar tf TvCastingApp.jar` shows the MatterEndpoint.java contained in it after the change.

```
$> jar tf TvCastingApp.jar | grep Endpoint
com/matter/casting/core/MatterEndpoint$2.class
com/matter/casting/core/MatterEndpoint$1.class
com/matter/casting/core/Endpoint.class
com/matter/casting/core/MatterEndpoint.class
com/matter/casting/support/EndpointFilter.class
```