### PR TITLE
[Silabs] Fix memoryleak in shell door lock commands

### DIFF
--- a/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/lock-app/silabs/src/EventHandlerLibShell.cpp
@@ -209,4 +209,7 @@ void EventWorkerFunction(intptr_t context)
         break;
     }
     }
+
+    // free the allocated memory from the event handlers
+    Platform::Delete(data);
 }


### PR DESCRIPTION
Doorlock shell command handler allocate an eventData for the EventWorkerFunctions but this data was never freed. 
Every `doorlock event lock-alarm` or `door_lock_state` would leak 8 bytes.

Fixed by freeing the context/data in EventWorkerFunction after the command process.

#### Testing
Build the lock app with `chip_build_libshell`, monitor the heap usage and send doorlock event commands. Validate that heap stays stable 
