### PR TITLE
[zephyr] Fixed GetNetworkInterfaces method

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -369,6 +369,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         }
 
         ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6AddressSpans, ipv6AddressesCount);
+        ifp->Next          = head;
         head               = ifp;
     }
 


### PR DESCRIPTION
GetNetworkInterfaces method does not set next pointer for the specific interfaces. Because of that, it is not possible to iterate through the elements returned by this method.


#### Testing

Tested using two-interface door lock example. It proven that current implementation returns only single interface and after the fix, both interfaces are listed.
