### PR TITLE
Parametrize app-common zap-generated path

### DIFF
--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -36,6 +36,10 @@ if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../.. REALPATH)
 endif()
 
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 # ==============================================================================
 # Find required programs
 # ==============================================================================
@@ -165,7 +169,7 @@ macro(matter_build target)
         ${CHIP_ROOT}/third_party/nlassert/repo/include
         ${CHIP_ROOT}/third_party/nlio/repo/include
         ${CHIP_ROOT}/third_party/nlfaultinjection/include
-        ${CHIP_ROOT}/zzz_generated/app-common
+        ${CHIP_APP_ZAP_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/gen/include
     )
 

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -41,6 +41,11 @@ include(generate_factory_data.cmake)
 if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
 endif()
+
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nrfconnect/chip-gn REALPATH)
 get_filename_component(COMMON_CMAKE_SOURCE_DIR ${CHIP_ROOT}/config/common/cmake REALPATH)
 
@@ -132,6 +137,7 @@ matter_common_gn_args(
 matter_add_gn_arg_string("zephyr_ar"                              ${CMAKE_AR})
 matter_add_gn_arg_string("zephyr_cc"                              ${CMAKE_C_COMPILER})
 matter_add_gn_arg_string("zephyr_cxx"                             ${CMAKE_CXX_COMPILER})
+matter_add_gn_arg_string("chip_app_zap_dir"                       ${CHIP_APP_ZAP_DIR})
 matter_add_gn_arg_bool  ("chip_logging"                           CONFIG_LOG)
 matter_add_gn_arg_bool  ("chip_enable_openthread"                 CONFIG_NET_L2_OPENTHREAD)
 matter_add_gn_arg_bool  ("chip_openthread_ftd"                    CONFIG_OPENTHREAD_FTD)

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -16,6 +16,10 @@
 
 set(CHIP_APP_BASE_DIR ${CMAKE_CURRENT_LIST_DIR})
 
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 include("${CHIP_ROOT}/build/chip/chip_codegen.cmake")
 include("${CHIP_ROOT}/src/data-model-providers/codegen/model.cmake")
 
@@ -144,7 +148,7 @@ function(chip_configure_data_model APP_TARGET)
     add_dependencies(${APP_TARGET} ${APP_TARGET}-zapgen)
 
     target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+        ${CHIP_APP_ZAP_DIR}/app-common/zap-generated/attributes/Accessors.cpp
         ${CHIP_APP_BASE_DIR}/reporting/reporting.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-storage.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-table.cpp

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -13,23 +13,24 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/common_flags.gni")
 
 config("includes") {
-  include_dirs = [ "${chip_root}/zzz_generated/app-common" ]
+  include_dirs = [ "${chip_app_zap_dir}" ]
 }
 
 source_set("attribute-type") {
-  sources = [ "${chip_root}/zzz_generated/app-common/app-common/zap-generated/attribute-type.h" ]
+  sources = [ "${chip_app_zap_dir}/app-common/zap-generated/attribute-type.h" ]
 
   public_configs = [ ":includes" ]
 }
 
 source_set("ids") {
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Events.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Attributes.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Clusters.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Commands.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Events.h",
   ]
 
   public_deps = [ "${chip_root}/src/app/util:types" ]
@@ -41,8 +42,8 @@ static_library("cluster-objects") {
   output_name = "libClusterObjects"
 
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.cpp",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.h",
   ]
 
   public_deps = [
@@ -61,8 +62,8 @@ static_library("cluster-objects") {
 
 source_set("enums") {
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-enums-check.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-enums.h",
     "CompatEnumNames.h",
   ]
 

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -25,6 +25,9 @@ declare_args() {
   # communicated to OperationalSessionSetup API consumers.
   chip_enable_busy_handling_for_operational_session_setup = true
 
+  # Flag that sets path to zap-generated app-common directory
+  chip_app_zap_dir = chip_root + "/zzz_generated/app-common"
+
   # Controls whether the device commissioning process requires the user to
   # acknowledge terms and conditions during commissioning.
   chip_terms_and_conditions_required = false


### PR DESCRIPTION
Parametrize app-common zap-generated path to allow building
Matter using custom generated zap files stored in different path.
When user adds custom clusters, full zap regeneration is needed.
Storing these files in fixed place requires regeneration every
time user wants to build different project (with different
clusters). This commit allows to store zap-generated files
separately and provide their path by seting `CHIP_APP_ZAP_DIR`
cmake and `chip_app_zap_dir` GN flags.


#### Testing

Tested locally on nrfconnect with custom clusters added and CHIP_APP_ZAP_DIR overridden, and with default clusters, with no CHIP_APP_ZAP_DIR override
