### PR TITLE
[ICD]Trigger resubscription when receiving check-in and subscription has not yet become abnormal

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1077,8 +1077,9 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
         // It is possible that pListItem is destroyed by the app in OnActiveModeNotification.
         // Get the next item before invoking `OnActiveModeNotification`.
         CATValues cats;
+        
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
-        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer && cats.CheckSubjectAgainstCATs(aMonitoredSubject))
+        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer && (cats.CheckSubjectAgainstCATs(aMonitoredSubject) || aMonitoredSubject == pListItem->GetLocalNodeId()))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1080,8 +1080,8 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
 
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
         if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
-           (cats.CheckSubjectAgainstCATs(aMonitoredSubject) ||
-            aMonitoredSubject == mpFabricTable->FindFabricWithIndex(pListItem->GetFabricIndex()->GetNodeId())))
+            (cats.CheckSubjectAgainstCATs(aMonitoredSubject) ||
+             aMonitoredSubject == mpFabricTable->FindFabricWithIndex(pListItem->GetFabricIndex()->GetNodeId())))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1069,18 +1069,14 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 }
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject)
+void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer)
 {
     for (ReadClient * pListItem = mpActiveReadClientList; pListItem != nullptr;)
     {
         auto pNextItem = pListItem->GetNextClient();
         // It is possible that pListItem is destroyed by the app in OnActiveModeNotification.
         // Get the next item before invoking `OnActiveModeNotification`.
-        // If caseTag for current subscription does not match with the one set in ICDManagementCluster::RegisterClient for check-in,
-        // when receiving check-in message, OnActiveModeNotification would do nothing for current subscription.
-        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
-           pListItem->GetSubjectDescriptor().HasValue() && pListItem->GetSubjectDescriptor().Value().cats.CheckSubjectAgainstCATs(aMonitoredSubject) &&
-           pListItem->GetSubjectDescriptor().Value().subject == aMonitoredSubject)
+        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer)
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1077,7 +1077,7 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
         // It is possible that pListItem is destroyed by the app in OnActiveModeNotification.
         // Get the next item before invoking `OnActiveModeNotification`.
         CATValues cats;
-        
+
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
         if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer && (cats.CheckSubjectAgainstCATs(aMonitoredSubject) || aMonitoredSubject == pListItem->GetLocalNodeId()))
         {

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1079,7 +1079,8 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
         CATValues cats;
 
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
-        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer && (cats.CheckSubjectAgainstCATs(aMonitoredSubject) || aMonitoredSubject == pListItem->GetLocalNodeId()))
+        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
+            (cats.CheckSubjectAgainstCATs(aMonitoredSubject) || aMonitoredSubject == pListItem->GetLocalNodeId()))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1081,7 +1081,7 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
         if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
             (cats.CheckSubjectAgainstCATs(aMonitoredSubject) ||
-             aMonitoredSubject == mpFabricTable->FindFabricWithIndex(pListItem->GetFabricIndex()->GetNodeId())))
+             aMonitoredSubject == mpFabricTable->FindFabricWithIndex(pListItem->GetFabricIndex())->GetNodeId()))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1069,14 +1069,16 @@ void InteractionModelEngine::OnResponseTimeout(Messaging::ExchangeContext * ec)
 }
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer)
+void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject)
 {
     for (ReadClient * pListItem = mpActiveReadClientList; pListItem != nullptr;)
     {
         auto pNextItem = pListItem->GetNextClient();
         // It is possible that pListItem is destroyed by the app in OnActiveModeNotification.
         // Get the next item before invoking `OnActiveModeNotification`.
-        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer)
+        CATValues cats;
+        mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
+        if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer && cats.CheckSubjectAgainstCATs(aMonitoredSubject))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1079,8 +1079,8 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
         // If caseTag for current subscription does not match with the one set in ICDManagementCluster::RegisterClient for check-in,
         // when receiving check-in message, OnActiveModeNotification would do nothing for current subscription.
         if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
-           pListItem->GetSubjectDescriptor().HasValue() && pListItem->GetSubjectDescriptor().cats.CheckSubjectAgainstCATs(aMonitoredSubject) &&
-           pListItem->GetSubjectDescriptor().subject == aMonitoredSubject)
+           pListItem->GetSubjectDescriptor().HasValue() && pListItem->GetSubjectDescriptor().Value().cats.CheckSubjectAgainstCATs(aMonitoredSubject) &&
+           pListItem->GetSubjectDescriptor().Value().subject == aMonitoredSubject)
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1080,7 +1080,8 @@ void InteractionModelEngine::OnActiveModeNotification(ScopedNodeId aPeer, uint64
 
         mpFabricTable->FetchCATs(pListItem->GetFabricIndex(), cats);
         if (ScopedNodeId(pListItem->GetPeerNodeId(), pListItem->GetFabricIndex()) == aPeer &&
-            (cats.CheckSubjectAgainstCATs(aMonitoredSubject) || aMonitoredSubject == pListItem->GetLocalNodeId()))
+           (cats.CheckSubjectAgainstCATs(aMonitoredSubject) ||
+            aMonitoredSubject == mpFabricTable->FindFabricWithIndex(pListItem->GetFabricIndex()->GetNodeId())))
         {
             pListItem->OnActiveModeNotification();
         }

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -238,13 +238,13 @@ public:
      *
      *  See ReadClient::OnActiveModeNotification
      */
-    void OnActiveModeNotification(ScopedNodeId aPeer);
+    void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);
 
     /**
      *  Used to notify when a peer becomes LIT ICD or vice versa.
      *
      *  ReadClient will call this function when it finds any updates of the OperatingMode attribute from ICD management
-     * cluster. The application doesn't need to call this function, usually.
+     *  cluster. The application doesn't need to call this function, usually.
      */
     void OnPeerTypeChange(ScopedNodeId aPeer, ReadClient::PeerType aType);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -235,9 +235,9 @@ public:
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     /**
      *
-     *  When a peer becomes active, it sends a check-in message because aMonitoredSubject does not have a subscription to it. 
+     *  When a peer becomes active, it sends a check-in message because aMonitoredSubject does not have a subscription to it.
      * Upon receiving this check-in message, the Client attempts to run the re-subscription process via OnActiveModeNotification
-     * 
+     *
      */
     void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -244,7 +244,7 @@ public:
      *  Used to notify when a peer becomes LIT ICD or vice versa.
      *
      *  ReadClient will call this function when it finds any updates of the OperatingMode attribute from ICD management
-     *  cluster. The application doesn't need to call this function, usually.
+     * cluster. The application doesn't need to call this function, usually.
      */
     void OnPeerTypeChange(ScopedNodeId aPeer, ReadClient::PeerType aType);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -234,9 +234,10 @@ public:
 
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     /**
-     *  Activate the idle subscriptions.
      *
-     *  See ReadClient::OnActiveModeNotification
+     *  When a peer becomes active, it sends a check-in message because aMonitoredSubject does not have a subscription to it. 
+     * Upon receiving this check-in message, the Client attempts to run the re-subscription process via OnActiveModeNotification
+     * 
      */
     void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -235,8 +235,8 @@ public:
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
     /**
      *
-     *  When a peer becomes active, it sends a check-in message because aMonitoredSubject does not have a subscription to it.
-     * Upon receiving this check-in message, the Client attempts to run the re-subscription process via OnActiveModeNotification
+     *  Notification that aPeer has sent a check-in message because aMonitoredSubject does
+     *  not have a subscription to it.
      *
      */
     void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -236,8 +236,7 @@ public:
     /**
      *  Activate the idle subscriptions.
      *
-     *  When subscribing to ICD and liveness timeout reached, the read client will move to `InactiveICDSubscription` state and
-     * resubscription can be triggered via OnActiveModeNotification().
+     *  See ReadClient::OnActiveModeNotification
      */
     void OnActiveModeNotification(ScopedNodeId aPeer);
 

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -238,7 +238,7 @@ public:
      *
      *  See ReadClient::OnActiveModeNotification
      */
-    void OnActiveModeNotification(ScopedNodeId aPeer);
+    void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);
 
     /**
      *  Used to notify when a peer becomes LIT ICD or vice versa.

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -238,7 +238,7 @@ public:
      *
      *  See ReadClient::OnActiveModeNotification
      */
-    void OnActiveModeNotification(ScopedNodeId aPeer, uint64_t aMonitoredSubject);
+    void OnActiveModeNotification(ScopedNodeId aPeer);
 
     /**
      *  Used to notify when a peer becomes LIT ICD or vice versa.

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1279,7 +1279,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     ReturnErrorOnFailure(mExchange->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
                                                 Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeer = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
+    mPeer  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
     mLocal = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetLocalNodeId();
 
     MoveToState(ClientState::AwaitingInitialReport);

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -516,12 +516,6 @@ void ReadClient::OnPeerTypeChange(PeerType aType)
     mIsPeerLIT = (aType == PeerType::kLITICD);
 
     ChipLogProgress(DataManagement, "Peer is now %s LIT ICD.", mIsPeerLIT ? "a" : "not a");
-
-    // If the peer is no longer LIT, try to wake up the subscription and do resubscribe when necessary.
-    if (!mIsPeerLIT)
-    {
-        OnActiveModeNotification();
-    }
 }
 
 CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -521,7 +521,8 @@ void ReadClient::OnPeerTypeChange(PeerType aType)
 
     ChipLogProgress(DataManagement, "Peer is now %s LIT ICD.", mIsPeerLIT ? "a" : "not a");
 
-    // If the peer is no longer LIT and in inactive ICD subscription status, try to wake up the subscription and do resubscribe.
+    // If the peer is no longer LIT and we were waiting for a check-in to try to resubscribe,
+    // just try to resubscribe now, because a SIT is not going to send a check-in.
     if (!mIsPeerLIT && IsInactiveICDSubscription())
     {
         TriggerResubscriptionForLivenessTimeout(CHIP_ERROR_TIMEOUT);

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -490,8 +490,8 @@ void ReadClient::OnActiveModeNotification()
     // called, either mEventPathParamsListSize or mAttributePathParamsListSize is not 0.
     VerifyOrReturn(mReadPrepareParams.mEventPathParamsListSize != 0 || mReadPrepareParams.mAttributePathParamsListSize != 0);
 
-    // If mCatsMatchCheckIn is true, it means cats used in icd registration matches with the one in current subscription, OnActiveModeNotification
-    // continues to revive the subscription as needed, otherwise, do nothing.
+    // If mCatsMatchCheckIn is true, it means cats used in icd registration matches with the one in current subscription,
+    // OnActiveModeNotification continues to revive the subscription as needed, otherwise, do nothing.
     VerifyOrReturn(mReadPrepareParams.mCatsMatchCheckIn);
 
     // When we reach here, the subscription definitely exceeded the liveness timeout. Just continue the unfinished resubscription
@@ -503,8 +503,8 @@ void ReadClient::OnActiveModeNotification()
     }
 
     // If the server sends out check-in message, and there is a tracked active subscription in client side at the same time, it
-    // means current client does not realize this tracked subscription has gone, and we should forcibly timeout current subscription, and
-    // schedule a new one.
+    // means current client does not realize this tracked subscription has gone, and we should forcibly timeout current
+    // subscription, and schedule a new one.
     if (!mIsResubscriptionScheduled)
     {
         // Closing will ultimately trigger ScheduleResubscription with the aReestablishCASE argument set to true, effectively

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1280,7 +1280,6 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
                                                 Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
     mPeer  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
-    mLocal = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetLocalNodeId();
 
     MoveToState(ClientState::AwaitingInitialReport);
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -498,8 +498,10 @@ void ReadClient::OnActiveModeNotification()
         return;
     }
 
-    // When receiving check-in message, it means all tracked subscriptions for this node has gone in server side, if there is a related active subscription
-    // and subscription has not yet rescheduled in client side, we should forcibly timeout the current subscription, and schedule a new one.
+    // If this API has been called, that means the subscription for this ReadClient is gone
+    // on the server side (because otherwise the server would not have checked in with us).
+    // Even if we think we have a live subscription, we are wrong, and should just forcibly time it
+    // out and schedule a new one.
     if (!mIsResubscriptionScheduled)
     {
         // Closing will ultimately trigger ScheduleResubscription with the aReestablishCASE argument set to true, effectively

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -508,8 +508,8 @@ void ReadClient::OnActiveModeNotification()
         return;
     }
 
-    // If the server sends a check-in message and a subscription is already scheduled, it indicates a client-side subscription
-    // timeout or failure. Cancel the scheduled subscription and initiate a new one immediately.
+    // If we have already detected subscription loss and are waiting to try to re-subscribe,
+    // now is a really good time to do it, since the server is listening.
     TriggerResubscribeIfScheduled("check-in message");
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -490,6 +490,10 @@ void ReadClient::OnActiveModeNotification()
     // called, either mEventPathParamsListSize or mAttributePathParamsListSize is not 0.
     VerifyOrDie(mReadPrepareParams.mEventPathParamsListSize != 0 || mReadPrepareParams.mAttributePathParamsListSize != 0);
 
+    // If mCatsMatchCheckIn is true, it means cats used in icd registration matches with the one in current subscription, OnActiveModeNotification
+    // continues to revive the subscription as needed, otherwise, do nothing.
+    VerifyOrReturn(mReadPrepareParams.mCatsMatchCheckIn);
+
     // When we reach here, the subscription definitely exceeded the liveness timeout. Just continue the unfinished resubscription
     // logic in `OnLivenessTimeoutCallback`.
     if (IsInactiveICDSubscription())

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -486,9 +486,9 @@ void ReadClient::OnActiveModeNotification()
 {
     VerifyOrDie(mpImEngine->InActiveReadClientList(this));
 
-    // Note: this API only works when issuing subscription via SendAutoResubscribeRequest, when SendAutoResubscribeRequest is
+    // Note: this API only works when issuing subscription via SendAutoResubscribeRequest. When SendAutoResubscribeRequest is
     // called, either mEventPathParamsListSize or mAttributePathParamsListSize is not 0.
-    VerifyOrDie(mReadPrepareParams.mEventPathParamsListSize != 0 || mReadPrepareParams.mAttributePathParamsListSize != 0);
+    VerifyOrReturn(mReadPrepareParams.mEventPathParamsListSize != 0 || mReadPrepareParams.mAttributePathParamsListSize != 0);
 
     // If mCatsMatchCheckIn is true, it means cats used in icd registration matches with the one in current subscription, OnActiveModeNotification
     // continues to revive the subscription as needed, otherwise, do nothing.
@@ -502,8 +502,8 @@ void ReadClient::OnActiveModeNotification()
         return;
     }
 
-    // If the server sends out check-in message, and there is no reschedule subscription yet in client side at the same time, it
-    // means current client does not realize subscription has gone, and we should forcibly timeout current subscription, and
+    // If the server sends out check-in message, and there is a tracked active subscription in client side at the same time, it
+    // means current client does not realize this tracked subscription has gone, and we should forcibly timeout current subscription, and
     // schedule a new one.
     if (!mIsResubscriptionScheduled)
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1280,6 +1280,8 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
                                                 Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
     mPeer = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
+    mLocal = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetLocalNodeId();
+
     MoveToState(ClientState::AwaitingInitialReport);
 
     return CHIP_NO_ERROR;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -484,6 +484,7 @@ CHIP_ERROR ReadClient::GenerateDataVersionFilterList(DataVersionFilterIBs::Build
 
 void ReadClient::OnActiveModeNotification()
 {
+    // Note: this API only works when issuing subscription via SendAutoResubscribeRequest.
     VerifyOrDie(mpImEngine->InActiveReadClientList(this));
     // When we reach here, the subscription definitely exceeded the liveness timeout. Just continue the unfinished resubscription
     // logic in `OnLivenessTimeoutCallback`.
@@ -493,6 +494,18 @@ void ReadClient::OnActiveModeNotification()
         return;
     }
 
+    // If the server sends out check-in message, and there is no reschedule subscription yet in client side at the same time, it means
+    // current client does not realize subscription has gone, and we should forcibly timeout current subscription, and schedule a new one.
+    if (!mIsResubscriptionScheduled)
+    {
+        // Closing will ultimately trigger ScheduleResubscription with the aReestablishCASE argument set to true, effectively 
+        // rendering the session defunct.
+        Close(CHIP_ERROR_TIMEOUT);
+        return;
+    }
+
+    // If the server sends a check-in message and a subscription is already scheduled, it indicates a client-side subscription timeout or failure.
+    // Cancel the scheduled subscription and initiate a new one immediately.
     TriggerResubscribeIfScheduled("check-in message");
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1279,7 +1279,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     ReturnErrorOnFailure(mExchange->SendMessage(Protocols::InteractionModel::MsgType::SubscribeRequest, std::move(msgBuf),
                                                 Messaging::SendFlags(Messaging::SendMessageFlags::kExpectResponse)));
 
-    mPeer  = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
+    mPeer = aReadPrepareParams.mSessionHolder->AsSecureSession()->GetPeer();
 
     MoveToState(ClientState::AwaitingInitialReport);
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -351,11 +351,17 @@ public:
      *  Re-activate an inactive subscription.
      *
      *  When subscribing to LIT-ICD and liveness timeout reached and OnResubscriptionNeeded returns
-     * CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT, the read client will move to the InactiveICDSubscription state and
-     * resubscription can be triggered via OnActiveModeNotification().
+     *  CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT, the read client will move to the InactiveICDSubscription state and
+     *  resubscription can be triggered via OnActiveModeNotification().
      *
      *  If the subscription is not in the `InactiveICDSubscription` state, this function will do nothing. So it is always safe to
-     * call this function when a check-in message is received.
+     *  call this function when a check-in message is received.
+     *
+     *  If the server sends out check-in message, and there is no reschedule subscription yet in client side at the same time, it
+     *  means current client does not realize subscription has gone, and we should forcibly timeout current subscription, and
+     * schedule a new one.
+     *
+     *  This API only works when issuing subscription via SendAutoResubscribeRequest.
      */
     void OnActiveModeNotification();
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -509,12 +509,6 @@ public:
      */
     Optional<System::Clock::Timeout> GetSubscriptionTimeout();
 
-    Optional<Access::SubjectDescriptor> GetSubjectDescriptor() const
-    {
-        VerifyOrReturnValue(mReadPrepareParams.mSessionHolder, NullOptional);
-        return MakeOptional(mReadPrepareParams.mSessionHolder->AsSecureSession()->GetSubjectDescriptor());
-    }
-
 private:
     friend class TestReadInteraction;
     friend class InteractionModelEngine;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -378,8 +378,6 @@ public:
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
 
-    NodeId GetLocalNodeId() const { return mLocal; }
-
     /*
      * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
      * interaction type and after a subscription has been established.
@@ -639,7 +637,6 @@ private:
     uint16_t mMaxInterval              = 0;
     SubscriptionId mSubscriptionId     = 0;
     ScopedNodeId mPeer;
-    NodeId mLocal;
     InteractionType mInteractionType = InteractionType::Read;
     Timestamp mEventTimestamp;
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -378,7 +378,7 @@ public:
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
 
-    NodeId GetLocalNodeId() const { return mLocal.GetNodeId(); }
+    NodeId GetLocalNodeId() const { return mLocal; }
 
     /*
      * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
@@ -639,7 +639,7 @@ private:
     uint16_t mMaxInterval              = 0;
     SubscriptionId mSubscriptionId     = 0;
     ScopedNodeId mPeer;
-    ScopedNodeId mLocal;
+    NodeId mLocal;
     InteractionType mInteractionType = InteractionType::Read;
     Timestamp mEventTimestamp;
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -350,7 +350,8 @@ public:
     /**
      *  Re-activate an inactive subscription.
      *
-     *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription that would cause that ICD to not need to check in anymore.
+     *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription
+     * that would cause that ICD to not need to check in anymore.
      *
      *  This API only works when issuing subscription via SendAutoResubscribeRequest.
      */

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -350,16 +350,7 @@ public:
     /**
      *  Re-activate an inactive subscription.
      *
-     *  When subscribing to LIT-ICD and liveness timeout reached and OnResubscriptionNeeded returns
-     *  CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT, the read client will move to the InactiveICDSubscription state and
-     *  resubscription can be triggered via OnActiveModeNotification().
-     *
-     *  If the subscription is not in the `InactiveICDSubscription` state, this function will do nothing. So it is always safe to
-     *  call this function when a check-in message is received.
-     *
-     *  If the server sends out check-in message, and there is a active tracked active subscription in client side at the same time,
-     * it means current client does not realize this tracked subscription has gone, and we should forcibly timeout current
-     * subscription, and schedule a new one.
+     *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription that would cause that ICD to not need to check in anymore.
      *
      *  This API only works when issuing subscription via SendAutoResubscribeRequest.
      */
@@ -385,6 +376,8 @@ public:
     NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
+
+    NodeId GetLocalNodeId() const { return mLocal.GetNodeId(); }
 
     /*
      * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
@@ -645,6 +638,7 @@ private:
     uint16_t mMaxInterval              = 0;
     SubscriptionId mSubscriptionId     = 0;
     ScopedNodeId mPeer;
+    ScopedNodeId mLocal;
     InteractionType mInteractionType = InteractionType::Read;
     Timestamp mEventTimestamp;
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -509,6 +509,12 @@ public:
      */
     Optional<System::Clock::Timeout> GetSubscriptionTimeout();
 
+    Optional<Access::SubjectDescriptor> GetSubjectDescriptor() const
+    {
+        VerifyOrReturnValue(mReadPrepareParams.mSessionHolder, NullOptional);
+        return MakeOptional(mReadPrepareParams.mSessionHolder->AsSecureSession()->GetSubjectDescriptor());
+    }
+
 private:
     friend class TestReadInteraction;
     friend class InteractionModelEngine;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -357,8 +357,8 @@ public:
      *  If the subscription is not in the `InactiveICDSubscription` state, this function will do nothing. So it is always safe to
      *  call this function when a check-in message is received.
      *
-     *  If the server sends out check-in message, and there is no reschedule subscription yet in client side at the same time, it
-     *  means current client does not realize subscription has gone, and we should forcibly timeout current subscription, and
+     *  If the server sends out check-in message, and there is a active tracked active subscription in client side at the same time, it
+     *  means current client does not realize this tracked subscription has gone, and we should forcibly timeout current subscription, and
      * schedule a new one.
      *
      *  This API only works when issuing subscription via SendAutoResubscribeRequest.

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -357,9 +357,9 @@ public:
      *  If the subscription is not in the `InactiveICDSubscription` state, this function will do nothing. So it is always safe to
      *  call this function when a check-in message is received.
      *
-     *  If the server sends out check-in message, and there is a active tracked active subscription in client side at the same time, it
-     *  means current client does not realize this tracked subscription has gone, and we should forcibly timeout current subscription, and
-     * schedule a new one.
+     *  If the server sends out check-in message, and there is a active tracked active subscription in client side at the same time,
+     * it means current client does not realize this tracked subscription has gone, and we should forcibly timeout current
+     * subscription, and schedule a new one.
      *
      *  This API only works when issuing subscription via SendAutoResubscribeRequest.
      */

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -50,7 +50,7 @@ struct ReadPrepareParams
     bool mIsPeerLIT                     = false;
 
     // see ReadClient::OnActiveModeNotification
-    bool mCatsMatchCheckIn              = true;
+    bool mCatsMatchCheckIn = true;
 
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -49,6 +49,9 @@ struct ReadPrepareParams
     bool mIsFabricFiltered              = true;
     bool mIsPeerLIT                     = false;
 
+    // see ReadClient::OnActiveModeNotification
+    bool mCatsMatchCheckIn              = true;
+
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
     ReadPrepareParams(ReadPrepareParams && other) : mSessionHolder(other.mSessionHolder)
@@ -66,6 +69,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mCatsMatchCheckIn                  = other.mCatsMatchCheckIn;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
@@ -91,6 +95,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mCatsMatchCheckIn                  = other.mCatsMatchCheckIn;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -49,9 +49,6 @@ struct ReadPrepareParams
     bool mIsFabricFiltered              = true;
     bool mIsPeerLIT                     = false;
 
-    // see ReadClient::OnActiveModeNotification
-    bool mCatsMatchCheckIn = true;
-
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
     ReadPrepareParams(ReadPrepareParams && other) : mSessionHolder(other.mSessionHolder)
@@ -69,7 +66,6 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
-        mCatsMatchCheckIn                  = other.mCatsMatchCheckIn;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
@@ -95,7 +91,6 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
-        mCatsMatchCheckIn                  = other.mCatsMatchCheckIn;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
         mpICDClientStorage->StoreEntry(clientInfo);
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(clientInfo.peer_node);
+        mpImEngine->OnActiveModeNotification(clientInfo.peer_node, clientInfo.monitored_subject);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
     }
 

--- a/src/app/icd/client/CheckInHandler.cpp
+++ b/src/app/icd/client/CheckInHandler.cpp
@@ -138,7 +138,7 @@ CHIP_ERROR CheckInHandler::OnMessageReceived(Messaging::ExchangeContext * ec, co
         mpICDClientStorage->StoreEntry(clientInfo);
         mpCheckInDelegate->OnCheckInComplete(clientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(clientInfo.peer_node, clientInfo.monitored_subject);
+        mpImEngine->OnActiveModeNotification(clientInfo.peer_node);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
     }
 

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
+        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node, mICDClientInfo.monitored_subject);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
+        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node,mICDClientInfo.monitored_subject);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node,mICDClientInfo.monitored_subject);
+        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node, mICDClientInfo.monitored_subject);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };

--- a/src/app/icd/client/RefreshKeySender.cpp
+++ b/src/app/icd/client/RefreshKeySender.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR RefreshKeySender::RegisterClientWithNewKey(Messaging::ExchangeManager
 
         mpCheckInDelegate->OnCheckInComplete(mICDClientInfo);
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
-        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node, mICDClientInfo.monitored_subject);
+        mpImEngine->OnActiveModeNotification(mICDClientInfo.peer_node);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
         mpCheckInDelegate->OnKeyRefreshDone(this, CHIP_NO_ERROR);
     };

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2355,8 +2355,8 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
 }
 
 /**
- * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the tracked
- * subscription would be torn down and a new one would be rescheduled in client side.
+ * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client
+ * side, the tracked subscription would be torn down and a new one would be rescheduled in client side.
  */
 TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
 {
@@ -2427,8 +2427,8 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
 }
 
 /**
- * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the
- * untracked subscription would be kept.
+ * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client
+ * side, the untracked subscription would be kept.
  */
 TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotification)
 {
@@ -2454,7 +2454,7 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
         attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
         attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
         readPrepareParams.mCatsMatchCheckIn            = false;
-        constexpr uint16_t maxIntervalCeilingSeconds = 1;
+        constexpr uint16_t maxIntervalCeilingSeconds   = 1;
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2427,7 +2427,7 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
 }
 
 /**
- * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the 
+ * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the
  * untracked subscription would be kept.
  */
 TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotification)

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2330,7 +2330,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), readClient.GetSubjectDescriptor().Value().subject);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2393,7 +2393,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), readClient.GetSubjectDescriptor().Value().subject);
         //
         // Drive servicing IO till we have established a subscription.
         //

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2354,6 +2354,139 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
+/**
+ * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the tracked
+ * subscription would be torn down and a new one would be rescheduled in client side.
+ */
+TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
+
+    {
+        TestResubscriptionCallback callback;
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
+
+        callback.mScheduleLITResubscribeImmediately = false;
+        callback.SetReadClient(&readClient);
+
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+
+        // Read full wildcard paths, repeat twice to ensure chunking.
+        AttributePathParams attributePathParams[1];
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = MATTER_ARRAY_SIZE(attributePathParams);
+        attributePathParams[0].mEndpointId             = kTestEndpointId;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
+
+        constexpr uint16_t maxIntervalCeilingSeconds = 1;
+
+        readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
+        readPrepareParams.mIsPeerLIT                 = true;
+
+        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount >= 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
+
+        GetLoopback().mNumMessagesToDrop = 0;
+        callback.ClearCounters();
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
+        EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
+
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount == 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+
+        //
+        // With re-sub enabled, we shouldn't have encountered any errors
+        //
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnDone, 0);
+    }
+
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
+
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
+/**
+ * When all tracked subscriptions go away in server, check-in message is received and OnActiveModeNotification is called in client side, the 
+ * untracked subscription would be kept.
+ */
+TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotification)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
+
+    {
+        TestResubscriptionCallback callback;
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
+
+        callback.mScheduleLITResubscribeImmediately = false;
+        callback.SetReadClient(&readClient);
+
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+
+        // Read full wildcard paths, repeat twice to ensure chunking.
+        AttributePathParams attributePathParams[1];
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = MATTER_ARRAY_SIZE(attributePathParams);
+        attributePathParams[0].mEndpointId             = kTestEndpointId;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
+        readPrepareParams.mCatsMatchCheckIn            = false;
+        constexpr uint16_t maxIntervalCeilingSeconds = 1;
+
+        readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
+        readPrepareParams.mIsPeerLIT                 = true;
+
+        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount >= 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
+
+        GetLoopback().mNumMessagesToDrop = 0;
+        callback.ClearCounters();
+        InteractionModelEngine::GetInstance()->OnActiveModeNotification(
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
+        EXPECT_EQ(callback.mLastError, CHIP_NO_ERROR);
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnDone, 0);
+    }
+
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
+
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
 TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
 {
     auto sessionHandle = GetSessionBobToAlice();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2330,7 +2330,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), readClient.GetSubjectDescriptor().Value().subject);
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2393,7 +2393,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), readClient.GetSubjectDescriptor().Value().subject);
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
         //
         // Drive servicing IO till we have established a subscription.
         //

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2330,7 +2330,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2402,7 +2402,7 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2453,7 +2453,6 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
         attributePathParams[0].mEndpointId             = kTestEndpointId;
         attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
         attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
-        readPrepareParams.mCatsMatchCheckIn            = false;
         constexpr uint16_t maxIntervalCeilingSeconds   = 1;
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
@@ -2474,7 +2473,7 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
         EXPECT_EQ(callback.mLastError, CHIP_NO_ERROR);
         EXPECT_EQ(callback.mOnError, 0);
@@ -2526,7 +2525,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
         //
         // Drive servicing IO till we have established a subscription.
         //

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2330,7 +2330,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0x12344321));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2402,7 +2402,7 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0x12344321));
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
         EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
 
@@ -2525,7 +2525,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
         GetLoopback().mNumMessagesToDrop = 0;
         callback.ClearCounters();
         InteractionModelEngine::GetInstance()->OnActiveModeNotification(
-            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0));
+            ScopedNodeId(readClient.GetPeerNodeId(), readClient.GetFabricIndex()), static_cast<uint64_t>(0x12344321));
         //
         // Drive servicing IO till we have established a subscription.
         //


### PR DESCRIPTION
If the server sends out check-in message, and there is no reschedule subscription yet in client side at the same time, it means current client does not realize subscription has gone, and we should forcibly timeout current subscription, and schedule a new one.

fixes https://github.com/project-chip/connectedhomeip/issues/30902


#### Testing
Drafting
