### PR TITLE
[nrfconnect] Fail ctest when it finds no tests

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -220,7 +220,7 @@ class NrfConnectBuilder(Builder):
             # Note: running zephyr/zephyr.elf has the same result except it creates
             # a flash.bin in the current directory. ctest has more options and does not
             # pollute the source directory
-            self._Execute(['ctest', '--build-nocmake', '-V', '--output-on-failure', '--test-dir', os.path.join(self.output_dir, 'nrfconnect')],
+            self._Execute(['ctest', '--build-nocmake', '-V', '--output-on-failure', '--test-dir', os.path.join(self.output_dir, 'nrfconnect'), '--no-tests=error'],
                           title='Run Tests ' + self.identifier)
 
     def _bundle(self):


### PR DESCRIPTION
Add `--no-tests=error` to `ctest` arguments to make it return error when it finds no tests.


#### Testing
Tested by running workflow with wrong `--test-dir`.
