### PR TITLE
Update ZAP: newest version and fix up path

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -213,7 +213,7 @@ up in `$PATH`.
 
 ZAP releases are copied to CIPD by an automated bot. You can check if a release
 was copied by looking at tags created for
-[ZAP CIPD Packages](https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/zap)
+[ZAP CIPD Packages](https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/3pp/zap)
 in various platforms.
 
 ### Custom ZAP

--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -1,20 +1,20 @@
 {
     "packages": [
         {
-            "path": "fuchsia/third_party/zap/${platform}",
+            "path": "fuchsia/third_party/3pp/zap/${platform}",
             "platforms": [
                 "linux-amd64",
                 "linux-arm64",
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2025.01.10-nightly.1"]
+            "tags": ["version:2@v2025.03.25-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
-            "path": "fuchsia/third_party/zap/mac-amd64",
+            "path": "fuchsia/third_party/3pp/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2025.01.10-nightly.1"]
+            "tags": ["version:2@v2025.03.25-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2025.01.10-nightly
+v2025.03.25-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2025.1.10'
+MIN_ZAP_VERSION = '2025.3.25'
 
 
 class ZapTool:


### PR DESCRIPTION
CIPD 3rd party package paths were migrated, it seems due to a builder separation. We missed the annoucement for this, so this PR updates the path to the new one and also updates to the newest ZAP release.

#### Testing

CI builds will validate. I checked that the new path https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/3pp/zap is valid and contains more recent package versions