### PR TITLE
Use std::vector for allocations instead of unique_ptr + new

### DIFF
--- a/src/setup_payload/tests/TestAdditionalDataPayload.cpp
+++ b/src/setup_payload/tests/TestAdditionalDataPayload.cpp
@@ -93,10 +93,12 @@ CHIP_ERROR ParseAdditionalDataPayload(const char * additionalDataPayload, size_t
         return CHIP_ERROR_INVALID_STRING_LENGTH;
     }
     size_t additionalDataPayloadBytesLength = additionalDataPayloadLength / 2;
-    std::unique_ptr<uint8_t[]> additionalDataPayloadBytes(new uint8_t[additionalDataPayloadBytesLength]);
+
+    std::vector<uint8_t> additionalDataPayloadBytes;
+    additionalDataPayloadBytes.resize(additionalDataPayloadBytesLength);
     size_t bufferSize = chip::Encoding::HexToBytes(additionalDataPayload, additionalDataPayloadLength,
-                                                   additionalDataPayloadBytes.get(), additionalDataPayloadBytesLength);
-    return AdditionalDataPayloadParser(additionalDataPayloadBytes.get(), bufferSize).populatePayload(outPayload);
+                                                   additionalDataPayloadBytes.data(), additionalDataPayloadBytesLength);
+    return AdditionalDataPayloadParser(additionalDataPayloadBytes.data(), bufferSize).populatePayload(outPayload);
 }
 
 class TestAdditionalDataPayload : public ::testing::Test


### PR DESCRIPTION
Unsure why clang-tidy complains here, however the allocation is effectively a dynamic array, so used vector here instead.

#### Testing

Tests should still pass. This is largely a noop.