### PR TITLE
Fix build: avoid implicit deletion of ChipDeviceEvent default constructor

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -408,7 +408,7 @@ struct ChipDeviceEvent final
 
     union
     {
-        ChipDevicePlatformEvent Platform;
+        ChipDevicePlatformEvent Platform = {};
         LambdaBridge LambdaEvent;
         struct
         {


### PR DESCRIPTION
Avoid build errors with clang:
```
src/protocols/secure_channel/PairingSession.cpp:84:38: error: call to implicitly-deleted default constructor of 'DeviceLayer::ChipDeviceEvent'
   84 |         DeviceLayer::ChipDeviceEvent event;
      |                                      ^
src/include/platform/CHIPDeviceEvent.h:403:33: note: default constructor of 'ChipDeviceEvent' is implicitly deleted because field 'Platform' has a deleted default constructor
  403 |         ChipDevicePlatformEvent Platform;
      |                                 ^
src/platform/Linux/CHIPDevicePlatformEvent.h:85:11: note: default constructor of 'ChipDevicePlatformEvent' is implicitly deleted because variant field 'BLECentralConnectFailed' has a non-trivial default constructor
   85 |         } BLECentralConnectFailed;
      |           ^
```

#### Testing

Manual build
