### PR TITLE
ESP32: lets configure esp32 qemu jobs to run manually

### DIFF
--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -38,7 +39,7 @@ jobs:
             BUILD_TYPE: esp32-qemu
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && github.repository_owner == 'espressif'
+        if: github.actor != 'restyled-io[bot]' && (github.repository_owner == 'espressif' || github.event_name == 'workflow_dispatch')
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32-qemu:119


### PR DESCRIPTION
There has been some instances where we need to run unit tests in the CI and for that we have to enable/disable this workflow. So to save that round trip we should make it run manually.


#### Testing

- Will be tested in CI.