### PR TITLE
[SILABS] Adds support for WiFi band details

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -310,6 +310,7 @@ void SlWiFiDriver::OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult)
         scanResponse.ssidLen = aScanResult->ssid_length;
         memcpy(scanResponse.ssid, aScanResult->ssid, scanResponse.ssidLen);
         memcpy(scanResponse.bssid, aScanResult->bssid, sizeof(scanResponse.bssid));
+        scanResponse.wiFiBand = aScanResult->wiFiBand;
 
         mScanResponseIter.Add(&scanResponse);
     }

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -260,7 +260,7 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
 
 uint32_t SlWiFiDriver::GetSupportedWiFiBandsMask() const
 {
-    return WifiInterface::GetInstance()._GetSupportedWiFiBandsMask();
+    return WifiInterface::GetInstance().GetSupportedWiFiBandsMask();
 }
 
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -258,6 +258,11 @@ chip::BitFlags<WiFiSecurity> SlWiFiDriver::ConvertSecuritytype(wfx_sec_t securit
     return securityType;
 }
 
+uint32_t SlWiFiDriver::GetSupportedWiFiBandsMask() const
+{
+    return WifiInterface::GetInstance()._GetSupportedWiFiBandsMask();
+}
+
 bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 {
     ChipLogProgress(DeviceLayer, "Start Scan WiFi Networks");

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.h
@@ -123,6 +123,7 @@ public:
     CHIP_ERROR ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen);
 
     chip::BitFlags<WiFiSecurity> ConvertSecuritytype(wfx_sec_t security);
+    uint32_t GetSupportedWiFiBandsMask() const override;
 
     void OnConnectWiFiNetwork();
     void UpdateNetworkingStatus();

--- a/src/platform/silabs/wifi/BUILD.gn
+++ b/src/platform/silabs/wifi/BUILD.gn
@@ -113,6 +113,7 @@ source_set("wifi-platform") {
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/inet",
     "${chip_root}/src/lib/support",
+    "${chip_root}/src/platform:platform_base",
   ]
 
   if (use_rs9116) {

--- a/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
@@ -68,6 +68,7 @@ extern "C" {
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
 using namespace chip::DeviceLayer::Silabs;
+using WiFiBandEnum = chip::app::Clusters::NetworkCommissioning::WiFiBandEnum;
 
 // TODO : Temporary work-around for wifi-init failure in 917NCP ACX module boards.
 // Can be removed after Wiseconnect fixes region code for all ACX module boards.
@@ -200,9 +201,9 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
     {
         wfx_wifi_scan_result_t currentScanResult = { 0 };
 
-        // Lenght excludes null-character
-        size_t scannedSsidLenght = strnlen(reinterpret_cast<char *>(result->scan_info[i].ssid), WFX_MAX_SSID_LENGTH);
-        chip::ByteSpan scannedSsidSpan(result->scan_info[i].ssid, scannedSsidLenght);
+        // Length excludes null-character
+        size_t scannedSsidLength = strnlen(reinterpret_cast<char *>(result->scan_info[i].ssid), WFX_MAX_SSID_LENGTH);
+        chip::ByteSpan scannedSsidSpan(result->scan_info[i].ssid, scannedSsidLength);
 
         // Copy the scanned SSID to the current scan ssid buffer that will be forwarded to the callback
         chip::MutableByteSpan currentScanSsid(currentScanResult.ssid, WFX_MAX_SSID_LENGTH);
@@ -217,6 +218,8 @@ sl_status_t BackgroundScanCallback(sl_wifi_event_t event, sl_wifi_scan_result_t 
         currentScanResult.security = static_cast<wfx_sec_t>(result->scan_info[i].security_mode);
         currentScanResult.rssi     = (-1) * result->scan_info[i].rssi_val; // The returned value is positive - we need to flip it
         currentScanResult.chan     = result->scan_info[i].rf_channel;
+        // TODO: change this when SDK provides values
+        currentScanResult.wiFiBand = WiFiBandEnum::k2g4;
 
         // if user has provided ssid, check if the current scan result ssid matches the user provided ssid
         if (!requestedSsidSpan.empty())

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -420,7 +420,7 @@ public:
      *
      *  @return a bitmask of supported Wi-Fi bands where each bit is associated with a WiFiBandEnum value.
      */
-    virtual uint32_t _GetSupportedWiFiBandsMask() const
+    virtual uint32_t GetSupportedWiFiBandsMask() const
     {
         // Default to 2.4G support only
         return static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k2g4));

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -412,7 +412,6 @@ public:
      */
     virtual void CancelScanNetworks() = 0;
 
-    using WiFiBandEnum = app::Clusters::NetworkCommissioning::WiFiBandEnum;
     /**
      *  @brief Provide all the frequency bands supported by the Wi-Fi interface.
      *
@@ -423,7 +422,7 @@ public:
     virtual uint32_t GetSupportedWiFiBandsMask() const
     {
         // Default to 2.4G support only
-        return static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k2g4));
+        return static_cast<uint32_t>(1UL << chip::to_underlying(app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4));
     }
 
 protected:

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -16,7 +16,9 @@
  */
 #pragma once
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/icd/server/ICDServerConfig.h>
+
 #include <array>
 #include <cmsis_os2.h>
 #include <lib/support/BitFlags.h>
@@ -409,6 +411,20 @@ public:
      *        If one isn't in-progress, function doesn't do anything
      */
     virtual void CancelScanNetworks() = 0;
+
+    using WiFiBandEnum = app::Clusters::NetworkCommissioning::WiFiBandEnum;
+    /**
+     *  @brief Provide all the frequency bands supported by the Wi-Fi interface.
+     *
+     *  The default implementation returns the 2.4 GHz band support.
+     *
+     *  @return a bitmask of supported Wi-Fi bands where each bit is associated with a WiFiBandEnum value.
+     */
+    virtual uint32_t _GetSupportedWiFiBandsMask() const
+    {
+        // Default to 2.4G support only
+        return static_cast<uint32_t>(1UL << chip::to_underlying(WiFiBandEnum::k2g4));
+    }
 
 protected:
     /**

--- a/src/platform/silabs/wifi/WifiInterface.h
+++ b/src/platform/silabs/wifi/WifiInterface.h
@@ -73,6 +73,7 @@ typedef struct wfx_wifi_scan_result
     uint8_t bssid[kWifiMacAddressLength];
     uint8_t chan;
     int16_t rssi; /* I suspect this is in dBm - so signed */
+    chip::app::Clusters::NetworkCommissioning::WiFiBandEnum wiFiBand;
 } wfx_wifi_scan_result_t;
 using ScanCallback = void (*)(wfx_wifi_scan_result_t *);
 
@@ -422,7 +423,7 @@ public:
     virtual uint32_t GetSupportedWiFiBandsMask() const
     {
         // Default to 2.4G support only
-        return static_cast<uint32_t>(1UL << chip::to_underlying(app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4));
+        return static_cast<uint32_t>(1UL << chip::to_underlying(chip::app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4));
     }
 
 protected:

--- a/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/rs911x/WifiInterfaceImpl.cpp
@@ -55,6 +55,7 @@ extern "C" {
 WfxRsi_t wfx_rsi;
 
 using namespace chip::DeviceLayer::Silabs;
+using WiFiBandEnum = chip::app::Clusters::NetworkCommissioning::WiFiBandEnum;
 
 namespace {
 
@@ -376,6 +377,8 @@ void WifiInterfaceImpl::ProcessEvent(WifiPlatformEvent event)
             chip::MutableByteSpan bssidSpan(ap.bssid, kWifiMacAddressLength);
             chip::ByteSpan scanBssidSpan(scan.bssid, kWifiMacAddressLength);
             chip::CopySpanToMutableSpan(scanBssidSpan, bssidSpan);
+            // TODO: change this when SDK provides values
+            ap.wiFiBand = WiFiBandEnum::k2g4;
 
             wfx_rsi.scan_cb(&ap);
 

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -42,6 +42,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Silabs;
+using WiFiBandEnum = chip::app::Clusters::NetworkCommissioning::WiFiBandEnum;
 
 // TODO: This is a workaround because we depend on the platform lib which depends on the platform implementation.
 //       As such we can't depend on the platform here as well
@@ -483,6 +484,8 @@ static void sl_wfx_scan_result_callback(sl_wfx_scan_result_ind_body_t * scan_res
 
     ap->scan.chan = scan_result->channel;
     ap->scan.rssi = ConvertRcpiToRssi(scan_result->rcpi);
+    // WF200 only supports 2.4GHz band
+    ap->scan.wiFiBand = WiFiBandEnum::k2g4;
 
     chip::ByteSpan scannedBssid(scan_result->mac, kWifiMacAddressLength);
     chip::MutableByteSpan outputBssid(ap->scan.bssid, kWifiMacAddressLength);


### PR DESCRIPTION
### Changelog
- Added hardcoded data for WiFi band details for the support wifi chips

### Testing

```sh
chip-tool networkcommissioning scan-networks $CHIP_NODE_ID 0
```
Executed the above command to verify results, since value is hardcoded verified that changing that also reflects in the results of `chip-tool`.
The device combinations tested:
917 SoC
EFR32 + 917 NCP
EFR32 + WF200