### PR TITLE
Integrate libtrustymatter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -354,3 +354,6 @@
 	url = https://github.com/paullouisageneau/libdatachannel.git
 	platforms = linux
 	recursive = true
+[submodule "third_party/libtrustymatter/repo"]
+	path = third_party/libtrustymatter/repo
+	url = https://github.com/nxp-imx/libtrustymatter

--- a/third_party/libtrustymatter/BUILD.gn
+++ b/third_party/libtrustymatter/BUILD.gn
@@ -1,0 +1,48 @@
+# Copyright (c) 2023 Project CHIP Authors
+# Copyright 2025 NXP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("libtrustymatter_config") {
+  include_dirs = [
+    "repo/matter_client/include",
+    "repo/libtrusty/include",
+  ]
+}
+
+source_set("libtrustymatter") {
+  sources = [
+    "repo/matter_client/trusty_matter.cpp",
+    "repo/matter_client/trusty_matter_ipc.cpp",
+    "repo/matter_client/matter_messages.cpp",
+    "repo/matter_client/serializable.cpp",
+    "repo/matter_client/include/mem.h",
+    "repo/matter_client/include/matter_defs.h",
+    "repo/matter_client/include/matter_ipc.h",
+    "repo/matter_client/include/matter_messages.h",
+    "repo/matter_client/include/serializable.h",
+    "repo/matter_client/include/trusty_matter.h",
+    "repo/matter_client/include/trusty_matter_ipc.h",
+    "repo/matter_client/include/UniquePtr.h",
+    "repo/libtrusty/trusty.c",
+    "repo/libtrusty/include/trusty/ipc.h",
+    "repo/libtrusty/include/trusty/tipc.h",
+  ]
+
+  cflags = [ "-Wno-implicit-fallthrough" ]
+  cflags_cc = [ "-std=c++17" ]
+
+  public_configs = [ ":libtrustymatter_config" ]
+}


### PR DESCRIPTION
the libtrustymatter third-party lib contains the Trusty IPC
infrastructure and client application in the Non-secure side.

#### Testing

Test passed on 8mm and 93
