### PR TITLE
Fix error handling in XPC version of invokeCommands.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -552,7 +552,11 @@ MTR_DEVICE_COMPLEX_REMOTE_XPC_GETTER(readAttributePaths
                              return;
                          }
 
-                         completion(responses, nil);
+                         if (error != nil) {
+                             MTR_LOG_ERROR("%@ got error trying to invokeCommands: %@", self, error);
+                         }
+
+                         completion(responses, error);
                      });
                  }];
     } @catch (NSException * exception) {


### PR DESCRIPTION
Two issues:

1. If we got an error we did not log it.
2. If we got an error we did not actually propagate it out to the API consumer.

#### Testing

Manual testing that devices still work, but not sure how to test this error path.
