### PR TITLE
Fix clang-tidy error in PersistedCounter.h

### DIFF
--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -229,6 +229,11 @@ private:
         T valueLE     = GetInitialCounterValue();
         uint16_t size = sizeof(valueLE);
 
+        // clang-tidy claims that we're returning without writing to 'aStartValue',
+        // assign 0 to supppress the warning. In case of error, the value wont't be
+        // used anyway.
+        aStartValue = 0;
+
         VerifyOrReturnError(mKey.IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
 
         CHIP_ERROR err = mStorage->SyncGetKeyValue(mKey.KeyName(), &valueLE, size);


### PR DESCRIPTION
Assign 0 to suppress the warning. In case of error, the value wont't be used anyway.

Fixes #37854.

#### Testing
Tested by CI

https://github.com/project-chip/connectedhomeip/actions/runs/13675355334/job/38234550494?pr=37855
```
2025-03-03T22:53:03.4922710Z INFO    Will tidy /Users/runner/work/connectedhomeip/connectedhomeip/src/app/server/Server.cpp
2025-03-03T22:53:14.1556740Z INFO    Successfully processed 1 path(s)
```
