### PR TITLE
[Chef] update chef force check-in command with shutdown all subs

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -485,9 +485,9 @@ public:
     virtual pw::Status TriggerIcdCheckin(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
 #if CHIP_CONFIG_ENABLE_ICD_CIP
-        chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptionHandlers();
         chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
+                chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptionHandlers();
                 ChipLogDetail(AppServer, "Being triggerred to send ICD check-in message to subscriber");
                 chip::app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
             },

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -485,6 +485,7 @@ public:
     virtual pw::Status TriggerIcdCheckin(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
 #if CHIP_CONFIG_ENABLE_ICD_CIP
+        chip::app::InteractionModelEngine::GetInstance()->ShutdownAllSubscriptionHandlers();
         chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
                 ChipLogDetail(AppServer, "Being triggerred to send ICD check-in message to subscriber");

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -387,6 +387,18 @@ void InteractionModelEngine::ShutdownAllSubscriptions()
     ShutdownMatchingSubscriptions();
 }
 
+void InteractionModelEngine::ShutdownAllSubscriptionHandlers()
+{
+    mReadHandlers.ForEachActiveObject([&](auto * handler) {
+        if (!handler->IsType(ReadHandler::InteractionType::Subscribe))
+        {
+            return Loop::Continue;
+        }
+        handler->Close();
+        return Loop::Continue;
+    });
+}
+
 void InteractionModelEngine::ShutdownMatchingSubscriptions(const Optional<FabricIndex> & aFabricIndex,
                                                            const Optional<NodeId> & aPeerNodeId)
 {

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -169,6 +169,12 @@ public:
      * Tears down all active subscriptions.
      */
     void ShutdownAllSubscriptions();
+
+    /**
+     * Tears down all subscription handlers.
+     */
+    void ShutdownAllSubscriptionHandlers();
+
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
     uint32_t GetNumActiveReadHandlers() const;

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -170,12 +170,12 @@ public:
      */
     void ShutdownAllSubscriptions();
 
+#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
+
     /**
      * Tears down all subscription handlers.
      */
     void ShutdownAllSubscriptionHandlers();
-
-#endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
     uint32_t GetNumActiveReadHandlers() const;
     uint32_t GetNumActiveReadHandlers(ReadHandler::InteractionType type) const;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1568,14 +1568,14 @@ TEST_F(TestRead, TestShutdownAllSubscriptionHandlers)
         EXPECT_EQ(callback.mOnError, 0);
         EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
 
-
-        InteractionModelEngine::GetInstance()->ShutdownAllSubscriptionHandlers();
-
         ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
 
         uint16_t minInterval;
         uint16_t maxInterval;
         readHandler->GetReportingIntervals(minInterval, maxInterval);
+
+        InteractionModelEngine::GetInstance()->ShutdownAllSubscriptionHandlers();
+
         GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)),
                                     [&]() { return callback.mOnResubscriptionsAttempted > 0; });
 
@@ -1601,7 +1601,7 @@ TEST_F(TestRead, TestShutdownAllSubscriptionHandlers)
 
     SetMRPMode(MessagingContext::MRPMode::kDefault);
 
-    InteractionModelEngine::GetInstance()->ShutdownAllSubscriptions();
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 


### PR DESCRIPTION
If controller has active subscriptions with chef-app, the check-in message cannot be sent even though we call TriggerIcdCheckin rpc command, we need close all subscriptions as well so that check-in message can be sent. In client side, client would consider all subscription has disappeared since check-in message has been sent, and further reschedule new subscripions.

fixes https://github.com/project-chip/connectedhomeip/issues/38012

#### Testing
unit test