### PR TITLE
Add factory reset event

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -616,8 +616,22 @@ void Server::GenerateShutDownEvent()
     PlatformMgr().ScheduleWork([](intptr_t) { PlatformMgr().HandleServerShuttingDown(); });
 }
 
+void Server::PostFactoryResetEvent()
+{
+    DeviceLayer::ChipDeviceEvent event;
+    event.Type = DeviceLayer::DeviceEventType::kFactoryReset;
+
+    CHIP_ERROR error = DeviceLayer::PlatformMgr().PostEvent(&event);
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "Posting kFactoryReset event failed with %" CHIP_ERROR_FORMAT, error.Format());
+    }
+}
+
 void Server::ScheduleFactoryReset()
 {
+    PostFactoryResetEvent();
+
     PlatformMgr().ScheduleWork([](intptr_t) {
         // Delete all fabrics and emit Leave event.
         GetInstance().GetFabricTable().DeleteAllFabrics();

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -458,6 +458,8 @@ private:
     void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent & event);
     void CheckServerReadyEvent();
 
+    void PostFactoryResetEvent();
+
     static void OnPlatformEventWrapper(const DeviceLayer::ChipDeviceEvent * event, intptr_t);
 
 #if CHIP_CONFIG_PERSIST_SUBSCRIPTIONS

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -241,6 +241,7 @@ chip_test_suite("tests") {
     "TestReadInteraction.cpp",
     "TestReportScheduler.cpp",
     "TestReportingEngine.cpp",
+    "TestServer.cpp",
     "TestStatusIB.cpp",
     "TestStatusResponseMessage.cpp",
     "TestTestEventTriggerDelegate.cpp",

--- a/src/app/tests/TestServer.cpp
+++ b/src/app/tests/TestServer.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <app/server/Server.h>
+#include <platform/CHIPDeviceLayer.h>
+
+namespace chip {
+
+using namespace chip::DeviceLayer;
+
+namespace app {
+namespace server {
+
+class TestServer : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
+        ASSERT_EQ(PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+    }
+    static void TearDownTestSuite()
+    {
+        Platform::MemoryShutdown();
+        PlatformMgr().Shutdown();
+    }
+};
+
+class TestEventHandler
+{
+public:
+    ChipDeviceEvent mEvent{};
+
+    static void EventHandler(const ChipDeviceEvent * event, intptr_t arg)
+    {
+        reinterpret_cast<TestEventHandler *>(arg)->mEvent = *event;
+    }
+};
+
+TEST_F(TestServer, TestFactoryResetEvent)
+{
+    TestEventHandler handler;
+    PlatformMgr().AddEventHandler(TestEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler));
+
+    Server::GetInstance().ScheduleFactoryReset();
+
+    PlatformMgr().ScheduleWork([](intptr_t) -> void { PlatformMgr().StopEventLoopTask(); });
+    PlatformMgr().RunEventLoop();
+
+    EXPECT_EQ(handler.mEvent.Type, DeviceEventType::kFactoryReset);
+
+    PlatformMgr().RemoveEventHandler(TestEventHandler::EventHandler, reinterpret_cast<intptr_t>(&handler));
+}
+
+} // namespace server
+} // namespace app
+} // namespace chip

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -255,6 +255,11 @@ enum PublicEventTypes
      * Signals that secure session is established.
      */
     kSecureSessionEstablished,
+
+    /**
+     * Signals that factory reset has started.
+     */
+    kFactoryReset,
 };
 
 /**

--- a/src/test_driver/nrfconnect/prj.conf
+++ b/src/test_driver/nrfconnect/prj.conf
@@ -83,3 +83,7 @@ CONFIG_CHIP_ENABLE_READ_CLIENT=y
 CONFIG_CHIP_DEVICE_VENDOR_ID=65521
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32768
 CONFIG_CHIP_PROJECT_CONFIG="main/include/CHIPProjectConfig.h"
+
+# Don't erase all settings as it deinitializes NVS/ZMS and causes issues with
+# testing Server::ScheduleFactoryReset
+CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS=n


### PR DESCRIPTION
Add `kFactoryReset` event and post it at the beginning of `ScheduleFactoryReset`.

This event may be useful to application as it provides clean way to perform additional cleanup steps during factory reset.


#### Testing
- Added unit test for `kFactoryReset`
- Tested usage with example from nRF Connected SDK.
