### PR TITLE
Actions: Use an instance of the Actions cluster per endpoint instead of having global delegate array.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -24,8 +24,10 @@ using namespace chip::app::Clusters::Actions;
 using namespace chip::app::Clusters::Actions::Attributes;
 using namespace chip::Protocols::InteractionModel;
 
+namespace {
 Clusters::Actions::ActionsDelegateImpl * sActionsDelegateImpl = nullptr;
 Clusters::Actions::ActionsServer * sActionsServer             = nullptr;
+} // namespace
 
 CHIP_ERROR ActionsDelegateImpl::ReadActionAtIndex(uint16_t index, ActionStructStorage & action)
 {

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -24,6 +24,9 @@ using namespace chip::app::Clusters::Actions;
 using namespace chip::app::Clusters::Actions::Attributes;
 using namespace chip::Protocols::InteractionModel;
 
+Clusters::Actions::ActionsDelegateImpl * sActionsDelegateImpl = nullptr;
+Clusters::Actions::ActionsServer * sActionsServer             = nullptr;
+
 CHIP_ERROR ActionsDelegateImpl::ReadActionAtIndex(uint16_t index, ActionStructStorage & action)
 {
     if (index >= kActionList.size())
@@ -128,4 +131,13 @@ Status ActionsDelegateImpl::HandleDisableActionWithDuration(uint16_t actionId, u
 {
     // Not implemented
     return Status::NotFound;
+}
+
+void emberAfActionsClusterInitCallback(EndpointId endpoint)
+{
+    VerifyOrReturn(endpoint == 1);
+    VerifyOrReturn(sActionsDelegateImpl == nullptr && sActionsServer == nullptr);
+    sActionsDelegateImpl = new Actions::ActionsDelegateImpl;
+    sActionsServer       = new Actions::ActionsServer(endpoint, sActionsDelegateImpl);
+    sActionsServer->Init();
 }

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -137,8 +137,10 @@ Status ActionsDelegateImpl::HandleDisableActionWithDuration(uint16_t actionId, u
 
 void emberAfActionsClusterInitCallback(EndpointId endpoint)
 {
-    VerifyOrReturn(endpoint == 1);
-    VerifyOrDie(emberAfContainsServer(endpoint, Actions::Id));
+    VerifyOrReturn(endpoint == 1,
+                   ChipLogError(Zcl, "Actions cluster delegate is not implemented for endpoint with id %d.", endpoint));
+    VerifyOrReturn(emberAfContainsServer(endpoint, Actions::Id) == true,
+                   ChipLogError(Zcl, "Endpoint %d does not support Actions cluster.", endpoint));
     VerifyOrReturn(!sActionsDelegateImpl && !sActionsServer);
 
     sActionsDelegateImpl = std::make_unique<Actions::ActionsDelegateImpl>();

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -54,7 +54,6 @@
 #include <app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
-#include <bridged-actions-stub.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -87,7 +86,6 @@ Clusters::TemperatureControl::AppSupportedTemperatureLevelsDelegate sAppSupporte
 Clusters::ModeSelect::StaticSupportedModesManager sStaticSupportedModesManager;
 Clusters::ValveConfigurationAndControl::ValveControlDelegate sValveDelegate;
 Clusters::TimeSynchronization::ExtendedTimeSyncDelegate sTimeSyncDelegate;
-Clusters::Actions::ActionsDelegateImpl sActionsDelegateImpl;
 
 // Please refer to https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces
 constexpr const uint8_t kNamespaceCommon   = 7;
@@ -340,12 +338,6 @@ void emberAfThermostatClusterInitCallback(EndpointId endpoint)
     auto & delegate = ThermostatDelegate::GetInstance();
 
     SetDefaultDelegate(endpoint, &delegate);
-}
-
-void emberAfActionsClusterInitCallback(EndpointId endpoint)
-{
-    VerifyOrReturn(endpoint == 1);
-    Clusters::Actions::ActionsServer::Instance().SetDefaultDelegate(endpoint, &sActionsDelegateImpl);
 }
 
 Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,

--- a/src/app/clusters/actions-server/actions-server.cpp
+++ b/src/app/clusters/actions-server/actions-server.cpp
@@ -45,9 +45,6 @@ void ActionsServer::Shutdown()
 
 CHIP_ERROR ActionsServer::Init()
 {
-    // Check if the cluster has been selected in zap
-    VerifyOrDie(emberAfContainsServer(mEndpointId, Actions::Id) == true);
-
     ReturnErrorOnFailure(CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(this));
     VerifyOrReturnError(AttributeAccessInterfaceRegistry::Instance().Register(this), CHIP_ERROR_INCORRECT_STATE);
     return CHIP_NO_ERROR;
@@ -111,7 +108,6 @@ CHIP_ERROR ActionsServer::ReadActionListAttribute(const ConcreteReadAttributePat
     {
         ActionStructStorage action;
         CHIP_ERROR err = mDelegate->ReadActionAtIndex(i, action);
-
         if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
         {
             return CHIP_NO_ERROR;
@@ -128,7 +124,6 @@ CHIP_ERROR ActionsServer::ReadEndpointListAttribute(const ConcreteReadAttributeP
     for (uint16_t i = 0; i < kMaxEndpointListLength; i++)
     {
         EndpointListStorage epList;
-
         CHIP_ERROR err = mDelegate->ReadEndpointListAtIndex(i, epList);
         if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
         {

--- a/src/app/clusters/actions-server/actions-server.cpp
+++ b/src/app/clusters/actions-server/actions-server.cpp
@@ -107,7 +107,7 @@ CHIP_ERROR ActionsServer::ReadActionListAttribute(const ConcreteReadAttributePat
     for (uint16_t i = 0; i < kMaxActionListLength; i++)
     {
         ActionStructStorage action;
-        CHIP_ERROR err = mDelegate->ReadActionAtIndex(i, action);
+        CHIP_ERROR err = mDelegate.ReadActionAtIndex(i, action);
         if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
         {
             return CHIP_NO_ERROR;
@@ -124,7 +124,7 @@ CHIP_ERROR ActionsServer::ReadEndpointListAttribute(const ConcreteReadAttributeP
     for (uint16_t i = 0; i < kMaxEndpointListLength; i++)
     {
         EndpointListStorage epList;
-        CHIP_ERROR err = mDelegate->ReadEndpointListAtIndex(i, epList);
+        CHIP_ERROR err = mDelegate.ReadEndpointListAtIndex(i, epList);
         if (err == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED)
         {
             return CHIP_NO_ERROR;
@@ -137,7 +137,7 @@ CHIP_ERROR ActionsServer::ReadEndpointListAttribute(const ConcreteReadAttributeP
 
 bool ActionsServer::HaveActionWithId(EndpointId aEndpointId, uint16_t aActionId, uint16_t & aActionIndex)
 {
-    return mDelegate->HaveActionWithId(aActionId, aActionIndex);
+    return mDelegate.HaveActionWithId(aActionId, aActionIndex);
 }
 
 template <typename RequestT, typename FuncT>
@@ -170,7 +170,7 @@ void ActionsServer::HandleCommand(HandlerContext & handlerContext, FuncT func)
         if (actionIndex != kMaxActionListLength)
         {
             ActionStructStorage action;
-            mDelegate->ReadActionAtIndex(actionIndex, action);
+            mDelegate.ReadActionAtIndex(actionIndex, action);
             // Check if the command bit is set in the SupportedCommands of an ations.
             if (!(action.supportedCommands.Raw() & (1 << handlerContext.mRequestPath.mCommandId)))
             {
@@ -186,90 +186,79 @@ void ActionsServer::HandleCommand(HandlerContext & handlerContext, FuncT func)
 
 void ActionsServer::HandleInstantAction(HandlerContext & ctx, const Commands::InstantAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleInstantAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleInstantAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleInstantActionWithTransition(HandlerContext & ctx,
                                                       const Commands::InstantActionWithTransition::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status = mDelegate->HandleInstantActionWithTransition(commandData.actionID, commandData.transitionTime, commandData.invokeID);
+    Status status =
+        mDelegate.HandleInstantActionWithTransition(commandData.actionID, commandData.transitionTime, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleStartAction(HandlerContext & ctx, const Commands::StartAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleStartAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleStartAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleStartActionWithDuration(HandlerContext & ctx,
                                                   const Commands::StartActionWithDuration::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleStartActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
+    Status status = mDelegate.HandleStartActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleStopAction(HandlerContext & ctx, const Commands::StopAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleStopAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleStopAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandlePauseAction(HandlerContext & ctx, const Commands::PauseAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandlePauseAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandlePauseAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandlePauseActionWithDuration(HandlerContext & ctx,
                                                   const Commands::PauseActionWithDuration::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandlePauseActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
+    Status status = mDelegate.HandlePauseActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleResumeAction(HandlerContext & ctx, const Commands::ResumeAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleResumeAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleResumeAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleEnableAction(HandlerContext & ctx, const Commands::EnableAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleEnableAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleEnableAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleEnableActionWithDuration(HandlerContext & ctx,
                                                    const Commands::EnableActionWithDuration::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleEnableActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
+    Status status = mDelegate.HandleEnableActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleDisableAction(HandlerContext & ctx, const Commands::DisableAction::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleDisableAction(commandData.actionID, commandData.invokeID);
+    Status status = mDelegate.HandleDisableAction(commandData.actionID, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 
 void ActionsServer::HandleDisableActionWithDuration(HandlerContext & ctx,
                                                     const Commands::DisableActionWithDuration::DecodableType & commandData)
 {
-    Status status = Status::InvalidInState;
-    status        = mDelegate->HandleDisableActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
+    Status status = mDelegate.HandleDisableActionWithDuration(commandData.actionID, commandData.duration, commandData.invokeID);
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, status);
 }
 

--- a/src/app/clusters/actions-server/actions-server.h
+++ b/src/app/clusters/actions-server/actions-server.h
@@ -114,9 +114,9 @@ class ActionsServer : public AttributeAccessInterface, public CommandHandlerInte
 {
 public:
     // Register for the Actions cluster on all endpoints.
-    ActionsServer(EndpointId aEndpointId, Delegate * aDelegate) :
-        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Actions::Id),
-        CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Actions::Id), mDelegate(aDelegate), mEndpointId(aEndpointId)
+    ActionsServer(EndpointId aEndpointId, Delegate & aDelegate) :
+        AttributeAccessInterface(MakeOptional(aEndpointId), Actions::Id),
+        CommandHandlerInterface(MakeOptional(aEndpointId), Actions::Id), mDelegate(aDelegate), mEndpointId(aEndpointId)
     {}
 
     ~ActionsServer();
@@ -165,7 +165,7 @@ public:
     void EndpointListModified(EndpointId aEndpoint);
 
 private:
-    Delegate * mDelegate;
+    Delegate & mDelegate;
     EndpointId mEndpointId;
     static ActionsServer sInstance;
     static constexpr size_t kMaxEndpointListLength = 256u;

--- a/src/app/clusters/actions-server/actions-server.h
+++ b/src/app/clusters/actions-server/actions-server.h
@@ -114,11 +114,24 @@ class ActionsServer : public AttributeAccessInterface, public CommandHandlerInte
 {
 public:
     // Register for the Actions cluster on all endpoints.
-    ActionsServer() :
-        AttributeAccessInterface(Optional<EndpointId>::Missing(), Actions::Id),
-        CommandHandlerInterface(Optional<EndpointId>::Missing(), Actions::Id)
+    ActionsServer(EndpointId aEndpointId, Delegate * aDelegate) :
+        AttributeAccessInterface(Optional<EndpointId>(aEndpointId), Actions::Id),
+        CommandHandlerInterface(Optional<EndpointId>(aEndpointId), Actions::Id), mDelegate(aDelegate), mEndpointId(aEndpointId)
     {}
-    static ActionsServer & Instance();
+
+    ~ActionsServer();
+
+    /**
+     * Initialise the Actions server instance.
+     * @return Returns an error if the given endpoint and cluster have not been enabled in zap, if the
+     * AttributeAccessInterface or AttributeAccessInterface registration fails returns an error.
+     */
+    CHIP_ERROR Init();
+
+    /**
+     * Unregisters the CommandHandlerInterface and AttributeAccessInterface.
+     */
+    void Shutdown();
 
     /**
      * @brief
@@ -152,6 +165,8 @@ public:
     void EndpointListModified(EndpointId aEndpoint);
 
 private:
+    Delegate * mDelegate;
+    EndpointId mEndpointId;
     static ActionsServer sInstance;
     static constexpr size_t kMaxEndpointListLength = 256u;
     static constexpr size_t kMaxActionListLength   = 256u;

--- a/src/app/tests/TestActionsCluster.cpp
+++ b/src/app/tests/TestActionsCluster.cpp
@@ -173,7 +173,7 @@ public:
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
         sActionsDelegateImpl = new TestActionsDelegateImpl;
-        sActionsServer       = new ActionsServer(1, sActionsDelegateImpl);
+        sActionsServer       = new ActionsServer(1, *sActionsDelegateImpl);
         sActionsServer->Init();
     }
     static void TearDownTestSuite()


### PR DESCRIPTION
#### Problem

- TODO: We should not use a global array for delegate mapping per endpoint, instead we can use one cluster instance per endpoint.

#### Changes

- Use an instance of the Actions cluster per endpoint instead of having a global delegate array.

#### Testing

- Manually tested actions cluster by sending read request on attributes and sending invoke command using chip-tool by creating actions cluster on two different endpoints. For each endpoint, I made a separate dataset of a delegate class to verify the results.
- Ran unit tests that tested the actions clusters interface.