### PR TITLE
Add a "commissionee has received network credentials" notification to Matter.framework.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.h
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.h
@@ -32,5 +32,6 @@
 - (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error;
 - (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error;
 - (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error nodeID:(NSNumber *)nodeID metrics:(MTRMetrics *)metrics;
+- (void)controller:(MTRDeviceController *)controller commissioneeHasReceivedNetworkCredentials:(NSNumber *)nodeID;
 
 @end

--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
@@ -75,4 +75,9 @@
     _commandBridge->SetCommandExitStatus(error, [message UTF8String]);
 }
 
+- (void)controller:(MTRDeviceController *)controller commissioneeHasReceivedNetworkCredentials:(NSNumber *)nodeID
+{
+    NSLog(@"Node %@ has received network credentials", nodeID);
+}
+
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -715,6 +715,15 @@ using namespace chip::Tracing::DarwinFramework;
     } logString:__PRETTY_FUNCTION__];
 }
 
+- (void)controller:(MTRDeviceController *)controller commissioneeHasReceivedNetworkCredentials:(NSNumber *)nodeID
+{
+    [self _callDelegatesWithBlock:^(id<MTRDeviceControllerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(controller:commissioneeHasReceivedNetworkCredentials:)]) {
+            [delegate controller:controller commissioneeHasReceivedNetworkCredentials:nodeID];
+        }
+    } logString:__PRETTY_FUNCTION__];
+}
+
 @end
 
 // TODO: This should not be in the superclass: either move to

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate.h
@@ -112,6 +112,14 @@ MTR_AVAILABLE(ios(16.4), macos(13.3), watchos(9.4), tvos(16.4))
  */
 - (void)devicesChangedForController:(MTRDeviceController *)controller MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4));
 
+/**
+ * Notify the delegate that we have successfully communicated the network
+ * credentials to the device being commissioned and are about to tell it to join
+ * that network.  Note that for devices that are already on-network this
+ * notification will not happen.
+ */
+- (void)controller:(MTRDeviceController *)controller commissioneeHasReceivedNetworkCredentials:(NSNumber *)nodeID MTR_AVAILABLE(ios(18.5), macos(15.5), watchos(11.5), tvos(18.5));
+
 @end
 
 typedef NS_ENUM(NSUInteger, MTRPairingStatus) {

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -41,6 +41,7 @@ public:
     void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
 
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+    void OnCommissioningStatusUpdate(chip::PeerId peerId, chip::Controller::CommissioningStage stageCompleted, CHIP_ERROR error) override;
 
     void SetDeviceNodeID(chip::NodeId deviceNodeId);
 


### PR DESCRIPTION
#### Testing

Manually checked, via logging, that when commissioning a non-on-network device (WiFi in my case) the relevant parts of the code are reached, including in the delegate darwin-framework-tool uses.