### PR TITLE
Pr test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -354,3 +354,6 @@
 	url = https://github.com/paullouisageneau/libdatachannel.git
 	platforms = linux
 	recursive = true
+[submodule "third_party/libtrustymatter/repo"]
+	path = third_party/libtrustymatter/repo
+	url = https://github.com/nxp-imx/libtrustymatter

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -126,6 +126,11 @@
 #include <platform/Linux/NetworkCommissioningDriver.h>
 #endif // CHIP_DEVICE_LAYER_TARGET_LINUX
 
+#if CHIP_ATTESTATION_TRUSTY_OS
+#include "DeviceAttestationCreds.h"
+using namespace chip::Credentials::Trusty;
+#endif
+
 using namespace chip;
 using namespace chip::ArgParser;
 using namespace chip::Credentials;
@@ -710,7 +715,11 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     PrintOnboardingCodes(LinuxDeviceOptions::GetInstance().payload);
 
     // Initialize device attestation config
+#if CHIP_ATTESTATION_TRUSTY_OS
+    SetDeviceAttestationCredentialsProvider(&TrustyDACProvider::GetTrustyDACProvider());
+#else
     SetDeviceAttestationCredentialsProvider(LinuxDeviceOptions::GetInstance().dacProvider);
+#endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     ChipLogProgress(AppServer, "Starting commissioner");

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -19,6 +19,7 @@ import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/lib/lib.gni")
 import("${chip_root}/src/tracing/tracing_args.gni")
+import("${chip_root}/src/lib/trusty.gni")
 
 if (current_os != "nuttx") {
   import("//build_overrides/jsoncpp.gni")
@@ -96,6 +97,13 @@ source_set("app-main") {
     "testing/CustomCSRResponseOperationalKeyStore.h",
   ]
 
+  if (chip_with_trusty_os == 1) {
+    sources += [
+      "DeviceAttestationCreds.cpp",
+      "DeviceAttestationCreds.h",
+    ]
+  }
+
   public_deps = [
     ":boolean-state-configuration-test-event-trigger",
     ":commissioner-main",
@@ -120,6 +128,16 @@ source_set("app-main") {
 
   if (current_os != "nuttx") {
     public_deps += [ jsoncpp_root ]
+  }
+
+  if (chip_with_trusty_os == 1) {
+    public_deps += [ "${chip_root}/third_party/libtrustymatter" ]
+  }
+
+  if (chip_with_trusty_os == 1) {
+    defines += [ "CHIP_ATTESTATION_TRUSTY_OS=1" ]
+  } else {
+    defines += [ "CHIP_ATTESTATION_TRUSTY_OS=0" ]
   }
 
   if (chip_enable_pw_rpc) {

--- a/examples/platform/linux/DeviceAttestationCreds.cpp
+++ b/examples/platform/linux/DeviceAttestationCreds.cpp
@@ -1,0 +1,106 @@
+/*
+ *
+ *    Copyright (c) 2021-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *    Copyright 2023 NXP
+ */
+#include "DeviceAttestationCreds.h"
+
+#include <crypto/CHIPCryptoPAL.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <trusty_matter.h>
+
+using namespace matter;
+
+namespace chip {
+namespace Credentials {
+namespace Trusty {
+
+CHIP_ERROR TrustyDACProvider::GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer)
+{
+    size_t out_size = 0;
+    int rc;
+
+    rc = trusty_matter.ExportDACCert(out_dac_buffer.data(), out_dac_buffer.size(), out_size);
+    if (rc == 0) {
+        out_dac_buffer.reduce_size(out_size);
+        return CHIP_NO_ERROR;
+    } else
+        return CHIP_ERROR_CERT_LOAD_FAILED;
+}
+
+CHIP_ERROR TrustyDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer)
+{
+    size_t out_size = 0;
+    int rc;
+
+    rc = trusty_matter.ExportPAICert(out_pai_buffer.data(), out_pai_buffer.size(), out_size);
+    if (rc == 0) {
+        out_pai_buffer.reduce_size(out_size);
+        return CHIP_NO_ERROR;
+    } else
+        return CHIP_ERROR_CERT_LOAD_FAILED;
+}
+
+CHIP_ERROR TrustyDACProvider::GetCertificationDeclaration(MutableByteSpan & out_cd_buffer)
+{
+    size_t out_size = 0;
+    int rc;
+
+    rc = trusty_matter.ExportCDCert(out_cd_buffer.data(), out_cd_buffer.size(), out_size);
+    if (rc == 0) {
+        out_cd_buffer.reduce_size(out_size);
+        return CHIP_NO_ERROR;
+    } else
+        return CHIP_ERROR_CERT_LOAD_FAILED;
+}
+
+CHIP_ERROR TrustyDACProvider::GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer)
+{
+    // TODO: We need a real example FirmwareInformation to be populated.
+    out_firmware_info_buffer.reduce_size(0);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR TrustyDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign,
+                                                            MutableByteSpan & out_signature_buffer)
+{
+    int rc = 0;
+    size_t out_size = 0;
+
+    VerifyOrReturnError(IsSpanUsable(out_signature_buffer), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(IsSpanUsable(message_to_sign), CHIP_ERROR_INVALID_ARGUMENT);
+
+    rc = trusty_matter.SignWithDACKey(message_to_sign.data(), message_to_sign.size(),
+                                     out_signature_buffer.data(), out_signature_buffer.size(), out_size);
+    if (rc == 0) {
+        out_signature_buffer.reduce_size(out_size);
+        return CHIP_NO_ERROR;
+    } else
+        return CHIP_ERROR_CERT_LOAD_FAILED;
+}
+
+TrustyDACProvider & TrustyDACProvider::GetTrustyDACProvider()
+{
+    static TrustyDACProvider trusty_dac_provider;
+
+    return trusty_dac_provider;
+}
+
+} // namespace Trusty
+} // namespace Credentials
+} // namespace chip

--- a/examples/platform/linux/DeviceAttestationCreds.h
+++ b/examples/platform/linux/DeviceAttestationCreds.h
@@ -1,0 +1,46 @@
+/*
+ *    Copyright 2023 NXP
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <trusty_matter.h>
+
+using namespace matter;
+
+namespace chip {
+namespace Credentials {
+namespace Trusty {
+
+class TrustyDACProvider : public DeviceAttestationCredentialsProvider
+{
+public:
+    static TrustyDACProvider & GetTrustyDACProvider();
+
+    CHIP_ERROR GetCertificationDeclaration(MutableByteSpan & out_cd_buffer) override;
+    CHIP_ERROR GetFirmwareInformation(MutableByteSpan & out_firmware_info_buffer) override;
+    CHIP_ERROR GetDeviceAttestationCert(MutableByteSpan & out_dac_buffer) override;
+    CHIP_ERROR GetProductAttestationIntermediateCert(MutableByteSpan & out_pai_buffer) override;
+    CHIP_ERROR SignWithDeviceAttestationKey(const ByteSpan & message_to_sign, MutableByteSpan & out_signature_buffer) override;
+
+private:
+    TrustyMatter trusty_matter;
+};
+
+} // namespace Trusty
+} // namespace Credentials
+} // namespace chip

--- a/src/lib/trusty.gni
+++ b/src/lib/trusty.gni
@@ -1,0 +1,17 @@
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+    chip_with_trusty_os = 0
+}

--- a/third_party/libtrustymatter/BUILD.gn
+++ b/third_party/libtrustymatter/BUILD.gn
@@ -1,0 +1,48 @@
+# Copyright (c) 2023 Project CHIP Authors
+# Copyright 2025 NXP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+config("libtrustymatter_config") {
+  include_dirs = [
+    "repo/matter_client/include",
+    "repo/libtrusty/include",
+  ]
+}
+
+source_set("libtrustymatter") {
+  sources = [
+    "repo/libtrusty/include/trusty/ipc.h",
+    "repo/libtrusty/include/trusty/tipc.h",
+    "repo/libtrusty/trusty.c",
+    "repo/matter_client/include/UniquePtr.h",
+    "repo/matter_client/include/matter_defs.h",
+    "repo/matter_client/include/matter_ipc.h",
+    "repo/matter_client/include/matter_messages.h",
+    "repo/matter_client/include/mem.h",
+    "repo/matter_client/include/serializable.h",
+    "repo/matter_client/include/trusty_matter.h",
+    "repo/matter_client/include/trusty_matter_ipc.h",
+    "repo/matter_client/matter_messages.cpp",
+    "repo/matter_client/serializable.cpp",
+    "repo/matter_client/trusty_matter.cpp",
+    "repo/matter_client/trusty_matter_ipc.cpp",
+  ]
+
+  cflags = [ "-Wno-implicit-fallthrough" ]
+  cflags_cc = [ "-std=c++17" ]
+
+  public_configs = [ ":libtrustymatter_config" ]
+}


### PR DESCRIPTION
the libtrustymatter third-party lib contains the Trusty IPC
infrastructure and client application in the Non-secure side.

#### Testing

Test passed on 8mm and 93
