### PR TITLE
[Darwin] MTRDevice work blocks should only weakly reference self

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3663,15 +3663,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         for (MTRCommandWithRequiredResponse * command in [commandGroup reverseObjectEnumerator]) {
             auto commandInvokeBlock = ^(BOOL allSucceededSoFar, NSArray<MTRDeviceResponseValueDictionary> * previousResponses) {
                 mtr_strongify(self);
-                if (!self) {
-                    MTR_LOG_DEBUG("invokeCommands commandInvokeBlock called back with nil MTRDevice");
-                    // Object is gone, but make sure next completion gets called appropriately.
-                    nextCompletion(NO, [previousResponses arrayByAddingObject:@{
-                        MTRCommandPathKey : command.path,
-                        MTRErrorKey : [MTRError errorForCHIPErrorCode:CHIP_ERROR_INTERNAL],
-                    }]);
-                    return;
-                }
+                VerifyOrReturn(self, MTR_LOG_DEBUG("invokeCommands commandInvokeBlock called back with nil MTRDevice"));
 
                 [self invokeCommandWithEndpointID:command.path.endpoint
                                         clusterID:command.path.cluster


### PR DESCRIPTION
This change fixes a previously missed spot in `_scheduleNextUpdate:` where self was strongly captured in a log line. This also added weakify/strongify for the blocks in the new `-invokeCommands:queue:completion` method.

#### Testing

Ran on-device testing with Xcode instruments and verified that once client goes away and the device screen is turned off, MTRDevice object was deallocated.