### PR TITLE
Fix cycle detection: parts_list_cycles

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py
@@ -107,12 +107,10 @@ def parts_list_cycles(tree_endpoints: list[int], endpoint_dict: dict[int, Any]) 
         return False
 
     cycles = []
-    visited = set()
-    stack = set()
     # This is quick enough that we can do all the endpoints without searching for the roots
     for endpoint_id in tree_endpoints:
-        if endpoint_id in visited:
-            continue
+        visited = set()
+        stack = set()
         if parts_list_cycle_detect(visited, endpoint_id, stack):
             cycles.append(endpoint_id)
     return cycles

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py
@@ -92,21 +92,28 @@ def find_tree_roots(tree_endpoints: list[int], endpoint_dict: dict[int, Any]) ->
 
 def parts_list_cycles(tree_endpoints: list[int], endpoint_dict: dict[int, Any]) -> list[int]:
     """Returns a list of all the endpoints in the tree_endpoints list that contain cycles"""
-    def parts_list_cycle_detect(visited: set, current_id: int) -> bool:
-        if current_id in visited:
-            return True
+    def parts_list_cycle_detect(visited: set, current_id: int, stack: set) -> bool:
         visited.add(current_id)
+        stack.add(current_id)
         for child in endpoint_dict[current_id][Clusters.Descriptor][Clusters.Descriptor.Attributes.PartsList]:
-            child_has_cycles = parts_list_cycle_detect(visited, child)
+            if child in stack:
+                return True
+            if child in visited:
+                continue
+            child_has_cycles = parts_list_cycle_detect(visited, child, stack)
             if child_has_cycles:
                 return True
+        stack.remove(current_id)
         return False
 
     cycles = []
+    visited = set()
+    stack = set()
     # This is quick enough that we can do all the endpoints without searching for the roots
     for endpoint_id in tree_endpoints:
-        visited = set()
-        if parts_list_cycle_detect(visited, endpoint_id):
+        if endpoint_id in visited:
+            continue
+        if parts_list_cycle_detect(visited, endpoint_id, stack):
             cycles.append(endpoint_id)
     return cycles
 


### PR DESCRIPTION
The current `parts_list_cycles` falsely reports a cycle with Oven device schema. Oven is being added in https://github.com/project-chip/connectedhomeip/pull/38108

Schema:

Using `chip-tool` to query `parts-list` for each endpoint:
```
./chip-tool descriptor read parts-list <node-id> <endpoint_id>
```

Endpoint1:
```
[1742947509.617] [2257175:2257177] [TOO] Endpoint: 1 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 542009323
[1742947509.617] [2257175:2257177] [TOO]   PartsList: 3 entries
[1742947509.617] [2257175:2257177] [TOO]     [1]: 2
[1742947509.617] [2257175:2257177] [TOO]     [2]: 3
[1742947509.617] [2257175:2257177] [TOO]     [3]: 4
```

Endpoint2:
```
[1742947554.063] [2257283:2257285] [TOO] Endpoint: 2 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 2071216269
[1742947554.063] [2257283:2257285] [TOO]   PartsList: 0 entries
```

Endpoint3
```
[1742947583.984] [2257421:2257423] [TOO] Endpoint: 3 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 3245782282
[1742947583.984] [2257421:2257423] [TOO]   PartsList: 1 entries
[1742947583.984] [2257421:2257423] [TOO]     [1]: 4
```

Endpoint4
```
[1742947603.231] [2257489:2257491] [TOO] Endpoint: 4 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 1249304863
[1742947603.231] [2257489:2257491] [TOO]   PartsList: 0 entries
```

Summary -
```
EP1 Parts List: 2, 3, 4
EP2 Parts List: None
EP3 Parts List: 4
EP4 Parts List: None
```

Output of current `TC_DeviceBasicComposition.py` -
```
[MatterTest] 03-26 00:13:37.376 INFO 
Problem: ProblemSeverity.ERROR
    test_name: test_TC_SM_1_2
    location: 
       Endpoint: 1,
       Cluster:  29 (0x1d) Descriptor
      Attribute:3 (0x03)
    problem: Endpoint 1 parts list includes a cycle
    spec_location: PartsList Attribute
```


When the above adjacency list represents a **directed** graph, there are no back edges and thus no cycle. But the current cycle detection function does not differentiate between back edges and cross edges.

#### Testing

src/python_testing/TC_DeviceBasicComposition.py



