### PR TITLE
Minor fixes for nm mapping

### DIFF
--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -416,7 +416,7 @@ def build_treemap(
     root = f"FILE: {name}"
     if zoom:
         root = root + f" (FILTER: {zoom})"
-    data: dict[str, list] = dict(name=[root], parent=[""], size=[0], hover=[""], name_with_size=[""], short_name=[""])
+    data: dict[str, list] = dict(name=[root], parent=[""], size=[0], hover=[""], name_with_size=[""], short_name=[""], id=[root])
 
     known_parents: set[str] = set()
     total_sizes: dict = {}
@@ -445,15 +445,19 @@ def build_treemap(
                 continue
 
         partial = ""
+        path = ""
         for name in tree_name[:-1]:
             if not partial:
                 next_value = name
             else:
                 next_value = partial + separator + name
+            parent_path = path if partial else root
+            path = path + separator + name
             if next_value not in known_parents:
                 known_parents.add(next_value)
                 data["name"].append(next_value)
-                data["parent"].append(partial if partial else root)
+                data["id"].append(path)
+                data["parent"].append(parent_path)
                 data["size"].append(0)
                 data["hover"].append(next_value)
                 data["name_with_size"].append("")
@@ -461,9 +465,11 @@ def build_treemap(
             total_sizes[next_value] = total_sizes.get(next_value, 0) + symbol.size
             partial = next_value
 
+
         # the name MUST be added
         data["name"].append(cxxfilt.demangle(symbol.name))
-        data["parent"].append(partial if partial else root)
+        data["id"].append(symbol.name)
+        data["parent"].append(path if partial else root)
         data["size"].append(symbol.size)
         data["hover"].append(f"{symbol.name} of type {symbol.symbol_type}")
         data["name_with_size"].append("")
@@ -492,7 +498,7 @@ def build_treemap(
     fig = figure_generator(
         data,
         names="name_with_size",
-        ids="name",
+        ids="id",
         parents="parent",
         values="size",
         maxdepth=max_depth,

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -465,7 +465,6 @@ def build_treemap(
             total_sizes[next_value] = total_sizes.get(next_value, 0) + symbol.size
             partial = next_value
 
-
         # the name MUST be added
         data["name"].append(cxxfilt.demangle(symbol.name))
         data["id"].append(symbol.name)

--- a/scripts/tools/file_size_from_nm.py
+++ b/scripts/tools/file_size_from_nm.py
@@ -873,10 +873,13 @@ def main(
     symbols, separator = fetch_symbols(elf_file, __FETCH_STYLES__[fetch_via], glob_filter)
     title = elf_file
 
+    if glob_filter:
+        title += f" FILTER {glob_filter}"
+
     if diff:
         diff_symbols, _ = fetch_symbols(diff, __FETCH_STYLES__[fetch_via], glob_filter)
         symbols = compute_symbol_diff(symbols, diff_symbols)
-        title = f"{elf_file} COMPARED TO {diff}"
+        title += f" COMPARED TO {diff}"
 
     build_treemap(
         title, symbols, separator, __CHART_STYLES__[display_type], __COLOR_SCALES__[color], max_depth, zoom, strip


### PR DESCRIPTION
- Fix conflict on `parent id` choice due to name (conflict between std namespaces and c-function std)
- fix truncation of method names by 2 bytes 
- Add a `--glob-filter` support to quickly be able to filter sizes for various intersting files/classes

#### Testing

Some unit tests added, ran pytest.
Local run, observed results

![image](https://github.com/user-attachments/assets/8672e220-90ea-46a9-b186-b2312564c086)

![image](https://github.com/user-attachments/assets/153aaee3-e5e6-4bdb-9268-ef390683c37c)


