### PR TITLE
[nrfconnect] Change Zephyr native tests target to native_sim

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -198,7 +198,7 @@ jobs:
               run: |
                   # Temporarily fix link issue
                   sed -i '151s/<LINK_FLAGS> //' /opt/NordicSemiconductor/nrfconnect/zephyr/cmake/linker/ld/target.cmake
-                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-posix-64-tests build"
+                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-sim-tests build"
             - name: Uploading Failed Test Logs
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -186,9 +186,9 @@ if (CONFIG_CHIP_CRYPTO_PSA)
     matter_add_gn_arg_bool  ("chip_crypto_psa_spake2p" CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER)
 endif()
 
-if (BOARD STREQUAL "native_posix")
+if (BOARD STREQUAL "native_sim")
     matter_add_gn_arg_string("target_cpu" "x86")
-elseif (BOARD STREQUAL "native_posix_64")
+elseif (BOARD STREQUAL "native_sim/native/64")
     matter_add_gn_arg_string("target_cpu" "x64")
 endif()
 

--- a/config/nxp/chip-module/CMakeLists.txt
+++ b/config/nxp/chip-module/CMakeLists.txt
@@ -122,9 +122,9 @@ else()
 endif()
 
 
-# if (BOARD STREQUAL "native_posix")
+# if (BOARD STREQUAL "native_sim")
 #     matter_add_gn_arg_string("target_cpu" "x86")
-# elseif (BOARD STREQUAL "native_posix_64")
+# elseif (BOARD STREQUAL "native_sim/native/64")
 #     matter_add_gn_arg_string("target_cpu" "x64")
 # endif()
 

--- a/config/zephyr/chip-module/CMakeLists.txt
+++ b/config/zephyr/chip-module/CMakeLists.txt
@@ -101,9 +101,9 @@ if(CONFIG_CHIP)
     matter_add_gn_arg_bool("chip_inet_config_enable_tcp_endpoint" FALSE)
     matter_add_gn_arg_bool("chip_enable_read_client" CONFIG_CHIP_ENABLE_READ_CLIENT)
 
-    if(BOARD STREQUAL "native_posix")
+    if(BOARD STREQUAL "native_sim")
         matter_add_gn_arg_string("target_cpu" "x86")
-    elseif(BOARD STREQUAL "native_posix_64")
+    elseif(BOARD STREQUAL "native_sim/native/64")
         matter_add_gn_arg_string("target_cpu" "x64")
     endif()
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -304,8 +304,8 @@ def BuildNrfNativeTarget():
     target = BuildTarget('nrf', NrfConnectBuilder)
 
     target.AppendFixedTargets([
-        TargetPart('native-posix-64-tests',
-                   board=NrfBoard.NATIVE_POSIX_64, app=NrfApp.UNIT_TESTS),
+        TargetPart('native-sim-tests',
+                   board=NrfBoard.NATIVE_SIM, app=NrfApp.UNIT_TESTS),
     ])
 
     return target

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -118,7 +118,7 @@ class NrfBoard(Enum):
     NRF52840DK = auto()
     NRF52840DONGLE = auto()
     NRF5340DK = auto()
-    NATIVE_POSIX_64 = auto()
+    NATIVE_SIM = auto()
 
     def GnArgName(self):
         if self == NrfBoard.NRF52840DK:
@@ -127,8 +127,8 @@ class NrfBoard(Enum):
             return 'nrf52840dongle_nrf52840'
         elif self == NrfBoard.NRF5340DK:
             return 'nrf5340dk_nrf5340_cpuapp'
-        elif self == NrfBoard.NATIVE_POSIX_64:
-            return 'native_posix_64'
+        elif self == NrfBoard.NATIVE_SIM:
+            return 'native_sim'
         else:
             raise Exception('Unknown board type: %r' % self)
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -17,7 +17,7 @@ nxp-{k32w0,k32w1,rt1060,rt1170,rw61x,rw61x_eth,mcxw71}-{zephyr,freertos}-{lighti
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,ota-requestor,shell}[-release][-develop][-debug]
 mw320-all-clusters-app
 nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,light-switch,shell,pump,pump-controller,window-covering}[-rpc]
-nrf-native-posix-64-tests
+nrf-native-sim-tests
 nuttx-x64-light
 qpg-qpg6105-{lock,light,shell,persistent-storage,light-switch,thermostat}[-updateimage]
 stm32-stm32wb5mm-dk-light

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -52,7 +52,7 @@ void AppContext::TearDownTestSuite()
     // This can particularly be a problem when this unprocessed work involves reporting engine runs,
     // since those can take a while and cause later tests to not reach their queued work before
     // their timeouts hit.  This is only an issue in setups where all unit tests are compiled into
-    // a single file (e.g. nRF CI (Zephyr native_posix)).
+    // a single file (e.g. nRF CI (Zephyr native_sim)).
     //
     // Work around this issue by doing a DrainAndServiceIO() here to attempt to flush out any queued-up work.
     //

--- a/src/test_driver/nrfconnect/CMakeLists.txt
+++ b/src/test_driver/nrfconnect/CMakeLists.txt
@@ -18,10 +18,10 @@
 #   @file
 #     CMake project for building and running selected CHIP unit tests using
 #     'nrfconnect' platform integration layer in CHIP and Zephyr
-#     'native_posix[_64]' platforms. Note that certain design decisions behind
-#     the native_posix platforms make them inapplicable for some unit tests,
+#     'native_sim[/native/64]' platforms. Note that certain design decisions behind
+#     the native_sim platforms make them inapplicable for some unit tests,
 #     hence only a subset of CHIP unit tests is listed in the project.
-#     See: https://docs.zephyrproject.org/1.12.0/boards/posix/native_posix/doc/board.html
+#     See: https://docs.zephyrproject.org/4.0.0/boards/native/native_sim/doc/index.html
 #     for more details.
 #
 

--- a/src/test_driver/nrfconnect/main/include/CHIPProjectConfig.h
+++ b/src/test_driver/nrfconnect/main/include/CHIPProjectConfig.h
@@ -33,7 +33,4 @@
 // Enable unit-test only features
 #define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1
 
-// Increase max. lambda event size
-#define CHIP_CONFIG_LAMBDA_EVENT_SIZE 32
-
 #endif // CHIP_PROJECT_CONFIG_H


### PR DESCRIPTION
#### Changes
* Build Zephyr native tests for 32-bit target.
* Use `native_sim` target as `native_posix_64` is deprecated and removed in recent version of Zephyr.

Depends on: #37685 and #37687

#### Testing
Tested by CI.