### PR TITLE
Fix false-positive compiler warning in ecoinfo cluster

### DIFF
--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.cpp
@@ -148,10 +148,10 @@ std::unique_ptr<EcosystemDeviceStruct> EcosystemDeviceStruct::Builder::Build()
         VerifyOrReturnValue(locationId.size() <= kUniqueLocationIdMaxSize, nullptr, ChipLogError(Zcl, "Location id too long"));
     }
 
-    // std::make_unique does not have access to private constructor we workaround with using new
-    std::unique_ptr<EcosystemDeviceStruct> ret{ new EcosystemDeviceStruct(
+    PrivateToken token;
+    std::unique_ptr<EcosystemDeviceStruct> ret = std::make_unique<EcosystemDeviceStruct>(
         std::move(mDeviceName), mDeviceNameLastEditEpochUs, mBridgedEndpoint, mOriginalEndpoint, std::move(mDeviceTypes),
-        std::move(mUniqueLocationIds), mUniqueLocationIdsLastEditEpochUs, mFabricIndex) };
+        std::move(mUniqueLocationIds), mUniqueLocationIdsLastEditEpochUs, mFabricIndex, token);
     mIsAlreadyBuilt = true;
     return ret;
 }
@@ -222,8 +222,9 @@ std::unique_ptr<EcosystemLocationStruct> EcosystemLocationStruct::Builder::Build
         ChipLogError(Zcl, "Location Name must be less than %u bytes", static_cast<uint16_t>(kLocationDescriptorNameMaxSize)));
 
     // std::make_unique does not have access to private constructor we workaround with using new
-    std::unique_ptr<EcosystemLocationStruct> ret{ new EcosystemLocationStruct(std::move(mLocationDescriptor),
-                                                                              mLocationDescriptorLastEditEpochUs) };
+    PrivateToken token;
+    std::unique_ptr<EcosystemLocationStruct> ret =
+        std::make_unique<EcosystemLocationStruct>(std::move(mLocationDescriptor), mLocationDescriptorLastEditEpochUs, token);
     mIsAlreadyBuilt = true;
     return ret;
 }

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -99,8 +99,9 @@ public:
                                    EndpointId aOriginalEndpoint, std::vector<Structs::DeviceTypeStruct::Type> && aDeviceTypes,
                                    std::vector<std::string> && aUniqueLocationIds, uint64_t aUniqueLocationIdsLastEditEpochUs,
                                    FabricIndex aFabricIndex, PrivateToken _) :
-        mDeviceName(std::move(aDeviceName)), mDeviceNameLastEditEpochUs(aDeviceNameLastEditEpochUs),
-        mBridgedEndpoint(aBridgedEndpoint), mOriginalEndpoint(aOriginalEndpoint), mDeviceTypes(std::move(aDeviceTypes)),
+        mDeviceName(std::move(aDeviceName)),
+        mDeviceNameLastEditEpochUs(aDeviceNameLastEditEpochUs), mBridgedEndpoint(aBridgedEndpoint),
+        mOriginalEndpoint(aOriginalEndpoint), mDeviceTypes(std::move(aDeviceTypes)),
         mUniqueLocationIds(std::move(aUniqueLocationIds)), mUniqueLocationIdsLastEditEpochUs(aUniqueLocationIdsLastEditEpochUs),
         mFabricIndex(aFabricIndex)
 
@@ -164,7 +165,8 @@ public:
 
     explicit EcosystemLocationStruct(LocationDescriptorStruct && aLocationDescriptor, uint64_t aLocationDescriptorLastEditEpochUs,
                                      PrivateToken _) :
-        mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
+        mLocationDescriptor(aLocationDescriptor),
+        mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
     {}
 
     CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const std::string & aUniqueLocationId,

--- a/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
+++ b/src/app/clusters/ecosystem-information-server/ecosystem-information-server.h
@@ -55,6 +55,17 @@ class TestOnlyParameter
 // of underlying types.
 class EcosystemDeviceStruct
 {
+private:
+    // Originally we wanted the constructor of EcosystemDeviceStruct to be private to ensure
+    // only Builder could construct it. This would ensure that this struct will only be
+    // created with values that conform to the spec. Unfortunately, std::make_unique is
+    // not able to call a private constructor. As a workaround, to ensure the constructor is
+    // only callable internally, we created this PrivateToken as a privately accessible
+    // parameter that needs to be passed into the constructor.
+    class PrivateToken
+    {
+    };
+
 public:
     class Builder
     {
@@ -84,23 +95,20 @@ public:
         bool mIsAlreadyBuilt                       = false;
     };
 
-    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder);
-
-private:
-    // Constructor is intentionally private. This is to ensure that it is only constructed with
-    // values that conform to the spec.
     explicit EcosystemDeviceStruct(std::string && aDeviceName, uint64_t aDeviceNameLastEditEpochUs, EndpointId aBridgedEndpoint,
                                    EndpointId aOriginalEndpoint, std::vector<Structs::DeviceTypeStruct::Type> && aDeviceTypes,
                                    std::vector<std::string> && aUniqueLocationIds, uint64_t aUniqueLocationIdsLastEditEpochUs,
-                                   FabricIndex aFabricIndex) :
-        mDeviceName(std::move(aDeviceName)),
-        mDeviceNameLastEditEpochUs(aDeviceNameLastEditEpochUs), mBridgedEndpoint(aBridgedEndpoint),
-        mOriginalEndpoint(aOriginalEndpoint), mDeviceTypes(std::move(aDeviceTypes)),
+                                   FabricIndex aFabricIndex, PrivateToken _) :
+        mDeviceName(std::move(aDeviceName)), mDeviceNameLastEditEpochUs(aDeviceNameLastEditEpochUs),
+        mBridgedEndpoint(aBridgedEndpoint), mOriginalEndpoint(aOriginalEndpoint), mDeviceTypes(std::move(aDeviceTypes)),
         mUniqueLocationIds(std::move(aUniqueLocationIds)), mUniqueLocationIdsLastEditEpochUs(aUniqueLocationIdsLastEditEpochUs),
         mFabricIndex(aFabricIndex)
 
     {}
 
+    CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder);
+
+private:
     const std::string mDeviceName;
     uint64_t mDeviceNameLastEditEpochUs;
     EndpointId mBridgedEndpoint;
@@ -122,6 +130,17 @@ struct LocationDescriptorStruct
 // of underlying types.
 class EcosystemLocationStruct
 {
+private:
+    // Originally we wanted the constructor of EcosystemLocationStruct to be private to ensure
+    // only Builder could construct it. This would ensure that this struct will only be
+    // created with values that conform to the spec. Unfortunately, std::make_unique is
+    // not able to call a private constructor. As a workaround, to ensure the constructor is
+    // only callable internally, we created this PrivateToken as a privately accessible
+    // parameter that needs to be passed into the constructor.
+    class PrivateToken
+    {
+    };
+
 public:
     class Builder
     {
@@ -143,15 +162,15 @@ public:
         bool mIsAlreadyBuilt                        = false;
     };
 
+    explicit EcosystemLocationStruct(LocationDescriptorStruct && aLocationDescriptor, uint64_t aLocationDescriptorLastEditEpochUs,
+                                     PrivateToken _) :
+        mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
+    {}
+
     CHIP_ERROR Encode(const AttributeValueEncoder::ListEncodeHelper & aEncoder, const std::string & aUniqueLocationId,
                       const FabricIndex & aFabricIndex);
 
 private:
-    // Constructor is intentionally private. This is to ensure that it is only constructed with
-    // values that conform to the spec.
-    explicit EcosystemLocationStruct(LocationDescriptorStruct && aLocationDescriptor, uint64_t aLocationDescriptorLastEditEpochUs) :
-        mLocationDescriptor(aLocationDescriptor), mLocationDescriptorLastEditEpochUs(aLocationDescriptorLastEditEpochUs)
-    {}
     // EcosystemLocationStruct is used as a value in a key-value map.
     // Because UniqueLocationId and FabricIndex are mandatory when an entry exist,
     // and needs to be unique, we use it as a key to the key-value pair and is why it is


### PR DESCRIPTION
Recently CI has started reporting false positive compiler warning saying there is a potential memory leak when there isn't one: https://github.com/project-chip/connectedhomeip/actions/runs/14065790619/job/39455812251?pr=38075

To make the intention a little more clean I was able to come up with another way to enforce via compiler that only `Builder` is able to call construct but making sure private type parameter is passed in that should only only be instantiated by something internal. This will allow creating `unique_ptr` by calling `std::make_unique`

#### Testing

CI validates eco info properly compiles and is able to run ECOINFO cert tests
