### PR TITLE
ESP32: bump encrypted ota component and fix the build errors

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -444,6 +444,10 @@ if (CONFIG_SEC_CERT_DAC_PROVIDER)
     list(APPEND matter_requires espressif__esp_secure_cert_mgr)
 endif()
 
+if (CONFIG_ENABLE_ENCRYPTED_OTA)
+    list(APPEND matter_requires espressif__esp_encrypted_img)
+endif()
+
 add_prebuilt_library(matterlib "${CMAKE_CURRENT_BINARY_DIR}/lib/libCHIP.a"
                      REQUIRES ${matter_requires})
 

--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -11,7 +11,7 @@ dependencies:
             - if: "idf_version >=4.3"
 
     espressif/esp_encrypted_img:
-        version: "2.1.0"
+        version: "2.3.0"
         require: public
         rules:
             - if: "idf_version >=4.4"

--- a/docs/platforms/esp32/ota.md
+++ b/docs/platforms/esp32/ota.md
@@ -109,23 +109,23 @@ Please follow the steps below to generate an application image for OTA upgrades:
     [esp_enc_img_gen.py](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/tools/esp_enc_img_gen.py)
     script.
 
-    -   Use the following command to encrypt the OTA image with the public key:
+    Use the following command to encrypt the OTA image with the public key:
 
-        ```
-        python3 esp_enc_img_gen.py encrypt lighting-app.bin esp_image_encryption_public_key.pem lighting-app-encrypted.bin
-        ```
+    ```
+    python3 esp_enc_img_gen.py encrypt lighting-app.bin esp_image_encryption_public_key.pem lighting-app-encrypted.bin
+    ```
 
     Optionally, you can use the cmake function `create_esp_enc_img()` to encrypt
     the OTA image during the build process. Please find the usage below. This is
     also demonstrated in the `examples/lighting-app/esp32/main/CMakeLists.txt`
     file.
 
-        ```
-        create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
-                           ${project_dir}/esp_image_encryption_public_key.pem
-                           ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
-                           app)
-        ```
+    ```
+    create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+                       ${project_dir}/esp_image_encryption_public_key.pem
+                       ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+                       app)
+    ```
 
 3.  Append the Matter OTA header
 

--- a/docs/platforms/esp32/ota.md
+++ b/docs/platforms/esp32/ota.md
@@ -120,17 +120,19 @@ Please follow the steps below to generate an application image for OTA upgrades:
     also demonstrated in the `examples/lighting-app/esp32/main/CMakeLists.txt`
     file.
 
-         ```
-             create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
-                                 ${project_dir}/esp_image_encryption_public_key.pem
-                                 ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
-                                 app)
-         ```
+        ```
+        create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+                           ${project_dir}/esp_image_encryption_public_key.pem
+                           ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+                           app)
+        ```
 
 3.  Append the Matter OTA header
 
     ```
-    src/app/ota_image_tool.py create --vendor-id 0xFFF1 --product-id 0x8000 --version 2 --version-str "v2.0" -da sha256 lighting-app-encrypted.bin lighting-app-encrypted-ota.bin
+    src/app/ota_image_tool.py create --vendor-id 0xFFF1 --product-id 0x8000 \
+                                     --version 2 --version-str "v2.0" -da sha256 \
+                                     lighting-app-encrypted.bin lighting-app-encrypted-ota.bin
     ```
 
 4.  Use the `lighting-app-encrypted-ota.bin` file with the OTA Provider app.

--- a/docs/platforms/esp32/ota.md
+++ b/docs/platforms/esp32/ota.md
@@ -115,12 +115,21 @@ Please follow the steps below to generate an application image for OTA upgrades:
         python3 esp_enc_img_gen.py encrypt lighting-app.bin esp_image_encryption_public_key.pem lighting-app-encrypted.bin
         ```
 
-    - Append the Matter OTA header:
+    Optionally, you can use the cmake function `create_esp_enc_img()` to encrypt the OTA image during the build process. Please find the usage below. This is also demonstrated in the `examples/lighting-app/esp32/main/CMakeLists.txt` file.
+
         ```
-        src/app/ota_image_tool.py create --vendor-id 0xFFF1 --product-id 0x8000 --version 2 --version-str "v2.0" -da sha256 lighting-app-encrypted.bin lighting-app-encrypted-ota.bin
+            create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+                                ${project_dir}/esp_image_encryption_public_key.pem
+                                ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+                                app)
         ```
 
-3. Use the `lighting-app-encrypted-ota.bin` file with the OTA Provider app.
+3. Append the Matter OTA header
+    ```
+    src/app/ota_image_tool.py create --vendor-id 0xFFF1 --product-id 0x8000 --version 2 --version-str "v2.0" -da sha256 lighting-app-encrypted.bin lighting-app-encrypted-ota.bin
+    ```
+
+4. Use the `lighting-app-encrypted-ota.bin` file with the OTA Provider app.
 
 ## Delta OTA
 

--- a/docs/platforms/esp32/ota.md
+++ b/docs/platforms/esp32/ota.md
@@ -92,7 +92,7 @@ image can be encrypted/decrypted using an RSA-3072 key pair.
 
 Please follow the steps below to generate an application image for OTA upgrades:
 
-1. Generate a new RSA-3072 key pair or use an existing one.
+1.  Generate a new RSA-3072 key pair or use an existing one.
 
     - To generate a key pair, use the following command:
 
@@ -105,9 +105,9 @@ Please follow the steps below to generate an application image for OTA upgrades:
         openssl rsa -in esp_image_encryption_key.pem -pubout -out esp_image_encryption_public_key.pem
         ```
 
-2. Encrypt the application binary using the
-   [esp_enc_img_gen.py](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/tools/esp_enc_img_gen.py)
-   script.
+2.  Encrypt the application binary using the
+    [esp_enc_img_gen.py](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/tools/esp_enc_img_gen.py)
+    script.
 
     - Use the following command to encrypt the OTA image with the public key:
 
@@ -115,21 +115,25 @@ Please follow the steps below to generate an application image for OTA upgrades:
         python3 esp_enc_img_gen.py encrypt lighting-app.bin esp_image_encryption_public_key.pem lighting-app-encrypted.bin
         ```
 
-    Optionally, you can use the cmake function `create_esp_enc_img()` to encrypt the OTA image during the build process. Please find the usage below. This is also demonstrated in the `examples/lighting-app/esp32/main/CMakeLists.txt` file.
+    Optionally, you can use the cmake function `create_esp_enc_img()` to encrypt
+    the OTA image during the build process. Please find the usage below. This is
+    also demonstrated in the `examples/lighting-app/esp32/main/CMakeLists.txt`
+    file.
 
-        ```
-            create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
-                                ${project_dir}/esp_image_encryption_public_key.pem
-                                ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
-                                app)
-        ```
+         ```
+             create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+                                 ${project_dir}/esp_image_encryption_public_key.pem
+                                 ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+                                 app)
+         ```
 
-3. Append the Matter OTA header
+3.  Append the Matter OTA header
+
     ```
     src/app/ota_image_tool.py create --vendor-id 0xFFF1 --product-id 0x8000 --version 2 --version-str "v2.0" -da sha256 lighting-app-encrypted.bin lighting-app-encrypted-ota.bin
     ```
 
-4. Use the `lighting-app-encrypted-ota.bin` file with the OTA Provider app.
+4.  Use the `lighting-app-encrypted-ota.bin` file with the OTA Provider app.
 
 ## Delta OTA
 

--- a/docs/platforms/esp32/ota.md
+++ b/docs/platforms/esp32/ota.md
@@ -94,13 +94,13 @@ Please follow the steps below to generate an application image for OTA upgrades:
 
 1.  Generate a new RSA-3072 key pair or use an existing one.
 
-    - To generate a key pair, use the following command:
+    -   To generate a key pair, use the following command:
 
         ```
         openssl genrsa -out esp_image_encryption_key.pem 3072
         ```
 
-    - Extract the public key from the key pair:
+    -   Extract the public key from the key pair:
         ```
         openssl rsa -in esp_image_encryption_key.pem -pubout -out esp_image_encryption_public_key.pem
         ```
@@ -109,7 +109,7 @@ Please follow the steps below to generate an application image for OTA upgrades:
     [esp_enc_img_gen.py](https://github.com/espressif/idf-extra-components/blob/master/esp_encrypted_img/tools/esp_enc_img_gen.py)
     script.
 
-    - Use the following command to encrypt the OTA image with the public key:
+    -   Use the following command to encrypt the OTA image with the public key:
 
         ```
         python3 esp_enc_img_gen.py encrypt lighting-app.bin esp_image_encryption_public_key.pem lighting-app-encrypted.bin

--- a/examples/lighting-app/esp32/main/CMakeLists.txt
+++ b/examples/lighting-app/esp32/main/CMakeLists.txt
@@ -82,6 +82,11 @@ target_compile_options(${COMPONENT_LIB} PUBLIC
            "-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>"
 )
 
+create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+                   ${project_dir}/esp_image_encryption_public_key.pem
+                   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+                   app)
+
 if (CONFIG_ENABLE_PW_RPC)
 
 get_filename_component(CHIP_ROOT ${CMAKE_SOURCE_DIR}/third_party/connectedhomeip REALPATH)

--- a/examples/lighting-app/esp32/main/CMakeLists.txt
+++ b/examples/lighting-app/esp32/main/CMakeLists.txt
@@ -82,10 +82,12 @@ target_compile_options(${COMPONENT_LIB} PUBLIC
            "-DCHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>"
 )
 
-create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
-                   ${project_dir}/esp_image_encryption_public_key.pem
-                   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
-                   app)
+if (CONFIG_ENABLE_ENCRYPTED_OTA)
+	create_esp_enc_img(${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin
+			   ${project_dir}/esp_image_encryption_public_key.pem
+			   ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-encrypted.bin
+			   app)
+endif()
 
 if (CONFIG_ENABLE_PW_RPC)
 


### PR DESCRIPTION
- Upgrade esp_encrypted_img dependency to version 2.3.0
- Update OTA documentation with new encrypted image generation method
- Add cmake function create_esp_enc_img() to lighting-app example


#### Testing
- Built the lighting-app/esp32 with encrypted ota configuration, built the ota-provider-app/linux. Verified that OTA works as per the [encrypted ota](https://github.com/project-chip/connectedhomeip/blob/master/docs/platforms/esp32/ota.md#encrypted-ota) guide.