### PR TITLE
Fix shadowing warning

### DIFF
--- a/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
+++ b/examples/darwin-framework-tool/commands/dcl/HTTPSRequest.mm
@@ -92,8 +92,8 @@ namespace tool {
                         break;
                     }
                     case HttpsSecurityMode::kDisableValidation: {
-                        tls_options = ^(nw_protocol_options_t tls_options) {
-                            sec_protocol_options_t sec_options = nw_tls_copy_sec_protocol_options(tls_options);
+                        tls_options = ^(nw_protocol_options_t options) {
+                            sec_protocol_options_t sec_options = nw_tls_copy_sec_protocol_options(options);
                             sec_protocol_options_set_verify_block(sec_options, NULL_VERIFIER, queue);
                         };
                         break;


### PR DESCRIPTION
Fix shadowing warning when building Darwin framework tool from #37783 with gn.

#### Testing

Compiles with gn now.
