### PR TITLE
[Silabs] Finish WifiInterface function API cleanup

### DIFF
--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -297,7 +297,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     }
 
     ChipLogProgress(DeviceLayer, "Clearing WiFi provision");
-    wfx_clear_wifi_provision();
+    ClearWifiCredentials();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 
     // Restart the system.

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -148,11 +148,11 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     wifiConfig.Clear();
 
     VerifyOrReturnError(ssidLen <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_BUFFER_TOO_SMALL);
-    memcpy(wifiConfig.ssid.data(), ssid, ssidLen);
+    memcpy(wifiConfig.ssid, ssid, ssidLen);
     wifiConfig.ssidLength = ssidLen;
 
     VerifyOrReturnError(keyLen < WFX_MAX_PASSKEY_LENGTH, CHIP_ERROR_BUFFER_TOO_SMALL);
-    memcpy(wifiConfig.passkey.data(), key, keyLen);
+    memcpy(wifiConfig.passkey, key, keyLen);
     wifiConfig.passkeyLength = keyLen;
 
     wifiConfig.security = WFX_SEC_WPA2;
@@ -337,7 +337,7 @@ CHIP_ERROR GetConnectedNetwork(Network & network)
 
     network.connected = true;
 
-    ByteSpan ssidSpan(wifiConfig.ssid.data(), wifiConfig.ssidLength);
+    ByteSpan ssidSpan(wifiConfig.ssid, wifiConfig.ssidLength);
     MutableByteSpan networkIdSpan(network.networkID, NetworkCommissioning::kMaxNetworkIDLen);
 
     ReturnErrorOnFailure(CopySpanToMutableSpan(ssidSpan, networkIdSpan));

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -428,8 +428,10 @@ sl_status_t SetWifiConfigurations()
             .ip = {{{0}}},
         }
     };
-    // Copy the full SSID buffer
-    std::copy(wfx_rsi.credentials.ssid.begin(), wfx_rsi.credentials.ssid.end(), profile.config.ssid.value);
+
+    chip::MutableByteSpan output(profile.config.ssid.value, WFX_MAX_SSID_LENGTH);
+    chip::ByteSpan input(wfx_rsi.credentials.ssid, wfx_rsi.credentials.ssidLength);
+    chip::CopySpanToMutableSpan(input, output);
 
     status = sl_net_set_profile((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID, &profile);
     VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%lx", status));

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -346,16 +346,16 @@ sl_status_t ScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t * scan_res
 
 sl_status_t InitiateScan()
 {
-    sl_status_t status = SL_STATUS_OK;
-
-    sl_wifi_ssid_t ssid = { 0 };
-
+    sl_status_t status                                   = SL_STATUS_OK;
+    sl_wifi_ssid_t ssid                                  = { 0 };
     sl_wifi_scan_configuration_t wifi_scan_configuration = default_wifi_scan_configuration;
 
-    ssid.length = wfx_rsi.sec.ssid_length;
+    ssid.length = wfx_rsi.credentials.ssidLength;
 
-    // TODO: workaround because the string management with the null termination is flawed
-    chip::Platform::CopyString((char *) &ssid.value[0], ssid.length + 1, wfx_rsi.sec.ssid);
+    chip::ByteSpan requestedSsidSpan(wfx_rsi.credentials.ssid.data(), wfx_rsi.credentials.ssidLength);
+    chip::MutableByteSpan ssidSpan(ssid.value, ssid.length);
+    chip::CopySpanToMutableSpan(requestedSsidSpan, ssidSpan);
+
     sl_wifi_set_scan_callback(ScanCallback, NULL);
 
     osSemaphoreAcquire(sScanInProgressSemaphore, osWaitForever);
@@ -394,10 +394,10 @@ sl_status_t SetWifiConfigurations()
     VerifyOrReturnError(status == SL_STATUS_OK, status);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
-    if (wfx_rsi.sec.passkey_length != 0)
+    if (wfx_rsi.credentials.passkeyLength != 0)
     {
-        status = sl_net_set_credential(SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID, SL_NET_WIFI_PSK, &wfx_rsi.sec.passkey[0],
-                                       wfx_rsi.sec.passkey_length);
+        status = sl_net_set_credential(SL_NET_DEFAULT_WIFI_CLIENT_CREDENTIAL_ID, SL_NET_WIFI_PSK, &wfx_rsi.credentials.passkey[0],
+                                       wfx_rsi.credentials.passkeyLength);
         VerifyOrReturnError(status == SL_STATUS_OK, status,
                             ChipLogError(DeviceLayer, "sl_net_set_credential failed: 0x%lx", status));
     }
@@ -405,8 +405,9 @@ sl_status_t SetWifiConfigurations()
     sl_net_wifi_client_profile_t profile = {
         .config = {
             .ssid = {
+                .value  = { 0 },
                 //static cast because the types dont match
-                .length = static_cast<uint8_t>(wfx_rsi.sec.ssid_length),
+                .length = static_cast<uint8_t>(wfx_rsi.credentials.ssidLength),
             },
             .channel = {
                 .channel = SL_WIFI_AUTO_CHANNEL,
@@ -427,8 +428,8 @@ sl_status_t SetWifiConfigurations()
             .ip = {{{0}}},
         }
     };
-    // TODO: memcpy for now since the types dont match
-    memcpy((char *) &profile.config.ssid.value, wfx_rsi.sec.ssid, wfx_rsi.sec.ssid_length);
+    // Copy the full SSID buffer
+    std::copy(wfx_rsi.credentials.ssid.begin(), wfx_rsi.credentials.ssid.end(), profile.config.ssid.value);
 
     status = sl_net_set_profile((sl_net_interface_t) SL_NET_WIFI_CLIENT_INTERFACE, SL_NET_DEFAULT_WIFI_CLIENT_PROFILE_ID, &profile);
     VerifyOrReturnError(status == SL_STATUS_OK, status, ChipLogError(DeviceLayer, "sl_net_set_profile failed: 0x%lx", status));
@@ -460,7 +461,7 @@ sl_status_t JoinCallback(sl_wifi_event_t event, char * result, uint32_t resultLe
         status = *reinterpret_cast<sl_status_t *>(result);
         ChipLogError(DeviceLayer, "JoinCallback: failed: 0x%lx", status);
         wfx_rsi.dev_state.Clear(WifiState::kStationConnected);
-        wfx_retry_connection(++wfx_rsi.join_retries);
+        ScheduleConnectionAttempt();
     }
 
     return status;
@@ -504,9 +505,7 @@ sl_status_t JoinWifiNetwork(void)
     ChipLogError(DeviceLayer, "sl_wifi_connect failed: 0x%lx", static_cast<uint32_t>(status));
 
     wfx_rsi.dev_state.Clear(WifiState::kStationConnecting).Clear(WifiState::kStationConnected);
-
-    ChipLogProgress(DeviceLayer, "Connection retry attempt %d", wfx_rsi.join_retries);
-    wfx_retry_connection(++wfx_rsi.join_retries);
+    ScheduleConnectionAttempt();
 
     return status;
 }
@@ -522,12 +521,11 @@ CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
 {
     // TODO: Convert this to a int8
     int32_t rssi  = 0;
-    info.security = wfx_rsi.sec.security;
+    info.security = wfx_rsi.credentials.security;
     info.chan     = wfx_rsi.ap_chan;
 
     chip::MutableByteSpan output(info.ssid, WFX_MAX_SSID_LENGTH);
-    // Cast is a workaround until the wfx_rsi structure is refactored
-    chip::ByteSpan ssid(reinterpret_cast<uint8_t *>(wfx_rsi.sec.ssid), wfx_rsi.sec.ssid_length);
+    chip::ByteSpan ssid(wfx_rsi.credentials.ssid.data(), wfx_rsi.credentials.ssidLength);
     chip::CopySpanToMutableSpan(ssid, output);
     info.ssid_length = output.size();
 
@@ -793,7 +791,7 @@ void MatterWifiTask(void * arg)
     VerifyOrReturn(status == SL_STATUS_OK,
                    ChipLogError(DeviceLayer, "MatterWifiTask: sl_wifi_siwx917_init failed: 0x%lx", static_cast<uint32_t>(status)));
 
-    sl_matter_wifi_task_started();
+    NotifyWifiTaskInitialized();
 
     ChipLogDetail(DeviceLayer, "MatterWifiTask: starting event loop");
     for (;;)

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -352,7 +352,7 @@ sl_status_t InitiateScan()
 
     ssid.length = wfx_rsi.credentials.ssidLength;
 
-    chip::ByteSpan requestedSsidSpan(wfx_rsi.credentials.ssid.data(), wfx_rsi.credentials.ssidLength);
+    chip::ByteSpan requestedSsidSpan(wfx_rsi.credentials.ssid, wfx_rsi.credentials.ssidLength);
     chip::MutableByteSpan ssidSpan(ssid.value, ssid.length);
     chip::CopySpanToMutableSpan(requestedSsidSpan, ssidSpan);
 
@@ -525,7 +525,7 @@ CHIP_ERROR GetAccessPointInfo(wfx_wifi_scan_result_t & info)
     info.chan     = wfx_rsi.ap_chan;
 
     chip::MutableByteSpan output(info.ssid, WFX_MAX_SSID_LENGTH);
-    chip::ByteSpan ssid(wfx_rsi.credentials.ssid.data(), wfx_rsi.credentials.ssidLength);
+    chip::ByteSpan ssid(wfx_rsi.credentials.ssid, wfx_rsi.credentials.ssidLength);
     chip::CopySpanToMutableSpan(ssid, output);
     info.ssid_length = output.size();
 

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -143,19 +143,19 @@ typedef enum
 // TODO: Figure out if we need this structure. We have different strcutures for the same use
 struct WifiCredentials
 {
-    std::array<uint8_t, WFX_MAX_SSID_LENGTH> ssid       = { 0 };
-    size_t ssidLength                                   = 0;
-    std::array<uint8_t, WFX_MAX_PASSKEY_LENGTH> passkey = { 0 };
-    size_t passkeyLength                                = 0;
-    wfx_sec_t security                                  = WFX_SEC_UNSPECIFIED;
+    uint8_t ssid[WFX_MAX_SSID_LENGTH]       = { 0 };
+    size_t ssidLength                       = 0;
+    uint8_t passkey[WFX_MAX_PASSKEY_LENGTH] = { 0 };
+    size_t passkeyLength                    = 0;
+    wfx_sec_t security                      = WFX_SEC_UNSPECIFIED;
 
     WifiCredentials & operator=(const WifiCredentials & other)
     {
         if (this != &other)
         {
-            ssid          = other.ssid;
-            ssidLength    = other.ssidLength;
-            passkey       = other.passkey;
+            memcpy(ssid, other.ssid, WFX_MAX_SSID_LENGTH);
+            ssidLength = other.ssidLength;
+            memcpy(passkey, other.passkey, WFX_MAX_PASSKEY_LENGTH);
             passkeyLength = other.passkeyLength;
             security      = other.security;
         }
@@ -164,9 +164,9 @@ struct WifiCredentials
 
     void Clear()
     {
-        ssid.fill(0);
+        memset(ssid, 0, WFX_MAX_SSID_LENGTH);
         ssidLength = 0;
-        passkey.fill(0);
+        memset(passkey, 0, WFX_MAX_PASSKEY_LENGTH);
         passkeyLength = 0;
         security      = WFX_SEC_UNSPECIFIED;
     }

--- a/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
+++ b/src/platform/silabs/wifi/icd/WifiSleepManager.cpp
@@ -148,11 +148,7 @@ CHIP_ERROR WifiSleepManager::VerifyAndTransitionToLowPowerMode(PowerEvent event)
         return CHIP_NO_ERROR;
     }
 
-    // TODO: Clean this up when the Wi-Fi interface re-work is finished
-    wfx_wifi_provision_t wifiConfig;
-    wfx_get_wifi_provision(&wifiConfig);
-
-    if (!(wifiConfig.ssid[0] != 0))
+    if (!IsWifiProvisioned())
     {
         return ConfigureDeepSleep();
     }

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -517,7 +517,7 @@ CHIP_ERROR ConnectToAccessPoint(void)
     sl_wfx_security_mode_t connect_security_mode;
 
     VerifyOrReturnError(IsWifiProvisioned(), CHIP_ERROR_INCORRECT_STATE);
-    ChipLogDetail(DeviceLayer, "WIFI:JOIN to %s", &wifi_provision.ssid[0]);
+    ChipLogDetail(DeviceLayer, "WIFI:JOIN to %s", wifi_provision.ssid);
 
     ChipLogDetail(DeviceLayer,
                   "WIFI Scan Paramter set to Active channel time %d, Passive Channel "
@@ -544,10 +544,9 @@ CHIP_ERROR ConnectToAccessPoint(void)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    VerifyOrReturnError(sl_wfx_send_join_command(wifi_provision.ssid.data(), wifi_provision.ssidLength, NULL, CHANNEL_0,
-                                                 connect_security_mode, PREVENT_ROAMING, DISABLE_PMF_MODE,
-                                                 wifi_provision.passkey.data(), wifi_provision.passkeyLength, NULL,
-                                                 IE_DATA_LENGTH) == SL_STATUS_OK,
+    VerifyOrReturnError(sl_wfx_send_join_command(wifi_provision.ssid, wifi_provision.ssidLength, NULL, CHANNEL_0,
+                                                 connect_security_mode, PREVENT_ROAMING, DISABLE_PMF_MODE, wifi_provision.passkey,
+                                                 wifi_provision.passkeyLength, NULL, IE_DATA_LENGTH) == SL_STATUS_OK,
                         CHIP_ERROR_INTERNAL);
 
     return CHIP_NO_ERROR;

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -245,14 +245,15 @@ CHIP_ERROR ConnectToAccessPoint()
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
 bool HasAnIPv4Address()
 {
-    VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
     return wfx_rsi.dev_state.Has(WifiState::kStationDhcpDone);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
 bool HasAnIPv6Address()
 {
-    return wfx_rsi.dev_state.Has(WifiState::kStationDhcpDone);
+    // TODO: WifiState::kStationConnected does not guarantee SLAAC IPv6 LLA, maybe use a different FLAG
+    // Once connect is sync instead of async, this should be fine
+    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
 }
 
 void CancelScanNetworks()

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -199,111 +199,63 @@ void GotIPv4Address(uint32_t ip)
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
-/*********************************************************************
- * @fn  void wfx_set_wifi_provision(wfx_wifi_provision_t *cfg)
- * @brief
- *      Driver set the wifi provision
- * @param[in]  cfg:  wifi configuration
- * @return
- *       None
- ***********************************************************************/
-void wfx_set_wifi_provision(wfx_wifi_provision_t * cfg)
+void ClearWifiCredentials()
 {
-    VerifyOrReturn(cfg != nullptr);
-    wfx_rsi.sec = *cfg;
+    ChipLogProgress(DeviceLayer, "Clear WiFi Provision");
+
+    wfx_rsi.credentials.Clear();
+    wfx_rsi.dev_state.Clear(WifiState::kStationProvisioned);
+}
+
+CHIP_ERROR GetWifiCredentials(WifiCredentials & credentials)
+{
+    VerifyOrReturnError(wfx_rsi.dev_state.Has(WifiState::kStationProvisioned), CHIP_ERROR_INCORRECT_STATE);
+    credentials = wfx_rsi.credentials;
+
+    return CHIP_NO_ERROR;
+}
+
+bool IsWifiProvisioned()
+{
+    return wfx_rsi.dev_state.Has(WifiState::kStationProvisioned);
+}
+
+void SetWifiCredentials(const WifiCredentials & credentials)
+{
+    wfx_rsi.credentials = credentials;
     wfx_rsi.dev_state.Set(WifiState::kStationProvisioned);
 }
 
-/*********************************************************************
- * @fn  bool wfx_get_wifi_provision(wfx_wifi_provision_t *wifiConfig)
- * @brief
- *      Driver get the wifi provision
- * @param[in]  wifiConfig:  wifi configuration
- * @return  return false if successful,
- *        true otherwise
- ***********************************************************************/
-bool wfx_get_wifi_provision(wfx_wifi_provision_t * wifiConfig)
+CHIP_ERROR ConnectToAccessPoint()
 {
-    VerifyOrReturnError(wifiConfig != nullptr, false);
-    VerifyOrReturnError(wfx_rsi.dev_state.Has(WifiState::kStationProvisioned), false);
-    *wifiConfig = wfx_rsi.sec;
-    return true;
-}
+    VerifyOrReturnError(IsWifiProvisioned(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(wfx_rsi.credentials.ssidLength, CHIP_ERROR_INCORRECT_STATE);
 
-/*********************************************************************
- * @fn  void wfx_clear_wifi_provision(void)
- * @brief
- *      Driver is clear the wifi provision
- * @param[in]  None
- * @return  None
- ***********************************************************************/
-void wfx_clear_wifi_provision(void)
-{
-    memset(&wfx_rsi.sec, 0, sizeof(wfx_rsi.sec));
-    wfx_rsi.dev_state.Clear(WifiState::kStationProvisioned);
-    ChipLogProgress(DeviceLayer, "Clear WiFi Provision");
-}
+    // TODO: We should move this validation to where we set the credentials. It is too late here.
+    VerifyOrReturnError(wfx_rsi.credentials.ssidLength <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_ARGUMENT);
 
-/*************************************************************************
- * @fn sl_status_t wfx_connect_to_ap(void)
- * @brief
- * Start a JOIN command to the AP - Done by the wfx_rsi task
- * @param[in]   None
- * @return  returns SL_STATUS_OK if successful
- ****************************************************************************/
-sl_status_t wfx_connect_to_ap(void)
-{
-    VerifyOrReturnError(wfx_rsi.dev_state.Has(WifiState::kStationProvisioned), SL_STATUS_INVALID_CONFIGURATION);
-    VerifyOrReturnError(wfx_rsi.sec.ssid_length, SL_STATUS_INVALID_CREDENTIALS);
-    VerifyOrReturnError(wfx_rsi.sec.ssid_length <= WFX_MAX_SSID_LENGTH, SL_STATUS_HAS_OVERFLOWED);
-    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.sec.ssid);
+    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.credentials.ssid.data());
 
     WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
     PostWifiPlatformEvent(event);
-    return SL_STATUS_OK;
+
+    return CHIP_NO_ERROR;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_IPV4
-/*********************************************************************
- * @fn  bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
- * @brief
- *      called fuction when driver have ipv4 address
- * @param[in]  which_if:
- * @return  returns ture if successful,
- *          false otherwise
- ***********************************************************************/
-bool wfx_have_ipv4_addr(sl_wfx_interface_t which_if)
+bool HasAnIPv4Address()
 {
     VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
     return wfx_rsi.dev_state.Has(WifiState::kStationDhcpDone);
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_IPV4 */
 
-/*********************************************************************
- * @fn  bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
- * @brief
- *      called fuction when driver have ipv6 address
- * @param[in]  which_if:
- * @return  returns ture if successful,
- *          false otherwise
- ***********************************************************************/
-bool wfx_have_ipv6_addr(sl_wfx_interface_t which_if)
+bool HasAnIPv6Address()
 {
-    VerifyOrReturnError(which_if == SL_WFX_STA_INTERFACE, false);
-    // TODO: WifiState::kStationConnected does not guarantee SLAAC IPv6 LLA, maybe use a different FLAG
-    return wfx_rsi.dev_state.Has(WifiState::kStationConnected);
+    return wfx_rsi.dev_state.Has(WifiState::kStationDhcpDone);
 }
 
-/***************************************************************************
- * @fn   void wfx_cancel_scan(void)
- * @brief
- *      called function when driver cancel scaning
- * @param[in]  None
- * @return
- *      None
- *****************************************************************************/
-void wfx_cancel_scan(void)
+void CancelScanNetworks()
 {
-    /* Not possible */
-    ChipLogError(DeviceLayer, "cannot cancel scan");
+    // TODO: Implement cancel scan
 }

--- a/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
+++ b/src/platform/silabs/wifi/wiseconnect-interface/WiseconnectWifiInterface.cpp
@@ -234,7 +234,7 @@ CHIP_ERROR ConnectToAccessPoint()
     // TODO: We should move this validation to where we set the credentials. It is too late here.
     VerifyOrReturnError(wfx_rsi.credentials.ssidLength <= WFX_MAX_SSID_LENGTH, CHIP_ERROR_INVALID_ARGUMENT);
 
-    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.credentials.ssid.data());
+    ChipLogProgress(DeviceLayer, "connect to access point: %s", wfx_rsi.credentials.ssid);
 
     WifiPlatformEvent event = WifiPlatformEvent::kStationStartJoin;
     PostWifiPlatformEvent(event);


### PR DESCRIPTION
#### Description
This PR continues the on-going Wi-Fi Interface refactor. The goal of this PR to finish the function API clean up for the Wi-Fi interface.

The only functionnal changes in the PR are in the `WifiCredentials` structure were a few types are changed to leverage the std::array wrapper.

#### Testing

To validate the `WifiCredentials` changes, tested the initial Wi-Fi connection during commissioning and the power cycle reconnection with the WF200 and the SiWx916 Wi-Fi platforms.

CI to validate other builds 
