### PR TITLE
[ESP32] Update the esp-insights component version to use the latest version.

### DIFF
--- a/config/esp32/components/chip/idf_component.yml
+++ b/config/esp32/components/chip/idf_component.yml
@@ -17,7 +17,7 @@ dependencies:
             - if: "idf_version >=4.4"
 
     espressif/esp_insights:
-        version: "1.2.2"
+        version: "^1.2.4"
         require: public
         # There is an issue with IDF-Component-Manager when ESP Insights is included.
         # Issue: https://github.com/project-chip/connectedhomeip/issues/29125


### PR DESCRIPTION
**Change Overview**
- Update the esp-insights component version to use the latest version.(1.2.4)

#### Testing
- Tested the lighting-app esp32 with latest esp-insights version.
