### PR TITLE
[Support Task] Adding CADMIN support module for task #514

### DIFF
--- a/src/python_testing/TC_CADMIN_1_11.py
+++ b/src/python_testing/TC_CADMIN_1_11.py
@@ -45,9 +45,14 @@ from chip.native import PyChipError
 from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
                                                                        default_matter_test_main)
 from mobly import asserts
+from support_modules.cadmin_support import CADMINSupport
 
 
 class TC_CADMIN_1_11(MatterBaseTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.support = CADMINSupport(self)
+
     async def OpenCommissioningWindow(self, th, expectedErrCode) -> CommissioningParameters:
         if expectedErrCode is None:
             params = await th.OpenCommissioningWindow(
@@ -81,12 +86,6 @@ class TC_CADMIN_1_11(MatterBaseTest):
             asserts.assert_false(errcode.is_success, 'Commissioning complete did not error as expected')
             asserts.assert_true(errcode.sdk_code == expectedErrCode,
                                 'Unexpected error code returned from CommissioningComplete')
-
-    async def read_currentfabricindex(self, th: ChipDeviceCtrl) -> int:
-        cluster = Clusters.OperationalCredentials
-        attribute = Clusters.OperationalCredentials.Attributes.CurrentFabricIndex
-        current_fabric_index = await self.read_single_attribute_check_success(dev_ctrl=th, endpoint=0, cluster=cluster, attribute=attribute)
-        return current_fabric_index
 
     def steps_TC_CADMIN_1_11(self) -> list[TestStep]:
         return [
@@ -211,7 +210,7 @@ class TC_CADMIN_1_11(MatterBaseTest):
 
         # Read CurrentFabricIndex attribute from the Operational Credentials cluster
         self.step(10)
-        th2_idx = await self.read_currentfabricindex(self.th2)
+        th2_idx = await self.support.read_currentfabricindex(self.th2)
 
         self.step(11)
         removeFabricCmd = Clusters.OperationalCredentials.Commands.RemoveFabric(th2_idx)

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -31,8 +31,6 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import random
-
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.exceptions import ChipStackError

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -40,6 +40,7 @@ from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_bod
 from mobly import asserts
 from support_modules.cadmin_support import CADMINSupport
 
+
 class TC_CADMIN_1_19(MatterBaseTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -38,19 +38,12 @@ from chip import ChipDeviceCtrl
 from chip.exceptions import ChipStackError
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
-
+from support_modules.cadmin_support import CADMINSupport
 
 class TC_CADMIN_1_19(MatterBaseTest):
-    def generate_unique_random_value(self, value):
-        while True:
-            random_value = random.randint(10000000, 99999999)
-            asserts.assert_equal(random_value, value)
-            return random_value
-
-    async def get_fabrics(self, th: ChipDeviceCtrl) -> int:
-        OC_cluster = Clusters.OperationalCredentials
-        fabrics = await self.read_single_attribute_check_success(dev_ctrl=th, fabric_filtered=False, endpoint=0, cluster=OC_cluster, attribute=OC_cluster.Attributes.Fabrics)
-        return fabrics
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.support = CADMINSupport(self)
 
     def steps_TC_CADMIN_1_19(self) -> list[TestStep]:
         return [
@@ -92,7 +85,7 @@ class TC_CADMIN_1_19(MatterBaseTest):
         self.max_window_duration = duration.maxCumulativeFailsafeSeconds
 
         self.step(2)
-        fabrics = await self.get_fabrics(th=self.th1)
+        fabrics = await self.support.get_fabrics(th=self.th1)
         initial_number_of_fabrics = len(fabrics)
 
         self.step(3)

--- a/src/python_testing/TC_CADMIN_1_22_24.py
+++ b/src/python_testing/TC_CADMIN_1_22_24.py
@@ -41,9 +41,13 @@ from chip.ChipDeviceCtrl import CommissioningParameters
 from chip.exceptions import ChipStackError
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
-
+from support_modules.cadmin_support import CADMINSupport
 
 class TC_CADMIN_1_22_24(MatterBaseTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.support = CADMINSupport(self)
+
     async def OpenCommissioningWindow(self) -> CommissioningParameters:
         try:
             params = await self.th1.OpenCommissioningWindow(
@@ -53,11 +57,6 @@ class TC_CADMIN_1_22_24(MatterBaseTest):
         except Exception as e:
             logging.exception('Error running OpenCommissioningWindow %s', e)
             asserts.fail('Failed to open commissioning window')
-
-    async def get_window_status(self) -> int:
-        AC_cluster = Clusters.AdministratorCommissioning
-        window_status = await self.read_single_attribute_check_success(dev_ctrl=self.th1, fabric_filtered=False, endpoint=0, cluster=AC_cluster, attribute=AC_cluster.Attributes.WindowStatus)
-        return window_status
 
     def pics_TC_CADMIN_1_22(self) -> list[str]:
         return ["CADMIN.S"]
@@ -93,7 +92,7 @@ class TC_CADMIN_1_22_24(MatterBaseTest):
         sleep(1)
 
         self.step(4)
-        window_status = await self.get_window_status()
+        window_status = await self.support.get_window_status(th=self.th1)
         asserts.assert_equal(window_status, Clusters.AdministratorCommissioning.Enums.CommissioningWindowStatusEnum.kWindowNotOpen,
                              "Commissioning window is expected to be closed, but was found to be open")
 
@@ -111,7 +110,7 @@ class TC_CADMIN_1_22_24(MatterBaseTest):
                                  "Expected to error as we provided failure value for opening commissioning window")
 
         self.step(6)
-        window_status2 = await self.get_window_status()
+        window_status2 = await self.support.get_window_status(th=self.th1)
         asserts.assert_equal(window_status2, Clusters.AdministratorCommissioning.Enums.CommissioningWindowStatusEnum.kWindowNotOpen,
                              "Commissioning window is expected to be closed, but was found to be open")
 
@@ -149,9 +148,9 @@ class TC_CADMIN_1_22_24(MatterBaseTest):
         # TODO: Issue noticed when initially attempting to check window status after waiting for timeout to occur, issue is detailed here: https://github.com/project-chip/connectedhomeip/issues/35983
         # Workaround in place below until above issue resolved
         try:
-            window_status = await self.get_window_status()
+            window_status = await self.support.get_window_status(th=self.th1)
         except asyncio.CancelledError:
-            window_status = await self.get_window_status()
+            window_status = await self.support.get_window_status(th=self.th1)
 
         asserts.assert_equal(window_status, Clusters.AdministratorCommissioning.Enums.CommissioningWindowStatusEnum.kWindowNotOpen,
                              "Commissioning window is expected to be closed, but was found to be open")
@@ -170,7 +169,7 @@ class TC_CADMIN_1_22_24(MatterBaseTest):
                                  "Expected to error as we provided failure value for opening commissioning window")
 
         self.step(6)
-        window_status2 = await self.get_window_status()
+        window_status2 = await self.support.get_window_status(th=self.th1)
         asserts.assert_equal(window_status2, Clusters.AdministratorCommissioning.Enums.CommissioningWindowStatusEnum.kWindowNotOpen,
                              "Commissioning window is expected to be closed, but was found to be open")
 

--- a/src/python_testing/TC_CADMIN_1_22_24.py
+++ b/src/python_testing/TC_CADMIN_1_22_24.py
@@ -43,6 +43,7 @@ from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_bod
 from mobly import asserts
 from support_modules.cadmin_support import CADMINSupport
 
+
 class TC_CADMIN_1_22_24(MatterBaseTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -49,7 +49,7 @@ from time import sleep
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
-from chip.ChipDeviceCtrl import ChipStackError
+from chip.exceptions import ChipStackError
 from chip.tlv import TLVReader
 from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
                                                                        default_matter_test_main)

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -49,6 +49,7 @@ from time import sleep
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
+from chip.ChipDeviceCtrl import ChipStackError
 from chip.tlv import TLVReader
 from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
                                                                        default_matter_test_main)

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -60,6 +60,7 @@ from support_modules.cadmin_support import CADMINSupport
 opcreds = Clusters.OperationalCredentials
 nonce = random.randbytes(32)
 
+
 class TC_CADMIN(MatterBaseTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -297,6 +298,7 @@ class TC_CADMIN(MatterBaseTest):
     @async_test_body
     async def test_TC_CADMIN_1_4(self):
         await self.combined_commission_val_steps(commission_type="BCM")
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_CADMIN_1_3_4.py
+++ b/src/python_testing/TC_CADMIN_1_3_4.py
@@ -49,8 +49,6 @@ from time import sleep
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
-from chip.exceptions import ChipStackError
-from chip.interaction_model import Status
 from chip.tlv import TLVReader
 from matter_testing_infrastructure.chip.testing.matter_testing import (MatterBaseTest, TestStep, async_test_body,
                                                                        default_matter_test_main)

--- a/src/python_testing/TC_CADMIN_1_9.py
+++ b/src/python_testing/TC_CADMIN_1_9.py
@@ -44,6 +44,7 @@ from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_bod
 from mobly import asserts
 from support_modules.cadmin_support import CADMINSupport
 
+
 class TC_CADMIN_1_9(MatterBaseTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -68,9 +69,9 @@ class TC_CADMIN_1_9(MatterBaseTest):
         ctx = asserts.assert_raises(ChipStackError)
         with ctx:
             await self.th2.CommissionOnNetwork(
-                nodeId=self.dut_node_id, 
+                nodeId=self.dut_node_id,
                 setupPinCode=setup_code,
-                filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, 
+                filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR,
                 filter=self.discriminator
             )
         errcode = PyChipError.from_code(ctx.exception.err)
@@ -96,7 +97,6 @@ class TC_CADMIN_1_9(MatterBaseTest):
             # TODO: Adding try or except clause here as the errcode code be either 50 for timeout or 3 for incorrect state at this time
             # until issue mentioned in https://github.com/project-chip/connectedhomeip/issues/34383 can be resolved
             asserts.assert_in(errcode.sdk_code, [expectedErrCode, 3], 'Unexpected error code returned from CommissioningComplete')
-
 
     def steps_TC_CADMIN_1_9(self) -> list[TestStep]:
         return [

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -1,3 +1,19 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 """
 Support module for CADMIN test modules containing shared functionality.
 """

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -62,7 +62,7 @@ class CADMINSupport:
     ) -> CommissioningParameters:
         """
         Open a commissioning window with the specified parameters.
-        
+
         Args:
             th: Controller to use
             timeout: Window timeout in seconds

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -9,7 +9,6 @@ from time import sleep
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.ChipDeviceCtrl import CommissioningParameters
-from chip.exceptions import ChipStackError
 from chip.interaction_model import Status
 from mdns_discovery import mdns_discovery
 from mobly import asserts

--- a/src/python_testing/support_modules/cadmin_support.py
+++ b/src/python_testing/support_modules/cadmin_support.py
@@ -1,0 +1,127 @@
+"""
+Support module for CADMIN test modules containing shared functionality.
+"""
+
+import logging
+import random
+from time import sleep
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.ChipDeviceCtrl import CommissioningParameters
+from chip.exceptions import ChipStackError
+from chip.interaction_model import Status
+from mdns_discovery import mdns_discovery
+from mobly import asserts
+
+
+class CADMINSupport:
+    def __init__(self, test_instance):
+        self.test = test_instance
+
+    async def get_fabrics(self, th: ChipDeviceCtrl, fabric_filtered: bool = True) -> int:
+        """Get fabrics information from the device."""
+        OC_cluster = Clusters.OperationalCredentials
+        fabric_info = await self.test.read_single_attribute_check_success(
+            dev_ctrl=th,
+            fabric_filtered=fabric_filtered,
+            endpoint=0,
+            cluster=OC_cluster,
+            attribute=OC_cluster.Attributes.Fabrics
+        )
+        return fabric_info
+
+    async def read_currentfabricindex(self, th: ChipDeviceCtrl) -> int:
+        """Read the current fabric index from the device."""
+        cluster = Clusters.OperationalCredentials
+        attribute = Clusters.OperationalCredentials.Attributes.CurrentFabricIndex
+        current_fabric_index = await self.test.read_single_attribute_check_success(
+            dev_ctrl=th,
+            endpoint=0,
+            cluster=cluster,
+            attribute=attribute
+        )
+        return current_fabric_index
+
+    async def get_txt_record(self):
+        discovery = mdns_discovery.MdnsDiscovery(verbose_logging=True)
+        comm_service = await discovery.get_commissionable_service(
+            discovery_timeout_sec=240,
+            log_output=False,
+        )
+        return comm_service
+
+    async def open_commissioning_window(
+        self,
+        th: ChipDeviceCtrl,
+        timeout: int,
+        node_id: int,
+        discriminator: int = None,
+        option: int = 1,
+        iteration: int = 10000
+    ) -> CommissioningParameters:
+        """
+        Open a commissioning window with the specified parameters.
+        
+        Args:
+            th: Controller to use
+            timeout: Window timeout in seconds
+            node_id: Target node ID
+            discriminator: Optional discriminator value
+            option: Commissioning option (default: 1)
+            iteration: Number of iterations (default: 10000)
+        """
+        try:
+            params = await th.OpenCommissioningWindow(
+                nodeid=node_id,
+                timeout=timeout,
+                iteration=iteration,
+                discriminator=discriminator if discriminator is not None else random.randint(0, 4095),
+                option=option
+            )
+            return params
+        except Exception as e:
+            logging.exception('Error running OpenCommissioningWindow %s', e)
+            asserts.fail('Failed to open commissioning window')
+
+    async def write_nl_attr(self, dut_node_id: int, th: ChipDeviceCtrl, attr_val: object):
+        result = await th.WriteAttribute(nodeid=dut_node_id, attributes=[(0, attr_val)])
+        asserts.assert_equal(result[0].Status, Status.Success, f"{th} node label write failed")
+
+    async def read_nl_attr(self, dut_node_id: int, th: ChipDeviceCtrl, attr_val: object):
+        try:
+            await th.ReadAttribute(nodeid=dut_node_id, attributes=[(0, attr_val)])
+        except Exception as e:
+            asserts.assert_equal(e.err, "Received error message from read attribute attempt")
+            self.print_step(0, e)
+
+    async def get_window_status(self, th: ChipDeviceCtrl) -> int:
+        """Get the current commissioning window status."""
+        AC_cluster = Clusters.AdministratorCommissioning
+        window_status = await self.test.read_single_attribute_check_success(
+            dev_ctrl=th,
+            fabric_filtered=False,
+            endpoint=0,
+            cluster=AC_cluster,
+            attribute=AC_cluster.Attributes.WindowStatus
+        )
+        return window_status
+
+    def generate_unique_random_value(self, exclude_value: int) -> int:
+        """Generate a random value that's different from the specified value."""
+        while True:
+            random_value = random.randint(10000000, 99999999)
+            if random_value != exclude_value:
+                return random_value
+
+    async def revoke_commissioning(self, th: ChipDeviceCtrl, node_id: int):
+        """Revoke the current commissioning window."""
+        revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
+        await th.SendCommand(
+            nodeid=node_id,
+            endpoint=0,
+            payload=revokeCmd,
+            timedRequestTimeoutMs=6000
+        )
+        # The failsafe cleanup is scheduled after the command completes
+        sleep(1)


### PR DESCRIPTION
**Adding CADMIN support module for task #[514](https://github.com/project-chip/matter-test-scripts/issues/514)**
- Created CADMIN support module "cadmin_support.py" for functions to share among CADMIN tests
- Created new folder to house support modules "support_modules" for easy use in test modules
- Updated current CADMIN tests to initialize CADMINSupport class to use functions in created "cadmin_support.py" support module

#### Testing
- WSL
