### PR TITLE
[Silabs] removed extern from AirQualitySensor.cpp

### DIFF
--- a/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
+++ b/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
@@ -22,11 +22,7 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #ifdef USE_SPARKFUN_AIR_QUALITY_SENSOR
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include <sparkfun_sgp40.h>
-}
 #include "sl_i2cspm_instances.h"
 #endif // USE_SPARKFUN_AIR_QUALITY_SENSOR
 

--- a/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
+++ b/examples/platform/silabs/sensors/AirQuality/AirQualitySensor.cpp
@@ -22,8 +22,8 @@
 #include <platform/CHIPDeviceLayer.h>
 
 #ifdef USE_SPARKFUN_AIR_QUALITY_SENSOR
-#include <sparkfun_sgp40.h>
 #include "sl_i2cspm_instances.h"
+#include <sparkfun_sgp40.h>
 #endif // USE_SPARKFUN_AIR_QUALITY_SENSOR
 
 namespace {


### PR DESCRIPTION
Removed the extern "C" from AirQualitySensor.cpp, as the source code has added the checks. 
#### Testing
Checked by building the app in simplicity studio with brd2704 and sparkfun sensor