### PR TITLE
[chip-repl] Fix for dependency failures: keeping pygobject==3.50.0

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -405,7 +405,7 @@ chip_python_wheel_action("chip-repl") {
   } else if (current_os == "linux") {
     py_package_reqs += [
       "dbus-python==1.2.18",
-      "pygobject",
+      "pygobject==3.50.0",
     ]
   }
 


### PR DESCRIPTION
- temporary workaround: keeping pygobject==3.50.0 to avoid dependency failures, that occured when pygobject was updated to a version that requires  `libgirepository-2.0-dev`

```bash
      ../meson.build:31:9: ERROR: Dependency 'girepository-2.0' is required but not found.
```
- Proper fix will be to change `libgirepository1.0-dev` to `libgirepository-2.0-dev` on all docker containers, scripts and Documentation. This will be done incrementally

#### Testing

CI Testing