### PR TITLE
Fix global merging on overlapping names

### DIFF
--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -579,6 +579,11 @@ class GlobalMapping:
         """
         global_types_added = set()
 
+        # cluster types are already accessible, so no need to add them back
+        global_types_added = global_types_added.union([v.name for v in cluster.bitmaps])
+        global_types_added = global_types_added.union([v.name for v in cluster.structs])
+        global_types_added = global_types_added.union([v.name for v in cluster.enums])
+
         changed = True
         while changed:
             changed = False
@@ -612,6 +617,7 @@ def _merge_global_types_into_clusters(idl: Idl) -> Idl:
     clusters reference those type names
     """
     mapping = GlobalMapping(idl)
+
     return dataclasses.replace(idl, clusters=[mapping.merge_global_types_into_cluster(cluster) for cluster in idl.clusters])
 
 

--- a/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_parser.py
@@ -515,9 +515,11 @@ class MatterIdlTransformer(Transformer):
             elif isinstance(item, Enum):
                 global_enums.append(dataclasses.replace(item, is_global=True))
             elif isinstance(item, Bitmap):
-                global_bitmaps.append(dataclasses.replace(item, is_global=True))
+                global_bitmaps.append(
+                    dataclasses.replace(item, is_global=True))
             elif isinstance(item, Struct):
-                global_structs.append(dataclasses.replace(item, is_global=True))
+                global_structs.append(
+                    dataclasses.replace(item, is_global=True))
             else:
                 raise Exception("UNKNOWN idl content item: %r" % item)
 
@@ -562,7 +564,8 @@ class GlobalMapping:
         self.enum_map = {e.name: e for e in idl.global_enums}
         self.struct_map = {s.name: s for s in idl.global_structs}
 
-        self.global_types = set(self.bitmap_map.keys()).union(set(self.enum_map.keys())).union(set(self.struct_map.keys()))
+        self.global_types = set(self.bitmap_map.keys()).union(
+            set(self.enum_map.keys())).union(set(self.struct_map.keys()))
 
         # Spec does not enforce unique naming in bitmap/enum/struct, however in practice
         # if we have both enum Foo and bitmap Foo for example, it would be impossible
@@ -580,9 +583,12 @@ class GlobalMapping:
         global_types_added = set()
 
         # cluster types are already accessible, so no need to add them back
-        global_types_added = global_types_added.union([v.name for v in cluster.bitmaps])
-        global_types_added = global_types_added.union([v.name for v in cluster.structs])
-        global_types_added = global_types_added.union([v.name for v in cluster.enums])
+        global_types_added = global_types_added.union(
+            [v.name for v in cluster.bitmaps])
+        global_types_added = global_types_added.union(
+            [v.name for v in cluster.structs])
+        global_types_added = global_types_added.union(
+            [v.name for v in cluster.enums])
 
         changed = True
         while changed:

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -986,7 +986,7 @@ server cluster A = 1 { /* Test comment */ }
                 Cluster(name="A", code=1, revision=1, enums=[
                     Enum(name="FooEnum", base_type="ENUM32",
                          entries=[ConstantEntry(name="B", code=234)])],
-                    structs=[
+                        structs=[
                         Struct(name="S", fields=[
                             Field(name="testEnum", code=0, data_type=DataType(
                                 name="FooEnum"), qualities=FieldQuality.NULLABLE)

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -835,8 +835,10 @@ server cluster A = 1 { /* Test comment */ }
             }
         """)
 
-        global_enum = Enum(name="TestEnum", base_type="ENUM16", entries=[], is_global=True)
-        global_bitmap = Bitmap(name="TestBitmap", base_type="BITMAP32", entries=[], is_global=True)
+        global_enum = Enum(name="TestEnum", base_type="ENUM16",
+                           entries=[], is_global=True)
+        global_bitmap = Bitmap(
+            name="TestBitmap", base_type="BITMAP32", entries=[], is_global=True)
         global_struct = Struct(name="TestStruct", fields=[], is_global=True)
         expected = Idl(
             global_enums=[global_enum],
@@ -893,18 +895,22 @@ server cluster A = 1 { /* Test comment */ }
             }
         """)
 
-        global_enum = Enum(name="TestEnum", base_type="ENUM16", entries=[], is_global=True)
-        global_bitmap = Bitmap(name="TestBitmap", base_type="BITMAP32", entries=[], is_global=True)
+        global_enum = Enum(name="TestEnum", base_type="ENUM16",
+                           entries=[], is_global=True)
+        global_bitmap = Bitmap(
+            name="TestBitmap", base_type="BITMAP32", entries=[], is_global=True)
         global_struct1 = Struct(name="TestStruct1", fields=[
             Field(name="enumField", code=0, data_type=DataType(name="TestEnum")),
 
         ], is_global=True)
         global_struct2 = Struct(name="TestStruct2", fields=[
-            Field(name="substruct", code=0, data_type=DataType(name="TestStruct1")),
+            Field(name="substruct", code=0,
+                  data_type=DataType(name="TestStruct1")),
 
         ], is_global=True)
         global_struct3 = Struct(name="TestStruct3", fields=[
-            Field(name="substruct", code=0, data_type=DataType(name="TestStruct2")),
+            Field(name="substruct", code=0,
+                  data_type=DataType(name="TestStruct2")),
             Field(name="bmp", code=1, data_type=DataType(name="TestBitmap")),
         ], is_global=True)
         expected = Idl(
@@ -960,6 +966,25 @@ server cluster A = 1 { /* Test comment */ }
             ])
         ])
 
+        self.assertIdlEqual(actual, expected)
+
+    def test_does_not_merge_duplicate(self):
+        actual = parseText("""
+            enum FooEnum : ENUM16 { A = 1234; }
+            server cluster A = 1 {
+                enum FooEnum : ENUM32 { B = 234; }
+            }
+        """)
+
+        expected = Idl(
+            global_enums=[
+                Enum(name="FooEnum", base_type="ENUM16",
+                     entries=[ConstantEntry(name="A", code=1234)],
+                     is_global=True)],
+            clusters=[
+                Cluster(name="A", code=1, revision=1, enums=[
+                    Enum(name="FooEnum", base_type="ENUM32",
+                         entries=[ConstantEntry(name="B", code=234)])])])
         self.assertIdlEqual(actual, expected)
 
     def test_revision(self):

--- a/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
+++ b/scripts/py_matter_idl/matter/idl/test_matter_idl_parser.py
@@ -973,6 +973,7 @@ server cluster A = 1 { /* Test comment */ }
             enum FooEnum : ENUM16 { A = 1234; }
             server cluster A = 1 {
                 enum FooEnum : ENUM32 { B = 234; }
+                struct S { nullable FooEnum testEnum = 0; }
             }
         """)
 
@@ -984,7 +985,13 @@ server cluster A = 1 { /* Test comment */ }
             clusters=[
                 Cluster(name="A", code=1, revision=1, enums=[
                     Enum(name="FooEnum", base_type="ENUM32",
-                         entries=[ConstantEntry(name="B", code=234)])])])
+                         entries=[ConstantEntry(name="B", code=234)])],
+                    structs=[
+                        Struct(name="S", fields=[
+                            Field(name="testEnum", code=0, data_type=DataType(
+                                name="FooEnum"), qualities=FieldQuality.NULLABLE)
+                        ])]
+                        )])
         self.assertIdlEqual(actual, expected)
 
     def test_revision(self):


### PR DESCRIPTION
Previous logic for globals was always merging global items, even if a local item existed with overlapping name.

If a cluster defines a local thing named `X`, we do not expect the global `X` to be visible or referenced.

#### Testing

Unit test created.