### PR TITLE
[ESP32]: Fixed the lighting-app build with external platform enabled.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -119,6 +119,9 @@ jobs:
             - name: Build example Lighting App (Target:ESP32C6)
               run: scripts/examples/esp_example.sh lighting-app sdkconfig.wifi_thread.defaults esp32c6
 
+            - name: Build example Lighting App (external platform)
+              run: scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
+
             - name: Uploading Size Reports
               uses: ./.github/actions/upload-size-reports
               if: ${{ !env.ACT }}
@@ -164,9 +167,6 @@ jobs:
 
             - name: Build example Light Switch App (Target:ESP32C3)
               run: scripts/examples/esp_example.sh light-switch-app sdkconfig.defaults esp32c3
-
-            - name: Build example Lighting App (external platform)
-              run: scripts/examples/esp_example.sh lighting-app sdkconfig.ext_plat.defaults
 
             - name: Build example Energy Gateway App
               run: scripts/examples/esp_example.sh energy-gateway-app sdkconfig.defaults

--- a/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
+++ b/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/buildconfig_header.gni")
+import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/platform/device.gni")
 
 declare_args() {
@@ -29,6 +30,7 @@ declare_args() {
   chip_bt_bluedroid_enabled = true
   chip_max_discovered_ip_addresses = 5
   chip_enable_route_hook = false
+  chip_memory_alloc_mode = "default"
 }
 
 buildconfig_header("custom_buildconfig") {
@@ -109,6 +111,16 @@ static_library("ESP32_custom") {
     "${chip_root}/src/crypto",
     "${chip_root}/src/platform:platform_base",
   ]
+
+  if (chip_config_memory_management == "platform") {
+    if (chip_memory_alloc_mode == "internal") {
+      sources += [ "CHIPMem-PlatformInternal.cpp" ]
+    } else if (chip_memory_alloc_mode == "external") {
+      sources += [ "CHIPMem-PlatformExternal.cpp" ]
+    } else {
+      sources += [ "CHIPMem-PlatformDefault.cpp" ]
+    }
+  }
 
   if (chip_enable_ota_requestor) {
     sources += [

--- a/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
+++ b/examples/platform/esp32/external_platform/ESP32_custom/BUILD.gn
@@ -25,10 +25,11 @@ declare_args() {
   chip_use_factory_data_provider = false
   chip_use_device_info_provider = false
   chip_config_software_version_number = 0
-  chip_enable_chipoble = true
-  chip_bt_nimble_enabled = true
-  chip_bt_bluedroid_enabled = true
+  chip_enable_chipoble = false
+  chip_bt_nimble_enabled = false
+  chip_bt_bluedroid_enabled = false
   chip_max_discovered_ip_addresses = 5
+  chip_enable_ble_controller = false
   chip_enable_route_hook = false
   chip_memory_alloc_mode = "default"
 }
@@ -50,6 +51,7 @@ buildconfig_header("custom_buildconfig") {
     "CHIP_DEVICE_LAYER_TARGET_ESP32=1",
     "CHIP_DEVICE_LAYER_TARGET=ESP32_custom",
     "CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER=1",
+    "CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE=${chip_enable_chipoble}",
     "BLE_PLATFORM_CONFIG_INCLUDE=<external_platform/ESP32_custom/BlePlatformConfig.h>",
     "CHIP_DEVICE_PLATFORM_CONFIG_INCLUDE=<external_platform/ESP32_custom/CHIPDevicePlatformConfig.h>",
     "CHIP_PLATFORM_CONFIG_INCLUDE=<external_platform/ESP32_custom/CHIPPlatformConfig.h>",
@@ -122,23 +124,36 @@ static_library("ESP32_custom") {
     }
   }
 
+  if (chip_enable_ble) {
+    sources += [ "BLEManagerImpl.h" ]
+    if (chip_enable_ble_controller) {
+      sources += [ "ChipDeviceScanner.h" ]
+    }
+
+    if (chip_bt_nimble_enabled) {
+      sources += [ "nimble/BLEManagerImpl.cpp" ]
+      if (chip_enable_ble_controller) {
+        sources += [
+          "nimble/ChipDeviceScanner.cpp",
+          "nimble/blecent.h",
+          "nimble/misc.c",
+          "nimble/peer.c",
+        ]
+      }
+    }
+    if (chip_bt_bluedroid_enabled) {
+      sources += [ "bluedroid/BLEManagerImpl.cpp" ]
+      if (chip_enable_ble_controller) {
+        sources += [ "bluedroid/ChipDeviceScanner.cpp" ]
+      }
+    }
+  }
+
   if (chip_enable_ota_requestor) {
     sources += [
       "OTAImageProcessorImpl.cpp",
       "OTAImageProcessorImpl.h",
     ]
-  }
-
-  if (chip_enable_chipoble) {
-    sources += [ "BLEManagerImpl.h" ]
-  }
-
-  if (chip_bt_nimble_enabled) {
-    sources += [ "nimble/BLEManagerImpl.cpp" ]
-  }
-
-  if (chip_bt_bluedroid_enabled) {
-    sources += [ "bluedroid/BLEManagerImpl.cpp" ]
   }
 
   if (chip_enable_wifi) {

--- a/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformDefault.cpp
+++ b/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformDefault.cpp
@@ -1,0 +1,1 @@
+../../../../../src/platform/ESP32/CHIPMem-PlatformDefault.cpp

--- a/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformExternal.cpp
+++ b/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformExternal.cpp
@@ -1,0 +1,1 @@
+../../../../../src/platform/ESP32/CHIPMem-PlatformExternal.cpp

--- a/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformInternal.cpp
+++ b/examples/platform/esp32/external_platform/ESP32_custom/CHIPMem-PlatformInternal.cpp
@@ -1,0 +1,1 @@
+../../../../../src/platform/ESP32/CHIPMem-PlatformInternal.cpp


### PR DESCRIPTION
#### Problem
-  The build for lighting-app esp32 with external platform enabled was failing post #37482.

#### Change Overview
-  Fixed the compilation for external platform build for lighting-app.

#### Testing
-  Tested the lighting-app esp32 with external platform enabled.
