### PR TITLE
Fix clearing up Door Lock users and credentials

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -2173,6 +2173,16 @@ bool DoorLockServer::clearFabricFromUsers(chip::EndpointId endpointId, chip::Fab
             user.lastModifiedBy = kUndefinedFabricIndex;
         }
 
+        if (user.createdBy == kUndefinedFabricIndex && user.lastModifiedBy == kUndefinedFabricIndex)
+        {
+            user.userName       = ""_span;
+            user.userUniqueId   = 0;
+            user.userStatus     = UserStatusEnum::kAvailable;
+            user.userType       = UserTypeEnum::kUnrestrictedUser;
+            user.credentialRule = CredentialRuleEnum::kSingle;
+            user.credentials    = {};
+        }
+
         if (!emberAfPluginDoorLockSetUser(endpointId, userIndex, user.createdBy, user.lastModifiedBy, user.userName,
                                           user.userUniqueId, user.userStatus, user.userType, user.credentialRule,
                                           user.credentials.data(), user.credentials.size()))
@@ -3307,6 +3317,12 @@ bool DoorLockServer::clearFabricFromCredentials(chip::EndpointId endpointId, Cre
         if (credential.lastModifiedBy == fabricToRemove)
         {
             credential.lastModifiedBy = kUndefinedFabricIndex;
+        }
+
+        if (credential.createdBy == kUndefinedFabricIndex && credential.lastModifiedBy == kUndefinedFabricIndex)
+        {
+            credential.status         = DlCredentialStatus::kAvailable;
+            credential.credentialData = {};
         }
 
         if (!emberAfPluginDoorLockSetCredential(endpointId, credentialIndex, credential.createdBy, credential.lastModifiedBy,


### PR DESCRIPTION
### Problem
Door Lock user/credential is not cleared during factory reset. The issue was observed on nRF52 and nRF53 platforms.

#### Reproduction steps:
1. Commission device
2. Set user
```
chip-tool doorlock set-user 0 1 xxx 6452 1 0 0 1 1  --timedInteractionTimeoutMs 1000
```
3. Set credential
```
chip-tool doorlock set-credential 0 '{ "credentialType": 1, "credentialIndex": 1 }' "12345678" 1 null null 1 1 --timedInteractionTimeoutMs 10000
```
4. Factory reset
5. Commission device
6. Get user
```
chip-tool doorlock get-user 1 1 1
```
##### Result
```
GetUserResponse: {
  userIndex: 1
  userName: xxx
  userUniqueID: 6452
  userStatus: 1
  userType: 0
  credentialRule: 0
  credentials: 1 entries
    [1]: {
      CredentialType: 1
      CredentialIndex: 1
     }
  creatorFabricIndex: 0
  lastModifiedFabricIndex: 0
  nextUserIndex: null
 }
```


### Changes

Properly clear user/credential by setting status to Available and clearing other attributes when removing user/credential during `OnFabricRemoved`.


### Testing
Manually verified removal of user/credential during factory reset.
