### PR TITLE
Switch to ubuntu-latest for ZAP workflows

### DIFF
--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -28,7 +28,7 @@ jobs:
     zap_regeneration:
         name: ZAP Regeneration
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:119
         defaults:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -33,7 +33,7 @@ jobs:
     zap_templates:
         name: ZAP templates generation
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:119
         defaults:


### PR DESCRIPTION
All other images are already updated. GitHub will start failing jobs for old ubuntu, so switch to new one:

![image](https://github.com/user-attachments/assets/bdc6d16b-82e2-4511-a01b-444b7c552484)

https://github.com/actions/runner-images/issues/11101 for details

#### Testing

CI will validate
