### PR TITLE
[chef][icd] update chef force check-in command with shutdown all subs

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -485,6 +485,7 @@ public:
     virtual pw::Status TriggerIcdCheckin(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
 #if CHIP_CONFIG_ENABLE_ICD_CIP
+        chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
         chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
                 ChipLogDetail(AppServer, "Being triggerred to send ICD check-in message to subscriber");

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -485,9 +485,9 @@ public:
     virtual pw::Status TriggerIcdCheckin(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-        chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
         chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
+                chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
                 ChipLogDetail(AppServer, "Being triggerred to send ICD check-in message to subscriber");
                 chip::app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
             },


### PR DESCRIPTION
When we have subscriptions with chef-app, the check-in message cannot be sent even though we call TriggerIcdCheckin rpc command, we need close all subscriptions as well so that check-in message can be sent. In client side, client would consider all subscription has disappeared since check-in message has been sent, and further reschedule new subscripions.

#### Testing
local testing
