### PR TITLE
Chef Oven Mode application code

### DIFF
--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -84,14 +84,14 @@ CHIP_ERROR OvenMode::ChefDelegate::Init()
 void OvenMode::ChefDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::ChangeToModeResponse::Type & response)
 {
     EndpointId endpointId = mInstance.GetEndpointId();
-    ChipLogDetail(DeviceLayer, "HandleChangeToMode: Endpoint %d", to_underlying(endpointId));
+    ChipLogDetail(DeviceLayer, "HandleChangeToMode: Endpoint %d", endpointId);
     response.status = to_underlying(ModeBase::StatusCode::kSuccess);
 }
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::MutableCharSpan & label)
 {
     EndpointId endpointId = mInstance.GetEndpointId();
-    ChipLogDetail(DeviceLayer, "GetModeLabelByIndex: Endpoint %d", to_underlying(endpointId));
+    ChipLogDetail(DeviceLayer, "GetModeLabelByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
@@ -102,7 +102,7 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::
 CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_t & value)
 {
     EndpointId endpointId = mInstance.GetEndpointId();
-    ChipLogDetail(DeviceLayer, "GetModeValueByIndex: Endpoint %d", to_underlying(endpointId));
+    ChipLogDetail(DeviceLayer, "GetModeValueByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
@@ -114,7 +114,7 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_
 CHIP_ERROR OvenMode::ChefDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<ModeTagStructType> & tags)
 {
     EndpointId endpointId = mInstance.GetEndpointId();
-    ChipLogDetail(DeviceLayer, "GetModeTagsByIndex: Endpoint %d", to_underlying(endpointId));
+    ChipLogDetail(DeviceLayer, "GetModeTagsByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -27,6 +27,9 @@ using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeBase;
 using chip::Protocols::InteractionModel::Status;
+template <typename T>
+using List              = chip::app::DataModel::List<T>;
+using ModeTagStructType = chip::app::Clusters::detail::Structs::ModeTagStruct::Type;
 
 namespace ChefOvenMode {
 

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -83,14 +83,14 @@ CHIP_ERROR OvenMode::ChefDelegate::Init()
 
 void OvenMode::ChefDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::ChangeToModeResponse::Type & response)
 {
-    EndpointId endpointId = mInstance.GetEndpointId();
+    EndpointId endpointId = mInstance->GetEndpointId();
     ChipLogDetail(DeviceLayer, "HandleChangeToMode: Endpoint %d", endpointId);
     response.status = to_underlying(ModeBase::StatusCode::kSuccess);
 }
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::MutableCharSpan & label)
 {
-    EndpointId endpointId = mInstance.GetEndpointId();
+    EndpointId endpointId = mInstance->GetEndpointId();
     ChipLogDetail(DeviceLayer, "GetModeLabelByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
@@ -101,7 +101,7 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_t & value)
 {
-    EndpointId endpointId = mInstance.GetEndpointId();
+    EndpointId endpointId = mInstance->GetEndpointId();
     ChipLogDetail(DeviceLayer, "GetModeValueByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
@@ -113,7 +113,7 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<ModeTagStructType> & tags)
 {
-    EndpointId endpointId = mInstance.GetEndpointId();
+    EndpointId endpointId = mInstance->GetEndpointId();
     ChipLogDetail(DeviceLayer, "GetModeTagsByIndex: Endpoint %d", endpointId);
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -23,6 +23,8 @@
 #include <app/util/endpoint-config-api.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#ifdef MATTER_DM_PLUGIN_OVEN_MODE_SERVER
+
 using namespace chip;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeBase;
@@ -122,3 +124,5 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<Mo
 
     return CHIP_NO_ERROR;
 }
+
+#endif // MATTER_DM_PLUGIN_OVEN_MODE_SERVER

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -70,6 +70,7 @@ void InitChefOvenModeCluster()
                            "Failed to read OvenMode feature map for endpoint %d", endpointId);
         gInstanceTable[epIndex] =
             std::make_unique<ModeBase::Instance>(gDelegateTable[epIndex].get(), endpointId, OvenMode::Id, featureMap);
+        gInstanceTable[epIndex]->Init();
 
         ChipLogProgress(DeviceLayer, "Endpoint %d OvenMode Initialized.", endpointId);
     }

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -17,6 +17,11 @@
  */
 
 #include "chef-oven-mode.h"
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app/reporting/reporting.h>
+#include <app/util/attribute-storage.h>
+#include <app/util/endpoint-config-api.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
 using namespace chip::app::Clusters;

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -63,8 +63,8 @@ void InitChefOvenModeCluster()
         gDelegateTable[epIndex] = std::make_unique<OvenMode::ChefDelegate>();
         gDelegateTable[epIndex]->Init();
 
-        uint32_t * featureMap;
-        VerifyOrDieWithMsg(OvenMode::Attributes::FeatureMap::Get(endpointId, featureMap) == Status::Success, DeviceLayer,
+        uint32_t featureMap = 0;
+        VerifyOrDieWithMsg(OvenMode::Attributes::FeatureMap::Get(endpointId, &featureMap) == Status::Success, DeviceLayer,
                            "Failed to read OvenMode feature map for endpoint %d", endpointId);
         gInstanceTable[epIndex] =
             std::make_unique<ModeBase::Instance>(gDelegateTable[epIndex].get(), endpointId, OvenMode::Id, featureMap);

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -71,8 +71,6 @@ void InitChefOvenModeCluster()
         gInstanceTable[epIndex] =
             std::make_unique<ModeBase::Instance>(gDelegateTable[epIndex].get(), endpointId, OvenMode::Id, featureMap);
 
-        gDelegateTable[epIndex]->SetInstance(gInstanceTable[epIndex].get());
-
         ChipLogProgress(DeviceLayer, "Endpoint %d OvenMode Initialized.", endpointId);
     }
 }
@@ -85,11 +83,15 @@ CHIP_ERROR OvenMode::ChefDelegate::Init()
 
 void OvenMode::ChefDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::ChangeToModeResponse::Type & response)
 {
+    EndpointId endpointId = mInstance.GetEndpointId();
+    ChipLogDetail(DeviceLayer, "HandleChangeToMode: Endpoint %d", to_underlying(endpointId));
     response.status = to_underlying(ModeBase::StatusCode::kSuccess);
 }
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::MutableCharSpan & label)
 {
+    EndpointId endpointId = mInstance.GetEndpointId();
+    ChipLogDetail(DeviceLayer, "GetModeLabelByIndex: Endpoint %d", to_underlying(endpointId));
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
@@ -99,6 +101,8 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_t & value)
 {
+    EndpointId endpointId = mInstance.GetEndpointId();
+    ChipLogDetail(DeviceLayer, "GetModeValueByIndex: Endpoint %d", to_underlying(endpointId));
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
@@ -109,6 +113,8 @@ CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_
 
 CHIP_ERROR OvenMode::ChefDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<ModeTagStructType> & tags)
 {
+    EndpointId endpointId = mInstance.GetEndpointId();
+    ChipLogDetail(DeviceLayer, "GetModeTagsByIndex: Endpoint %d", to_underlying(endpointId));
     if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
     {
         return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.cpp
@@ -1,0 +1,116 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "chef-oven-mode.h"
+
+using namespace chip;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::ModeBase;
+using chip::Protocols::InteractionModel::Status;
+
+namespace ChefOvenMode {
+
+constexpr size_t kOvenModeTableSize = MATTER_DM_OVEN_MODE_CLUSTER_SERVER_ENDPOINT_COUNT;
+static_assert(kOvenModeTableSize <= kEmberInvalidEndpointIndex, "OvenMode table size error");
+
+std::unique_ptr<OvenMode::ChefDelegate> gDelegateTable[kOvenModeTableSize];
+std::unique_ptr<ModeBase::Instance> gInstanceTable[kOvenModeTableSize];
+
+CHIP_ERROR OvenMode::ChefDelegate::Init()
+{
+    return CHIP_NO_ERROR;
+}
+
+void OvenMode::ChefDelegate::HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::ChangeToModeResponse::Type & response)
+{
+    response.status = to_underlying(ModeBase::StatusCode::kSuccess);
+}
+
+CHIP_ERROR OvenMode::ChefDelegate::GetModeLabelByIndex(uint8_t modeIndex, chip::MutableCharSpan & label)
+{
+    if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+    return chip::CopyCharSpanToMutableCharSpan(kModeOptions[modeIndex].label, label);
+}
+
+CHIP_ERROR OvenMode::ChefDelegate::GetModeValueByIndex(uint8_t modeIndex, uint8_t & value)
+{
+    if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+    value = kModeOptions[modeIndex].mode;
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OvenMode::ChefDelegate::GetModeTagsByIndex(uint8_t modeIndex, List<ModeTagStructType> & tags)
+{
+    if (modeIndex >= MATTER_ARRAY_SIZE(kModeOptions))
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+
+    if (tags.size() < kModeOptions[modeIndex].modeTags.size())
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    std::copy(kModeOptions[modeIndex].modeTags.begin(), kModeOptions[modeIndex].modeTags.end(), tags.begin());
+    tags.reduce_size(kModeOptions[modeIndex].modeTags.size());
+
+    return CHIP_NO_ERROR;
+}
+
+/**
+ * Initializes OvenMode cluster for the app (all endpoints).
+ */
+void InitChefOvenModeCluster()
+{
+    const uint16_t endpointCount = emberAfEndpointCount();
+
+    for (uint16_t endpointIndex = 0; endpointIndex < endpointCount; endpointIndex++)
+    {
+        EndpointId endpointId = emberAfEndpointFromIndex(endpointIndex);
+        if (endpointId == kInvalidEndpointId)
+        {
+            continue;
+        }
+
+        // Check if endpoint has OvenMode cluster enabled
+        uint16_t epIndex =
+            emberAfGetClusterServerEndpointIndex(endpointId, OvenMode::Id, MATTER_DM_OVEN_MODE_CLUSTER_SERVER_ENDPOINT_COUNT);
+        if (epIndex >= kOvenModeTableSize)
+            continue;
+
+        gDelegateTable[epIndex] = std::make_unique<OvenMode::ChefDelegate>();
+        gDelegateTable[epIndex]->Init();
+
+        uint32_t * featureMap;
+        VerifyOrDieWithMsg(OvenMode::Attributes::FeatureMap::Get(endpointId, featureMap) == Status::Success, DeviceLayer,
+                           "Failed to read OvenMode feature map for endpoint %d", endpointId);
+        gInstanceTable[epIndex] =
+            std::make_unique<ModeBase::Instance>(gDelegateTable[epIndex].get(), endpointId, OvenMode::Id, featureMap);
+
+        gDelegateTable[epIndex]->SetInstance(gInstanceTable[epIndex].get());
+
+        ChipLogProgress(DeviceLayer, "Endpoint %d OvenMode Initialized.", endpointId);
+    }
+}
+} // namespace ChefOvenMode

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
@@ -101,3 +101,7 @@ public:
 } // namespace Clusters
 } // namespace app
 } // namespace chip
+
+namespace ChefOvenMode {
+void InitChefOvenModeCluster();
+} // namespace ChefOvenMode

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
@@ -26,7 +26,6 @@
 namespace chip {
 namespace app {
 namespace Clusters {
-namespace ModeBase {
 namespace OvenMode {
 
 const uint8_t ModeBake            = 0;
@@ -39,7 +38,7 @@ const uint8_t ModeConvectionRoast = 6;
 const uint8_t ModeWarming         = 7;
 const uint8_t ModeProofing        = 8;
 
-class ChefDelegate : public Delegate
+class ChefDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType                      = detail::Structs::ModeTagStruct::Type;
@@ -99,7 +98,6 @@ public:
 };
 
 } // namespace OvenMode
-} // namespace ModeBase
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#ifdef MATTER_DM_PLUGIN_OVEN_MODE_SERVER
+
 namespace chip {
 namespace app {
 namespace Clusters {
@@ -105,3 +107,5 @@ public:
 namespace ChefOvenMode {
 void InitChefOvenModeCluster();
 } // namespace ChefOvenMode
+
+#endif // MATTER_DM_PLUGIN_OVEN_MODE_SERVER

--- a/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
+++ b/examples/chef/common/clusters/oven-mode/chef-oven-mode.h
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/mode-base-server/mode-base-server.h>
+#include <app/util/config.h>
+#include <cstring>
+#include <utility>
+
+#pragma once
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace ModeBase {
+namespace OvenMode {
+
+const uint8_t ModeBake            = 0;
+const uint8_t ModeConvection      = 1;
+const uint8_t ModeGrill           = 2;
+const uint8_t ModeRoast           = 3;
+const uint8_t ModeClean           = 4;
+const uint8_t ModeConvectionBake  = 5;
+const uint8_t ModeConvectionRoast = 6;
+const uint8_t ModeWarming         = 7;
+const uint8_t ModeProofing        = 8;
+
+class ChefDelegate : public Delegate
+{
+private:
+    using ModeTagStructType                      = detail::Structs::ModeTagStruct::Type;
+    ModeTagStructType ModeTagsBake[1]            = { { .value = to_underlying(ModeTag::kBake) } };
+    ModeTagStructType ModeTagsConvection[1]      = { { .value = to_underlying(ModeTag::kConvection) } };
+    ModeTagStructType ModeTagsGrill[1]           = { { .value = to_underlying(ModeTag::kGrill) } };
+    ModeTagStructType ModeTagsRoast[1]           = { { .value = to_underlying(ModeTag::kRoast) } };
+    ModeTagStructType ModeTagsClean[1]           = { { .value = to_underlying(ModeTag::kClean) } };
+    ModeTagStructType ModeTagsConvectionBake[1]  = { { .value = to_underlying(ModeTag::kConvectionBake) } };
+    ModeTagStructType ModeTagsConvectionRoast[1] = { { .value = to_underlying(ModeTag::kConvectionRoast) } };
+    ModeTagStructType ModeTagsWarming[1]         = { { .value = to_underlying(ModeTag::kWarming) } };
+    ModeTagStructType ModeTagsProofing[1]        = { { .value = to_underlying(ModeTag::kProofing) } };
+
+    const detail::Structs::ModeOptionStruct::Type kModeOptions[9] = {
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Bake"),
+                                                 .mode     = ModeBake,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsBake) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection"),
+                                                 .mode     = ModeConvection,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvection) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Grill"),
+                                                 .mode     = ModeGrill,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsGrill) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Roast"),
+                                                 .mode     = ModeRoast,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsRoast) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Clean"),
+                                                 .mode     = ModeClean,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsClean) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Bake"),
+                                                 .mode     = ModeConvectionBake,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionBake) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Convection Roast"),
+                                                 .mode     = ModeConvectionRoast,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsConvectionRoast) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Warming"),
+                                                 .mode     = ModeWarming,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsWarming) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Proofing"),
+                                                 .mode     = ModeProofing,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsProofing) },
+    };
+
+public:
+    CHIP_ERROR Init() override;
+
+    CHIP_ERROR GetModeLabelByIndex(uint8_t modeIndex, MutableCharSpan & label) override;
+
+    CHIP_ERROR GetModeValueByIndex(uint8_t modeIndex, uint8_t & value) override;
+
+    CHIP_ERROR GetModeTagsByIndex(uint8_t modeIndex, DataModel::List<detail::Structs::ModeTagStruct::Type> & modeTags) override;
+
+    void HandleChangeToMode(uint8_t NewMode, ModeBase::Commands::ChangeToModeResponse::Type & response) override;
+
+    ~ChefDelegate() = default;
+    ChefDelegate()  = default;
+};
+
+} // namespace OvenMode
+} // namespace ModeBase
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -85,6 +85,10 @@ const Clusters::Descriptor::Structs::SemanticTagStruct::Type freezerTagList[]   
 #include "window-covering/chef-window-covering.h"
 #endif // MATTER_DM_PLUGIN_WINDOW_COVERING_SERVER
 
+#ifdef MATTER_DM_PLUGIN_OVEN_MODE_SERVER
+#include "oven-mode/chef-oven-mode.h"
+#endif // MATTER_DM_PLUGIN_OVEN_MODE_SERVER
+
 Protocols::InteractionModel::Status emberAfExternalAttributeReadCallback(EndpointId endpoint, ClusterId clusterId,
                                                                          const EmberAfAttributeMetadata * attributeMetadata,
                                                                          uint8_t * buffer, uint16_t maxReadLength)
@@ -364,6 +368,11 @@ void ApplicationInit()
     ChipLogProgress(NotSpecified, "Initializing WindowCovering cluster delegate.");
     ChefWindowCovering::InitChefWindowCoveringCluster();
 #endif // MATTER_DM_PLUGIN_WINDOW_COVERING_SERVER
+
+#ifdef MATTER_DM_PLUGIN_OVEN_MODE_SERVER
+    ChipLogProgress(NotSpecified, "Initializing OvenMode cluster.");
+    ChefOvenMode::InitChefOvenModeCluster();
+#endif // MATTER_DM_PLUGIN_OVEN_MODE_SERVER
 }
 
 void ApplicationShutdown()

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SRC_DIRS_LIST
                       "${CHEF}/common/clusters/low-power/"
                       "${CHEF}/common/clusters/media-input/"
                       "${CHEF}/common/clusters/media-playback/"
+                      "${CHEF}/common/clusters/oven-mode/"
                       "${CHEF}/common/clusters/refrigerator-and-temperature-controlled-cabinet-mode/"
                       "${CHEF}/common/clusters/resource-monitoring/"
                       "${CHEF}/common/clusters/switch/"

--- a/examples/chef/linux/BUILD.gn
+++ b/examples/chef/linux/BUILD.gn
@@ -60,6 +60,7 @@ executable("${sample_name}") {
     "${project_dir}/common/clusters/low-power/LowPowerManager.cpp",
     "${project_dir}/common/clusters/media-input/MediaInputManager.cpp",
     "${project_dir}/common/clusters/media-playback/MediaPlaybackManager.cpp",
+    "${project_dir}/common/clusters/oven-mode/chef-oven-mode.cpp",
     "${project_dir}/common/clusters/refrigerator-and-temperature-controlled-cabinet-mode/tcc-mode.cpp",
     "${project_dir}/common/clusters/resource-monitoring/chef-resource-monitoring-delegates.cpp",
     "${project_dir}/common/clusters/switch/SwitchEventHandler.cpp",

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -97,6 +97,7 @@ target_sources(app PRIVATE
     ${CHEF}/common/clusters/low-power/LowPowerManager.cpp
     ${CHEF}/common/clusters/media-input/MediaInputManager.cpp
     ${CHEF}/common/clusters/media-playback/MediaPlaybackManager.cpp
+    ${CHEF}/common/clusters/oven-mode/chef-oven-mode.cpp
     ${CHEF}/common/clusters/refrigerator-and-temperature-controlled-cabinet-mode/tcc-mode.cpp
     ${CHEF}/common/clusters/resource-monitoring/chef-resource-monitoring-delegates.cpp
     ${CHEF}/common/clusters/switch/SwitchEventHandler.cpp


### PR DESCRIPTION
OvenMode cluster code for chef.

#### Testing

Created temporary device with `OvenMode` cluster enabled on EP 2.

1. Compilation
```
./chef.py -br -d <device_name> -t linux # Linux
./chef.py -br -d <device_name> -t esp32
```

2. Compilation
```
./chip-tool pairing code 0x20 MT:Y.####
```

3. Read Supported Modes
```
./chip-tool ovenmode read supported-modes 0x20 2
```
Output -
```
1742852652.815] [1822387:1822389] [TOO] Endpoint: 2 Cluster: 0x0000_0049 Attribute 0x0000_0000 DataVersion: 405420695
[1742852652.815] [1822387:1822389] [TOO]   SupportedModes: 9 entries
[1742852652.815] [1822387:1822389] [TOO]     [1]: {
[1742852652.815] [1822387:1822389] [TOO]       Label: Bake
[1742852652.815] [1822387:1822389] [TOO]       Mode: 0
[1742852652.815] [1822387:1822389] [TOO]       ModeTags: 1 entries
[1742852652.815] [1822387:1822389] [TOO]         [1]: {
[1742852652.815] [1822387:1822389] [TOO]           Value: 16384
[1742852652.815] [1822387:1822389] [TOO]          }
[1742852652.815] [1822387:1822389] [TOO]      }
[1742852652.815] [1822387:1822389] [TOO]     [2]: {
[1742852652.815] [1822387:1822389] [TOO]       Label: Convection
[1742852652.815] [1822387:1822389] [TOO]       Mode: 1
[1742852652.815] [1822387:1822389] [TOO]       ModeTags: 1 entries
[1742852652.815] [1822387:1822389] [TOO]         [1]: {
[1742852652.815] [1822387:1822389] [TOO]           Value: 16385
[1742852652.815] [1822387:1822389] [TOO]          }
[1742852652.815] [1822387:1822389] [TOO]      }
.
.
.
```

4. Current Mode
```
./chip-tool ovenmode change-to-mode 5 0x20 2 # Change to mode with value = 5
./chip-tool ovenmode read current-mode 0x20 2 | grep "CurrentMode" # Output = 5
```

