### PR TITLE
[Darwin] MTRMockCB reference in MTRTestCase should not be behind  HAV E_NSTASK

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -27,8 +27,6 @@
 // Tasks that are not scoped to a specific test, but rather to a specific test suite.
 static NSMutableSet<NSTask *> * sRunningCrossTestTasks;
 
-static MTRMockCB * sMockCB;
-
 static void ClearTaskSet(NSMutableSet<NSTask *> * __strong & tasks)
 {
     for (NSTask * task in tasks) {
@@ -38,6 +36,8 @@ static void ClearTaskSet(NSMutableSet<NSTask *> * __strong & tasks)
     tasks = nil;
 }
 #endif // HAVE_NSTASK
+
+static MTRMockCB * sMockCB;
 
 @implementation MTRTestCase {
 #if HAVE_NSTASK


### PR DESCRIPTION
This is a fix for a unit test, where an expected global declaration is put behind the wrong ifdef.

#### Testing

Testing is through running local unit test that this change fixes.