### PR TITLE
[Linux] Restore required signals removed in 96bf5df

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -529,11 +529,12 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
         mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED;
         ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant interface proxy");
 
-        g_signal_connect(mWpaSupplicant.iface, "properties-changed",
-                         G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * properties, ConnectivityManagerImpl * self) {
-                             return self->_OnWpaPropertiesChanged(proxy, properties);
-                         }),
-                         this);
+        g_signal_connect(
+            mWpaSupplicant.iface, "g-properties-changed",
+            G_CALLBACK(+[](WpaSupplicant1Interface * proxy, GVariant * properties, const char * const * invalidatedProps,
+                           ConnectivityManagerImpl * self) { return self->_OnWpaPropertiesChanged(proxy, properties); }),
+            this);
+
         g_signal_connect(mWpaSupplicant.iface, "scan-done",
                          G_CALLBACK(+[](WpaSupplicant1Interface * proxy, gboolean success, ConnectivityManagerImpl * self) {
                              return self->_OnWpaInterfaceScanDone(proxy, success);

--- a/src/platform/Linux/dbus/wpa/DBusWpa.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpa.xml
@@ -30,6 +30,7 @@ the wpa_supplicant integration with the Matter SDK.
 
 <node>
     <interface name="fi.w1.wpa_supplicant1">
+
         <method name="CreateInterface">
             <arg name="args" type="a{sv}" direction="in" />
             <arg name="path" type="o" direction="out" />
@@ -38,5 +39,14 @@ the wpa_supplicant integration with the Matter SDK.
             <arg name="ifname" type="s" direction="in" />
             <arg name="path" type="o" direction="out" />
         </method>
+
+        <signal name="InterfaceAdded">
+            <arg name="path" type="o" />
+            <arg name="properties" type="a{sv}" />
+        </signal>
+        <signal name="InterfaceRemoved">
+            <arg name="path" type="o" />
+        </signal>
+
     </interface>
 </node>

--- a/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
@@ -101,5 +101,20 @@ the wpa_supplicant integration with the Matter SDK.
         <property name="AuthStatusCode" type="i" access="read" />
         <property name="AssocStatusCode" type="i" access="read" />
 
+        <signal name="ScanDone">
+            <arg name="success" type="b" />
+        </signal>
+        <signal name="NanDiscoveryresult">
+            <arg name="result" type="b" />
+            <arg name="discov_info" type="a{sv}" />
+        </signal>
+        <signal name="NanReceive">
+            <arg name="nanrx" type="a{sv}" />
+        </signal>
+        <signal name="NanSubscribeterminated">
+            <arg name="term_subscribe_id" type="i" />
+            <arg name="reason" type="i" />
+        </signal>
+
     </interface>
 </node>


### PR DESCRIPTION
#### Problem

By mistake some required signals were removed in the https://github.com/project-chip/connectedhomeip/pull/37492

Also, it might be a fix for: https://github.com/project-chip/connectedhomeip/issues/37802

#### Chnages

- restored missing signals
- changed `properties-changed` to `g-properties-changed` to use glib built-in support for `org.freedesktop.DBus.Properties`

#### Testing

Checked locally that there are no warnings like that:

```
(process:861): GLib-GObject-WARNING **: 18:47:51.180: ../../../gobject/gsignal.c:2620: signal 'interface-added' is invalid for instance '0x7fb400a8a0' of type 'WpaSupplicant1Proxy'
```

and ble-wifi commissioning works as expected:

```
rpi:~ $ chip-lighting-app --wifi
```
```
host:~$ out/linux-x64-chip-tool/chip-tool pairing ble-wifi 1 MATTER-AP password 20202021 3840
```
