### PR TITLE
[ServerClusterContext] Remove unused constructor from struct that prevents aggregate init

### DIFF
--- a/src/app/server-cluster/ServerClusterContext.h
+++ b/src/app/server-cluster/ServerClusterContext.h
@@ -38,8 +38,6 @@ struct ServerClusterContext
     PersistentStorageDelegate * const storage                     = nullptr; /// read/write persistent storage
     DataModel::InteractionModelContext * const interactionContext = nullptr; /// outside-world communication
 
-    ServerClusterContext(ServerClusterContext &&) = default;
-
     bool operator!=(const ServerClusterContext & other) const
     {
         return (provider != other.provider)                     //


### PR DESCRIPTION
Fix this error:

```
codegen/CodegenDataModelProvider.cpp:167:33: error: initialization of non-aggregate type 'ServerClusterContext' with a designated initializer list
  167 |     return mRegistry.SetContext(ServerClusterContext{
      |                                 ^                   ~
  168 |         .provider           = this,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~
  169 |         .storage            = mPersistentStorageDelegate,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  170 |         .interactionContext = &mContext,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  171 |     });
      |     ~
1 error generated.
```

#### Testing

Error no longer occurs after removing the user provided constructor from the struct.
