### PR TITLE
[app] Remove external_clusters flag

### DIFF
--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -39,13 +39,9 @@ endfunction()
 #
 # Configure ${APP_TARGET} with source files associated with clusters enabled in the ${ZAP_FILE}
 #
-function(chip_configure_zap_file APP_TARGET ZAP_FILE EXTERNAL_CLUSTERS)
+function(chip_configure_zap_file APP_TARGET ZAP_FILE)
     find_package(Python3 REQUIRED)
     set(args --zap_file ${ZAP_FILE})
-
-    if(EXTERNAL_CLUSTERS)
-        list(APPEND args --external-clusters ${EXTERNAL_CLUSTERS})
-    endif()
 
     execute_process(
         COMMAND ${Python3_EXECUTABLE} ${CHIP_APP_BASE_DIR}/zap_cluster_list.py ${args}
@@ -74,13 +70,10 @@ endfunction()
 # supported by the application.
 # IDL               .matter IDL file to use for codegen. Inferred from ZAP_FILE
 # if not provided
-# EXTERNAL_CLUSTERS Clusters with external implementations. The default implementations
-# will not be used nor required for these clusters.
-# Format: MY_CUSTOM_CLUSTER'.
 #
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)
-    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
+    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL" "" ${ARGN})
 
     if(ARG_SCOPE)
         set(SCOPE ${ARG_SCOPE})
@@ -104,7 +97,7 @@ function(chip_configure_data_model APP_TARGET)
     )
 
     if(ARG_ZAP_FILE)
-        chip_configure_zap_file(${APP_TARGET} ${ARG_ZAP_FILE} "${ARG_EXTERNAL_CLUSTERS}")
+        chip_configure_zap_file(${APP_TARGET} ${ARG_ZAP_FILE})
 
         if(NOT ARG_IDL)
             string(REPLACE ".zap" ".matter" ARG_IDL ${ARG_ZAP_FILE})

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -171,7 +171,6 @@ template("chip_data_model") {
                            [
                              "zap_file",
                              "is_server",
-                             "external_clusters",
                            ])
 
     if (!defined(sources)) {
@@ -221,10 +220,7 @@ template("chip_data_model") {
         "--zap_file",
         _zap_file,
       ]
-      if (defined(invoker.external_clusters)) {
-        _script_args += [ "--external-clusters" ]
-        _script_args += invoker.external_clusters
-      }
+
       _cluster_sources = exec_script("${_app_root}/zap_cluster_list.py",
                                      _script_args,
                                      "list lines",

--- a/src/app/zap_cluster_list.py
+++ b/src/app/zap_cluster_list.py
@@ -21,18 +21,14 @@ def get_cluster_sources(clusters: typing.Set[str],
     cluster_sources: typing.Set[str] = set()
 
     for cluster in clusters:
-        if cluster not in source_map:
-            raise ValueError("Unhandled %s cluster: %s"
-                             " (hint: add to src/app/zap_cluster_list.json)" % (side, cluster))
-
-        cluster_sources.update(source_map[cluster])
+        if cluster in source_map:
+            cluster_sources.update(source_map[cluster])
 
     return cluster_sources
 
 
 def dump_zapfile_clusters(zap_file_path: pathlib.Path,
-                          implementation_data_path: pathlib.Path,
-                          external_clusters: typing.List[str]):
+                          implementation_data_path: pathlib.Path):
     """Prints all of the source directories to build for a given ZAP file.
 
     Arguments:
@@ -58,8 +54,6 @@ def dump_zapfile_clusters(zap_file_path: pathlib.Path,
 
         for endpoint_type in zap_json.get('endpointTypes'):
             for cluster in endpoint_type.get('clusters'):
-                if cluster.get('define') in external_clusters:
-                    continue
                 side: str = cluster.get('side')
                 if side == 'client':
                     clusters_set = client_clusters
@@ -94,17 +88,10 @@ def main():
                         required=False,
                         type=pathlib.Path,
                         default=os.path.join(os.path.dirname(__file__), "zap_cluster_list.json"))
-    parser.add_argument('--external-clusters',
-                        help='Clusters with external implementations. ' +
-                             'The default implementations will not be used nor required for these clusters. ' +
-                             'Format: MY_CUSTOM_CLUSTER',
-                        nargs='+',
-                        metavar='EXTERNAL_CLUSTER',
-                        default=[])
 
     args = parser.parse_args()
 
-    dump_zapfile_clusters(args.zap_file, args.cluster_implementation_data, args.external_clusters)
+    dump_zapfile_clusters(args.zap_file, args.cluster_implementation_data)
 
     sys.exit(0)
 


### PR DESCRIPTION
`external_clusters` flag is redundant as if an external cluster is created without correct implementation, build will fail anyway. Without the flag, clusters not provided in `zap_cluster_list.json` can be skipped without requiring to always provide full list of custom clusters.


#### Testing

tested on nrfconnect build with custom cluster added