### PR TITLE
Energy Management App - enabled ConnectMaxTimeSeconds attribute to Network Commissioning Cluster for WiFi commissioning

### DIFF
--- a/examples/energy-management-app/energy-management-common/energy-management-app.matter
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.matter
@@ -2696,6 +2696,7 @@ endpoint 0 {
   server cluster NetworkCommissioning {
     ram      attribute maxNetworks;
     callback attribute networks;
+    ram      attribute connectMaxTimeSeconds default = 20;
     ram      attribute interfaceEnabled;
     ram      attribute lastNetworkingStatus;
     ram      attribute lastNetworkID;

--- a/examples/energy-management-app/energy-management-common/energy-management-app.zap
+++ b/examples/energy-management-app/energy-management-common/energy-management-app.zap
@@ -1542,6 +1542,22 @@
               "reportableChange": 0
             },
             {
+              "name": "ConnectMaxTimeSeconds",
+              "code": 3,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int8u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "20",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
               "name": "InterfaceEnabled",
               "code": 4,
               "mfgCode": null,


### PR DESCRIPTION
Fixes #37868 


#### Testing

Tested with ESP32 target and Matter Test Harness (1.5 TE1)