### PR TITLE
Updated chip-cert-bins/Dockerfile to avoid PyGObject conflit

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -332,6 +332,9 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 # PIP requires MASON package compilation, which seems to require a JDK
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
+# This is necessary to avoid dependency conflict of PyGObject
+RUN apt-get remove -y python3-gi
+
 RUN pip install --break-system-packages --no-cache-dir \
     python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
     python_lib/controller/python/chip*.whl


### PR DESCRIPTION
The goal of this PR is change Docker file in order to avoid PyGObject conflit. 
It fixes this issue: https://github.com/project-chip/connectedhomeip/issues/37984

#### Testing
CI testing
