### PR TITLE
[NXP] Fix NVS issue into ClearConfigValue API

### DIFF
--- a/src/platform/nxp/common/NXPConfigNVS.cpp
+++ b/src/platform/nxp/common/NXPConfigNVS.cpp
@@ -333,7 +333,9 @@ CHIP_ERROR NXPConfig::ClearConfigValue(Key key)
 {
     char key_name[SETTINGS_MAX_NAME_LEN + 1];
     sprintf(key_name, CHIP_DEVICE_INTEGER_SETTINGS_KEY "/%04x", key);
-    return ClearConfigValue(key_name);
+    if (settings_delete(key_name) != 0)
+        return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR NXPConfig::ClearConfigValue(const char * keyString)


### PR DESCRIPTION
#### Context

Issue identify into NXP ClearConfigValue API, it tried to delete the key under "mt_s/mt_i/" instead of "mt_i/"

#### Testing

Tested locally with adding NXP thermostat app cli custom command to be able to write and erase a key using the fixed API:
```
static CHIP_ERROR NVS_test(int argc, char * argv[])
{
    CHIP_ERROR err = CHIP_NO_ERROR;
    if (!strcmp(argv[0], "erase"))
    {
        ChipLogProgress(DeviceLayer, "KVS, deleting key id:: %d", NXPConfig::kCounterKey_RebootCount);

        err = NXPConfig::ClearConfigValue(NXPConfig::kCounterKey_RebootCount);

        if (err != CHIP_NO_ERROR){
            ChipLogError(DeviceLayer, "KVS, failed to delete key!");
        }
        if (NXPConfig::ConfigValueExists(NXPConfig::kCounterKey_RebootCount)){
            ChipLogError(DeviceLayer, "KVS, failed to delete key!");
        }
    }
    return err;
}
```

before applied the fix, this test failed when checking if the key exist after deleted it, test is passing with this fix

