### PR TITLE
Add verbose flag to build_examples.py

### DIFF
--- a/scripts/build/build/__init__.py
+++ b/scripts/build/build/__init__.py
@@ -19,11 +19,12 @@ class Context:
          to generate make/ninja instructions and to compile.
       """
 
-    def __init__(self, runner, repository_path: str, output_prefix: str, ninja_jobs: int):
+    def __init__(self, runner, repository_path: str, output_prefix: str, verbose: bool, ninja_jobs: int):
         self.builders = []
         self.runner = runner
         self.repository_path = repository_path
         self.output_prefix = output_prefix
+        self.verbose = verbose
         self.ninja_jobs = ninja_jobs
         self.completed_steps = set()
 
@@ -38,7 +39,8 @@ class Context:
             found = False
             for choice in BUILD_TARGETS:
                 builder = choice.Create(target, self.runner, self.repository_path,
-                                        self.output_prefix, self.ninja_jobs, options)
+                                        self.output_prefix, self.verbose, self.ninja_jobs,
+                                        options)
                 if builder:
                     self.builders.append(builder)
                     found = True

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -389,7 +389,7 @@ class BuildTarget:
         return _StringIntoParts(value, suffix, self.fixed_targets, self.modifiers)
 
     def Create(self, name: str, runner, repository_path: str, output_prefix: str,
-               ninja_jobs: int, builder_options: BuilderOptions):
+               verbose: bool, ninja_jobs: int, builder_options: BuilderOptions):
 
         parts = self.StringIntoTargetParts(name)
 
@@ -406,6 +406,7 @@ class BuildTarget:
         builder.target = self
         builder.identifier = name
         builder.output_dir = os.path.join(output_prefix, name)
+        builder.verbose = verbose
         builder.ninja_jobs = ninja_jobs
         builder.chip_dir = os.path.abspath(repository_path)
         builder.options = builder_options

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -79,6 +79,11 @@ def ValidateTargetNames(context, parameter, values):
     type=click.Choice(__LOG_LEVELS__.keys(), case_sensitive=False),
     help='Determines the verbosity of script output.')
 @click.option(
+    '--verbose',
+    default=False,
+    is_flag=True,
+    help='Pass verbose flag to ninja.')
+@click.option(
     '--target',
     default=[],
     multiple=True,
@@ -142,7 +147,7 @@ def ValidateTargetNames(context, parameter, values):
         'Set pigweed command launcher. E.g.: "--pw-command-launcher=ccache" '
         'for using ccache when building examples.'))
 @click.pass_context
-def main(context, log_level, target, enable_link_map_file, repo,
+def main(context, log_level, verbose, target, enable_link_map_file, repo,
          out_prefix, ninja_jobs, pregen_dir, clean, dry_run, dry_run_output,
          enable_flashbundle, no_log_timestamps, pw_command_launcher):
     # Ensures somewhat pretty logging of what is going on
@@ -168,7 +173,9 @@ before running this script.
     logging.info('Building targets: %s', CommaSeparate(requested_targets))
 
     context.obj = build.Context(
-        repository_path=repo, output_prefix=out_prefix, ninja_jobs=ninja_jobs, runner=runner)
+        repository_path=repo, output_prefix=out_prefix, verbose=verbose,
+        ninja_jobs=ninja_jobs, runner=runner
+    )
     context.obj.SetupBuilders(targets=requested_targets, options=BuilderOptions(
         enable_link_map_file=enable_link_map_file,
         enable_flashbundle=enable_flashbundle,

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -95,6 +95,8 @@ class GnBuilder(Builder):
         self.PreBuildCommand()
 
         cmd = ['ninja', '-C', self.output_dir]
+        if self.verbose:
+            cmd.append('-v')
         if self.ninja_jobs is not None:
             cmd.append('-j' + str(self.ninja_jobs))
         if self.build_command:


### PR DESCRIPTION
### Feature
Oftentimes verbose output from `ninja` is helpful for debugging when using `build_examples.py` and the current way to do it is to use `--dry-run` flag and then run the commands manually and modify the one with `ninja`. Adding `--verbose` flag to `build_examples.py` makes that process simpler and more straightforward.

### Testing
Tested the script with and without the flag and the result is as expected - call to `ninja` has `-v` flag when we pass `--verbose` to the `build_examples.py`.