### PR TITLE
Devirtualize destructors

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -306,11 +306,11 @@ config("strict_warnings") {
     cflags -= [ "-Wshadow" ]
   }
 
-  cflags_cc = [ "-Wnon-virtual-dtor" ]
+  cflags_cc = [ "-Wdelete-non-virtual-dtor" ]
 
   if (current_os == "nuttx") {
     cflags -= [ "-Wshadow" ]
-    cflags_cc -= [ "-Wnon-virtual-dtor" ]
+    cflags_cc -= [ "-Wdelete-non-virtual-dtor" ]
   }
 
   configs = []

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -47,9 +47,10 @@ public:
     struct DeviceTypeResolver
     {
     public:
-        virtual ~DeviceTypeResolver() = default;
-
         virtual bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) = 0;
+
+    protected:
+        ~DeviceTypeResolver() = default;
     };
 
     /**
@@ -76,11 +77,10 @@ public:
         {
         public:
             Delegate() = default;
+            virtual ~Delegate() = default;
 
             Delegate(const Delegate &)             = delete;
             Delegate & operator=(const Delegate &) = delete;
-
-            virtual ~Delegate() = default;
 
             virtual void Release() {}
 
@@ -250,11 +250,10 @@ public:
         {
         public:
             Delegate() = default;
+            virtual ~Delegate() = default;
 
             Delegate(const Delegate &)             = delete;
             Delegate & operator=(const Delegate &) = delete;
-
-            virtual ~Delegate() = default;
 
             virtual void Release() {}
 
@@ -304,8 +303,6 @@ public:
             kUpdated = 3
         };
 
-        virtual ~EntryListener() = default;
-
         /**
          * Notifies of a change in the access control list.
          *
@@ -322,6 +319,9 @@ public:
         virtual void OnEntryChanged(const SubjectDescriptor * subjectDescriptor, FabricIndex fabric, size_t index,
                                     const Entry * entry, ChangeType changeType) = 0;
 
+    protected:
+        ~EntryListener() = default;
+
     private:
         EntryListener * mNext = nullptr;
 
@@ -335,8 +335,6 @@ public:
 
         Delegate(const Delegate &)             = delete;
         Delegate & operator=(const Delegate &) = delete;
-
-        virtual ~Delegate() = default;
 
         virtual void Release() {}
 
@@ -402,6 +400,9 @@ public:
         {
             return CHIP_ERROR_ACCESS_DENIED;
         }
+
+    protected:
+        ~Delegate() = default;
     };
 
     AccessControl() = default;

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -172,7 +172,6 @@ public:
     class GroupListener
     {
     public:
-        virtual ~GroupListener() = default;
         /**
          *  Callback invoked when a new group is added.
          *
@@ -185,6 +184,9 @@ public:
          *  @param[in] old_group  GroupInfo structure of the removed group.
          */
         virtual void OnGroupRemoved(FabricIndex fabric_index, const GroupInfo & old_group) = 0;
+
+    protected:
+        ~GroupListener() = default;
     };
 
     using GroupInfoIterator    = CommonIterator<GroupInfo>;

--- a/src/crypto/OperationalKeystore.h
+++ b/src/crypto/OperationalKeystore.h
@@ -28,8 +28,6 @@ namespace Crypto {
 class OperationalKeystore
 {
 public:
-    virtual ~OperationalKeystore() {}
-
     // ==== API designed for commisionables to support fail-safe (although can be used by controllers) ====
 
     /**
@@ -246,6 +244,9 @@ public:
      * @brief Release an ephemeral keypair previously provided by `AllocateEphemeralKeypairForCASE()`
      */
     virtual void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) = 0;
+
+protected:
+    ~OperationalKeystore() = default;
 };
 
 } // namespace Crypto

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -179,13 +179,15 @@ protected:
     virtual CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value)  = 0;
 
     // Construction/destruction limited to subclasses.
-    ConfigurationManager()          = default;
-    virtual ~ConfigurationManager() = default;
+    ConfigurationManager() = default;
 
     // No copy, move or assignment.
     ConfigurationManager(const ConfigurationManager &)             = delete;
     ConfigurationManager(const ConfigurationManager &&)            = delete;
     ConfigurationManager & operator=(const ConfigurationManager &) = delete;
+
+protected:
+    ~ConfigurationManager() = default;
 };
 
 /**

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -68,14 +68,15 @@ class ConnectivityManagerImpl;
 class ConnectivityManagerDelegate
 {
 public:
-    virtual ~ConnectivityManagerDelegate() {}
-
     /**
      * @brief
      *   Called when any network interface on the Node is changed
      *
      */
     virtual void OnNetworkInfoChanged() {}
+
+protected:
+    ~ConnectivityManagerDelegate() {}
 };
 
 /**

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -44,7 +44,6 @@ public:
     class Iterator
     {
     public:
-        virtual ~Iterator() = default;
         /**
          *  @retval The number of entries in total that will be iterated.
          */
@@ -63,6 +62,7 @@ public:
 
     protected:
         Iterator() = default;
+        ~Iterator() = default;
     };
 
     using FixedLabelType = app::Clusters::FixedLabel::Structs::LabelStruct::Type;

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -69,8 +69,6 @@ class DiagnosticDataProviderImpl;
 class WiFiDiagnosticsDelegate
 {
 public:
-    virtual ~WiFiDiagnosticsDelegate() {}
-
     /**
      * @brief
      *   Called when the Node detects Node’s Wi-Fi connection has been disconnected.
@@ -88,6 +86,9 @@ public:
      *   Called when the Node’s connection status to a Wi-Fi network has changed.
      */
     virtual void OnConnectionStatusChanged(uint8_t connectionStatus) {}
+
+protected:
+    ~WiFiDiagnosticsDelegate() = default;
 };
 
 /**
@@ -96,8 +97,6 @@ public:
 class ThreadDiagnosticsDelegate
 {
 public:
-    virtual ~ThreadDiagnosticsDelegate() {}
-
     /**
      * @brief
      *   Called when the Node’s connection status to a Thread network has changed.
@@ -111,6 +110,9 @@ public:
     virtual void OnNetworkFaultChanged(const GeneralFaults<kMaxNetworkFaults> & previous,
                                        const GeneralFaults<kMaxNetworkFaults> & current)
     {}
+
+protected:
+    ~ThreadDiagnosticsDelegate() {}
 };
 
 /**

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -115,8 +115,6 @@ public:
 #endif
     void LogDeviceConfig() override;
 
-    ~GenericConfigurationManagerImpl() override = default;
-
 protected:
 #if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
     chip::LifetimePersistedCounter<uint32_t> mLifetimePersistedCounter;


### PR DESCRIPTION
According to the C++ Core Guideline C.35 [1], "A base class destructor should be either public and virtual, or protected and non-virtual".

Matter has a ton of virtual interfaces but objects are very rarely destroyed polymorphically. Hence, the virtual d-tors play no role but bloating the firmware.

Turn some virtual d-tors into non-virtual protected.

[1] https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual

#### Testing

This is work in progress. I created this PR to see the reception of this proposal and assess the gain.
So far, I see over 0.5kB flash reduction on nRF lock-app by changing just a few d-tors, so I think it can give us a few K and the effort is pretty mechanical.
