### PR TITLE
If compiling against libc++ without filesystem, don't reference fstream

### DIFF
--- a/src/qrcodetool/BUILD.gn
+++ b/src/qrcodetool/BUILD.gn
@@ -30,6 +30,6 @@ executable("qrcodetool") {
   public_deps = [
     "${chip_root}/src/lib/support",
     "${chip_root}/src/platform/logging:stdio",
-    "${chip_root}/src/setup_payload",
+    "${chip_root}/src/setup_payload:setup_payload_helper",
   ]
 }

--- a/src/setup_payload/BUILD.gn
+++ b/src/setup_payload/BUILD.gn
@@ -66,8 +66,6 @@ static_library("setup_payload") {
     "QRCodeSetupPayloadParser.h",
     "SetupPayload.cpp",
     "SetupPayload.h",
-    "SetupPayloadHelper.cpp",
-    "SetupPayloadHelper.h",
   ]
 
   cflags = [ "-Wconversion" ]
@@ -78,6 +76,15 @@ static_library("setup_payload") {
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]
+}
+
+source_set("setup_payload_helper") {
+  sources = [
+    "SetupPayloadHelper.cpp",
+    "SetupPayloadHelper.h",
+  ]
+
+  public_deps = [ "${chip_root}/src/setup_payload" ]
 }
 
 source_set("onboarding-codes-utils") {


### PR DESCRIPTION
SetupPayloadHelper.cpp is compiled as part of the `setup_payload` static library, which is built for (almost?) all targets, even if those targets may not have an onboard filesystem. For GCC's libstdc++ this doesn't matter as it still provides a stub for std::ifstream, but LLVM's libc++ doesn't and throws a compiletime error because of this reference.

The alternative to this patch is to move out SetupPayloadHelper.cpp from the `setup_payload` library into the `qrcodetool` executable, since that seems to be the only place the contents of SetupPayloadHelper are in use?


#### Testing

Tested on EFR32 with GCC and ARM LLVM toolchains.
