### PR TITLE
darwin-framework-tool: Add options to disable HTTPS or certificate validation

### DIFF
--- a/examples/chip-tool/commands/dcl/DCLClient.cpp
+++ b/examples/chip-tool/commands/dcl/DCLClient.cpp
@@ -159,12 +159,9 @@ CHIP_ERROR RequestTermsAndConditions(const Json::Value & json, Json::Value & tc,
 
 } // namespace
 
-DCLClient::DCLClient(Optional<const char *> hostname, Optional<uint16_t> port, https::HttpsSecurityMode httpsSecurityMode)
-    : mHostName(hostname.ValueOr(kDefaultDCLHostName)),
-      mPort(port.ValueOr(0)),
-      mHttpsSecurityMode(httpsSecurityMode)
-{
-}
+DCLClient::DCLClient(Optional<const char *> hostname, Optional<uint16_t> port, https::HttpsSecurityMode httpsSecurityMode) :
+    mHostName(hostname.ValueOr(kDefaultDCLHostName)), mPort(port.ValueOr(0)), mHttpsSecurityMode(httpsSecurityMode)
+{}
 
 CHIP_ERROR DCLClient::Model(const char * onboardingPayload, Json::Value & outModel)
 {

--- a/examples/chip-tool/commands/dcl/DCLClient.cpp
+++ b/examples/chip-tool/commands/dcl/DCLClient.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR ValidateTermsAndConditionsSchema(const Json::Value & tc, unsigned int
     return ValidateTCCountryEntries(tc["countryEntries"]);
 }
 
-CHIP_ERROR RequestTermsAndConditions(const Json::Value & json, Json::Value & tc)
+CHIP_ERROR RequestTermsAndConditions(const Json::Value & json, Json::Value & tc, tool::https::HttpsSecurityMode httpsSecurityMode)
 {
     auto & model = json["model"];
     if ((model["enhancedSetupFlowOptions"].asUInt() & 0x01) == 0)
@@ -151,7 +151,7 @@ CHIP_ERROR RequestTermsAndConditions(const Json::Value & json, Json::Value & tc)
     auto * tcUrl                = enhancedSetupFlowTCUrl.asCString();
     const auto optionalFileSize = MakeOptional(static_cast<uint32_t>(enhancedSetupFlowTCFileSize.asUInt()));
     const auto optionalDigest   = MakeOptional(enhancedSetupFlowTCDigest.asCString());
-    ReturnErrorOnFailure(https::Request(tcUrl, tc, optionalFileSize, optionalDigest));
+    ReturnErrorOnFailure(https::Request(tcUrl, tc, optionalFileSize, optionalDigest, httpsSecurityMode));
     ReturnErrorOnFailure(ValidateTermsAndConditionsSchema(tc, enhancedSetupFlowTCRevision.asUInt()));
 
     return CHIP_NO_ERROR;
@@ -159,10 +159,11 @@ CHIP_ERROR RequestTermsAndConditions(const Json::Value & json, Json::Value & tc)
 
 } // namespace
 
-DCLClient::DCLClient(Optional<const char *> hostname, Optional<uint16_t> port)
+DCLClient::DCLClient(Optional<const char *> hostname, Optional<uint16_t> port, https::HttpsSecurityMode httpsSecurityMode)
+    : mHostName(hostname.ValueOr(kDefaultDCLHostName)),
+      mPort(port.ValueOr(0)),
+      mHttpsSecurityMode(httpsSecurityMode)
 {
-    mHostName = hostname.ValueOr(kDefaultDCLHostName);
-    mPort     = port.ValueOr(0);
 }
 
 CHIP_ERROR DCLClient::Model(const char * onboardingPayload, Json::Value & outModel)
@@ -209,7 +210,7 @@ CHIP_ERROR DCLClient::Model(const chip::VendorId vendorId, const uint16_t produc
     char path[kRequestPathBufferSize];
     VerifyOrReturnError(snprintf(path, sizeof(path), kRequestModelVendorProductPath, to_underlying(vendorId), productId) >= 0,
                         CHIP_ERROR_INVALID_ARGUMENT);
-    ReturnErrorOnFailure(https::Request(mHostName, mPort, path, outModel));
+    ReturnErrorOnFailure(https::Request(mHostName, mPort, path, outModel, NullOptional, NullOptional, mHttpsSecurityMode));
 
     CHIP_ERROR error = ValidateModelSchema(outModel);
     VerifyOrReturnError(CHIP_NO_ERROR == error, error,
@@ -223,7 +224,7 @@ CHIP_ERROR DCLClient::TermsAndConditions(const char * onboardingPayload, Json::V
     Json::Value json;
     ReturnErrorOnFailure(Model(onboardingPayload, json));
     VerifyOrReturnError(Json::nullValue != json.type(), CHIP_NO_ERROR, outTc = Json::nullValue);
-    ReturnErrorOnFailure(RequestTermsAndConditions(json, outTc));
+    ReturnErrorOnFailure(RequestTermsAndConditions(json, outTc, mHttpsSecurityMode));
     return CHIP_NO_ERROR;
 }
 
@@ -232,7 +233,7 @@ CHIP_ERROR DCLClient::TermsAndConditions(const chip::VendorId vendorId, const ui
     Json::Value json;
     ReturnErrorOnFailure(Model(vendorId, productId, json));
     VerifyOrReturnError(Json::nullValue != json.type(), CHIP_NO_ERROR, outTc = Json::nullValue);
-    ReturnErrorOnFailure(RequestTermsAndConditions(json, outTc));
+    ReturnErrorOnFailure(RequestTermsAndConditions(json, outTc, mHttpsSecurityMode));
     return CHIP_NO_ERROR;
 }
 

--- a/examples/chip-tool/commands/dcl/DCLClient.h
+++ b/examples/chip-tool/commands/dcl/DCLClient.h
@@ -16,6 +16,10 @@
  *
  */
 
+#pragma once
+
+#include "HTTPSRequest.h"
+
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <lib/core/Optional.h>
@@ -29,7 +33,8 @@ namespace dcl {
 class DCLClient
 {
 public:
-    DCLClient(Optional<const char *> hostname, Optional<uint16_t> port);
+    DCLClient(Optional<const char *> hostname, Optional<uint16_t> port,
+              https::HttpsSecurityMode httpsSecurityMode = https::HttpsSecurityMode::kDefault);
 
     /**
      * @brief Retrieves the model information from the DCL based on the onboarding payload.
@@ -94,6 +99,7 @@ public:
 private:
     std::string mHostName;
     uint16_t mPort;
+    https::HttpsSecurityMode mHttpsSecurityMode;
 };
 } // namespace dcl
 } // namespace tool

--- a/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
@@ -102,10 +102,10 @@ class AddressInfoHolder
 public:
     AddressInfoHolder(std::string & hostname, uint16_t port)
     {
-        struct addrinfo hints = {};
-        hints.ai_family       = AF_INET;
-        hints.ai_socktype     = SOCK_STREAM;
-        int err               = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &mRes);
+        struct addrinfo hints                       = {};
+        hints.ai_family                             = AF_INET;
+        hints.ai_socktype                           = SOCK_STREAM;
+        int err                                     = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &mRes);
 #if CHIP_ERROR_LOGGING
         constexpr const char * kErrorGetAddressInfo = "Failed to get address info: ";
         VerifyOrDo(nullptr != mRes, ChipLogError(chipTool, "%s%s", kErrorGetAddressInfo, gai_strerror(err)));

--- a/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.cpp
@@ -64,7 +64,7 @@ namespace {
 class HTTPSSessionHolder
 {
 public:
-    CHIP_ERROR Init(std::string & hostname, uint16_t port) { return LogNotImplementedError(); }
+    CHIP_ERROR Init(std::string & hostname, uint16_t port, HttpsSecurityMode securityMode) { return LogNotImplementedError(); }
 
     CHIP_ERROR SendRequest(std::string & request) { return LogNotImplementedError(); }
 
@@ -102,10 +102,10 @@ class AddressInfoHolder
 public:
     AddressInfoHolder(std::string & hostname, uint16_t port)
     {
-        struct addrinfo hints                       = {};
-        hints.ai_family                             = AF_INET;
-        hints.ai_socktype                           = SOCK_STREAM;
-        int err                                     = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &mRes);
+        struct addrinfo hints = {};
+        hints.ai_family       = AF_INET;
+        hints.ai_socktype     = SOCK_STREAM;
+        int err               = getaddrinfo(hostname.c_str(), std::to_string(port).c_str(), &hints, &mRes);
 #if CHIP_ERROR_LOGGING
         constexpr const char * kErrorGetAddressInfo = "Failed to get address info: ";
         VerifyOrDo(nullptr != mRes, ChipLogError(chipTool, "%s%s", kErrorGetAddressInfo, gai_strerror(err)));
@@ -152,9 +152,10 @@ public:
 #endif
     }
 
-    CHIP_ERROR Init(std::string & hostname, uint16_t port)
+    CHIP_ERROR Init(std::string & hostname, uint16_t port, HttpsSecurityMode securityMode)
     {
         int sock;
+        VerifyOrReturnError(securityMode == HttpsSecurityMode::kDefault, CHIP_ERROR_NOT_IMPLEMENTED);
         ReturnErrorOnFailure(InitSocket(hostname, port, sock));
         ReturnErrorOnFailure(InitSSL(sock));
         return CHIP_NO_ERROR;
@@ -363,17 +364,18 @@ CHIP_ERROR ExtractHostNamePortPath(std::string url, std::string & outHostName, u
 } // namespace
 
 CHIP_ERROR Request(std::string url, Json::Value & jsonResponse, const Optional<uint32_t> & optionalExpectedSize,
-                   const Optional<const char *> & optionalExpectedDigest)
+                   const Optional<const char *> & optionalExpectedDigest, HttpsSecurityMode securityMode)
 {
     std::string hostname;
     uint16_t port;
     std::string path;
     ReturnErrorOnFailure(ExtractHostNamePortPath(url, hostname, port, path));
-    return Request(hostname, port, path, jsonResponse, optionalExpectedSize, optionalExpectedDigest);
+    return Request(hostname, port, path, jsonResponse, optionalExpectedSize, optionalExpectedDigest, securityMode);
 }
 
 CHIP_ERROR Request(std::string hostname, uint16_t port, std::string path, Json::Value & jsonResponse,
-                   const Optional<uint32_t> & optionalExpectedSize, const Optional<const char *> & optionalExpectedDigest)
+                   const Optional<uint32_t> & optionalExpectedSize, const Optional<const char *> & optionalExpectedDigest,
+                   HttpsSecurityMode securityMode)
 {
     VerifyOrDo(port != 0, port = kHttpsPort);
 
@@ -383,7 +385,7 @@ CHIP_ERROR Request(std::string hostname, uint16_t port, std::string path, Json::
     std::string response;
 
     HTTPSSessionHolder session;
-    ReturnErrorOnFailure(session.Init(hostname, port));
+    ReturnErrorOnFailure(session.Init(hostname, port, securityMode));
     ReturnErrorOnFailure(session.SendRequest(request));
     ReturnErrorOnFailure(session.ReceiveResponse(response));
     ReturnErrorOnFailure(RemoveHeader(response));

--- a/examples/chip-tool/commands/dcl/HTTPSRequest.h
+++ b/examples/chip-tool/commands/dcl/HTTPSRequest.h
@@ -16,6 +16,8 @@
  *
  */
 
+#pragma once
+
 #include <lib/core/CHIPError.h>
 #include <lib/core/Optional.h>
 
@@ -26,13 +28,22 @@ namespace chip {
 namespace tool {
 namespace https {
 
+enum class HttpsSecurityMode
+{
+    kDefault           = 0,
+    kDisableValidation = 1, // Use HTTPS, but disable all validations (cert, server name, ...)
+    kDisableHttps      = 2, // Disable HTTPS, i.e. use plain HTTP
+};
+
 CHIP_ERROR Request(std::string url, Json::Value & jsonResponse,
                    const chip::Optional<uint32_t> & optionalExpectedSize       = chip::NullOptional,
-                   const chip::Optional<const char *> & optionalExpectedDigest = chip::NullOptional);
+                   const chip::Optional<const char *> & optionalExpectedDigest = chip::NullOptional,
+                   HttpsSecurityMode securityMode                              = HttpsSecurityMode::kDefault);
 
 CHIP_ERROR Request(std::string hostname, uint16_t port, std::string path, Json::Value & jsonResponse,
                    const chip::Optional<uint32_t> & optionalExpectedSize       = chip::NullOptional,
-                   const chip::Optional<const char *> & optionalExpectedDigest = chip::NullOptional);
+                   const chip::Optional<const char *> & optionalExpectedDigest = chip::NullOptional,
+                   HttpsSecurityMode securityMode                              = HttpsSecurityMode::kDefault);
 
 } // namespace https
 } // namespace tool

--- a/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
+++ b/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
@@ -59,6 +59,13 @@ namespace tool {
             constexpr const char * kErrorConnectionTimeout = "Timeout connecting to: ";
             constexpr const char * kErrorConnectionUnknowState = "Unknown connection state";
             constexpr const char * kErrorDigestMismatch = "The response digest does not match the expected digest";
+
+            constexpr sec_protocol_verify_t NULL_VERIFIER = ^(sec_protocol_metadata_t metadata,
+                                                              sec_trust_t trust_ref,
+                                                              sec_protocol_verify_complete_t complete) {
+                complete(true);
+            };
+
             class HTTPSSessionHolder {
             public:
                 HTTPSSessionHolder() {};
@@ -70,13 +77,36 @@ namespace tool {
                     mConnection = nullptr;
                 }
 
-                CHIP_ERROR Init(std::string & hostname, uint16_t port)
+                CHIP_ERROR Init(std::string & hostname, uint16_t port, HttpsSecurityMode securityMode)
                 {
                     __auto_type semaphore = dispatch_semaphore_create(0);
                     __block CHIP_ERROR result = CHIP_NO_ERROR;
+                    __auto_type queue = dispatch_queue_create(kDispatchQueueName, DISPATCH_QUEUE_SERIAL);
 
                     __auto_type endpoint = nw_endpoint_create_host(hostname.c_str(), std::to_string(port).c_str());
-                    nw_parameters_t parameters = nw_parameters_create_secure_tcp(NW_PARAMETERS_DEFAULT_CONFIGURATION, NW_PARAMETERS_DEFAULT_CONFIGURATION);
+
+                    nw_parameters_configure_protocol_block_t tls_options;
+                    switch (securityMode)
+                    {
+                        case HttpsSecurityMode::kDefault: {
+                            tls_options = NW_PARAMETERS_DEFAULT_CONFIGURATION;
+                            break;
+                        }
+                        case HttpsSecurityMode::kDisableValidation: {
+                            tls_options = ^(nw_protocol_options_t tls_options) {
+                                sec_protocol_options_t sec_options = nw_tls_copy_sec_protocol_options(tls_options);
+                                sec_protocol_options_set_verify_block(sec_options, NULL_VERIFIER, queue);
+                            };
+                            break;
+                        }
+                        case HttpsSecurityMode::kDisableHttps: {
+                            tls_options = NW_PARAMETERS_DISABLE_PROTOCOL;
+                            break;
+                        }
+                    }
+
+                    // NW_PARAMETERS_DISABLE_PROTOCOL
+                    nw_parameters_t parameters = nw_parameters_create_secure_tcp(tls_options, NW_PARAMETERS_DEFAULT_CONFIGURATION);
 
                     mConnection = nw_connection_create(endpoint, parameters);
                     VerifyOrReturnError(nullptr != mConnection, CHIP_ERROR_INTERNAL);
@@ -101,7 +131,6 @@ namespace tool {
                         }
                     });
 
-                    __auto_type queue = dispatch_queue_create(kDispatchQueueName, DISPATCH_QUEUE_SERIAL);
                     nw_connection_set_queue(mConnection, queue);
                     nw_connection_start(mConnection);
 
@@ -185,6 +214,7 @@ namespace tool {
 
             CHIP_ERROR RemoveHeader(std::string & response)
             {
+                // TODO: Parse the response status. Why are we doing HTTP by hand?
                 size_t headerEnd = response.find("\r\n\r\n");
                 VerifyOrReturnError(std::string::npos != headerEnd, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -290,27 +320,40 @@ namespace tool {
         } // namespace
 
         CHIP_ERROR Request(std::string url, Json::Value & jsonResponse, const Optional<uint32_t> & optionalExpectedSize,
-            const Optional<const char *> & optionalExpectedDigest)
+                           const Optional<const char *> & optionalExpectedDigest, HttpsSecurityMode securityMode)
         {
             std::string hostname;
             uint16_t port;
             std::string path;
             ReturnErrorOnFailure(ExtractHostNamePortPath(url, hostname, port, path));
-            return Request(hostname, port, path, jsonResponse, optionalExpectedSize, optionalExpectedDigest);
+            return Request(hostname, port, path, jsonResponse, optionalExpectedSize, optionalExpectedDigest, securityMode);
         }
 
         CHIP_ERROR Request(std::string hostname, uint16_t port, std::string path, Json::Value & jsonResponse,
-            const Optional<uint32_t> & optionalExpectedSize, const Optional<const char *> & optionalExpectedDigest)
+            const Optional<uint32_t> & optionalExpectedSize, const Optional<const char *> & optionalExpectedDigest,
+            HttpsSecurityMode securityMode)
         {
             VerifyOrDo(port != 0, port = kHttpsPort);
 
-            ChipLogDetail(chipTool, "HTTPS request to %s:%u%s", hostname.c_str(), port, path.c_str());
+            char const * protocol;
+            switch (securityMode) {
+                case HttpsSecurityMode::kDefault:
+                    protocol = "HTTPS";
+                    break;
+                case HttpsSecurityMode::kDisableValidation:
+                    protocol = "HTTPS (no validation)";
+                    break;
+                case HttpsSecurityMode::kDisableHttps:
+                    protocol = "HTTP";
+                    break;
+            }
+            ChipLogDetail(chipTool, "%s request to %s:%u%s", protocol, hostname.c_str(), port, path.c_str());
 
             std::string request = BuildRequest(hostname, path);
             std::string response;
 
             HTTPSSessionHolder session;
-            ReturnErrorOnFailure(session.Init(hostname, port));
+            ReturnErrorOnFailure(session.Init(hostname, port, securityMode));
             ReturnErrorOnFailure(session.SendRequest(request));
             ReturnErrorOnFailure(session.ReceiveResponse(response));
             ReturnErrorOnFailure(RemoveHeader(response));

--- a/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
+++ b/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
@@ -61,8 +61,8 @@ namespace tool {
             constexpr const char * kErrorDigestMismatch = "The response digest does not match the expected digest";
 
             constexpr sec_protocol_verify_t NULL_VERIFIER = ^(sec_protocol_metadata_t metadata,
-                                                              sec_trust_t trust_ref,
-                                                              sec_protocol_verify_complete_t complete) {
+                sec_trust_t trust_ref,
+                sec_protocol_verify_complete_t complete) {
                 complete(true);
             };
 
@@ -86,23 +86,22 @@ namespace tool {
                     __auto_type endpoint = nw_endpoint_create_host(hostname.c_str(), std::to_string(port).c_str());
 
                     nw_parameters_configure_protocol_block_t tls_options;
-                    switch (securityMode)
-                    {
-                        case HttpsSecurityMode::kDefault: {
-                            tls_options = NW_PARAMETERS_DEFAULT_CONFIGURATION;
-                            break;
-                        }
-                        case HttpsSecurityMode::kDisableValidation: {
-                            tls_options = ^(nw_protocol_options_t tls_options) {
-                                sec_protocol_options_t sec_options = nw_tls_copy_sec_protocol_options(tls_options);
-                                sec_protocol_options_set_verify_block(sec_options, NULL_VERIFIER, queue);
-                            };
-                            break;
-                        }
-                        case HttpsSecurityMode::kDisableHttps: {
-                            tls_options = NW_PARAMETERS_DISABLE_PROTOCOL;
-                            break;
-                        }
+                    switch (securityMode) {
+                    case HttpsSecurityMode::kDefault: {
+                        tls_options = NW_PARAMETERS_DEFAULT_CONFIGURATION;
+                        break;
+                    }
+                    case HttpsSecurityMode::kDisableValidation: {
+                        tls_options = ^(nw_protocol_options_t tls_options) {
+                            sec_protocol_options_t sec_options = nw_tls_copy_sec_protocol_options(tls_options);
+                            sec_protocol_options_set_verify_block(sec_options, NULL_VERIFIER, queue);
+                        };
+                        break;
+                    }
+                    case HttpsSecurityMode::kDisableHttps: {
+                        tls_options = NW_PARAMETERS_DISABLE_PROTOCOL;
+                        break;
+                    }
                     }
 
                     // NW_PARAMETERS_DISABLE_PROTOCOL
@@ -320,7 +319,7 @@ namespace tool {
         } // namespace
 
         CHIP_ERROR Request(std::string url, Json::Value & jsonResponse, const Optional<uint32_t> & optionalExpectedSize,
-                           const Optional<const char *> & optionalExpectedDigest, HttpsSecurityMode securityMode)
+            const Optional<const char *> & optionalExpectedDigest, HttpsSecurityMode securityMode)
         {
             std::string hostname;
             uint16_t port;
@@ -337,15 +336,15 @@ namespace tool {
 
             char const * protocol;
             switch (securityMode) {
-                case HttpsSecurityMode::kDefault:
-                    protocol = "HTTPS";
-                    break;
-                case HttpsSecurityMode::kDisableValidation:
-                    protocol = "HTTPS (no validation)";
-                    break;
-                case HttpsSecurityMode::kDisableHttps:
-                    protocol = "HTTP";
-                    break;
+            case HttpsSecurityMode::kDefault:
+                protocol = "HTTPS";
+                break;
+            case HttpsSecurityMode::kDisableValidation:
+                protocol = "HTTPS (no validation)";
+                break;
+            case HttpsSecurityMode::kDisableHttps:
+                protocol = "HTTP";
+                break;
             }
             ChipLogDetail(chipTool, "%s request to %s:%u%s", protocol, hostname.c_str(), port, path.c_str());
 

--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
@@ -17,7 +17,10 @@
  */
 
 #pragma once
+
 #include "../common/CHIPCommandBridge.h"
+#include <commands/dcl/HTTPSRequest.h>
+
 #import <Matter/Matter.h>
 
 enum class PairingMode
@@ -66,6 +69,8 @@ public:
             AddArgument("dcl-hostname", &mDCLHostName,
                         "Hostname of the DCL server to fetch information from. Defaults to 'on.dcl.csa-iot.org'.");
             AddArgument("dcl-port", 0, UINT16_MAX, &mDCLPort, "Port number for connecting to the DCL server. Defaults to '443'.");
+            AddArgument("dcl-disable-https", 0, 1, &mDCLDisableHttps, "Disable HTTPS (use plain HTTP)");
+            AddArgument("dcl-disable-https-validation", 0, 1, &mDCLDisableHttpsValidation, "Disable HTTPS validation");
             AddArgument("use-dcl", 0, 1, &mUseDCL, "Use DCL to fetch onboarding information");
             break;
         case PairingMode::Ble:
@@ -121,5 +126,7 @@ private:
     chip::Optional<char *> mCountryCode;
     chip::Optional<char *> mDCLHostName;
     chip::Optional<uint16_t> mDCLPort;
+    chip::Optional<bool> mDCLDisableHttps;
+    chip::Optional<bool> mDCLDisableHttpsValidation;
     chip::Optional<bool> mUseDCL;
 };

--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
@@ -103,7 +103,11 @@ void PairingCommandBridge::MaybeDisplayTermsAndConditions(MTRCommissioningParame
     VerifyOrReturn(mUseDCL.ValueOr(false));
 
     Json::Value tc;
-    auto client = tool::dcl::DCLClient(mDCLHostName, mDCLPort);
+    auto securityMode =
+        mDCLDisableHttps.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableHttps :
+        mDCLDisableHttpsValidation.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableValidation :
+        tool::https::HttpsSecurityMode::kDefault;
+    auto client = tool::dcl::DCLClient(mDCLHostName, mDCLPort, securityMode);
     CHIP_ERROR err = client.TermsAndConditions(mOnboardingPayload, tc);
 
     if (CHIP_NO_ERROR != err) {

--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.mm
@@ -103,10 +103,8 @@ void PairingCommandBridge::MaybeDisplayTermsAndConditions(MTRCommissioningParame
     VerifyOrReturn(mUseDCL.ValueOr(false));
 
     Json::Value tc;
-    auto securityMode =
-        mDCLDisableHttps.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableHttps :
-        mDCLDisableHttpsValidation.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableValidation :
-        tool::https::HttpsSecurityMode::kDefault;
+    auto securityMode = mDCLDisableHttps.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableHttps : mDCLDisableHttpsValidation.ValueOr(false) ? tool::https::HttpsSecurityMode::kDisableValidation
+                                                                                                                                                    : tool::https::HttpsSecurityMode::kDefault;
     auto client = tool::dcl::DCLClient(mDCLHostName, mDCLPort, securityMode);
     CHIP_ERROR err = client.TermsAndConditions(mOnboardingPayload, tc);
 


### PR DESCRIPTION
Note that while the Darwin and generic implementation of HTTPSRequest share the same header, only the Darwin implementation currently supports the two new non-default security modes.

#### Testing

Tested manually with badssl.com
