### PR TITLE
Remove dependency between DataModel::Provider and CommandHandlerInterface

### DIFF
--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -25,6 +25,7 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/LinkedList.h>
 #include <lib/support/Span.h>
+#include <messaging/ExchangeContext.h>
 
 #include <limits>
 

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -362,10 +362,25 @@ source_set("status-response") {
   ]
 }
 
-source_set("command-handler-interface") {
+source_set("command-handler") {
   sources = [
     "CommandHandler.cpp",
     "CommandHandler.h",
+  ]
+
+  public_deps = [
+    ":paths",
+    "${chip_root}/src/access:types",
+    "${chip_root}/src/app/data-model",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support",
+    "${chip_root}/src/messaging",
+    "${chip_root}/src/protocols/interaction_model",
+  ]
+}
+
+source_set("command-handler-interface") {
+  sources = [
     "CommandHandlerExchangeInterface.h",
     "CommandHandlerInterface.h",
     "CommandHandlerInterfaceRegistry.cpp",
@@ -373,9 +388,11 @@ source_set("command-handler-interface") {
   ]
 
   public_deps = [
+    ":command-handler",
     ":paths",
     "${chip_root}/src/access:types",
     "${chip_root}/src/app/data-model",
+    "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging",

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-#include <app/CommandHandlerExchangeInterface.h>
+#include <access/SubjectDescriptor.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/EncodableToTLV.h>
 #include <app/data-model/Encode.h>
@@ -25,6 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <messaging/ExchangeContext.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {

--- a/src/app/CommandHandlerImpl.h
+++ b/src/app/CommandHandlerImpl.h
@@ -18,6 +18,8 @@
 
 #include <app/CommandHandler.h>
 
+#include <app/CommandHandlerExchangeInterface.h>
+#include <app/CommandHandlerInterface.h>
 #include <app/CommandPathRegistry.h>
 #include <app/MessageDef/InvokeRequestMessage.h>
 #include <app/MessageDef/InvokeResponseMessage.h>

--- a/src/app/data-model-provider/BUILD.gn
+++ b/src/app/data-model-provider/BUILD.gn
@@ -45,7 +45,7 @@ source_set("data-model-provider") {
   public_deps = [
     ":metadata",
     "${chip_root}/src/app:attribute-access",
-    "${chip_root}/src/app:command-handler-interface",
+    "${chip_root}/src/app:command-handler",
     "${chip_root}/src/app:events",
     "${chip_root}/src/app:paths",
     "${chip_root}/src/app/MessageDef",


### PR DESCRIPTION
This splits out the CHI to be separate from command handlers and keep the command handler as a stand-alone item.

#### Testing

CI will validate, tested locally for a `-test` build to see that a first pass is ok.