### PR TITLE
[NXP] Fix WiFiNetworkDiagnostics cluster status report issue

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -259,7 +259,7 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
     {
     case WLAN_REASON_SUCCESS:
         ChipLogProgress(DeviceLayer, "Connected to WLAN network = %d", is_sta_ipv6_connected());
-        if (sInstance._GetWiFiStationState() == kWiFiStationState_Connecting)
+        if (sInstance._GetWiFiStationState() != kWiFiStationState_Connected)
         {
             sInstance._SetWiFiStationState(kWiFiStationState_Connecting_Succeeded);
             sInstance._SetWiFiStationState(kWiFiStationState_Connected);
@@ -318,7 +318,7 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
             sInstance.OnStationDisconnected();
             if (delegate)
             {
-                delegate->OnAssociationFailureDetected(associationFailureCause, wlan_status_code);
+                delegate->OnDisconnectionDetected(wlan_status_code);
             }
         }
         break;
@@ -329,7 +329,7 @@ void ConnectivityManagerImpl::ProcessWlanEvent(enum wlan_event_reason wlanEvent)
         sInstance.OnStationDisconnected();
         if (delegate)
         {
-            delegate->OnAssociationFailureDetected(associationFailureCause, wlan_status_code);
+            delegate->OnDisconnectionDetected(wlan_status_code);
         }
         break;
 


### PR DESCRIPTION
Fix WiFiNetworkDiagnostics cluster status report issue found on TC-DGWIFI-2.2


#### Testing
Fixes for TC-DGWIFI-2.2. 
TH should receive Disconnection event if DUT disconnect from Wi-Fi and then reconnect. 
TH should receive ConnectionStatus change event if DUT disconnect from Wi-Fi and then reconnect.

