### PR TITLE
Add dependabot as conditional to not fail checks.

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -45,7 +45,7 @@ jobs:
       #       })
 
       - name: Fail if PR instructions were not deleted
-        if: (steps.check-instructions.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot')
+        if: (steps.check-instructions.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot[bot]')
         run: |
           python -c 'import sys; print("PR instructions were not replaced"); sys.exit(1)'
 
@@ -63,7 +63,7 @@ jobs:
       #       })
 
       - name: Fail if `### Testing` section not in PR
-        if: (steps.check-testing.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot')
+        if: (steps.check-testing.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot[bot]')
 
         run: |
           python -c 'import sys; print("Testing section missing (test failed)"); sys.exit(1)'

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -45,7 +45,7 @@ jobs:
       #       })
 
       - name: Fail if PR instructions were not deleted
-        if: steps.check-instructions.outcome == 'failure'
+        if: (steps.check-instructions.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot')
         run: |
           python -c 'import sys; print("PR instructions were not replaced"); sys.exit(1)'
 
@@ -63,7 +63,8 @@ jobs:
       #       })
 
       - name: Fail if `### Testing` section not in PR
-        if: steps.check-testing.outcome == 'failure'
+        if: (steps.check-testing.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot')
+
         run: |
           python -c 'import sys; print("Testing section missing (test failed)"); sys.exit(1)'
 

--- a/.github/workflows/third-party-check.yaml
+++ b/.github/workflows/third-party-check.yaml
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Fail
-              if: (github.event.pull_request.user.login != 'dependabot') && !contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose')
+              if: (github.event.pull_request.user.login != 'dependabot[bot]') && !contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose')
               run: |
                   echo This pull request attempts to update submodules without the changing-submodules-on-purpose label. Please apply that label if the changes are intentional, or remove those changes.
                   exit 1

--- a/.github/workflows/third-party-check.yaml
+++ b/.github/workflows/third-party-check.yaml
@@ -28,13 +28,13 @@ jobs:
         name: Check For Submodule Update Label
         runs-on: ubuntu-latest
         steps:
-            - if: ${{ !contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose') }}
-              name: Fail
+            - name: Fail
+              if: (github.event.pull_request.user.login != 'dependabot') && !contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose')
               run: |
                   echo This pull request attempts to update submodules without the changing-submodules-on-purpose label. Please apply that label if the changes are intentional, or remove those changes.
                   exit 1
-            - if: ${{ contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose') }}
-              name: Success
+            - name: Success
+              if: contains(github.event.pull_request.labels.*.name, 'changing-submodules-on-purpose')
               run: |
                   echo PR looks good.
                   exit 0


### PR DESCRIPTION
Dependabot almost always changes submodules and has its own template for PRs. Remove some of the checks for PRs created by dependabot.

#### Testing

Will wait for CI to pass on this PR, which will validate syntax. Validated the bot name manually via github API. 