### PR TITLE
Adding Mandatory Endpoint Composition to Oven Device Type for ZAP XML

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2541,6 +2541,9 @@ limitations under the License.
             <endpoint conformance="M" constraint="min 1">
                     <deviceType>0x0071</deviceType>
             </endpoint>
+             <endpoint conformance="O" constraint="max 1">
+                    <deviceType>0x0078</deviceType>
+            </endpoint>
         </endpointComposition>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2536,6 +2536,12 @@ limitations under the License.
         <deviceId editable="false">0x007B</deviceId>
         <class>Simple</class>
         <scope>Endpoint</scope>
+        <endpointComposition>
+            <compositionType>tree</compositionType>
+            <endpoint conformance="M" constraint="min 1">
+                    <deviceType>0x0071</deviceType>
+            </endpoint>
+        </endpointComposition>
         <clusters lockOthers="true">
             <include cluster="Identify" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true"></include>


### PR DESCRIPTION
### Testing

The update to Oven Device Type in ZAP XML requires at least one Temperature Controlled Cabinet on a separate endpoint and ZAP must consume composition type.

**ZAP Requirements:**

**Composite Device Identification:** ZAP must know the "composite device" (device type with the endpointComposition tag) to accurately manage its composition.

**Endpoint Requirements:** ZAP must be aware of which device types require a new endpoint to ensure proper integration and functionality.

**Mandatory Device Tracking:** ZAP must have visibility into which devices are considered "mandatory" to ensure that all necessary devices are included in the composition and are correctly handled.
