### PR TITLE
Allow objdump to be used for displaying elf sizes

### DIFF
--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -289,6 +289,8 @@ def build_treemap(
         tree_name = symbol.tree_path
 
         if zoom is not None:
+            if not zoom.startswith(separator):
+                zoom = separator + zoom
             partial = ""
             # try to filter out the tree name. If it contains the zoom item, keep it, otherwise discard
             while tree_name and partial != zoom:
@@ -308,7 +310,10 @@ def build_treemap(
 
         partial = ""
         for name in tree_name[:-1]:
-            next_value = partial + separator + name
+            if not partial:
+                next_value = name
+            else:
+                next_value = partial + separator + name
             if next_value not in known_parents:
                 known_parents.add(next_value)
                 data["name"].append(next_value)

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -350,6 +350,7 @@ def build_treemap(
     fig.update_traces(root_color="lightgray")
     fig.show()
 
+
 def symbols_from_objdump(elf_file: str) -> list[Symbol]:
 
     sources = {}
@@ -357,7 +358,7 @@ def symbols_from_objdump(elf_file: str) -> list[Symbol]:
 
     # First try to figure out `source paths`. Do the "ugly" way and search for all strings that
     # seem to match a 'source'
-    for line in subprocess.check_output(["strings", elf_file ]).decode("utf8").split('\n'):
+    for line in subprocess.check_output(["strings", elf_file]).decode("utf8").split('\n'):
         if '/' not in line:
             # want directory paths...
             continue
@@ -367,7 +368,7 @@ def symbols_from_objdump(elf_file: str) -> list[Symbol]:
 
         path = m.groupdict()['path']
 
-        # heuristics: 
+        # heuristics:
         #   - some paths start with relative paths and we remove that
         #   - remove intermediate ../
         while path.startswith('../'):
@@ -495,12 +496,13 @@ def symbols_from_objdump(elf_file: str) -> list[Symbol]:
             name=captures['name'],
             symbol_type=captures['section'],
             size=size,
-            tree_path = path,
+            tree_path=path,
         )
 
         symbols.append(s)
 
     return symbols
+
 
 def symbols_from_nm(elf_file: str) -> list[Symbol]:
     items = subprocess.check_output(
@@ -542,7 +544,7 @@ def symbols_from_nm(elf_file: str) -> list[Symbol]:
             "V",
         }:
             logging.debug("Found %s of size %d", name, size)
-            symbols.append(Symbol(name=name, symbol_type=t, size=size, tree_path = tree_display_name(name)))
+            symbols.append(Symbol(name=name, symbol_type=t, size=size, tree_path=tree_display_name(name)))
         elif t in {
             # BSS - 0-initialized, not code
             "b",

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -356,7 +356,7 @@ def symbols_from_nm(elf_file: str) -> list[Symbol]:
     for line in items.split("\n"):
         if not line.strip():
             continue
-        _offset, size, t, name = line.split(" ")
+        _, size, t, name = line.split(" ")
 
         size = int(size, 10)
 

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -79,8 +79,8 @@ __CHART_STYLES__ = {
 class Symbol:
     name: str
     symbol_type: str
-    offset: int
     size: int
+    tree_path: list[str]
 
 
 def tree_display_name(name: str) -> list[str]:
@@ -273,7 +273,7 @@ def build_treemap(
     total_sizes: dict = {}
 
     for symbol in symbols:
-        tree_name = tree_display_name(symbol.name)
+        tree_name = symbol.tree_path
 
         if zoom is not None:
             partial = ""
@@ -356,10 +356,9 @@ def symbols_from_nm(elf_file: str) -> list[Symbol]:
     for line in items.split("\n"):
         if not line.strip():
             continue
-        offset, size, t, name = line.split(" ")
+        _offset, size, t, name = line.split(" ")
 
         size = int(size, 10)
-        offset = int(offset, 10)
 
         if t in {
             # Text section
@@ -379,7 +378,7 @@ def symbols_from_nm(elf_file: str) -> list[Symbol]:
             "V",
         }:
             logging.debug("Found %s of size %d", name, size)
-            symbols.append(Symbol(name=name, symbol_type=t, offset=offset, size=size))
+            symbols.append(Symbol(name=name, symbol_type=t, size=size, tree_path = tree_display_name(name)))
         elif t in {
             # BSS - 0-initialized, not code
             "b",

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -265,6 +265,7 @@ def test_tree_display_name():
 def build_treemap(
     name: str,
     symbols: list[Symbol],
+    separator: str,
     style: ChartStyle,
     max_depth: int,
     zoom: Optional[str],
@@ -291,7 +292,7 @@ def build_treemap(
             partial = ""
             # try to filter out the tree name. If it contains the zoom item, keep it, otherwise discard
             while tree_name and partial != zoom:
-                partial += "::" + tree_name[0]
+                partial += separator + tree_name[0]
                 tree_name = tree_name[1:]
             if not tree_name:
                 continue
@@ -299,7 +300,7 @@ def build_treemap(
         if strip is not None:
             partial = ""
             for part_name in tree_name:
-                partial = "::" + part_name
+                partial = separator + part_name
                 if partial == strip:
                     break
             if partial == strip:
@@ -307,7 +308,7 @@ def build_treemap(
 
         partial = ""
         for name in tree_name[:-1]:
-            next_value = partial + "::" + name
+            next_value = partial + separator + name
             if next_value not in known_parents:
                 known_parents.add(next_value)
                 data["name"].append(next_value)
@@ -611,11 +612,13 @@ def main(
 
     if __FETCH_STYLES__[fetch_via] == FetchStyle.NM:
         symbols = symbols_from_nm(elf_file.absolute().as_posix())
+        separator = "::"
     else:
         symbols = symbols_from_objdump(elf_file.absolute().as_posix())
+        separator = "/"
 
     build_treemap(
-        elf_file.name, symbols, __CHART_STYLES__[display_type], max_depth, zoom, strip
+        elf_file.name, symbols, separator, __CHART_STYLES__[display_type], max_depth, zoom, strip
     )
 
 

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -455,6 +455,7 @@ def symbols_from_objdump(elf_file: str) -> list[Symbol]:
 
     offset_file_map = {}
     symbols = []
+    unknown_file_names = set()
 
     for line in items.split("\n"):
         line = line.strip()
@@ -483,10 +484,12 @@ def symbols_from_objdump(elf_file: str) -> list[Symbol]:
                     symbol_file_name = offset_file_map[offset - delta]
 
         if symbol_file_name not in sources:
-            logging.warning('Source %s is not known', symbol_file_name)
-            path = [captures['section'], 'UNKNOWN', 'symbol_file_name']
+            if symbol_file_name not in unknown_file_names:
+                logging.warning('Source %r is not known', symbol_file_name)
+                unknown_file_names.add(symbol_file_name)
+            path = [captures['section'], 'UNKNOWN', symbol_file_name, captures['name']]
         else:
-            path = [captures['section']] + sources[symbol_file_name]
+            path = [captures['section']] + sources[symbol_file_name] + [captures['name']]
 
         s = Symbol(
             name=captures['name'],


### PR DESCRIPTION
This allows filtering by source files. I grabbed the source file path via `strings` (which is terrible, but seems to work).
We can now view per section and per path sizes (e.g. we can figure out that zzz_generated uses up 16K of flash)

#### Testing

Ran locally on a qpg light example:

![image](https://github.com/user-attachments/assets/956ef82f-4678-4348-9149-83c2461a88da)

![image](https://github.com/user-attachments/assets/d0fb2396-4467-441c-905e-92dc56d51ab6)

![image](https://github.com/user-attachments/assets/df461e17-db15-4e65-b736-5b0eb3760c18)

![image](https://github.com/user-attachments/assets/5097480e-f94c-42ed-bafa-553b7a81b4b0)

