### PR TITLE
Remove unneeded include: AttributePathExpandIterator has no need of Exchange Contexts

### DIFF
--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -25,7 +25,6 @@
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/LinkedList.h>
 #include <lib/support/Span.h>
-#include <messaging/ExchangeContext.h>
 
 #include <limits>
 


### PR DESCRIPTION
In #37747 I added some extra includes, however this one seems not needed

#### Testing
Compilation should still pass (tried compiling and running tests localy).