### PR TITLE
Fix chef general commissioning feature map (6 is invalid, replaced it with 0)

### DIFF
--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -2142,7 +2142,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -2470,7 +2470,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -2182,7 +2182,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -1679,7 +1679,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -1854,7 +1854,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_onofflight_samplemei.matter
+++ b/examples/chef/devices/rootnode_onofflight_samplemei.matter
@@ -1886,7 +1886,7 @@ endpoint 0 {
     callback attribute regulatoryConfig;
     callback attribute locationCapability;
     callback attribute supportsConcurrentConnection;
-    ram      attribute featureMap default = 6;
+    ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 0x0001;
 
     handle command ArmFailSafe;

--- a/examples/chef/devices/rootnode_onofflight_samplemei.zap
+++ b/examples/chef/devices/rootnode_onofflight_samplemei.zap
@@ -1061,7 +1061,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "6",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
It seems chef copied&pasted several examples of invalid general commissioning flags and has `6` for the feature map for general commissioning in several examples. Switched it to 0.

#### Testing

N/A - trivial change
