### PR TITLE
[Darwin] MTRDevice_XPC needs to initialize queue

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -85,11 +85,12 @@
 @implementation MTRDevice_XPC
 
 @synthesize _internalState;
+@synthesize queue = _queue;
 
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController_XPC *)controller
 {
     if (self = [super initForSubclassesWithNodeID:nodeID controller:controller]) {
-        // Nothing else to do, all set.
+        _queue = dispatch_queue_create("org.csa-iot.matter.framework.devicexpc.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
     }
 
     return self;


### PR DESCRIPTION
After the previous change to dispatch_async onto its own queue, we discovered that self.queue for MTRDevice_XPC is apparently uninitialized, and the testing did not exercise this path.

This change adds the queue initialization

#### Testing

Working on testing locally the MTRDevice_XPC path.