### PR TITLE
ESP32: handle nimble_port_init's return values based on idf version

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -942,8 +942,13 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     SuccessOrExit(err);
 #endif
 
+// For ESP-IDF 5.0.1 and below, nimble_port_init() returns void
+#if ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 0, 1)
+    nimble_port_init();
+#else
     err = MapBLEError(nimble_port_init());
     SuccessOrExit(err);
+#endif
 
     /* Initialize the NimBLE host configuration. */
     ble_hs_cfg.reset_cb          = bleprph_on_reset;


### PR DESCRIPTION
nimble_port_init() on idf v5.0.1 and prior returns void, and from v5.0.2 it returns esp_err_t.

Regression introduced in https://github.com/project-chip/connectedhomeip/pull/37488

#### Testing

Manually verified building/flashing/commissioning the application with esp-idf v4.4.3