### PR TITLE
[camera-controller] Fix run time error during initialization

### DIFF
--- a/examples/camera-controller/commands/common/CHIPCommand.cpp
+++ b/examples/camera-controller/commands/common/CHIPCommand.cpp
@@ -50,6 +50,7 @@ constexpr char kCDTrustStorePathVariable[]      = "CAMERACONTROLLER_CD_TRUST_STO
 
 const chip::Credentials::AttestationTrustStore * CHIPCommand::sTrustStore = nullptr;
 chip::Credentials::GroupDataProviderImpl CHIPCommand::sGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
+chip::Crypto::RawKeySessionKeystore CHIPCommand::sSessionKeystore;
 
 namespace {
 
@@ -109,6 +110,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     factoryInitParams.operationalKeystore      = &mOperationalKeystore;
     factoryInitParams.opCertStore              = &mOpCertStore;
     factoryInitParams.enableServerInteractions = NeedsOperationalAdvertising();
+    factoryInitParams.sessionKeystore          = &sSessionKeystore;
     factoryInitParams.dataModelProvider        = chip::app::CodegenDataModelProviderInstance(&mDefaultStorage);
 
     // Init group data provider that will be used for all group keys and IPKs for the


### PR DESCRIPTION
```
yufengw@yufengw-MX70:~/connectedhomeip$ ./out/linux-x64-camera-controller/camera-controller
[1741240469.117] [168734:168734] [DL] ChipLinuxStorage::Init: Using KVS config file: /tmp/chip_tool_kvs
[1741240469.118] [168734:168734] [-] src/credentials/GroupDataProviderImpl.cpp:822: Error 0x00000003 at ../../examples/camera-controller/commands/common/CHIPCommand.cpp:121
[1741240469.118] [168734:168734] [-] Run command failure: src/credentials/GroupDataProviderImpl.cpp:822: Error 0x00000003
```
The sSessionKeystore was accidentally removed while addressing the review comments to clean up the ICD.

#### Testing

Manually validated
