### PR TITLE
Fix openjdk version for vscode image: JAVA_PATH was mismatched with installed jdk

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-118 : [Telink] Update Docker image (Zephyr update)
+119 : [vscode/java/android] Install JDK 11 in vscode image (java path already set to it)

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -99,7 +99,7 @@ RUN set -x \
     expect \
     telnet \
     srecord \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line


### PR DESCRIPTION
JAVA_HOME was already set to 11 since #37697, however the installed java was still 8 since te original PR (#9795)

#### Testing

Trivial fix.