### PR TITLE
Increase unit test coverage for app data model provider

### DIFF
--- a/src/app/data-model-provider/MetadataList.h
+++ b/src/app/data-model-provider/MetadataList.h
@@ -156,11 +156,11 @@ public:
     ListBuilder(const ListBuilder &)                   = delete;
     ListBuilder & operator=(const ListBuilder & other) = delete;
 
-    ListBuilder(ListBuilder && other) : GenericAppendOnlyBuffer(sizeof(T)) { *this = std::move(other); }
+    ListBuilder(ListBuilder && other) : GenericAppendOnlyBuffer{std::move(other)} {}
 
     ListBuilder & operator=(ListBuilder && other)
     {
-        *static_cast<GenericAppendOnlyBuffer *>(this) = std::move(other);
+        detail::GenericAppendOnlyBuffer::operator=(std::move(other));
         return *this;
     }
 

--- a/src/app/data-model-provider/MetadataList.h
+++ b/src/app/data-model-provider/MetadataList.h
@@ -156,7 +156,7 @@ public:
     ListBuilder(const ListBuilder &)                   = delete;
     ListBuilder & operator=(const ListBuilder & other) = delete;
 
-    ListBuilder(ListBuilder && other) : GenericAppendOnlyBuffer{std::move(other)} {}
+    ListBuilder(ListBuilder && other) : GenericAppendOnlyBuffer{ std::move(other) } {}
 
     ListBuilder & operator=(ListBuilder && other)
     {

--- a/src/app/data-model-provider/tests/TestMetadataList.cpp
+++ b/src/app/data-model-provider/tests/TestMetadataList.cpp
@@ -218,7 +218,7 @@ TEST_F(TestMetadataList, BufferMoveOperationsWork)
         movedFromList.Append(11);
         movedFromList.Append(12);
 
-        LIST movedToList{std::move(movedFromList)};
+        LIST movedToList{ std::move(movedFromList) };
 
         ASSERT_EQ(movedFromList.Size(), size_t{ 0 }); // NOLINT(bugprone-use-after-move)
         ASSERT_TRUE(movedFromList.IsEmpty());         // NOLINT(bugprone-use-after-move)

--- a/src/app/data-model-provider/tests/TestMetadataList.cpp
+++ b/src/app/data-model-provider/tests/TestMetadataList.cpp
@@ -226,8 +226,8 @@ TEST_F(TestMetadataList, BufferMoveOperationsWork)
         /// move constructor called for the second time here
         GenericAppendOnlyBuffer newBuffer{ std::move(originalBuffer) };
 
-        ASSERT_EQ(originalBuffer.Size(), size_t{ 0 });
-        ASSERT_TRUE(originalBuffer.IsEmpty());
+        ASSERT_EQ(originalBuffer.Size(), size_t{ 0 }); // NOLINT(bugprone-use-after-move)
+        ASSERT_TRUE(originalBuffer.IsEmpty());         // NOLINT(bugprone-use-after-move)
 
         ASSERT_EQ(newBuffer.Size(), size_t{ 3 });
         ASSERT_FALSE(newBuffer.IsEmpty());
@@ -262,8 +262,8 @@ TEST_F(TestMetadataList, BufferMoveOperationsWork)
         originalBuffer = std::move(anotherBuffer);
 
         ASSERT_EQ(originalBuffer.Size(), size_t{ 2 });
-        ASSERT_EQ(anotherBuffer.Size(), size_t{ 0 });
-        ASSERT_TRUE(anotherBuffer.IsEmpty());
+        ASSERT_EQ(anotherBuffer.Size(), size_t{ 0 }); // NOLINT(bugprone-use-after-move)
+        ASSERT_TRUE(anotherBuffer.IsEmpty());         // NOLINT(bugprone-use-after-move)
     }
 }
 } // namespace


### PR DESCRIPTION
Fixes #37223

#### Testing

new `TEST_F(TestMetadataList, BufferMoveOperationsWork)` added into `src/app/data-model-provider/tests/TestMetadataList.cpp`
