### PR TITLE
Stop relying on an externally-started all-clusters app in Darwin XCTests.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -112,7 +112,6 @@ jobs:
               working-directory: src/darwin/Framework
               run: |
                   mkdir -p /tmp/darwin/framework-tests
-                  ../../../out/debug/all-clusters-app/chip-all-clusters-app --interface-id -1 > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
 
                   export TEST_RUNNER_ASAN_OPTIONS=__CURRENT_VALUE__:detect_stack_use_after_return=1
 

--- a/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRBackwardsCompatTests.m
@@ -19,40 +19,25 @@
 #import <Matter/Matter.h>
 
 #import "MTRErrorTestUtils.h"
+#import "MTRTestCase+ServerAppRunner.h"
+#import "MTRTestCase.h"
 #import "MTRTestKeys.h"
-#import "MTRTestResetCommissioneeHelper.h"
 #import "MTRTestStorage.h"
 
 #import <math.h> // For INFINITY
 
-// system dependencies
-#import <XCTest/XCTest.h>
-
-// Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
-
 static const uint16_t kPairingTimeoutInSeconds = 30;
 static const uint16_t kCASESetupTimeoutInSeconds = 30;
-static const uint16_t kTimeoutInSeconds = 3;
 static const uint64_t kDeviceId = 0x12344321;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kLocalPort = 5541;
 static const uint16_t kTestVendorId = 0xFFF1u;
-
-// This test suite reuses a device object to speed up the test process for CI.
-// The following global variable holds the reference to the device object.
-static MTRBaseDevice * sConnectedDevice;
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;
 
 // Keys we can use to restart the controller.
 static MTRTestKeys * sTestKeys = nil;
-
-static MTRBaseDevice * GetConnectedDevice(void)
-{
-    XCTAssertNotNil(sConnectedDevice);
-    return sConnectedDevice;
-}
 
 @interface MTRBackwardsCompatTestPairingDelegate : NSObject <MTRDevicePairingDelegate>
 @property (nonatomic, strong) XCTestExpectation * expectation;
@@ -88,7 +73,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
 @end
 
-@interface MTRBackwardsCompatTests : XCTestCase
+@interface MTRBackwardsCompatTests : MTRTestCase
 @end
 
 @implementation MTRBackwardsCompatTests
@@ -96,6 +81,11 @@ static MTRBaseDevice * GetConnectedDevice(void)
 + (void)setUp
 {
     [super setUp];
+
+    BOOL started = [self startAppWithName:@"all-clusters"
+                                arguments:@[]
+                                  payload:kOnboardingPayload];
+    XCTAssertTrue(started);
 
     XCTestExpectation * expectation = [[XCTestExpectation alloc] initWithDescription:@"Pairing Complete"];
 
@@ -140,7 +130,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
             completionHandler:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
                 XCTAssertEqual(error.code, 0);
                 [connectionExpectation fulfill];
-                sConnectedDevice = device;
                 connectionExpectation = nil;
             }];
     XCTAssertEqual([XCTWaiter waitForExpectations:@[ connectionExpectation ] timeout:kCASESetupTimeoutInSeconds], XCTWaiterResultCompleted);
@@ -148,8 +137,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
 + (void)tearDown
 {
-    ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), nil, kTimeoutInSeconds);
-
     [sController shutdown];
     XCTAssertFalse([sController isRunning]);
     [[MTRControllerFactory sharedInstance] shutdown];

--- a/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCommissionableBrowserTests.m
@@ -23,8 +23,6 @@
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
-// Fixture 1: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
-
 static const uint16_t kTestVendorId = 0xFFF1u;
 static const __auto_type kTestProductIds = @[ @(0x8000u), @(0x8001u), @(0x8002u) ];
 static const __auto_type kTestDiscriminators = @[ @(2000), @(3839u), @(3840u), @(0xb1e) ];
@@ -168,6 +166,7 @@ static NSDictionary<NSString *, id> * ResultSnapshot(MTRCommissionableBrowserRes
 
     // Start the helper apps our tests use. Note these payloads match kTestDiscriminators etc.
     for (NSString * payload in @[
+             @"MT:-24J0AFN00KA0648G00",
              @"MT:Y.K90SO527JA0648G00",
              @"MT:-24J0AFN00I40648G00",
          ]) {

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -32,18 +32,14 @@
 #import "MTRDeviceTestDelegate.h"
 #import "MTRDevice_Internal.h"
 #import "MTRErrorTestUtils.h"
+#import "MTRTestCase+ServerAppRunner.h"
+#import "MTRTestCase.h"
 #import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
-#import "MTRTestResetCommissioneeHelper.h"
 #import "MTRTestStorage.h"
 
 #import <math.h> // For INFINITY
 #import <os/lock.h>
-
-// system dependencies
-#import <XCTest/XCTest.h>
-
-// Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
 
 static const uint16_t kPairingTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
@@ -128,7 +124,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
 @end
 
-@interface MTRDeviceTests : XCTestCase
+@interface MTRDeviceTests : MTRTestCase
 
 @end
 
@@ -138,6 +134,13 @@ static BOOL slocalTestStorageEnabledBeforeUnitTest;
 
 + (void)setUp
 {
+    [super setUp];
+
+    BOOL started = [self startAppWithName:@"all-clusters"
+                                arguments:@[]
+                                  payload:kOnboardingPayload];
+    XCTAssertTrue(started);
+
     XCTestExpectation * pairingExpectation = [[XCTestExpectation alloc] initWithDescription:@"Pairing Complete"];
 
     slocalTestStorageEnabledBeforeUnitTest = MTRDeviceControllerLocalTestStorage.localTestStorageEnabled;
@@ -190,8 +193,6 @@ static BOOL slocalTestStorageEnabledBeforeUnitTest;
 
 + (void)tearDown
 {
-    ResetCommissionee(GetConnectedDevice(), dispatch_get_main_queue(), nil, kTimeoutInSeconds);
-
     // Restore testing setting to previous state, and remove all persisted attributes
     MTRDeviceControllerLocalTestStorage.localTestStorageEnabled = slocalTestStorageEnabledBeforeUnitTest;
     [sController.controllerDataStore clearAllStoredClusterData];

--- a/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROperationalCertificateIssuerTests.m
@@ -18,11 +18,10 @@
 #import <Matter/Matter.h>
 
 #import "MTRErrorTestUtils.h"
+#import "MTRTestCase+ServerAppRunner.h"
+#import "MTRTestCase.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
-
-// system dependencies
-#import <XCTest/XCTest.h>
 
 static const uint16_t kPairingTimeoutInSeconds = 30;
 static const uint64_t kDeviceId = 0x12344321;
@@ -110,7 +109,7 @@ static MTRTestKeys * sTestKeys = nil;
 
 @end
 
-@interface MTROperationalCertificateIssuerTests : XCTestCase
+@interface MTROperationalCertificateIssuerTests : MTRTestCase
 @end
 
 @implementation MTROperationalCertificateIssuerTests
@@ -123,6 +122,11 @@ static MTRTestKeys * sTestKeys = nil;
 
 - (void)testFailedCertificateIssuance
 {
+    BOOL started = [self startAppWithName:@"all-clusters"
+                                arguments:@[]
+                                  payload:kOnboardingPayload];
+    XCTAssertTrue(started);
+
     XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
 
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -334,6 +334,21 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     BOOL _localTestStorageEnabledBeforeUnitTest;
 }
 
++ (void)setUp
+{
+    // Start one instance of all-clusters-app that the various tests below can
+    // then use, so we're not doing quite as much startup logging.  Though it's
+    // not clear that the ResetCommissionee logging is really shorter, so maybe
+    // we should start these on a per-test basis, e.g. in
+    // commissionWithController:newNodeID:onboardingPayload:
+    [super setUp];
+
+    BOOL started = [self startAppWithName:@"all-clusters"
+                                arguments:@[]
+                                  payload:kOnboardingPayload];
+    XCTAssertTrue(started);
+}
+
 - (void)setUp
 {
     // Set detectLeaks true first, in case our superclass wants to do something

--- a/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftDeviceTests.swift
@@ -1,9 +1,6 @@
 import Matter
-import XCTest
 
 // This should eventually grow into a Swift copy of MTRDeviceTests
-
-// Fixture: chip-all-clusters-app --KVS "$(mktemp -t chip-test-kvs)" --interface-id -1
 
 struct DeviceConstants {
     static let testVendorID = 0xFFF1
@@ -102,11 +99,14 @@ class MTRSwiftDeviceTestDelegate : NSObject, MTRDeviceDelegate {
     }
 }
 
-class MTRSwiftDeviceTests : XCTestCase {
+class MTRSwiftDeviceTests : MTRTestCase {
     static override func setUp()
     {
         super.setUp()
-
+        
+        let started = self.startApp(withName: "all-clusters", arguments: [], payload: PairingConstants.onboardingPayload)
+        XCTAssertTrue(started);
+        
         let factory = MTRDeviceControllerFactory.sharedInstance()
         
         let storage = MTRTestStorage()
@@ -164,7 +164,6 @@ class MTRSwiftDeviceTests : XCTestCase {
     
     static override func tearDown() {
         XCTAssertNotNil(sConnectedDevice)
-        ResetCommissionee(sConnectedDevice!, DispatchQueue.main, nil, UInt16(DeviceConstants.timeoutInSeconds))
         let controller = sController
         XCTAssertNotNil(controller)
         controller!.shutdown()

--- a/src/darwin/Framework/CHIPTests/MTRSwiftPairingTests.swift
+++ b/src/darwin/Framework/CHIPTests/MTRSwiftPairingTests.swift
@@ -1,5 +1,4 @@
 import Matter
-import XCTest
 
 // This more or less parallels the "no delegate" case in MTRPairingTests, but uses the "normal"
 // all-clusters-app, since it does not do any of the "interesting" VID/PID notification so far.  If
@@ -45,8 +44,11 @@ class MTRSwiftPairingTestControllerDelegate : NSObject, MTRDeviceControllerDeleg
     }
 }
 
-class MTRSwiftPairingTests : XCTestCase {
+class MTRSwiftPairingTests : MTRTestCase {
     func test001_BasicPairing() {
+        let started = self.startApp(withName: "all-clusters", arguments: [], payload: PairingConstants.onboardingPayload)
+        XCTAssertTrue(started);
+        
         let factory = MTRDeviceControllerFactory.sharedInstance()
 
         let storage = MTRTestStorage()
@@ -98,8 +100,6 @@ class MTRSwiftPairingTests : XCTestCase {
         }
 
         wait(for: [expectation], timeout: TimeInterval(PairingConstants.pairingTimeoutInSeconds))
-
-        ResetCommissionee(MTRBaseDevice(nodeID: PairingConstants.deviceID as NSNumber, controller: controller), DispatchQueue.main, self, PairingConstants.timeoutInSeconds)
 
         controller.shutdown()
         XCTAssertFalse(controller.isRunning)

--- a/src/darwin/Framework/CHIPTests/MatterTests-Bridging-Header.h
+++ b/src/darwin/Framework/CHIPTests/MatterTests-Bridging-Header.h
@@ -2,6 +2,8 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "MTRTestCase+ServerAppRunner.h"
+#import "MTRTestCase.h"
 #import "MTRTestKeys.h"
 #import "MTRTestResetCommissioneeHelper.h"
 #import "MTRTestStorage.h"

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
@@ -29,6 +29,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRTestCase : XCTestCase
 
++ (void)setUp NS_REQUIRES_SUPER;
++ (void)tearDown NS_REQUIRES_SUPER;
+- (void)setUp NS_REQUIRES_SUPER;
+- (void)tearDown NS_REQUIRES_SUPER;
+
 // It would be nice to do the leak-detection automatically, but running "leaks"
 // on every single sub-test is slow, and some of our tests seem to have leaks
 // outside Matter.framework.  So have it be opt-in for now, and improve later.


### PR DESCRIPTION
Now that we have machinery for starting an app from inside the test, do that for all the tests that need one.

#### Testing

Unit tests should still pass.