### PR TITLE
[ZAP] Add superset for Mounted device types

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -857,6 +857,7 @@ limitations under the License.
         <deviceId editable="false">0x010F</deviceId>
         <class>Simple</class>
         <scope>Endpoint</scope>
+        <superset>On/Off Plug-in Unit</superset>
         <clusters>
             <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
@@ -887,6 +888,7 @@ limitations under the License.
         <deviceId editable="false">0x0110</deviceId>
         <class>Simple</class>
         <scope>Endpoint</scope>
+        <superset>Dimmable Plug-in Unit</superset>
         <clusters>
             <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">


### PR DESCRIPTION
In 1.5 the mounted devices types have been marked as super set of the plug-in device types. This PR adds this to the XML in order to let ZAP allow these to be selected on the same EP.

NOTE: It was a bit unclear to me if I needed to also adjust the "<clusters lockOthers="true">" part. Some seems to have it and others do not.

### Testing
Verified by modifying existing zap tile to include both Device types on a single EP.