### PR TITLE
[NXP] Fix OTA Factory Data compilation

### DIFF
--- a/src/platform/nxp/common/ota/OTAFactoryDataProcessor.h
+++ b/src/platform/nxp/common/ota/OTAFactoryDataProcessor.h
@@ -24,12 +24,10 @@
 #include <platform/nxp/common/factory_data/legacy/FactoryDataDriver.h>
 #include <platform/nxp/common/factory_data/legacy/FactoryDataProvider.h>
 #include <platform/nxp/common/ota/OTATlvProcessor.h>
-#include PLATFORM_FACTORY_DATA_PROVIDER_IMPL_HEADER
 
 namespace chip {
 
 using FactoryProvider     = DeviceLayer::FactoryDataProvider;
-using FactoryProviderImpl = DeviceLayer::FactoryDataProviderImpl;
 using FactoryDataDriver   = DeviceLayer::FactoryDataDriver;
 using Tags                = FactoryProvider::FactoryDataId;
 

--- a/src/platform/nxp/common/ota/OTAFactoryDataProcessor.h
+++ b/src/platform/nxp/common/ota/OTAFactoryDataProcessor.h
@@ -27,9 +27,9 @@
 
 namespace chip {
 
-using FactoryProvider     = DeviceLayer::FactoryDataProvider;
-using FactoryDataDriver   = DeviceLayer::FactoryDataDriver;
-using Tags                = FactoryProvider::FactoryDataId;
+using FactoryProvider   = DeviceLayer::FactoryDataProvider;
+using FactoryDataDriver = DeviceLayer::FactoryDataDriver;
+using Tags              = FactoryProvider::FactoryDataId;
 
 /**
  * OTA custom payload that uses Matter TLVs.

--- a/src/platform/nxp/mcxw71_k32w1/BUILD.gn
+++ b/src/platform/nxp/mcxw71_k32w1/BUILD.gn
@@ -43,8 +43,6 @@ source_set("nxp_factory_data") {
     "${chip_root}/src/credentials/CertificationDeclaration.h",
   ]
 
-  defines = [ "PLATFORM_FACTORY_DATA_PROVIDER_IMPL_HEADER=\"platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.h\"" ]
-
   deps = [
     ":nxp_platform",
     "${chip_root}/src/credentials:credentials",


### PR DESCRIPTION
 ### Description
 
The PLATFORM_FACTORY_DATA_PROVIDER_IMPL_HEADER macro is set in e different source_set (nxp_factory_data) than nxp_ota where it is used (that is OTAFactoryDataProcessor.cpp) so it doesn't compile.
However FactoryDataProviderImpl is not used in OTAFactoryDataProcessor.cpp so it can be removed.

### Testing
* `gn gen -C out/debug --args="nxp_use_factory_data=true chip_enable_ota_requestor=false"`
* OTA FactoryData local testing