### PR TITLE
Remove the log line that prints the Output Event for each BDX message…

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -354,8 +354,6 @@ void MTROTAImageTransferHandler::HandleTransferSessionOutput(TransferSession::Ou
 
     TransferSession::OutputEventType eventType = event.EventType;
 
-    ChipLogDetail(BDX, "OutputEvent type: %s", event.ToString(eventType));
-
     CHIP_ERROR err = CHIP_NO_ERROR;
     switch (event.EventType) {
     case TransferSession::OutputEventType::kInitReceived:


### PR DESCRIPTION
… received by the MTROTAImageTransferHandler to reduce spammy logging

Fixes: https://github.com/project-chip/connectedhomeip/issues/37419

#### Testing

Ran MTROTAProviderTests to verify.
