### PR TITLE
[Darwin] MTRDevice subscription onDone callback needs to acquire lock

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -2887,6 +2887,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                                    [matterCPPObjectsHolder setReadClient:nullptr subscriptionCallback:nullptr];
 
                                    // OnDone
+                                   std::lock_guard lock(self->_lock);
                                    [self _doHandleSubscriptionReset:nil];
                                },
                                ^(void) {


### PR DESCRIPTION
Introduced a bug in https://github.com/project-chip/connectedhomeip/pull/37418 where subscription onDone callback was not acquiring the MTRDevice_Concrete lock as needed. This PR puts it back.

#### Testing

Will do on device testing and run unit tests.