### PR TITLE
Delete persisted subscriptions that are in subscription resumption state when a subscribeRequest command comes in with keepSubscription flag set to false from the same subscriber

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -745,8 +745,10 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                     {
                         ChipLogProgress(InteractionModel,
                                         "Deleting previous non-active subscription from NodeId: " ChipLogFormatX64
-                                        ", FabricIndex: %u",
-                                        ChipLogValueX64(subscriptionInfo.mNodeId), subscriptionInfo.mFabricIndex);
+                                        ", FabricIndex: %u, SubscriptionId: 0x%" PRIx32,
+                                        ChipLogValueX64(subscriptionInfo.mNodeId), 
+                                        subscriptionInfo.mFabricIndex, 
+                                        subscriptionInfo.mSubscriptionId);
                         mpSubscriptionResumptionStorage->Delete(subscriptionInfo.mNodeId, subscriptionInfo.mFabricIndex,
                                                                 subscriptionInfo.mSubscriptionId);
                     }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -754,8 +754,8 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                 }
                 iterator->Release();
 
-                // If we have no subscriptions to resume, we can cancel the Timer, to make sure it is cleared in the case,
-                // we deleted a subscription in resumption mode.
+                // If we have no subscriptions to resume, we can cancel the timer, which might be armed
+                // if one of the subscriptions we deleted was about to be resumed.
                 if (!HasSubscriptionsToResume())
                 {
                     mpExchangeMgr->GetSessionManager()->SystemLayer()->CancelTimer(ResumeSubscriptionsTimerCallback, this);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -746,8 +746,8 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                         ChipLogProgress(InteractionModel,
                                         "Deleting previous non-active subscription from NodeId: " ChipLogFormatX64
                                         ", FabricIndex: %u, SubscriptionId: 0x%" PRIx32,
-                                        ChipLogValueX64(subscriptionInfo.mNodeId), 
-                                        subscriptionInfo.mFabricIndex, 
+                                        ChipLogValueX64(subscriptionInfo.mNodeId),
+                                        subscriptionInfo.mFabricIndex,
                                         subscriptionInfo.mSubscriptionId);
                         mpSubscriptionResumptionStorage->Delete(subscriptionInfo.mNodeId, subscriptionInfo.mFabricIndex,
                                                                 subscriptionInfo.mSubscriptionId);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -737,7 +737,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
             {
                 SubscriptionResumptionStorage::SubscriptionInfo subscriptionInfo;
                 auto * iterator = mpSubscriptionResumptionStorage->IterateSubscriptions();
-    
+
                 while (iterator->Next(subscriptionInfo))
                 {
                     if (subscriptionInfo.mNodeId == apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId() &&
@@ -751,7 +751,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                     }
                 }
                 iterator->Release();
-    
+
                 // If we have no subscriptions to resume, we can cancel the Timer, to make sure it is cleared in the case,
                 // we deleted a subscription in resumption mode.
                 if (!HasSubscriptionsToResume())

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -744,7 +744,8 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                         subscriptionInfo.mFabricIndex == apExchangeContext->GetSessionHandle()->GetFabricIndex())
                     {
                         ChipLogProgress(InteractionModel,
-                                        "Deleting previous non-active subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
+                                        "Deleting previous non-active subscription from NodeId: " ChipLogFormatX64
+                                        ", FabricIndex: %u",
                                         ChipLogValueX64(subscriptionInfo.mNodeId), subscriptionInfo.mFabricIndex);
                         mpSubscriptionResumptionStorage->Delete(subscriptionInfo.mNodeId, subscriptionInfo.mFabricIndex,
                                                                 subscriptionInfo.mSubscriptionId);

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -746,8 +746,7 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
                         ChipLogProgress(InteractionModel,
                                         "Deleting previous non-active subscription from NodeId: " ChipLogFormatX64
                                         ", FabricIndex: %u, SubscriptionId: 0x%" PRIx32,
-                                        ChipLogValueX64(subscriptionInfo.mNodeId),
-                                        subscriptionInfo.mFabricIndex,
+                                        ChipLogValueX64(subscriptionInfo.mNodeId), subscriptionInfo.mFabricIndex,
                                         subscriptionInfo.mSubscriptionId);
                         mpSubscriptionResumptionStorage->Delete(subscriptionInfo.mNodeId, subscriptionInfo.mFabricIndex,
                                                                 subscriptionInfo.mSubscriptionId);


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/37739

The Matter specification is saying:
"If KeepSubscriptions is FALSE, all existing or pending subscriptions on the publisher for this subscriber SHALL be terminated."

Currently only active readHandlers and corresponding persisted subscription were removed. The subscriptions that were persisted and in subscription resumption mode, were kept in persistent storage, keeping the subscription resumption mechanism active, so pending subscriptions were not terminated. This fixes, when a subscribeRequest come in with keepSubscriptions flag set to false, these persisted non-active subscriptions can be deleted as well and the subscription resumption mechanism can be stopped if no other subscription were resuming.


#### Testing
Verified with QPG switch device based on the instructions listed in https://github.com/project-chip/connectedhomeip/issues/37739
