### PR TITLE
Fix running Fail-Safe cleanup after device is reset during commissioning

### DIFF
--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -82,7 +82,7 @@ void FailSafeContext::CheckAddNOCStartedMarker()
         }
 
         // Found a marker! We need to trigger a cleanup.
-        ChipLogError(FailSafe, "Found a Fail-Safe marker for index 0x%x, preparing cleanup!",
+        ChipLogError(FailSafe, "Found a AddNOCStartedMarker for index 0x%x, preparing cleanup!",
                      static_cast<unsigned>(marker.fabricIndex));
 
         // Fake arm Fail-Safe and trigger timer expiry.
@@ -96,7 +96,7 @@ void FailSafeContext::CheckAddNOCStartedMarker()
     else if (err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // Got an error, but somehow value is not missing altogether: inconsistent state but touch nothing.
-        ChipLogError(FailSafe, "Error loading Fail-Safe marker: %" CHIP_ERROR_FORMAT ", hope for the best!", err.Format());
+        ChipLogError(FailSafe, "Error loading AddNOCStartedMarker: %" CHIP_ERROR_FORMAT ", hope for the best!", err.Format());
     }
 }
 

--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -34,6 +34,15 @@ using namespace chip::DeviceLayer;
 namespace chip {
 namespace app {
 
+CHIP_ERROR FailSafeContext::Init(const InitParams & initParams)
+{
+    VerifyOrReturnError(initParams.storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mStorage = initParams.storage;
+
+    return CHIP_NO_ERROR;
+}
+
 void FailSafeContext::HandleArmFailSafeTimer(System::Layer * layer, void * aAppState)
 {
     FailSafeContext * failSafeContext = reinterpret_cast<FailSafeContext *>(aAppState);

--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -68,7 +68,11 @@ void FailSafeContext::CheckAddNOCStartedMarker()
     if (err == CHIP_NO_ERROR)
     {
         // This should not be possible at this point
-        VerifyOrDie(IsFailSafeArmed() == false);
+        if (IsFailSafeArmed())
+        {
+            ChipLogError(FailSafe, "Found a AddNOCStartedMarker, but Fail-Safe is armed. Something went wrong.");
+            return;
+        }
 
         // Fail-Safe may be busy due to cleanup scheduled by failed commit to FabricTable.
         // We can ignore it here, AddNOCStartedMarker will be deleted when Fail-Safe is disarmed.

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -27,7 +27,6 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <system/SystemClock.h>
 
 namespace chip {
 namespace app {
@@ -114,6 +113,15 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
+    // Stored to indicate a Fail-Safe is in armed, so that clean-up cana run on next boot
+    // if device is reset e.g. during commissioning.
+    struct AddNOCStartedMarker
+    {
+        AddNOCStartedMarker() = default;
+        AddNOCStartedMarker(FabricIndex fabricIndex_) : fabricIndex{ fabricIndex_ } {}
+        FabricIndex fabricIndex = kUndefinedFabricIndex;
+    };
+
     PersistentStorageDelegate * mStorage   = nullptr;
     bool mFailSafeArmed                    = false;
     bool mFailSafeBusy                     = false;
@@ -162,6 +170,9 @@ private:
     }
 
     void FailSafeTimerExpired();
+    CHIP_ERROR GetAddNOCStartedMarker(AddNOCStartedMarker & outMarker);
+    CHIP_ERROR StoreAddNOCStartedMarker(const AddNOCStartedMarker & marker);
+    void ClearAddNOCStartedMarker();
 };
 
 } // namespace app

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -56,11 +56,21 @@ public:
      * @brief Cleanly disarm failsafe timer, such as on CommissioningComplete
      */
     void DisarmFailSafe();
+
+    bool SetAddNocCommandStarted(FabricIndex nocFabricIndex)
+    {
+        mFabricIndex = nocFabricIndex;
+
+        AddNOCStartedMarker marker{ mFabricIndex };
+        return StoreAddNOCStartedMarker(marker) == CHIP_NO_ERROR;
+    }
+
     void SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
     {
         mAddNocCommandHasBeenInvoked = true;
         mFabricIndex                 = nocFabricIndex;
     }
+
     void SetUpdateNocCommandInvoked() { mUpdateNocCommandHasBeenInvoked = true; }
     void SetAddTrustedRootCertInvoked() { mAddTrustedRootCertHasBeenInvoked = true; }
     void SetCsrRequestForUpdateNoc(bool isForUpdateNoc) { mIsCsrRequestForUpdateNoc = isForUpdateNoc; }
@@ -167,6 +177,8 @@ private:
         mFailSafeBusy                           = false;
         mIsCsrRequestForUpdateNoc               = false;
         mUpdateTermsAndConditionsHasBeenInvoked = false;
+
+        ClearAddNOCStartedMarker();
     }
 
     void FailSafeTimerExpired();

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -42,6 +42,8 @@ public:
 
     CHIP_ERROR Init(const InitParams & initParams);
 
+    void CheckAddNOCStartedMarker();
+
     // ===== Members for internal use by other Device Layer components.
 
     /**

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "lib/core/CHIPPersistentStorageDelegate.h"
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
@@ -34,6 +35,14 @@ namespace app {
 class FailSafeContext
 {
 public:
+    struct InitParams
+    {
+        // PersistentStorageDelegate for marker storage (MANDATORY).
+        PersistentStorageDelegate * storage = nullptr;
+    };
+
+    CHIP_ERROR Init(const InitParams & initParams);
+
     // ===== Members for internal use by other Device Layer components.
 
     /**
@@ -105,6 +114,7 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
+    PersistentStorageDelegate * mStorage   = nullptr;
     bool mFailSafeArmed                    = false;
     bool mFailSafeBusy                     = false;
     bool mAddNocCommandHasBeenInvoked      = false;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -650,6 +650,9 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
                                                                  &newFabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
+    // Inform FailSafeContext about starting adding NOC for specified fabric
+    VerifyOrExit(failSafeContext.SetAddNocCommandStarted(newFabricIndex), nonDefaultStatus = Status::Failure);
+
     // From here if we error-out, we should revert the fabric table pending updates
     needRevert = true;
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -185,6 +185,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         SuccessOrExit(err);
     }
 
+    {
+        app::FailSafeContext::InitParams failSafeInitParams;
+        failSafeInitParams.storage = mDeviceStorage;
+
+        err = mFailSafeContext.Init(failSafeInitParams);
+        SuccessOrExit(err);
+    }
+
     SuccessOrExit(err = mAccessControl.Init(initParams.accessDelegate, sDeviceTypeResolver));
     Access::SetAccessControl(mAccessControl);
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -475,6 +475,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         }
     }
 
+    // Run fail-safe check for marker. If marker is present, then device was reset while fail-safe was armed
+    // and we need to trigger a cleanup.
+    GetFailSafeContext().CheckAddNOCStartedMarker();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT // support UDC port for commissioner declaration msgs
     mUdcTransportMgr = Platform::New<UdcTransportMgr>();
     ReturnErrorOnFailure(mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())

--- a/src/app/tests/TestFailSafeContext.cpp
+++ b/src/app/tests/TestFailSafeContext.cpp
@@ -34,6 +34,7 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
@@ -66,7 +67,10 @@ public:
 
 TEST_F(TestFailSafeContext, TestFailSafeContext_ArmFailSafe)
 {
+    chip::TestPersistentStorageDelegate testStorage;
     chip::app::FailSafeContext failSafeContext;
+
+    failSafeContext.Init({ &testStorage });
 
     EXPECT_EQ(failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1)), CHIP_NO_ERROR);
     EXPECT_TRUE(failSafeContext.IsFailSafeArmed());
@@ -80,7 +84,10 @@ TEST_F(TestFailSafeContext, TestFailSafeContext_ArmFailSafe)
 
 TEST_F(TestFailSafeContext, TestFailSafeContext_NocCommandInvoked)
 {
+    chip::TestPersistentStorageDelegate testStorage;
     chip::app::FailSafeContext failSafeContext;
+
+    failSafeContext.Init({ &testStorage });
 
     EXPECT_EQ(failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1)), CHIP_NO_ERROR);
     EXPECT_EQ(failSafeContext.GetFabricIndex(), kTestAccessingFabricIndex1);

--- a/src/app/tests/TestThreadBorderRouterManagementCluster.cpp
+++ b/src/app/tests/TestThreadBorderRouterManagementCluster.cpp
@@ -31,6 +31,7 @@
 #include <lib/support/BitFlags.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <optional>
@@ -154,6 +155,7 @@ public:
 
 constexpr EndpointId kTestEndpointId            = 1;
 constexpr FabricIndex kTestAccessingFabricIndex = 1;
+static chip::TestPersistentStorageDelegate sTestStorage;
 static FailSafeContext sTestFailsafeContext;
 static TestDelegate sTestDelegate;
 static ServerInstance sTestSeverInstance(kTestEndpointId, &sTestDelegate, sTestFailsafeContext);
@@ -211,6 +213,7 @@ public:
     {
         ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+        ASSERT_EQ(sTestFailsafeContext.Init({ &sTestStorage }), CHIP_NO_ERROR);
     }
 
     static void TearDownTestSuite()

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -104,6 +104,7 @@ public:
 
     // Fail-safe handling
     static StorageKeyName FabricTableCommitMarkerKey() { return StorageKeyName::FromConst("g/fs/c"); }
+    static StorageKeyName FailSafeAddNOCStartedMarkerKey() { return StorageKeyName::FromConst("g/fs/m"); }
     static StorageKeyName FailSafeNetworkConfig() { return StorageKeyName::FromConst("g/fs/n"); }
 
     // LastKnownGoodTime


### PR DESCRIPTION
#### Problem
Due to changes in #20010, when a device is reset during commissioning, Fail-Safe loses information about it. This leads to a situation when after a reset, some partial fabric data is present in the device storage, e.g. following keys:
```
f/1/ac/0/0
f/1/g
f/1/k/0
```
Additionally, if this was first fabric, factory reset is not triggered.

#### Changes
This PR adds `AddNOCStartedMarker` for Fail-Safe which is stored when `AddNOC` command is processed, before any fabric data is stored and deleted when Fail-Safe is disarmed or triggered. Presence of the marker is checked during boot after handling `FabricTable::CommitMarker`, which is still used for keeping consistency of a fabric data during other operations e.g. `UpdateNOC`.

#### Testing
* Added unit tests for `FailSafeContext::AddNOCStartedMarker`.
* Manually verified that all partial fabric data is removed from settings and factory reset is triggered in case this was the only fabric.