### PR TITLE
[v1.4][ESP32] Fix total operation hours attribute value get incorrect

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -156,20 +156,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetUpTime(uint64_t & upTime)
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
 {
-    uint64_t upTime = 0;
-
-    if (GetUpTime(upTime) == CHIP_NO_ERROR)
-    {
-        uint32_t totalHours = 0;
-        if (ConfigurationMgr().GetTotalOperationalHours(totalHours) == CHIP_NO_ERROR)
-        {
-            VerifyOrReturnError(upTime / 3600 <= UINT32_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
-            totalOperationalHours = totalHours + static_cast<uint32_t>(upTime / 3600);
-            return CHIP_NO_ERROR;
-        }
-    }
-
-    return CHIP_ERROR_INVALID_TIME;
+    return ConfigurationMgr().GetTotalOperationalHours(totalOperationalHours);
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -90,24 +90,15 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
 void PlatformManagerImpl::_Shutdown()
 {
-    uint64_t upTime = 0;
+    uint32_t totalOperationalHours = 0;
 
-    if (GetDiagnosticDataProvider().GetUpTime(upTime) == CHIP_NO_ERROR)
+    if (ConfigurationMgr().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
     {
-        uint32_t totalOperationalHours = 0;
-
-        if (ConfigurationMgr().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
-        {
-            ConfigurationMgr().StoreTotalOperationalHours(totalOperationalHours + static_cast<uint32_t>(upTime / 3600));
-        }
-        else
-        {
-            ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
-        }
+        ConfigurationMgr().StoreTotalOperationalHours(totalOperationalHours);
     }
     else
     {
-        ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
+        ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
     }
 
     Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();


### PR DESCRIPTION
The total operation hours attribute value will add up time hours when read attribute, actually it has been increased every hour, after add the up time hours, the value will be incorrect.

This PR remove the up time hours.

Cherry pick https://github.com/project-chip/connectedhomeip/pull/37891

#### Testing
Test lighting-app example on ESP32-C3 DevKit board
