### PR TITLE
Clean up partial fabric data after device is reset during CommitPendingFabricData

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1046,12 +1046,17 @@ CHIP_ERROR FabricTable::Delete(FabricIndex fabricIndex)
         }
     }
 
-    // Only return error after trying really hard to remove everything we could
-    ReturnErrorOnFailure(metadataErr);
-    ReturnErrorOnFailure(opKeyErr);
-    ReturnErrorOnFailure(opCertsErr);
+    if (fabricIsInitialized)
+    {
+        // Only return error after trying really hard to remove everything we could
+        ReturnErrorOnFailure(metadataErr);
+        ReturnErrorOnFailure(opKeyErr);
+        ReturnErrorOnFailure(opCertsErr);
 
-    return CHIP_NO_ERROR;
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 void FabricTable::DeleteAllFabrics()

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1002,39 +1002,35 @@ CHIP_ERROR FabricTable::Delete(FabricIndex fabricIndex)
         }
     }
 
-    if (!fabricIsInitialized)
+    if (fabricIsInitialized)
     {
-        // Make sure to return the error our API promises, not whatever storage
-        // chose to return.
-        return CHIP_ERROR_NOT_FOUND;
-    }
+        // Since fabricIsInitialized was true, fabric is not null.
+        fabricInfo->Reset();
 
-    // Since fabricIsInitialized was true, fabric is not null.
-    fabricInfo->Reset();
+        if (!mNextAvailableFabricIndex.HasValue())
+        {
+            // We must have been in a situation where CHIP_CONFIG_MAX_FABRICS is 254
+            // and our fabric table was full, so there was no valid next index.  We
+            // have a single available index now, though; use it as
+            // mNextAvailableFabricIndex.
+            mNextAvailableFabricIndex.SetValue(fabricIndex);
+        }
+        // If StoreFabricIndexInfo fails here, that's probably OK.  When we try to
+        // read things from storage later we will realize there is nothing for this
+        // index.
+        StoreFabricIndexInfo();
 
-    if (!mNextAvailableFabricIndex.HasValue())
-    {
-        // We must have been in a situation where CHIP_CONFIG_MAX_FABRICS is 254
-        // and our fabric table was full, so there was no valid next index.  We
-        // have a single available index now, though; use it as
-        // mNextAvailableFabricIndex.
-        mNextAvailableFabricIndex.SetValue(fabricIndex);
-    }
-    // If StoreFabricIndexInfo fails here, that's probably OK.  When we try to
-    // read things from storage later we will realize there is nothing for this
-    // index.
-    StoreFabricIndexInfo();
-
-    // If we ever start moving the FabricInfo entries around in the array on
-    // delete, we should update DeleteAllFabrics to handle that.
-    if (mFabricCount == 0)
-    {
-        ChipLogError(FabricProvisioning, "Trying to delete a fabric, but the current fabric count is already 0");
-    }
-    else
-    {
-        mFabricCount--;
-        ChipLogProgress(FabricProvisioning, "Fabric (0x%x) deleted.", static_cast<unsigned>(fabricIndex));
+        // If we ever start moving the FabricInfo entries around in the array on
+        // delete, we should update DeleteAllFabrics to handle that.
+        if (mFabricCount == 0)
+        {
+            ChipLogError(FabricProvisioning, "Trying to delete a fabric, but the current fabric count is already 0");
+        }
+        else
+        {
+            mFabricCount--;
+            ChipLogProgress(FabricProvisioning, "Fabric (0x%x) deleted.", static_cast<unsigned>(fabricIndex));
+        }
     }
 
     if (mDelegateListRoot != nullptr)

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -412,7 +412,14 @@ public:
         No
     };
 
-    // Returns CHIP_ERROR_NOT_FOUND if there is no fabric for that index.
+    /**
+     * @brief Delete the fabric with given `fabricIndex`.
+     *
+     * @param fabricIndex - Index of fabric for deletion
+     * @retval CHIP_NO_ERROR on success
+     * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds
+     * @retval other CHIP_ERROR on internal errors
+     */
     CHIP_ERROR Delete(FabricIndex fabricIndex);
     void DeleteAllFabrics();
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -417,6 +417,7 @@ public:
      *
      * @param fabricIndex - Index of fabric for deletion
      * @retval CHIP_NO_ERROR on success
+     * @retval CHIP_ERROR_NOT_FOUND if there is no fabric for that index
      * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds
      * @retval other CHIP_ERROR on internal errors
      */

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -3058,6 +3058,8 @@ TEST_F(TestFabricTable, Delete)
     fabricTable.Delete(newFabricIndex);
     EXPECT_TRUE(fabricDelegate.willBeRemovedCalled);
     EXPECT_TRUE(fabricDelegate.onRemovedCalled);
+
+    fabricTable.RemoveFabricDelegate(&fabricDelegate);
 }
 
 } // namespace

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -72,6 +72,16 @@ public:
         return mFabricTable.Init(initParams);
     }
 
+    CHIP_ERROR ReinitFabricTable(chip::TestPersistentStorageDelegate * storage)
+    {
+        chip::FabricTable::InitParams initParams;
+        initParams.storage             = storage;
+        initParams.operationalKeystore = &mOpKeyStore;
+        initParams.opCertStore         = &mOpCertStore;
+
+        return mFabricTable.Init(initParams);
+    }
+
     FabricTable & GetFabricTable() { return mFabricTable; }
 
 private:
@@ -2996,6 +3006,58 @@ TEST_F(TestFabricTable, TestCommitMarker)
         }
     }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+}
+
+class TestFabricTableDelegate : public FabricTable::Delegate
+{
+public:
+    void FabricWillBeRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override { willBeRemovedCalled = true; }
+
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override { onRemovedCalled = true; }
+
+    bool willBeRemovedCalled = false;
+    bool onRemovedCalled     = false;
+};
+
+TEST_F(TestFabricTable, Delete)
+{
+    Credentials::TestOnlyLocalCertificateAuthority fabricCertAuthority;
+    EXPECT_TRUE(fabricCertAuthority.Init().IsSuccess());
+
+    chip::TestPersistentStorageDelegate storage;
+    ScopedFabricTable fabricTableHolder;
+    EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
+
+    FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
+    FabricId fabricId         = 1;
+    NodeId nodeId             = 10;
+
+    // Simulate AddNOC
+    uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
+    MutableByteSpan csrSpan{ csrBuf };
+    EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
+
+    EXPECT_EQ(fabricCertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(), CHIP_NO_ERROR);
+    ByteSpan rcac = fabricCertAuthority.GetRcac();
+    ByteSpan icac = fabricCertAuthority.GetIcac();
+    ByteSpan noc  = fabricCertAuthority.GetNoc();
+
+    fabricTable.AddNewPendingTrustedRootCert(rcac);
+
+    constexpr uint16_t kVendorId = 0xFFF1u;
+    FabricIndex newFabricIndex   = kUndefinedFabricIndex;
+    EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, icac, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
+
+    // Reinitialize FabricTable to simulate device reboot
+    EXPECT_EQ(fabricTableHolder.ReinitFabricTable(&storage), CHIP_NO_ERROR);
+
+    TestFabricTableDelegate fabricDelegate;
+    fabricTable.AddFabricDelegate(&fabricDelegate);
+
+    // Check if calling Delete invokes OnFabricRemoved on delegates
+    fabricTable.Delete(newFabricIndex);
+    EXPECT_TRUE(fabricDelegate.willBeRemovedCalled);
+    EXPECT_TRUE(fabricDelegate.onRemovedCalled);
 }
 
 } // namespace


### PR DESCRIPTION
### Problem
When a device is reset during `FabricTable::CommitPendingFabricData` (with `CommitMarker` stored in settings), it doesn't clean up all fabric data and in case if this was the only fabric, factory reset is not performed.

### Changes
* Change `FabricTable::Delete` to always clean up all data for a given fabric index, even if some of them are missing.

### Testing
* Tested with nrfconnect example by resetting device in `FabricTable::CommitPendingFabricData` after `StoreCommitMarker` and examining logs and settings content.
* Added unit test for FabricTable::Delete behavior.

#### Before
<details>
<summary>Simplified logs from device</summary>

```
[00:00:32.074,958] <inf> chip: [FS]GeneralCommissioning: Received CommissioningComplete
SETTINGS_SAVE mt/g/fs/c

RESET HERE

SETTINGS_SAVE mt/ctr/reboot-count
[00:00:33.105,914] <inf> app: Init CHIP stack
SETTINGS_SAVE ot/3
SETTINGS_DELETE its/0000000000020003
SETTINGS_DELETE its/0000000000020004
SETTINGS_DELETE ot/1
SETTINGS_DELETE mt/g/fs/n
[00:00:33.159,891] <dbg> chip: LogV: [FP]Initializing FabricTable from persistent storage
[00:00:33.160,583] <inf> chip: [TS]Last Known Good Time: 2023-10-14T01:16:48
[00:00:33.161,339] <err> chip: [FP]Found a FabricTable aborted commit for index 0x1 (isAddition: 1), removing!
[00:00:33.162,033] <err> chip: [FP]Warning: metadata not found during delete of fabric 0x1
SETTINGS_DELETE its/0000000000030001
SETTINGS_SAVE mt/g/gcc
SETTINGS_SAVE mt/g/gdc
SETTINGS_SAVE mt/g/im/ec
[00:00:33.189,315] <err> chip: [ZCL]OpCreds: Got FailSafeTimerExpired
[00:00:33.189,356] <err> chip: [ZCL]OpCreds: Proceeding to FailSafeCleanup on fail-safe expiry!
[00:00:33.189,400] <dbg> chip: LogV: [IN]Expiring all sessions for fabric 0x1!!
[00:00:33.189,510] <inf> chip: [TS]Pending Last Known Good Time: 2023-10-14T01:16:48
[00:00:33.190,256] <inf> chip: [TS]Previous Last Known Good Time: 2023-10-14T01:16:48
[00:00:33.190,294] <inf> chip: [TS]Reverted Last Known Good Time to previous value
[00:00:33.190,573] <dbg> chip: LogV: [EVL]LogEvent event number: 0x0000000000010002 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0028 event id: 0x2 Sys timestamp: 0x000000000000001F
[00:00:33.190,662] <dbg> chip: LogV: [DMG]All ReadHandler-s are clean, clear GlobalDirtySet
[00:00:33.191,420] <err> chip: [FP]Warning: metadata not found during delete of fabric 0x1
[00:00:33.194,121] <err> chip: [ZCL]OpCreds: failed to delete fabric at index 1: d8
[00:00:33.194,187] <dbg> chip: LogV: [ZCL]Failsafe timeout, tell platform driver to revert network credentials.
[00:00:33.195,008] <inf> chip: [FS]Fail-safe cleanly disarmed
SETTINGS_DELETE mt/g/fs/c
[00:00:33.196,092] <inf> chip: [SVR]Cleared FabricTable pending commit marker
```
</details>

<details>
<summary>Settings content</summary>

```
mt/g/sri
mt/g/s/ccjW4zjTVz2mDpx71gu82g\e\e
mt/f/1/s/000000000001B669
ot/c
its/0000000000020007
ot/7
ot/3
ot/4
mt/f/1/ac/0/0
mt/f/1/g
mt/g/gfl
mt/f/1/k/0
mt/cfg/country-code
mt/cfg/regulatory-location
mt/g/im/ec
mt/g/gdc
mt/g/gcc
mt/g/lkgt
mt/ctr/reboot-count
mt/cfg/unique-id
its/0000000000020001
```
</details>

#### After
<details>
<summary>Simplified logs from device</summary>

```
[00:00:36.991,312] <inf> chip: [FS]GeneralCommissioning: Received CommissioningComplete
SETTINGS_SAVE mt/g/fs/c

RESET HERE

SETTINGS_SAVE mt/ctr/reboot-count
[00:00:38.006,709] <inf> app: Init CHIP stack
SETTINGS_SAVE ot/3
SETTINGS_DELETE its/0000000000020003
SETTINGS_DELETE its/0000000000020004
SETTINGS_DELETE ot/1
SETTINGS_DELETE mt/g/fs/n
[00:00:38.060,725] <dbg> chip: LogV: [FP]Initializing FabricTable from persistent storage
[00:00:38.061,417] <inf> chip: [TS]Last Known Good Time: 2023-10-14T01:16:48
[00:00:38.062,171] <err> chip: [FP]Found a FabricTable aborted commit for index 0x1 (isAddition: 1), removing!
[00:00:38.062,865] <err> chip: [FP]Warning: metadata not found during delete of fabric 0x1
SETTINGS_DELETE its/0000000000030001
SETTINGS_SAVE mt/g/gcc
SETTINGS_SAVE mt/g/gdc
SETTINGS_SAVE mt/g/im/ec
[00:00:38.090,121] <err> chip: [ZCL]OpCreds: Got FailSafeTimerExpired
[00:00:38.090,161] <err> chip: [ZCL]OpCreds: Proceeding to FailSafeCleanup on fail-safe expiry!
[00:00:38.090,205] <dbg> chip: LogV: [IN]Expiring all sessions for fabric 0x1!!
[00:00:38.090,315] <inf> chip: [TS]Pending Last Known Good Time: 2023-10-14T01:16:48
[00:00:38.091,002] <inf> chip: [TS]Previous Last Known Good Time: 2023-10-14T01:16:48
[00:00:38.091,040] <inf> chip: [TS]Reverted Last Known Good Time to previous value
[00:00:38.091,289] <dbg> chip: LogV: [EVL]LogEvent event number: 0x0000000000010002 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0028 event id: 0x2 Sys timestamp: 0x000000000000001F
[00:00:38.091,338] <dbg> chip: LogV: [DMG]All ReadHandler-s are clean, clear GlobalDirtySet
[00:00:38.092,035] <err> chip: [FP]Warning: metadata not found during delete of fabric 0x1
[00:00:38.094,585] <inf> chip: [ZCL]OpCreds: Fabric index 0x1 was removed
SETTINGS_DELETE mt/g/s/FgybbCSP7jlDbAJIjJHrXw\e\e
SETTINGS_DELETE mt/f/1/s/000000000001B669
SETTINGS_SAVE mt/g/sri
SETTINGS_DELETE mt/f/1/k/0
SETTINGS_SAVE mt/f/1/g
SETTINGS_SAVE mt/g/gfl
SETTINGS_DELETE mt/f/1/g
[00:00:38.122,271] <dbg> chip: LogV: [ZCL]Failsafe timeout, tell platform driver to revert network credentials.
[00:00:38.123,094] <inf> chip: [FS]Fail-safe cleanly disarmed
SETTINGS_DELETE mt/g/fs/c
[00:00:38.124,220] <inf> chip: [SVR]Cleared FabricTable pending commit marker
[00:00:39.094,798] <inf> chip: [TS]Pending Last Known Good Time: 2023-10-14T01:16:48
[00:00:39.095,462] <inf> chip: [TS]Previous Last Known Good Time: 2023-10-14T01:16:48
[00:00:39.095,499] <inf> chip: [TS]Reverted Last Known Good Time to previous value
[00:00:39.095,535] <dbg> chip: LogV: [ZCL]Emitting ShutDown event
[00:00:39.095,909] <inf> chip: [DL]Performing factory reset
SETTINGS_SAVE its/0000000000020001

REBOOT DUE TO FACTORY RESET

SETTINGS_SAVE mt/cfg/unique-id
SETTINGS_SAVE mt/ctr/reboot-count
[00:00:42.059,240] <inf> app: Init CHIP stack
[00:00:42.060,475] <dbg> chip: LogV: [FP]Initializing FabricTable from persistent storage
[00:00:42.060,604] <inf> chip: [TS]Last Known Good Time: [unknown]
[00:00:42.060,710] <inf> chip: [TS]Setting Last Known Good Time to firmware build time 2023-10-14T01:16:48
SETTINGS_SAVE mt/g/lkgt
SETTINGS_SAVE mt/g/gcc
SETTINGS_SAVE mt/g/gdc
SETTINGS_SAVE mt/g/im/ec
```
</details>

<details>
<summary>Settings content</summary>

```
mt/g/im/ec
mt/g/gdc
mt/g/gcc
mt/g/lkgt
mt/ctr/reboot-count
mt/cfg/unique-id
its/0000000000020001
```
</details>

This PR is a subset of https://github.com/project-chip/connectedhomeip/pull/37807, which may require more work.