### PR TITLE
fix(testing): Move CloseSession call after factory reset in TC_CGEN_2_8

### DIFF
--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -129,14 +129,14 @@ class TC_CGEN_2_8(MatterBaseTest):
             "First CommissioningComplete failed",
         )
 
-        # Close the commissioner session with the device to clean up resources
-        commissioner.CloseSession(nodeid=self.dut_node_id)
-
         # Step 5: Factory reset is handled by test operator
         self.step(5)
         if not self.check_pics('PICS_USER_PROMPT'):
             self.skip_all_remaining_steps(6)
             return
+
+        # Close the commissioner session with the device to clean up resources
+        commissioner.CloseSession(nodeid=self.dut_node_id)
 
         self.wait_for_user_input(prompt_msg="Manually trigger factory reset on the DUT, then continue")
 

--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -135,10 +135,10 @@ class TC_CGEN_2_8(MatterBaseTest):
             self.skip_all_remaining_steps(6)
             return
 
+        self.wait_for_user_input(prompt_msg="Manually trigger factory reset on the DUT, then continue")
+
         # Close the commissioner session with the device to clean up resources
         commissioner.CloseSession(nodeid=self.dut_node_id)
-
-        self.wait_for_user_input(prompt_msg="Manually trigger factory reset on the DUT, then continue")
 
         # Step 6: Put device in commissioning mode (requiring user input, so skip in CI)
         self.step(6)


### PR DESCRIPTION
Fixes #37774

The current implementation of commissioner.CloseSession only marks the session as defunct rather than fully closing it. This state can be reactivated if messages are exchanged on the session.

By moving the CloseSession call to after the factory reset step, we ensure that the device session is already destroyed before marking it as defunct, preventing any possibility of message exchange that could reactivate the session. This allows the commissioner to successfully create a new session in subsequent steps.

A follow-up change will be needed to properly fix the CloseSession function to use MarkForEviction instead of MarkAsDefunct, and potentially rename the current function to better reflect its behavior.


#### Testing

Validated at 1.4.1 SVE event