### PR TITLE
Update chip-build version in lint workflow to 115

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:98
+            image: ghcr.io/project-chip/chip-build:115
 
         steps:
             - name: Checkout

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,6 +7,8 @@ exclude = [
     "out",
     "third_party",
     "examples/common/QRCode/",
+    # TODO(#37698)
+    "docs/development_controllers/chip-repl/*.ipynb",
 ]
 target-version = "py310"
 


### PR DESCRIPTION
* Update image version to 115.
* Disable ruff on notebooks until https://github.com/project-chip/connectedhomeip/issues/37698 is resolved.

#### Testing
Tested by running workflow locally using `act`.
