### PR TITLE
[SILABS] lock storage refactor

### DIFF
--- a/examples/lock-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lock-app/silabs/include/CHIPProjectConfig.h
@@ -115,54 +115,6 @@ static constexpr uint8_t kMaxCredentialSize          = 20;
 static constexpr uint8_t kNumCredentialTypes         = 6;
 
 } // namespace ResourceRanges
-
-namespace LockInitParams {
-
-struct LockParam
-{
-    // Read from zap attributes
-    uint16_t numberOfUsers                  = 0;
-    uint8_t numberOfCredentialsPerUser      = 0;
-    uint8_t numberOfWeekdaySchedulesPerUser = 0;
-    uint8_t numberOfYeardaySchedulesPerUser = 0;
-    uint8_t numberOfHolidaySchedules        = 0;
-};
-
-class ParamBuilder
-{
-public:
-    ParamBuilder & SetNumberOfUsers(uint16_t numberOfUsers)
-    {
-        lockParam_.numberOfUsers = numberOfUsers;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfCredentialsPerUser(uint8_t numberOfCredentialsPerUser)
-    {
-        lockParam_.numberOfCredentialsPerUser = numberOfCredentialsPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfWeekdaySchedulesPerUser(uint8_t numberOfWeekdaySchedulesPerUser)
-    {
-        lockParam_.numberOfWeekdaySchedulesPerUser = numberOfWeekdaySchedulesPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfYeardaySchedulesPerUser(uint8_t numberOfYeardaySchedulesPerUser)
-    {
-        lockParam_.numberOfYeardaySchedulesPerUser = numberOfYeardaySchedulesPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfHolidaySchedules(uint8_t numberOfHolidaySchedules)
-    {
-        lockParam_.numberOfHolidaySchedules = numberOfHolidaySchedules;
-        return *this;
-    }
-    LockParam GetLockParam() { return lockParam_; }
-
-private:
-    LockParam lockParam_;
-};
-
-} // namespace LockInitParams
 } // namespace SilabsDoorLockConfig
 
 /**

--- a/examples/lock-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lock-app/silabs/include/CHIPProjectConfig.h
@@ -105,15 +105,15 @@
 
 namespace SilabsDoorLockConfig {
 namespace ResourceRanges {
-    // Used to size arrays
-    static constexpr uint16_t kMaxUsers                  = 10;
-    static constexpr uint8_t kMaxCredentialsPerUser      = 10;
-    static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
-    static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
-    static constexpr uint8_t kMaxHolidaySchedules        = 10;
-    static constexpr uint8_t kMaxCredentialSize          = 20;
-    static constexpr uint8_t kNumCredentialTypes         = 6;
-    
+// Used to size arrays
+static constexpr uint16_t kMaxUsers                  = 10;
+static constexpr uint8_t kMaxCredentialsPerUser      = 10;
+static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
+static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
+static constexpr uint8_t kMaxHolidaySchedules        = 10;
+static constexpr uint8_t kMaxCredentialSize          = 20;
+static constexpr uint8_t kNumCredentialTypes         = 6;
+
 } // namespace ResourceRanges
 
 namespace LockInitParams {
@@ -169,19 +169,19 @@ private:
  * DOOR_LOCK_USE_LOCAL_BUFFER
  *
  * If enabled, door-lock-server will use a local buffer for stored data to be copied into.
- */ 
+ */
 #define DOOR_LOCK_USE_LOCAL_BUFFER 1
 
 /**
  * DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH
  *
  * A size, in bytes, of an individual credential.
- */ 
- 
+ */
+
 #define DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialsPerUser
 /**
  * DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH
  *
  * Number of CredentialStructs attached to a user.
- */ 
+ */
 #define DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialSize

--- a/examples/lock-app/silabs/include/CHIPProjectConfig.h
+++ b/examples/lock-app/silabs/include/CHIPProjectConfig.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 // Use a default pairing code if one hasn't been provisioned in flash.
 #ifndef CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
@@ -100,3 +102,86 @@
  *
  */
 #define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)
+
+namespace SilabsDoorLockConfig {
+namespace ResourceRanges {
+    // Used to size arrays
+    static constexpr uint16_t kMaxUsers                  = 10;
+    static constexpr uint8_t kMaxCredentialsPerUser      = 10;
+    static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
+    static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
+    static constexpr uint8_t kMaxHolidaySchedules        = 10;
+    static constexpr uint8_t kMaxCredentialSize          = 20;
+    static constexpr uint8_t kNumCredentialTypes         = 6;
+    
+} // namespace ResourceRanges
+
+namespace LockInitParams {
+
+struct LockParam
+{
+    // Read from zap attributes
+    uint16_t numberOfUsers                  = 0;
+    uint8_t numberOfCredentialsPerUser      = 0;
+    uint8_t numberOfWeekdaySchedulesPerUser = 0;
+    uint8_t numberOfYeardaySchedulesPerUser = 0;
+    uint8_t numberOfHolidaySchedules        = 0;
+};
+
+class ParamBuilder
+{
+public:
+    ParamBuilder & SetNumberOfUsers(uint16_t numberOfUsers)
+    {
+        lockParam_.numberOfUsers = numberOfUsers;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfCredentialsPerUser(uint8_t numberOfCredentialsPerUser)
+    {
+        lockParam_.numberOfCredentialsPerUser = numberOfCredentialsPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfWeekdaySchedulesPerUser(uint8_t numberOfWeekdaySchedulesPerUser)
+    {
+        lockParam_.numberOfWeekdaySchedulesPerUser = numberOfWeekdaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfYeardaySchedulesPerUser(uint8_t numberOfYeardaySchedulesPerUser)
+    {
+        lockParam_.numberOfYeardaySchedulesPerUser = numberOfYeardaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfHolidaySchedules(uint8_t numberOfHolidaySchedules)
+    {
+        lockParam_.numberOfHolidaySchedules = numberOfHolidaySchedules;
+        return *this;
+    }
+    LockParam GetLockParam() { return lockParam_; }
+
+private:
+    LockParam lockParam_;
+};
+
+} // namespace LockInitParams
+} // namespace SilabsDoorLockConfig
+
+/**
+ * DOOR_LOCK_USE_LOCAL_BUFFER
+ *
+ * If enabled, door-lock-server will use a local buffer for stored data to be copied into.
+ */ 
+#define DOOR_LOCK_USE_LOCAL_BUFFER 1
+
+/**
+ * DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH
+ *
+ * A size, in bytes, of an individual credential.
+ */ 
+ 
+#define DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialsPerUser
+/**
+ * DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH
+ *
+ * Number of CredentialStructs attached to a user.
+ */ 
+#define DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH SilabsDoorLockConfig::ResourceRanges::kMaxCredentialSize

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -91,48 +91,48 @@ private:
 } // namespace LockInitParams
 namespace Storage {
 
-    using namespace EFR32DoorLock::ResourceRanges;
-    struct WeekDayScheduleInfo
-    {
-        DlScheduleStatus status;
-        EmberAfPluginDoorLockWeekDaySchedule schedule;
-    };
-    
-    struct YearDayScheduleInfo
-    {
-        DlScheduleStatus status;
-        EmberAfPluginDoorLockYearDaySchedule schedule;
-    };
-    
-    struct HolidayScheduleInfo
-    {
-        DlScheduleStatus status;
-        EmberAfPluginDoorLockHolidaySchedule schedule;
-    };
-    
-    struct LockUserInfo
-    {
-        char userName[DOOR_LOCK_MAX_USER_NAME_SIZE];
-        size_t userNameSize;
-        uint32_t userUniqueId;
-        UserStatusEnum userStatus;
-        UserTypeEnum userType;
-        CredentialRuleEnum credentialRule;
-        chip::EndpointId endpointId;
-        chip::FabricIndex createdBy;
-        chip::FabricIndex lastModifiedBy;
-        uint16_t currentCredentialCount;
-    };
-    
-    struct LockCredentialInfo
-    {
-        DlCredentialStatus status;
-        CredentialTypeEnum credentialType;
-        chip::FabricIndex createdBy;
-        chip::FabricIndex lastModifiedBy;
-        uint8_t credentialData[kMaxCredentialSize];
-        size_t credentialDataSize;
-    };
+using namespace EFR32DoorLock::ResourceRanges;
+struct WeekDayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockWeekDaySchedule schedule;
+};
+
+struct YearDayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockYearDaySchedule schedule;
+};
+
+struct HolidayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockHolidaySchedule schedule;
+};
+
+struct LockUserInfo
+{
+    char userName[DOOR_LOCK_MAX_USER_NAME_SIZE];
+    size_t userNameSize;
+    uint32_t userUniqueId;
+    UserStatusEnum userStatus;
+    UserTypeEnum userType;
+    CredentialRuleEnum credentialRule;
+    chip::EndpointId endpointId;
+    chip::FabricIndex createdBy;
+    chip::FabricIndex lastModifiedBy;
+    uint16_t currentCredentialCount;
+};
+
+struct LockCredentialInfo
+{
+    DlCredentialStatus status;
+    CredentialTypeEnum credentialType;
+    chip::FabricIndex createdBy;
+    chip::FabricIndex lastModifiedBy;
+    uint8_t credentialData[kMaxCredentialSize];
+    size_t credentialDataSize;
+};
 } // namespace Storage
 } // namespace EFR32DoorLock
 

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -225,7 +225,7 @@ private:
     static StorageKeyName LockCredentialEndpoint(chip::EndpointId endpoint, CredentialTypeEnum credentialType,
                                                  uint16_t credentialIndex)
     {
-        return StorageKeyName::Formatted("g/e/%x/ct/%x/lc/%x", endpoint, static_cast<uint16_t>(credentialType), credentialIndex);
+        return StorageKeyName::Formatted("g/e/%x/ct/%x/lc/%x", endpoint, to_underlying(credentialType), credentialIndex);
     }
     // Stores all the credential indices that belong to a user
     static StorageKeyName LockUserCredentialMap(uint16_t userIndex) { return StorageKeyName::Formatted("g/lu/%x/lc", userIndex); }

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -116,10 +116,10 @@ using namespace EFR32DoorLock::ResourceRanges;
 
 struct LockUserInfo
 {
-    char userName[DOOR_LOCK_USER_NAME_BUFFER_SIZE]; 
+    char userName[DOOR_LOCK_USER_NAME_BUFFER_SIZE];
     size_t userNameSize;
-    uint32_t userUniqueId; 
-    UserStatusEnum userStatus; 
+    uint32_t userUniqueId;
+    UserStatusEnum userStatus;
     UserTypeEnum userType;
     CredentialRuleEnum credentialRule;
     chip::EndpointId endpointId;
@@ -271,21 +271,38 @@ private:
 
     EFR32DoorLock::LockInitParams::LockParam LockParams;
 
-    static StorageKeyName LockUserEndpoint(uint16_t userIndex, chip::EndpointId endpoint) { return StorageKeyName::Formatted("g/lu/%x/e/%x", userIndex, endpoint); }
-    static StorageKeyName LockCredentialEndpoint(uint16_t credentialIndex, chip::EndpointId endpoint) { return StorageKeyName::Formatted("g/lc/%x/e/%x", credentialIndex, endpoint); }
-    static StorageKeyName LockUserCredentialMap(uint16_t userIndex) { return StorageKeyName::Formatted("g/lu/%x/lc", userIndex); } // Stores all the credential indices that belong to a user    
-    static StorageKeyName LockUserWeekDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint) { return StorageKeyName::Formatted("g/lu/%x/lw/%x/e/%x", userIndex, scheduleIndex, endpoint); }
-    static StorageKeyName LockUserYearDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint) { return StorageKeyName::Formatted("g/lu/%x/ly/%x/e/%x", userIndex, scheduleIndex, endpoint); }
-    static StorageKeyName LockHolidayScheduleEndpoint(uint16_t scheduleIndex, chip::EndpointId endpoint) { return StorageKeyName::Formatted("g/lh/%x/e/%x", scheduleIndex, endpoint); }
+    static StorageKeyName LockUserEndpoint(uint16_t userIndex, chip::EndpointId endpoint)
+    {
+        return StorageKeyName::Formatted("g/lu/%x/e/%x", userIndex, endpoint);
+    }
+    static StorageKeyName LockCredentialEndpoint(uint16_t credentialIndex, chip::EndpointId endpoint)
+    {
+        return StorageKeyName::Formatted("g/lc/%x/e/%x", credentialIndex, endpoint);
+    }
+    static StorageKeyName LockUserCredentialMap(uint16_t userIndex)
+    {
+        return StorageKeyName::Formatted("g/lu/%x/lc", userIndex);
+    } // Stores all the credential indices that belong to a user
+    static StorageKeyName LockUserWeekDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
+    {
+        return StorageKeyName::Formatted("g/lu/%x/lw/%x/e/%x", userIndex, scheduleIndex, endpoint);
+    }
+    static StorageKeyName LockUserYearDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
+    {
+        return StorageKeyName::Formatted("g/lu/%x/ly/%x/e/%x", userIndex, scheduleIndex, endpoint);
+    }
+    static StorageKeyName LockHolidayScheduleEndpoint(uint16_t scheduleIndex, chip::EndpointId endpoint)
+    {
+        return StorageKeyName::Formatted("g/lh/%x/e/%x", scheduleIndex, endpoint);
+    }
 
     LockUserInfo userInStorage;
-    LockCredentialInfo credentialInStorage;    
+    LockCredentialInfo credentialInStorage;
     WeekDayScheduleInfo weekDayScheduleInStorage;
     YearDayScheduleInfo yearDayScheduleInStorage;
     HolidayScheduleInfo holidayScheduleInStorage;
     CredentialStruct mCredential;
     CredentialStruct mCredentials[kMaxCredentialsPerUser];
-
 };
 
 LockManager & LockMgr();

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -217,32 +217,31 @@ private:
     SilabsDoorLockConfig::LockInitParams::LockParam LockParams;
 
     // Stores LockUserInfo corresponding to a user index
-    static StorageKeyName LockUserEndpoint(uint16_t userIndex, chip::EndpointId endpoint)
+    static StorageKeyName LockUserEndpoint(chip::EndpointId endpoint, uint16_t userIndex)
     {
-        return StorageKeyName::Formatted("g/lu/%x/e/%x", userIndex, endpoint);
+        return StorageKeyName::Formatted("g/e/%x/lu/%x", endpoint, userIndex);
     }
     // Stores LockCredentialInfo corresponding to a credential index and type
-    static StorageKeyName LockCredentialEndpoint(uint16_t credentialIndex, CredentialTypeEnum credentialType,
-                                                 chip::EndpointId endpoint)
+    static StorageKeyName LockCredentialEndpoint(chip::EndpointId endpoint, CredentialTypeEnum credentialType, uint16_t credentialIndex)
     {
-        return StorageKeyName::Formatted("g/lc/%x/t/%x/e/%x", credentialIndex, static_cast<uint16_t>(credentialType), endpoint);
+        return StorageKeyName::Formatted("g/e/%x/t/%x/lc/%x", endpoint, static_cast<uint16_t>(credentialType), credentialIndex);
     }
     // Stores all the credential indices that belong to a user
     static StorageKeyName LockUserCredentialMap(uint16_t userIndex) { return StorageKeyName::Formatted("g/lu/%x/lc", userIndex); }
     // Stores WeekDayScheduleInfo corresponding to a user and schedule index
-    static StorageKeyName LockUserWeekDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
+    static StorageKeyName LockUserWeekDayScheduleEndpoint(chip::EndpointId endpoint, uint16_t userIndex, uint16_t scheduleIndex)
     {
-        return StorageKeyName::Formatted("g/lu/%x/lw/%x/e/%x", userIndex, scheduleIndex, endpoint);
+        return StorageKeyName::Formatted("g/e/%x/lu/%x/lw/%x", endpoint, userIndex, scheduleIndex);
     }
     // Stores YearDayScheduleInfo corresponding to a user and schedule index
     static StorageKeyName LockUserYearDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
     {
-        return StorageKeyName::Formatted("g/lu/%x/ly/%x/e/%x", userIndex, scheduleIndex, endpoint);
+        return StorageKeyName::Formatted("g/e/%x/lu/%x/ly/%x", endpoint, userIndex, scheduleIndex);
     }
     // Stores HolidayScheduleInfo corresponding to a schedule index
     static StorageKeyName LockHolidayScheduleEndpoint(uint16_t scheduleIndex, chip::EndpointId endpoint)
     {
-        return StorageKeyName::Formatted("g/lh/%x/e/%x", scheduleIndex, endpoint);
+        return StorageKeyName::Formatted("g/e/%x/lh/%x", endpoint, scheduleIndex);
     }
 
     // Pointer to the PeristentStorage

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -271,26 +271,30 @@ private:
 
     EFR32DoorLock::LockInitParams::LockParam LockParams;
 
+    // Stores LockUserInfo corresponding to a user index
     static StorageKeyName LockUserEndpoint(uint16_t userIndex, chip::EndpointId endpoint)
     {
         return StorageKeyName::Formatted("g/lu/%x/e/%x", userIndex, endpoint);
     }
-    static StorageKeyName LockCredentialEndpoint(uint16_t credentialIndex, chip::EndpointId endpoint)
+    // Stores LockCredentialInfo corresponding to a credential index and type
+    static StorageKeyName LockCredentialEndpoint(uint16_t credentialIndex, CredentialTypeEnum credentialType,
+                                                 chip::EndpointId endpoint)
     {
-        return StorageKeyName::Formatted("g/lc/%x/e/%x", credentialIndex, endpoint);
+        return StorageKeyName::Formatted("g/lc/%x/t/%x/e/%x", credentialIndex, static_cast<uint16_t>(credentialType), endpoint);
     }
-    static StorageKeyName LockUserCredentialMap(uint16_t userIndex)
-    {
-        return StorageKeyName::Formatted("g/lu/%x/lc", userIndex);
-    } // Stores all the credential indices that belong to a user
+    // Stores all the credential indices that belong to a user
+    static StorageKeyName LockUserCredentialMap(uint16_t userIndex) { return StorageKeyName::Formatted("g/lu/%x/lc", userIndex); }
+    // Stores WeekDayScheduleInfo corresponding to a user and schedule index
     static StorageKeyName LockUserWeekDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
     {
         return StorageKeyName::Formatted("g/lu/%x/lw/%x/e/%x", userIndex, scheduleIndex, endpoint);
     }
+    // Stores YearDayScheduleInfo corresponding to a user and schedule index
     static StorageKeyName LockUserYearDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
     {
         return StorageKeyName::Formatted("g/lu/%x/ly/%x/e/%x", userIndex, scheduleIndex, endpoint);
     }
+    // Stores HolidayScheduleInfo corresponding to a schedule index
     static StorageKeyName LockHolidayScheduleEndpoint(uint16_t scheduleIndex, chip::EndpointId endpoint)
     {
         return StorageKeyName::Formatted("g/lh/%x/e/%x", scheduleIndex, endpoint);
@@ -301,7 +305,6 @@ private:
     WeekDayScheduleInfo weekDayScheduleInStorage;
     YearDayScheduleInfo yearDayScheduleInStorage;
     HolidayScheduleInfo holidayScheduleInStorage;
-    CredentialStruct mCredential;
     CredentialStruct mCredentials[kMaxCredentialsPerUser];
 };
 

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -302,9 +302,6 @@ private:
 
     LockUserInfo userInStorage;
     LockCredentialInfo credentialInStorage;
-    WeekDayScheduleInfo weekDayScheduleInStorage;
-    YearDayScheduleInfo yearDayScheduleInStorage;
-    HolidayScheduleInfo holidayScheduleInStorage;
     CredentialStruct mCredentials[kMaxCredentialsPerUser];
 };
 

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -116,7 +116,7 @@ using namespace EFR32DoorLock::ResourceRanges;
 
 struct LockUserInfo
 {
-    char userName[DOOR_LOCK_USER_NAME_BUFFER_SIZE];
+    char userName[DOOR_LOCK_MAX_USER_NAME_SIZE];
     size_t userNameSize;
     uint32_t userUniqueId;
     UserStatusEnum userStatus;

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -161,7 +161,7 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                    EFR32DoorLock::LockInitParams::LockParam lockParam);
+                    EFR32DoorLock::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -300,8 +300,11 @@ private:
         return StorageKeyName::Formatted("g/lh/%x/e/%x", scheduleIndex, endpoint);
     }
 
-    LockUserInfo userInStorage;
-    LockCredentialInfo credentialInStorage;
+    // Pointer to the PeristentStorage
+    PersistentStorageDelegate * mStorage = nullptr;
+
+    LockUserInfo mUserInStorage;
+    LockCredentialInfo mCredentialInStorage;
     CredentialStruct mCredentials[kMaxCredentialsPerUser];
 };
 

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -23,75 +23,18 @@
 #include <stdint.h>
 
 #include "AppEvent.h"
+#include "CHIPProjectConfig.h"
 
 #include <cmsis_os2.h>
 #include <lib/core/CHIPError.h>
 
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
-namespace EFR32DoorLock {
-namespace ResourceRanges {
-// Used to size arrays
-static constexpr uint16_t kMaxUsers                  = 10;
-static constexpr uint8_t kMaxCredentialsPerUser      = 10;
-static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
-static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
-static constexpr uint8_t kMaxHolidaySchedules        = 10;
-static constexpr uint8_t kMaxCredentialSize          = 20;
-static constexpr uint8_t kNumCredentialTypes         = 6;
+namespace SilabsDoorLock {
 
-} // namespace ResourceRanges
-
-namespace LockInitParams {
-
-struct LockParam
-{
-    // Read from zap attributes
-    uint16_t numberOfUsers                  = 0;
-    uint8_t numberOfCredentialsPerUser      = 0;
-    uint8_t numberOfWeekdaySchedulesPerUser = 0;
-    uint8_t numberOfYeardaySchedulesPerUser = 0;
-    uint8_t numberOfHolidaySchedules        = 0;
-};
-
-class ParamBuilder
-{
-public:
-    ParamBuilder & SetNumberOfUsers(uint16_t numberOfUsers)
-    {
-        lockParam_.numberOfUsers = numberOfUsers;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfCredentialsPerUser(uint8_t numberOfCredentialsPerUser)
-    {
-        lockParam_.numberOfCredentialsPerUser = numberOfCredentialsPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfWeekdaySchedulesPerUser(uint8_t numberOfWeekdaySchedulesPerUser)
-    {
-        lockParam_.numberOfWeekdaySchedulesPerUser = numberOfWeekdaySchedulesPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfYeardaySchedulesPerUser(uint8_t numberOfYeardaySchedulesPerUser)
-    {
-        lockParam_.numberOfYeardaySchedulesPerUser = numberOfYeardaySchedulesPerUser;
-        return *this;
-    }
-    ParamBuilder & SetNumberOfHolidaySchedules(uint8_t numberOfHolidaySchedules)
-    {
-        lockParam_.numberOfHolidaySchedules = numberOfHolidaySchedules;
-        return *this;
-    }
-    LockParam GetLockParam() { return lockParam_; }
-
-private:
-    LockParam lockParam_;
-};
-
-} // namespace LockInitParams
 namespace Storage {
 
-using namespace EFR32DoorLock::ResourceRanges;
+using namespace SilabsDoorLockConfig::ResourceRanges;
 struct WeekDayScheduleInfo
 {
     DlScheduleStatus status;
@@ -134,11 +77,11 @@ struct LockCredentialInfo
     size_t credentialDataSize;
 };
 } // namespace Storage
-} // namespace EFR32DoorLock
+} // namespace SilabsDoorLock
 
 using namespace ::chip;
-using namespace EFR32DoorLock::ResourceRanges;
-using namespace EFR32DoorLock::Storage;
+using namespace SilabsDoorLockConfig::ResourceRanges;
+using namespace SilabsDoorLock::Storage;
 
 class LockManager
 {
@@ -163,7 +106,7 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                    EFR32DoorLock::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
+        SilabsDoorLockConfig::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -271,7 +214,7 @@ private:
 
     osTimerId_t mLockTimer;
 
-    EFR32DoorLock::LockInitParams::LockParam LockParams;
+    SilabsDoorLockConfig::LockInitParams::LockParam LockParams;
 
     // Stores LockUserInfo corresponding to a user index
     static StorageKeyName LockUserEndpoint(uint16_t userIndex, chip::EndpointId endpoint)

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -106,7 +106,7 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-        SilabsDoorLockConfig::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
+                    SilabsDoorLockConfig::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -222,9 +222,10 @@ private:
         return StorageKeyName::Formatted("g/e/%x/lu/%x", endpoint, userIndex);
     }
     // Stores LockCredentialInfo corresponding to a credential index and type
-    static StorageKeyName LockCredentialEndpoint(chip::EndpointId endpoint, CredentialTypeEnum credentialType, uint16_t credentialIndex)
+    static StorageKeyName LockCredentialEndpoint(chip::EndpointId endpoint, CredentialTypeEnum credentialType,
+                                                 uint16_t credentialIndex)
     {
-        return StorageKeyName::Formatted("g/e/%x/t/%x/lc/%x", endpoint, static_cast<uint16_t>(credentialType), credentialIndex);
+        return StorageKeyName::Formatted("g/e/%x/ct/%x/lc/%x", endpoint, static_cast<uint16_t>(credentialType), credentialIndex);
     }
     // Stores all the credential indices that belong to a user
     static StorageKeyName LockUserCredentialMap(uint16_t userIndex) { return StorageKeyName::Formatted("g/lu/%x/lc", userIndex); }
@@ -234,22 +235,18 @@ private:
         return StorageKeyName::Formatted("g/e/%x/lu/%x/lw/%x", endpoint, userIndex, scheduleIndex);
     }
     // Stores YearDayScheduleInfo corresponding to a user and schedule index
-    static StorageKeyName LockUserYearDayScheduleEndpoint(uint16_t userIndex, uint16_t scheduleIndex, chip::EndpointId endpoint)
+    static StorageKeyName LockUserYearDayScheduleEndpoint(chip::EndpointId endpoint, uint16_t userIndex, uint16_t scheduleIndex)
     {
         return StorageKeyName::Formatted("g/e/%x/lu/%x/ly/%x", endpoint, userIndex, scheduleIndex);
     }
     // Stores HolidayScheduleInfo corresponding to a schedule index
-    static StorageKeyName LockHolidayScheduleEndpoint(uint16_t scheduleIndex, chip::EndpointId endpoint)
+    static StorageKeyName LockHolidayScheduleEndpoint(chip::EndpointId endpoint, uint16_t scheduleIndex)
     {
         return StorageKeyName::Formatted("g/e/%x/lh/%x", endpoint, scheduleIndex);
     }
 
     // Pointer to the PeristentStorage
     PersistentStorageDelegate * mStorage = nullptr;
-
-    LockUserInfo mUserInStorage;
-    LockCredentialInfo mCredentialInStorage;
-    CredentialStruct mCredentials[kMaxCredentialsPerUser];
 };
 
 LockManager & LockMgr();

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -32,6 +32,54 @@
 
 namespace SilabsDoorLock {
 
+namespace LockInitParams {
+
+struct LockParam
+{
+    // Read from zap attributes
+    uint16_t numberOfUsers                  = 0;
+    uint8_t numberOfCredentialsPerUser      = 0;
+    uint8_t numberOfWeekdaySchedulesPerUser = 0;
+    uint8_t numberOfYeardaySchedulesPerUser = 0;
+    uint8_t numberOfHolidaySchedules        = 0;
+};
+
+class ParamBuilder
+{
+public:
+    ParamBuilder & SetNumberOfUsers(uint16_t numberOfUsers)
+    {
+        lockParam_.numberOfUsers = numberOfUsers;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfCredentialsPerUser(uint8_t numberOfCredentialsPerUser)
+    {
+        lockParam_.numberOfCredentialsPerUser = numberOfCredentialsPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfWeekdaySchedulesPerUser(uint8_t numberOfWeekdaySchedulesPerUser)
+    {
+        lockParam_.numberOfWeekdaySchedulesPerUser = numberOfWeekdaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfYeardaySchedulesPerUser(uint8_t numberOfYeardaySchedulesPerUser)
+    {
+        lockParam_.numberOfYeardaySchedulesPerUser = numberOfYeardaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfHolidaySchedules(uint8_t numberOfHolidaySchedules)
+    {
+        lockParam_.numberOfHolidaySchedules = numberOfHolidaySchedules;
+        return *this;
+    }
+    LockParam GetLockParam() { return lockParam_; }
+
+private:
+    LockParam lockParam_;
+};
+
+} // namespace LockInitParams
+
 namespace Storage {
 
 using namespace SilabsDoorLockConfig::ResourceRanges;
@@ -106,7 +154,7 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                    SilabsDoorLockConfig::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
+                    SilabsDoorLock::LockInitParams::LockParam lockParam, PersistentStorageDelegate * storage);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -214,7 +262,7 @@ private:
 
     osTimerId_t mLockTimer;
 
-    SilabsDoorLockConfig::LockInitParams::LockParam LockParams;
+    SilabsDoorLock::LockInitParams::LockParam LockParams;
 
     // Stores LockUserInfo corresponding to a user index
     static StorageKeyName LockUserEndpoint(chip::EndpointId endpoint, uint16_t userIndex)

--- a/examples/lock-app/silabs/include/LockManager.h
+++ b/examples/lock-app/silabs/include/LockManager.h
@@ -29,24 +29,6 @@
 
 #include <lib/support/DefaultStorageKeyAllocator.h>
 
-struct WeekDayScheduleInfo
-{
-    DlScheduleStatus status;
-    EmberAfPluginDoorLockWeekDaySchedule schedule;
-};
-
-struct YearDayScheduleInfo
-{
-    DlScheduleStatus status;
-    EmberAfPluginDoorLockYearDaySchedule schedule;
-};
-
-struct HolidayScheduleInfo
-{
-    DlScheduleStatus status;
-    EmberAfPluginDoorLockHolidaySchedule schedule;
-};
-
 namespace EFR32DoorLock {
 namespace ResourceRanges {
 // Used to size arrays
@@ -57,8 +39,6 @@ static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
 static constexpr uint8_t kMaxHolidaySchedules        = 10;
 static constexpr uint8_t kMaxCredentialSize          = 20;
 static constexpr uint8_t kNumCredentialTypes         = 6;
-
-static constexpr uint8_t kMaxCredentials = kMaxUsers * kMaxCredentialsPerUser;
 
 } // namespace ResourceRanges
 
@@ -109,34 +89,56 @@ private:
 };
 
 } // namespace LockInitParams
+namespace Storage {
+
+    using namespace EFR32DoorLock::ResourceRanges;
+    struct WeekDayScheduleInfo
+    {
+        DlScheduleStatus status;
+        EmberAfPluginDoorLockWeekDaySchedule schedule;
+    };
+    
+    struct YearDayScheduleInfo
+    {
+        DlScheduleStatus status;
+        EmberAfPluginDoorLockYearDaySchedule schedule;
+    };
+    
+    struct HolidayScheduleInfo
+    {
+        DlScheduleStatus status;
+        EmberAfPluginDoorLockHolidaySchedule schedule;
+    };
+    
+    struct LockUserInfo
+    {
+        char userName[DOOR_LOCK_MAX_USER_NAME_SIZE];
+        size_t userNameSize;
+        uint32_t userUniqueId;
+        UserStatusEnum userStatus;
+        UserTypeEnum userType;
+        CredentialRuleEnum credentialRule;
+        chip::EndpointId endpointId;
+        chip::FabricIndex createdBy;
+        chip::FabricIndex lastModifiedBy;
+        uint16_t currentCredentialCount;
+    };
+    
+    struct LockCredentialInfo
+    {
+        DlCredentialStatus status;
+        CredentialTypeEnum credentialType;
+        chip::FabricIndex createdBy;
+        chip::FabricIndex lastModifiedBy;
+        uint8_t credentialData[kMaxCredentialSize];
+        size_t credentialDataSize;
+    };
+} // namespace Storage
 } // namespace EFR32DoorLock
 
 using namespace ::chip;
 using namespace EFR32DoorLock::ResourceRanges;
-
-struct LockUserInfo
-{
-    char userName[DOOR_LOCK_MAX_USER_NAME_SIZE];
-    size_t userNameSize;
-    uint32_t userUniqueId;
-    UserStatusEnum userStatus;
-    UserTypeEnum userType;
-    CredentialRuleEnum credentialRule;
-    chip::EndpointId endpointId;
-    chip::FabricIndex createdBy;
-    chip::FabricIndex lastModifiedBy;
-    uint16_t currentCredentialCount;
-};
-
-struct LockCredentialInfo
-{
-    DlCredentialStatus status;
-    CredentialTypeEnum credentialType;
-    chip::FabricIndex createdBy;
-    chip::FabricIndex lastModifiedBy;
-    uint8_t credentialData[kMaxCredentialSize];
-    size_t credentialDataSize;
-};
+using namespace EFR32DoorLock::Storage;
 
 class LockManager
 {

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -206,7 +206,8 @@ CHIP_ERROR AppTask::Init()
                              .SetNumberOfWeekdaySchedulesPerUser(numberOfWeekdaySchedulesPerUser)
                              .SetNumberOfYeardaySchedulesPerUser(numberOfYeardaySchedulesPerUser)
                              .SetNumberOfHolidaySchedules(numberOfHolidaySchedules)
-                             .GetLockParam());
+                             .GetLockParam(),
+                         &Server::GetInstance().GetPersistentStorage());
 
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -67,7 +67,7 @@ using namespace chip::app;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
 using namespace ::chip::DeviceLayer::Internal;
-using namespace SilabsDoorLockConfig::LockInitParams;
+using namespace SilabsDoorLock::LockInitParams;
 
 namespace {
 LEDWidget sLockLED;

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -37,9 +37,9 @@
 #include <app-common/zap-generated/cluster-objects.h>
 
 #include <app/clusters/door-lock-server/door-lock-server.h>
-#include <setup_payload/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <setup_payload/OnboardingCodesUtil.h>
 
 #include <assert.h>
 
@@ -266,7 +266,6 @@ void AppTask::AppTaskMain(void * pvParameter)
 
     SILABS_LOG("App Task started");
 
-
     while (true)
     {
         osStatus_t eventReceived = osMessageQueueGet(sAppEventQueue, &event, NULL, osWaitForever);
@@ -410,4 +409,3 @@ void AppTask::UpdateClusterState(intptr_t context)
         SILABS_LOG("ERR: updating lock state %x", to_underlying(status));
     }
 }
- 

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -20,6 +20,7 @@
 #include "AppTask.h"
 #include "AppConfig.h"
 #include "AppEvent.h"
+#include "CHIPProjectConfig.h"
 #if defined(ENABLE_CHIP_SHELL)
 #include "EventHandlerLibShell.h"
 #endif // ENABLE_CHIP_SHELL
@@ -66,7 +67,7 @@ using namespace chip::app;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
 using namespace ::chip::DeviceLayer::Internal;
-using namespace EFR32DoorLock::LockInitParams;
+using namespace SilabsDoorLockConfig::LockInitParams;
 
 namespace {
 LEDWidget sLockLED;

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -37,9 +37,9 @@
 #include <app-common/zap-generated/cluster-objects.h>
 
 #include <app/clusters/door-lock-server/door-lock-server.h>
+#include <setup_payload/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
-#include <setup_payload/OnboardingCodesUtil.h>
 
 #include <assert.h>
 
@@ -266,8 +266,6 @@ void AppTask::AppTaskMain(void * pvParameter)
 
     SILABS_LOG("App Task started");
 
-    // Users and credentials should be checked once from nvm flash on boot
-    LockMgr().ReadConfigValues();
 
     while (true)
     {
@@ -412,3 +410,4 @@ void AppTask::UpdateClusterState(intptr_t context)
         SILABS_LOG("ERR: updating lock state %x", to_underlying(status));
     }
 }
+ 

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -26,6 +26,7 @@
 
 using chip::app::DataModel::MakeNullable;
 using namespace ::chip::DeviceLayer::Internal;
+using namespace EFR32DoorLock;
 using namespace EFR32DoorLock::LockInitParams;
 
 namespace {

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -631,7 +631,7 @@ DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 
     error = mStorage->SyncGetKeyValue(scheduleDataKey.KeyName(), &weekDayScheduleInStorage, scheduleSize);
 
-    // If no data is found at scheduleUserMapKey key
+    // If no data is found at scheduleDataKey
     if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");
@@ -723,7 +723,7 @@ DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
 
     error = mStorage->SyncGetKeyValue(scheduleDataKey.KeyName(), &yearDayScheduleInStorage, scheduleSize);
 
-    // If no data is found at scheduleUserMapKey key
+    // If no data is found at scheduleDataKey
     if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");
@@ -808,7 +808,7 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
 
     error = mStorage->SyncGetKeyValue(scheduleDataKey.KeyName(), &holidayScheduleInStorage, scheduleSize);
 
-    // If no data is found at scheduleUserMapKey key
+    // If no data is found at scheduleDataKey
     if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -27,7 +27,7 @@
 using chip::app::DataModel::MakeNullable;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace SilabsDoorLock;
-using namespace SilabsDoorLockConfig::LockInitParams;
+using namespace SilabsDoorLock::LockInitParams;
 
 static constexpr uint16_t LockUserInfoSize        = sizeof(LockUserInfo);
 static constexpr uint16_t LockCredentialInfoSize  = sizeof(LockCredentialInfo);

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -445,7 +445,7 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
         return false;
     }
 
-    chip::Platform::CopyString(userInStorage.userName, userName.data());
+    memcpy(userInStorage.userName, userName.data(), userName.size());
     userInStorage.userNameSize   = userName.size();
     userInStorage.userUniqueId   = uniqueId;
     userInStorage.userStatus     = userStatus;

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -372,6 +372,9 @@ bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, Ember
     user.modificationSource = DlAssetSource::kMatterIM;
     user.lastModifiedBy     = userInStorage.lastModifiedBy;
 
+    // Ensure userInStorage.currentCredentialCount <= kMaxCredentialsPerUser to avoid buffer overflow
+    VerifyOrReturnValue(userInStorage.currentCredentialCount <= kMaxCredentialsPerUser, false);
+
     // Get credential struct from nvm3
     chip::StorageKeyName credentialKey = LockUserCredentialMap(userIndex);
 
@@ -595,7 +598,7 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
                                                                        static_cast<uint16_t>(sizeof(LockCredentialInfo)));
 
     // Clear credentialInStorage.credentialData
-    memset(credentialInStorage.credentialData, 0, sizeof(uint8_t)*kMaxCredentialSize);
+    memset(credentialInStorage.credentialData, 0, sizeof(uint8_t) * kMaxCredentialSize);
 
     if ((error != CHIP_NO_ERROR))
     {

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -616,6 +616,8 @@ DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 {
     CHIP_ERROR error;
 
+    WeekDayScheduleInfo weekDayScheduleInStorage;
+
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(weekdayIndex > 0, DlStatus::kFailure); // indices are one-indexed
@@ -667,6 +669,8 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 {
     CHIP_ERROR error;
 
+    WeekDayScheduleInfo weekDayScheduleInStorage;
+
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(weekdayIndex > 0, DlStatus::kFailure); // indices are one-indexed
@@ -704,6 +708,8 @@ DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
                                          EmberAfPluginDoorLockYearDaySchedule & schedule)
 {
     CHIP_ERROR error;
+
+    YearDayScheduleInfo yearDayScheduleInStorage;
 
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
@@ -755,6 +761,8 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
 {
     CHIP_ERROR error;
 
+    YearDayScheduleInfo yearDayScheduleInStorage;
+
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(yearDayIndex > 0, DlStatus::kFailure); // indices are one-indexed
@@ -789,6 +797,8 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
                                          EmberAfPluginDoorLockHolidaySchedule & schedule)
 {
     CHIP_ERROR error;
+
+    HolidayScheduleInfo holidayScheduleInStorage;
 
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
@@ -836,6 +846,8 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
                                          uint32_t localStartTime, uint32_t localEndTime, OperatingModeEnum operatingMode)
 {
     CHIP_ERROR error;
+
+    HolidayScheduleInfo holidayScheduleInStorage;
 
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -21,8 +21,8 @@
 
 #include "AppConfig.h"
 #include "AppTask.h"
-#include <app/server/Server.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/server/Server.h>
 #include <cstring>
 #include <lib/support/logging/CHIPLogging.h>
 
@@ -332,11 +332,11 @@ bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, Ember
 
     chip::StorageKeyName userKey = LockUserEndpoint(userIndex, endpointId);
 
-    uint16_t size  = static_cast<uint16_t>(sizeof(LockUserInfo));
+    uint16_t size = static_cast<uint16_t>(sizeof(LockUserInfo));
 
     error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(userKey.KeyName(), &userInStorage, size);
     // If no data is found at user key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         user.userStatus = UserStatusEnum::kAvailable;
 
@@ -344,16 +344,15 @@ bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, Ember
         return true;
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
         user.userStatus = userInStorage.userStatus;
 
-        if(userInStorage.userStatus == UserStatusEnum::kAvailable)
+        if (userInStorage.userStatus == UserStatusEnum::kAvailable)
         {
             ChipLogDetail(Zcl, "Found unoccupied user [endpoint=%d]", endpointId);
             return true;
         }
-
     }
     else
     {
@@ -371,28 +370,29 @@ bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, Ember
     user.createdBy          = userInStorage.createdBy;
     user.modificationSource = DlAssetSource::kMatterIM;
     user.lastModifiedBy     = userInStorage.lastModifiedBy;
-    
+
     // Get credential struct from nvm3
     chip::StorageKeyName credentialKey = LockUserCredentialMap(userIndex);
 
-    uint16_t credentialSize = static_cast<uint16_t>(sizeof(CredentialStruct)*userInStorage.currentCredentialCount);
+    uint16_t credentialSize = static_cast<uint16_t>(sizeof(CredentialStruct) * userInStorage.currentCredentialCount);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(credentialKey.KeyName(), &mCredential, credentialSize);
+    error =
+        chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(credentialKey.KeyName(), &mCredential, credentialSize);
 
     // If no data is found at credential key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // No credentials found for this user
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
-        user.credentials = chip::Span<const CredentialStruct> {&mCredential, userInStorage.currentCredentialCount};
+        user.credentials = chip::Span<const CredentialStruct>{ &mCredential, userInStorage.currentCredentialCount };
     }
     else
     {
         ChipLogError(Zcl, "Error reading KVS key");
-        return false;        
+        return false;
     }
 
     ChipLogDetail(Zcl,
@@ -425,7 +425,7 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
     userIndex--;
 
     VerifyOrReturnValue(IsValidUserIndex(userIndex), false);
-    
+
     VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
 
     if (userName.size() > DOOR_LOCK_MAX_USER_NAME_SIZE)
@@ -455,24 +455,26 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
     // Save credential struct in nvm3
     chip::StorageKeyName credentialKey = LockUserCredentialMap(userIndex);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(credentialKey.KeyName(), credentials, static_cast<uint16_t>(sizeof(CredentialStruct)*totalCredentials));
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(
+        credentialKey.KeyName(), credentials, static_cast<uint16_t>(sizeof(CredentialStruct) * totalCredentials));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return false;     
+        return false;
     }
-    
+
     // Save user in nvm3
     chip::StorageKeyName userKey = LockUserEndpoint(userIndex, endpointId);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(userKey.KeyName(), &userInStorage, static_cast<uint16_t>(sizeof(LockUserInfo)));
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(userKey.KeyName(), &userInStorage,
+                                                                               static_cast<uint16_t>(sizeof(LockUserInfo)));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return false;     
-    }    
+        return false;
+    }
 
     ChipLogProgress(Zcl, "Successfully set the user [mEndpointId=%d,index=%d]", endpointId, userIndex);
 
@@ -499,14 +501,14 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
     ChipLogProgress(Zcl, "Lock App: LockManager::GetCredential [credentialType=%u], credentialIndex=%d",
                     to_underlying(credentialType), credentialIndex);
 
-    uint16_t size  = static_cast<uint16_t>(sizeof(LockCredentialInfo));
+    uint16_t size = static_cast<uint16_t>(sizeof(LockCredentialInfo));
 
     chip::StorageKeyName key = LockCredentialEndpoint(credentialIndex, endpointId);
 
     error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(key.KeyName(), &credentialInStorage, size);
 
     // If no data is found at credential key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         // No credentials found
         credential.status = DlCredentialStatus::kAvailable;
@@ -514,16 +516,15 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
         return true;
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
         credential.status = credentialInStorage.status;
         ChipLogDetail(Zcl, "CredentialStatus: %d, CredentialIndex: %d ", (int) credential.status, credentialIndex);
-
     }
     else
     {
         ChipLogError(Zcl, "Error reading KVS key");
-        return false;        
+        return false;
     }
 
     if (DlCredentialStatus::kAvailable == credential.status)
@@ -569,28 +570,29 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
                     "[credentialStatus=%u,credentialType=%u,credentialDataSize=%u,creator=%d,modifier=%d]",
                     to_underlying(credentialStatus), to_underlying(credentialType), credentialData.size(), creator, modifier);
 
-    credentialInStorage.status         = credentialStatus;
-    credentialInStorage.credentialType = credentialType;
-    credentialInStorage.createdBy      = creator;
-    credentialInStorage.lastModifiedBy = modifier;
+    credentialInStorage.status             = credentialStatus;
+    credentialInStorage.credentialType     = credentialType;
+    credentialInStorage.createdBy          = creator;
+    credentialInStorage.lastModifiedBy     = modifier;
     credentialInStorage.credentialDataSize = credentialData.size();
 
     memcpy(credentialInStorage.credentialData, credentialData.data(), credentialInStorage.credentialDataSize);
 
     chip::StorageKeyName key = LockCredentialEndpoint(credentialIndex, endpointId);
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return false;     
+        return false;
     }
 
-    chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(key.KeyName(), &credentialInStorage, static_cast<uint16_t>(sizeof(LockCredentialInfo)));
+    chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(key.KeyName(), &credentialInStorage,
+                                                                       static_cast<uint16_t>(sizeof(LockCredentialInfo)));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return false;     
+        return false;
     }
 
     ChipLogProgress(Zcl, "Successfully set the credential [credentialType=%u]", to_underlying(credentialType));
@@ -617,23 +619,23 @@ DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 
     uint16_t scheduleSize = static_cast<uint16_t>(sizeof(WeekDayScheduleInfo));
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &weekDayScheduleInStorage, scheduleSize);
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &weekDayScheduleInStorage,
+                                                                               scheduleSize);
 
     // If no data is found at scheduleUserMapKey key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");
         return DlStatus::kNotFound;
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
 
         if (weekDayScheduleInStorage.status == DlScheduleStatus::kAvailable)
         {
             return DlStatus::kNotFound;
         }
-    
     }
     else
     {
@@ -671,13 +673,14 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
     // Save schedule data in nvm3
     chip::StorageKeyName scheduleDataKey = LockUserWeekDayScheduleEndpoint(userIndex, weekdayIndex, endpointId);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &weekDayScheduleInStorage, static_cast<uint16_t>(sizeof(WeekDayScheduleInfo)));
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &weekDayScheduleInStorage,
+                                                                               static_cast<uint16_t>(sizeof(WeekDayScheduleInfo)));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return DlStatus::kFailure;     
-    }  
+        return DlStatus::kFailure;
+    }
 
     return DlStatus::kSuccess;
 }
@@ -701,23 +704,23 @@ DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
 
     uint16_t scheduleSize = static_cast<uint16_t>(sizeof(YearDayScheduleInfo));
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &yearDayScheduleInStorage, scheduleSize);
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &yearDayScheduleInStorage,
+                                                                               scheduleSize);
 
     // If no data is found at scheduleUserMapKey key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");
         return DlStatus::kNotFound;
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
 
         if (yearDayScheduleInStorage.status == DlScheduleStatus::kAvailable)
         {
             return DlStatus::kNotFound;
         }
-    
     }
     else
     {
@@ -751,13 +754,14 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
     // Save schedule data in nvm3
     chip::StorageKeyName scheduleDataKey = LockUserYearDayScheduleEndpoint(userIndex, yearDayIndex, endpointId);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &yearDayScheduleInStorage, static_cast<uint16_t>(sizeof(YearDayScheduleInfo)));
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &yearDayScheduleInStorage,
+                                                                               static_cast<uint16_t>(sizeof(YearDayScheduleInfo)));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return DlStatus::kFailure;     
-    } 
+        return DlStatus::kFailure;
+    }
 
     return DlStatus::kSuccess;
 }
@@ -778,23 +782,23 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
 
     uint16_t scheduleSize = static_cast<uint16_t>(sizeof(HolidayScheduleInfo));
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &holidayScheduleInStorage, scheduleSize);
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(scheduleDataKey.KeyName(), &holidayScheduleInStorage,
+                                                                               scheduleSize);
 
     // If no data is found at scheduleUserMapKey key
-    if(error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (error == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(Zcl, "No schedule data found for user");
         return DlStatus::kNotFound;
     }
     // Else if KVS read was successful
-    else if(error == CHIP_NO_ERROR)
+    else if (error == CHIP_NO_ERROR)
     {
 
         if (holidayScheduleInStorage.status == DlScheduleStatus::kAvailable)
         {
             return DlStatus::kNotFound;
         }
-    
     }
     else
     {
@@ -826,13 +830,14 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
     // Save schedule data in nvm3
     chip::StorageKeyName scheduleDataKey = LockHolidayScheduleEndpoint(holidayIndex, endpointId);
 
-    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &holidayScheduleInStorage, static_cast<uint16_t>(sizeof(HolidayScheduleInfo)));
+    error = chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(scheduleDataKey.KeyName(), &holidayScheduleInStorage,
+                                                                               static_cast<uint16_t>(sizeof(HolidayScheduleInfo)));
 
-    if((error != CHIP_NO_ERROR))
+    if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
-        return DlStatus::kFailure;     
-    } 
+        return DlStatus::kFailure;
+    }
 
     return DlStatus::kSuccess;
 }
@@ -890,75 +895,77 @@ bool LockManager::setLockState(chip::EndpointId endpointId, const Nullable<chip:
     }
 
     // Check all pin codes associated to all users to see if this pin code exists
-    for(int userIndex = 0; userIndex < kMaxUsers; userIndex++)
+    for (int userIndex = 0; userIndex < kMaxUsers; userIndex++)
     {
         // Get user data to obtain currentCredentialCount
         chip::StorageKeyName userKey = LockUserEndpoint(userIndex, endpointId);
 
-        uint16_t size  = static_cast<uint16_t>(sizeof(LockUserInfo));
+        uint16_t size = static_cast<uint16_t>(sizeof(LockUserInfo));
 
         error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(userKey.KeyName(), &userInStorage, size);
 
         // No user exists at this index
-        if(error != CHIP_NO_ERROR)
-        {            
+        if (error != CHIP_NO_ERROR)
+        {
             continue;
         }
 
         chip::StorageKeyName credentialKey = LockUserCredentialMap(userIndex);
 
-        uint16_t credentialSize = static_cast<uint16_t>(sizeof(CredentialStruct)*userInStorage.currentCredentialCount);
+        uint16_t credentialSize = static_cast<uint16_t>(sizeof(CredentialStruct) * userInStorage.currentCredentialCount);
 
         // Get array of credential indices and types associated to user
-        error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(credentialKey.KeyName(), &mCredentials, credentialSize);
+        error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(credentialKey.KeyName(), &mCredentials,
+                                                                                   credentialSize);
 
         // No credential data associated with user
-        if(error != CHIP_NO_ERROR)
-        {            
+        if (error != CHIP_NO_ERROR)
+        {
             continue;
         }
 
-        for(int j = 0; j < userInStorage.currentCredentialCount; j++)
+        for (int j = 0; j < userInStorage.currentCredentialCount; j++)
         {
             // If the current credential is a pin type, then check it against pin input. Otherwise ignore
-            if(mCredentials[j].credentialType == CredentialTypeEnum::kPin)
+            if (mCredentials[j].credentialType == CredentialTypeEnum::kPin)
             {
                 // Read the individual credential at credentialIndex j
-                uint16_t size  = static_cast<uint16_t>(sizeof(LockCredentialInfo));
+                uint16_t size = static_cast<uint16_t>(sizeof(LockCredentialInfo));
 
                 chip::StorageKeyName key = LockCredentialEndpoint(mCredentials[j].credentialIndex, endpointId);
 
-                error = chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(key.KeyName(), &credentialInStorage, size);
+                error =
+                    chip::Server::GetInstance().GetPersistentStorage().SyncGetKeyValue(key.KeyName(), &credentialInStorage, size);
 
-                if(error != CHIP_NO_ERROR)
-                {            
+                if (error != CHIP_NO_ERROR)
+                {
                     ChipLogError(Zcl, "Error reading credential");
                     return false;
                 }
 
-               // See if it matches the provided PIN
-               if (credentialInStorage.status == DlCredentialStatus::kAvailable)
-               {
-                   continue;
-               }
+                // See if it matches the provided PIN
+                if (credentialInStorage.status == DlCredentialStatus::kAvailable)
+                {
+                    continue;
+                }
 
-               chip::ByteSpan currentCredential = chip::ByteSpan{ credentialInStorage.credentialData, credentialInStorage.credentialDataSize };
-       
-               if (currentCredential.data_equal(pin.Value()))
-               {
-                   ChipLogDetail(Zcl,
-                                 "Lock App: specified PIN code was found in the database, setting lock state to \"%s\" [endpointId=%d]",
-                                 lockStateToString(lockState), endpointId);
+                chip::ByteSpan currentCredential =
+                    chip::ByteSpan{ credentialInStorage.credentialData, credentialInStorage.credentialDataSize };
+
+                if (currentCredential.data_equal(pin.Value()))
+                {
+                    ChipLogDetail(
+                        Zcl, "Lock App: specified PIN code was found in the database, setting lock state to \"%s\" [endpointId=%d]",
+                        lockStateToString(lockState), endpointId);
 
                     LockOpCredentials userCredential[] = { { CredentialTypeEnum::kPin, mCredentials[j].credentialIndex } };
                     auto userCredentials               = MakeNullable<List<const LockOpCredentials>>(userCredential);
-       
-                   DoorLockServer::Instance().SetLockState(endpointId, lockState, OperationSourceEnum::kRemote, userIndex, userCredentials,
-                                                           fabricIdx, nodeId);
-       
-                   return true;
-               }               
 
+                    DoorLockServer::Instance().SetLockState(endpointId, lockState, OperationSourceEnum::kRemote, userIndex,
+                                                            userCredentials, fabricIdx, nodeId);
+
+                    return true;
+                }
             }
         }
     }

--- a/examples/lock-app/silabs/src/LockManager.cpp
+++ b/examples/lock-app/silabs/src/LockManager.cpp
@@ -327,6 +327,8 @@ bool LockManager::GetUser(chip::EndpointId endpointId, uint16_t userIndex, Ember
 
     VerifyOrReturnValue(IsValidUserIndex(userIndex), false);
 
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
+
     ChipLogProgress(Zcl, "Door Lock App: LockManager::GetUser [endpoint=%d,userIndex=%hu]", endpointId, userIndex);
 
     chip::StorageKeyName userKey = LockUserEndpoint(userIndex, endpointId);
@@ -419,13 +421,13 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
                     endpointId, userIndex, creator, modifier, userName.data(), uniqueId, to_underlying(userStatus),
                     to_underlying(usertype), to_underlying(credentialRule), credentials, totalCredentials);
 
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
+
     VerifyOrReturnValue(userIndex > 0, false); // indices are one-indexed
 
     userIndex--;
 
     VerifyOrReturnValue(IsValidUserIndex(userIndex), false);
-
-    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
 
     if (userName.size() > DOOR_LOCK_MAX_USER_NAME_SIZE)
     {
@@ -484,6 +486,8 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
                                 EmberAfPluginDoorLockCredentialInfo & credential)
 {
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
 
     VerifyOrReturnValue(IsValidCredentialType(credentialType), false);
 
@@ -552,6 +556,8 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
 {
     CHIP_ERROR error;
 
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
+
     VerifyOrReturnValue(IsValidCredentialType(credentialType), false);
 
     if (CredentialTypeEnum::kProgrammingPIN == credentialType)
@@ -588,6 +594,9 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
     chip::Server::GetInstance().GetPersistentStorage().SyncSetKeyValue(key.KeyName(), &credentialInStorage,
                                                                        static_cast<uint16_t>(sizeof(LockCredentialInfo)));
 
+    // Clear credentialInStorage.credentialData
+    memset(credentialInStorage.credentialData, 0, sizeof(uint8_t)*kMaxCredentialSize);
+
     if ((error != CHIP_NO_ERROR))
     {
         ChipLogError(Zcl, "Error reading from KVS key");
@@ -603,6 +612,8 @@ DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
                                          EmberAfPluginDoorLockWeekDaySchedule & schedule)
 {
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(weekdayIndex > 0, DlStatus::kFailure); // indices are one-indexed
     VerifyOrReturnValue(userIndex > 0, DlStatus::kFailure);    // indices are one-indexed
@@ -653,6 +664,8 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 {
     CHIP_ERROR error;
 
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
+
     VerifyOrReturnValue(weekdayIndex > 0, DlStatus::kFailure); // indices are one-indexed
     VerifyOrReturnValue(userIndex > 0, DlStatus::kFailure);    // indices are one-indexed
 
@@ -688,6 +701,8 @@ DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
                                          EmberAfPluginDoorLockYearDaySchedule & schedule)
 {
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(yearDayIndex > 0, DlStatus::kFailure); // indices are one-indexed
     VerifyOrReturnValue(userIndex > 0, DlStatus::kFailure);    // indices are one-indexed
@@ -737,6 +752,8 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
 {
     CHIP_ERROR error;
 
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
+
     VerifyOrReturnValue(yearDayIndex > 0, DlStatus::kFailure); // indices are one-indexed
     VerifyOrReturnValue(userIndex > 0, DlStatus::kFailure);    // indices are one-indexed
 
@@ -769,6 +786,8 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
                                          EmberAfPluginDoorLockHolidaySchedule & schedule)
 {
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(holidayIndex > 0, DlStatus::kFailure); // indices are one-indexed
 
@@ -814,6 +833,8 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
                                          uint32_t localStartTime, uint32_t localEndTime, OperatingModeEnum operatingMode)
 {
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, DlStatus::kFailure);
 
     VerifyOrReturnValue(holidayIndex > 0, DlStatus::kFailure); // indices are one-indexed
 
@@ -866,6 +887,8 @@ bool LockManager::setLockState(chip::EndpointId endpointId, const Nullable<chip:
 {
 
     CHIP_ERROR error;
+
+    VerifyOrReturnValue(kInvalidEndpointId != endpointId, false);
 
     // Assume pin is required until told otherwise
     bool requirePin = true;

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -774,7 +774,7 @@ struct EmberAfPluginDoorLockCredentialInfo
 #if DOOR_LOCK_USE_LOCAL_BUFFER
     chip::MutableByteSpan credentialData; /**< Credential data bytes. */
 #else
-    chip::ByteSpan credentialData; /**< Credential data bytes. */
+    chip::ByteSpan credentialData;                  /**< Credential data bytes. */
 #endif
     DlAssetSource creationSource;
     chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -771,16 +771,12 @@ struct EmberAfPluginDoorLockCredentialInfo
 {
     DlCredentialStatus status = DlCredentialStatus::kAvailable; /**< Indicates if credential slot is occupied or not. */
     CredentialTypeEnum credentialType;                          /**< Specifies the type of the credential (PIN, RFID, etc.). */
-#if DOOR_LOCK_USE_LOCAL_BUFFER
     chip::MutableByteSpan credentialData;                       /**< Credential data bytes. */
-#else
-    chip::ByteSpan credentialData;                              /**< Credential data bytes. */
-#endif
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy;                                /**< Index of the fabric that created the user. */
+    chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */
 
     DlAssetSource modificationSource;
-    chip::FabricIndex lastModifiedBy;                           /**< ID of the fabric that modified the user. */
+    chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
 
 #if DOOR_LOCK_USE_LOCAL_BUFFER
     uint8_t credentialDataBuffer[DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH];
@@ -793,22 +789,17 @@ struct EmberAfPluginDoorLockCredentialInfo
  */
 struct EmberAfPluginDoorLockUserInfo
 {
-#if DOOR_LOCK_USE_LOCAL_BUFFER
     chip::MutableCharSpan userName;                         /**< Name of the user. */
     chip::Span<CredentialStruct> credentials;               /**< Credentials that are associated with user (without data).*/
-#else
-    chip::CharSpan userName;                                /**< Name of the user. */
-    chip::Span<const CredentialStruct> credentials;         /**< Credentials that are associated with user (without data).*/
-#endif
     uint32_t userUniqueId;                                  /**< Unique user identifier. */
     UserStatusEnum userStatus = UserStatusEnum::kAvailable; /**< Status of the user slot (available/occupied). */
     UserTypeEnum userType;                                  /**< Type of the user. */
     CredentialRuleEnum credentialRule;                      /**< Number of supported credentials. */
 
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy;                            /**< ID of the fabric that created the user. */
+    chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */
     DlAssetSource modificationSource;
-    chip::FabricIndex lastModifiedBy;                       /**< ID of the fabric that modified the user. */
+    chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
 
 #if DOOR_LOCK_USE_LOCAL_BUFFER
     char nameBuffer[DOOR_LOCK_MAX_USER_NAME_SIZE];

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -39,6 +39,10 @@
 #define DOOR_LOCK_SERVER_ENDPOINT 1
 #endif
 
+#ifndef DOOR_LOCK_USE_LOCAL_BUFFER
+#define DOOR_LOCK_USE_LOCAL_BUFFER 0
+#endif
+
 using chip::Optional;
 using chip::app::Clusters::DoorLock::AlarmCodeEnum;
 using chip::app::Clusters::DoorLock::CredentialRuleEnum;
@@ -767,13 +771,21 @@ struct EmberAfPluginDoorLockCredentialInfo
 {
     DlCredentialStatus status = DlCredentialStatus::kAvailable; /**< Indicates if credential slot is occupied or not. */
     CredentialTypeEnum credentialType;                          /**< Specifies the type of the credential (PIN, RFID, etc.). */
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    chip::MutableByteSpan credentialData;                       /**< Credential data bytes. */
+#else
     chip::ByteSpan credentialData;                              /**< Credential data bytes. */
-
+#endif
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */
+    chip::FabricIndex createdBy;                                /**< Index of the fabric that created the user. */
 
     DlAssetSource modificationSource;
-    chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
+    chip::FabricIndex lastModifiedBy;                           /**< ID of the fabric that modified the user. */
+
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    uint8_t credentialDataBuffer[DOOR_LOCK_CREDENTIAL_BUFFER_LENGTH];
+    EmberAfPluginDoorLockCredentialInfo() { credentialData = chip::MutableByteSpan(credentialDataBuffer); }
+#endif
 };
 
 /**
@@ -781,18 +793,32 @@ struct EmberAfPluginDoorLockCredentialInfo
  */
 struct EmberAfPluginDoorLockUserInfo
 {
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    chip::MutableCharSpan userName;                         /**< Name of the user. */
+    chip::Span<CredentialStruct> credentials;               /**< Credentials that are associated with user (without data).*/
+#else
     chip::CharSpan userName;                                /**< Name of the user. */
     chip::Span<const CredentialStruct> credentials;         /**< Credentials that are associated with user (without data).*/
+#endif
     uint32_t userUniqueId;                                  /**< Unique user identifier. */
     UserStatusEnum userStatus = UserStatusEnum::kAvailable; /**< Status of the user slot (available/occupied). */
     UserTypeEnum userType;                                  /**< Type of the user. */
     CredentialRuleEnum credentialRule;                      /**< Number of supported credentials. */
 
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */
-
+    chip::FabricIndex createdBy;                            /**< ID of the fabric that created the user. */
     DlAssetSource modificationSource;
-    chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
+    chip::FabricIndex lastModifiedBy;                       /**< ID of the fabric that modified the user. */
+
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    char nameBuffer[DOOR_LOCK_MAX_USER_NAME_SIZE];
+    CredentialStruct credentialsBuffer[DOOR_LOCK_USER_CREDENTIALS_BUFFER_LENGTH];
+    EmberAfPluginDoorLockUserInfo()
+    {
+        userName    = chip::MutableCharSpan(nameBuffer);
+        credentials = chip::Span<CredentialStruct>(credentialsBuffer);
+    }
+#endif
 };
 
 /**

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -771,7 +771,11 @@ struct EmberAfPluginDoorLockCredentialInfo
 {
     DlCredentialStatus status = DlCredentialStatus::kAvailable; /**< Indicates if credential slot is occupied or not. */
     CredentialTypeEnum credentialType;                          /**< Specifies the type of the credential (PIN, RFID, etc.). */
-    chip::MutableByteSpan credentialData;                       /**< Credential data bytes. */
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    chip::MutableByteSpan credentialData; /**< Credential data bytes. */
+#else
+    chip::ByteSpan credentialData; /**< Credential data bytes. */
+#endif
     DlAssetSource creationSource;
     chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */
 
@@ -789,8 +793,13 @@ struct EmberAfPluginDoorLockCredentialInfo
  */
 struct EmberAfPluginDoorLockUserInfo
 {
-    chip::MutableCharSpan userName;                         /**< Name of the user. */
-    chip::Span<CredentialStruct> credentials;               /**< Credentials that are associated with user (without data).*/
+#if DOOR_LOCK_USE_LOCAL_BUFFER
+    chip::MutableCharSpan userName;           /**< Name of the user. */
+    chip::Span<CredentialStruct> credentials; /**< Credentials that are associated with user (without data).*/
+#else
+    chip::CharSpan userName;                        /**< Name of the user. */
+    chip::Span<const CredentialStruct> credentials; /**< Credentials that are associated with user (without data).*/
+#endif
     uint32_t userUniqueId;                                  /**< Unique user identifier. */
     UserStatusEnum userStatus = UserStatusEnum::kAvailable; /**< Status of the user slot (available/occupied). */
     UserTypeEnum userType;                                  /**< Type of the user. */


### PR DESCRIPTION
The original silabs lock-app implementation was a basic example and did not take in to account RAM and NVM3 efficiency. 

This refactor 
- reduces the RAM usage of the lock-app by removing static arrays of users/credentials
- Using KVS to create individual nvm3 entries for each user, credential and schedule rather than directly storing multi-dimensional arrays into NVM3, reducing NVM3 max object size. This allows allows the app to have nvm3 storage increase only as the amount of data being stored increases, rather than storing partially empty arrays in storage.
- Adds new storage structs, LockUserInfo and LockCredentialInfo, which don't include the Span types that are received from door-lock-server to reduce storage size further.
- Improves security by segmenting user/credential/schedule storage in nvm3
- Moves all lock configurations from LockManager.h ChipProjectConfig.h
- Add door lock server configuration such that user/credential structs can own outparam buffer


#### Testing

Tested by running the TC_DRLK test cases in pipeline that runs silabs hardware. 
