### PR TITLE
[Silabs] Fix for length comparision of connected SSID

### DIFF
--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -339,7 +339,7 @@ CHIP_ERROR GetConnectedNetwork(Network & network)
     // we are able to fetch the wifi provision data and STA should be connected
     VerifyOrReturnError(WifiInterface::GetInstance().IsStationConnected(), CHIP_ERROR_NOT_CONNECTED);
     ReturnErrorOnFailure(WifiInterface::GetInstance().GetWifiCredentials(wifiConfig));
-    VerifyOrReturnError(wifiConfig.ssidLength < NetworkCommissioning::kMaxNetworkIDLen, CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrReturnError(wifiConfig.ssidLength <= NetworkCommissioning::kMaxNetworkIDLen, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     network.connected = true;
 


### PR DESCRIPTION
#### Description
Issue : When the length of connected SSID is 32, observing NetworkID as False during read network. While returning the connected network details, error is being returned if the length of SSID is <32, but it should be <=32 since the maximum allowed length of SSID is 32. Added this small fix in length comparision.

#### Testing
Tested locally by commissioning to a network with SSID of length 32, the read networks command is returning correct response