### PR TITLE
ICD: Remove the aborts for ICD manager checks

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2140,14 +2140,10 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
 void InteractionModelEngine::DecrementNumSubscriptionsToResume()
 {
     VerifyOrReturn(mNumOfSubscriptionsToResume > 0);
-#if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    VerifyOrDie(mICDManager);
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-
     mNumOfSubscriptionsToResume--;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    if (!mNumOfSubscriptionsToResume)
+    if (mICDManager && !mNumOfSubscriptionsToResume)
     {
         mICDManager->SetBootUpResumeSubscriptionExecuted();
     }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -149,8 +149,11 @@ CHIP_ERROR DnssdServer::SetEphemeralDiscriminator(Optional<uint16_t> discriminat
 template <class AdvertisingParams>
 void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 {
-    VerifyOrDieWithMsg(mICDManager != nullptr, Discovery,
-                       "Invalid pointer to the ICDManager which is required for the LIT operating mode");
+    if (mICDManager == nullptr)
+    {
+        ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key");
+        return;
+    }
 
     Dnssd::ICDModeAdvertise ICDModeToAdvertise = Dnssd::ICDModeAdvertise::kNone;
     // Only advertise the ICD key if the device can operate as a LIT


### PR DESCRIPTION
#### Problem
The user might unregister ICD manager for the DNS-SD server and IM engine after server initialization to disable ICD.

This might happen on the device which could be powered by battery or USB cable, and when the device is powered by USB cable, We  might not want it to run as an ICD. So we will unregister and deinitialize the ICD manager. 

```
ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
chip::app::DnssdServer::Instance().SetICDManager(nullptr);
chip::app::InteractionModelEngine::GetInstance()->SetICDManager(nullptr);
auto &icd_manager = chip::Server::GetInstance().GetICDManager();
if (chip::Server::GetInstance().GetTestEventTriggerDelegate()) {
    chip::Server::GetInstance().GetTestEventTriggerDelegate()->RemoveHandler(&icd_manager);
}
icd_manager.Shutdown();
```

But it will cause crash at the ICD manager check in DNS-SD server or IM engine.

 #### Testing
Tested ICD example on ESP32-H2, the unregistration works and the device is not an ICD after that.