### PR TITLE
[WriteClient][ACL] Modify how Attributes with List Data Type are encoded in WriteRequests

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -234,7 +234,7 @@ CHIP_ERROR AccessControl::CreateEntry(const SubjectDescriptor * subjectDescripto
 
     VerifyOrReturnError((count + 1) <= maxCount, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
 
     size_t i = 0;
     ReturnErrorOnFailure(mDelegate->CreateEntry(&i, entry, &fabric));
@@ -252,7 +252,7 @@ CHIP_ERROR AccessControl::UpdateEntry(const SubjectDescriptor * subjectDescripto
                                       const Entry & entry)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(mDelegate->UpdateEntry(index, entry, &fabric));
     NotifyEntryChanged(subjectDescriptor, fabric, index, &entry, EntryListener::ChangeType::kUpdated);
     return CHIP_NO_ERROR;
@@ -626,7 +626,7 @@ exit:
 }
 #endif
 
-bool AccessControl::IsValid(const Entry & entry)
+bool AccessControl::Entry::IsValid() const
 {
     const char * log = "unexpected error";
     IgnoreUnusedVariable(log); // logging may be disabled
@@ -638,11 +638,11 @@ bool AccessControl::IsValid(const Entry & entry)
     size_t targetCount      = 0;
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SuccessOrExit(err = entry.GetAuthMode(authMode));
-    SuccessOrExit(err = entry.GetFabricIndex(fabricIndex));
-    SuccessOrExit(err = entry.GetPrivilege(privilege));
-    SuccessOrExit(err = entry.GetSubjectCount(subjectCount));
-    SuccessOrExit(err = entry.GetTargetCount(targetCount));
+    SuccessOrExit(err = GetAuthMode(authMode));
+    SuccessOrExit(err = GetFabricIndex(fabricIndex));
+    SuccessOrExit(err = GetPrivilege(privilege));
+    SuccessOrExit(err = GetSubjectCount(subjectCount));
+    SuccessOrExit(err = GetTargetCount(targetCount));
 
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
     ChipLogProgress(DataManagement, "AccessControl: validating f=%u p=%c a=%c s=%d t=%d", fabricIndex,
@@ -665,7 +665,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < subjectCount; ++i)
     {
         NodeId subject;
-        SuccessOrExit(err = entry.GetSubject(i, subject));
+        SuccessOrExit(err = GetSubject(i, subject));
         const bool kIsCase  = authMode == AuthMode::kCase;
         const bool kIsGroup = authMode == AuthMode::kGroup;
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
@@ -677,7 +677,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < targetCount; ++i)
     {
         Entry::Target target;
-        SuccessOrExit(err = entry.GetTarget(i, target));
+        SuccessOrExit(err = GetTarget(i, target));
         const bool kHasCluster    = target.flags & Entry::Target::kCluster;
         const bool kHasEndpoint   = target.flags & Entry::Target::kEndpoint;
         const bool kHasDeviceType = target.flags & Entry::Target::kDeviceType;

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -662,7 +662,11 @@ public:
      */
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
 
-    // TODO: Is this ok? if yes, add doxygen comment
+    /**
+     * Validate whether a decoded AccessControlEntry is valid and complies with all defined constraints.
+     *
+     * @retval true if all the fields within the AccessControlEntryStruct are valid and compliant.
+     */
     bool IsValid(const Entry & entry);
 
 #if CHIP_ACCESS_CONTROL_DUMP_ENABLED

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -663,9 +663,9 @@ public:
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
 
     /**
-     * Validate whether a decoded AccessControlEntry is valid and complies with all defined constraints.
+     * Validate whether an AccessControlEntryStruct is valid and complies with all defined constraints.
      *
-     * @retval true if all the fields within the AccessControlEntryStruct are valid and compliant.
+     * @retval true if all the fields within the AccessControlEntry are valid and compliant.
      */
     bool IsValid(const Entry & entry);
 

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -233,6 +233,13 @@ public:
             mDelegate = &mDefaultDelegate.get();
         }
 
+        /**
+         * Validate whether an ACL Entry is valid and complies with all defined constraints.
+         *
+         * @retval true if all the fields within the Entry are valid and compliant.
+         */
+        bool IsValid() const;
+
     private:
         static Global<Delegate> mDefaultDelegate;
         Delegate * mDelegate = &mDefaultDelegate.get();
@@ -501,7 +508,7 @@ public:
      */
     CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex = nullptr)
     {
-        VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->CreateEntry(index, entry, fabricIndex);
     }
@@ -551,7 +558,7 @@ public:
      */
     CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex = nullptr)
     {
-        VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->UpdateEntry(index, entry, fabricIndex);
     }
@@ -661,13 +668,6 @@ public:
      * @retval #CHIP_NO_ERROR if allowed.
      */
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
-
-    /**
-     * Validate whether an ACL Entry is valid and complies with all defined constraints.
-     *
-     * @retval true if all the fields within the Entry are valid and compliant.
-     */
-    static bool IsValid(const Entry & entry);
 
 #if CHIP_ACCESS_CONTROL_DUMP_ENABLED
     CHIP_ERROR Dump(const Entry & entry);

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -662,14 +662,15 @@ public:
      */
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
 
+    // TODO: Is this ok? if yes, add doxygen comment
+    bool IsValid(const Entry & entry);
+
 #if CHIP_ACCESS_CONTROL_DUMP_ENABLED
     CHIP_ERROR Dump(const Entry & entry);
 #endif
 
 private:
     bool IsInitialized() const { return (mDelegate != nullptr); }
-
-    bool IsValid(const Entry & entry);
 
     void NotifyEntryChanged(const SubjectDescriptor * subjectDescriptor, FabricIndex fabric, size_t index, const Entry * entry,
                             EntryListener::ChangeType changeType);

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -663,11 +663,11 @@ public:
     CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const RequestPath & requestPath, Privilege requestPrivilege);
 
     /**
-     * Validate whether an AccessControlEntryStruct is valid and complies with all defined constraints.
+     * Validate whether an ACL Entry is valid and complies with all defined constraints.
      *
-     * @retval true if all the fields within the AccessControlEntry are valid and compliant.
+     * @retval true if all the fields within the Entry are valid and compliant.
      */
-    bool IsValid(const Entry & entry);
+    static bool IsValid(const Entry & entry);
 
 #if CHIP_ACCESS_CONTROL_DUMP_ENABLED
     CHIP_ERROR Dump(const Entry & entry);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -169,6 +169,7 @@ CHIP_ERROR WriteClient::StartNewMessage()
     if (mState == State::AddAttribute)
     {
         ReturnErrorOnFailure(FinalizeMessage(true));
+        mIsWriteRequestChunked = true;
     }
 
     // Do not allow timed request with chunks.
@@ -247,6 +248,7 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     return err;
 }
 
+// TODO Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList
 CHIP_ERROR
 WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
                                                            TLV::TLVReader & valueReader, bool & outChunkingNeeded,

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -187,7 +187,7 @@ CHIP_ERROR WriteClient::StartNewMessage()
     reservedSize = static_cast<uint16_t>(reservedSize + Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES);
 
     // ... and the overhead for end of AttributeDataIBs (end of container), more chunks flag, end of WriteRequestMessage (another
-    // end of container).
+    // end of container), the End of the List (EndOfContainer as well) and End of AttributeDataIB (EndOfContainer)
     reservedSize = static_cast<uint16_t>(reservedSize + kReservedSizeForTLVEncodingOverhead);
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -188,7 +188,8 @@ CHIP_ERROR WriteClient::StartNewMessage()
 
     // ... and the overhead for end of AttributeDataIBs (end of container), more chunks flag, end of WriteRequestMessage (another
     // end of container), the End of the List (EndOfContainer as well) and End of AttributeDataIB (EndOfContainer)
-    reservedSize = static_cast<uint16_t>(reservedSize + kReservedSizeForTLVEncodingOverhead);
+    reservedSize = static_cast<uint16_t>(reservedSize + kReservedSizeForTLVEncodingOverhead + kReservedSizeForEndOfListContainer +
+                                         kReservedSizeForEndOfAttributeDataIB);
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     // ... and for unit tests.
@@ -250,7 +251,7 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
 CHIP_ERROR
 WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app::ConcreteDataAttributePath & attributePath,
                                                                  TLV::TLVReader & valueReader, bool & chunkingNeeded,
-                                                                 ListIndex & outNumSuccessfullyEncodedItems)
+                                                                 ListIndex & outEncodedItemCount)
 {
     TLV::TLVWriter backupWriter;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -262,7 +263,7 @@ WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app
     chip::TLV::TLVWriter * writer = nullptr;
     VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    outNumSuccessfullyEncodedItems = 0;
+    outEncodedItemCount = 0;
 
     while ((err = valueReader.Next()) == CHIP_NO_ERROR)
     {
@@ -277,7 +278,7 @@ WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app
             break;
         }
         ReturnErrorOnFailure(err);
-        outNumSuccessfullyEncodedItems++;
+        outEncodedItemCount++;
     }
     VerifyOrReturnError(err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR, err);
 
@@ -295,35 +296,33 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
 
         TLV::TLVReader dataReader;
         TLV::TLVReader valueReader;
-        CHIP_ERROR err                       = CHIP_NO_ERROR;
-        uint16_t numSuccessfullyEncodedItems = kInvalidListIndex;
-        ConcreteDataAttributePath path       = attributePath;
+        uint16_t encodedItemCount      = 0;
+        ConcreteDataAttributePath path = attributePath;
 
-        //    ListIndex nextItemToAppendIndex      = kInvalidListIndex;
-        bool chunkingNeeded = false;
-
-        //  dataReader.Init(data);
-        //   dataReader.OpenContainer(valueReader);
-
-        // Encode an empty list for the chunking protocol.
+        // BACKWARD COMPATIBILITY: Legacy OTA Requestor Servers( Pre-Matter 1.4) only support having an empty list for ReplaceAll
+        // when writing to the DefaultOTAProviders attribute and they will only Decode List Items that are received as part of the
+        // AppendItem List operation. So we must allow this for backward compatiblity.
+        // TODO remove this special case when Matter 1.3 is Sunsetted
         bool encodeEmptyListAsReplaceAll =
             (path.mClusterId == Clusters::OtaSoftwareUpdateRequestor::Id &&
              path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id);
+
         if (encodeEmptyListAsReplaceAll)
         {
             ReturnErrorOnFailure(EnsureMessage());
             ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
-            numSuccessfullyEncodedItems = 0;
+            encodedItemCount = 0;
         }
         else
         {
             dataReader.Init(data);
             dataReader.OpenContainer(valueReader);
+            bool chunkingNeeded = false;
 
             ReturnErrorOnFailure(StartNewMessage());
 
-            ReturnErrorOnFailure(TryPutPreencodedListIntoSingleAttributeWritePayload(path, valueReader, chunkingNeeded,
-                                                                                     numSuccessfullyEncodedItems));
+            ReturnErrorOnFailure(
+                TryPutPreencodedListIntoSingleAttributeWritePayload(path, valueReader, chunkingNeeded, encodedItemCount));
 
             if (!chunkingNeeded)
             {
@@ -332,28 +331,24 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
 
             // Start a new WriteRequest chunk.
             ReturnErrorOnFailure(StartNewMessage());
-            //   nextItemToAppendIndex = numSuccessfullyEncodedItems;
         }
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
-        // TODO HOW WOULD I KNOW WHERE TO CONTINUE? if chunking is needed, where to put the index?
-        // This ?
 
-        //    TLV::TLVReader dataReader2;
-        //  dataReader2.Init(valueReader.GetReadPoint(), valueReader.GetRemainingLength());
-        //   TLV::TLVUpdater UpdateReader2;
-        // UpdateReader2.Init(dataReader, )
-
+        // We will restart iterating again on ValueReader, Only Appending the Items we need to Append
         dataReader.Init(data);
         dataReader.OpenContainer(valueReader);
-        ListIndex nextItemToAppendIndex = 0;
+
+        CHIP_ERROR err            = CHIP_NO_ERROR;
+        uint16_t currentItemCount = 0;
 
         while ((err = valueReader.Next()) == CHIP_NO_ERROR)
         {
-            if (nextItemToAppendIndex >= numSuccessfullyEncodedItems)
+            currentItemCount++;
+
+            if (currentItemCount > encodedItemCount)
             {
                 ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
             }
-            nextItemToAppendIndex++;
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -362,9 +357,9 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         }
         return err;
     }
-    ReturnErrorOnFailure(EnsureMessage());
 
     // We are writing a non-list attribute, or we are writing a single element of a list.
+    ReturnErrorOnFailure(EnsureMessage());
     return PutSinglePreencodedAttributeWritePayload(attributePath, data);
 }
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -248,9 +248,9 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
 }
 
 CHIP_ERROR
-WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app::ConcreteDataAttributePath & attributePath,
-                                                                 TLV::TLVReader & valueReader, bool & chunkingNeeded,
-                                                                 ListIndex & outEncodedItemCount)
+WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
+                                                           TLV::TLVReader & valueReader, bool & outChunkingNeeded,
+                                                           ListIndex & outEncodedItemCount)
 {
 
     ReturnErrorOnFailure(EnsureListStarted(attributePath));
@@ -270,8 +270,8 @@ WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app
         if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
             mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
-            chunkingNeeded = true;
-            err            = CHIP_NO_ERROR;
+            outChunkingNeeded = true;
+            err               = CHIP_NO_ERROR;
             break;
         }
         ReturnErrorOnFailure(err);
@@ -320,8 +320,7 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
             bool chunkingNeeded = false;
 
             ReturnErrorOnFailure(
-                TryPutPreencodedListIntoSingleAttributeWritePayload(path, valueReader, chunkingNeeded, encodedItemCount));
-
+                TryPutPreencodedAttributeWritePayloadIntoList(path, valueReader, chunkingNeeded, encodedItemCount));
             if (!chunkingNeeded)
             {
                 return CHIP_NO_ERROR;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -279,9 +279,7 @@ WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::Conc
     }
     VerifyOrReturnError(err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR, err);
 
-    ReturnErrorOnFailure(EnsureListEnded());
-
-    return CHIP_NO_ERROR;
+    return EnsureListEnded();
 }
 
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -288,47 +288,72 @@ WriteClient::TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app
 
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
-    ReturnErrorOnFailure(EnsureMessage());
 
     // ListIndex is missing and the data is an array -- we are writing a whole list.
     if (!attributePath.IsListOperation() && data.GetType() == TLV::TLVType::kTLVType_Array)
     {
+
         TLV::TLVReader dataReader;
         TLV::TLVReader valueReader;
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
-        dataReader.Init(data);
-        dataReader.OpenContainer(valueReader);
+        CHIP_ERROR err                       = CHIP_NO_ERROR;
+        uint16_t numSuccessfullyEncodedItems = kInvalidListIndex;
+        ConcreteDataAttributePath path       = attributePath;
 
         //    ListIndex nextItemToAppendIndex      = kInvalidListIndex;
-        uint16_t numSuccessfullyEncodedItems = kInvalidListIndex;
-        bool chunkingNeeded                  = false;
-
-        ConcreteDataAttributePath path = attributePath;
+        bool chunkingNeeded = false;
 
         //  dataReader.Init(data);
         //   dataReader.OpenContainer(valueReader);
 
         // Encode an empty list for the chunking protocol.
-        // ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
-        ReturnErrorOnFailure(
-            TryPutPreencodedListIntoSingleAttributeWritePayload(path, valueReader, chunkingNeeded, numSuccessfullyEncodedItems));
-
-        if (!chunkingNeeded)
+        bool encodeEmptyListAsReplaceAll =
+            (path.mClusterId == Clusters::OtaSoftwareUpdateRequestor::Id &&
+             path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id);
+        if (encodeEmptyListAsReplaceAll)
         {
-            return CHIP_NO_ERROR;
+            ReturnErrorOnFailure(EnsureMessage());
+            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+            numSuccessfullyEncodedItems = 0;
         }
+        else
+        {
+            dataReader.Init(data);
+            dataReader.OpenContainer(valueReader);
 
-        // Start a new WriteRequest chunk.
-        ReturnErrorOnFailure(StartNewMessage());
-        //   nextItemToAppendIndex = numSuccessfullyEncodedItems;
+            ReturnErrorOnFailure(StartNewMessage());
 
+            ReturnErrorOnFailure(TryPutPreencodedListIntoSingleAttributeWritePayload(path, valueReader, chunkingNeeded,
+                                                                                     numSuccessfullyEncodedItems));
+
+            if (!chunkingNeeded)
+            {
+                return CHIP_NO_ERROR;
+            }
+
+            // Start a new WriteRequest chunk.
+            ReturnErrorOnFailure(StartNewMessage());
+            //   nextItemToAppendIndex = numSuccessfullyEncodedItems;
+        }
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
         // TODO HOW WOULD I KNOW WHERE TO CONTINUE? if chunking is needed, where to put the index?
         // This ?
+
+        //    TLV::TLVReader dataReader2;
+        //  dataReader2.Init(valueReader.GetReadPoint(), valueReader.GetRemainingLength());
+        //   TLV::TLVUpdater UpdateReader2;
+        // UpdateReader2.Init(dataReader, )
+
+        dataReader.Init(data);
+        dataReader.OpenContainer(valueReader);
+        ListIndex nextItemToAppendIndex = 0;
+
         while ((err = valueReader.Next()) == CHIP_NO_ERROR)
         {
-            ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
+            if (nextItemToAppendIndex >= numSuccessfullyEncodedItems)
+            {
+                ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
+            }
+            nextItemToAppendIndex++;
         }
 
         if (err == CHIP_END_OF_TLV)
@@ -337,6 +362,8 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         }
         return err;
     }
+    ReturnErrorOnFailure(EnsureMessage());
+
     // We are writing a non-list attribute, or we are writing a single element of a list.
     return PutSinglePreencodedAttributeWritePayload(attributePath, data);
 }

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -187,9 +187,8 @@ CHIP_ERROR WriteClient::StartNewMessage()
     reservedSize = static_cast<uint16_t>(reservedSize + Crypto::CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES);
 
     // ... and the overhead for end of AttributeDataIBs (end of container), more chunks flag, end of WriteRequestMessage (another
-    // end of container), the End of the List (EndOfContainer as well) and End of AttributeDataIB (EndOfContainer)
-    reservedSize = static_cast<uint16_t>(reservedSize + kReservedSizeForTLVEncodingOverhead + kReservedSizeForEndOfListContainer +
-                                         kReservedSizeForEndOfAttributeDataIB);
+    // end of container).
+    reservedSize = static_cast<uint16_t>(reservedSize + kReservedSizeForTLVEncodingOverhead);
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     // ... and for unit tests.

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -397,8 +397,7 @@ private:
             outEncodedItemCount++;
         }
 
-        ReturnErrorOnFailure(EnsureListEnded());
-        return CHIP_NO_ERROR;
+        return EnsureListEnded();
     }
 
     /**

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -254,28 +254,23 @@ private:
     /**
      *  Encode an attribute value that can be directly encoded using DataModel::Encode.
      */
-    template <class T, std::enable_if_t<!DataModel::IsFabricScoped<T>::value, int> = 0>
+    template <class T>
     CHIP_ERROR TryEncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)
     {
         chip::TLV::TLVWriter * writer = nullptr;
 
         ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
         VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        ReturnErrorOnFailure(DataModel::Encode(*writer, chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), value));
-        ReturnErrorOnFailure(FinishAttributeIB());
-
-        return CHIP_NO_ERROR;
-    }
-
-    template <class T, std::enable_if_t<DataModel::IsFabricScoped<T>::value, int> = 0>
-    CHIP_ERROR TryEncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)
-    {
-        chip::TLV::TLVWriter * writer = nullptr;
-
-        ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
-        VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
-        ReturnErrorOnFailure(
-            DataModel::EncodeForWrite(*writer, chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), value));
+        // Use if constexpr to make compile-time decision on which encoding method to use
+        if constexpr (DataModel::IsFabricScoped<T>::value)
+        {
+            ReturnErrorOnFailure(
+                DataModel::EncodeForWrite(*writer, chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), value));
+        }
+        else
+        {
+            ReturnErrorOnFailure(DataModel::Encode(*writer, chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), value));
+        }
         ReturnErrorOnFailure(FinishAttributeIB());
 
         return CHIP_NO_ERROR;

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -187,7 +187,9 @@ public:
         uint16_t numSuccessfullyEncodedItems = kInvalidListIndex;
         bool chunkingNeeded                  = false;
 
-        VerifyOrReturnError(!listValue.empty(), CHIP_ERROR_INVALID_LIST_LENGTH);
+        // TODO Should we be able to send an empty List? In TestUserLabelCluster.yaml we send an empty list to CLEAR User Label
+        // List, This means this should be supported?
+        // VerifyOrReturnError(!listValue.empty(), CHIP_ERROR_INVALID_LIST_LENGTH);
 
         // BACKWARD COMPATIBILITY: Legacy OTA Requestor Servers( Pre-Matter 1.4) only support having an empty list for ReplaceAll
         // when writing to the DefaultOTAProviders attribute and they will only Decode List Items that are  of the AppendItem List
@@ -195,7 +197,11 @@ public:
         // TODO remove this special case when Matter 1.3 is Sunsetted
         bool encodeEmptyListAsReplaceAll =
             (path.mClusterId == Clusters::OtaSoftwareUpdateRequestor::Id &&
-             path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id);
+             path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id) ||
+            // TODO, fix the ListNullablesAndOptionalsStruct in test-cluster-server, do we need to keep this for backward
+            // compatibility?
+            (path.mClusterId == Clusters::UnitTesting::Id &&
+             path.mAttributeId == Clusters::UnitTesting::Attributes::ListNullablesAndOptionalsStruct::Id);
 
         if (encodeEmptyListAsReplaceAll)
         {

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -197,11 +197,7 @@ public:
         // TODO remove this special case when Matter 1.3 is Sunsetted
         bool encodeEmptyListAsReplaceAll =
             (path.mClusterId == Clusters::OtaSoftwareUpdateRequestor::Id &&
-             path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id) ||
-            // TODO, fix the ListNullablesAndOptionalsStruct in test-cluster-server, do we need to keep this for backward
-            // compatibility?
-            (path.mClusterId == Clusters::UnitTesting::Id &&
-             path.mAttributeId == Clusters::UnitTesting::Attributes::ListNullablesAndOptionalsStruct::Id);
+             path.mAttributeId == Clusters::OtaSoftwareUpdateRequestor::Attributes::DefaultOTAProviders::Id);
 
         if (encodeEmptyListAsReplaceAll)
         {

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -167,11 +167,9 @@ public:
      *
      * This function will Attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
      cluster server as a ReplaceAll Item operation
-     * If the list is too large, WriteRequest will be chunked and remaining items will be encoded as AppendItem operations, chunking
-     them as needed
+     * If the list is too large, the WriteRequest will be chunked and remaining items will be encoded as AppendItem operations,
+     chunking them as needed
      *
-        // The items in this list will be decoded by servers as part of the ReplaceAll list.
-
      */
     template <class T>
     CHIP_ERROR EncodeAttribute(const AttributePathParams & attributePath, const DataModel::List<T> & listValue,
@@ -429,7 +427,7 @@ private:
     }
 
     /**
-     * Encode a preencoded attribute data, returns TLV encode error if the ramaining space of current chunk is too small for the
+     * Encode a preencoded attribute data, returns TLV encode error if the remaining space of current chunk is too small for the
      * AttributeDataIB.
      */
     CHIP_ERROR TryPutSinglePreencodedAttributeWritePayload(const ConcreteDataAttributePath & attributePath,
@@ -441,9 +439,13 @@ private:
     CHIP_ERROR PutSinglePreencodedAttributeWritePayload(const ConcreteDataAttributePath & attributePath,
                                                         const TLV::TLVReader & data);
 
-    CHIP_ERROR TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app::ConcreteDataAttributePath & attributePath,
-                                                                   TLV::TLVReader & valueReader, bool & chunkingNeeded,
-                                                                   uint16_t & outEncodedItemCount);
+    /**
+     * Encodes preencoded attribute data into a list, that will be decoded by Cluster Servers as a "ReplaceAll ListOperation".
+     * Returns outChunkingNeeded = true if it was not possible to fit all the data into a single list.
+     */
+    CHIP_ERROR TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
+                                                             TLV::TLVReader & valueReader, bool & outChunkingNeeded,
+                                                             uint16_t & outEncodedItemCount);
     CHIP_ERROR EnsureMessage();
 
     /**

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -369,7 +369,7 @@ private:
     template <class T>
     CHIP_ERROR TryEncodeListIntoSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath,
                                                       const DataModel::List<T> & list, bool & chunkingNeeded,
-                                                      ListIndex & numSuccessfullyEncodedItems)
+                                                      ListIndex & outNumSuccessfullyEncodedItems)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
         TLV::TLVWriter backupWriter;
@@ -379,7 +379,7 @@ private:
         chip::TLV::TLVWriter * writer = nullptr;
         VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-        numSuccessfullyEncodedItems = 0;
+        outNumSuccessfullyEncodedItems = 0;
 
         for (auto & item : list)
         {
@@ -400,7 +400,7 @@ private:
                 break;
             }
             ReturnErrorOnFailure(err);
-            numSuccessfullyEncodedItems++;
+            outNumSuccessfullyEncodedItems++;
         }
 
         ReturnErrorOnFailure(EnsureListEnded());
@@ -448,6 +448,9 @@ private:
     CHIP_ERROR PutSinglePreencodedAttributeWritePayload(const ConcreteDataAttributePath & attributePath,
                                                         const TLV::TLVReader & data);
 
+    CHIP_ERROR TryPutPreencodedListIntoSingleAttributeWritePayload(const chip::app::ConcreteDataAttributePath & attributePath,
+                                                                   TLV::TLVReader & valueReader, bool & chunkingNeeded,
+                                                                   ListIndex & outNumSuccessfullyEncodedItems);
     CHIP_ERROR EnsureMessage();
 
     /**

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -331,6 +331,9 @@ private:
 
         TLV::TLVType outerType;
 
+        ReturnErrorOnFailure(
+            mMessageWriter.ReserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB));
+
         ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
         VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
         ReturnErrorOnFailure(
@@ -543,7 +546,8 @@ private:
         kReservedSizeForEndOfContainer + kReservedSizeForEndOfContainer;
     bool mHasDataVersion = false;
 
-    // This was not added to kReservedSizeForTLVEncodingOverhead since it will be "Unreserved" before the others.
+    // These were not added to kReservedSizeForTLVEncodingOverhead since they will only be Reserved and Unreserved when Encoding
+    // Attributes that use a list Data Type
     static constexpr uint32_t kReservedSizeForEndOfListContainer   = 1;
     static constexpr uint32_t kReservedSizeForEndOfAttributeDataIB = 1;
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -129,7 +129,7 @@ public:
                 bool aSuppressResponse = false) :
         mpExchangeMgr(apExchangeMgr),
         mExchangeCtx(*this), mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs),
-        mSuppressResponse(aSuppressResponse)
+        mSuppressResponse(aSuppressResponse), mIsWriteRequestChunked(false)
     {
         assertChipStackLockedByCurrentThread();
     }
@@ -272,6 +272,11 @@ public:
      *  consumer is responsible for calling Shutdown on the WriteClient.
      */
     CHIP_ERROR SendWriteRequest(const SessionHandle & session, System::Clock::Timeout timeout = System::Clock::kZero);
+
+    /**
+     *  Returns true if the WriteRequest is Chunked.
+     */
+    bool IsWriteRequestChunked() { return mIsWriteRequestChunked; };
 
 private:
     friend class TestWriteInteraction;
@@ -503,6 +508,8 @@ private:
 
     // A list of buffers, one buffer for each chunk.
     System::PacketBufferHandle mChunks;
+
+    bool mIsWriteRequestChunked = false;
 
     // TODO: This file might be compiled with different build flags on Darwin platform (when building WriteClient.cpp and
     // CHIPClustersObjc.mm), which will cause undefined behavior when building write requests. Uncomment the #if and #endif after

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -209,7 +209,8 @@ public:
             // StartNewMessage was called to make sure we always create a new chunk when we have a new Attribute to Encode, this
             // might be more efficient
             // TODO should we keep this or just use EnsureMessage; if we choose EnsureMessage, we will have to adapt
-            // EnsureListStarted to make sure we create a New Chunk if it fails (could happens when a new Attribute is added)
+            // EnsureListStarted to make sure we create a New Chunk if it fails (could happens when a new Attribute is added to the
+            // same chunk)
             ReturnErrorOnFailure(StartNewMessage());
 
             // TODO CHANGE NAME OF numEncodedItems

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -298,6 +298,8 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         // Validating all ACL entries in the ReplaceAll list, before Updating or Deleting any entries, if any of the entries has an
         // invalid field, the whole "ReplaceAll" list will be rejected.
+        // TODO Discuss: if this fail, should we make it invalidate ALL received list Entries (i.e. even those that will be part of
+        // ListOperation::AppendItem? in case of chunking?)
         ReturnErrorOnFailure(IsValidAclEntryList(list));
 
         auto iterator = list.begin();

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -270,7 +270,7 @@ CHIP_ERROR AccessControlAttribute::IsValidAclEntryList(const DataModel::Decodabl
     auto validationIterator = list.begin();
     while (validationIterator.Next())
     {
-        VerifyOrReturnError(GetAccessControl().IsValid(validationIterator.GetValue().GetEntry()), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(validationIterator.GetValue().GetEntry().IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
     }
     ReturnErrorOnFailure(validationIterator.GetStatus());
 
@@ -296,10 +296,8 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         VerifyOrReturnError(newCount <= maxCount, CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
 
-        // Validating all ACL entries in the ReplaceAll list, before Updating or Deleting any entries, if any of the entries has an
+        // Validating all ACL entries in the ReplaceAll list before Updating or Deleting any entries. If any of the entries has an
         // invalid field, the whole "ReplaceAll" list will be rejected.
-        // TODO Discuss: if this fail, should we make it invalidate ALL received list Entries (i.e. even those that will be part of
-        // ListOperation::AppendItem? in case of chunking?)
         ReturnErrorOnFailure(IsValidAclEntryList(list));
 
         auto iterator = list.begin();

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -270,8 +270,6 @@ CHIP_ERROR AccessControlAttribute::IsValidAclEntryList(const DataModel::Decodabl
     auto validationIterator = list.begin();
     while (validationIterator.Next())
     {
-        // validationIterator.Next() will implicity call Decode and check that each field of an Access Control Entry
-        // (AccessControlEntryStruct) is valid
         VerifyOrReturnError(GetAccessControl().IsValid(validationIterator.GetValue().GetEntry()), CHIP_ERROR_INVALID_ARGUMENT);
     }
     ReturnErrorOnFailure(validationIterator.GetStatus());
@@ -298,8 +296,8 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         VerifyOrReturnError(newCount <= maxCount, CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
 
-        // Validating all ACL entries in the ReplaceAll list, if any of the entries has an invalid field, we will reject the whole
-        // list.
+        // Validating all ACL entries in the ReplaceAll list, before Updating or Deleting any entries, if any of the entries has an
+        // invalid field, the whole "ReplaceAll" list will be rejected.
         ReturnErrorOnFailure(IsValidAclEntryList(list));
 
         auto iterator = list.begin();

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -559,7 +559,7 @@ CHIP_ERROR TestAttrAccess::WriteListNullablesAndOptionalsStructAttribute(const C
             return CHIP_NO_ERROR;
         }
         // If count is greater than 0, this means we have a non-empty ReplaceAll List; We should process this list.
-        else if (count > 0)
+        if (count > 0)
         {
             auto iterator = list.begin();
             while (iterator.Next())

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -627,13 +627,16 @@ TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteHandlerReceiveInvalidMessage)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 96 bytes, so that we make sure to chunk.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 96) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    // it was empirically determined that we need a list of at least 25 items to make sure we chunk (when the reserved buffer size =
+    // kMaxSecureSduLengthBytes - 96)
+    constexpr uint8_t kTestListLength = 30;
+    ByteSpan list[kTestListLength];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)), CHIP_NO_ERROR);
 
     GetLoopback().mSentMessageCount                 = 0;
     GetLoopback().mNumMessagesToDrop                = 1;
@@ -641,6 +644,7 @@ TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteHandlerReceiveInvalidMessage)
     EXPECT_EQ(writeClient.SendWriteRequest(sessionHandle), CHIP_NO_ERROR);
     DrainAndServiceIO();
 
+    // TODO failure here, we have NULLPTR ERROR or a segmentation fault
     EXPECT_EQ(InteractionModelEngine::GetInstance()->GetNumActiveWriteHandlers(), 1u);
     EXPECT_EQ(GetLoopback().mSentMessageCount, 3u);
     EXPECT_EQ(GetLoopback().mDroppedMessageCount, 1u);
@@ -692,13 +696,13 @@ TEST_F(TestWriteInteraction, TestWriteHandlerInvalidateFabric)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 96 bytes, so that we make sure to chunk.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 96) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    ByteSpan list[30];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 30)), CHIP_NO_ERROR);
 
     GetLoopback().mDroppedMessageCount              = 0;
     GetLoopback().mSentMessageCount                 = 0;

--- a/src/app/tests/suites/TestAccessControlCluster.yaml
+++ b/src/app/tests/suites/TestAccessControlCluster.yaml
@@ -215,6 +215,14 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid auth mode"
@@ -248,6 +256,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -289,6 +304,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid target"
@@ -323,6 +345,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -386,6 +415,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry too many targets"
@@ -441,6 +477,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -520,54 +563,21 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value: [
+          value: # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+              [
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
                       Subjects: null,
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 0, DeviceType: null },
-                              { Cluster: 1, Endpoint: null, DeviceType: null },
-                              { Cluster: 2, Endpoint: 3, DeviceType: null },
-                          ],
+                      Targets: null,
                   },
                   {
                       FabricIndex: 1,
                       Privilege: 1, # view
                       AuthMode: 2, # case
-                      Subjects: [4, 5, 6, 7],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 8, DeviceType: null },
-                              { Cluster: 9, Endpoint: null, DeviceType: null },
-                              { Cluster: 10, Endpoint: 11, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 3, # operate
-                      AuthMode: 3, # group
-                      Subjects: [12, 13, 14, 15],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 16, DeviceType: null },
-                              { Cluster: 17, Endpoint: null, DeviceType: null },
-                              { Cluster: 18, Endpoint: 19, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 1, # view
-                      AuthMode: 2, # case
-                      Subjects: [20, 21, 22, 23],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 24, DeviceType: null },
-                              { Cluster: 25, Endpoint: null, DeviceType: null },
-                              { Cluster: 26, Endpoint: 27, DeviceType: null },
-                          ],
+                      Subjects: null,
+                      Targets: null,
                   },
               ]
 

--- a/src/app/tests/suites/TestAccessControlCluster.yaml
+++ b/src/app/tests/suites/TestAccessControlCluster.yaml
@@ -594,6 +594,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Verify"
@@ -604,6 +611,107 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in first ACL Entry, with 2nd ACL Entry completely
+          valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Even though a malformed entry was sent, nothing has changed and we still retain the Valid ACLs from previous step
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in second ACL Entry, with 1st ACL Entry being
+          Valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Test: If second ACL Entry had invalid field, even 1st ACL Entry should be rejected. While retaining the previous Valid ACLs
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
@@ -257,7 +257,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
+          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 19: TH1 writes DUT Endpoint 0 AccessControl cluster Extension

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -1101,12 +1101,20 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value:
-              [
+          value: [
                   {
                       Privilege: 5,
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
+                      Targets: null,
+                      FabricIndex: CurrentFabricIndexValue,
+                  },
+                  # TODO is this ok? since when running automatically, we are retaining the value from Step 21 and Step 22 (Steps 24, 25 27 and 28 are skipped)
+                  # TODO can we make this as a variable? depending on what was executed? if Step 27 was Executed, we would expect its ACL to be printed instead of Step 21's ACL
+                  {
+                      Privilege: 3,
+                      AuthMode: 2,
+                      Subjects: [CAT1, CAT2, CAT3, CAT4],
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,
                   },

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -1109,8 +1109,7 @@ tests:
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,
                   },
-                  # TODO is this ok? since when running automatically, we are retaining the value from Step 21 and Step 22 (Steps 24, 25 27 and 28 are skipped)
-                  # TODO can we make this as a variable? depending on what was executed? if Step 27 was Executed, we would expect its ACL to be printed instead of Step 21's ACL
+                  # We are retaining the ACLs from Step 21 and Step 22
                   {
                       Privilege: 3,
                       AuthMode: 2,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -140,20 +140,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Data: D_OK_EMPTY,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Data: D_OK_SINGLE,
@@ -174,26 +161,18 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 8, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
-      response:
-          value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 2,
-                  LatestValue:
-                      {
-                          Data: D_OK_SINGLE,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+      response: 
+            value:
+              {}
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -211,26 +190,18 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 10, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 11: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
           value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 1,
-                  LatestValue:
-                      {
-                          Data: D_OK_EMPTY,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+              {}
 
     - label:
           "Step 12: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -256,7 +227,8 @@ tests:
                   ChangeType: 2,
                   LatestValue:
                       {
-                          Data: D_OK_EMPTY,
+                        # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed 
+                          Data: D_OK_SINGLE,
                           FabricIndex: CurrentFabricIndexValue,
                       },
                   FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -170,9 +170,8 @@ tests:
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
-      response: 
-            value:
-              {}
+      response:
+          value: {}
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -200,8 +199,7 @@ tests:
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value:
-              {}
+          value: {}
 
     - label:
           "Step 12: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -225,9 +223,8 @@ tests:
                   AdminNodeID: CommissionerNodeId,
                   AdminPasscodeID: null,
                   ChangeType: 2,
-                  LatestValue:
-                      {
-                        # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed 
+                  LatestValue: {
+                          # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed
                           Data: D_OK_SINGLE,
                           FabricIndex: CurrentFabricIndexValue,
                       },

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -114,23 +114,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -190,59 +174,23 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since in Step 6 one of the ACL List Entries had an invalid item, then the whole ACL Entries List was rejected, As such no change will happen to the already-existing AccessControl Entries, and thus no AccessControlEntryChanged event will be generated
+      # SKIP for Now, as YAML does not provide a way to check that the received ReportDataMessage does NOT contain an EventReportIB
+      # Example of Output of this Step
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] ReportDataMessage =
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] {
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	SuppressResponse = true, 
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	InteractionModelRevision = 12
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] }
+
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
-      PICS: ACL.S.E00
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
           - values:
                 - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 3,
-                                  AuthMode: 3,
-                                  Subjects: null,
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
+                      {}

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -174,15 +174,15 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+
       # Since in Step 6 one of the ACL List Entries had an invalid item, then the whole ACL Entries List was rejected, As such no change will happen to the already-existing AccessControl Entries, and thus no AccessControlEntryChanged event will be generated
       # SKIP for Now, as YAML does not provide a way to check that the received ReportDataMessage does NOT contain an EventReportIB
       # Example of Output of this Step
       # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] ReportDataMessage =
       # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] {
-      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	SuppressResponse = true, 
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	SuppressResponse = true,
       # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	InteractionModelRevision = 12
       # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] }
-
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
@@ -192,5 +192,4 @@ tests:
       eventNumber: "LastReceivedEventNumber + 1"
       response:
           - values:
-                - value:
-                      {}
+                - value: {}

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -174,7 +174,6 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
-
       # Since in Step 6 one of the ACL List Entries had an invalid item, then the whole ACL Entries List was rejected, As such no change will happen to the already-existing AccessControl Entries, and thus no AccessControlEntryChanged event will be generated
       # SKIP for Now, as YAML does not provide a way to check that the received ReportDataMessage does NOT contain an EventReportIB
       # Example of Output of this Step

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
@@ -378,23 +378,7 @@ tests:
                       {
                           AdminNodeID: TH1CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH1CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH1FabricIndex,
-                              },
-                          FabricIndex: TH1FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH1CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -435,23 +419,7 @@ tests:
                       {
                           AdminNodeID: TH2CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH2CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH2FabricIndex,
-                              },
-                          FabricIndex: TH2FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH2CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -57,7 +57,10 @@ uint32_t gIterationCount = 0;
 constexpr EndpointId kTestEndpointId      = 2;
 constexpr AttributeId kTestListAttribute  = 6;
 constexpr AttributeId kTestListAttribute2 = 7;
-constexpr uint32_t kTestListLength        = 5;
+constexpr uint32_t kTestListLength        = 1;
+// constexpr uint32_t kTestListLengthTRANSACTION = 25;
+
+// constexpr uint32_t kTestListLengthv2 = 5;
 
 // We don't really care about the content, we just need a buffer.
 uint8_t sByteSpanData[app::kMaxSecureSduLengthBytes];
@@ -183,14 +186,14 @@ CHIP_ERROR TestAttrAccess::Write(const app::ConcreteDataAttributePath & aPath, a
     {
         app::DataModel::Nullable<app::DataModel::DecodableList<ByteSpan>> list;
         CHIP_ERROR err = aDecoder.Decode(list);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "NotList/Replace All: Decode result: %s", err.AsString());
         return err;
     }
     if (aPath.mListOp == app::ConcreteDataAttributePath::ListOperation::AppendItem)
     {
         ByteSpan listItem;
         CHIP_ERROR err = aDecoder.Decode(listItem);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "AppendItem: Decode result: %s", err.AsString());
         return err;
     }
 
@@ -227,7 +230,23 @@ TEST_F(TestWriteChunking, TestListChunking)
     // AttributeDataIBs into the packet. ~30-40 bytes covers a single write chunk, but let's 2-3x that
     // to ensure we'll sweep from fitting 2 chunks to 3-4 chunks.
     //
-    constexpr size_t minReservationSize = kMaxSecureSduLengthBytes - 75 - 100;
+
+    // uint8_t list_binary[] = {
+    //     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    // };
+
+    //  ByteSpan list(list_binary);
+
+    // CHIP_ERROR err = CHIP_NO_ERROR;
+
+    //  err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<uint8_t>(list_binary));
+    //  EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    // We've empirically determined that by reserving all but 60 bytes in the packet buffer, we can fit 1
+    // AttributeDataIB into the packet with a List of ByteSpans with 5 empty items.
+    constexpr size_t minReservationSize = kMaxSecureSduLengthBytes - 60 - 100;
+
     for (uint32_t i = 100; i > 0; i--)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -240,9 +259,11 @@ TEST_F(TestWriteChunking, TestListChunking)
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
                                      static_cast<uint16_t>(minReservationSize + i) /* reserved buffer size */);
 
-        ByteSpan list[kTestListLength];
+        ByteSpan list[40];
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 40));
+
+        //  err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, sizeof(list_binary)));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         err = writeClient.SendWriteRequest(sessionHandle);
@@ -258,7 +279,9 @@ TEST_F(TestWriteChunking, TestListChunking)
             DrainAndServiceIO();
         }
 
-        EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength + 1 /* an extra item for the empty list at the beginning */);
+        // IN THE WAY THE WRITE CHUNKING WORKS NOW, THE NUMBER OF SUCCESSes depende on how many chunks we get, and that is not
+        // predictable EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength /* an extra item for the empty list at the beginning
+        // */);
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -308,13 +331,13 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
 
-        ByteSpan list[kTestListLength];
+        ByteSpan list[5];
         for (auto & item : list)
         {
             item = ByteSpan(sByteSpanData, static_cast<uint32_t>(i));
         }
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5));
         if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
             // This kind of error is expected.
@@ -338,7 +361,7 @@ TEST_F(TestWriteChunking, TestBadChunking)
             DrainAndServiceIO();
         }
 
-        EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength + 1 /* an extra item for the empty list at the beginning */);
+        //   EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength /* an extra item for the empty list at the beginning */);
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -388,13 +411,19 @@ TEST_F(TestWriteChunking, TestConflictWrite)
     app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
                                   static_cast<uint16_t>(kReserveSize));
 
-    ByteSpan list[kTestListLength];
+    uint8_t list_binary[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
+                              0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
+                              0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89
+
+    };
+
+    ByteSpan list(list_binary);
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
+    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<uint8_t>(list_binary));
     EXPECT_EQ(err, CHIP_NO_ERROR);
-    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
+    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<uint8_t>(list_binary));
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = writeClient1.SendWriteRequest(sessionHandle);
@@ -417,10 +446,21 @@ TEST_F(TestWriteChunking, TestConflictWrite)
             writeCallbackRef1 = &writeCallback2;
         }
 
-        EXPECT_EQ(writeCallbackRef1->mSuccessCount, kTestListLength + 1 /* an extra item for the empty list at the beginning */);
-        EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
+        // TODO resolve this:
+        // chunking is done automatically, it is difficult to predict how many success or Errors we get,
+
+        //        For Sure WriteCallbackRef2 will not succeed
+        // but we will get many errors in others, (is it because we get as many Busy Errors as we have WriteRequest messages? so it
+        // becomes unpredictable)
+
+        //    EXPECT_EQ(writeCallbackRef1->mSuccessCount,
+        //     kTestListLengthv2 /* an extra item for the empty list at the beginning */); // TODO remove the comments on extra
+        // list item
+        //   EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
+
         EXPECT_EQ(writeCallbackRef2->mSuccessCount, 0u);
-        EXPECT_EQ(writeCallbackRef2->mErrorCount, kTestListLength + 1);
+        //     EXPECT_EQ(writeCallbackRef2->mErrorCount, kTestListLengthv2);
+
         EXPECT_EQ(writeCallbackRef2->mLastErrorReason.mStatus, Protocols::InteractionModel::Status::Busy);
 
         EXPECT_EQ(writeCallbackRef1->mOnDoneCount, 1u);
@@ -483,9 +523,9 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
 
     {
         EXPECT_EQ(writeCallback1.mErrorCount, 0u);
-        EXPECT_EQ(writeCallback1.mSuccessCount, kTestListLength + 1);
+        EXPECT_EQ(writeCallback1.mSuccessCount, kTestListLength);
         EXPECT_EQ(writeCallback2.mErrorCount, 0u);
-        EXPECT_EQ(writeCallback2.mSuccessCount, kTestListLength + 1);
+        EXPECT_EQ(writeCallback2.mSuccessCount, kTestListLength);
 
         EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
         EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
@@ -505,7 +545,7 @@ void TestWriteChunking::RunTest(Instructions instructions)
     std::unique_ptr<WriteClient> writeClient = std::make_unique<WriteClient>(
         &GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
         static_cast<uint16_t>(kMaxSecureSduLengthBytes -
-                              128) /* use a smaller chunk so we only need a few attributes in the write request. */);
+                              100) /* use a smaller chunk so we only need a few attributes in the write request. */);
 
     ConcreteAttributePath onGoingPath = ConcreteAttributePath();
     std::vector<PathStatus> status;
@@ -535,8 +575,15 @@ void TestWriteChunking::RunTest(Instructions instructions)
                         aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
     };
 
-    ByteSpan list[kTestListLength];
-    uint8_t badList[kTestListLength];
+    // uint8_t list_binary[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
+    //                           0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89
+
+    // };
+
+    // ByteSpan list(list_binary);
+
+    ByteSpan list[30];
+    uint8_t badList[30];
 
     if (instructions.data.size() == 0)
     {
@@ -556,12 +603,12 @@ void TestWriteChunking::RunTest(Instructions instructions)
         }
         case ListData::kList: {
             err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
-                                               DataModel::List<ByteSpan>(list, kTestListLength));
+                                               app::DataModel::List<ByteSpan>(list));
             break;
         }
         case ListData::kBadValue: {
             err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
-                                               DataModel::List<uint8_t>(badList, kTestListLength));
+                                               app::DataModel::List<uint8_t>(badList, 30));
             break;
         }
         }
@@ -601,27 +648,28 @@ TEST_F(TestWriteChunking, TestTransactionalList)
     AttributeAccessInterfaceRegistry::Instance().Register(&testServer);
 
     // Test 1: we should receive transaction notifications
-    ChipLogProgress(Zcl, "Test 1: we should receive transaction notifications");
+    ChipLogProgress(Zcl, "AAAAAAA Test 1: we should receive transaction notifications");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .expectedStatus = { true },
     });
-
-    ChipLogProgress(Zcl, "Test 2: we should receive transaction notifications for incomplete list operations");
+    // TODO test 2 fails
+    ChipLogProgress(Zcl, "AAAAAAA Test 2: we should receive transaction notifications for incomplete list operations");
     RunTest(Instructions{
         .paths                   = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .onListWriteBeginActions = [&](const app::ConcreteAttributePath & aPath) { return Operations::kShutdownWriteClient; },
         .expectedStatus          = { false },
     });
 
-    ChipLogProgress(Zcl, "Test 3: we should receive transaction notifications for every list in the transaction");
+    ChipLogProgress(Zcl, "AAAAAAA Test 3: we should receive transaction notifications for every list in the transaction");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute2) },
         .expectedStatus = { true, true },
     });
 
-    ChipLogProgress(Zcl, "Test 4: we should receive transaction notifications with the status of each list");
+    // TODO test 4 fails
+    ChipLogProgress(Zcl, "AAAAAAA Test 4: we should receive transaction notifications with the status of each list");
     RunTest(Instructions{
         .paths = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                    ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute2) },
@@ -636,9 +684,10 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true, false },
     });
 
-    ChipLogProgress(Zcl,
-                    "Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-                    "null value before non null values");
+    ChipLogProgress(
+        Zcl,
+        "AAAAAAA Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+        "null value before non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
@@ -646,9 +695,10 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(Zcl,
-                    "Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-                    "null value after non null values");
+    ChipLogProgress(
+        Zcl,
+        "AAAAAAA Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+        "null value after non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
@@ -656,9 +706,10 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(Zcl,
-                    "Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-                    "null value between non null values");
+    ChipLogProgress(
+        Zcl,
+        "AAAAAAA Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+        "null value between non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
@@ -667,16 +718,19 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(Zcl, "Test 8: transactional list callbacks will be called for nullable lists");
+    ChipLogProgress(Zcl, "AAAAAAA Test 8: transactional list callbacks will be called for nullable lists");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .data           = { ListData::kNull },
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(Zcl,
-                    "Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
-                    "during processing the requests");
+    // TODO test 9 fails
+
+    ChipLogProgress(
+        Zcl,
+        "AAAAAAA Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
+        "during processing the requests");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .data           = { ListData::kBadValue },

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -259,9 +259,9 @@ TEST_F(TestWriteChunking, TestListChunking)
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
                                      static_cast<uint16_t>(minReservationSize + i) /* reserved buffer size */);
 
-        ByteSpan list[40];
+        ByteSpan list[20];
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 40));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 20));
 
         //  err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, sizeof(list_binary)));
         EXPECT_EQ(err, CHIP_NO_ERROR);

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -223,8 +223,10 @@ TEST_F(TestWriteChunking, TestListChunking)
     app::AttributePathParams attributePath(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute);
 
     // We've empirically determined that by reserving all but 60 bytes in the packet buffer, we can fit 1
-    // AttributeDataIB into the packet with a List of ByteSpans with 5 empty items.
+    // AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of 10 items, our
+    // initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
     constexpr size_t minReservationSize = kMaxSecureSduLengthBytes - 60 - 100;
+    constexpr uint8_t kTestListLength   = 10;
 
     for (uint32_t i = 100; i > 0; i--)
     {
@@ -238,9 +240,9 @@ TEST_F(TestWriteChunking, TestListChunking)
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
                                      static_cast<uint16_t>(minReservationSize + i) /* reserved buffer size */);
 
-        ByteSpan list[20];
+        ByteSpan list[kTestListLength];
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 20));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
 
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -257,8 +259,8 @@ TEST_F(TestWriteChunking, TestListChunking)
             DrainAndServiceIO();
         }
 
-        // IN THE WAY THE WRITE CHUNKING WORKS NOW, THE NUMBER OF SUCCESSes depende on how many chunks we get, and that is not
-        // predictable
+        // Due to the way Write Chunking is done, it is difficult to predict mSuccessCount. It all depends on how much was
+        // packed into the initial ReplaceAll List.
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -297,6 +299,8 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
     app::AttributePathParams attributePath(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute);
 
+    constexpr uint8_t kTestListLength = 5;
+
     for (int i = 850; i < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); i++)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -308,13 +312,13 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
 
-        ByteSpan list[5];
+        ByteSpan list[kTestListLength];
         for (auto & item : list)
         {
             item = ByteSpan(sByteSpanData, static_cast<uint32_t>(i));
         }
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
         if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
             // This kind of error is expected.
@@ -338,7 +342,8 @@ TEST_F(TestWriteChunking, TestBadChunking)
             DrainAndServiceIO();
         }
 
-        //   EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength /* an extra item for the empty list at the beginning */);
+        // Due to the way Write Chunking is done, it is difficult to predict mSuccessCount. It all depends on how much was
+        // packed into the initial ReplaceAll List.
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -379,8 +384,12 @@ TEST_F(TestWriteChunking, TestConflictWrite)
 
     app::AttributePathParams attributePath(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute);
 
-    /* use a smaller chunk (128 bytes) so we only need a few attributes in the write request. */
-    constexpr size_t kReserveSize = kMaxSecureSduLengthBytes - 128;
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet buffer,
+    // we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of
+    // 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize     = kMaxSecureSduLengthBytes - 60;
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
 
     TestWriteCallback writeCallback1;
     app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
@@ -390,19 +399,11 @@ TEST_F(TestWriteChunking, TestConflictWrite)
     app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
                                   static_cast<uint16_t>(kReserveSize));
 
-    uint8_t list_binary[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
-                              0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
-                              0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89
-
-    };
-
-    ByteSpan list(list_binary);
-
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<uint8_t>(list_binary));
+    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
     EXPECT_EQ(err, CHIP_NO_ERROR);
-    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<uint8_t>(list_binary));
+    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
     EXPECT_EQ(err, CHIP_NO_ERROR);
 
     err = writeClient1.SendWriteRequest(sessionHandle);

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -57,6 +57,7 @@ uint32_t gIterationCount = 0;
 constexpr EndpointId kTestEndpointId      = 2;
 constexpr AttributeId kTestListAttribute  = 6;
 constexpr AttributeId kTestListAttribute2 = 7;
+constexpr uint8_t kTestListLength         = 10;
 
 // We don't really care about the content, we just need a buffer.
 uint8_t sByteSpanData[app::kMaxSecureSduLengthBytes];
@@ -226,7 +227,6 @@ TEST_F(TestWriteChunking, TestListChunking)
     // AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of 10 items, our
     // initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
     constexpr size_t minReservationSize = kMaxSecureSduLengthBytes - 60 - 100;
-    constexpr uint8_t kTestListLength   = 10;
 
     for (uint32_t i = 100; i > 0; i--)
     {
@@ -259,8 +259,10 @@ TEST_F(TestWriteChunking, TestListChunking)
             DrainAndServiceIO();
         }
 
-        // Due to the way Write Chunking is done, it is difficult to predict mSuccessCount. It all depends on how much was
-        // packed into the initial ReplaceAll List.
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List, before
+        // starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into the initial
+        // ReplaceAll List.
+        // However, we know for sure that writeCallback should NEVER fail.
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -299,7 +301,7 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
     app::AttributePathParams attributePath(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute);
 
-    constexpr uint8_t kTestListLength = 5;
+    constexpr uint8_t kTestListLengthBadChunking = 5;
 
     for (int i = 850; i < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); i++)
     {
@@ -312,13 +314,13 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
 
-        ByteSpan list[kTestListLength];
+        ByteSpan list[kTestListLengthBadChunking];
         for (auto & item : list)
         {
             item = ByteSpan(sByteSpanData, static_cast<uint32_t>(i));
         }
 
-        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength));
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLengthBadChunking));
         if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
             // This kind of error is expected.
@@ -368,8 +370,6 @@ TEST_F(TestWriteChunking, TestBadChunking)
  */
 TEST_F(TestWriteChunking, TestConflictWrite)
 {
-    // constexpr uint32_t kTestListLengthv2 = 5;
-
     auto sessionHandle = GetSessionBobToAlice();
 
     // Initialize the ember side server logic
@@ -387,8 +387,7 @@ TEST_F(TestWriteChunking, TestConflictWrite)
     // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet buffer,
     // we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of
     // 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
-    constexpr size_t kReserveSize     = kMaxSecureSduLengthBytes - 60;
-    constexpr uint8_t kTestListLength = 10;
+    constexpr size_t kReserveSize = kMaxSecureSduLengthBytes - 60;
     ByteSpan list[kTestListLength];
 
     TestWriteCallback writeCallback1;
@@ -426,20 +425,12 @@ TEST_F(TestWriteChunking, TestConflictWrite)
             writeCallbackRef1 = &writeCallback2;
         }
 
-        // TODO resolve this:
-        // chunking is done automatically, it is difficult to predict how many success or Errors we get,
-
-        //        For Sure WriteCallbackRef2 will not succeed
-        // but we will get many errors in others, (is it because we get as many Busy Errors as we have WriteRequest messages? so it
-        // becomes unpredictable)
-
-        //    EXPECT_EQ(writeCallbackRef1->mSuccessCount,
-        //     kTestListLengthv2 /* an extra item for the empty list at the beginning */); // TODO remove the comments on extra
-        // list item
-        //   EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
-
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List, before
+        // starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into the initial
+        // ReplaceAll List. However, we know for sure that writeCallbackRef1 should NEVER fail, and that writeCallbackRef2 should
+        // NEVER Succeed.
+        EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
         EXPECT_EQ(writeCallbackRef2->mSuccessCount, 0u);
-        //     EXPECT_EQ(writeCallbackRef2->mErrorCount, kTestListLengthv2);
 
         EXPECT_EQ(writeCallbackRef2->mLastErrorReason.mStatus, Protocols::InteractionModel::Status::Busy);
 
@@ -473,8 +464,10 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
     app::AttributePathParams attributePath1(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute);
     app::AttributePathParams attributePath2(kTestEndpointId, app::Clusters::UnitTesting::Id, kTestListAttribute2);
 
-    /* use a smaller chunk (128 bytes) so we only need a few attributes in the write request. */
-    constexpr size_t kReserveSize = kMaxSecureSduLengthBytes - 128;
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet buffer,
+    // we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of
+    // 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize = kMaxSecureSduLengthBytes - 60;
 
     TestWriteCallback writeCallback1;
     app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
@@ -483,8 +476,6 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
     TestWriteCallback writeCallback2;
     app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
                                   static_cast<uint16_t>(kReserveSize));
-
-    constexpr uint32_t kTestListLength = 1;
 
     ByteSpan list[kTestListLength];
 
@@ -504,10 +495,11 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
     DrainAndServiceIO();
 
     {
+        // Due to Write Chunking being done dynamically, it is fragile to try to predict mSuccessCount. It all depends on how much
+        // was packed into the initial ReplaceAll List.
+        // However, we know for sure that writeCallback1 and writeCallback2 should NEVER fail.
         EXPECT_EQ(writeCallback1.mErrorCount, 0u);
-        EXPECT_EQ(writeCallback1.mSuccessCount, kTestListLength);
         EXPECT_EQ(writeCallback2.mErrorCount, 0u);
-        EXPECT_EQ(writeCallback2.mSuccessCount, kTestListLength);
 
         EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
         EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
@@ -527,7 +519,7 @@ void TestWriteChunking::RunTest(Instructions instructions)
     std::unique_ptr<WriteClient> writeClient = std::make_unique<WriteClient>(
         &GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
         static_cast<uint16_t>(kMaxSecureSduLengthBytes -
-                              100) /* use a smaller chunk so we only need a few attributes in the write request. */);
+                              64) /* use a smaller chunk so we only need a few attributes in the write request. */);
 
     ConcreteAttributePath onGoingPath = ConcreteAttributePath();
     std::vector<PathStatus> status;
@@ -557,15 +549,8 @@ void TestWriteChunking::RunTest(Instructions instructions)
                         aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
     };
 
-    // uint8_t list_binary[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
-    //                           0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89
-
-    // };
-
-    // ByteSpan list(list_binary);
-
-    ByteSpan list[30];
-    uint8_t badList[30];
+    ByteSpan list[kTestListLength];
+    uint8_t badList[kTestListLength];
 
     if (instructions.data.size() == 0)
     {
@@ -585,12 +570,12 @@ void TestWriteChunking::RunTest(Instructions instructions)
         }
         case ListData::kList: {
             err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
-                                               app::DataModel::List<ByteSpan>(list));
+                                               DataModel::List<ByteSpan>(list, kTestListLength));
             break;
         }
         case ListData::kBadValue: {
             err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
-                                               app::DataModel::List<uint8_t>(badList, 30));
+                                               DataModel::List<uint8_t>(badList, kTestListLength));
             break;
         }
         }
@@ -630,28 +615,27 @@ TEST_F(TestWriteChunking, TestTransactionalList)
     AttributeAccessInterfaceRegistry::Instance().Register(&testServer);
 
     // Test 1: we should receive transaction notifications
-    ChipLogProgress(Zcl, "AAAAAAA Test 1: we should receive transaction notifications");
+    ChipLogProgress(Zcl, "Test 1: we should receive transaction notifications");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .expectedStatus = { true },
     });
-    // TODO test 2 fails
-    ChipLogProgress(Zcl, "AAAAAAA Test 2: we should receive transaction notifications for incomplete list operations");
+
+    ChipLogProgress(Zcl, "Test 2: we should receive transaction notifications for incomplete list operations");
     RunTest(Instructions{
         .paths                   = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .onListWriteBeginActions = [&](const app::ConcreteAttributePath & aPath) { return Operations::kShutdownWriteClient; },
         .expectedStatus          = { false },
     });
 
-    ChipLogProgress(Zcl, "AAAAAAA Test 3: we should receive transaction notifications for every list in the transaction");
+    ChipLogProgress(Zcl, "Test 3: we should receive transaction notifications for every list in the transaction");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute2) },
         .expectedStatus = { true, true },
     });
 
-    // TODO test 4 fails
-    ChipLogProgress(Zcl, "AAAAAAA Test 4: we should receive transaction notifications with the status of each list");
+    ChipLogProgress(Zcl, "Test 4: we should receive transaction notifications with the status of each list");
     RunTest(Instructions{
         .paths = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                    ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute2) },
@@ -666,10 +650,9 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true, false },
     });
 
-    ChipLogProgress(
-        Zcl,
-        "AAAAAAA Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-        "null value before non null values");
+    ChipLogProgress(Zcl,
+                    "Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value before non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
@@ -677,10 +660,9 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(
-        Zcl,
-        "AAAAAAA Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-        "null value after non null values");
+    ChipLogProgress(Zcl,
+                    "Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value after non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
@@ -688,10 +670,9 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(
-        Zcl,
-        "AAAAAAA Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
-        "null value between non null values");
+    ChipLogProgress(Zcl,
+                    "Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value between non null values");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
                             ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute),
@@ -700,19 +681,16 @@ TEST_F(TestWriteChunking, TestTransactionalList)
         .expectedStatus = { true },
     });
 
-    ChipLogProgress(Zcl, "AAAAAAA Test 8: transactional list callbacks will be called for nullable lists");
+    ChipLogProgress(Zcl, "Test 8: transactional list callbacks will be called for nullable lists");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .data           = { ListData::kNull },
         .expectedStatus = { true },
     });
 
-    // TODO test 9 fails
-
-    ChipLogProgress(
-        Zcl,
-        "AAAAAAA Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
-        "during processing the requests");
+    ChipLogProgress(Zcl,
+                    "Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
+                    "during processing the requests");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
         .data           = { ListData::kBadValue },


### PR DESCRIPTION
# EDIT:
- **THE APPROACH HAS BEEN CHANGED, AND THIS PR HAS BEEN REPLACED BY** https://github.com/project-chip/connectedhomeip/pull/38263
----------------------------------

- Fix for https://github.com/project-chip/connectedhomeip/issues/36535

- If a malformed ACL is written to a Device, the ACL on the Device is left empty or incomplete. This can block access not only for devices within the same fabric but also for the administrator.
### Cause of Issue

- Basically, The issue is related to how Clients Encode Attribute Lists (not only ACLs) into WriteRequests.
- `ReplaceAll List Operation`: Currently, an Empty List is always Encoded first, This triggers a clearing of all Entries on the server side.
- `AppendItem List Operation` Followed by all the Items that are meant to be written; Those Items are Appended one by one on the Server's side.


### The Fix

1. Modify how the `WriteClient` Encodes a List Attribute:
2. Instead of Encoding and sending an Empty Initial List (the `ReplaceAll` list that used to clear all List Entries), and then following it up with Items sent seperately.
3. We will now encode the maximum number of items possible into the initial `ReplaceAll` List, and will only chunk if needed.
4.  In Addition, for ACL solely, I added a check that all List Entries in that initial `ReplaceAll` list are valid, before starting to Update or Delete any Entries.

### Scope of Fix

- The main two methods impacted are:
  1. `WriteClient::EncodeAttribute()`: used by Linux-based WriteClients
  2. `WriteClient::PutPreencodedAttribute()`: used by Python and Android WriteClients

- The Attributes impacted by these changes:
  1. Access Control->ACL
  2. Access Control-->Extension
  3. Binding-->Binding
  4. Group Key Management-->GroupKeyMap
  5. User Label-->LabelList
  6. OTA Software Update Requestor-->DefaultOTAProviders
  7. Thermostat-->Presets

- `OTA Software Update Requestor-->DefaultOTAProviders` was treated as an exception (we still send an initial empty list) due to a bug in its server-implementation that existed in Matter 1.3: https://github.com/project-chip/connectedhomeip/pull/33000
### Follow-ups:

1. [ ] if an entry fails in a list, make sure all subsequent Entries in List are also rejected (even across future chunks)
2. [ ] Possible change in Spec (10.6.4.3.1. Lists)
3. [ ] Add More Unit Tests (for PutPreencodedAttribute)
4. [ ] Modify TestPlans as appropriate 
5. [ ] When Matter 1.3 is sunsetted, remove the exception created for `DefaultOTAProviders`

#### Testing
- tested behaviour manually on all impacted attributes
- Modified ACL-based YAML Tests 
- Added TestCases to AccessControlCluster.yaml
- Modified UnitTests

