### PR TITLE
Use Stdio instead of default log for linux apps

### DIFF
--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -108,7 +108,7 @@ source_set("app-main") {
     ":wifi-diagnostics-test-event-trigger",
     "${chip_root}/src/data-model-providers/codegen:instance-header",
     "${chip_root}/src/lib",
-    "${chip_root}/src/platform/logging:default",
+    "${chip_root}/src/platform/logging:stdio",
   ]
   deps = [
     ":ota-test-event-trigger",


### PR DESCRIPTION
- Use logging backend defined in `src/platform/logging/impl/Stdio.cpp` instead of `src/platform/Linux/Logging.cpp` since it has colours and better formatting 
#### Testing

- I ran chip-all-clusters before and after