### PR TITLE
Add the ability to add a `diff` for the file size differ

### DIFF
--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -437,7 +437,7 @@ def build_treemap(
                 labels=data["name"],
                 parents=data["parent"],
                 values=data["size"],
-                textinfo="label+value+percent parent",
+                textinfo="label+value+percent parent+percent root",
                 hovertext=data["hover"],
                 maxdepth=max_depth,
             )

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -67,11 +67,13 @@ __LOG_LEVELS__ = {
 class ChartStyle(Enum):
     TREE_MAP = auto()
     SUNBURST = auto()
+    ICICLE = auto()
 
 
 __CHART_STYLES__ = {
     "treemap": ChartStyle.TREE_MAP,
     "sunburst": ChartStyle.SUNBURST,
+    "icicle": ChartStyle.ICICLE,
 }
 
 
@@ -440,8 +442,17 @@ def build_treemap(
                 maxdepth=max_depth,
             )
         )
-    else:
+    elif style == ChartStyle.SUNBURST:
         fig = px.sunburst(
+            data,
+            names="name",
+            parents="parent",
+            values="size",
+            maxdepth=max_depth,
+        )
+    else:
+        assert(style == ChartStyle.ICICLE)
+        fig = px.icicle(
             data,
             names="name",
             parents="parent",

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -488,7 +488,7 @@ def build_treemap(
             maxdepth=max_depth,
         )
     else:
-        assert(style == ChartStyle.ICICLE)
+        assert (style == ChartStyle.ICICLE)
         fig = px.icicle(
             data,
             names="name_with_size",
@@ -716,6 +716,7 @@ def fetch_symbols(elf_file: str, fetch: FetchStyle) -> Tuple[list[Symbol], str]:
     else:
         return symbols_from_objdump(elf_file), '/'
 
+
 def list_id(l: list[str]) -> str:
     return "->".join(l)
 
@@ -745,16 +746,16 @@ def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:
                 raise AssertionError("Internal logic error: paths should be valid somewhere")
 
             result.append(replace(base_symbol,
-                name=f"REMOVED: {base_symbol.name}",
-                tree_path = ["DECREASE"] + base_symbol.tree_path,
-            ))
+                                  name=f"REMOVED: {base_symbol.name}",
+                                  tree_path=["DECREASE"] + base_symbol.tree_path,
+                                  ))
             continue
 
         if not base_symbol:
             result.append(replace(orig_symbol,
-                name=f"ADDED: {orig_symbol.name}",
-                tree_path = ["INCREASE"] + orig_symbol.tree_path,
-            ))
+                                  name=f"ADDED: {orig_symbol.name}",
+                                  tree_path=["INCREASE"] + orig_symbol.tree_path,
+                                  ))
             continue
 
         if orig_symbol.size == base_symbol.size:
@@ -765,20 +766,18 @@ def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:
 
         if size_delta > 0:
             result.append(replace(orig_symbol,
-                name=f"CHANGED: {orig_symbol.name}",
-                tree_path = ["INCREASE"] + orig_symbol.tree_path,
-                size=size_delta,
-            ))
+                                  name=f"CHANGED: {orig_symbol.name}",
+                                  tree_path=["INCREASE"] + orig_symbol.tree_path,
+                                  size=size_delta,
+                                  ))
         else:
             result.append(replace(orig_symbol,
-                name=f"CHANGED: {orig_symbol.name}",
-                tree_path = ["DECREASE"] + orig_symbol.tree_path,
-                size=-size_delta,
-            ))
+                                  name=f"CHANGED: {orig_symbol.name}",
+                                  tree_path=["DECREASE"] + orig_symbol.tree_path,
+                                  size=-size_delta,
+                                  ))
 
     return result
-
-
 
 
 @click.command()

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -488,7 +488,7 @@ def build_treemap(
             maxdepth=max_depth,
         )
     else:
-        assert (style == ChartStyle.ICICLE)
+        assert style == ChartStyle.ICICLE
         fig = px.icicle(
             data,
             names="name_with_size",
@@ -713,8 +713,9 @@ def fetch_symbols(elf_file: str, fetch: FetchStyle) -> Tuple[list[Symbol], str]:
     """
     if fetch == FetchStyle.NM:
         return symbols_from_nm(elf_file), "::"
-    else:
-        return symbols_from_objdump(elf_file), '/'
+
+    assert fetch == FetchStyle.OBJDUMP
+    return symbols_from_objdump(elf_file), '/'
 
 
 def list_id(tree_path: list[str]) -> str:

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -46,7 +46,7 @@ import re
 import subprocess
 from dataclasses import dataclass, replace
 from enum import Enum, auto
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import click
 import coloredlogs
@@ -63,16 +63,10 @@ __LOG_LEVELS__ = {
 }
 
 
-class ChartStyle(Enum):
-    TREE_MAP = auto()
-    SUNBURST = auto()
-    ICICLE = auto()
-
-
 __CHART_STYLES__ = {
-    "treemap": ChartStyle.TREE_MAP,
-    "sunburst": ChartStyle.SUNBURST,
-    "icicle": ChartStyle.ICICLE,
+    "treemap": px.treemap,
+    "sunburst": px.sunburst,
+    "icicle": px.icicle,
 }
 
 
@@ -363,7 +357,7 @@ def build_treemap(
     name: str,
     symbols: list[Symbol],
     separator: str,
-    style: ChartStyle,
+    figure_generator: Callable,
     max_depth: int,
     zoom: Optional[str],
     strip: Optional[str],
@@ -464,15 +458,6 @@ def build_treemap(
                 short_name = short_name[separate_idx+2:]
 
             data["name_with_size"][idx] = f"{short_name}: {data["size"][idx]}"
-
-
-    match style:
-        case ChartStyle.TREE_MAP:
-            figure_generator = px.treemap
-        case ChartStyle.SUNBURST:
-            figure_generator = px.sunburst
-        case ChartStyle.ICICLE:
-            figure_generator = px.icicle
 
     fig = figure_generator(
                 data,

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -475,13 +475,13 @@ def build_treemap(
         extra_args['color'] = "size"
 
     fig = figure_generator(
-                data,
-                names="name_with_size",
-                ids="name",
-                parents="parent",
-                values="size",
-                maxdepth=max_depth,
-                **extra_args,
+        data,
+        names="name_with_size",
+        ids="name",
+        parents="parent",
+        values="size",
+        maxdepth=max_depth,
+        **extra_args,
     )
 
     fig.update_traces(

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -52,7 +52,6 @@ import click
 import coloredlogs
 import cxxfilt
 import plotly.express as px
-import plotly.graph_objects as go
 
 # Supported log levels, mapping string values required for argument
 # parsing into logging constants
@@ -466,39 +465,29 @@ def build_treemap(
 
             data["name_with_size"][idx] = f"{short_name}: {data["size"][idx]}"
 
+
     match style:
         case ChartStyle.TREE_MAP:
-            fig = go.Figure(
-                go.Treemap(
-                    labels=data["name_with_size"],
-                    ids=data["name"],
-                    parents=data["parent"],
-                    values=data["size"],
-                    textinfo="label+value+percent parent+percent root",
-                    hovertext=data["hover"],
-                    maxdepth=max_depth,
-                )
-            )
+            figure_generator = px.treemap
         case ChartStyle.SUNBURST:
-            fig = px.sunburst(
-                data,
-                names="name_with_size",
-                ids="name",
-                parents="parent",
-                values="size",
-                maxdepth=max_depth,
-            )
+            figure_generator = px.sunburst
         case ChartStyle.ICICLE:
-            fig = px.icicle(
+            figure_generator = px.icicle
+
+    fig = figure_generator(
                 data,
                 names="name_with_size",
                 ids="name",
                 parents="parent",
                 values="size",
                 maxdepth=max_depth,
-            )
+    )
 
-    fig.update_traces(root_color="lightgray")
+    fig.update_traces(
+        root_color="lightgray",
+        textinfo="label+value+percent parent+percent root",
+        hovertext="hover",
+    )
     fig.show()
 
 

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -694,14 +694,14 @@ def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:
 
             result.append(replace(base_symbol,
                 name=f"REMOVED: {base_symbol.name}",
-                tree_path = ["REMOVED"] + base_symbol.tree_path,
+                tree_path = ["DECREASE"] + base_symbol.tree_path,
             ))
             continue
 
         if not base_symbol:
             result.append(replace(orig_symbol,
                 name=f"ADDED: {orig_symbol.name}",
-                tree_path = ["ADDED"] + orig_symbol.tree_path,
+                tree_path = ["INCREASE"] + orig_symbol.tree_path,
             ))
             continue
 
@@ -709,10 +709,20 @@ def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:
             # symbols are identical
             continue
 
-        result.append(replace(orig_symbol,
-            name=f"CHANGED: {orig_symbol.name}",
-            tree_path = ["CHANGED"] + orig_symbol.tree_path,
-        ))
+        size_delta = orig_symbol.size - base_symbol.size
+
+        if size_delta > 0:
+            result.append(replace(orig_symbol,
+                name=f"CHANGED: {orig_symbol.name}",
+                tree_path = ["INCREASE"] + orig_symbol.tree_path,
+                size=size_delta,
+            ))
+        else:
+            result.append(replace(orig_symbol,
+                name=f"CHANGED: {orig_symbol.name}",
+                tree_path = ["DECREASE"] + orig_symbol.tree_path,
+                size=-size_delta,
+            ))
 
     return result
 

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -717,8 +717,9 @@ def fetch_symbols(elf_file: str, fetch: FetchStyle) -> Tuple[list[Symbol], str]:
         return symbols_from_objdump(elf_file), '/'
 
 
-def list_id(l: list[str]) -> str:
-    return "->".join(l)
+def list_id(tree_path: list[str]) -> str:
+    """Converts a tree path in to a single string (so that it is hashable)"""
+    return "->".join(tree_path)
 
 
 def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -70,6 +70,15 @@ __CHART_STYLES__ = {
 }
 
 
+# Scales from https://plotly.com/python/builtin-colorscales/
+__COLOR_SCALES__ = {
+    "none": None,
+    "tempo": px.colors.sequential.tempo,
+    "blues": px.colors.sequential.Blues,
+    "plasma": px.colors.sequential.Plasma_r,
+}
+
+
 class FetchStyle(Enum):
     NM = auto()
     OBJDUMP = auto()
@@ -358,6 +367,7 @@ def build_treemap(
     symbols: list[Symbol],
     separator: str,
     figure_generator: Callable,
+    color: Optional[list[str]],
     max_depth: int,
     zoom: Optional[str],
     strip: Optional[str],
@@ -459,6 +469,11 @@ def build_treemap(
 
             data["name_with_size"][idx] = f"{short_name}: {data["size"][idx]}"
 
+    extra_args = {}
+    if color is not None:
+        extra_args['color_continuous_scale'] = color
+        extra_args['color'] = "size"
+
     fig = figure_generator(
                 data,
                 names="name_with_size",
@@ -466,6 +481,7 @@ def build_treemap(
                 parents="parent",
                 values="size",
                 maxdepth=max_depth,
+                **extra_args,
     )
 
     fig.update_traces(
@@ -772,6 +788,13 @@ def compute_symbol_diff(orig: list[Symbol], base: list[Symbol]) -> list[Symbol]:
     help="Style of the chart",
 )
 @click.option(
+    "--color",
+    default="None",
+    show_default=True,
+    type=click.Choice(list(__COLOR_SCALES__.keys()), case_sensitive=False),
+    help="Color display (if any)",
+)
+@click.option(
     "--fetch-via",
     default="nm",
     show_default=True,
@@ -806,6 +829,7 @@ def main(
     log_level,
     elf_file: str,
     display_type: str,
+    color: str,
     fetch_via: str,
     max_depth: int,
     zoom: Optional[str],
@@ -824,7 +848,7 @@ def main(
         title = f"{elf_file} COMPARED TO {diff}"
 
     build_treemap(
-        title, symbols, separator, __CHART_STYLES__[display_type], max_depth, zoom, strip
+        title, symbols, separator, __CHART_STYLES__[display_type], __COLOR_SCALES__[color], max_depth, zoom, strip
     )
 
 

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -466,37 +466,37 @@ def build_treemap(
 
             data["name_with_size"][idx] = f"{short_name}: {data["size"][idx]}"
 
-    if style == ChartStyle.TREE_MAP:
-        fig = go.Figure(
-            go.Treemap(
-                labels=data["name_with_size"],
-                ids=data["name"],
-                parents=data["parent"],
-                values=data["size"],
-                textinfo="label+value+percent parent+percent root",
-                hovertext=data["hover"],
+    match style:
+        case ChartStyle.TREE_MAP:
+            fig = go.Figure(
+                go.Treemap(
+                    labels=data["name_with_size"],
+                    ids=data["name"],
+                    parents=data["parent"],
+                    values=data["size"],
+                    textinfo="label+value+percent parent+percent root",
+                    hovertext=data["hover"],
+                    maxdepth=max_depth,
+                )
+            )
+        case ChartStyle.SUNBURST:
+            fig = px.sunburst(
+                data,
+                names="name_with_size",
+                ids="name",
+                parents="parent",
+                values="size",
                 maxdepth=max_depth,
             )
-        )
-    elif style == ChartStyle.SUNBURST:
-        fig = px.sunburst(
-            data,
-            names="name_with_size",
-            ids="name",
-            parents="parent",
-            values="size",
-            maxdepth=max_depth,
-        )
-    else:
-        assert style == ChartStyle.ICICLE
-        fig = px.icicle(
-            data,
-            names="name_with_size",
-            ids="name",
-            parents="parent",
-            values="size",
-            maxdepth=max_depth,
-        )
+        case ChartStyle.ICICLE:
+            fig = px.icicle(
+                data,
+                names="name_with_size",
+                ids="name",
+                parents="parent",
+                values="size",
+                maxdepth=max_depth,
+            )
 
     fig.update_traces(root_color="lightgray")
     fig.show()
@@ -711,11 +711,11 @@ def symbols_from_nm(elf_file: str) -> list[Symbol]:
 def fetch_symbols(elf_file: str, fetch: FetchStyle) -> Tuple[list[Symbol], str]:
     """Returns the sumbol list and the separator used to split symbols
     """
-    if fetch == FetchStyle.NM:
-        return symbols_from_nm(elf_file), "::"
-
-    assert fetch == FetchStyle.OBJDUMP
-    return symbols_from_objdump(elf_file), '/'
+    match fetch:
+        case FetchStyle.NM:
+            return symbols_from_nm(elf_file), "::"
+        case FetchStyle.OBJDUMP:
+            return symbols_from_objdump(elf_file), '/'
 
 
 def list_id(tree_path: list[str]) -> str:


### PR DESCRIPTION
- adds the ability to "diff" sizes
- Adds an "icicle" display option
- update naming formatting: show short name for per-file/path expansion, include sizes in name expansion
- Added the ability to specify a "color" for color updates, shows somewhat nicely for what items are larger than others

#### Testing
Ran locally, saw display like:

```sh
./scripts/tools/file_size_from_nm.py ./out/qpg-qpg6105-light/chip-qpg6105-lighting-example.out --fetch-via objdump --diff out/qpg-light-master.out --max-depth 20
```

![image](https://github.com/user-attachments/assets/7194b215-c3ed-4696-a483-3e7314ab9a0f)

and 

```sh
./scripts/tools/file_size_from_nm.py ./out/qpg-qpg6105-light/chip-qpg6105-lighting-example.out --fetch-via objdump --diff out/qpg-light-master.out --max-depth 20 --display-type icicle
```

![image](https://github.com/user-attachments/assets/65c9dafe-e850-4110-95a2-5a07914250b3)

and

```sh
./scripts/tools/file_size_from_nm.py ./out/qpg-qpg6105-light/chip-qpg6105-lighting-example.out --fetch-via objdump --diff out/qpg-light-master.out --max-depth 20 --color blue
```

![image](https://github.com/user-attachments/assets/0c7af92c-7f79-4e90-b086-6cf814235b4b)


