### PR TITLE
[zephyr] Fixed error check in BLE manager impl

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -122,13 +122,14 @@ int InitRandomStaticAddress(bool idPresent, int & id)
     // generating the address
     addr.type = BT_ADDR_LE_RANDOM;
     error     = sys_csrand_get(addr.a.val, sizeof(addr.a.val));
-    BT_ADDR_SET_STATIC(&addr.a);
 
     if (error)
     {
         ChipLogError(DeviceLayer, "Failed to create BLE address: %d", error);
         return error;
     }
+
+    BT_ADDR_SET_STATIC(&addr.a);
 
     if (!idPresent)
     {


### PR DESCRIPTION
The error check for rand address generation is done after the address is set, what is too late.


#### Testing

Tested with CI
