### PR TITLE
Allow platforms to disable BLE-related device events and add BleLayer state accessors

### DIFF
--- a/src/ble/BleConfig.h
+++ b/src/ble/BleConfig.h
@@ -130,6 +130,16 @@
 #endif // BLE_READ_REQUEST_CONTEXT
 
 /**
+ *  @def BLE_USES_DEVICE_EVENTS
+ *
+ * @brief Whether the platform uses / supports BLE-related device events.
+ * @see chip::DeviceLayer::ChipDeviceEvent
+ */
+#ifndef BLE_USES_DEVICE_EVENTS
+#define BLE_USES_DEVICE_EVENTS 1
+#endif
+
+/**
  *  @def BLE_MAX_RECEIVE_WINDOW_SIZE
  *
  *  @brief

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -223,7 +223,7 @@ public:
         kState_NotInitialized = 0,
         kState_Initialized    = 1,
         kState_Disconnecting  = 2
-    } mState; ///< [READ-ONLY] Current state
+    } mState; ///< [READ-ONLY] external access is deprecated, use IsInitialized() / IsBleClosing()
 
     // This app state is not used by ble transport etc, it will be used by external ble implementation like Android
     void * mAppState                 = nullptr;
@@ -236,7 +236,9 @@ public:
                     chip::System::Layer * systemLayer);
     CHIP_ERROR Init(BlePlatformDelegate * platformDelegate, BleConnectionDelegate * connDelegate,
                     BleApplicationDelegate * appDelegate, chip::System::Layer * systemLayer);
+    bool IsInitialized() { return mState != kState_NotInitialized; }
     void IndicateBleClosing();
+    bool IsBleClosing() { return mState == kState_Disconnecting; }
     void Shutdown();
 
     CHIP_ERROR CancelBleIncompleteConnection();

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -381,7 +381,10 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 #include CHIPDEVICEPLATFORMEVENT_HEADER
 #endif // defined(CHIP_DEVICE_LAYER_TARGET)
 
+#if CONFIG_NETWORK_LAYER_BLE
 #include <ble/Ble.h>
+#endif
+
 #include <inet/InetInterface.h>
 #include <lib/support/LambdaBridge.h>
 #include <system/SystemEvent.h>
@@ -467,6 +470,7 @@ struct ChipDeviceEvent final
             uint8_t SessionType;
             bool IsCommissioner;
         } SessionEstablished;
+#if CONFIG_NETWORK_LAYER_BLE && BLE_USES_DEVICE_EVENTS
         struct
         {
             BLE_CONNECTION_OBJECT ConId;
@@ -493,6 +497,7 @@ struct ChipDeviceEvent final
         {
             BLE_CONNECTION_OBJECT ConId;
         } CHIPoBLENotifyConfirm;
+#endif // CONFIG_NETWORK_LAYER_BLE && BLE_USES_DEVICE_EVENTS
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         struct
         {


### PR DESCRIPTION
CHIPDeviceEvents related to BLE are not generated / used on all platforms (e.g. Darwin), and the inclusion of `BLE_CONNECTION_OBJECT` objects in CHIPDeviceEvents precludes platforms from using non-trivial types like std::shared_ptr for `BLE_CONNECTION_OBJECT`.

Also two inline methods to get the state of the BleLayer, and discourage accessing mState directly.

#### Testing

Will be tested as part of related Darwin work.
