### PR TITLE
[Darwin] MTRDevice delegate callbacks should call out without holding lock

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -72,7 +72,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 
 - (void)_updateRegistrationInfo
 {
-    std::lock_guard lock(*self.deviceMapLock);
+    os_unfair_lock_lock(self.deviceMapLock);
 
     NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
@@ -80,7 +80,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
     NSMutableArray * nodeIDs = [NSMutableArray array];
 
     for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-        MTRDevice * device = self.nodeIDToDeviceMap[nodeID];
+        MTRDevice * device = [self.nodeIDToDeviceMap objectForKey:nodeID];
         if ([device delegateExists]) {
             NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
             MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
@@ -92,6 +92,8 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
     MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
 
     [self updateControllerConfiguration:registrationInfo];
+
+    os_unfair_lock_unlock(self.deviceMapLock);
 }
 
 - (void)_registerNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -72,28 +72,26 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 
 - (void)_updateRegistrationInfo
 {
-    dispatch_async(self.workQueue, ^{
-        std::lock_guard lock(*self.deviceMapLock);
+    std::lock_guard lock(*self.deviceMapLock);
 
-        NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
+    NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
-        NSMutableDictionary * controllerContext = [NSMutableDictionary dictionary];
-        NSMutableArray * nodeIDs = [NSMutableArray array];
+    NSMutableDictionary * controllerContext = [NSMutableDictionary dictionary];
+    NSMutableArray * nodeIDs = [NSMutableArray array];
 
-        for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-            MTRDevice * device = self.nodeIDToDeviceMap[nodeID];
-            if ([device delegateExists]) {
-                NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
-                MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
+    for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
+        MTRDevice * device = self.nodeIDToDeviceMap[nodeID];
+        if ([device delegateExists]) {
+            NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
+            MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
 
-                [nodeIDs addObject:nodeDictionary];
-            }
+            [nodeIDs addObject:nodeDictionary];
         }
-        MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDsKey, nodeIDs, registrationInfo)
-        MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
+    }
+    MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDsKey, nodeIDs, registrationInfo)
+    MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
 
-        [self updateControllerConfiguration:registrationInfo];
-    });
+    [self updateControllerConfiguration:registrationInfo];
 }
 
 - (void)_registerNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -23,6 +23,7 @@
 #import "MTRDevice_XPC_Internal.h"
 #import "MTRError_Internal.h"
 #import "MTRLogging_Internal.h"
+#import "MTRUnfairLock.h"
 #import "MTRXPCClientProtocol.h"
 #import "MTRXPCServerProtocol.h"
 
@@ -72,7 +73,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 
 - (void)_updateRegistrationInfo
 {
-    os_unfair_lock_lock(self.deviceMapLock);
+    std::lock_guard lock(*self.deviceMapLock);
 
     NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
@@ -92,8 +93,6 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
     MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
 
     [self updateControllerConfiguration:registrationInfo];
-
-    os_unfair_lock_unlock(self.deviceMapLock);
 }
 
 - (void)_registerNodeID:(NSNumber *)nodeID

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -151,16 +151,28 @@
 
 - (void)_delegateAdded:(id<MTRDeviceDelegate>)delegate
 {
+    os_unfair_lock_assert_owner(&self->_lock);
+
     [super _delegateAdded:delegate];
     MTR_LOG("%@ delegate added: %@", self, delegate);
-    [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
+
+    // dispatch to own queue to exit lock when calling out to other code
+    dispatch_async(self.queue, ^{
+        [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
+    });
 }
 
 - (void)_delegateRemoved:(id<MTRDeviceDelegate>)delegate
 {
+    os_unfair_lock_assert_owner(&self->_lock);
+
     [super _delegateRemoved:delegate];
     MTR_LOG("%@ delegate removed: %@", self, delegate);
-    [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
+
+    // dispatch to own queue to exit lock when calling out to other code
+    dispatch_async(self.queue, ^{
+        [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
+    });
 }
 
 #pragma mark - Client Callbacks (MTRDeviceDelegate)

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -169,7 +169,7 @@
     [super _delegateRemoved:delegate];
     MTR_LOG("%@ delegate removed: %@", self, delegate);
 
-    // dispatch to own queue to exit lock when calling out to other code
+    // dispatch to own queue so we're not holding our lock while calling out to the controller code.
     dispatch_async(self.queue, ^{
         [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
     });

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -156,7 +156,7 @@
     [super _delegateAdded:delegate];
     MTR_LOG("%@ delegate added: %@", self, delegate);
 
-    // dispatch to own queue to exit lock when calling out to other code
+    // dispatch to own queue so we're not holding our lock while calling out to the controller code.
     dispatch_async(self.queue, ^{
         [(MTRDeviceController_XPC *) [self deviceController] _updateRegistrationInfo];
     });


### PR DESCRIPTION
As a followup to https://github.com/project-chip/connectedhomeip/pull/37664/files , @bzbarsky-apple mentioned that it's more proper to have MTRDevice methods not call out to other code while holding its lock.

This change reverts MTRDeviceController_XPC's own dispatch_async, and puts the responsibility rightfully on MTRDevice.

Also fixed compilation issues introduced in previous PR.

#### Testing

Standard unit tests to verify no regressions.