### PR TITLE
CHIPDeviceEvent.h: Guard WIFIPAF include

### DIFF
--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -397,7 +397,10 @@ typedef void (*AsyncWorkFunct)(intptr_t arg);
 #include <system/SystemEvent.h>
 #include <system/SystemLayer.h>
 #include <system/SystemPacketBuffer.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 #include <wifipaf/WiFiPAFRole.h>
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
This PR guards the wifipaf include with `#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF`. This fixes an issue where targets that don't have this setting enabled still included this file, which is undesirable.

#### Testing
Targets without `CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF` now build successfully.