### PR TITLE
Cancel diagnostic log transfers in Matter.framework when a new one starts

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
+++ b/src/darwin/Framework/CHIP/MTRDiagnosticLogsDownloader.mm
@@ -419,6 +419,10 @@ private:
 {
     assertChipStackLockedByCurrentThread();
 
+    // Fow now, we only support one download at a time per controller; abort
+    // any existing ones so we can start this new one.
+    [self abortDownloadsForController:controller];
+
     uint16_t timeoutInSeconds = 0;
     if (timeout <= 0) {
         timeoutInSeconds = 0;


### PR DESCRIPTION
The goal is to avoid Thread congestion issues.

#### Testing

Just tested that this compiles so far.