### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-117 : [TI] Update java version for chip-build-vscode
+118 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=ce4027fc0768b8509758af2e43f74e3fd2c7d58d
+ARG ZEPHYR_REVISION=fdccaba1ebc147908e9cca653e6c6743def3332b
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- telink: net: kconfig: use native zephyr ethernet L2 for w91
- telink: tl3218x: balance ram usage and add add retention mode
    - add option TELINK_TLX_MATTER_RETENTION_LAYOUT in zephyr
    - add mcu_boot_tlx.ld to balance dram/iram usage for mcuboot
    - set CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=78000 same as Matter needs
    - solve the compilation error of driver gpio
    - update the RAM distribution in retention state
    - update tl321x_pm library
- drivers: ieee802154: tlx: Fix RX timestamp error for TL721x.
- telink: tl721x: fix tercel pm mode.
- telink: tl721x: revert mspi frequency

**Changes of N22 binary:**

(latest hash 4d7b3e5962b9d34e28f7b24981ebac7e969b1115)
- Add build_zephyr_3.7_app stage to CI and remove ipc-nuttx app
- Add zephyr ethernet l2 data processing to wifi-ipc_wrap

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully
