### PR TITLE
Thoroughly Shutdown The Stack On Non-Interactive Chip Command

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -225,6 +225,11 @@ void CHIPCommand::MaybeTearDownStack()
     {
         ShutdownCommissioner(commissioner.first);
     }
+    mCommissioners.clear();
+    sICDClientStorage.Shutdown();
+    sCheckInHandler.Shutdown();
+    sGroupDataProvider.Finish();
+    DeviceControllerFactory::GetInstance().Shutdown();
 
     StopTracing();
 }


### PR DESCRIPTION
When there is a non-interactive CHIP Command, be sure to completely shutdown the stack. In the case where the stack is not completely shutdown, it is impossible to run another CHIP Command from within the same address space.


#### Testing

WIP