### PR TITLE
[EFR32] Fix missing include of stdio when using snprintf in mbedtls

### DIFF
--- a/src/platform/silabs/efr32/efr32-chip-mbedtls-config.h
+++ b/src/platform/silabs/efr32/efr32-chip-mbedtls-config.h
@@ -95,6 +95,8 @@
 #define MBEDTLS_ECDSA_DETERMINISTIC
 #endif // SL_MATTER_PROVISION_FLASH
 
+// If defining snprintf we are also responsible for including its declaration
+#include <stdio.h>
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 
 #define MBEDTLS_AES_ROM_TABLES


### PR DESCRIPTION
Usage of MBEDTLS_PLATFORM_NO_STD_FUNCTIONS means the mbedtls headers are not including stdio by default, leading to usage of snprintf without prior declaration in x509_csr.c.


#### Testing

Tested on EFR32 with ARMGCC and ARM LLVM.
