### PR TITLE
Chef window covering compilation - Fix missing dependency on esp32 target

### DIFF
--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SRC_DIRS_LIST
                       "${CHEF}/common/clusters/target-navigator/"
                       "${CHEF}/common/clusters/temperature-control/"
                       "${CHEF}/common/clusters/wake-on-lan/"
+                      "${CHEF}/common/clusters/window-covering/"
                       "${CHIP_ROOT}/zzz_generated/app-common/app-common/zap-generated/attributes"
 )
 


### PR DESCRIPTION
#### Testing

Will be compiled in CI