### PR TITLE
[Telink] Fix Thermostat App build

### DIFF
--- a/examples/thermostat/telink/src/TemperatureManager.cpp
+++ b/examples/thermostat/telink/src/TemperatureManager.cpp
@@ -19,6 +19,7 @@
 #include "TemperatureManager.h"
 #include "AppConfig.h"
 #include "AppTask.h"
+#include <app-common/zap-generated/cluster-objects.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);


### PR DESCRIPTION
Add missing cluster-objects.h after changes from #37433.

#### Testing
Tested by building Thermostat App locally using `act`.
