### PR TITLE
Documentation for python API - Docstring Updates

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -2143,13 +2143,21 @@ class ChipDeviceController(ChipDeviceControllerBase):
             return await asyncio.futures.wrap_future(ctx.future)
 
     async def CommissionThread(self, discriminator, setupPinCode, nodeId, threadOperationalDataset: bytes, isShortDiscriminator: bool = False) -> int:
-        ''' Commissions a Thread device over BLE
+        ''' 
+        Commissions a Thread device over BLE
+
+        Returns:
+            - Effective Node ID of the device (as defined by the assigned NOC)
         '''
         self.SetThreadOperationalDataset(threadOperationalDataset)
         return await self.ConnectBLE(discriminator, setupPinCode, nodeId, isShortDiscriminator)
 
     async def CommissionWiFi(self, discriminator, setupPinCode, nodeId, ssid: str, credentials: str, isShortDiscriminator: bool = False) -> int:
-        ''' Commissions a Wi-Fi device over BLE.
+        ''' 
+        Commissions a Wi-Fi device over BLE.
+
+        Returns:
+            - Effective Node ID of the device (as defined by the assigned NOC)
         '''
         self.SetWiFiCredentials(ssid, credentials)
         return await self.ConnectBLE(discriminator, setupPinCode, nodeId, isShortDiscriminator)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -602,8 +602,15 @@ class ChipDeviceControllerBase():
         return self._isActive
 
     def Shutdown(self):
-        ''' Shuts down this controller and reclaims any used resources, including the bound
-            C++ constructor instance in the SDK.
+        ''' 
+        Shuts down this controller and reclaims any used resources, including the bound
+        C++ constructor instance in the SDK.
+
+        Raises: 
+            ChipStackError: On failure.
+
+        Returns:
+            None
         '''
         if not self._isActive:
             return
@@ -639,6 +646,12 @@ class ChipDeviceControllerBase():
         ChipDeviceController.activeList.clear()
 
     def CheckIsActive(self):
+        '''
+        Checks if the device controller is active.
+
+        Raises: 
+            RuntimeError: On failure.
+        '''
         if (not self._isActive):
             raise RuntimeError(
                 "DeviceCtrl instance was already shutdown previously!")
@@ -647,6 +660,12 @@ class ChipDeviceControllerBase():
         self.Shutdown()
 
     def IsConnected(self):
+        '''
+        Checks if the device controller is connected.
+
+        Returns:
+            bool: True if is connected, False if not connected.
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -655,11 +674,12 @@ class ChipDeviceControllerBase():
         )
 
     async def ConnectBLE(self, discriminator: int, setupPinCode: int, nodeid: int, isShortDiscriminator: bool = False) -> int:
-        """Connect to a BLE device using the given discriminator and setup pin code.
+        '''
+        Connect to a BLE device using the given discriminator and setup pin code.
 
         Returns:
-            - Effective Node ID of the device (as defined by the assigned NOC)
-        """
+            Effective Node ID of the device (as defined by the assigned NOC)
+        '''
         self.CheckIsActive()
 
         async with self._commissioning_context as ctx:
@@ -672,6 +692,12 @@ class ChipDeviceControllerBase():
             return await asyncio.futures.wrap_future(ctx.future)
 
     async def UnpairDevice(self, nodeid: int) -> None:
+        '''
+        Unpairs the device with the specified node ID.
+
+        Returns:
+            None.
+        '''
         self.CheckIsActive()
 
         async with self._unpair_device_context as ctx:
@@ -683,6 +709,12 @@ class ChipDeviceControllerBase():
             return await asyncio.futures.wrap_future(ctx.future)
 
     def CloseBLEConnection(self):
+        '''
+        Closes the BLE connection for the device controller.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         self._ChipStack.Call(
@@ -691,13 +723,17 @@ class ChipDeviceControllerBase():
         ).raise_on_error()
 
     def ExpireSessions(self, nodeid):
-        """Close all sessions with `nodeid` (if any existed) so that sessions get re-established.
+        '''
+        Close all sessions with `nodeid` (if any existed) so that sessions get re-established.
 
         This is needed to properly handle operations that invalidate a node's state, such as
         UpdateNOC.
 
         WARNING: ONLY CALL THIS IF YOU UNDERSTAND THE SIDE-EFFECTS
-        """
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         self._ChipStack.Call(lambda: self._dmLib.pychip_ExpireSessions(self.devCtrl, nodeid)).raise_on_error()
@@ -778,6 +814,12 @@ class ChipDeviceControllerBase():
         )
 
     def GetTestCommissionerUsed(self):
+        '''
+        Retrieves the status of test commissioner in use.
+
+        Returns:
+            bool: True if the test commissioner is in use, False if not.
+        '''
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_TestCommissionerUsed()
         )
@@ -786,28 +828,64 @@ class ChipDeviceControllerBase():
         self._dmLib.pychip_ResetCommissioningTests()
 
     def SetTestCommissionerSimulateFailureOnStage(self, stage: int):
+        '''
+        Simulates a failure on a specific stage of the test commissioner.
+
+        Returns:
+            bool: True if the failure simulate success, False if not.
+        '''
         return self._dmLib.pychip_SetTestCommissionerSimulateFailureOnStage(
             stage)
 
     def SetTestCommissionerSimulateFailureOnReport(self, stage: int):
+        '''
+        Simulates a failure on report of the test commissioner.
+
+        Returns:
+            bool: True if the failure simulate success, False if not.
+        '''
         return self._dmLib.pychip_SetTestCommissionerSimulateFailureOnReport(
             stage)
 
     def SetTestCommissionerPrematureCompleteAfter(self, stage: int):
+        '''
+        Premature complete of the test commissioner.
+
+        Returns:
+            bool: True if the premature complete success, False if not.
+        '''
         return self._dmLib.pychip_SetTestCommissionerPrematureCompleteAfter(
             stage)
 
     def CheckTestCommissionerCallbacks(self):
+        '''
+        Check the test commissioner callbacks.
+
+        Returns:
+            bool: True if the test commissioner callbacks success, False if not.
+        '''
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_TestCommissioningCallbacks()
         )
 
     def CheckStageSuccessful(self, stage: int):
+        '''
+        Check the test commissioner stage sucess.
+
+        Returns:
+            bool: True if test commissioner stage success, False if not.
+        '''
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_TestCommissioningStageSuccessful(stage)
         )
 
     def CheckTestCommissionerPaseConnection(self, nodeid):
+        '''
+        Check the test commissioner Pase connection sucess.
+
+        Returns:
+            bool: True if test commissioner Pase connection success, False if not.
+        '''
         return self._dmLib.pychip_TestPaseConnection(nodeid)
 
     def ResolveNode(self, nodeid):
@@ -816,6 +894,12 @@ class ChipDeviceControllerBase():
         self.GetConnectedDeviceSync(nodeid, allowPASE=False)
 
     def GetAddressAndPort(self, nodeid):
+        '''
+        Retrieves the address and port.
+
+        Returns:
+            tuple: The address and port if no error occurs or None on failure.
+        '''
         self.CheckIsActive()
 
         address = create_string_buffer(64)
@@ -846,6 +930,9 @@ class ChipDeviceControllerBase():
 
             This function will always return a list of CommissionableDevice. When stopOnFirst is set,
             this function will return when at least one device is discovered or on timeout.
+
+        Returns:
+            list: A list of discovered devices.
         '''
         self.CheckIsActive()
 
@@ -880,6 +967,12 @@ class ChipDeviceControllerBase():
             return await self.GetDiscoveredDevices()
 
     async def GetDiscoveredDevices(self):
+        '''
+        Retrieves the discovered devices.
+
+        Returns:
+            list: A list of discovered devices.
+        '''
         def GetDevices(devCtrl):
             devices = []
 
@@ -896,6 +989,12 @@ class ChipDeviceControllerBase():
         return await self._ChipStack.CallAsyncWithResult(lambda: GetDevices(self))
 
     def GetIPForDiscoveredDevice(self, idx, addrStr, length):
+        '''
+        Retrieves the IP address for a discovered device.
+
+        Returns:
+            bool: True if IP for discovered device success, False if not.
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -2126,10 +2126,11 @@ class ChipDeviceController(ChipDeviceControllerBase):
         auto-commissioning should use the supplied "CommissionWithCode" function, which will
         establish the PASE connection and commission automatically.
 
-        Raises a ChipStackError on failure.
+        Raises:
+            - A ChipStackError on failure.
 
         Returns:
-            - Effective Node ID of the device (as defined by the assigned NOC)
+            - Effective Node ID of the device (as defined by the assigned NOC).
         '''
         self.CheckIsActive()
 
@@ -2144,10 +2145,17 @@ class ChipDeviceController(ChipDeviceControllerBase):
 
     async def CommissionThread(self, discriminator, setupPinCode, nodeId, threadOperationalDataset: bytes, isShortDiscriminator: bool = False) -> int:
         ''' 
-        Commissions a Thread device over BLE
+        Commissions a Thread device over BLE.
+
+        Args:
+            discriminator (int): The discriminator to use for commissioning the device.
+            setupPinCode (str): The PIN code required for setup.
+            nodeId (int): The node ID of the device.
+            threadOperationalDataset (bytes): The operational dataset for the Thread device.
+            isShortDiscriminator (bool, optional): Whether the discriminator is short. Defaults to False.
 
         Returns:
-            - Effective Node ID of the device (as defined by the assigned NOC)
+            int: Effective Node ID of the device (as defined by the assigned NOC).
         '''
         self.SetThreadOperationalDataset(threadOperationalDataset)
         return await self.ConnectBLE(discriminator, setupPinCode, nodeId, isShortDiscriminator)
@@ -2157,13 +2165,18 @@ class ChipDeviceController(ChipDeviceControllerBase):
         Commissions a Wi-Fi device over BLE.
 
         Returns:
-            - Effective Node ID of the device (as defined by the assigned NOC)
+            int: Effective Node ID of the device (as defined by the assigned NOC).
         '''
         self.SetWiFiCredentials(ssid, credentials)
         return await self.ConnectBLE(discriminator, setupPinCode, nodeId, isShortDiscriminator)
 
     def SetWiFiCredentials(self, ssid: str, credentials: str):
-        ''' Set the Wi-Fi credentials to set during commissioning.'''
+        ''' 
+        Set the Wi-Fi credentials to set during commissioning.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         self._ChipStack.Call(
@@ -2172,7 +2185,12 @@ class ChipDeviceController(ChipDeviceControllerBase):
         ).raise_on_error()
 
     def SetThreadOperationalDataset(self, threadOperationalDataset):
-        ''' Set the Thread operational dataset to set during commissioning.'''
+        ''' 
+        Set the Thread operational dataset to set during commissioning.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         self._ChipStack.Call(
@@ -2181,56 +2199,96 @@ class ChipDeviceController(ChipDeviceControllerBase):
         ).raise_on_error()
 
     def ResetCommissioningParameters(self):
-        ''' Sets the commissioning parameters back to the default values.'''
+        ''' 
+        Sets the commissioning parameters back to the default values.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_ResetCommissioningParameters()
         ).raise_on_error()
 
     def SetTimeZone(self, offset: int, validAt: int, name: str = ""):
-        ''' Set the time zone to set during commissioning. Currently only one time zone entry is supported'''
+        ''' 
+        Set the time zone to set during commissioning. Currently only one time zone entry is supported.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetTimeZone(offset, validAt, name.encode("utf-8"))
         ).raise_on_error()
 
     def SetDSTOffset(self, offset: int, validStarting: int, validUntil: int):
-        ''' Set the DST offset to set during commissioning. Currently only one DST entry is supported'''
+        ''' 
+        Set the DST offset to set during commissioning. Currently only one DST entry is supported.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetDSTOffset(offset, validStarting, validUntil)
         ).raise_on_error()
 
     def SetTCAcknowledgements(self, tcAcceptedVersion: int, tcUserResponse: int):
-        ''' Set the TC acknowledgements to set during commissioning'''
+        ''' 
+        Set the TC acknowledgements to set during commissioning.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetTermsAcknowledgements(tcAcceptedVersion, tcUserResponse)
         ).raise_on_error()
 
     def SetSkipCommissioningComplete(self, skipCommissioningComplete: bool):
-        ''' Set whether to skip the commissioning complete callback'''
+        ''' 
+        Set whether to skip the commissioning complete callback.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetSkipCommissioningComplete(skipCommissioningComplete)
         ).raise_on_error()
 
     def SetDefaultNTP(self, defaultNTP: str):
-        ''' Set the DefaultNTP to set during commissioning'''
+        ''' 
+        Set the DefaultNTP to set during commissioning.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetDefaultNtp(defaultNTP.encode("utf-8"))
         ).raise_on_error()
 
     def SetTrustedTimeSource(self, nodeId: int, endpoint: int):
-        ''' Set the trusted time source nodeId to set during commissioning. This must be a node on the commissioner fabric.'''
+        ''' 
+        Set the trusted time source nodeId to set during commissioning. This must be a node on the commissioner fabric.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetTrustedTimeSource(nodeId, endpoint)
         ).raise_on_error()
 
     def SetCheckMatchingFabric(self, check: bool):
-        ''' Instructs the auto-commissioner to perform a matching fabric check before commissioning.'''
+        '''
+        Instructs the auto-commissioner to perform a matching fabric check before commissioning.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetCheckMatchingFabric(check)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -815,7 +815,7 @@ class ChipDeviceControllerBase():
 
     def GetTestCommissionerUsed(self):
         '''
-        Retrieves the status of test commissioner in use.
+        Get the status of test commissioner in use.
 
         Returns:
             bool: True if the test commissioner is in use, False if not.
@@ -895,7 +895,7 @@ class ChipDeviceControllerBase():
 
     def GetAddressAndPort(self, nodeid):
         '''
-        Retrieves the address and port.
+        Get the address and port.
 
         Returns:
             tuple: The address and port if no error occurs or None on failure.
@@ -968,7 +968,7 @@ class ChipDeviceControllerBase():
 
     async def GetDiscoveredDevices(self):
         '''
-        Retrieves the discovered devices.
+        Get the discovered devices.
 
         Returns:
             list: A list of discovered devices.
@@ -990,7 +990,7 @@ class ChipDeviceControllerBase():
 
     def GetIPForDiscoveredDevice(self, idx, addrStr, length):
         '''
-        Retrieves the IP address for a discovered device.
+        Get the IP address for a discovered device.
 
         Returns:
             bool: True if IP for discovered device success, False if not.
@@ -1019,7 +1019,8 @@ class ChipDeviceControllerBase():
             option:        0 = kOriginalSetupCode
                            1 = kTokenWithRandomPIN
 
-            Returns CommissioningParameters
+            Returns:
+                CommissioningParameters
         '''
         self.CheckIsActive()
 
@@ -1032,6 +1033,15 @@ class ChipDeviceControllerBase():
             return await asyncio.futures.wrap_future(ctx.future)
 
     def GetCompressedFabricId(self):
+        '''
+        Get compressed fabric Id.
+
+        Returns:
+            int: The compressed fabric ID as a 64-bit integer.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         fabricid = c_uint64(0)
@@ -1044,7 +1054,15 @@ class ChipDeviceControllerBase():
         return fabricid.value
 
     def GetFabricIdInternal(self):
-        """Get the fabric ID from the object. Only used to validate cached value from property."""
+        '''
+        Get the fabric ID from the object. Only used to validate cached value from property.
+
+        Returns:
+            int: The compressed fabric ID as a 64-bit integer.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         fabricid = c_uint64(0)
@@ -1057,7 +1075,15 @@ class ChipDeviceControllerBase():
         return fabricid.value
 
     def GetFabricIndexInternal(self):
-        """Get the fabric index from the object. Only used to validate cached value from property."""
+        '''
+        Get the fabric index from the object. Only used to validate cached value from property.
+
+        Returns:
+            int: The compressed fabric ID as a 64-bit integer.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         fabricindex = c_uint8(0)
@@ -1070,7 +1096,15 @@ class ChipDeviceControllerBase():
         return fabricindex.value
 
     def GetNodeIdInternal(self) -> int:
-        """Get the node ID from the object. Only used to validate cached value from property."""
+        '''
+        Get the node ID from the object. Only used to validate cached value from property.
+
+        Returns:
+            int: The compressed fabric ID as a 64-bit integer.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         nodeid = c_uint64(0)
@@ -1083,12 +1117,23 @@ class ChipDeviceControllerBase():
         return nodeid.value
 
     def GetClusterHandler(self):
+        '''
+        Get cluster handler
+
+        Returns:
+            ChipClusters: An instance of the ChipClusters class.        
+        '''
         self.CheckIsActive()
 
         return self._Cluster
 
     async def FindOrEstablishPASESession(self, setupCode: str, nodeid: int, timeoutMs: typing.Optional[int] = None) -> typing.Optional[DeviceProxyWrapper]:
-        ''' Returns CommissioneeDeviceProxy if we can find or establish a PASE connection to the specified device'''
+        ''' 
+        Returns CommissioneeDeviceProxy if we can find or establish a PASE connection to the specified device
+
+        Returns:
+            DeviceProxyWrapper on success, if not is None.
+        '''
         self.CheckIsActive()
         returnDevice = c_void_p(None)
         res = await self._ChipStack.CallAsyncWithResult(lambda: self._dmLib.pychip_GetDeviceBeingCommissioned(
@@ -1106,14 +1151,16 @@ class ChipDeviceControllerBase():
         return None
 
     def GetConnectedDeviceSync(self, nodeid, allowPASE=True, timeoutMs: typing.Optional[int] = None, payloadCapability: int = TransportPayloadCapability.MRP_PAYLOAD):
-        ''' Gets an OperationalDeviceProxy or CommissioneeDeviceProxy for the specified Node.
+        ''' 
+        Gets an OperationalDeviceProxy or CommissioneeDeviceProxy for the specified Node.
 
-        nodeId: Target's Node ID
-        allowPASE: Get a device proxy of a device being commissioned.
-        timeoutMs: Timeout for a timed invoke request. Omit or set to 'None' to indicate a non-timed request.
+        Arg:
+            nodeId: Target's Node ID
+            allowPASE: Get a device proxy of a device being commissioned.
+            timeoutMs: Timeout for a timed invoke request. Omit or set to 'None' to indicate a non-timed request.
 
         Returns:
-            - DeviceProxyWrapper on success
+            DeviceProxyWrapper on success.
         '''
         self.CheckIsActive()
 
@@ -1163,27 +1210,31 @@ class ChipDeviceControllerBase():
         return DeviceProxyWrapper(returnDevice, DeviceProxyWrapper.DeviceProxyType.OPERATIONAL, self._dmLib)
 
     async def WaitForActive(self, nodeid, *, timeoutSeconds=30.0, stayActiveDurationMs=30000):
-        ''' Waits a LIT ICD device to become active. Will send a StayActive command to the device on active to allow human operations.
+        ''' 
+        Waits a LIT ICD device to become active. Will send a StayActive command to the device on active to allow human operations.
 
-        nodeId: Node ID of the LID ICD
-        stayActiveDurationMs: The duration in the StayActive command, in milliseconds
+        Args:
+            nodeId: Node ID of the LID ICD
+            stayActiveDurationMs: The duration in the StayActive command, in milliseconds
 
         Returns:
-            - StayActiveResponse on success
+            StayActiveResponse on success
         '''
         await WaitForCheckIn(ScopedNodeId(nodeid, self._fabricIndex), timeoutSeconds=timeoutSeconds)
         return await self.SendCommand(nodeid, 0, Clusters.IcdManagement.Commands.StayActiveRequest(stayActiveDuration=stayActiveDurationMs))
 
     async def GetConnectedDevice(self, nodeid, allowPASE: bool = True, timeoutMs: typing.Optional[int] = None,
                                  payloadCapability: int = TransportPayloadCapability.MRP_PAYLOAD):
-        ''' Gets an OperationalDeviceProxy or CommissioneeDeviceProxy for the specified Node.
+        ''' 
+        Gets an OperationalDeviceProxy or CommissioneeDeviceProxy for the specified Node.
 
-        nodeId: Target's Node ID
-        allowPASE: Get a device proxy of a device being commissioned.
-        timeoutMs: Timeout for a timed invoke request. Omit or set to 'None' to indicate a non-timed request.
+        Args:
+            nodeId: Target's Node ID
+            allowPASE: Get a device proxy of a device being commissioned.
+            timeoutMs: Timeout for a timed invoke request. Omit or set to 'None' to indicate a non-timed request.
 
         Returns:
-            - DeviceProxyWrapper on success
+            DeviceProxyWrapper on success
         '''
         self.CheckIsActive()
 
@@ -1236,12 +1287,16 @@ class ChipDeviceControllerBase():
         return DeviceProxyWrapper(future.result(), DeviceProxyWrapper.DeviceProxyType.OPERATIONAL, self._dmLib)
 
     def ComputeRoundTripTimeout(self, nodeid, upperLayerProcessingTimeoutMs: int = 0):
-        ''' Returns a computed timeout value based on the round-trip time it takes for the peer at the other end of the session to
-            receive a message, process it and send it back. This is computed based on the session type, the type of transport,
-            sleepy characteristics of the target and a caller-provided value for the time it takes to process a message
-            at the upper layer on the target For group sessions.
+        ''' 
+        Returns a computed timeout value based on the round-trip time it takes for the peer at the other end of the session to
+        receive a message, process it and send it back. This is computed based on the session type, the type of transport,
+        sleepy characteristics of the target and a caller-provided value for the time it takes to process a message
+        at the upper layer on the target For group sessions.
 
-            This will result in a session being established if one wasn't already.
+        This will result in a session being established if one wasn't already.
+
+        Returns:
+            int: The computed timeout value in milliseconds, representing the round-trip time.
         '''
         device = self.GetConnectedDeviceSync(nodeid)
         res = self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceProxy_ComputeRoundTripTimeout(
@@ -1249,10 +1304,14 @@ class ChipDeviceControllerBase():
         return res
 
     def GetRemoteSessionParameters(self, nodeid) -> typing.Optional[SessionParameters]:
-        ''' Returns the SessionParameters of reported by the remote node associated with `nodeid`.
-            If there is some error in getting SessionParameters None is returned.
+        ''' 
+        Returns the SessionParameters of reported by the remote node associated with `nodeid`.
+        If there is some error in getting SessionParameters None is returned.
 
-            This will result in a session being established if one wasn't already established.
+        This will result in a session being established if one wasn't already established.
+
+        Returns:
+            SessionParameters: The session parameters.
         '''
 
         # First creating the struct to make building the ByteArray to be sent to CFFI easier.
@@ -1286,7 +1345,7 @@ class ChipDeviceControllerBase():
             commandRefsOverride: List of commandRefs to use for each command with the same index in `commands`.
 
         Returns:
-            - TestOnlyBatchCommandResponse
+            TestOnlyBatchCommandResponse
         '''
         self.CheckIsActive()
 
@@ -1306,8 +1365,13 @@ class ChipDeviceControllerBase():
     async def TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke(self, nodeid: int, endpoint: int,
                                                                    payload: ClusterObjects.ClusterCommand, responseType=None):
         '''
-
         Please see SendCommand for description.
+
+        Returns:
+            Command response. The type of the response is defined by the command.
+
+        Raises:
+            InteractionModelError on error
         '''
         self.CheckIsActive()
 
@@ -1338,9 +1402,10 @@ class ChipDeviceControllerBase():
                               right timeout value based on transport characteristics as well as the responsiveness of the target.
 
         Returns:
-            - command response. The type of the response is defined by the command.
+            command response. The type of the response is defined by the command.
+
         Raises:
-            - InteractionModelError on error
+            InteractionModelError on error
         '''
         self.CheckIsActive()
 
@@ -1403,10 +1468,12 @@ class ChipDeviceControllerBase():
         '''
         Send a group cluster-object encapsulated command to a group_id and get returned a future
         that can be awaited upon to get confirmation command was sent.
+
         Returns:
-            - None: responses are not sent to group commands
+            None: responses are not sent to group commands.
+
         Raises:
-            - InteractionModelError on error
+            InteractionModelError on error.
         '''
         self.CheckIsActive()
 
@@ -1435,7 +1502,10 @@ class ChipDeviceControllerBase():
             to the XYZ attribute on the test cluster to endpoint 1
 
         Returns:
-            - [AttributeStatus] (list - one for each path)
+            [AttributeStatus] (list - one for each path).
+
+        Raises:
+            InteractionModelError on error.
         '''
         self.CheckIsActive()
 
@@ -1467,7 +1537,13 @@ class ChipDeviceControllerBase():
         attributes: A list of tuples of type (cluster-object, data-version). The data-version can be omitted.
 
         E.g
-            (Clusters.UnitTesting.Attributes.XYZAttribute('hello'), 1) -- Group Write 'hello' with data version 1
+            (Clusters.UnitTesting.Attributes.XYZAttribute('hello'), 1) -- Group Write 'hello' with data version 1.
+
+        Returns:
+            list = An empty list
+
+        Raises:
+            InteractionModelError on error.
         '''
         self.CheckIsActive()
 
@@ -1492,7 +1568,10 @@ class ChipDeviceControllerBase():
         Sets up the system to expect a node to initiate a BDX transfer. The transfer will send data here.
 
         Returns:
-            - a future that will yield a BdxTransfer with the init message from the transfer.
+            a future that will yield a BdxTransfer with the init message from the transfer.
+
+        Raises:
+            InteractionModelError on error.
         '''
         self.CheckIsActive()
 
@@ -1507,7 +1586,10 @@ class ChipDeviceControllerBase():
         Sets up the system to expect a node to initiate a BDX transfer. The transfer will send data to the node.
 
         Returns:
-            - a future that will yield a BdxTransfer with the init message from the transfer.
+            A future that will yield a BdxTransfer with the init message from the transfer.
+
+        Raises:
+            InteractionModelError on error.
         '''
         self.CheckIsActive()
 
@@ -1891,12 +1973,23 @@ class ChipDeviceControllerBase():
             return res.events
 
     def SetIpk(self, ipk: bytes):
+        '''
+        Sets the Identity Protection Key (IPK) for the device controller.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetIpk(self.devCtrl, ipk, len(ipk))
         ).raise_on_error()
 
     def InitGroupTestingData(self):
-        """Populates the Device Controller's GroupDataProvider with known test group info and keys."""
+        '''
+        Populates the Device Controller's GroupDataProvider with known test group info and keys.
+
+        Raises: 
+            ChipStackError: On failure.
+        '''
         self.CheckIsActive()
 
         self._ChipStack.Call(
@@ -1905,7 +1998,14 @@ class ChipDeviceControllerBase():
         ).raise_on_error()
 
     def CreateManualCode(self, discriminator: int, passcode: int) -> str:
-        """ Creates a standard flow manual code from the given discriminator and passcode."""
+        '''
+        Creates a standard flow manual code from the given discriminator and passcode.
+
+        Returns:
+            str: The decoded string from the buffer.
+        Raises:
+            MemoryError: If the output size is invalid during manual code creation.
+        '''
         # 64 bytes is WAY more than required, but let's be safe
         in_size = 64
         out_size = c_size_t(0)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -665,6 +665,9 @@ class ChipDeviceControllerBase():
 
         Returns:
             bool: True if is connected, False if not connected.
+
+        Raises: 
+            RuntimeError: If '_isActive' is False (from the call to CheckIsActive).
         '''
         self.CheckIsActive()
 
@@ -675,7 +678,7 @@ class ChipDeviceControllerBase():
 
     async def ConnectBLE(self, discriminator: int, setupPinCode: int, nodeid: int, isShortDiscriminator: bool = False) -> int:
         '''
-        Connect to a BLE device using the given discriminator and setup pin code.
+        Connect to a BLE device via PASE using the given discriminator and setup pin code.
 
         Returns:
             Effective Node ID of the device (as defined by the assigned NOC)


### PR DESCRIPTION
### Description
This PR is focused on implementing and validating the **Documentation for python API [#37751](https://github.com/project-chip/connectedhomeip/issues/37751)**
**Fixes:** https://github.com/project-chip/connectedhomeip/issues/37751

### Purpose ###
**Scope:** 
The task focusing on the `ChipDeviceController`, `ChipDeviceControllerBase` , `BareChipDeviceController`, `CommissioningWindowPasscode` and their methods. 

The [Coding Style guide](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html#python) does not specify a specific docstring template, but it is understood that each method should include a general description along with sections for `raises` and `returns` when applicable. It has been noted that some methods lack information about their `return` or `raise` values in the docstrings, and this will be addressed as part of the task. 

Please find below the scope on the classes: `ChipDeviceController`, `ChipDeviceControllerBase` , `BareChipDeviceController`, `CommissioningWindowPasscode` and their methods that should be updated.
_**Path:** src/controller/python/chip/ChipDeviceCtrl.py_

| Function Name                                          | Action                             |
|--------------------------------------------------------|------------------------------------|
| CommissionThread                                        | Update docstring raise             |
| CommissionWiFi                                          | Update docstring return            |
| SetWiFiCredentials                                     | Update docstring raise             |
| SetThreadOperationalDataset                            | Update docstring raise             |
| ResetCommissioningParameters                           | Update docstring raise             |
| SetTimeZone                                            | Update docstring raise             |
| SetDSTOffset                                           | Update docstring raise             |
| SetTCAcknowledgements                                   | Update docstring raise             |
| SetSkipCommissioningComplete                           | Update docstring raise             |
| SetDefaultNTP                                          | Update docstring raise             |
| SetTrustedTimeSource                                   | Update docstring raise             |
| SetCheckMatchingFabric                                 | Update docstring raise             |
| GenerateICDRegistrationParameters                      | Update docstring return            |
| EnableICDRegistration                                  | Update docstring raise             |
| DisableICDRegistration                                 | Update docstring raise             |
| GetFabricCheckResult                                   | Update docstring return            |
| get_rcac                                               | Update docstring return            |
| NOCChainCallback                                       | Update docstring return            |
| IssueNOCChain                                          | Update docstring return            |
| SetDACRevocationSetPath                                | Update docstring raise             |
| Shutdown                                              | Update docstring raise, return    |
| CheckIsActive                                          | Update docstring raise             |
| IsConnected                                            | Update docstring return            |
| UnpairDevice                                           | Update docstring return            |
| CloseBLEConnection                                     | Update docstring raise             |
| ExpireSessions                                         | Update docstring raise             |
| GetTestCommissionerUsed                                | Update docstring return            |
| SetTestCommissionerSimulateFailureOnStage              | Update docstring return            |
| SetTestCommissionerSimulateFailureOnReport             | Update docstring return            |
| SetTestCommissionerPrematureCompleteAfter              | Update docstring return            |
| CheckTestCommissionerCallbacks                         | Update docstring return            |
| CheckStageSuccessful                                   | Update docstring return            |
| CheckTestCommissionerPaseConnection                    | Update docstring return            |
| GetAddressAndPort                                      | Update docstring return            |
| DiscoverCommissionableNodes                            | Update docstring return            |
| GetDiscoveredDevices                                   | Update docstring return            |
| GetIPForDiscoveredDevice                               | Update docstring return            |
| OpenCommissioningWindow                                | Update docstring return            |
| GetCompressedFabricId                                  | Update docstring raise, return    |
| GetFabricIdInternal                                    | Update docstring raise, return    |
| GetFabricIndexInternal                                 | Update docstring raise, return    |
| GetNodeIdInternal                                      | Update docstring raise, return    |
| GetClusterHandler                                      | Update docstring return            |
| FindOrEstablishPASESession                             | Update docstring return            |
| GetConnectedDeviceSync                                 | Update docstring raise             |
| ComputeRoundTripTimeout                                | Update docstring return            |
| GetRemoteSessionParameters                             | Update docstring raise, return    |
| TestOnlySendBatchCommands                              | Update docstring raise             |
| TestOnlySendCommandTimedRequestFlagWithNoTimedInvoke   | Update docstring raise, return    |
| WriteAttribute                                         | Update docstring raise             |
| WriteGroupAttribute                                    | Update docstring raise, return    |
| TestOnlyPrepareToReceiveBdxData                        | Update docstring raise             |
| TestOnlyPrepareToSendBdxData                           | Update docstring raise             |
| ReadAttribute                                          | Check code raise by docstring      |
| ReadEvent                                              | Check code raise by docstring      |
| SetIpk                                                 | Update docstring raise             |
| InitGroupTestingData                                   | Update docstring raise             |
| CreateManualCode                                       | Update docstring raise, return    |

### Notes ###
 _Private methods out of scope_

#### Testing
N/A, No testing was required as the changes only involve updates to docstrings.