### PR TITLE
Fix the Build Flags Conflict

### DIFF
--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -29,7 +29,7 @@ config("config") {
     "include",
     "include/clusters/chime",
     "${chip_root}/examples/camera-app/camera-common/include",
-    "${chip_root}/third_party/libdatachannel/repo/include",    
+    "${chip_root}/third_party/libdatachannel/repo/include",
   ]
 }
 

--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -16,18 +16,26 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tools.gni")
-import("${chip_root}/src/app/common_flags.gni")
 
 assert(chip_build_tools)
 
-config("includes") {
+config("config") {
+  cflags = [
+    "-Wconversion",
+    "-Wno-shadow",
+  ]
+
   include_dirs = [
-    ".",
     "include",
+    "include/clusters/chime",
+    "${chip_root}/examples/camera-app/camera-common/include",
+    "${chip_root}/third_party/libdatachannel/repo/include",    
   ]
 }
 
 executable("chip-camera-app") {
+  configs += [ ":config" ]
+
   sources = [
     "${chip_root}/examples/camera-app/linux/src/camera-device.cpp",
     "${chip_root}/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp",
@@ -46,15 +54,6 @@ executable("chip-camera-app") {
   libs = [ "datachannel" ]
   lib_dirs =
       [ rebase_path("${chip_root}/third_party/libdatachannel/repo/build") ]
-
-  include_dirs = [
-    "include",
-    "include/clusters/chime",
-    "${chip_root}/examples/camera-app/camera-common/include",
-    "${chip_root}/third_party/libdatachannel/repo/include",
-  ]
-
-  cflags = [ "-Wconversion" ]
 
   output_dir = root_out_dir
 }

--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -23,12 +23,18 @@ import("${chip_root}/src/lib/core/core.gni")
 assert(chip_build_tools)
 
 config("config") {
+  cflags = [
+    "-Wconversion",
+    "-Wno-shadow",
+  ]
+
   include_dirs = [
     ".",
     "${chip_root}/examples/common",
     "${chip_root}/zzz_generated/app-common/app-common",
     "${chip_root}/zzz_generated/chip-tool",
     "${chip_root}/src/lib",
+    "${chip_root}/third_party/libdatachannel/repo/include",
   ]
 
   defines = [ "CONFIG_USE_SEPARATE_EVENTLOOP=${config_use_separate_eventloop}" ]
@@ -113,8 +119,6 @@ executable("camera-controller") {
   libs = [ "datachannel" ]
   lib_dirs =
       [ rebase_path("${chip_root}/third_party/libdatachannel/repo/build") ]
-
-  include_dirs = [ "${chip_root}/third_party/libdatachannel/repo/include" ]
 
   output_dir = root_out_dir
 }


### PR DESCRIPTION
Got following build error when enable WebRTC.

```
INFO    g++ -MMD -MF obj/chip-camera-app.main.cpp.o.d -Wconversion -Wno-shadow -O0 -g2 -fno-common -ffunction-sections -fdata-sections -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -fPIC -Wall -Werror -Wextra -Wshadow -Wunreachable-code -Wvla -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wno-deprecated-declarations -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-unused-parameter -Wno-cast-function-type -Wno-psabi -Wno-maybe-uninitialized -fdiagnostics-color -fno-strict-aliasing -fmacro-prefix-map=../../examples/camera-app/linux/third_party/connectedhomeip/= -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/libmount -I/usr/include/blkid -Wno-format-nonliteral -Wno-format-nonliteral -std=gnu++17 -fno-rtti -Wnon-virtual-dtor -DCHIP_HAVE_CONFIG_H=1 -DCHIP_MINMDNS_USE_EPHEMERAL_UNICAST_PORT=1 -DCHIP_MINMDNS_HIGH_VERBOSITY=0 -DCHIP_MINMDNS_DEFAULT_POLICY=1 -I../../examples/camera-app/linux/include -I../../examples/camera-app/linux/include/clusters/chime -I../../examples/camera-app/linux/third_party/connectedhomeip/examples/camera-app/camera-common/include -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include -Igen/third_party/connectedhomeip/examples/camera-app/camera-common -Igen/third_party/connectedhomeip/examples/camera-app/camera-common/zapgen -I../../examples/camera-app/linux/third_party/connectedhomeip/src/include -I../../examples/camera-app/linux/third_party/connectedhomeip/src -Igen/include -I../../examples/camera-app/linux/third_party/connectedhomeip/examples/camera-app/linux/include -I../../examples/camera-app/linux/third_party/connectedhomeip/config/standalone -I../../examples/camera-app/linux/third_party/connectedhomeip/zzz_generated/app-common -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/nlassert/repo/include -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/nlio/repo/include -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/nlfaultinjection/include -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/inipp/repo/inipp -I../../examples/camera-app/linux/third_party/connectedhomeip/src/tracing/perfetto/include -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/perfetto/repo/sdk -I../../examples/camera-app/linux/third_party/connectedhomeip/examples/platform/linux -I../../examples/camera-app/linux/third_party/connectedhomeip/third_party/jsoncpp/repo/include -c ../../examples/camera-app/linux/main.cpp -o obj/chip-camera-app.main.cpp.o
INFO    In file included from ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/message.hpp:13,
INFO                     from ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/mediahandler.hpp:15,
INFO                     from ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/track.hpp:15,
INFO                     from ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/peerconnection.hpp:18,
INFO                     from ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/rtc.hpp:17,
INFO                     from ../../examples/camera-app/linux/main.cpp:23:
INFO    ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/frameinfo.hpp: In constructor ‘rtc::FrameInfo::FrameInfo(uint32_t)’:
INFO    ../../examples/camera-app/linux/third_party/connectedhomeip/third_party/libdatachannel/repo/include/rtc/frameinfo.hpp:19:28: error: declaration of ‘timestamp’ shadows a member of ‘rtc::FrameInfo’ [-Werror=shadow]
```

The error arises because the compiler flags -Wshadow (enable shadow warnings) and -Wno-shadow (disable shadow warnings) are conflicting. 

We need to make sure -Wno-shadow  is applied after all default config to take effect.

#### Testing

Validated by CI