### PR TITLE
Use relative imports in Matter Python library

### DIFF
--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -26,10 +26,9 @@ from traitlets.config import Config
 def main():
     c = Config()
     c.InteractiveShellApp.exec_lines = [
-        "import chip",                         # Load chip package
-        "from chip.ChipReplStartup import *",  # Load REPL add-ons
-        "from chip import ChipReplStartup",
-        f"ChipReplStartup.main({repr(sys.argv[1:])})",
+        "import importlib.util",
+        "spec = importlib.util.find_spec('chip.ChipReplStartup')",
+        "%run {spec.origin} " + " ".join(sys.argv[1:])
     ]
 
     sys.argv = [sys.argv[0]]

--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -26,9 +26,8 @@ from traitlets.config import Config
 def main():
     c = Config()
     c.InteractiveShellApp.exec_lines = [
-        "import importlib.util",
-        "spec = importlib.util.find_spec('chip.ChipReplStartup')",
-        "%run {spec.origin} " + " ".join(sys.argv[1:])
+        "from chip import ChipReplStartup",
+        "ChipReplStartup.main()",
     ]
 
     sys.argv = [sys.argv[0]]

--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -27,7 +27,7 @@ def main():
     c = Config()
     c.InteractiveShellApp.exec_lines = [
         "from chip import ChipReplStartup",
-        "ChipReplStartup.main()",
+        f"ChipReplStartup.main({repr(sys.argv[1:])})",
     ]
 
     sys.argv = [sys.argv[0]]

--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -26,6 +26,8 @@ from traitlets.config import Config
 def main():
     c = Config()
     c.InteractiveShellApp.exec_lines = [
+        "import chip",                         # Load chip package
+        "from chip.ChipReplStartup import *",  # Load REPL add-ons
         "from chip import ChipReplStartup",
         f"ChipReplStartup.main({repr(sys.argv[1:])})",
     ]

--- a/src/controller/python/chip/CertificateAuthority.py
+++ b/src/controller/python/chip/CertificateAuthority.py
@@ -24,10 +24,9 @@ from ctypes import c_void_p
 from datetime import timedelta
 from typing import List, Optional
 
-import chip.exceptions
-from chip import ChipStack, FabricAdmin
-from chip.native import PyChipError
-from chip.storage import PersistentStorage
+from . import ChipStack, FabricAdmin
+from .native import GetLibraryHandle, PyChipError
+from .storage import PersistentStorage
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,7 +52,7 @@ class CertificateAuthority:
     '''
     @classmethod
     def _Handle(cls):
-        return chip.native.GetLibraryHandle()
+        return GetLibraryHandle()
 
     @classmethod
     def logger(cls):
@@ -229,7 +228,7 @@ class CertificateAuthorityManager:
     '''
     @classmethod
     def _Handle(cls):
-        return chip.native.GetLibraryHandle()
+        return GetLibraryHandle()
 
     @classmethod
     def logger(cls):

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -26,7 +26,8 @@ import coloredlogs
 from rich import inspect, pretty
 from rich.console import Console
 
-from . import CertificateAuthority, FabricAdmin
+from . import FabricAdmin  # noqa: F401
+from . import CertificateAuthority
 from . import clusters as Clusters  # noqa: F401
 from .ChipStack import ChipStack
 from .logging import RedirectToPythonLogging

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -22,16 +22,15 @@ import logging
 import os
 import pathlib
 
+import chip.CertificateAuthority
+import chip.clusters as Clusters  # noqa: F401
+import chip.FabricAdmin
+import chip.logging
+import chip.native
 import coloredlogs
+from chip.ChipStack import ChipStack
 from rich import inspect, pretty
 from rich.console import Console
-
-from . import FabricAdmin  # noqa: F401
-from . import CertificateAuthority
-from . import clusters as Clusters  # noqa: F401
-from .ChipStack import ChipStack
-from .logging import RedirectToPythonLogging
-from .native import Init as NativeInit
 
 
 def ReplInit(debug):
@@ -58,7 +57,7 @@ def ReplInit(debug):
     console.rule()
 
     coloredlogs.install(level='DEBUG')
-    RedirectToPythonLogging()
+    chip.logging.RedirectToPythonLogging()
 
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -98,7 +97,7 @@ def mattersetdebug(enableDebugMode: bool = True):
     builtins.enableDebugMode = enableDebugMode
 
 
-def main(args=None):
+def main():
     console = Console()
 
     parser = argparse.ArgumentParser()
@@ -115,7 +114,7 @@ def main(args=None):
         "-b", "--ble-adapter", help="Set the Bluetooth adapter index.", type=int, default=None)
     parser.add_argument(
         "-s", "--server-interactions", help="Enable server interactions.", action="store_true")
-    args = parser.parse_args(args)
+    args = parser.parse_args()
 
     if not os.path.exists(args.trust_store):
         # there is a chance that the script is being run from a sub-path of a checkout.
@@ -149,7 +148,7 @@ or run `os.chdir` to the root of your CHIP repository checkout.
         # nothing we can do ... things will NOT work
         return
 
-    NativeInit(bluetoothAdapter=args.ble_adapter)
+    chip.native.Init(bluetoothAdapter=args.ble_adapter)
 
     global certificateAuthorityManager
     global chipStack
@@ -159,7 +158,7 @@ or run `os.chdir` to the root of your CHIP repository checkout.
     ReplInit(args.debug)
 
     chipStack = ChipStack(persistentStoragePath=args.storagepath, enableServerInteractions=args.server_interactions)
-    certificateAuthorityManager = CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
+    certificateAuthorityManager = chip.CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
 
     certificateAuthorityManager.LoadAuthoritiesFromStorage()
 

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -100,7 +100,7 @@ def mattersetdebug(enableDebugMode: bool = True):
     builtins.enableDebugMode = enableDebugMode
 
 
-def main():
+def main(args=None):
     console = Console()
 
     parser = argparse.ArgumentParser()
@@ -117,7 +117,7 @@ def main():
         "-b", "--ble-adapter", help="Set the Bluetooth adapter index.", type=int, default=None)
     parser.add_argument(
         "-s", "--server-interactions", help="Enable server interactions.", action="store_true")
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if not os.path.exists(args.trust_store):
         # there is a chance that the script is being run from a sub-path of a checkout.

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -1,3 +1,20 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
 import argparse
 import atexit
 import builtins
@@ -5,15 +22,15 @@ import logging
 import os
 import pathlib
 
-import chip.CertificateAuthority
-import chip.clusters as Clusters  # noqa: F401
-import chip.FabricAdmin
-import chip.logging
-import chip.native
 import coloredlogs
-from chip.ChipStack import ChipStack
 from rich import inspect, pretty
 from rich.console import Console
+
+from . import CertificateAuthority, FabricAdmin
+from . import clusters as Clusters  # noqa: F401
+from .ChipStack import ChipStack
+from .logging import RedirectToPythonLogging
+from .native import Init as NativeInit
 
 _fabricAdmins = None
 
@@ -42,7 +59,7 @@ def ReplInit(debug):
     console.rule()
 
     coloredlogs.install(level='DEBUG')
-    chip.logging.RedirectToPythonLogging()
+    RedirectToPythonLogging()
 
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -133,7 +150,7 @@ or run `os.chdir` to the root of your CHIP repository checkout.
         # nothing we can do ... things will NOT work
         return
 
-    chip.native.Init(bluetoothAdapter=args.ble_adapter)
+    NativeInit(bluetoothAdapter=args.ble_adapter)
 
     global certificateAuthorityManager
     global chipStack
@@ -143,7 +160,7 @@ or run `os.chdir` to the root of your CHIP repository checkout.
     ReplInit(args.debug)
 
     chipStack = ChipStack(persistentStoragePath=args.storagepath, enableServerInteractions=args.server_interactions)
-    certificateAuthorityManager = chip.CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
+    certificateAuthorityManager = CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
 
     certificateAuthorityManager.LoadAuthoritiesFromStorage()
 

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -33,8 +33,6 @@ from .ChipStack import ChipStack
 from .logging import RedirectToPythonLogging
 from .native import Init as NativeInit
 
-_fabricAdmins = None
-
 
 def ReplInit(debug):
     #

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -32,14 +32,12 @@ from ctypes import CFUNCTYPE, Structure, c_bool, c_char_p, c_uint16, c_uint32, c
 from threading import Condition, Lock
 from typing import Any, Optional
 
-import chip.native
-from chip.native import PyChipError
-
 from .bdx import Bdx
 from .clusters import Attribute as ClusterAttribute
 from .clusters import Command as ClusterCommand
 from .exceptions import ChipStackError, ChipStackException, DeviceError
 from .interaction_model import delegate as im
+from .native import FindNativeLibraryPath, GetLibraryHandle, Library, PyChipError
 from .storage import PersistentStorage
 
 __all__ = [
@@ -264,8 +262,8 @@ class ChipStack(object):
 
     def _loadLib(self):
         if self._ChipStackLib is None:
-            self._ChipStackLib = chip.native.GetLibraryHandle()
-            self._chipDLLPath = chip.native.FindNativeLibraryPath(chip.native.Library.CONTROLLER)
+            self._ChipStackLib = GetLibraryHandle()
+            self._chipDLLPath = FindNativeLibraryPath(Library.CONTROLLER)
 
             self._ChipStackLib.pychip_DeviceController_StackInit.argtypes = [c_void_p, c_bool]
             self._ChipStackLib.pychip_DeviceController_StackInit.restype = PyChipError

--- a/src/controller/python/chip/FabricAdmin.py
+++ b/src/controller/python/chip/FabricAdmin.py
@@ -21,9 +21,9 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
-from chip import CertificateAuthority, ChipDeviceCtrl
-from chip.crypto import p256keypair
-from chip.native import GetLibraryHandle
+from . import CertificateAuthority, ChipDeviceCtrl
+from .crypto import p256keypair
+from .native import GetLibraryHandle
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/controller/python/chip/bdx/Bdx.py
+++ b/src/controller/python/chip/bdx/Bdx.py
@@ -22,9 +22,7 @@ from asyncio.futures import Future
 from ctypes import CFUNCTYPE, POINTER, c_char_p, c_size_t, c_uint8, c_uint16, c_uint64, c_void_p, py_object
 from typing import Callable, Optional
 
-import chip
-from chip.native import PyChipError
-
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 from . import BdxTransfer
 
 c_uint8_p = POINTER(c_uint8)
@@ -121,7 +119,7 @@ def _PrepareForBdxTransfer(future: Future, data: Optional[bytes]) -> PyChipError
 
     Returns the CHIP_ERROR result from the C++ side.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     transaction = AsyncTransferObtainedTransaction(future=future, event_loop=asyncio.get_running_loop(), data=data)
 
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
@@ -163,7 +161,7 @@ def AcceptTransferAndReceiveData(transfer: c_void_p, dataReceivedClosure: Callab
 
     Returns an error if one is encountered while accepting the transfer.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     complete_transaction = AsyncTransferCompletedTransaction(future=transferComplete, event_loop=asyncio.get_running_loop())
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(dataReceivedClosure))
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(complete_transaction))
@@ -184,7 +182,7 @@ def AcceptTransferAndSendData(transfer: c_void_p, data: bytearray, transferCompl
 
     Returns an error if one is encountered while accepting the transfer.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     complete_transaction = AsyncTransferCompletedTransaction(future=transferComplete, event_loop=asyncio.get_running_loop())
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(complete_transaction))
     res = builtins.chipStack.Call(
@@ -200,17 +198,17 @@ async def RejectTransfer(transfer: c_void_p):
 
     Returns an error if one is encountered while rejecting the transfer.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     return await builtins.chipStack.CallAsyncWithResult(
         lambda: handle.pychip_Bdx_RejectTransfer(transfer)
     )
 
 
 def Init():
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     # Uses one of the type decorators as an indicator for everything being initialized.
     if not handle.pychip_Bdx_ExpectBdxTransfer.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_Bdx_ExpectBdxTransfer',
                    PyChipError, [py_object])

--- a/src/controller/python/chip/ble/__init__.py
+++ b/src/controller/python/chip/ble/__init__.py
@@ -11,8 +11,8 @@
 #    limitations under the License.
 """BLE-related functionality within CHIP"""
 
-from chip.ble.get_adapters import GetAdapters
-from chip.ble.scan_devices import DiscoverAsync, DiscoverSync
+from .get_adapters import GetAdapters
+from .scan_devices import DiscoverAsync, DiscoverSync
 
 __all__ = [
     'GetAdapters',

--- a/src/controller/python/chip/ble/commissioning/__init__.py
+++ b/src/controller/python/chip/ble/commissioning/__init__.py
@@ -19,8 +19,8 @@ from enum import Enum
 from queue import Queue
 from typing import Optional
 
-from chip.internal import GetCommissioner
-from chip.internal.commissioner import PairingState
+from ...internal import GetCommissioner
+from ...internal.commissioner import PairingState
 
 TEST_NODE_ID = 11223344
 

--- a/src/controller/python/chip/ble/get_adapters.py
+++ b/src/controller/python/chip/ble/get_adapters.py
@@ -1,7 +1,23 @@
+#
+#    Copyright (c) 2021 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
 from dataclasses import dataclass
 from typing import List
 
-from chip.ble.library_handle import _GetBleLibraryHandle
+from .library_handle import _GetBleLibraryHandle
 
 
 @dataclass

--- a/src/controller/python/chip/ble/library_handle.py
+++ b/src/controller/python/chip/ble/library_handle.py
@@ -17,8 +17,8 @@
 import ctypes
 from ctypes import c_bool, c_char_p, c_uint32, c_void_p, py_object
 
-import chip.native
-from chip.ble.types import DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments
+from .types import DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
 
 
 # This prevents python auto-casting c_void_p to integers and
@@ -32,16 +32,16 @@ class VoidPointer(c_void_p):
 def _GetBleLibraryHandle() -> ctypes.CDLL:
     """ Get the native library handle with BLE method initialization.
 
-      Retreives the CHIP native library handle and attaches signatures to
+      Retrieves the CHIP native library handle and attaches signatures to
       native methods.
       """
 
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized. Native methods default to c_int return types
     if handle.pychip_ble_adapter_list_new.restype != VoidPointer:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_ble_adapter_list_new', VoidPointer, [])
         setter.Set('pychip_ble_adapter_list_next', c_bool, [VoidPointer])

--- a/src/controller/python/chip/ble/scan_devices.py
+++ b/src/controller/python/chip/ble/scan_devices.py
@@ -20,8 +20,8 @@ from queue import Queue
 from threading import Thread
 from typing import Generator
 
-from chip.ble.library_handle import _GetBleLibraryHandle
-from chip.ble.types import DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
+from .library_handle import _GetBleLibraryHandle
+from .types import DeviceScannedCallback, ScanDoneCallback, ScanErrorCallback
 
 
 @DeviceScannedCallback

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -37,7 +37,7 @@ from ..interaction_model import (AttributePathIBstruct, DataVersionFilterIBstruc
 from ..interaction_model import Status as InteractionModelStatus
 from ..native import ErrorSDKPart, GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 from ..tlv import TLVReader
-from . import Objects as GeneratedObjects
+from . import Objects as GeneratedObjects  # noqa: F401
 from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
 
 LOGGER = logging.getLogger(__name__)

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -254,8 +254,8 @@ def _BuildAttributeIndex():
         it takes about 300ms for a single query.
         This is acceptable during init, but unacceptable when the server returns lots of attributes at the same time.
     '''
-    for clusterName, obj in inspect.getmembers(sys.modules['matter.clusters.Objects']):
-        if ('matter.clusters.Objects' in str(obj)) and inspect.isclass(obj):
+    for clusterName, obj in inspect.getmembers(sys.modules['chip.clusters.Objects']):
+        if ('chip.clusters.Objects' in str(obj)) and inspect.isclass(obj):
             for objName, subclass in inspect.getmembers(obj):
                 if inspect.isclass(subclass) and (('Attributes') in str(subclass)):
                     for attributeName, attribute in inspect.getmembers(subclass):
@@ -269,14 +269,14 @@ def _BuildAttributeIndex():
                                 continue
 
                             _AttributeIndex[(attribute.cluster_id, attribute.attribute_id)] = (eval(
-                                'matter.clusters.Objects.' + clusterName + '.Attributes.' + attributeName), obj)
+                                'chip.clusters.Objects.' + clusterName + '.Attributes.' + attributeName), obj)
 
 
 def _BuildClusterIndex():
     ''' Build internal cluster index for locating the corresponding cluster object by path in the future.
     '''
-    for clusterName, obj in inspect.getmembers(sys.modules['matter.clusters.Objects']):
-        if ('matter.clusters.Objects' in str(obj)) and inspect.isclass(obj) and issubclass(obj, Cluster):
+    for clusterName, obj in inspect.getmembers(sys.modules['chip.clusters.Objects']):
+        if ('chip.clusters.Objects' in str(obj)) and inspect.isclass(obj) and issubclass(obj, Cluster):
             _ClusterIndex[obj.id] = obj
 
 
@@ -626,8 +626,8 @@ def _BuildEventIndex():
     We do this because this operation will take a long time when there are lots of events, it takes about 300ms for a single query.
     This is acceptable during init, but unacceptable when the server returns lots of events at the same time.
     '''
-    for clusterName, obj in inspect.getmembers(sys.modules['matter.clusters.Objects']):
-        if ('matter.clusters.Objects' in str(obj)) and inspect.isclass(obj):
+    for clusterName, obj in inspect.getmembers(sys.modules['chip.clusters.Objects']):
+        if ('chip.clusters.Objects' in str(obj)) and inspect.isclass(obj):
             for objName, subclass in inspect.getmembers(obj):
                 if inspect.isclass(subclass) and (('Events' == objName)):
                     for eventName, event in inspect.getmembers(subclass):
@@ -641,7 +641,7 @@ def _BuildEventIndex():
                                 continue
 
                             _EventIndex[str(EventPath(ClusterId=event.cluster_id, EventId=event.event_id))] = eval(
-                                'matter.clusters.Objects.' + clusterName + '.Events.' + eventName)
+                                'chip.clusters.Objects.' + clusterName + '.Events.' + eventName)
 
 
 class AsyncReadTransaction:

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -38,6 +38,7 @@ from ..interaction_model import Status as InteractionModelStatus
 from ..native import ErrorSDKPart, GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 from ..tlv import TLVReader
 from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
+from . import Objects as GeneratedObjects
 
 LOGGER = logging.getLogger(__name__)
 
@@ -269,7 +270,7 @@ def _BuildAttributeIndex():
                                 continue
 
                             _AttributeIndex[(attribute.cluster_id, attribute.attribute_id)] = (eval(
-                                'chip.clusters.Objects.' + clusterName + '.Attributes.' + attributeName), obj)
+                                'GeneratedObjects.' + clusterName + '.Attributes.' + attributeName), obj)
 
 
 def _BuildClusterIndex():
@@ -641,7 +642,7 @@ def _BuildEventIndex():
                                 continue
 
                             _EventIndex[str(EventPath(ClusterId=event.cluster_id, EventId=event.event_id))] = eval(
-                                'chip.clusters.Objects.' + clusterName + '.Events.' + eventName)
+                                'GeneratedObjects.' + clusterName + '.Events.' + eventName)
 
 
 class AsyncReadTransaction:

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -37,8 +37,8 @@ from ..interaction_model import (AttributePathIBstruct, DataVersionFilterIBstruc
 from ..interaction_model import Status as InteractionModelStatus
 from ..native import ErrorSDKPart, GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 from ..tlv import TLVReader
-from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
 from . import Objects as GeneratedObjects
+from .ClusterObjects import Cluster, ClusterAttributeDescriptor, ClusterEvent
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/controller/python/chip/clusters/ClusterObjects.py
+++ b/src/controller/python/chip/clusters/ClusterObjects.py
@@ -20,9 +20,10 @@ import typing
 from dataclasses import asdict, dataclass, field, make_dataclass
 from typing import Any, ClassVar, Dict, List, Mapping, Union
 
-from chip import ChipUtility, tlv
-from chip.clusters.Types import Nullable, NullValue
 from dacite import from_dict  # type: ignore
+
+from .. import ChipUtility, tlv
+from ..clusters.Types import Nullable, NullValue
 
 
 def GetUnionUnderlyingType(typeToCheck, matchingType=None):

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -29,6 +29,7 @@ from ..interaction_model import InteractionModelError, PyInvokeRequestData
 from ..interaction_model import Status as InteractionModelStatus
 from ..interaction_model import TestOnlyPyBatchCommandsOverrides, TestOnlyPyOnDoneInfo
 from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
+from . import Objects as GeneratedObjects  # noqa: F401
 from .ClusterObjects import ClusterCommand
 
 logger = logging.getLogger('chip.cluster.Command')
@@ -79,7 +80,7 @@ def FindCommandClusterObject(isClientSideCommand: bool, path: CommandPath):
                                 if ('__dataclass_fields__' in name):
                                     if (field['cluster_id'].default == path.ClusterId) and (field['command_id'].default ==
                                                                                             path.CommandId) and (field['is_client'].default == isClientSideCommand):
-                                        return eval('chip.clusters.Objects.' + clusterName + '.Commands.' + commandName)
+                                        return eval('GeneratedObjects.' + clusterName + '.Commands.' + commandName)
     return None
 
 

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -25,11 +25,10 @@ from ctypes import CFUNCTYPE, POINTER, c_bool, c_char_p, c_size_t, c_uint8, c_ui
 from dataclasses import dataclass
 from typing import List, Optional, Type, Union
 
-import chip.exceptions
-import chip.interaction_model
-from chip.interaction_model import PyInvokeRequestData, TestOnlyPyBatchCommandsOverrides, TestOnlyPyOnDoneInfo
-from chip.native import PyChipError
-
+from ..interaction_model import InteractionModelError, PyInvokeRequestData
+from ..interaction_model import Status as InteractionModelStatus
+from ..interaction_model import TestOnlyPyBatchCommandsOverrides, TestOnlyPyOnDoneInfo
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 from .ClusterObjects import ClusterCommand
 
 logger = logging.getLogger('chip.cluster.Command')
@@ -127,11 +126,11 @@ class AsyncCommandTransaction:
                 # add it to the except block below. We changed Exception->AttributeError as
                 # that is what we thought we are trying to catch here.
                 self._future.set_exception(
-                    chip.interaction_model.InteractionModelError(chip.interaction_model.Status(imError.IMStatus), imError.ClusterStatus))
+                    InteractionModelError(InteractionModelStatus(imError.IMStatus), imError.ClusterStatus))
             except AttributeError:
                 logger.exception("Failed to map interaction model status received: %s. Remapping to Failure." % imError)
-                self._future.set_exception(chip.interaction_model.InteractionModelError(
-                    chip.interaction_model.Status.Failure, imError.ClusterStatus))
+                self._future.set_exception(InteractionModelError(
+                    InteractionModelStatus.Failure, imError.ClusterStatus))
 
     def handleError(self, status: Status, chipError: PyChipError):
         self._event_loop.call_soon_threadsafe(
@@ -147,8 +146,8 @@ class AsyncBatchCommandsTransaction:
         self._event_loop = eventLoop
         self._future = future
         self._expect_types = expectTypes
-        default_im_failure = chip.interaction_model.InteractionModelError(
-            chip.interaction_model.Status.NoCommandResponse)
+        default_im_failure = InteractionModelError(
+            InteractionModelStatus.NoCommandResponse)
         self._responses = [default_im_failure] * len(expectTypes)
 
     def _handleResponse(self, path: CommandPath, index: int, status: Status, response: bytes):
@@ -156,10 +155,10 @@ class AsyncBatchCommandsTransaction:
             self._handleError(status, 0, IndexError(f"CommandSenderCallback has given us an unexpected index value {index}"))
             return
 
-        if status.IMStatus != chip.interaction_model.Status.Success:
+        if status.IMStatus != InteractionModelStatus.Success:
             try:
-                self._responses[index] = chip.interaction_model.InteractionModelError(
-                    chip.interaction_model.Status(status.IMStatus), status.ClusterStatus)
+                self._responses[index] = InteractionModelError(
+                    InteractionModelStatus(status.IMStatus), status.ClusterStatus)
             except AttributeError as ex:
                 self._handleError(status, 0, ex)
         elif (len(response) == 0):
@@ -198,11 +197,11 @@ class AsyncBatchCommandsTransaction:
                 # add it to the except block below. We changed Exception->AttributeError as
                 # that is what we thought we are trying to catch here.
                 self._future.set_exception(
-                    chip.interaction_model.InteractionModelError(chip.interaction_model.Status(imError.IMStatus), imError.ClusterStatus))
+                    InteractionModelError(InteractionModelStatus(imError.IMStatus), imError.ClusterStatus))
             except AttributeError:
                 logger.exception("Failed to map interaction model status received: %s. Remapping to Failure." % imError)
-                self._future.set_exception(chip.interaction_model.InteractionModelError(
-                    chip.interaction_model.Status.Failure, imError.ClusterStatus))
+                self._future.set_exception(InteractionModelError(
+                    InteractionModelStatus.Failure, imError.ClusterStatus))
 
     def handleError(self, status: Status, chipError: PyChipError):
         self._event_loop.call_soon_threadsafe(
@@ -276,7 +275,7 @@ def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(future: Future, eventLo
     if (responseType is not None) and (not issubclass(responseType, ClusterCommand)):
         raise ValueError("responseType must be a ClusterCommand or None")
 
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     transaction = AsyncCommandTransaction(future, eventLoop, responseType)
 
     payloadTLV = payload.ToTLV()
@@ -309,9 +308,9 @@ async def SendCommand(future: Future, eventLoop, responseType: Type, device, com
     if (responseType is not None) and (not issubclass(responseType, ClusterCommand)):
         raise ValueError("responseType must be a ClusterCommand or None")
     if payload.must_use_timed_invoke and timedRequestTimeoutMs is None or timedRequestTimeoutMs == 0:
-        raise chip.interaction_model.InteractionModelError(chip.interaction_model.Status.NeedsTimedInteraction)
+        raise InteractionModelError(InteractionModelStatus.NeedsTimedInteraction)
 
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     transaction = AsyncCommandTransaction(future, eventLoop, responseType)
 
     payloadTLV = payload.ToTLV()
@@ -338,7 +337,7 @@ def _BuildPyInvokeRequestData(commands: List[InvokeRequestInfo], timedRequestTim
             raise ValueError("responseType must be a ClusterCommand or None")
         if clusterCommand.must_use_timed_invoke and timedRequestTimeoutMs is None or timedRequestTimeoutMs == 0:
             if not suppressTimedRequestMessage:
-                raise chip.interaction_model.InteractionModelError(chip.interaction_model.Status.NeedsTimedInteraction)
+                raise InteractionModelError(InteractionModelStatus.NeedsTimedInteraction)
 
         payloadTLV = clusterCommand.ToTLV()
 
@@ -380,7 +379,7 @@ async def SendBatchCommands(future: Future, eventLoop, device, commands: List[In
                   a specific command.
         - Non-path-specific error: An `InteractionModelError` exception is raised through the future.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     responseTypes: List[Type] = []
     pyBatchCommandsData = _BuildPyInvokeRequestData(commands, timedRequestTimeoutMs, responseTypes)
@@ -415,7 +414,7 @@ def TestOnlySendBatchCommands(future: Future, eventLoop, device, commands: List[
         overrideCommandRefsType = c_uint16 * len(commandRefsOverride)
         overrideCommandRefs = overrideCommandRefsType()
 
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     responseTypes: List[Type] = []
     pyBatchCommandsData = _BuildPyInvokeRequestData(commands, timedRequestTimeoutMs,
@@ -447,7 +446,7 @@ def SendGroupCommand(groupId: int, devCtrl: c_void_p, payload: ClusterCommand, b
             - None (on a successful response containing no data)
             - Raises an exception if any errors are encountered.
     '''
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     payloadTLV = payload.ToTLV()
     return builtins.chipStack.Call(
@@ -459,12 +458,12 @@ def SendGroupCommand(groupId: int, devCtrl: c_void_p, payload: ClusterCommand, b
 
 
 def Init():
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized.
     if not handle.pychip_CommandSender_SendCommand.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_CommandSender_SendCommand',
                    PyChipError, [py_object, c_void_p, c_uint16, c_uint16, c_uint32, c_uint32, c_char_p, c_size_t, c_uint16, c_uint16, c_bool])

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -29,14 +29,12 @@ import typing
 from dataclasses import dataclass, field
 from enum import IntFlag
 
-from chip import ChipUtility
-from chip.clusters.enum import MatterIntEnum
-from chip.tlv import float32, uint
-
+from .. import ChipUtility
+from ..clusters.enum import MatterIntEnum
+from ..tlv import float32, uint
 from .ClusterObjects import (Cluster, ClusterAttributeDescriptor, ClusterCommand, ClusterEvent, ClusterObject,
                              ClusterObjectDescriptor, ClusterObjectFieldDescriptor)
 from .Types import Nullable, NullValue
-
 
 __all__ = [
     "Globals",

--- a/src/controller/python/chip/clusters/TestObjects.py
+++ b/src/controller/python/chip/clusters/TestObjects.py
@@ -20,8 +20,7 @@ import typing
 from dataclasses import dataclass
 from enum import IntEnum
 
-from chip import ChipUtility
-
+from .. import ChipUtility
 from .ClusterObjects import ClusterCommand, ClusterObjectDescriptor
 
 

--- a/src/controller/python/chip/credentials/cert.py
+++ b/src/controller/python/chip/credentials/cert.py
@@ -17,16 +17,16 @@
 
 import ctypes
 
-import chip.native
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 
 
 def _handle():
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     if handle.pychip_ConvertX509CertToChipCert.argtypes is None:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
-        setter.Set("pychip_ConvertX509CertToChipCert", chip.native.PyChipError, [ctypes.POINTER(
+        setter = NativeLibraryHandleMethodArguments(handle)
+        setter.Set("pychip_ConvertX509CertToChipCert", PyChipError, [ctypes.POINTER(
             ctypes.c_uint8), ctypes.c_size_t, ctypes.POINTER(ctypes.c_uint8), ctypes.POINTER(ctypes.c_size_t)])
-        setter.Set("pychip_ConvertChipCertToX509Cert", chip.native.PyChipError, [ctypes.POINTER(
+        setter.Set("pychip_ConvertChipCertToX509Cert", PyChipError, [ctypes.POINTER(
             ctypes.c_uint8), ctypes.c_size_t, ctypes.POINTER(ctypes.c_uint8), ctypes.POINTER(ctypes.c_size_t)])
     return handle
 

--- a/src/controller/python/chip/discovery/__init__.py
+++ b/src/controller/python/chip/discovery/__init__.py
@@ -21,9 +21,9 @@ import time
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Set
 
-from chip.discovery.library_handle import _GetDiscoveryLibraryHandle
-from chip.discovery.types import DiscoverFailureCallback_t, DiscoverSuccessCallback_t
-from chip.native import PyChipError
+from ..native import PyChipError
+from .library_handle import _GetDiscoveryLibraryHandle
+from .types import DiscoverFailureCallback_t, DiscoverSuccessCallback_t
 
 
 class DiscoveryType(enum.IntEnum):

--- a/src/controller/python/chip/discovery/library_handle.py
+++ b/src/controller/python/chip/discovery/library_handle.py
@@ -16,9 +16,8 @@
 
 import ctypes
 
-import chip.native
-from chip.discovery.types import DiscoverFailureCallback_t, DiscoverSuccessCallback_t
-from chip.native import PyChipError
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
+from .types import DiscoverFailureCallback_t, DiscoverSuccessCallback_t
 
 
 def _GetDiscoveryLibraryHandle() -> ctypes.CDLL:
@@ -28,12 +27,12 @@ def _GetDiscoveryLibraryHandle() -> ctypes.CDLL:
       native methods.
       """
 
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized.
     if not handle.pychip_discovery_resolve.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_discovery_resolve', PyChipError,
                    [ctypes.c_uint64, ctypes.c_uint64])

--- a/src/controller/python/chip/discovery/types.py
+++ b/src/controller/python/chip/discovery/types.py
@@ -16,7 +16,7 @@
 
 from ctypes import CFUNCTYPE, c_char_p, c_uint16, c_uint32, c_uint64
 
-from chip.native import PyChipError
+from ..native import PyChipError
 
 DiscoverSuccessCallback_t = CFUNCTYPE(
     None,  # void return

--- a/src/controller/python/chip/exceptions/__init__.py
+++ b/src/controller/python/chip/exceptions/__init__.py
@@ -31,7 +31,7 @@ __all__ = [
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from chip.native import PyChipError
+    from ..native import PyChipError
 
 
 class ChipStackException(Exception):

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -24,8 +24,7 @@
 
 import enum
 
-from chip.exceptions import ChipStackException
-
+from ..exceptions import ChipStackException
 from .delegate import (AttributePath, AttributePathIBstruct, DataVersionFilterIBstruct, EventPath, EventPathIBstruct,
                        PyInvokeRequestData, PyWriteAttributeData, SessionParameters, SessionParametersStruct,
                        TestOnlyPyBatchCommandsOverrides, TestOnlyPyOnDoneInfo)

--- a/src/controller/python/chip/interaction_model/delegate.py
+++ b/src/controller/python/chip/interaction_model/delegate.py
@@ -20,10 +20,9 @@ from ctypes import CFUNCTYPE, POINTER, c_uint8, c_uint32, c_uint64, c_void_p
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-import chip.exceptions
-import chip.native
-import chip.tlv
 from construct import Int8ul, Int16ul, Int32ul, Int64ul, Struct  # type: ignore
+
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 
 # The type should match CommandStatus in interaction_model/Delegate.h
 # CommandStatus should not contain padding
@@ -285,7 +284,7 @@ def _SetCommandIndexStatus(commandHandle: int, commandIndex: int, status):
         _commandIndexStatusDict[commandHandle] = indexDict
 
 
-@ _OnCommandResponseStatusCodeReceivedFunct
+@_OnCommandResponseStatusCodeReceivedFunct
 def _OnCommandResponseStatusCodeReceived(commandHandle: int, IMCommandStatusBuf, IMCommandStatusBufLen):
     status = IMCommandStatus.parse(ctypes.string_at(
         IMCommandStatusBuf, IMCommandStatusBufLen))
@@ -293,12 +292,12 @@ def _OnCommandResponseStatusCodeReceived(commandHandle: int, IMCommandStatusBuf,
                            status["CommandIndex"], status)
 
 
-@ _OnCommandResponseProtocolErrorFunct
+@_OnCommandResponseProtocolErrorFunct
 def _OnCommandResponseProtocolError(commandHandle: int, errorcode: int):
     pass
 
 
-@ _OnCommandResponseFunct
+@_OnCommandResponseFunct
 def _OnCommandResponse(commandHandle: int, errorcode: int):
     _SetCommandStatus(PLACEHOLDER_COMMAND_HANDLE, errorcode)
 
@@ -320,9 +319,9 @@ def _OnWriteResponseStatus(IMAttributeWriteResult, IMAttributeWriteResultLen):
 
 
 def InitIMDelegate():
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     if not handle.pychip_InteractionModelDelegate_SetCommandResponseStatusCallback.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseStatusCallback", None, [
                    _OnCommandResponseStatusCodeReceivedFunct])
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseProtocolErrorCallback", None, [
@@ -330,7 +329,7 @@ def InitIMDelegate():
         setter.Set("pychip_InteractionModelDelegate_SetCommandResponseErrorCallback", None, [
                    _OnCommandResponseFunct])
         setter.Set("pychip_InteractionModel_GetCommandSenderHandle",
-                   chip.native.PyChipError, [ctypes.POINTER(c_uint64)])
+                   PyChipError, [ctypes.POINTER(c_uint64)])
         setter.Set("pychip_InteractionModelDelegate_SetOnWriteResponseStatusCallback", None, [
                    _OnWriteResponseStatusFunct])
 
@@ -387,7 +386,7 @@ def WaitCommandIndexStatus(commandHandle: int, commandIndex: int):
 
 
 def GetCommandSenderHandle() -> int:
-    handle = chip.native.GetLibraryHandle()
+    handle = GetLibraryHandle()
     resPointer = c_uint64()
     handle.pychip_InteractionModel_GetCommandSenderHandle(
         ctypes.pointer(resPointer)).raise_on_error()

--- a/src/controller/python/chip/internal/__init__.py
+++ b/src/controller/python/chip/internal/__init__.py
@@ -17,7 +17,7 @@
 # Classes and methods in this module are generally to be used internally
 # by the BLE constructs and are not meant as a public API.
 
-from chip.internal.commissioner import GetCommissioner
+from .commissioner import GetCommissioner
 
 __all__ = [
     'GetCommissioner'

--- a/src/controller/python/chip/internal/commissioner.py
+++ b/src/controller/python/chip/internal/commissioner.py
@@ -17,9 +17,9 @@ import ctypes
 from enum import Enum
 from typing import Optional
 
-from chip.configuration import GetCommissionerCAT, GetLocalNodeId
-from chip.internal.types import NetworkCredentialsRequested, OperationalCredentialsRequested, PairingComplete
-from chip.native import GetLibraryHandle, NativeLibraryHandleMethodArguments
+from ..configuration import GetCommissionerCAT, GetLocalNodeId
+from ..internal.types import NetworkCredentialsRequested, OperationalCredentialsRequested, PairingComplete
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments
 
 # Not using c_void_p directly is IMPORTANT. Python auto-casts c_void_p
 # to intergers and this can cause 32/64 bit issues.

--- a/src/controller/python/chip/logging/__init__.py
+++ b/src/controller/python/chip/logging/__init__.py
@@ -16,8 +16,8 @@
 
 import logging
 
-from chip.logging.library_handle import _GetLoggingLibraryHandle
-from chip.logging.types import LogRedirectCallback_t
+from .library_handle import _GetLoggingLibraryHandle
+from .types import LogRedirectCallback_t
 
 # Defines match src/lib/support/logging/Constants.h (LogCategory enum)
 LOG_CATEGORY_NONE = 0

--- a/src/controller/python/chip/logging/library_handle.py
+++ b/src/controller/python/chip/logging/library_handle.py
@@ -16,8 +16,8 @@
 
 import ctypes
 
-import chip.native
-from chip.logging.types import LogRedirectCallback_t
+from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArguments
+from .types import LogRedirectCallback_t
 
 
 def _GetLoggingLibraryHandle() -> ctypes.CDLL:
@@ -29,12 +29,12 @@ def _GetLoggingLibraryHandle() -> ctypes.CDLL:
 
     # Getting a handle without requiring init, as logging methods
     # do not require chip stack startup
-    handle = chip.native.GetLibraryHandle(chip.native.HandleFlags(0))
+    handle = GetLibraryHandle(HandleFlags(0))
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized.
     if not handle.pychip_logging_set_callback.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_logging_set_callback',
                    ctypes.c_void_p, [LogRedirectCallback_t])

--- a/src/controller/python/chip/native/__init__.py
+++ b/src/controller/python/chip/native/__init__.py
@@ -23,8 +23,9 @@ import platform
 import typing
 from dataclasses import dataclass
 
-import chip.exceptions
 import construct  # type: ignore
+
+from ..exceptions import ChipStackError
 
 
 class Library(enum.Enum):
@@ -121,9 +122,9 @@ class PyChipError(ctypes.Structure):
             return None
         return self.code & 0xFF
 
-    def to_exception(self) -> typing.Optional[chip.exceptions.ChipStackError]:
+    def to_exception(self) -> typing.Optional[ChipStackError]:
         if not self.is_success:
-            return chip.exceptions.ChipStackError.from_chip_error(self)
+            return ChipStackError.from_chip_error(self)
         return None
 
     def __str__(self):
@@ -139,7 +140,7 @@ class PyChipError(ctypes.Structure):
             return self.code == other
         if isinstance(other, PyChipError):
             return self.code == other.code
-        if isinstance(other, chip.exceptions.ChipStackError):
+        if isinstance(other, ChipStackError):
             return self.code == other.err
         raise ValueError(f"Cannot compare PyChipError with {type(other)}")
 

--- a/src/controller/python/chip/server/__init__.py
+++ b/src/controller/python/chip/server/__init__.py
@@ -16,8 +16,7 @@
 
 import ctypes
 
-from .. import native as MatterNative
-from ..native import PostAttributeChangeCallback
+from ..native import Library, PostAttributeChangeCallback, _GetLibraryHandle, c_PostAttributeChangeCallback
 
 __all__ = [
     "GetLibraryHandle",
@@ -25,14 +24,14 @@ __all__ = [
 ]
 
 
-def GetLibraryHandle(cb: MatterNative.c_PostAttributeChangeCallback) -> ctypes.CDLL:
+def GetLibraryHandle(cb: c_PostAttributeChangeCallback) -> ctypes.CDLL:
     """Get a memoized handle to the chip native code dll.
 
     Args:
       cb: A callback decorated by PostAttributeChangeCallback decorator.
     """
 
-    handle = MatterNative._GetLibraryHandle(MatterNative.Library.SERVER, False)
+    handle = _GetLibraryHandle(Library.SERVER, False)
     if not handle.initialized:
         handle.dll.pychip_server_native_init().raise_on_error()
         handle.dll.pychip_server_set_callbacks(cb)

--- a/src/controller/python/chip/server/__init__.py
+++ b/src/controller/python/chip/server/__init__.py
@@ -16,8 +16,8 @@
 
 import ctypes
 
-from chip import native
-from chip.native import PostAttributeChangeCallback, c_PostAttributeChangeCallback
+from .. import native as MatterNative
+from ..native import PostAttributeChangeCallback
 
 __all__ = [
     "GetLibraryHandle",
@@ -25,14 +25,14 @@ __all__ = [
 ]
 
 
-def GetLibraryHandle(cb: c_PostAttributeChangeCallback) -> ctypes.CDLL:
+def GetLibraryHandle(cb: MatterNative.c_PostAttributeChangeCallback) -> ctypes.CDLL:
     """Get a memoized handle to the chip native code dll.
 
     Args:
       cb: A callback decorated by PostAttributeChangeCallback decorator.
     """
 
-    handle = native._GetLibraryHandle(native.Library.SERVER, False)
+    handle = MatterNative._GetLibraryHandle(MatterNative.Library.SERVER, False)
     if not handle.initialized:
         handle.dll.pychip_server_native_init().raise_on_error()
         handle.dll.pychip_server_set_callbacks(cb)

--- a/src/controller/python/chip/setup_payload/__init__.py
+++ b/src/controller/python/chip/setup_payload/__init__.py
@@ -14,6 +14,6 @@
 #    limitations under the License.
 #
 
-from chip.setup_payload.setup_payload import SetupPayload
+from .setup_payload import SetupPayload
 
 __all__ = ["SetupPayload"]

--- a/src/controller/python/chip/setup_payload/setup_payload.py
+++ b/src/controller/python/chip/setup_payload/setup_payload.py
@@ -17,7 +17,7 @@
 from ctypes import CFUNCTYPE, c_char_p, c_uint8, c_uint16, c_uint32, c_uint64, create_string_buffer
 from typing import Optional
 
-from chip.native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
+from ..native import GetLibraryHandle, NativeLibraryHandleMethodArguments, PyChipError
 
 
 class SetupPayload:

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -26,8 +26,7 @@ import logging
 from ctypes import CFUNCTYPE, POINTER, c_bool, c_char, c_char_p, c_uint16, c_void_p, py_object
 from typing import IO, Dict, Optional
 
-import chip.exceptions
-import chip.native
+from ..native import GetLibraryHandle
 
 LOGGER = logging.getLogger(__name__)
 
@@ -112,7 +111,7 @@ class PersistentStorage:
         else:
             LOGGER.info("Initializing persistent storage from dict")
 
-        self._handle = chip.native.GetLibraryHandle()
+        self._handle = GetLibraryHandle()
         self._isActive = True
         self._path = path
 

--- a/src/controller/python/chip/tracing/__init__.py
+++ b/src/controller/python/chip/tracing/__init__.py
@@ -18,25 +18,24 @@ import ctypes
 from enum import Enum, auto
 from typing import Optional
 
-import chip.native
-from chip.native import PyChipError
+from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArguments, PyChipError
 
 
 def _GetTracingLibraryHandle() -> ctypes.CDLL:
     """ Get the native library handle with tracing methods initialized.
 
-      Retreives the CHIP native library handle and attaches signatures to
+      Retrieves the CHIP native library handle and attaches signatures to
       native methods.
       """
 
     # Getting a handle without requiring init, as tracing methods
     # do not require chip stack startup
-    handle = chip.native.GetLibraryHandle(chip.native.HandleFlags(0))
+    handle = GetLibraryHandle(HandleFlags(0))
 
     # Uses one of the type decorators as an indicator for everything being
     # initialized.
     if not handle.pychip_tracing_start_json_file.argtypes:
-        setter = chip.native.NativeLibraryHandleMethodArguments(handle)
+        setter = NativeLibraryHandleMethodArguments(handle)
 
         setter.Set('pychip_tracing_start_json_log', None, [])
         setter.Set('pychip_tracing_start_json_file', PyChipError, [ctypes.c_char_p])

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -19,12 +19,12 @@ import logging
 import os
 import typing
 
-import chip.clusters as Clusters
-from chip.ChipDeviceCtrl import ChipDeviceController, NOCChain
-from chip.clusters import GeneralCommissioning as generalCommissioning
-from chip.clusters import OperationalCredentials as opCreds
-from chip.clusters.Types import NullValue
-from chip.FabricAdmin import FabricAdmin as FabricAdmin
+from .. import clusters as Clusters
+from ..ChipDeviceCtrl import ChipDeviceController, NOCChain
+from ..clusters import GeneralCommissioning as generalCommissioning
+from ..clusters import OperationalCredentials as opCreds
+from ..clusters.Types import NullValue
+from ..FabricAdmin import FabricAdmin as FabricAdmin
 
 _UINT16_MAX = 65535
 

--- a/src/controller/python/chip/yaml/data_model_lookup.py
+++ b/src/controller/python/chip/yaml/data_model_lookup.py
@@ -17,7 +17,7 @@
 
 from abc import ABC, abstractmethod
 
-import chip.clusters as Clusters
+from .. import clusters as Clusters
 
 
 def _case_insensitive_getattr(object, attr_name, default):

--- a/src/controller/python/chip/yaml/format_converter.py
+++ b/src/controller/python/chip/yaml/format_converter.py
@@ -23,7 +23,7 @@ from matter.idl import matter_idl_types
 from ..clusters.enum import MatterIntEnum
 from ..clusters.Types import Nullable, NullValue
 from ..tlv import float32, uint
-from ..yaml.errors import ValidationError
+from .errors import ValidationError
 
 
 @dataclass

--- a/src/controller/python/chip/yaml/format_converter.py
+++ b/src/controller/python/chip/yaml/format_converter.py
@@ -18,12 +18,12 @@
 import typing
 from dataclasses import dataclass
 
-from chip.clusters.enum import MatterIntEnum
-from chip.clusters.Types import Nullable, NullValue
-from chip.tlv import float32, uint
-from chip.yaml.errors import ValidationError
-
 from matter.idl import matter_idl_types
+
+from ..clusters.enum import MatterIntEnum
+from ..clusters.Types import Nullable, NullValue
+from ..tlv import float32, uint
+from ..yaml.errors import ValidationError
 
 
 @dataclass

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -22,19 +22,18 @@ from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from typing import Any, Optional, Tuple
 
-import chip.interaction_model
-import chip.yaml.format_converter as Converter
-from chip.ChipDeviceCtrl import ChipDeviceController, discovery
-from chip.clusters import ClusterObjects
-from chip.clusters.Attribute import (AttributeStatus, EventReadResult, SubscriptionTransaction, TypedAttributePath,
-                                     ValueDecodeFailure)
-from chip.exceptions import ChipStackError
-from chip.yaml.data_model_lookup import DataModelLookup
-from chip.yaml.errors import ActionCreationError, UnexpectedActionCreationError
 from matter_yamltests.pseudo_clusters.pseudo_clusters import get_default_pseudo_clusters
 
 from matter.idl.generators.filters import to_pascal_case, to_snake_case
 
+from .. import interaction_model as MatterInteractionModel
+from ..ChipDeviceCtrl import ChipDeviceController, discovery
+from ..clusters import ClusterObjects
+from ..clusters.Attribute import AttributeStatus, EventReadResult, SubscriptionTransaction, TypedAttributePath, ValueDecodeFailure
+from ..exceptions import ChipStackError
+from ..yaml import format_converter as Converter
+from ..yaml.data_model_lookup import DataModelLookup
+from ..yaml.errors import ActionCreationError, UnexpectedActionCreationError
 from .data_model_lookup import PreDefinedDataModelLookup
 
 _PSEUDO_CLUSTERS = get_default_pseudo_clusters()
@@ -197,7 +196,7 @@ class InvokeAction(BaseAction):
                     self._node_id, self._endpoint, self._request_object,
                     timedRequestTimeoutMs=self._interation_timeout_ms,
                     busyWaitMs=self._busy_wait_ms)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
         # Commands with no response give a None response. In those cases we return a success
@@ -254,7 +253,7 @@ class ReadAttributeAction(BaseAction):
             raw_resp = await dev_ctrl.ReadAttribute(self._node_id,
                                                     [(self._endpoint, self._request_object)],
                                                     fabricFiltered=self._fabric_filtered)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
         except ChipStackError as error:
             _CHIP_TIMEOUT_ERROR = 50
@@ -272,7 +271,7 @@ class ReadAttributeAction(BaseAction):
         resp = raw_resp[self._endpoint][self._cluster_object][self._request_object]
 
         if isinstance(resp, ValueDecodeFailure):
-            # response.Reason is of type chip.interaction_model.Status.
+            # response.Reason is of type MatterInteractionModel.Status.
             return _ActionResult(status=_ActionStatus.ERROR, response=resp.Reason)
 
         # decode() is expecting to get a DataModelLookup Object type to grab certain attributes
@@ -323,7 +322,7 @@ class ReadEventAction(BaseAction):
             request = [(self._endpoint, self._request_object, urgent)]
             resp = await dev_ctrl.ReadEvent(self._node_id, events=request, eventNumberFilter=self._event_number_filter,
                                             fabricFiltered=self._fabric_filtered)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
         parsed_resp = EventResponse(event_result_list=resp)
@@ -442,7 +441,7 @@ class SubscribeAttributeAction(ReadAttributeAction):
             subscription = await dev_ctrl.ReadAttribute(self._node_id, [(self._endpoint, self._request_object)],
                                                         reportInterval=(self._min_interval, self._max_interval),
                                                         keepSubscriptions=False)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
         self._context.subscriptions.append(subscription)
@@ -496,7 +495,7 @@ class SubscribeEventAction(ReadEventAction):
             subscription = await dev_ctrl.ReadEvent(self._node_id, events=request, eventNumberFilter=self._event_number_filter,
                                                     reportInterval=(self._min_interval, self._max_interval),
                                                     keepSubscriptions=False)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
         self._context.subscriptions.append(subscription)
@@ -578,7 +577,7 @@ class WriteAttributeAction(BaseAction):
                 resp = await dev_ctrl.WriteAttribute(self._node_id, [(self._endpoint, self._request_object)],
                                                      timedRequestTimeoutMs=self._interation_timeout_ms,
                                                      busyWaitMs=self._busy_wait_ms)
-        except chip.interaction_model.InteractionModelError as error:
+        except MatterInteractionModel.InteractionModelError as error:
             return _ActionResult(status=_ActionStatus.ERROR, response=error)
 
         # Group writes are expected to have no response upon success.
@@ -586,7 +585,7 @@ class WriteAttributeAction(BaseAction):
             return _ActionResult(status=_ActionStatus.SUCCESS, response=None)
 
         if len(resp) == 1 and isinstance(resp[0], AttributeStatus):
-            if resp[0].Status == chip.interaction_model.Status.Success:
+            if resp[0].Status == MatterInteractionModel.Status.Success:
                 return _ActionResult(status=_ActionStatus.SUCCESS, response=None)
             else:
                 return _ActionResult(status=_ActionStatus.ERROR, response=resp[0].Status)
@@ -890,12 +889,12 @@ class ReplTestRunner:
         if isinstance(response, dict):
             return response
 
-        if isinstance(response, chip.interaction_model.InteractionModelError):
+        if isinstance(response, MatterInteractionModel.InteractionModelError):
             decoded_response['error'] = to_snake_case(response.status.name).upper()
             decoded_response['clusterError'] = response.clusterStatus
             return decoded_response
 
-        if isinstance(response, chip.interaction_model.Status):
+        if isinstance(response, MatterInteractionModel.Status):
             decoded_response['error'] = to_snake_case(response.name).upper()
             return decoded_response
 
@@ -903,7 +902,7 @@ class ReplTestRunner:
             decoded_response['value'] = {'nodeId': response.node_id}
             return decoded_response
 
-        if isinstance(response, chip.discovery.CommissionableNode):
+        if isinstance(response, discovery.CommissionableNode):
             decoded_response['value'] = {
                 'instanceName': response.instanceName,
                 'hostName': response.hostName,
@@ -940,7 +939,7 @@ class ReplTestRunner:
                 return decoded_response
             decoded_response = []
             for event in response.event_result_list:
-                if event.Status != chip.interaction_model.Status.Success:
+                if event.Status != MatterInteractionModel.Status.Success:
                     error_message = to_snake_case(event.Status.name).upper()
                     decoded_response.append({'error': error_message})
                     continue

--- a/src/controller/python/chip/yaml/runner.py
+++ b/src/controller/python/chip/yaml/runner.py
@@ -31,10 +31,9 @@ from ..ChipDeviceCtrl import ChipDeviceController, discovery
 from ..clusters import ClusterObjects
 from ..clusters.Attribute import AttributeStatus, EventReadResult, SubscriptionTransaction, TypedAttributePath, ValueDecodeFailure
 from ..exceptions import ChipStackError
-from ..yaml import format_converter as Converter
-from ..yaml.data_model_lookup import DataModelLookup
-from ..yaml.errors import ActionCreationError, UnexpectedActionCreationError
-from .data_model_lookup import PreDefinedDataModelLookup
+from . import format_converter as Converter
+from .data_model_lookup import DataModelLookup, PreDefinedDataModelLookup
+from .errors import ActionCreationError, UnexpectedActionCreationError
 
 _PSEUDO_CLUSTERS = get_default_pseudo_clusters()
 logger = logging.getLogger('YamlParser')

--- a/src/controller/python/templates/python-cluster-Objects-py.zapt
+++ b/src/controller/python/templates/python-cluster-Objects-py.zapt
@@ -12,14 +12,12 @@ import typing
 from dataclasses import dataclass, field
 from enum import IntFlag
 
-from chip import ChipUtility
-from chip.clusters.enum import MatterIntEnum
-from chip.tlv import float32, uint
-
+from .. import ChipUtility
+from ..clusters.enum import MatterIntEnum
+from ..tlv import float32, uint
 from .ClusterObjects import (Cluster, ClusterAttributeDescriptor, ClusterCommand, ClusterEvent, ClusterObject,
                              ClusterObjectDescriptor, ClusterObjectFieldDescriptor)
 from .Types import Nullable, NullValue
-
 
 __all__ = [
     "Globals",


### PR DESCRIPTION
Using relative imports in Python library will simplify transition from `chip` to `matter` namespace.

#### Testing

CI will verify for potential breaks