### PR TITLE
fix: missing field initializer build error

### DIFF
--- a/src/app/data-model-provider/Context.h
+++ b/src/app/data-model-provider/Context.h
@@ -31,9 +31,9 @@ namespace DataModel {
 /// as well as fetching current state (via actionContext)
 struct InteractionModelContext
 {
-    EventsGenerator * eventsGenerator;
-    ProviderChangeListener * dataModelChangeListener;
-    ActionContext * actionContext;
+    EventsGenerator * eventsGenerator                = nullptr;
+    ProviderChangeListener * dataModelChangeListener = nullptr;
+    ActionContext * actionContext                    = nullptr;
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -118,7 +118,7 @@ public:
                                                             CommandHandler * handler) = 0;
 
 protected:
-    InteractionModelContext mContext = { nullptr };
+    InteractionModelContext mContext = {};
 };
 
 } // namespace DataModel


### PR DESCRIPTION
Fix clang build error:
```
src/app/data-model-provider/Provider.h:119:50: error: missing field 'dataModelChangeListener' initializer [-Werror,-Wmissing-field-initializers]
  119 |     InteractionModelContext mContext = { nullptr };
```

#### Testing

Manual build
