### PR TITLE
Add gstreamer to Docker file and sysroot creation.

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -46,6 +46,8 @@ RUN set -x \
     git \
     git-lfs \
     gperf \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-tools \
     iproute2 \
     iwyu \
     jq \
@@ -60,6 +62,8 @@ RUN set -x \
     libgif-dev \
     libgirepository-1.0-1 \
     libglib2.0-dev \
+    libgstreamer1.0-0 \
+    libgstreamer1.0-dev \
     libical-dev \
     libjpeg-dev \
     libmbedtls-dev \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-125 : [Tizen] Fix Tizen SDK installer when more than one CPU is selected
+126 : Upgrade docker to build with gstreamer for camera-app

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
@@ -112,11 +112,15 @@ package_upgrade: true
 packages:
   - g++
   - gcc
+  - gstreamer1.0-plugins-base
+  - gstreamer1.0-tools
   - libavahi-client-dev
   - libcairo2-dev
   - libdbus-1-dev
   - libgirepository1.0-dev
   - libglib2.0-dev
+  - libgstreamer1.0-0
+  - libgstreamer1.0-dev
   - libpcsclite-dev
   - libreadline-dev
   - libsdl2-dev


### PR DESCRIPTION
These additions would help the camera-app that uses gstreamer to be built by CI as well as allow any test tools to be run. 
#### Testing
Validate by running docker build scripts locally.
