### PR TITLE
Remove C++ 17 workarounds for esp32.

### DIFF
--- a/config/ameba/chip.cmake
+++ b/config/ameba/chip.cmake
@@ -117,7 +117,6 @@ endif (matter_enable_persistentstorage_audit)
 
 # Build RPC
 if (matter_enable_rpc)
-#string(APPEND CHIP_GN_ARGS "remove_default_configs = [\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_build:cpp17\"]\n")
 string(APPEND CHIP_GN_ARGS "chip_build_pw_rpc_lib = true\n")
 string(APPEND CHIP_GN_ARGS "pw_log_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_log_basic\"\n")
 string(APPEND CHIP_GN_ARGS "pw_assert_BACKEND = \"//third_party/connectedhomeip/third_party/pigweed/repo/pw_assert_log:check_backend\"\n")

--- a/examples/energy-management-app/esp32/CMakeLists.txt
+++ b/examples/energy-management-app/esp32/CMakeLists.txt
@@ -80,8 +80,4 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/lighting-app/esp32/CMakeLists.txt
+++ b/examples/lighting-app/esp32/CMakeLists.txt
@@ -80,8 +80,4 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/lock-app/esp32/CMakeLists.txt
+++ b/examples/lock-app/esp32/CMakeLists.txt
@@ -61,10 +61,6 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)
 
 flashing_script()

--- a/examples/ota-requestor-app/esp32/CMakeLists.txt
+++ b/examples/ota-requestor-app/esp32/CMakeLists.txt
@@ -61,10 +61,6 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)
 
 

--- a/examples/pigweed-app/esp32/CMakeLists.txt
+++ b/examples/pigweed-app/esp32/CMakeLists.txt
@@ -62,9 +62,4 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
-
 flashing_script(DEPENDS "${CMAKE_CURRENT_LIST_DIR}/echo_test_config.yml" "${CMAKE_CURRENT_LIST_DIR}/third_party/connectedhomeip/examples/pigweed-app/mobly_tests/echo_test.py")

--- a/examples/temperature-measurement-app/esp32/CMakeLists.txt
+++ b/examples/temperature-measurement-app/esp32/CMakeLists.txt
@@ -63,8 +63,4 @@ add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/examples/platform/esp32/pw_sys_io)
 
-get_target_property(_target_cxx_flags pw_build.cpp17._public_config INTERFACE_COMPILE_OPTIONS)
-list(REMOVE_ITEM _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
-list(APPEND _target_cxx_flags $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
-set_target_properties(pw_build.cpp17._public_config PROPERTIES INTERFACE_COMPILE_OPTIONS "${_target_cxx_flags}")
 endif(CONFIG_ENABLE_PW_RPC)


### PR DESCRIPTION
These fail to compile currently with an error like:

```
CMake Error at CMakeLists.txt:83 (get_target_property):
  get_target_property() called with non-existent target
  "pw_build.cpp17._public_config".

CMake Error at CMakeLists.txt:86 (set_target_properties):
  set_target_properties Can not find target to add properties to:
  pw_build.cpp17._public_config
```

The target of `_public_config` seems private so we should not mess with it. Tested that RPC compiles locally.

#### Testing

Locally compiled with rpc using target `esp32-devkitc-light-rpc`