### PR TITLE
Fix name conflicts in chef: Add namespace for chef window covering.

### DIFF
--- a/examples/chef/common/clusters/window-covering/chef-window-covering.cpp
+++ b/examples/chef/common/clusters/window-covering/chef-window-covering.cpp
@@ -29,6 +29,8 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using chip::Protocols::InteractionModel::Status;
 
+namespace ChefWindowCovering {
+
 constexpr size_t kWindowCoveringDelegateTableSize = MATTER_DM_WINDOW_COVERING_CLUSTER_SERVER_ENDPOINT_COUNT;
 static_assert(kWindowCoveringDelegateTableSize <= kEmberInvalidEndpointIndex, "WindowCovering Delegate table size error");
 
@@ -68,6 +70,7 @@ void InitChefWindowCoveringCluster()
         WindowCovering::SetDefaultDelegate(endpointId, gDelegateTable[epIndex].get());
     }
 }
+} // namespace ChefWindowCovering
 
 CHIP_ERROR WindowCovering::ChefDelegate::HandleMovement(WindowCoveringType type)
 {

--- a/examples/chef/common/clusters/window-covering/chef-window-covering.h
+++ b/examples/chef/common/clusters/window-covering/chef-window-covering.h
@@ -65,4 +65,6 @@ public:
 } // namespace app
 } // namespace chip
 
+namespace ChefWindowCovering {
 void InitChefWindowCoveringCluster();
+} // namespace ChefWindowCovering

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -362,7 +362,7 @@ void ApplicationInit()
 
 #ifdef MATTER_DM_PLUGIN_WINDOW_COVERING_SERVER
     ChipLogProgress(NotSpecified, "Initializing WindowCovering cluster delegate.");
-    InitChefWindowCoveringCluster();
+    ChefWindowCovering::InitChefWindowCoveringCluster();
 #endif // MATTER_DM_PLUGIN_WINDOW_COVERING_SERVER
 }
 


### PR DESCRIPTION
#### Testing

Compiled all chef devices using custom script -

```
import subprocess


def main():
    raw = subprocess.check_output(["ls", "devices"])
    device_files = raw.decode("ascii")
    for file_name in device_files.split("\n"):
        print("FILE_NAME:", file_name)
        if (not file_name.endswith(".matter")):
            continue
        device = file_name[:-len(".matter")]
        if (not device.startswith("rootnode_")):
            continue
        if device == "rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680":
            print(f"{device} is deprecated. Skipping.")
            continue
        print(f"Compiling {device} ...", flush=True)
        subprocess.check_call(["./chef.py", "-br", "-d", device, "-t", "linux"])
        print(f"Device {device} compiled successfully", flush=True)


if __name__ == "__main__":
    main()
```