### PR TITLE
Add Matter*PluginServerShutdownCallback

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/application/PluginApplicationCallbacksHeader.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/application/PluginApplicationCallbacksHeader.jinja
@@ -4,9 +4,20 @@
 void Matter{{ cluster.name }}PluginServerInitCallback();
 {%- endfor %}
 
+{%- for cluster in clusters | sort(attribute='name') %}
+void Matter{{ cluster.name }}PluginServerShutdownCallback();
+{%- endfor %}
+
 #define MATTER_PLUGINS_INIT \
 {%- for cluster in clusters | sort(attribute='name') %}
     Matter{{ cluster.name }}PluginServerInitCallback();{{ " \\" if not loop.last else ""}}
+{%- else %}
+    (void)0; /* No server side clusters */
+{%- endfor %}
+
+#define MATTER_PLUGINS_SHUTDOWN \
+{%- for cluster in clusters | sort(attribute='name') %}
+    Matter{{ cluster.name }}PluginServerShutdownCallback();{{ " \\" if not loop.last else ""}}
 {%- else %}
     (void)0; /* No server side clusters */
 {%- endfor %}

--- a/scripts/py_matter_idl/matter/idl/tests/outputs/large_all_clusters_app/cpp-app/PluginApplicationCallbacks.h
+++ b/scripts/py_matter_idl/matter/idl/tests/outputs/large_all_clusters_app/cpp-app/PluginApplicationCallbacks.h
@@ -59,6 +59,66 @@ void MatterUserLabelPluginServerInitCallback();
 void MatterWakeOnLanPluginServerInitCallback();
 void MatterWiFiNetworkDiagnosticsPluginServerInitCallback();
 void MatterWindowCoveringPluginServerInitCallback();
+void MatterAccessControlPluginServerShutdownCallback();
+void MatterAccountLoginPluginServerShutdownCallback();
+void MatterActionsPluginServerShutdownCallback();
+void MatterAdministratorCommissioningPluginServerShutdownCallback();
+void MatterApplicationBasicPluginServerShutdownCallback();
+void MatterApplicationLauncherPluginServerShutdownCallback();
+void MatterAudioOutputPluginServerShutdownCallback();
+void MatterBasicInformationPluginServerShutdownCallback();
+void MatterBinaryInputBasicPluginServerShutdownCallback();
+void MatterBindingPluginServerShutdownCallback();
+void MatterBooleanStatePluginServerShutdownCallback();
+void MatterChannelPluginServerShutdownCallback();
+void MatterColorControlPluginServerShutdownCallback();
+void MatterContentLauncherPluginServerShutdownCallback();
+void MatterDescriptorPluginServerShutdownCallback();
+void MatterDiagnosticLogsPluginServerShutdownCallback();
+void MatterDoorLockPluginServerShutdownCallback();
+void MatterEthernetNetworkDiagnosticsPluginServerShutdownCallback();
+void MatterFanControlPluginServerShutdownCallback();
+void MatterFaultInjectionPluginServerShutdownCallback();
+void MatterFixedLabelPluginServerShutdownCallback();
+void MatterFlowMeasurementPluginServerShutdownCallback();
+void MatterGeneralCommissioningPluginServerShutdownCallback();
+void MatterGeneralDiagnosticsPluginServerShutdownCallback();
+void MatterGroupKeyManagementPluginServerShutdownCallback();
+void MatterGroupsPluginServerShutdownCallback();
+void MatterIdentifyPluginServerShutdownCallback();
+void MatterIlluminanceMeasurementPluginServerShutdownCallback();
+void MatterKeypadInputPluginServerShutdownCallback();
+void MatterLevelControlPluginServerShutdownCallback();
+void MatterLocalizationConfigurationPluginServerShutdownCallback();
+void MatterLowPowerPluginServerShutdownCallback();
+void MatterMatterScenesPluginServerShutdownCallback();
+void MatterMediaInputPluginServerShutdownCallback();
+void MatterMediaPlaybackPluginServerShutdownCallback();
+void MatterModeSelectPluginServerShutdownCallback();
+void MatterNetworkCommissioningPluginServerShutdownCallback();
+void MatterOccupancySensingPluginServerShutdownCallback();
+void MatterOnOffPluginServerShutdownCallback();
+void MatterOperationalCredentialsPluginServerShutdownCallback();
+void MatterOtaSoftwareUpdateRequestorPluginServerShutdownCallback();
+void MatterPowerSourcePluginServerShutdownCallback();
+void MatterPowerSourceConfigurationPluginServerShutdownCallback();
+void MatterPressureMeasurementPluginServerShutdownCallback();
+void MatterPumpConfigurationAndControlPluginServerShutdownCallback();
+void MatterRelativeHumidityMeasurementPluginServerShutdownCallback();
+void MatterSoftwareDiagnosticsPluginServerShutdownCallback();
+void MatterSwitchPluginServerShutdownCallback();
+void MatterTargetNavigatorPluginServerShutdownCallback();
+void MatterTemperatureMeasurementPluginServerShutdownCallback();
+void MatterThermostatPluginServerShutdownCallback();
+void MatterThermostatUserInterfaceConfigurationPluginServerShutdownCallback();
+void MatterThreadNetworkDiagnosticsPluginServerShutdownCallback();
+void MatterTimeFormatLocalizationPluginServerShutdownCallback();
+void MatterUnitLocalizationPluginServerShutdownCallback();
+void MatterUnitTestingPluginServerShutdownCallback();
+void MatterUserLabelPluginServerShutdownCallback();
+void MatterWakeOnLanPluginServerShutdownCallback();
+void MatterWiFiNetworkDiagnosticsPluginServerShutdownCallback();
+void MatterWindowCoveringPluginServerShutdownCallback();
 
 #define MATTER_PLUGINS_INIT \
     MatterAccessControlPluginServerInitCallback(); \
@@ -121,4 +181,66 @@ void MatterWindowCoveringPluginServerInitCallback();
     MatterWakeOnLanPluginServerInitCallback(); \
     MatterWiFiNetworkDiagnosticsPluginServerInitCallback(); \
     MatterWindowCoveringPluginServerInitCallback();
+
+#define MATTER_PLUGINS_SHUTDOWN \
+    MatterAccessControlPluginServerShutdownCallback(); \
+    MatterAccountLoginPluginServerShutdownCallback(); \
+    MatterActionsPluginServerShutdownCallback(); \
+    MatterAdministratorCommissioningPluginServerShutdownCallback(); \
+    MatterApplicationBasicPluginServerShutdownCallback(); \
+    MatterApplicationLauncherPluginServerShutdownCallback(); \
+    MatterAudioOutputPluginServerShutdownCallback(); \
+    MatterBasicInformationPluginServerShutdownCallback(); \
+    MatterBinaryInputBasicPluginServerShutdownCallback(); \
+    MatterBindingPluginServerShutdownCallback(); \
+    MatterBooleanStatePluginServerShutdownCallback(); \
+    MatterChannelPluginServerShutdownCallback(); \
+    MatterColorControlPluginServerShutdownCallback(); \
+    MatterContentLauncherPluginServerShutdownCallback(); \
+    MatterDescriptorPluginServerShutdownCallback(); \
+    MatterDiagnosticLogsPluginServerShutdownCallback(); \
+    MatterDoorLockPluginServerShutdownCallback(); \
+    MatterEthernetNetworkDiagnosticsPluginServerShutdownCallback(); \
+    MatterFanControlPluginServerShutdownCallback(); \
+    MatterFaultInjectionPluginServerShutdownCallback(); \
+    MatterFixedLabelPluginServerShutdownCallback(); \
+    MatterFlowMeasurementPluginServerShutdownCallback(); \
+    MatterGeneralCommissioningPluginServerShutdownCallback(); \
+    MatterGeneralDiagnosticsPluginServerShutdownCallback(); \
+    MatterGroupKeyManagementPluginServerShutdownCallback(); \
+    MatterGroupsPluginServerShutdownCallback(); \
+    MatterIdentifyPluginServerShutdownCallback(); \
+    MatterIlluminanceMeasurementPluginServerShutdownCallback(); \
+    MatterKeypadInputPluginServerShutdownCallback(); \
+    MatterLevelControlPluginServerShutdownCallback(); \
+    MatterLocalizationConfigurationPluginServerShutdownCallback(); \
+    MatterLowPowerPluginServerShutdownCallback(); \
+    MatterMatterScenesPluginServerShutdownCallback(); \
+    MatterMediaInputPluginServerShutdownCallback(); \
+    MatterMediaPlaybackPluginServerShutdownCallback(); \
+    MatterModeSelectPluginServerShutdownCallback(); \
+    MatterNetworkCommissioningPluginServerShutdownCallback(); \
+    MatterOccupancySensingPluginServerShutdownCallback(); \
+    MatterOnOffPluginServerShutdownCallback(); \
+    MatterOperationalCredentialsPluginServerShutdownCallback(); \
+    MatterOtaSoftwareUpdateRequestorPluginServerShutdownCallback(); \
+    MatterPowerSourcePluginServerShutdownCallback(); \
+    MatterPowerSourceConfigurationPluginServerShutdownCallback(); \
+    MatterPressureMeasurementPluginServerShutdownCallback(); \
+    MatterPumpConfigurationAndControlPluginServerShutdownCallback(); \
+    MatterRelativeHumidityMeasurementPluginServerShutdownCallback(); \
+    MatterSoftwareDiagnosticsPluginServerShutdownCallback(); \
+    MatterSwitchPluginServerShutdownCallback(); \
+    MatterTargetNavigatorPluginServerShutdownCallback(); \
+    MatterTemperatureMeasurementPluginServerShutdownCallback(); \
+    MatterThermostatPluginServerShutdownCallback(); \
+    MatterThermostatUserInterfaceConfigurationPluginServerShutdownCallback(); \
+    MatterThreadNetworkDiagnosticsPluginServerShutdownCallback(); \
+    MatterTimeFormatLocalizationPluginServerShutdownCallback(); \
+    MatterUnitLocalizationPluginServerShutdownCallback(); \
+    MatterUnitTestingPluginServerShutdownCallback(); \
+    MatterUserLabelPluginServerShutdownCallback(); \
+    MatterWakeOnLanPluginServerShutdownCallback(); \
+    MatterWiFiNetworkDiagnosticsPluginServerShutdownCallback(); \
+    MatterWindowCoveringPluginServerShutdownCallback();
 

--- a/scripts/py_matter_idl/matter/idl/tests/outputs/large_lighting_app/cpp-app/PluginApplicationCallbacks.h
+++ b/scripts/py_matter_idl/matter/idl/tests/outputs/large_lighting_app/cpp-app/PluginApplicationCallbacks.h
@@ -25,6 +25,32 @@ void MatterThreadNetworkDiagnosticsPluginServerInitCallback();
 void MatterTimeFormatLocalizationPluginServerInitCallback();
 void MatterUserLabelPluginServerInitCallback();
 void MatterWiFiNetworkDiagnosticsPluginServerInitCallback();
+void MatterAccessControlPluginServerShutdownCallback();
+void MatterAdministratorCommissioningPluginServerShutdownCallback();
+void MatterBasicInformationPluginServerShutdownCallback();
+void MatterColorControlPluginServerShutdownCallback();
+void MatterDescriptorPluginServerShutdownCallback();
+void MatterDiagnosticLogsPluginServerShutdownCallback();
+void MatterEthernetNetworkDiagnosticsPluginServerShutdownCallback();
+void MatterFixedLabelPluginServerShutdownCallback();
+void MatterGeneralCommissioningPluginServerShutdownCallback();
+void MatterGeneralDiagnosticsPluginServerShutdownCallback();
+void MatterGroupKeyManagementPluginServerShutdownCallback();
+void MatterGroupsPluginServerShutdownCallback();
+void MatterIdentifyPluginServerShutdownCallback();
+void MatterLevelControlPluginServerShutdownCallback();
+void MatterLocalizationConfigurationPluginServerShutdownCallback();
+void MatterNetworkCommissioningPluginServerShutdownCallback();
+void MatterOccupancySensingPluginServerShutdownCallback();
+void MatterOnOffPluginServerShutdownCallback();
+void MatterOperationalCredentialsPluginServerShutdownCallback();
+void MatterOtaSoftwareUpdateRequestorPluginServerShutdownCallback();
+void MatterSoftwareDiagnosticsPluginServerShutdownCallback();
+void MatterSwitchPluginServerShutdownCallback();
+void MatterThreadNetworkDiagnosticsPluginServerShutdownCallback();
+void MatterTimeFormatLocalizationPluginServerShutdownCallback();
+void MatterUserLabelPluginServerShutdownCallback();
+void MatterWiFiNetworkDiagnosticsPluginServerShutdownCallback();
 
 #define MATTER_PLUGINS_INIT \
     MatterAccessControlPluginServerInitCallback(); \
@@ -53,4 +79,32 @@ void MatterWiFiNetworkDiagnosticsPluginServerInitCallback();
     MatterTimeFormatLocalizationPluginServerInitCallback(); \
     MatterUserLabelPluginServerInitCallback(); \
     MatterWiFiNetworkDiagnosticsPluginServerInitCallback();
+
+#define MATTER_PLUGINS_SHUTDOWN \
+    MatterAccessControlPluginServerShutdownCallback(); \
+    MatterAdministratorCommissioningPluginServerShutdownCallback(); \
+    MatterBasicInformationPluginServerShutdownCallback(); \
+    MatterColorControlPluginServerShutdownCallback(); \
+    MatterDescriptorPluginServerShutdownCallback(); \
+    MatterDiagnosticLogsPluginServerShutdownCallback(); \
+    MatterEthernetNetworkDiagnosticsPluginServerShutdownCallback(); \
+    MatterFixedLabelPluginServerShutdownCallback(); \
+    MatterGeneralCommissioningPluginServerShutdownCallback(); \
+    MatterGeneralDiagnosticsPluginServerShutdownCallback(); \
+    MatterGroupKeyManagementPluginServerShutdownCallback(); \
+    MatterGroupsPluginServerShutdownCallback(); \
+    MatterIdentifyPluginServerShutdownCallback(); \
+    MatterLevelControlPluginServerShutdownCallback(); \
+    MatterLocalizationConfigurationPluginServerShutdownCallback(); \
+    MatterNetworkCommissioningPluginServerShutdownCallback(); \
+    MatterOccupancySensingPluginServerShutdownCallback(); \
+    MatterOnOffPluginServerShutdownCallback(); \
+    MatterOperationalCredentialsPluginServerShutdownCallback(); \
+    MatterOtaSoftwareUpdateRequestorPluginServerShutdownCallback(); \
+    MatterSoftwareDiagnosticsPluginServerShutdownCallback(); \
+    MatterSwitchPluginServerShutdownCallback(); \
+    MatterThreadNetworkDiagnosticsPluginServerShutdownCallback(); \
+    MatterTimeFormatLocalizationPluginServerShutdownCallback(); \
+    MatterUserLabelPluginServerShutdownCallback(); \
+    MatterWiFiNetworkDiagnosticsPluginServerShutdownCallback();
 

--- a/scripts/py_matter_idl/matter/idl/tests/outputs/several_clusters/cpp-app/PluginApplicationCallbacks.h
+++ b/scripts/py_matter_idl/matter/idl/tests/outputs/several_clusters/cpp-app/PluginApplicationCallbacks.h
@@ -1,6 +1,10 @@
 #pragma once
 void MatterThirdPluginServerInitCallback();
+void MatterThirdPluginServerShutdownCallback();
 
 #define MATTER_PLUGINS_INIT \
     MatterThirdPluginServerInitCallback();
+
+#define MATTER_PLUGINS_SHUTDOWN \
+    MatterThirdPluginServerShutdownCallback();
 

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -598,6 +598,22 @@ void MatterAccessControlPluginServerInitCallback()
 #endif
 }
 
+void MatterAccessControlPluginServerShutdownCallback()
+{
+    ChipLogProgress(DataManagement, "AccessControlCluster: shutdown");
+
+#if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
+    auto accessRestrictionProvider = GetAccessControl().GetAccessRestrictionProvider();
+    if (accessRestrictionProvider != nullptr)
+    {
+        accessRestrictionProvider->RemoveListener(sAttribute);
+    }
+#endif
+
+    GetAccessControl().RemoveEntryListener(sAttribute);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&sAttribute);
+}
+
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
 bool emberAfAccessControlClusterReviewFabricRestrictionsCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -263,3 +263,8 @@ void MatterAccountLoginPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gAccountLoginAttrAccess);
 }
+
+void MatterAccountLoginPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gAccountLoginAttrAccess);
+}

--- a/src/app/clusters/actions-server/actions-server.cpp
+++ b/src/app/clusters/actions-server/actions-server.cpp
@@ -333,3 +333,4 @@ void ActionsServer::EndpointListModified(EndpointId aEndpoint)
 }
 
 void MatterActionsPluginServerInitCallback() {}
+void MatterActionsPluginServerShutdownCallback() {}

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -244,3 +244,10 @@ void MatterAdministratorCommissioningPluginServerInitCallback()
     CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gAdminCommissioningServer);
     AttributeAccessInterfaceRegistry::Instance().Register(&gAdminCommissioningServer);
 }
+
+void MatterAdministratorCommissioningPluginServerShutdownCallback()
+{
+    ChipLogProgress(Zcl, "Shutdown Admin Commissioning cluster.");
+    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gAdminCommissioningServer);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAdminCommissioningServer);
+}

--- a/src/app/clusters/application-basic-server/application-basic-server.cpp
+++ b/src/app/clusters/application-basic-server/application-basic-server.cpp
@@ -248,3 +248,8 @@ void MatterApplicationBasicPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gApplicationBasicAttrAccess);
 }
+
+void MatterApplicationBasicPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gApplicationBasicAttrAccess);
+}

--- a/src/app/clusters/application-launcher-server/application-launcher-server.cpp
+++ b/src/app/clusters/application-launcher-server/application-launcher-server.cpp
@@ -497,3 +497,8 @@ void MatterApplicationLauncherPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gApplicationLauncherAttrAccess);
 }
+
+void MatterApplicationLauncherPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gApplicationLauncherAttrAccess);
+}

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -246,3 +246,8 @@ void MatterAudioOutputPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gAudioOutputAttrAccess);
 }
+
+void MatterAudioOutputPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gAudioOutputAttrAccess);
+}

--- a/src/app/clusters/basic-information/basic-information.cpp
+++ b/src/app/clusters/basic-information/basic-information.cpp
@@ -479,3 +479,9 @@ void MatterBasicInformationPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
     PlatformMgr().SetDelegate(&gPlatformMgrDelegate);
 }
+
+void MatterBasicInformationPluginServerShutdownCallback()
+{
+    PlatformMgr().SetDelegate(nullptr);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/bindings/bindings.cpp
+++ b/src/app/clusters/bindings/bindings.cpp
@@ -271,6 +271,11 @@ void MatterBindingPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
 
+void MatterBindingPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}
+
 CHIP_ERROR AddBindingEntry(const EmberBindingTableEntry & entry)
 {
     CHIP_ERROR err = BindingTable::GetInstance().Add(entry);

--- a/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
+++ b/src/app/clusters/boolean-state-configuration-server/boolean-state-configuration-server.cpp
@@ -455,3 +455,8 @@ void MatterBooleanStateConfigurationPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterBooleanStateConfigurationPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1904,3 +1904,4 @@ void CameraAVStreamMgmtServer::HandleCaptureSnapshot(HandlerContext & ctx,
  *
  */
 void MatterCameraAvStreamManagementPluginServerInitCallback() {}
+void MatterCameraAvStreamManagementPluginServerShutdownCallback() {}

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -410,3 +410,8 @@ void MatterChannelPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gChannelAttrAccess);
 }
+
+void MatterChannelPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gChannelAttrAccess);
+}

--- a/src/app/clusters/chime-server/chime-server.cpp
+++ b/src/app/clusters/chime-server/chime-server.cpp
@@ -277,3 +277,4 @@ void ChimeServer::HandlePlayChimeSound(HandlerContext & ctx, const Commands::Pla
  *
  */
 void MatterChimePluginServerInitCallback() {}
+void MatterChimePluginServerShutdownCallback() {}

--- a/src/app/clusters/closure-control-server/closure-control-server.cpp
+++ b/src/app/clusters/closure-control-server/closure-control-server.cpp
@@ -311,3 +311,4 @@ void Instance::HandleCalibrate(HandlerContext & ctx, const Commands::Calibrate::
 // Plugin initialization
 
 void MatterClosureControlPluginServerInitCallback() {}
+void MatterClosureControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -3339,3 +3339,4 @@ void emberAfPluginColorControlServerHueSatTransitionEventHandler(EndpointId endp
 #endif // MATTER_DM_PLUGIN_COLOR_CONTROL_SERVER_HSV
 
 void MatterColorControlPluginServerInitCallback() {}
+void MatterColorControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
+++ b/src/app/clusters/commissioner-control-server/commissioner-control-server.cpp
@@ -274,3 +274,8 @@ void MatterCommissionerControlPluginServerInitCallback()
 {
     ChipLogProgress(Zcl, "Initializing Commissioner Control cluster.");
 }
+
+void MatterCommissionerControlPluginServerShutdownCallback()
+{
+    ChipLogProgress(Zcl, "Shutdown Commissioner Control cluster.");
+}

--- a/src/app/clusters/content-app-observer/content-app-observer.cpp
+++ b/src/app/clusters/content-app-observer/content-app-observer.cpp
@@ -152,3 +152,4 @@ exit:
 // Plugin initialization
 
 void MatterContentAppObserverPluginServerInitCallback() {}
+void MatterContentAppObserverPluginServerShutdownCallback() {}

--- a/src/app/clusters/content-control-server/content-control-server.cpp
+++ b/src/app/clusters/content-control-server/content-control-server.cpp
@@ -416,3 +416,4 @@ exit:
 // Plugin initialization
 
 void MatterContentControlPluginServerInitCallback() {}
+void MatterContentControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/content-launch-server/content-launch-server.cpp
+++ b/src/app/clusters/content-launch-server/content-launch-server.cpp
@@ -289,3 +289,8 @@ void MatterContentLauncherPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gContentLauncherAttrAccess);
 }
+
+void MatterContentLauncherPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gContentLauncherAttrAccess);
+}

--- a/src/app/clusters/descriptor/descriptor.cpp
+++ b/src/app/clusters/descriptor/descriptor.cpp
@@ -284,3 +284,8 @@ void MatterDescriptorPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterDescriptorPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
+++ b/src/app/clusters/device-energy-management-server/device-energy-management-server.cpp
@@ -924,3 +924,4 @@ Status Instance::GetMatterEpochTimeFromUnixTime(uint32_t & currentUtcTime) const
 } // namespace chip
 
 void MatterDeviceEnergyManagementPluginServerInitCallback() {}
+void MatterDeviceEnergyManagementPluginServerShutdownCallback() {}

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -194,4 +194,5 @@ bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(chip::app::CommandH
 }
 
 void MatterDiagnosticLogsPluginServerInitCallback() {}
+void MatterDiagnosticLogsPluginServerShutdownCallback() {}
 #endif // #ifdef MATTER_DM_DIAGNOSTIC_LOGS_CLUSTER_SERVER_ENDPOINT_COUNT

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -4309,6 +4309,14 @@ void MatterDoorLockPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&DoorLockServer::Instance());
 }
 
+void MatterDoorLockPluginServerShutdownCallback()
+{
+    ChipLogProgress(Zcl, "Door Lock server shutdown");
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&gFabricDelegate);
+
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&DoorLockServer::Instance());
+}
+
 void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath) {}
 
 void MatterDoorLockClusterServerShutdownCallback(EndpointId endpoint)

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -378,3 +378,8 @@ void MatterEcosystemInformationPluginServerInitCallback()
 {
     chip::app::AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterEcosystemInformationPluginServerShutdownCallback()
+{
+    chip::app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/energy-evse-server/energy-evse-server.cpp
+++ b/src/app/clusters/energy-evse-server/energy-evse-server.cpp
@@ -505,3 +505,4 @@ void Instance::HandleClearTargets(HandlerContext & ctx, const Commands::ClearTar
 // Plugin initialization
 
 void MatterEnergyEvsePluginServerInitCallback() {}
+void MatterEnergyEvsePluginServerShutdownCallback() {}

--- a/src/app/clusters/energy-preference-server/energy-preference-server.cpp
+++ b/src/app/clusters/energy-preference-server/energy-preference-server.cpp
@@ -230,3 +230,8 @@ void MatterEnergyPreferencePluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gEnergyPrefAttrAccess);
 }
+
+void MatterEnergyPreferencePluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gEnergyPrefAttrAccess);
+}

--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -188,3 +188,8 @@ void MatterEthernetNetworkDiagnosticsPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterEthernetNetworkDiagnosticsPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/fault-injection-server/fault-injection-server.cpp
+++ b/src/app/clusters/fault-injection-server/fault-injection-server.cpp
@@ -148,3 +148,4 @@ bool emberAfFaultInjectionClusterFailRandomlyAtFaultCallback(CommandHandler * co
 }
 
 void MatterFaultInjectionPluginServerInitCallback() {}
+void MatterFaultInjectionPluginServerShutdownCallback() {}

--- a/src/app/clusters/fixed-label-server/fixed-label-server.cpp
+++ b/src/app/clusters/fixed-label-server/fixed-label-server.cpp
@@ -112,3 +112,8 @@ void MatterFixedLabelPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterFixedLabelPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -674,6 +674,16 @@ void MatterGeneralCommissioningPluginServerInitCallback()
     Server::GetInstance().GetFabricTable().AddFabricDelegate(&fabricDelegate);
 }
 
+void MatterGeneralCommissioningPluginServerShutdownCallback()
+{
+    static GeneralCommissioningFabricTableDelegate fabricDelegate;
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&fabricDelegate);
+
+    DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gGeneralCommissioningInstance);
+    ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gGeneralCommissioningInstance));
+}
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -663,6 +663,10 @@ public:
     }
 };
 
+namespace {
+    static GeneralCommissioningFabricTableDelegate fabricDelegate;
+}
+
 void MatterGeneralCommissioningPluginServerInitCallback()
 {
     Breadcrumb::Set(0, 0);
@@ -670,13 +674,11 @@ void MatterGeneralCommissioningPluginServerInitCallback()
     ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gGeneralCommissioningInstance));
     DeviceLayer::PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler);
 
-    static GeneralCommissioningFabricTableDelegate fabricDelegate;
     Server::GetInstance().GetFabricTable().AddFabricDelegate(&fabricDelegate);
 }
 
 void MatterGeneralCommissioningPluginServerShutdownCallback()
 {
-    static GeneralCommissioningFabricTableDelegate fabricDelegate;
     Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&fabricDelegate);
 
     DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler);

--- a/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
+++ b/src/app/clusters/general-commissioning-server/general-commissioning-server.cpp
@@ -664,7 +664,7 @@ public:
 };
 
 namespace {
-    static GeneralCommissioningFabricTableDelegate fabricDelegate;
+static GeneralCommissioningFabricTableDelegate fabricDelegate;
 }
 
 void MatterGeneralCommissioningPluginServerInitCallback()

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-server.cpp
@@ -527,3 +527,11 @@ void MatterGeneralDiagnosticsPluginServerInitCallback()
         GeneralDiagnosticsServer::Instance().OnDeviceReboot(bootReason);
     }
 }
+
+void MatterGeneralDiagnosticsPluginServerShutdownCallback()
+{
+    ConnectivityMgr().SetDelegate(nullptr);
+
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gGeneralDiagnosticsInstance);
+    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gGeneralDiagnosticsInstance);
+}

--- a/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
+++ b/src/app/clusters/group-key-mgmt-server/group-key-mgmt-server.cpp
@@ -458,6 +458,10 @@ void MatterGroupKeyManagementPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttribute);
 }
 
+void MatterGroupKeyManagementPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttribute);
+}
 //
 // Commands
 //

--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -387,3 +387,4 @@ bool emberAfGroupsClusterEndpointInGroupCallback(chip::FabricIndex fabricIndex, 
 void emberAfPluginGroupsServerSetGroupNameCallback(EndpointId endpoint, GroupId groupId, const CharSpan & groupName) {}
 
 void MatterGroupsPluginServerInitCallback() {}
+void MatterGroupsPluginServerShutdownCallback() {}

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -503,8 +503,6 @@ void MatterIcdManagementPluginServerShutdownCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttribute);
 
-    ICDManagementServer::Shutdown();
-
 #if CHIP_CONFIG_ENABLE_ICD_CIP
     FabricTable & fabricTable = Server::GetInstance().GetFabricTable();
     fabricTable.RemoveFabricDelegate(&gFabricDelegate);

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -498,3 +498,15 @@ void MatterIcdManagementPluginServerInitCallback()
     // Configure ICD Management
     ICDManagementServer::Init(storage, symmetricKeystore, icdConfigurationData);
 }
+
+void MatterIcdManagementPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttribute);
+
+    ICDManagementServer::Shutdown();
+
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+    FabricTable & fabricTable = Server::GetInstance().GetFabricTable();
+    fabricTable.RemoveFabricDelegate(&gFabricDelegate);
+#endif // CHIP_CONFIG_ENABLE_ICD_CIP
+}

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -253,3 +253,4 @@ Identify::~Identify()
 }
 
 void MatterIdentifyPluginServerInitCallback() {}
+void MatterIdentifyPluginServerShutdownCallback() {}

--- a/src/app/clusters/keypad-input-server/keypad-input-server.cpp
+++ b/src/app/clusters/keypad-input-server/keypad-input-server.cpp
@@ -199,3 +199,8 @@ void MatterKeypadInputPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gKeypadInputAttrAccess);
 }
+
+void MatterKeypadInputPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gKeypadInputAttrAccess);
+}

--- a/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
+++ b/src/app/clusters/laundry-dryer-controls-server/laundry-dryer-controls-server.cpp
@@ -152,6 +152,12 @@ void MatterLaundryDryerControlsPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&laundryDryerControlsServer);
 }
 
+void MatterLaundryDryerControlsPluginServerShutdownCallback()
+{
+    LaundryDryerControlsServer & laundryDryerControlsServer = LaundryDryerControlsServer::Instance();
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&laundryDryerControlsServer);
+}
+
 Status MatterLaundryDryerControlsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                           EmberAfAttributeType attributeType, uint16_t size,
                                                                           uint8_t * value)

--- a/src/app/clusters/laundry-washer-controls-server/laundry-washer-controls-server.cpp
+++ b/src/app/clusters/laundry-washer-controls-server/laundry-washer-controls-server.cpp
@@ -190,6 +190,12 @@ void MatterLaundryWasherControlsPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&laundryWasherControlsServer);
 }
 
+void MatterLaundryWasherControlsPluginServerShutdownCallback()
+{
+    LaundryWasherControlsServer & laundryWasherControlsServer = LaundryWasherControlsServer::Instance();
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&laundryWasherControlsServer);
+}
+
 Status MatterLaundryWasherControlsClusterServerPreAttributeChangedCallback(const chip::app::ConcreteAttributePath & attributePath,
                                                                            EmberAfAttributeType attributeType, uint16_t size,
                                                                            uint8_t * value)

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1593,3 +1593,4 @@ bool LevelControlHasFeature(EndpointId endpoint, Feature feature)
 }
 
 void MatterLevelControlPluginServerInitCallback() {}
+void MatterLevelControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
+++ b/src/app/clusters/localization-configuration-server/localization-configuration-server.cpp
@@ -223,3 +223,8 @@ void MatterLocalizationConfigurationPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterLocalizationConfigurationPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/low-power-server/low-power-server.cpp
+++ b/src/app/clusters/low-power-server/low-power-server.cpp
@@ -116,3 +116,4 @@ bool emberAfLowPowerClusterSleepCallback(app::CommandHandler * command, const ap
 }
 
 void MatterLowPowerPluginServerInitCallback() {}
+void MatterLowPowerPluginServerShutdownCallback() {}

--- a/src/app/clusters/media-input-server/media-input-server.cpp
+++ b/src/app/clusters/media-input-server/media-input-server.cpp
@@ -296,3 +296,8 @@ void MatterMediaInputPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gMediaInputAttrAccess);
 }
+
+void MatterMediaInputPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gMediaInputAttrAccess);
+}

--- a/src/app/clusters/media-playback-server/media-playback-server.cpp
+++ b/src/app/clusters/media-playback-server/media-playback-server.cpp
@@ -711,3 +711,8 @@ void MatterMediaPlaybackPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gMediaPlaybackAttrAccess);
 }
+
+void MatterMediaPlaybackPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gMediaPlaybackAttrAccess);
+}

--- a/src/app/clusters/messages-server/messages-server.cpp
+++ b/src/app/clusters/messages-server/messages-server.cpp
@@ -295,3 +295,8 @@ void MatterMessagesPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gMessagesAttrAccess);
 }
+
+void MatterMessagesPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gMessagesAttrAccess);
+}

--- a/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
+++ b/src/app/clusters/microwave-oven-control-server/microwave-oven-control-server.cpp
@@ -385,3 +385,4 @@ bool IsPowerSettingNumberInRange(uint8_t powerSettingNum, uint8_t minCookPowerNu
  *
  */
 void MatterMicrowaveOvenControlPluginServerInitCallback() {}
+void MatterMicrowaveOvenControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -418,6 +418,11 @@ void MatterModeSelectPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gModeSelectAttrAccess);
 }
 
+void MatterModeSelectPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gModeSelectAttrAccess);
+}
+
 /**
  * Callback for Mode Select Cluster Server Pre Attribute Changed
  * Enabled in src/app/zap-templates/templates/app/helper.js

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -1448,3 +1448,4 @@ void MatterNetworkCommissioningPluginServerInitCallback()
 {
     // Nothing to do, the server init routine will be done in Instance::Init()
 }
+void MatterNetworkCommissioningPluginServerShutdownCallback() {}

--- a/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
+++ b/src/app/clusters/occupancy-sensor-server/occupancy-sensor-server.cpp
@@ -269,3 +269,4 @@ HalOccupancySensorType __attribute__((weak)) halOccupancyGetSensorType(EndpointI
 }
 
 void MatterOccupancySensingPluginServerInitCallback() {}
+void MatterOccupancySensingPluginServerShutdownCallback() {}

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -1038,3 +1038,5 @@ void onOffWaitTimeOffEventHandler(chip::EndpointId endpoint)
 void emberAfPluginOnOffClusterServerPostInitCallback(EndpointId endpoint) {}
 
 void MatterOnOffPluginServerInitCallback() {}
+
+void MatterOnOffPluginServerShutdownCallback() {}

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -403,6 +403,13 @@ void MatterOperationalCredentialsPluginServerInitCallback()
     DeviceLayer::PlatformMgrImpl().AddEventHandler(OnPlatformEventHandler);
 }
 
+void MatterOperationalCredentialsPluginServerShutdownCallback()
+{
+    DeviceLayer::PlatformMgrImpl().RemoveEventHandler(OnPlatformEventHandler);
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&gFabricDelegate);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}
+
 bool emberAfOperationalCredentialsClusterRemoveFabricCallback(app::CommandHandler * commandObj,
                                                               const app::ConcreteCommandPath & commandPath,
                                                               const Commands::RemoveFabric::DecodableType & commandData)

--- a/src/app/clusters/ota-provider/ota-provider.cpp
+++ b/src/app/clusters/ota-provider/ota-provider.cpp
@@ -241,3 +241,4 @@ void SetDelegate(EndpointId endpoint, OTAProviderDelegate * delegate)
 } // namespace chip
 
 void MatterOtaSoftwareUpdateProviderPluginServerInitCallback() {}
+void MatterOtaSoftwareUpdateProviderPluginServerShutdownCallback() {}

--- a/src/app/clusters/ota-requestor/ota-requestor-server.cpp
+++ b/src/app/clusters/ota-requestor/ota-requestor-server.cpp
@@ -297,3 +297,8 @@ void MatterOtaSoftwareUpdateRequestorPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterOtaSoftwareUpdateRequestorPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
+++ b/src/app/clusters/power-source-configuration-server/power-source-configuration-server.cpp
@@ -102,3 +102,8 @@ void MatterPowerSourceConfigurationPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterPowerSourceConfigurationPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/power-source-server/power-source-server.cpp
+++ b/src/app/clusters/power-source-server/power-source-server.cpp
@@ -89,6 +89,11 @@ void MatterPowerSourcePluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
 
+void MatterPowerSourcePluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}
+
 namespace chip {
 namespace app {
 namespace Clusters {

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -369,3 +369,4 @@ void MatterPumpConfigurationAndControlClusterServerAttributeChangedCallback(cons
 }
 
 void MatterPumpConfigurationAndControlPluginServerInitCallback() {}
+void MatterPumpConfigurationAndControlPluginServerShutdownCallback() {}

--- a/src/app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.cpp
+++ b/src/app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.cpp
@@ -196,3 +196,4 @@ void RefrigeratorAlarmServer::SendNotifyEvent(EndpointId endpointId, BitMask<Ala
  *********************************************************/
 
 void MatterRefrigeratorAlarmPluginServerInitCallback() {}
+void MatterRefrigeratorAlarmPluginServerShutdownCallback() {}

--- a/src/app/clusters/sample-mei-server/sample-mei-server.cpp
+++ b/src/app/clusters/sample-mei-server/sample-mei-server.cpp
@@ -34,11 +34,10 @@ void MatterSampleMeiPluginServerInitCallback()
     VerifyOrReturn(AttributeAccessInterfaceRegistry::Instance().Register(&SampleMeiServer::Instance()), CHIP_ERROR_INCORRECT_STATE);
 }
 
-void MatterSampleMeiPluginServerInitCallback()
+void MatterSampleMeiPluginServerShutdownCallback()
 {
-    ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&SampleMeiServer::Instance()));
-    VerifyOrReturn(AttributeAccessInterfaceRegistry::Instance().Unregister(&SampleMeiServer::Instance()),
-                   CHIP_ERROR_INCORRECT_STATE);
+    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&SampleMeiServer::Instance());
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&SampleMeiServer::Instance());
 }
 
 void emberAfSampleMeiClusterServerInitCallback(chip::EndpointId endpoint)

--- a/src/app/clusters/sample-mei-server/sample-mei-server.cpp
+++ b/src/app/clusters/sample-mei-server/sample-mei-server.cpp
@@ -34,6 +34,13 @@ void MatterSampleMeiPluginServerInitCallback()
     VerifyOrReturn(AttributeAccessInterfaceRegistry::Instance().Register(&SampleMeiServer::Instance()), CHIP_ERROR_INCORRECT_STATE);
 }
 
+void MatterSampleMeiPluginServerInitCallback()
+{
+    ReturnOnFailure(CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&SampleMeiServer::Instance()));
+    VerifyOrReturn(AttributeAccessInterfaceRegistry::Instance().Unregister(&SampleMeiServer::Instance()),
+                   CHIP_ERROR_INCORRECT_STATE);
+}
+
 void emberAfSampleMeiClusterServerInitCallback(chip::EndpointId endpoint)
 {
     ChipLogProgress(Zcl, "Creating Sample MEI cluster, Ep %d", endpoint);

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -1167,3 +1167,8 @@ void MatterScenesManagementPluginServerInitCallback()
         ChipLogError(Zcl, "ScenesServer::Instance().Init() error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
+
+void MatterScenesManagementPluginServerShutdownCallback()
+{
+    ScenesServer::Instance().Shutdown();
+}

--- a/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.cpp
+++ b/src/app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.cpp
@@ -512,3 +512,4 @@ bool emberAfSmokeCoAlarmClusterSelfTestRequestCallback(CommandHandler * commandO
 }
 
 void MatterSmokeCoAlarmPluginServerInitCallback() {}
+void MatterSmokeCoAlarmPluginServerShutdownCallback() {}

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -225,3 +225,9 @@ void MatterSoftwareDiagnosticsPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
     CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gCommandHandler);
 }
+
+void MatterSoftwareDiagnosticsPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gCommandHandler);
+}

--- a/src/app/clusters/switch-server/switch-server.cpp
+++ b/src/app/clusters/switch-server/switch-server.cpp
@@ -152,3 +152,4 @@ void SwitchServer::OnMultiPressComplete(EndpointId endpoint, uint8_t previousPos
 } // namespace chip
 
 void MatterSwitchPluginServerInitCallback() {}
+void MatterSwitchPluginServerShutdownCallback() {}

--- a/src/app/clusters/target-navigator-server/target-navigator-server.cpp
+++ b/src/app/clusters/target-navigator-server/target-navigator-server.cpp
@@ -264,3 +264,8 @@ void MatterTargetNavigatorPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gTargetNavigatorAttrAccess);
 }
+
+void MatterTargetNavigatorPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gTargetNavigatorAttrAccess);
+}

--- a/src/app/clusters/temperature-control-server/temperature-control-server.cpp
+++ b/src/app/clusters/temperature-control-server/temperature-control-server.cpp
@@ -230,3 +230,8 @@ void MatterTemperatureControlPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterTemperatureControlPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -1187,3 +1187,8 @@ void MatterUnitTestingPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterUnitTestingPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -1352,3 +1352,9 @@ void MatterThermostatPluginServerInitCallback()
     Server::GetInstance().GetFabricTable().AddFabricDelegate(&gThermostatAttrAccess);
     AttributeAccessInterfaceRegistry::Instance().Register(&gThermostatAttrAccess);
 }
+
+void MatterThermostatPluginServerShutdownCallback()
+{
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&gThermostatAttrAccess);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gThermostatAttrAccess);
+}

--- a/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
+++ b/src/app/clusters/thread-border-router-management-server/thread-border-router-management-server.cpp
@@ -379,3 +379,4 @@ void MatterThreadBorderRouterManagementPluginServerInitCallback()
 {
     // Nothing to do, the server init routine will be done in Instance::Init()
 }
+void MatterThreadBorderRouterManagementPluginServerShutdownCallback() {}

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-server.cpp
@@ -207,3 +207,9 @@ void MatterThreadNetworkDiagnosticsPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
     GetDiagnosticDataProvider().SetThreadDiagnosticsDelegate(&gDiagnosticDelegate);
 }
+
+void MatterThreadNetworkDiagnosticsPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+    GetDiagnosticDataProvider().SetThreadDiagnosticsDelegate(nullptr);
+}

--- a/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
+++ b/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
@@ -316,3 +316,4 @@ exit:
 } // namespace chip
 
 void MatterThreadNetworkDirectoryPluginServerInitCallback() {}
+void MatterThreadNetworkDirectoryPluginServerShutdownCallback() {}

--- a/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
+++ b/src/app/clusters/time-format-localization-server/time-format-localization-server.cpp
@@ -234,3 +234,8 @@ void MatterTimeFormatLocalizationPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterTimeFormatLocalizationPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
+++ b/src/app/clusters/time-synchronization-server/time-synchronization-server.cpp
@@ -1292,3 +1292,9 @@ void MatterTimeSynchronizationPluginServerInitCallback()
     TimeSynchronizationServer::Instance().Init();
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterTimeSynchronizationPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+    TimeSynchronizationServer::Instance().Shutdown();
+}

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -230,3 +230,9 @@ void MatterUserLabelPluginServerInitCallback()
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
     Server::GetInstance().GetFabricTable().AddFabricDelegate(&gUserLabelFabricDelegate);
 }
+
+void MatterUserLabelPluginServerShutdownCallback()
+{
+    Server::GetInstance().GetFabricTable().RemoveFabricDelegate(&gUserLabelFabricDelegate);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
+++ b/src/app/clusters/valve-configuration-and-control-server/valve-configuration-and-control-server.cpp
@@ -529,3 +529,8 @@ void MatterValveConfigurationAndControlPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
 }
+
+void MatterValveConfigurationAndControlPluginServerShutdownCallback()
+{
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
+}

--- a/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
+++ b/src/app/clusters/wake-on-lan-server/wake-on-lan-server.cpp
@@ -144,3 +144,8 @@ void MatterWakeOnLanPluginServerInitCallback()
 {
     app::AttributeAccessInterfaceRegistry::Instance().Register(&gWakeOnLanAttrAccess);
 }
+
+void MatterWakeOnLanPluginServerShutdownCallback()
+{
+    app::AttributeAccessInterfaceRegistry::Instance().Unregister(&gWakeOnLanAttrAccess);
+}

--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
@@ -571,3 +571,8 @@ void MatterWebRTCTransportProviderPluginServerInitCallback()
 {
     ChipLogProgress(Zcl, "Initializing WebRTC Transport Provider cluster.");
 }
+
+void MatterWebRTCTransportProviderPluginServerShutdownCallback()
+{
+    ChipLogProgress(Zcl, "Shutdown WebRTC Transport Provider cluster.");
+}

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -359,3 +359,11 @@ void MatterWiFiNetworkDiagnosticsPluginServerInitCallback()
 
     GetDiagnosticDataProvider().SetWiFiDiagnosticsDelegate(&WiFiDiagnosticsServer::Instance());
 }
+
+void MatterWiFiNetworkDiagnosticsPluginServerShutdownCallback()
+{
+    GetDiagnosticDataProvider().SetWiFiDiagnosticsDelegate(nullptr);
+
+    AttributeAccessInterfaceRegistry::Instance().Unregister(&gWiFiDiagnosticsInstance);
+    CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gWiFiDiagnosticsInstance);
+}

--- a/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
+++ b/src/app/clusters/wifi-network-management-server/wifi-network-management-server.cpp
@@ -166,3 +166,4 @@ void WiFiNetworkManagementServer::HandleNetworkPassphraseRequest(HandlerContext 
 } // namespace chip
 
 void MatterWiFiNetworkManagementPluginServerInitCallback() {}
+void MatterWiFiNetworkManagementPluginServerShutdownCallback() {}

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -975,3 +975,4 @@ MatterWindowCoveringClusterServerAttributeChangedCallback(const app::ConcreteAtt
  * @brief Cluster Plugin Init Callback
  */
 void MatterWindowCoveringPluginServerInitCallback() {}
+void MatterWindowCoveringPluginServerShutdownCallback() {}


### PR DESCRIPTION
#### Problem

- A part of ShutdownDataModelHandler from https://github.com/project-chip/connectedhomeip/issues/11352 and https://github.com/project-chip/connectedhomeip/issues/38092

#### Changes

- Add a template for Matter*PluginServerShutdownCallback.
- Add function definition for every cluster implementation.

#### Testing

- Ran test `test_generators.py`
- Build all-clusters linux app.
