### PR TITLE
Reset retry counter for subscription resumption once subscription resumption succeeded.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2155,5 +2155,15 @@ void InteractionModelEngine::DecrementNumSubscriptionsToResume()
 }
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
+#if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+void InteractionModelEngine::ResetNumSubscriptionsRetries()
+{
+    // Check if there are any subscriptions to resume, if not the retry counter can be reset.
+    if (!HasSubscriptionsToResume())
+    {
+        mNumSubscriptionResumptionRetries = 0;
+    }
+}
+#endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS && CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 } // namespace app
 } // namespace chip

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -328,7 +328,7 @@ public:
     /**
      * @brief Function resets the number of retries of subscriptions resumption - mNumSubscriptionResumptionRetries.
      *        This should be called after we have completed a re-subscribe attempt successfully on a persisted subscription,
-     *        or when the subscription resumption gets terminated. 
+     *        or when the subscription resumption gets terminated.
      */
     void ResetNumSubscriptionsRetries();
 #endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -324,6 +324,14 @@ public:
      *        was successful or not.
      */
     void DecrementNumSubscriptionsToResume();
+#if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    /**
+     * @brief Function resets the number of retries of subscriptions resumption - mNumSubscriptionResumptionRetries.
+     *        This should be called after we have completed a re-subscribe attempt successfully on a persisted subscription,
+     *        or when the subscription resumption gets terminated. 
+     */
+    void ResetNumSubscriptionsRetries();
+#endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
 #endif // CHIP_CONFIG_PERSIST_SUBSCRIPTIONS
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/app/SubscriptionResumptionSessionEstablisher.cpp
+++ b/src/app/SubscriptionResumptionSessionEstablisher.cpp
@@ -114,6 +114,7 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnected(void * cont
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     // Reset the resumption retries to 0 if subscription is resumed
     subscriptionInfo.mResumptionRetries  = 0;
+    imEngine->ResetNumSubscriptionsRetries();
     auto * subscriptionResumptionStorage = InteractionModelEngine::GetInstance()->GetSubscriptionResumptionStorage();
     if (subscriptionResumptionStorage)
     {
@@ -157,6 +158,9 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnectionFailure(voi
         // Clean up the persistent subscription information storage.
         subscriptionResumptionStorage->Delete(subscriptionInfo.mNodeId, subscriptionInfo.mFabricIndex,
                                               subscriptionInfo.mSubscriptionId);
+#if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+        imEngine->ResetNumSubscriptionsRetries();
+#endif // CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     }
 }
 

--- a/src/app/SubscriptionResumptionSessionEstablisher.cpp
+++ b/src/app/SubscriptionResumptionSessionEstablisher.cpp
@@ -113,7 +113,7 @@ void SubscriptionResumptionSessionEstablisher::HandleDeviceConnected(void * cont
     readHandler->OnSubscriptionResumed(sessionHandle, *establisher);
 #if CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
     // Reset the resumption retries to 0 if subscription is resumed
-    subscriptionInfo.mResumptionRetries  = 0;
+    subscriptionInfo.mResumptionRetries = 0;
     imEngine->ResetNumSubscriptionsRetries();
     auto * subscriptionResumptionStorage = InteractionModelEngine::GetInstance()->GetSubscriptionResumptionStorage();
     if (subscriptionResumptionStorage)


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/37738

A retry counter is used to monitor the number of retries done for subscription resumption. Based on this retry counter, a backoff mechanism is in place to calculate the next try for subscription resumption. How bigger the retry counter is, how longer it will take before subscription resumption is retried. It was seen that this retry counter was not reset after the subscription successfully resumed. When after that subscription resumption mechanism is kicked in again, it was using the last retry counter, leading to very big retry timings from the start. This is not desired behavior. This commit makes sure the reset counter is reset after a successful subscription resumption is seen.


#### Testing

Verified with QPG switch device, tested using instruction listed in https://github.com/project-chip/connectedhomeip/issues/37738
