### PR TITLE
[Scenes] Fix OnOff Scenes Handler registration

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -520,12 +520,6 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
             status = setOnOffValue(endpoint, onOffValueForStartUp, true);
         }
 
-#if defined(MATTER_DM_PLUGIN_SCENES_MANAGEMENT) && CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
-        // Registers Scene handlers for the On/Off cluster on the server
-        app::Clusters::ScenesManagement::ScenesServer::Instance().RegisterSceneHandler(endpoint,
-                                                                                       OnOffServer::Instance().GetSceneHandler());
-#endif // defined(MATTER_DM_PLUGIN_SCENES_MANAGEMENT) && CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
-
 #ifdef MATTER_DM_PLUGIN_MODE_SELECT
         // If OnMode is not a null value, then change the current mode to it.
         if (onOffValueForStartUp && emberAfContainsServer(endpoint, ModeSelect::Id) &&
@@ -541,6 +535,12 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
 #endif
     }
 #endif // IGNORE_ON_OFF_CLUSTER_START_UP_ON_OFF
+
+#if defined(MATTER_DM_PLUGIN_SCENES_MANAGEMENT) && CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
+    // Registers Scene handlers for the On/Off cluster on the server
+    app::Clusters::ScenesManagement::ScenesServer::Instance().RegisterSceneHandler(endpoint,
+                                                                                   OnOffServer::Instance().GetSceneHandler());
+#endif // defined(MATTER_DM_PLUGIN_SCENES_MANAGEMENT) && CHIP_CONFIG_SCENES_USE_DEFAULT_HANDLERS
 
     emberAfPluginOnOffClusterServerPostInitCallback(endpoint);
 }


### PR DESCRIPTION
Moved the scenes-handler registration outside of the #ifndef IGNORE_ON_OFF_CLUSTER_START_UP_ON_OFF condition since the usage of the handler should not be tied to this attribute.

Fixes: https://github.com/project-chip/connectedhomeip/issues/38007

#### Testing

Build and ran lighting app, performed the steps in issue https://github.com/project-chip/connectedhomeip/issues/38007 and confirmed the usage of NVM was as expected.
