### PR TITLE
[Silabs] Fix race condition in the UART driver used by the matter shell

### DIFF
--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -288,7 +288,7 @@ static uint16_t RetrieveFromFifo(Fifo_t * fifo, uint8_t * pData, uint16_t SizeTo
     VerifyOrDie(SizeToRead <= fifo->MaxSize);
     CORE_DECLARE_IRQ_STATE;
 
-    uint16_t ReadSize        = std::min(SizeToRead, AvailableDataCount(fifo));
+    uint16_t ReadSize = std::min(SizeToRead, AvailableDataCount(fifo));
 
     CORE_ENTER_ATOMIC();
     uint16_t nBytesBeforWrap = (fifo->MaxSize - fifo->Head);


### PR DESCRIPTION
### Description

We are using some FIFO API like **RetrieveFromFifo**, **WriteToFifo**, **AvailableDataCount** and **RemainingSpace** that are use by the UART DMA interrupt and use by the MatterShell thread.

Those API were not thread safe. A race condition happens when **AvailableDataCount** was checking the number of byte available in the matter shell thread while the UART DMA interrupt was writing to the FIFO.


#### Testing

I've tested the fix with a BRD4186C. My endurance test consist of sending a custom CLI command every 250ms for a complete weekend.
