### PR TITLE
[IM] Add InternalEventOptions

### DIFF
--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -128,12 +128,18 @@ class EventOptions
 {
 public:
     EventOptions() : mPriority(PriorityLevel::Invalid) {}
-    EventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp), mPriority(PriorityLevel::Invalid) {}
     ConcreteEventPath mPath;
-    Timestamp mTimestamp;
     PriorityLevel mPriority = PriorityLevel::Invalid;
     // kUndefinedFabricIndex 0 means not fabric associated at all
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
+};
+
+class InternalEventOptions : public EventOptions
+{
+public:
+    InternalEventOptions() {}
+    InternalEventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp) {}
+    Timestamp mTimestamp;
 };
 
 /**

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -262,7 +262,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR EventManagement::CalculateEventSize(EventLoggingDelegate * apDelegate, const EventOptions * apOptions,
+CHIP_ERROR EventManagement::CalculateEventSize(EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions,
                                                uint32_t & requiredSize)
 {
     System::PacketBufferTLVWriter writer;
@@ -285,7 +285,7 @@ CHIP_ERROR EventManagement::CalculateEventSize(EventLoggingDelegate * apDelegate
 }
 
 CHIP_ERROR EventManagement::ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate,
-                                           const EventOptions * apOptions)
+                                           const InternalEventOptions * apOptions)
 {
     VerifyOrReturnError(apContext->mCurrentEventNumber >= apContext->mStartingEventNumber, CHIP_NO_ERROR
                         /* no-op: don't write event, but advance current event Number */);
@@ -425,7 +425,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
     aEventNumber                 = 0;
     CircularTLVWriter checkpoint = writer;
     EventLoadOutContext ctxt     = EventLoadOutContext(writer, aEventOptions.mPriority, mLastEventNumber);
-    EventOptions opts;
+    InternalEventOptions opts;
 
     Timestamp timestamp;
 #if CHIP_DEVICE_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
@@ -442,7 +442,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
         timestamp         = Timestamp::System(systemTimeMs);
     }
 
-    opts = EventOptions(timestamp);
+    opts = InternalEventOptions(timestamp);
     // Start the event container (anonymous structure) in the circular buffer
     writer.Init(*mpEventBuffer);
 

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -291,14 +291,6 @@ public:
      * priority does not meet the current threshold, it is dropped and
      * the function returns a `0` as the resulting event ID.
      *
-     * This variant of the invocation permits the caller to set any
-     * combination of `EventOptions`:
-     * - timestamp, when 0 defaults to the current time at the point of
-     *   the call,
-     * - "root" section of the event source (event source and cluster ID);
-     *   if NULL, it defaults to the current device. the event is marked as
-     *   relating to the device that is making the call,
-     *
      * @param[in] apDelegate The EventLoggingDelegate to serialize the event data
      *
      * @param[in] aEventOptions    The options for the event metadata.
@@ -422,7 +414,7 @@ private:
     };
 
     void VendEventNumber();
-    CHIP_ERROR CalculateEventSize(EventLoggingDelegate * apDelegate, const EventOptions * apOptions, uint32_t & requiredSize);
+    CHIP_ERROR CalculateEventSize(EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions, uint32_t & requiredSize);
     /**
      * @brief Helper function for writing event header and data according to event
      *   logging protocol.
@@ -433,11 +425,11 @@ private:
      *
      * @param[in] apDelegate The EventLoggingDelegate to serialize the event data
      *
-     * @param[in] apOptions     EventOptions describing timestamp and other tags
+     * @param[in] apOptions     InternalEventOptions describing timestamp and other tags
      *                          relevant to this event.
      *
      */
-    CHIP_ERROR ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate, const EventOptions * apOptions);
+    CHIP_ERROR ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions);
 
     // Internal function to log event
     CHIP_ERROR LogEventPrivate(EventLoggingDelegate * apDelegate, const EventOptions & aEventOptions, EventNumber & aEventNumber);

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -414,7 +414,8 @@ private:
     };
 
     void VendEventNumber();
-    CHIP_ERROR CalculateEventSize(EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions, uint32_t & requiredSize);
+    CHIP_ERROR CalculateEventSize(EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions,
+                                  uint32_t & requiredSize);
     /**
      * @brief Helper function for writing event header and data according to event
      *   logging protocol.
@@ -429,7 +430,8 @@ private:
      *                          relevant to this event.
      *
      */
-    CHIP_ERROR ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate, const InternalEventOptions * apOptions);
+    CHIP_ERROR ConstructEvent(EventLoadOutContext * apContext, EventLoggingDelegate * apDelegate,
+                              const InternalEventOptions * apOptions);
 
     // Internal function to log event
     CHIP_ERROR LogEventPrivate(EventLoggingDelegate * apDelegate, const EventOptions & aEventOptions, EventNumber & aEventNumber);


### PR DESCRIPTION
Timestamps in EventOptions has not yet been used externally, and only been used inside LogEvent. 
We could remove Timestamps in EventOptions and introduce InternalEventOptions that inherits EventOptions and has timestamps member

Cleanup comments

This PR should not involve the logic change

#### Testing
Existing tests cover
