### PR TITLE
Add mock_server folder to the cert-bins image

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -306,6 +306,9 @@ RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requ
 COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing/requirements.txt /tmp/requirements.txt
 RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requirements.txt
 
+# Stage 3.2: Setup the Mock Server
+COPY --from=chip-build-cert-bins /root/connectedhomeip/integrations/mock_server mock_server
+
 # PIP requires MASON package compilation, which seems to require a JDK
 RUN set -x && DEBIAN_FRONTEND=noninteractive apt-get update; apt-get install -fy openjdk-8-jdk
 


### PR DESCRIPTION
#### What Changed
Updated cert-bins Dockerfile in order to make mock_server folder available in cert-bins image.

### Related Issue: https://github.com/project-chip/certification-tool/issues/530


#### Testing
After performing the build locally, the mock_server folder is accessible in cert-bin image
<img width="266" alt="Screenshot 2025-03-24 at 10 31 40" src="https://github.com/user-attachments/assets/2d7a6fe4-180b-4a8d-8db0-92565cec2c35" />
