### PR TITLE
[chip-tool] onnetwork pairing Thread device

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -124,6 +124,10 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
         params.SetThreadOperationalDataset(mOperationalDataset);
         break;
     case PairingNetworkType::None:
+        if (mThreadDataset.HasValue())
+        {
+            params.SetThreadOperationalDataset(mThreadDataset.Value());
+        }
         break;
     }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -85,6 +85,7 @@ public:
         switch (networkType)
         {
         case PairingNetworkType::None:
+            AddArgument("thread-dataset", &mThreadDataset, "Thread operational dataset");
             break;
         case PairingNetworkType::WiFi:
             AddArgument("ssid", &mSSID);
@@ -277,6 +278,7 @@ private:
     chip::Optional<char *> mDCLHostName;
     chip::Optional<uint16_t> mDCLPort;
     chip::Optional<bool> mUseDCL;
+    chip::Optional<chip::ByteSpan> mThreadDataset;
     chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type> mTimeZoneList;
     TypedComplexArgument<chip::app::DataModel::List<chip::app::Clusters::TimeSynchronization::Structs::TimeZoneStruct::Type>>
         mComplex_TimeZones;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -1001,5 +1001,10 @@ CHIP_ERROR AutoCommissioner::SetPAI(const chip::ByteSpan & pai)
     return CHIP_NO_ERROR;
 }
 
+void AutoCommissioner::SetThreadNetworkProvisionNeeded(bool needed)
+{
+    mNeedsNetworkSetup = mNeedsNetworkSetup || needed;
+}
+
 } // namespace Controller
 } // namespace chip

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -48,6 +48,8 @@ public:
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
     ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
+    void SetThreadNetworkProvisionNeeded(bool needed) override;
+
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);
     DeviceCommissioner * GetCommissioner() { return mCommissioner; }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2485,6 +2485,7 @@ CHIP_ERROR DeviceCommissioner::ParseNetworkCommissioningInfo(ReadCommissioningIn
             {
                 ChipLogProgress(Controller, "NetworkCommissioning Features: has Thread. endpointid = %u", path.mEndpointId);
                 info.network.thread.endpoint = path.mEndpointId;
+                mDefaultCommissioner->SetThreadNetworkProvisionNeeded(true);
             }
             else if (features.Has(NetworkCommissioning::Feature::kEthernetNetworkInterface))
             {

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -866,6 +866,7 @@ public:
     virtual void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate * operationalCredentialsDelegate) = 0;
     virtual CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy)       = 0;
     virtual CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningReport report)                        = 0;
+    virtual void SetThreadNetworkProvisionNeeded(bool needed)                                                       = 0;
 };
 
 } // namespace Controller


### PR DESCRIPTION
This commit adds an optional argument to onnetwork pairing command to provision Thread network if the Thread network commissioning cluster is present.


#### Testing

Locally verified on real device and simulation.