### PR TITLE
Adding a GitHub Security Policy, that redirects to CSA's Vulnerability Reporting page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+Thank you for helping us keep the Matter SDK secure!
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please follow the instructions at
+[Report a Vulnerability | How to Report - CSA-IOT](https://csa-iot.org/vulnerability-reporting/).
+
+We appreciate responsible disclosure and will work to address any issues
+promptly.


### PR DESCRIPTION
- Adding a GitHub Security Policy that redirects to CSA's Vulnerability Reporting Page.
- This will be visible in "Security" Tab, which is often where Security Researchers go to search for information on reporting issues. 
- Without the policy, a non-member of project-chip will see the following when clicking "Security" Tab
![image](https://github.com/user-attachments/assets/25118e61-6962-463a-8ec9-901a714d2c5b)

#### Testing

It is just a Markdown file, no need.