### PR TITLE
[Darwin] MTRDevice _reattemptSubscriptionNowIfNeededWithReason needs …

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1072,6 +1072,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     // The subscription reattempt here eventually asyncs onto the matter queue for session,
     // and should be called after the above ReleaseSession call, to avoid churn.
     if (shouldReattemptSubscription) {
+        std::lock_guard lock(_lock);
         [self _reattemptSubscriptionNowIfNeededWithReason:reason];
     }
 }


### PR DESCRIPTION
…to be called while holding lock

In #37624 the moved `_reattemptSubscriptionNowIfNeededWithReason` call was moved outside of MTRDevice lock. This change adds the locking back.

#### Testing

Working on manually triggering and testing this case locally.