### PR TITLE
[NXP]Enable SoftwareDiagnostics cluster's feature WTRMRK for apps run on RW612 Zephyr platform

### DIFF
--- a/examples/laundry-washer-app/nxp/zephyr/prj_ota.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/prj_ota.conf
@@ -29,3 +29,6 @@ CONFIG_CHIP_OTA_IMAGE_BUILD=y
 # Note: You need to use the same signature key used by MCUBOOT, i.e BOOT_SIGNATURE_KEY_FILE.
 #       Default CONFIG_BOOT_SIGNATURE_KEY_FILE is defined in config/nxp/app/bootloader.conf
 CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="./bootloader/mcuboot/root-rsa-2048.pem"
+
+# To enable SoftwareDiagnostics cluster's feature WTRMRK on endpoint 0
+CONFIG_CHIP_MALLOC_SYS_HEAP_WATERMARKS_SUPPORT=y

--- a/examples/thermostat/nxp/zephyr/prj_ota.conf
+++ b/examples/thermostat/nxp/zephyr/prj_ota.conf
@@ -29,3 +29,6 @@ CONFIG_CHIP_OTA_IMAGE_BUILD=y
 # Note: You need to use the same signature key used by MCUBOOT, i.e BOOT_SIGNATURE_KEY_FILE.
 #       Default CONFIG_BOOT_SIGNATURE_KEY_FILE is defined in config/nxp/app/bootloader.conf
 CONFIG_MCUBOOT_SIGNATURE_KEY_FILE="./bootloader/mcuboot/root-rsa-2048.pem"
+
+# To enable SoftwareDiagnostics cluster's feature WTRMRK on endpoint 0
+CONFIG_CHIP_MALLOC_SYS_HEAP_WATERMARKS_SUPPORT=y


### PR DESCRIPTION
Enable SoftwareDiagnostics cluster's feature WTRMRK for laundry-washer and thermostat apps on RW612 Zephyr platform


#### Testing

To enable SoftwareDiagnostics cluster's feature WTRMRK for laundry-washer and thermostat apps on RW612 Zephyr platform

