### PR TITLE
Use a reference to the context on ServerClusterInterface::Startup

### DIFF
--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -85,10 +85,10 @@ CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, Da
     return builder.ReferenceExisting(GlobalAttributes());
 }
 
-CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext * context)
+CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext &context)
 {
     VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
-    mContext = context;
+    mContext = &context;
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -85,7 +85,7 @@ CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, Da
     return builder.ReferenceExisting(GlobalAttributes());
 }
 
-CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext &context)
+CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext & context)
 {
     VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
     mContext = &context;

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <app/server-cluster/ServerClusterInterface.h>
+#include <optional>
 
 namespace chip {
 namespace app {
@@ -45,7 +46,7 @@ public:
     /// been initialized.
     ///
     /// Call Shutdown to de-initialize the object.
-    CHIP_ERROR Startup(ServerClusterContext * context) override;
+    CHIP_ERROR Startup(ServerClusterContext & context) override;
     void Shutdown() override;
 
     [[nodiscard]] DataVersion GetDataVersion() const override { return mDataVersion; }

--- a/src/app/server-cluster/ServerClusterInterface.h
+++ b/src/app/server-cluster/ServerClusterInterface.h
@@ -46,8 +46,13 @@ public:
     /// Starts up the server cluster interface.
     ///
     /// The `context` lifetime must be guaranteed to last
-    /// until `Shutdown` is called.
-    virtual CHIP_ERROR Startup(ServerClusterContext * context) = 0;
+    /// until `Shutdown` is called:
+    ///
+    /// - You are allowed to take and use a pointer to it until
+    ///   shutdown is called.
+    /// - If context is needed, you SHOULD store a pointer rather
+    ///   than a copy to save RAM usage.
+    virtual CHIP_ERROR Startup(ServerClusterContext & context) = 0;
 
     /// A shutdown will always be paired with a corresponding Startup.
     virtual void Shutdown() = 0;

--- a/src/app/server-cluster/testing/TestServerClusterContext.h
+++ b/src/app/server-cluster/testing/TestServerClusterContext.h
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include "app/data-model-provider/Context.h"
 #include <app/data-model-provider/ActionContext.h>
+#include <app/data-model-provider/Context.h>
 #include <app/data-model-provider/Provider.h>
 #include <app/server-cluster/ServerClusterContext.h>
 #include <app/server-cluster/testing/EmptyProvider.h>
@@ -59,7 +59,7 @@ public:
     }
 
     /// Get a stable pointer to the underlying context
-    app::ServerClusterContext * Get() { return &mContext; }
+    app::ServerClusterContext & Get() { return mContext; }
 
     /// Create a new context bound to this test context
     app::ServerClusterContext Create()

--- a/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
+++ b/src/data-model-providers/codegen/ServerClusterInterfaceRegistry.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ServerClusterInterfaceRegistry::Register(ServerClusterRegistration & 
 
     if (mContext.has_value())
     {
-        ReturnErrorOnFailure(entry.serverClusterInterface->Startup(&*mContext));
+        ReturnErrorOnFailure(entry.serverClusterInterface->Startup(*mContext));
     }
 
     entry.next     = mRegistrations;
@@ -193,7 +193,7 @@ CHIP_ERROR ServerClusterInterfaceRegistry::SetContext(ServerClusterContext && co
 
     for (ServerClusterRegistration * registration = mRegistrations; registration != nullptr; registration = registration->next)
     {
-        CHIP_ERROR err = registration->serverClusterInterface->Startup(&*mContext);
+        CHIP_ERROR err = registration->serverClusterInterface->Startup(*mContext);
         if (err != CHIP_NO_ERROR)
         {
 #if CHIP_ERROR_LOGGING

--- a/src/data-model-providers/codegen/tests/TestServerClusterInterfaceRegistry.cpp
+++ b/src/data-model-providers/codegen/tests/TestServerClusterInterfaceRegistry.cpp
@@ -76,7 +76,7 @@ class CannotStartUpCluster : public FakeServerClusterInterface
 {
 public:
     CannotStartUpCluster(EndpointId endpoint, ClusterId id) : FakeServerClusterInterface(endpoint, id) {}
-    CHIP_ERROR Startup(ServerClusterContext * context) override { return CHIP_ERROR_BUSY; }
+    CHIP_ERROR Startup(ServerClusterContext & context) override { return CHIP_ERROR_BUSY; }
 };
 
 struct TestServerClusterInterfaceRegistry : public ::testing::Test


### PR DESCRIPTION
This is to make it clear that the input value is never null.

This is to address https://github.com/project-chip/connectedhomeip/pull/37851#discussion_r1985262059

#### Testing
CI and compilation should still pass