### PR TITLE
[Darwin] MTRDevice shouldn't persist data version if report gets interrupted

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceClusterData.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceClusterData.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_TESTABLE
 @interface MTRDeviceClusterData : NSObject <NSSecureCoding, NSCopying>
 @property (nonatomic, nullable) NSNumber * dataVersion;
+@property (nonatomic, nullable) NSNumber * pendingDataVersion; // for holding new data version during a report
 @property (nonatomic, readonly) NSDictionary<NSNumber *, MTRDeviceDataValueDictionary> * attributes; // attributeID => data-value dictionary
 
 - (void)storeValue:(MTRDeviceDataValueDictionary _Nullable)value forAttribute:(NSNumber *)attribute;

--- a/src/darwin/Framework/CHIP/MTRDeviceClusterData.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceClusterData.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 MTR_TESTABLE
 @interface MTRDeviceClusterData : NSObject <NSSecureCoding, NSCopying>
 @property (nonatomic, nullable) NSNumber * dataVersion;
-@property (nonatomic, nullable) NSNumber * pendingDataVersion; // for holding new data version during a report
+@property (nonatomic, nullable) NSNumber * pendingDataVersion; // for holding new data version during a report, and not encoded
 @property (nonatomic, readonly) NSDictionary<NSNumber *, MTRDeviceDataValueDictionary> * attributes; // attributeID => data-value dictionary
 
 - (void)storeValue:(MTRDeviceDataValueDictionary _Nullable)value forAttribute:(NSNumber *)attribute;

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1873,6 +1873,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         return;
     }
 
+    // Do not persist partial data in the middle of receiving a report. _handleReportEnd will schedule next persistence
+    if (_receivingReport) {
+        return;
+    }
+
     NSDate * lastReportTime = [_mostRecentReportTimes lastObject];
     NSTimeInterval intervalSinceLastReport = -[lastReportTime timeIntervalSinceNow];
     if (intervalSinceLastReport < [self _reportToPersistenceDelayTimeAfterMutiplier]) {
@@ -2072,6 +2077,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     _receivingPrimingReport = NO;
     _estimatedStartTimeFromGeneralDiagnosticsUpTime = nil;
 
+    [self _commitPendingDataVersions];
     [self _scheduleClusterDataPersistence];
 
     // After the handling of the report, if we detected a device configuration change, notify the delegate
@@ -2562,6 +2568,30 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     MTR_LOG_DEBUG("%@ _getCachedDataVersions dataVersions count: %lu", self, static_cast<unsigned long>(dataVersions.count));
 
     return dataVersions;
+}
+
+- (void)_commitPendingDataVersionsForClusterPath:(MTRClusterPath *)path
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+    MTRDeviceClusterData * clusterData = _clusterDataToPersist[path];
+    if (clusterData.pendingDataVersion) {
+        clusterData.dataVersion = clusterData.pendingDataVersion;
+        clusterData.pendingDataVersion = nil;
+    }
+}
+
+- (void)_commitPendingDataVersions
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    if (!_clusterDataToPersist) {
+        // nothing to do
+        return;
+    }
+
+    for (MTRClusterPath * path in _clusterDataToPersist) {
+        [self _commitPendingDataVersionsForClusterPath:path];
+    }
 }
 
 - (MTRDeviceDataValueDictionary _Nullable)_cachedAttributeValueForPath:(MTRAttributePath *)path
@@ -3976,7 +4006,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         clusterData = [[MTRDeviceClusterData alloc] initWithDataVersion:dataVersion attributes:nil];
         dataVersionChanged = YES;
     } else if (![clusterData.dataVersion isEqualToNumber:dataVersion]) {
-        clusterData.dataVersion = dataVersion;
+        clusterData.pendingDataVersion = dataVersion;
         dataVersionChanged = YES;
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -4000,7 +4000,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     os_unfair_lock_assert_owner(&self->_lock);
 
     if (dataVersion == nil || clusterPath == nil) {
-        MTR_LOG_ERROR("%@ Attempted to update data version with a nil value. ClusterPath: %@, NewVersion: %@", self, clusterPath, newVersion);
+        MTR_LOG_ERROR("%@ Attempted to update data version with a nil value. clusterPath: %@, dataVersion: %@", self, clusterPath, dataVersion);
         return;
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -4003,7 +4003,8 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
     // Update data version used for subscription filtering
     MTRDeviceClusterData * clusterData = [self _clusterDataForPath:clusterPath];
     if (!clusterData) {
-        clusterData = [[MTRDeviceClusterData alloc] initWithDataVersion:dataVersion attributes:nil];
+        clusterData = [[MTRDeviceClusterData alloc] init];
+        clusterData.pendingDataVersion = dataVersion;
         dataVersionChanged = YES;
     } else if (![clusterData.dataVersion isEqualToNumber:dataVersion]) {
         clusterData.pendingDataVersion = dataVersion;

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3999,6 +3999,11 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 {
     os_unfair_lock_assert_owner(&self->_lock);
 
+    if (dataVersion == nil || clusterPath == nil) {
+        MTR_LOG_ERROR("%@ Attempted to update data version with a nil value. ClusterPath: %@, NewVersion: %@", self, clusterPath, newVersion);
+        return;
+    }
+
     BOOL dataVersionChanged = NO;
     // Update data version used for subscription filtering
     MTRDeviceClusterData * clusterData = [self _clusterDataForPath:clusterPath];


### PR DESCRIPTION
Fixes #37364

See the issue for details. Also, this change also ensures that if persistence timer hits and MTRDevice is receiving a report, that persistence is postponed.

#### Testing

Adding unit test to test for when a report is interrupted.