### PR TITLE
Allow running camera apps in CI

### DIFF
--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -53,9 +53,19 @@ executable("chip-camera-app") {
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
 
-  libs = [ "datachannel" ]
-  lib_dirs =
-      [ rebase_path("${chip_root}/third_party/libdatachannel/repo/build") ]
+  libs = [
+    "datachannel",
+    "usrsctp",
+    "srtp2",
+    "juice",
+  ]
+
+  lib_dirs = [
+    rebase_path("${chip_root}/third_party/libdatachannel/repo/build"),
+    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
+    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
+    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
+  ]      
 
   output_dir = root_out_dir
 }

--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -62,10 +62,13 @@ executable("chip-camera-app") {
 
   lib_dirs = [
     rebase_path("${chip_root}/third_party/libdatachannel/repo/build"),
-    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
-    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
-    rebase_path("${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
-  ]      
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
+  ]
 
   output_dir = root_out_dir
 }

--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -53,23 +53,6 @@ executable("chip-camera-app") {
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
 
-  libs = [
-    "datachannel",
-    "usrsctp",
-    "srtp2",
-    "juice",
-  ]
-
-  lib_dirs = [
-    rebase_path("${chip_root}/third_party/libdatachannel/repo/build"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
-  ]
-
   output_dir = root_out_dir
 }
 

--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -122,23 +122,6 @@ executable("chip-camera-controller") {
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
 
-  libs = [
-    "datachannel",
-    "usrsctp",
-    "srtp2",
-    "juice",
-  ]
-
-  lib_dirs = [
-    rebase_path("${chip_root}/third_party/libdatachannel/repo/build"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
-    rebase_path(
-        "${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
-  ]
-
   output_dir = root_out_dir
 }
 

--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -122,9 +122,22 @@ executable("chip-camera-controller") {
     "${chip_root}/third_party/libdatachannel:libdatachannel",
   ]
 
-  libs = [ "datachannel" ]
-  lib_dirs =
-      [ rebase_path("${chip_root}/third_party/libdatachannel/repo/build") ]
+  libs = [
+    "datachannel",
+    "usrsctp",
+    "srtp2",
+    "juice",
+  ]
+
+  lib_dirs = [
+    rebase_path("${chip_root}/third_party/libdatachannel/repo/build"),
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/usrsctp/usrsctplib"),
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/libsrtp"),
+    rebase_path(
+        "${chip_root}/third_party/libdatachannel/repo/build/deps/libjuice"),
+  ]
 
   output_dir = root_out_dir
 }

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -18,6 +18,23 @@ action("build_libdatachannel") {
   args = []
 }
 
-shared_library("libdatachannel") {
+config("datachannel_config") {
+  libs = [
+    "datachannel",
+    "usrsctp",
+    "srtp2",
+    "juice",
+  ]
+
+  lib_dirs = [
+    rebase_path("repo/build"),
+    rebase_path("repo/build/deps/usrsctp/usrsctplib"),
+    rebase_path("repo/build/deps/libsrtp"),
+    rebase_path("repo/build/deps/libjuice"),
+  ]
+}
+
+static_library("libdatachannel") {
   deps = [ ":build_libdatachannel" ]
+  public_configs = [ ":datachannel_config" ]
 }

--- a/third_party/libdatachannel/scripts/build_libdatachannel.py
+++ b/third_party/libdatachannel/scripts/build_libdatachannel.py
@@ -23,6 +23,7 @@ def main():
         "-DUSE_NICE=0",
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_CXX_FLAGS=-Wno-shadow",
+        "-DBUILD_SHARED_LIBS=OFF"
     ]
 
     print(f"Running: {' '.join(cmake_cmd)}")


### PR DESCRIPTION
When try to run camera apps in CI, we got the following errors:

```
yufengwang@yufengwang:~/connectedhomeip/out/linux-x64-camera$ ./chip-camera-app 
./chip-camera-app: error while loading shared libraries: libdatachannel.so.0.22: cannot open shared object file: No such file or directory
```

This is because installing the generated shared library system-wide (e.g., to /usr/local/lib) requires elevated permissions, which are not available in CI, a simpler approach is to statically link libdatachannel directly into the camera apps. This ensures the camera apps run on various environments without requiring additional setup steps.

When libdatachannel is built as a static library, its transitive dependencies (libsrtp, libjuice, usrsctp, etc.) are not automatically pulled in at link time.

That means the final link step for the chip-camera-app target must include all the libraries that libdatachannel depends on. With a shared library (e.g. -ldatachannel.so), those dependencies can get pulled in automatically. With a static library (.a), you have to explicitly link all required libraries yourself.

#### Testing

Validated by CI
