### PR TITLE
Updating the Level Control to Server only for Pump

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1289,7 +1289,7 @@ limitations under the License.
                 <requireAttribute>Capacity</requireAttribute>
                 <requireAttribute>OperationMode</requireAttribute>
             </include>
-            <include cluster="Level Control" client="false" server="false" clientLocked="false" serverLocked="false"></include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
             <include cluster="Pressure Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
             <include cluster="Flow Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>


### PR DESCRIPTION
**Description**
This PR fixes the **level control cluster** conformance from the **Pump device type** in **matter-devices.xml**.
The cluster shall remain **clientLocked** since it cannot be a client, according to the device type specification.

This fix comes with the changes from https://github.com/project-chip/connectedhomeip/pull/37636

#### Testing
Tested with a Zap Instance by trying to select the Level Control to the client in a Pump Endpoint.