### PR TITLE
Implement emberAf*ClusterShutdownCallback for clusters of all-clusters-app

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/air-quality-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/air-quality-instance.cpp
@@ -45,3 +45,8 @@ void emberAfAirQualityClusterInitCallback(chip::EndpointId endpointId)
     gAirQualityCluster = new Instance(1, airQualityFeatures);
     gAirQualityCluster->Init();
 }
+
+void emberAfAirQualityClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    AirQuality::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -151,9 +151,10 @@ void emberAfActionsClusterInitCallback(EndpointId endpoint)
 
 void emberAfActionsClusterShutdownCallback(EndpointId endpoint)
 {
-    VerifyOrReturn(sActionsDelegateImpl && sActionsServer);
-
-    sActionsServer->Shutdown();
+    if (sActionsServer)
+    {
+        sActionsServer->Shutdown();
+    }
     sActionsDelegateImpl = nullptr;
     sActionsServer       = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
@@ -148,3 +148,12 @@ void emberAfActionsClusterInitCallback(EndpointId endpoint)
 
     sActionsServer->Init();
 }
+
+void emberAfActionsClusterShutdownCallback(EndpointId endpoint)
+{
+    VerifyOrReturn(sActionsDelegateImpl && sActionsServer);
+
+    sActionsServer->Shutdown();
+    sActionsDelegateImpl = nullptr;
+    sActionsServer       = nullptr;
+}

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -360,11 +360,6 @@ void emberAfCameraAvStreamManagementClusterInitCallback(EndpointId endpoint)
 
 void emberAfCameraAvStreamManagementClusterShutdownCallback(EndpointId endpoint)
 {
-    VerifyOrReturn(sCameraAVStreamMgrInstance && sCameraAVStreamMgmtClusterServerInstance);
-
-    // TODO: CameraAVStreamMgmtServer class should have Shutdown correponding to Init.
     sCameraAVStreamMgmtClusterServerInstance = nullptr;
-
-    // TODO: CameraAVStreamManager class should have Shutdown correponding to Init.
-    sCameraAVStreamMgrInstance = nullptr;
+    sCameraAVStreamMgrInstance               = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -357,3 +357,14 @@ void emberAfCameraAvStreamManagementClusterInitCallback(EndpointId endpoint)
         spkrCapabilities, twowayTalkSupport, supportedSnapshotParams, maxNetworkBandwidth, supportedStreamUsages);
     sCameraAVStreamMgmtClusterServerInstance->Init();
 }
+
+void emberAfCameraAvStreamManagementClusterShutdownCallback(EndpointId endpoint)
+{
+    VerifyOrReturn(sCameraAVStreamMgrInstance && sCameraAVStreamMgmtClusterServerInstance);
+
+    // TODO: CameraAVStreamMgmtServer class should have Shutdown correponding to Init.
+    sCameraAVStreamMgmtClusterServerInstance = nullptr;
+
+    // TODO: CameraAVStreamManager class should have Shutdown correponding to Init.
+    sCameraAVStreamMgrInstance = nullptr;
+}

--- a/examples/all-clusters-app/all-clusters-common/src/chime-instance.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/chime-instance.cpp
@@ -69,3 +69,5 @@ void emberAfChimeClusterInitCallback(EndpointId endpoint)
 {
     gChimeClusterServerInstance.Init();
 }
+
+void emberAfChimeClusterShutdownCallback(EndpointId endpoint) {}

--- a/examples/all-clusters-app/all-clusters-common/src/concentration-measurement-instances.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/concentration-measurement-instances.cpp
@@ -215,3 +215,14 @@ void emberAfFormaldehydeConcentrationMeasurementClusterInitCallback(EndpointId e
     gFormaldehydeConcentrationMeasurementInstance.SetUncertainty(0.0f);
     gFormaldehydeConcentrationMeasurementInstance.SetLevelValue(LevelValueEnum::kLow);
 }
+
+void emberAfCarbonDioxideConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfCarbonMonoxideConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfNitrogenDioxideConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfPm1ConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfPm10ConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfPm25ConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfRadonConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfTotalVolatileOrganicCompoundsConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfOzoneConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}
+void emberAfFormaldehydeConcentrationMeasurementClusterShutdownCallback(EndpointId endpoint) {}

--- a/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
@@ -70,3 +70,17 @@ void emberAfDeviceEnergyManagementClusterInitCallback(chip::EndpointId endpointI
         return;
     }
 }
+
+void emberAfDeviceEnergyManagementClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gInstance)
+    {
+        gInstance->Shutdown();
+        gInstance = nullptr;
+    }
+
+    if (gDelegate)
+    {
+        gDelegate = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/device-energy-management-stub.cpp
@@ -76,11 +76,7 @@ void emberAfDeviceEnergyManagementClusterShutdownCallback(chip::EndpointId endpo
     if (gInstance)
     {
         gInstance->Shutdown();
-        gInstance = nullptr;
     }
-
-    if (gDelegate)
-    {
-        gDelegate = nullptr;
-    }
+    gInstance = nullptr;
+    gDelegate = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
@@ -104,3 +104,13 @@ void emberAfDishwasherModeClusterInitCallback(chip::EndpointId endpointId)
         new ModeBase::Instance(gDishwasherModeDelegate, 0x1, DishwasherMode::Id, chip::to_underlying(Feature::kOnOff));
     gDishwasherModeInstance->Init();
 }
+
+void emberAfDishwasherModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    VerifyOrDie(endpointId == 1); // this cluster is only enabled for endpoint 1.
+    if (gDishwasherModeInstance)
+    {
+        gDishwasherModeInstance->Shutdown();
+    }
+    DishwasherMode::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/electrical-energy-measurement-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/electrical-energy-measurement-stub.cpp
@@ -46,6 +46,6 @@ void emberAfElectricalEnergyMeasurementClusterShutdownCallback(chip::EndpointId 
     if (gAttrAccess)
     {
         gAttrAccess->Shutdown();
-        gAttrAccess = nullptr;
     }
+    gAttrAccess = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/electrical-energy-measurement-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/electrical-energy-measurement-stub.cpp
@@ -40,3 +40,12 @@ void emberAfElectricalEnergyMeasurementClusterInitCallback(chip::EndpointId endp
         gAttrAccess->Init();
     }
 }
+
+void emberAfElectricalEnergyMeasurementClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gAttrAccess)
+    {
+        gAttrAccess->Shutdown();
+        gAttrAccess = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/electrical-power-measurement-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/electrical-power-measurement-stub.cpp
@@ -51,3 +51,17 @@ void emberAfElectricalPowerMeasurementClusterInitCallback(chip::EndpointId endpo
         gEPMDelegate->SetPowerMode(PowerModeEnum::kAc);
     }
 }
+
+void emberAfElectricalPowerMeasurementClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gEPMInstance)
+    {
+        gEPMInstance->Shutdown();
+        gEPMInstance = nullptr;
+    }
+
+    if (gEPMDelegate)
+    {
+        gEPMDelegate = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/electrical-power-measurement-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/electrical-power-measurement-stub.cpp
@@ -57,11 +57,7 @@ void emberAfElectricalPowerMeasurementClusterShutdownCallback(chip::EndpointId e
     if (gEPMInstance)
     {
         gEPMInstance->Shutdown();
-        gEPMInstance = nullptr;
     }
-
-    if (gEPMDelegate)
-    {
-        gEPMDelegate = nullptr;
-    }
+    gEPMInstance = nullptr;
+    gEPMDelegate = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/energy-evse-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/energy-evse-stub.cpp
@@ -65,14 +65,8 @@ void emberAfEnergyEvseClusterShutdownCallback(chip::EndpointId endpointId)
     if (gInstance)
     {
         gInstance->Shutdown();
-        gInstance = nullptr;
     }
-    if (gDelegate)
-    {
-        gInstance = nullptr;
-    }
-    if (gEvseTargetsDelegate)
-    {
-        gEvseTargetsDelegate = nullptr;
-    }
+    gInstance            = nullptr;
+    gDelegate            = nullptr;
+    gEvseTargetsDelegate = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/energy-evse-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/energy-evse-stub.cpp
@@ -59,3 +59,20 @@ void emberAfEnergyEvseClusterInitCallback(chip::EndpointId endpointId)
         gInstance->Init(); /* Register Attribute & Command handlers */
     }
 }
+
+void emberAfEnergyEvseClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gInstance)
+    {
+        gInstance->Shutdown();
+        gInstance = nullptr;
+    }
+    if (gDelegate)
+    {
+        gInstance = nullptr;
+    }
+    if (gEvseTargetsDelegate)
+    {
+        gEvseTargetsDelegate = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
@@ -184,6 +184,6 @@ void emberAfFanControlClusterShutdownCallback(EndpointId endpoint)
     if (mFanControlManager)
     {
         delete mFanControlManager;
-        mFanControlManager = nullptr;
     }
+    mFanControlManager = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
@@ -176,3 +176,14 @@ void emberAfFanControlClusterInitCallback(EndpointId endpoint)
     AttributeAccessInterfaceRegistry::Instance().Register(mFanControlManager);
     FanControl::SetDefaultDelegate(endpoint, mFanControlManager);
 }
+
+void emberAfFanControlClusterShutdownCallback(EndpointId endpoint)
+{
+    FanControl::SetDefaultDelegate(endpoint, nullptr);
+    AttributeAccessInterfaceRegistry::Instance().Unregister(mFanControlManager);
+    if (mFanControlManager)
+    {
+        delete mFanControlManager;
+        mFanControlManager = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
@@ -103,3 +103,12 @@ void emberAfLaundryWasherModeClusterInitCallback(chip::EndpointId endpointId)
         new ModeBase::Instance(gLaundryWasherModeDelegate, 0x1, LaundryWasherMode::Id, chip::to_underlying(Feature::kOnOff));
     gLaundryWasherModeInstance->Init();
 }
+
+void emberAfLaundryWasherModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gLaundryWasherModeInstance)
+    {
+        gLaundryWasherModeInstance->Shutdown();
+    }
+    LaundryWasherMode::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/microwave-oven-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/microwave-oven-mode.cpp
@@ -104,3 +104,12 @@ void emberAfMicrowaveOvenModeClusterInitCallback(chip::EndpointId endpointId)
         new ModeBase::Instance(gMicrowaveOvenModeDelegate, endpointId, MicrowaveOvenMode::Id, chip::to_underlying(Feature::kOnOff));
     gMicrowaveOvenModeInstance->Init();
 }
+
+void emberAfMicrowaveOvenModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gMicrowaveOvenModeInstance)
+    {
+        gMicrowaveOvenModeInstance->Shutdown();
+    }
+    MicrowaveOvenMode::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/occupancy-sensing-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/occupancy-sensing-stub.cpp
@@ -74,3 +74,18 @@ void emberAfOccupancySensingClusterInitCallback(EndpointId endpointId)
         ChipLogError(AppServer, "Error: invalid/unexpected OccupancySensing Cluster endpoint index.");
     }
 }
+
+void emberAfOccupancySensingClusterShutdownCallback(EndpointId endpointId)
+{
+    uint16_t epIndex = emberAfGetClusterServerEndpointIndex(endpointId, chip::app::Clusters::OccupancySensing::Id,
+                                                            MATTER_DM_OCCUPANCY_SENSING_CLUSTER_SERVER_ENDPOINT_COUNT);
+
+    if (epIndex < kOccupancySensingClusterTableSize)
+    {
+        if (gOccupancySensingClusterInstances[epIndex])
+        {
+            gOccupancySensingClusterInstances[epIndex]->Shutdown();
+            gOccupancySensingClusterInstances[epIndex] = nullptr;
+        }
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/occupancy-sensing-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/occupancy-sensing-stub.cpp
@@ -85,7 +85,7 @@ void emberAfOccupancySensingClusterShutdownCallback(EndpointId endpointId)
         if (gOccupancySensingClusterInstances[epIndex])
         {
             gOccupancySensingClusterInstances[epIndex]->Shutdown();
-            gOccupancySensingClusterInstances[epIndex] = nullptr;
         }
+        gOccupancySensingClusterInstances[epIndex] = nullptr;
     }
 }

--- a/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
@@ -215,3 +215,8 @@ void emberAfOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
     gOperationalStateInstance->Init();
 }
+
+void emberAfOperationalStateClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    OperationalState::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/oven-modes.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/oven-modes.cpp
@@ -104,3 +104,12 @@ void emberAfOvenModeClusterInitCallback(chip::EndpointId endpointId)
     gOvenModeInstance = new ModeBase::Instance(gOvenModeDelegate, 0x1, OvenMode::Id, 0x0);
     gOvenModeInstance->Init();
 }
+
+void emberAfOvenModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gOvenModeInstance)
+    {
+        gOvenModeInstance->Shutdown();
+    }
+    OvenMode::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/oven-operational-state-delegate.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/oven-operational-state-delegate.cpp
@@ -59,6 +59,11 @@ void emberAfOvenCavityOperationalStateClusterInitCallback(chip::EndpointId endpo
     gOvenCavityOperationalStateInstance->Init();
 }
 
+void emberAfOvenCavityOperationalStateClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    OvenCavityOperationalState::Shutdown();
+}
+
 CHIP_ERROR
 OvenCavityOperationalStateDelegate::GetOperationalStateAtIndex(size_t index,
                                                                OperationalState::GenericOperationalState & operationalState)

--- a/examples/all-clusters-app/all-clusters-common/src/power-topology-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/power-topology-stub.cpp
@@ -70,3 +70,16 @@ void emberAfPowerTopologyClusterInitCallback(chip::EndpointId endpointId)
         gInstance->Init();
     }
 }
+
+void emberAfPowerTopologyClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gInstance)
+    {
+        gInstance->Shutdown();
+        gInstance = nullptr;
+    }
+    if (gDelegate)
+    {
+        gDelegate = nullptr;
+    }
+}

--- a/examples/all-clusters-app/all-clusters-common/src/power-topology-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/power-topology-stub.cpp
@@ -76,10 +76,7 @@ void emberAfPowerTopologyClusterShutdownCallback(chip::EndpointId endpointId)
     if (gInstance)
     {
         gInstance->Shutdown();
-        gInstance = nullptr;
     }
-    if (gDelegate)
-    {
-        gDelegate = nullptr;
-    }
+    gInstance = nullptr;
+    gDelegate = nullptr;
 }

--- a/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
@@ -133,6 +133,16 @@ void emberAfHepaFilterMonitoringClusterInitCallback(chip::EndpointId endpoint)
     gHepaFilterInstance->Init();
 }
 
+void emberAfActivatedCarbonFilterMonitoringClusterShutdownCallback(chip::EndpointId endpoint)
+{
+    ActivatedCarbonFilterMonitoring::Shutdown();
+}
+
+void emberAfHepaFilterMonitoringClusterShutdownCallback(chip::EndpointId endpoint)
+{
+    HepaFilterMonitoring::Shutdown();
+}
+
 CHIP_ERROR ImmutableReplacementProductListManager::Next(ReplacementProductStruct & item)
 {
     if (mIndex >= kReplacementProductListMaxSize)

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
@@ -132,6 +132,15 @@ void emberAfRvcRunModeClusterInitCallback(chip::EndpointId endpointId)
     gRvcRunModeInstance->Init();
 }
 
+void emberAfRvcRunModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gRvcRunModeInstance)
+    {
+        gRvcRunModeInstance->Shutdown();
+    }
+    RvcRunMode::Shutdown();
+}
+
 // RVC Clean
 static RvcCleanModeDelegate * gRvcCleanModeDelegate = nullptr;
 static ModeBase::Instance * gRvcCleanModeInstance   = nullptr;
@@ -223,4 +232,13 @@ void emberAfRvcCleanModeClusterInitCallback(chip::EndpointId endpointId)
     gRvcCleanModeInstance = new ModeBase::Instance(gRvcCleanModeDelegate, 0x1, RvcCleanMode::Id,
                                                    chip::to_underlying(RvcCleanMode::Feature::kDirectModeChange));
     gRvcCleanModeInstance->Init();
+}
+
+void emberAfRvcCleanModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gRvcCleanModeInstance)
+    {
+        gRvcCleanModeInstance->Shutdown();
+    }
+    RvcCleanMode::Shutdown();
 }

--- a/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
@@ -119,3 +119,8 @@ void emberAfRvcOperationalStateClusterInitCallback(chip::EndpointId endpointId)
 
     gRvcOperationalStateInstance->Init();
 }
+
+void emberAfRvcOperationalStateClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    RvcOperationalState::Shutdown();
+}

--- a/examples/all-clusters-app/all-clusters-common/src/tcc-mode.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/tcc-mode.cpp
@@ -98,3 +98,12 @@ void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterInitCallback(c
                                               chip::to_underlying(Feature::kOnOff));
     gTccModeInstance->Init();
 }
+
+void emberAfRefrigeratorAndTemperatureControlledCabinetModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gTccModeInstance)
+    {
+        gTccModeInstance->Shutdown();
+    }
+    RefrigeratorAndTemperatureControlledCabinetMode::Shutdown();
+}


### PR DESCRIPTION
#### Problem
- Follow-up example changes after https://github.com/project-chip/connectedhomeip/pull/38130.

#### Changes
- Add emberAf*ClusterShutdownCallback definition for the clusters of all-clusters-app.

#### Testing
- Build the Linux app locally and rely on CI to pass.