### PR TITLE
Fix variable name in iOS CHIPTool.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/FabricKeys.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/FabricKeys.m
@@ -227,7 +227,7 @@ static const NSString * MTRCAKeyChainLabel = @"matter-tool.nodeopcerts.CA:0";
         return nil;
     }
 
-    return (__bridge_transfer NSData *) outData;
+    return (__bridge_transfer NSData *) cfData;
 }
 
 - (void)dealloc


### PR DESCRIPTION
This did not get updated correctly in #36736.

Fixes https://github.com/project-chip/connectedhomeip/issues/37626

#### Testing

Compiled locally.