### PR TITLE
[Silabs] Clanup CHIPoBLEConState struct

### DIFF
--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -159,9 +159,6 @@ private:
 
     struct CHIPoBLEConState
     {
-#if !(SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
-        bd_addr address;
-#endif
         uint16_t mtu : 10;
         uint16_t allocated : 1;
         uint16_t subscribed : 1;


### PR DESCRIPTION
**Description :** 
The clean-up of CHIPoBLEConState struct is being done in this PR by removing the unused variables

#### Testing
Tested commissioning and command processing on 917SOC and 917NCP.

