### PR TITLE
zap-template: remove provisional markings for the NIM clusters that were added in v1.4 SPEC

### DIFF
--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1439,7 +1439,7 @@ cluster GroupKeyManagement = 63 {
 }
 
 /** Functionality to retrieve operational information about a managed Wi-Fi network. */
-provisional cluster WiFiNetworkManagement = 1105 {
+cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
   readonly attribute nullable octet_string<32> ssid = 0;
@@ -1460,19 +1460,19 @@ provisional cluster WiFiNetworkManagement = 1105 {
 }
 
 /** Manage the Thread network of Thread Border Router */
-provisional cluster ThreadBorderRouterManagement = 1106 {
+cluster ThreadBorderRouterManagement = 1106 {
   revision 1;
 
   bitmap Feature : bitmap32 {
     kPANChange = 0x1;
   }
 
-  provisional readonly attribute char_string<63> borderRouterName = 0;
-  provisional readonly attribute octet_string<254> borderAgentID = 1;
-  provisional readonly attribute int16u threadVersion = 2;
-  provisional readonly attribute boolean interfaceEnabled = 3;
-  provisional readonly attribute nullable int64u activeDatasetTimestamp = 4;
-  provisional readonly attribute nullable int64u pendingDatasetTimestamp = 5;
+  readonly attribute char_string<63> borderRouterName = 0;
+  readonly attribute octet_string<254> borderAgentID = 1;
+  readonly attribute int16u threadVersion = 2;
+  readonly attribute boolean interfaceEnabled = 3;
+  readonly attribute nullable int64u activeDatasetTimestamp = 4;
+  readonly attribute nullable int64u pendingDatasetTimestamp = 5;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -1504,7 +1504,7 @@ provisional cluster ThreadBorderRouterManagement = 1106 {
 }
 
 /** Manages the names and credentials of Thread networks visible to the user. */
-provisional cluster ThreadNetworkDirectory = 1107 {
+cluster ThreadNetworkDirectory = 1107 {
   revision 1;
 
   struct ThreadNetworkStruct {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -6724,19 +6724,19 @@ cluster OccupancySensing = 1030 {
 }
 
 /** Manage the Thread network of Thread Border Router */
-provisional cluster ThreadBorderRouterManagement = 1106 {
+cluster ThreadBorderRouterManagement = 1106 {
   revision 1;
 
   bitmap Feature : bitmap32 {
     kPANChange = 0x1;
   }
 
-  provisional readonly attribute char_string<63> borderRouterName = 0;
-  provisional readonly attribute octet_string<254> borderAgentID = 1;
-  provisional readonly attribute int16u threadVersion = 2;
-  provisional readonly attribute boolean interfaceEnabled = 3;
-  provisional readonly attribute nullable int64u activeDatasetTimestamp = 4;
-  provisional readonly attribute nullable int64u pendingDatasetTimestamp = 5;
+  readonly attribute char_string<63> borderRouterName = 0;
+  readonly attribute octet_string<254> borderAgentID = 1;
+  readonly attribute int16u threadVersion = 2;
+  readonly attribute boolean interfaceEnabled = 3;
+  readonly attribute nullable int64u activeDatasetTimestamp = 4;
+  readonly attribute nullable int64u pendingDatasetTimestamp = 5;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;

--- a/examples/thermostat/nxp/zap/thermostat_matter_br.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_br.matter
@@ -2077,19 +2077,19 @@ cluster Thermostat = 513 {
 }
 
 /** Manage the Thread network of Thread Border Router */
-provisional cluster ThreadBorderRouterManagement = 1106 {
+cluster ThreadBorderRouterManagement = 1106 {
   revision 1;
 
   bitmap Feature : bitmap32 {
     kPANChange = 0x1;
   }
 
-  provisional readonly attribute char_string<63> borderRouterName = 0;
-  provisional readonly attribute octet_string<254> borderAgentID = 1;
-  provisional readonly attribute int16u threadVersion = 2;
-  provisional readonly attribute boolean interfaceEnabled = 3;
-  provisional readonly attribute nullable int64u activeDatasetTimestamp = 4;
-  provisional readonly attribute nullable int64u pendingDatasetTimestamp = 5;
+  readonly attribute char_string<63> borderRouterName = 0;
+  readonly attribute octet_string<254> borderAgentID = 1;
+  readonly attribute int16u threadVersion = 2;
+  readonly attribute boolean interfaceEnabled = 3;
+  readonly attribute nullable int64u activeDatasetTimestamp = 4;
+  readonly attribute nullable int64u pendingDatasetTimestamp = 5;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;

--- a/examples/thread-br-app/thread-br-common/thread-br-app.matter
+++ b/examples/thread-br-app/thread-br-common/thread-br-app.matter
@@ -1357,19 +1357,19 @@ cluster UserLabel = 65 {
 }
 
 /** Manage the Thread network of Thread Border Router */
-provisional cluster ThreadBorderRouterManagement = 1106 {
+cluster ThreadBorderRouterManagement = 1106 {
   revision 1;
 
   bitmap Feature : bitmap32 {
     kPANChange = 0x1;
   }
 
-  provisional readonly attribute char_string<63> borderRouterName = 0;
-  provisional readonly attribute octet_string<254> borderAgentID = 1;
-  provisional readonly attribute int16u threadVersion = 2;
-  provisional readonly attribute boolean interfaceEnabled = 3;
-  provisional readonly attribute nullable int64u activeDatasetTimestamp = 4;
-  provisional readonly attribute nullable int64u pendingDatasetTimestamp = 5;
+  readonly attribute char_string<63> borderRouterName = 0;
+  readonly attribute octet_string<254> borderAgentID = 1;
+  readonly attribute int16u threadVersion = 2;
+  readonly attribute boolean interfaceEnabled = 3;
+  readonly attribute nullable int64u activeDatasetTimestamp = 4;
+  readonly attribute nullable int64u pendingDatasetTimestamp = 5;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;

--- a/src/app/zap-templates/zcl/data-model/chip/thread-border-router-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-border-router-management-cluster.xml
@@ -22,7 +22,7 @@ limitations under the License.
     <field name="PANChange" mask="0x1"/>
   </bitmap>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>Network Infrastructure</domain>
     <name>Thread Border Router Management</name>
     <code>0x0452</code>
@@ -33,49 +33,49 @@ limitations under the License.
 
     <globalAttribute code="0xFFFD" side="either" value="1"/>
 
-    <attribute side="server" code="0x0000" name="BorderRouterName" apiMaturity="provisional" define="BORDER_ROUTER_NAME" type="char_string" length="63">
+    <attribute side="server" code="0x0000" name="BorderRouterName" define="BORDER_ROUTER_NAME" type="char_string" length="63">
       <mandatoryConform/>
     </attribute>
 
-    <attribute side="server" code="0x0001" name="BorderAgentID" apiMaturity="provisional" define="BORDER_AGENT_ID" type="octet_string">
+    <attribute side="server" code="0x0001" name="BorderAgentID" define="BORDER_AGENT_ID" type="octet_string">
       <mandatoryConform/>
     </attribute>
     
-    <attribute side="server" code="0x0002" name="ThreadVersion" apiMaturity="provisional" define="THREAD_VERSION" type="int16u">
+    <attribute side="server" code="0x0002" name="ThreadVersion" define="THREAD_VERSION" type="int16u">
       <mandatoryConform/>
     </attribute>
 
-    <attribute side="server" code="0x0003" name="InterfaceEnabled" apiMaturity="provisional" define="INTERFACE_ENABLED" type="boolean" default="0">
+    <attribute side="server" code="0x0003" name="InterfaceEnabled" define="INTERFACE_ENABLED" type="boolean" default="0">
       <mandatoryConform/>
     </attribute>
 
-    <attribute side="server" code="0x0004" name="ActiveDatasetTimestamp" apiMaturity="provisional" define="ACTIVE_DATASET_TIMESTAMP" type="int64u" isNullable="true">
+    <attribute side="server" code="0x0004" name="ActiveDatasetTimestamp" define="ACTIVE_DATASET_TIMESTAMP" type="int64u" isNullable="true">
       <mandatoryConform/>
     </attribute>
 
-    <attribute side="server" code="0x0005" name="PendingDatasetTimestamp" apiMaturity="provisional" define="PENDING_DATASET_TIMESTAMP" type="int64u" isNullable="true">
+    <attribute side="server" code="0x0005" name="PendingDatasetTimestamp" define="PENDING_DATASET_TIMESTAMP" type="int64u" isNullable="true">
       <mandatoryConform/>
     </attribute>
     
-    <command source="client" code="0x00" apiMaturity="provisional" name="GetActiveDatasetRequest" response="DatasetResponse" optional="false">
+    <command source="client" code="0x00" name="GetActiveDatasetRequest" response="DatasetResponse" optional="false">
       <description>Command to request the active operational dataset of the Thread network to which the border router is connected. This command must be sent over a valid CASE session</description>
       <access op="invoke" privilege="manage"/>
       <mandatoryConform/>
     </command>
 
-    <command source="client" code="0x01" apiMaturity="provisional" name="GetPendingDatasetRequest" response="DatasetResponse" optional="false">
+    <command source="client" code="0x01" name="GetPendingDatasetRequest" response="DatasetResponse" optional="false">
       <description>Command to request the pending dataset of the Thread network to which the border router is connected. This command must be sent over a valid CASE session</description>
       <access op="invoke" privilege="manage"/>
       <mandatoryConform/>
     </command>
 
-   <command source="server" code="0x02" apiMaturity="provisional" name="DatasetResponse" optional="false">
+   <command source="server" code="0x02" name="DatasetResponse" optional="false">
       <description>Generated response to GetActiveDatasetRequest or GetPendingDatasetRequest commands.</description>
       <arg name="Dataset" type="octet_string" length="254"/>
       <mandatoryConform/>
     </command>
 
-    <command source="client" code="0x03" apiMaturity="provisional" name="SetActiveDatasetRequest" optional="false">
+    <command source="client" code="0x03" name="SetActiveDatasetRequest" optional="false">
       <description>Command to set or update the active Dataset of the Thread network to which the Border Router is connected.</description>
       <arg name="ActiveDataset" type="octet_string" length="254"/>
       <arg name="Breadcrumb" type="int64u" optional="true"/>
@@ -83,7 +83,7 @@ limitations under the License.
       <mandatoryConform/>
     </command>
 
-    <command source="client" code="0x04" apiMaturity="provisional" name="SetPendingDatasetRequest" optional="true">
+    <command source="client" code="0x04" name="SetPendingDatasetRequest" optional="true">
       <description>Command set or update the pending Dataset of the Thread network to which the Border Router is connected.</description>
       <arg name="PendingDataset" type="octet_string" length="254"/>
       <access op="invoke" privilege="manage"/>

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
   
-  <struct name="ThreadNetworkStruct" apiMaturity="provisional">
+  <struct name="ThreadNetworkStruct">
     <cluster code="0x0453"/>
     <item name="ExtendedPanID" type="octet_string" length="8"/>
     <item name="NetworkName" type="char_string" length="16"/>
@@ -25,7 +25,7 @@ limitations under the License.
     <item name="ActiveTimestamp" type="int64u"/>
   </struct>
 
-  <cluster apiMaturity="provisional">
+  <cluster>
     <domain>Network Infrastructure</domain>
     <name>Thread Network Directory</name>
     <code>0x0453</code>

--- a/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/wifi-network-management-cluster.xml
@@ -17,7 +17,7 @@ limitations under the License.
 <configurator>
     <domain name="CHIP"/>
 
-    <cluster apiMaturity="provisional">
+    <cluster>
         <domain>Network Infrastructure</domain>
         <name>Wi-Fi Network Management</name>
         <code>0x0451</code>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8403,7 +8403,7 @@ cluster RadonConcentrationMeasurement = 1071 {
 }
 
 /** Functionality to retrieve operational information about a managed Wi-Fi network. */
-provisional cluster WiFiNetworkManagement = 1105 {
+cluster WiFiNetworkManagement = 1105 {
   revision 1;
 
   readonly attribute nullable octet_string<32> ssid = 0;
@@ -8424,19 +8424,19 @@ provisional cluster WiFiNetworkManagement = 1105 {
 }
 
 /** Manage the Thread network of Thread Border Router */
-provisional cluster ThreadBorderRouterManagement = 1106 {
+cluster ThreadBorderRouterManagement = 1106 {
   revision 1;
 
   bitmap Feature : bitmap32 {
     kPANChange = 0x1;
   }
 
-  provisional readonly attribute char_string<63> borderRouterName = 0;
-  provisional readonly attribute octet_string<254> borderAgentID = 1;
-  provisional readonly attribute int16u threadVersion = 2;
-  provisional readonly attribute boolean interfaceEnabled = 3;
-  provisional readonly attribute nullable int64u activeDatasetTimestamp = 4;
-  provisional readonly attribute nullable int64u pendingDatasetTimestamp = 5;
+  readonly attribute char_string<63> borderRouterName = 0;
+  readonly attribute octet_string<254> borderAgentID = 1;
+  readonly attribute int16u threadVersion = 2;
+  readonly attribute boolean interfaceEnabled = 3;
+  readonly attribute nullable int64u activeDatasetTimestamp = 4;
+  readonly attribute nullable int64u pendingDatasetTimestamp = 5;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
   readonly attribute event_id eventList[] = 65530;
@@ -8468,7 +8468,7 @@ provisional cluster ThreadBorderRouterManagement = 1106 {
 }
 
 /** Manages the names and credentials of Thread networks visible to the user. */
-provisional cluster ThreadNetworkDirectory = 1107 {
+cluster ThreadNetworkDirectory = 1107 {
   revision 1;
 
   struct ThreadNetworkStruct {


### PR DESCRIPTION
It seems we forgot to remove the provisional markings for the Network Infrastructure clusters that were added in Matter v1.4 release.

PR will be cherry-pick to the v1.4 branch once it is merged.

#### Testing
Just a zap re-generate, no tests required.