### PR TITLE
[Darwin] MTRDevice compile issue fixes

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_XPC.mm
@@ -73,7 +73,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
 - (void)_updateRegistrationInfo
 {
     dispatch_async(self.workQueue, ^{
-        std::lock_guard lock(*self.deviceMapLock);
+        os_unfair_lock_lock(self.deviceMapLock);
 
         NSMutableDictionary * registrationInfo = [NSMutableDictionary dictionary];
 
@@ -81,7 +81,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
         NSMutableArray * nodeIDs = [NSMutableArray array];
 
         for (NSNumber * nodeID in [self.nodeIDToDeviceMap keyEnumerator]) {
-            MTRDevice * device = self.nodeIDToDeviceMap[nodeID];
+            MTRDevice * device = [self.nodeIDToDeviceMap objectForKey:nodeID];
             if ([device delegateExists]) {
                 NSMutableDictionary * nodeDictionary = [NSMutableDictionary dictionary];
                 MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationNodeIDKey, nodeID, nodeDictionary)
@@ -93,6 +93,7 @@ MTR_DEVICECONTROLLER_SIMPLE_REMOTE_XPC_GETTER(nodesWithStoredData,
         MTR_REQUIRED_ATTRIBUTE(MTRDeviceControllerRegistrationControllerContextKey, controllerContext, registrationInfo)
 
         [self updateControllerConfiguration:registrationInfo];
+        os_unfair_lock_unlock(self.deviceMapLock);
     });
 }
 


### PR DESCRIPTION
Due to merging too fast for the previous PRs, I've introduced some compilation errors. This is to fix them.

#### Testing

Standard unit tests to verify no regressions.