### PR TITLE
[chip-cert-bins][1.4] temporary workaround: make sure python3-gi is removed

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -332,6 +332,14 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 # PIP requires MASON package compilation, which seems to require a JDK
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 
+# TODO: remove this dependency conflict workaround --> issue: #37975
+# python3-gi is being installed as a dependency by 'openjdk-8-jdk'. python3-gi is not wanted since it installs PyGObject 3.48.2 (which we are not using),
+# This issue showed up when we pinned pygobject==3.50.0 in the chip-repl in https://github.com/project-chip/connectedhomeip/pull/37948
+# having pygobject ==3.50.0 being installed through pip creates a conflict, and pip can not unintstall the PyGObject (python3-gi's version) because the system APT installed it
+# Error log:
+#   ERROR: Cannot uninstall 'PyGObject'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
+RUN apt-get remove -y python3-gi
+
 RUN pip install --break-system-packages --no-cache-dir \
     python_lib/python/obj/src/python_testing/matter_testing_infrastructure/chip-testing._build_wheel/chip_testing-*.whl \
     python_lib/controller/python/chip*.whl


### PR DESCRIPTION
- cherry-pick of #37996


### Testing
Tested workflow manually using
docker buildx build --load --build-arg COMMITHASH=dea605e6b5ab7116b800cf6381d70d686db3161f -progress=plain --tag connectedhomeip/chip-cert-bins:dea605e6b5ab7116b800cf6381d70d686db3161f .
