### PR TITLE
[Silabs][lit-icd-app] Disable ota requestor support code. 

### DIFF
--- a/examples/lit-icd-app/silabs/build_for_wifi_args.gni
+++ b/examples/lit-icd-app/silabs/build_for_wifi_args.gni
@@ -20,7 +20,6 @@ silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 chip_enable_openthread = false
 import("${chip_root}/src/platform/silabs/wifi/args.gni")
 
-chip_enable_ota_requestor = true
 app_data_model = "${chip_root}/examples/lit-icd-app/lit-icd-common"
 
 sl_enable_test_event_trigger = true

--- a/examples/lit-icd-app/silabs/openthread.gni
+++ b/examples/lit-icd-app/silabs/openthread.gni
@@ -20,7 +20,6 @@ import("${chip_root}/src/platform/silabs/efr32/args.gni")
 silabs_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 app_data_model = "${chip_root}/examples/lit-icd-app/lit-icd-common"
-chip_enable_ota_requestor = true
 chip_enable_openthread = true
 
 openthread_external_platform =


### PR DESCRIPTION
The OTA requestor cluster/device type was removed from the lit-icd-app in the pr #37518
Causing build failures for the lit-icd-app with silabs platforms.

The fix is to remove `chip_enable_ota_requestor=true` from our example setting. The default is that the OTA requestor support code is disabled.

#### Testing
Confirmed the lit-icd-app now builds with silabs platform. OTA requestor will not be supported on this app with this configuration which ties the common zap config for this sample app.
