### PR TITLE
[Silabs] LCD init BaseApplication 

### DIFF
--- a/examples/air-quality-sensor-app/silabs/include/AppConfig.h
+++ b/examples/air-quality-sensor-app/silabs/include/AppConfig.h
@@ -25,7 +25,7 @@
 
 #define APP_TASK_NAME "AQS"
 
-#define BLE_DEV_NAME "SiLabs-Air-Quality-Sensor"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // APP Logo, boolean only. must be 64x64

--- a/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
+++ b/examples/air-quality-sensor-app/silabs/src/AppTask.cpp
@@ -73,7 +73,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 #ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Air-Quality-Sensor");
     GetLCD().SetCustomUI(AirQualitySensorUI::DrawUI);
 #endif
 

--- a/examples/chef/silabs/include/AppConfig.h
+++ b/examples/chef/silabs/include/AppConfig.h
@@ -22,7 +22,7 @@
 
 // ---- Lighting Example App Config ----
 
-#define APP_TASK_NAME "Lit"
+#define APP_TASK_NAME "Chef"
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/dishwasher-app/silabs/include/AppTask.h
+++ b/examples/dishwasher-app/silabs/include/AppTask.h
@@ -75,11 +75,11 @@ public:
 private:
     static AppTask sAppTask;
     /**
-     * @brief AppTask initialisation function
+     * @brief Override of BaseApplication::AppInit() virtual method, called by BaseApplication::Init()
      *
      * @return CHIP_ERROR
      */
-    CHIP_ERROR Init();
+    CHIP_ERROR AppInit() override;
 
     /**
      * @brief PB0 Button event processing function

--- a/examples/dishwasher-app/silabs/src/AppTask.cpp
+++ b/examples/dishwasher-app/silabs/src/AppTask.cpp
@@ -60,21 +60,10 @@ static EnergyReportingTestEventTriggerHandler sEnergyReportingTestEventTriggerHa
 static DeviceEnergyManagementTestEventTriggerHandler sDeviceEnergyManagementTestEventTriggerHandler;
 #endif
 
-CHIP_ERROR AppTask::Init()
+CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
-
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Dishwasher-App");
-#endif
-
-    err = BaseApplication::Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        SILABS_LOG("BaseApplication::Init() failed");
-        appError(err);
-    }
 
     PlatformMgr().LockChipStack();
     err = DeviceEnergyManager::Instance().Init();

--- a/examples/energy-management-app/silabs/include/AppConfig.h
+++ b/examples/energy-management-app/silabs/include/AppConfig.h
@@ -23,6 +23,10 @@
 
 // ---- EVSE Example App Config ----
 
+#if SL_MATTER_CONFIG_ENABLE_EXAMPLE_EVSE_DEVICE
 #define APP_TASK_NAME "EVSE"
+#else
+#define APP_TASK_NAME "W-Heater"
+#endif
 
-#define BLE_DEV_NAME "SiLabs-EVSE"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME

--- a/examples/energy-management-app/silabs/src/AppTask.cpp
+++ b/examples/energy-management-app/silabs/src/AppTask.cpp
@@ -181,15 +181,6 @@ CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
-
-#ifdef DISPLAY_ENABLED
-#if SL_MATTER_CONFIG_ENABLE_EXAMPLE_EVSE_DEVICE
-    GetLCD().Init((uint8_t *) "energy-management-App (EVSE)");
-#elif SL_CONFIG_ENABLE_EXAMPLE_WATER_HEATER_DEVICE
-    GetLCD().Init((uint8_t *) "energy-management-App (WaterHeater)");
-#endif
-#endif
-
     ApplicationInit();
 
 #ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED

--- a/examples/light-switch-app/silabs/include/AppConfig.h
+++ b/examples/light-switch-app/silabs/include/AppConfig.h
@@ -23,9 +23,9 @@
 
 // ---- Lighting Example App Config ----
 
-#define APP_TASK_NAME "Lit"
+#define APP_TASK_NAME "Light-Sw"
 
-#define BLE_DEV_NAME "SiLabs-Light-Switch"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/light-switch-app/silabs/src/AppTask.cpp
+++ b/examples/light-switch-app/silabs/src/AppTask.cpp
@@ -76,10 +76,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Light Switch");
-#endif
-
     err = LightSwitchMgr::GetInstance().Init(kLightSwitchEndpoint, kGenericSwitchEndpoint);
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/lighting-app/silabs/include/AppConfig.h
+++ b/examples/lighting-app/silabs/include/AppConfig.h
@@ -23,9 +23,9 @@
 
 // ---- Lighting Example App Config ----
 
-#define APP_TASK_NAME "Lit"
+#define APP_TASK_NAME "Light"
 
-#define BLE_DEV_NAME "SiLabs-Light"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/lighting-app/silabs/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/src/AppTask.cpp
@@ -67,10 +67,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Lighting-App");
-#endif
-
     err = LightMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/lit-icd-app/silabs/include/AppConfig.h
+++ b/examples/lit-icd-app/silabs/include/AppConfig.h
@@ -24,7 +24,7 @@
 
 #define APP_TASK_NAME "Lit"
 
-#define BLE_DEV_NAME "SiLabs-LIT-ICD"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // APP Logo, boolean only. must be 64x64
 #define ON_DEMO_BITMAP                                                                                                             \

--- a/examples/lit-icd-app/silabs/src/AppTask.cpp
+++ b/examples/lit-icd-app/silabs/src/AppTask.cpp
@@ -72,11 +72,6 @@ CHIP_ERROR AppTask::AppInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
-
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "LIT ICD");
-#endif
-
     return err;
 }
 

--- a/examples/lock-app/silabs/include/AppConfig.h
+++ b/examples/lock-app/silabs/include/AppConfig.h
@@ -25,7 +25,7 @@
 
 #define APP_TASK_NAME "Lock"
 
-#define BLE_DEV_NAME "SiLabs-Door-Lock"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/lock-app/silabs/src/AppTask.cpp
+++ b/examples/lock-app/silabs/src/AppTask.cpp
@@ -122,10 +122,6 @@ CHIP_ERROR AppTask::AppInit()
 
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Lock-App", true);
-#endif
-
 #if defined(ENABLE_CHIP_SHELL)
     err = RegisterLockEvents();
     if (err != CHIP_NO_ERROR)

--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -288,6 +288,10 @@ CHIP_ERROR BaseApplication::BaseInit()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+#ifdef DISPLAY_ENABLED
+    GetLCD().Init((uint8_t *) APP_TASK_NAME);
+#endif
+
 #ifdef SL_WIFI
     /*
      * Wait for the WiFi to be initialized

--- a/examples/pump-app/silabs/include/AppConfig.h
+++ b/examples/pump-app/silabs/include/AppConfig.h
@@ -23,9 +23,9 @@
 
 // ---- Lighting Example App Config ----
 
-#define APP_TASK_NAME "Lit"
+#define APP_TASK_NAME "Pump"
 
-#define BLE_DEV_NAME "SiLabs-Pump"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 #define ON_DEMO_BITMAP                                                                                                             \
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  \

--- a/examples/pump-app/silabs/src/AppTask.cpp
+++ b/examples/pump-app/silabs/src/AppTask.cpp
@@ -76,10 +76,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Pump-App");
-#endif
-
     err = PumpMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/refrigerator-app/silabs/include/AppConfig.h
+++ b/examples/refrigerator-app/silabs/include/AppConfig.h
@@ -24,7 +24,7 @@
 
 #define APP_TASK_NAME "Refr"
 
-#define BLE_DEV_NAME "SiLabs-Refrigerator"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/refrigerator-app/silabs/src/AppTask.cpp
+++ b/examples/refrigerator-app/silabs/src/AppTask.cpp
@@ -80,10 +80,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Refrigrator-App");
-#endif
-
     err = RefrigeratorMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/smoke-co-alarm-app/silabs/include/AppConfig.h
+++ b/examples/smoke-co-alarm-app/silabs/include/AppConfig.h
@@ -21,9 +21,9 @@
 
 // ---- Smoke CO Alarm Example App Config ----
 
-#define APP_TASK_NAME "Alm"
+#define APP_TASK_NAME "Smoke"
 
-#define BLE_DEV_NAME "SiLabs-Alarm"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/AppTask.cpp
@@ -59,10 +59,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Smoke-CO-Alarm-App");
-#endif
-
     err = AlarmMgr().Init();
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/thermostat/silabs/include/AppConfig.h
+++ b/examples/thermostat/silabs/include/AppConfig.h
@@ -23,9 +23,9 @@
 
 // ---- Lighting Example App Config ----
 
-#define APP_TASK_NAME "Lit"
+#define APP_TASK_NAME "Therm"
 
-#define BLE_DEV_NAME "SiLabs-Thermostat"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 // Time it takes in ms for the simulated actuator to move from one
 // state to another.

--- a/examples/thermostat/silabs/src/AppTask.cpp
+++ b/examples/thermostat/silabs/src/AppTask.cpp
@@ -79,7 +79,6 @@ CHIP_ERROR AppTask::AppInit()
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(AppTask::ButtonEventHandler);
 
 #ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Thermostat-App");
     GetLCD().SetCustomUI(ThermostatUI::DrawUI);
 #endif
 

--- a/examples/window-app/silabs/include/AppConfig.h
+++ b/examples/window-app/silabs/include/AppConfig.h
@@ -22,9 +22,9 @@
 #include "silabs_utils.h"
 
 // ---- Window Example App Config ----
-#define APP_TASK_NAME "APP"
+#define APP_TASK_NAME "Window"
 #define APP_EVENT_QUEUE_SIZE 20
-#define BLE_DEV_NAME "SiLabs-Window"
+#define BLE_DEV_NAME "SL-" APP_TASK_NAME
 
 #define LCD_SIZE 128
 #define LCD_MARGIN_SIZE 1

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -50,10 +50,6 @@ CHIP_ERROR AppTask::AppInit()
     CHIP_ERROR err = CHIP_NO_ERROR;
     chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(WindowManager::ButtonEventHandler);
 
-#ifdef DISPLAY_ENABLED
-    GetLCD().Init((uint8_t *) "Window-App");
-#endif
-
     err = WindowManager::sWindow.Init();
 
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
Moved all LCD init into BaseApplication to reduce code duplication.

Added the recent BaseApp change in the dishwasher app.

Standardized BLE_ADV naming with app display naming.

#### Testing

Compile & Flash app with app name on display such as: light app, dishwasher app, etc.
