### PR TITLE
server/Server.cpp Initialize ChipDeviceEvent on instantiation

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -618,8 +618,7 @@ void Server::GenerateShutDownEvent()
 
 void Server::PostFactoryResetEvent()
 {
-    DeviceLayer::ChipDeviceEvent event;
-    event.Type = DeviceLayer::DeviceEventType::kFactoryReset;
+    DeviceLayer::ChipDeviceEvent event{ .Type = DeviceLayer::DeviceEventType::kFactoryReset };
 
     CHIP_ERROR error = DeviceLayer::PlatformMgr().PostEvent(&event);
     if (error != CHIP_NO_ERROR)


### PR DESCRIPTION
This fixes an error:
```
src/app/server/Server.cpp:621:34: error: call to implicitly-deleted default constructor of 'DeviceLayer::ChipDeviceEvent'
  621 |     DeviceLayer::ChipDeviceEvent event;
      |                                  ^
src/include/platform/CHIPDeviceEvent.h:508:11: note: default constructor of 'ChipDeviceEvent' is implicitly deleted because variant field 'CHIPoBLEConnectionError' has a non-trivial default constructor
  508 |         } CHIPoBLEConnectionError;
      |           ^
1 error generated.
```

#### Testing
Verified the error is fixed.