### PR TITLE
[camera-controller] Implement the initial end-to-end WebRTC Normal Flow

### DIFF
--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -18,6 +18,7 @@ import("//build_overrides/chip.gni")
 import("//build_overrides/editline.gni")
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/examples/camera-controller/camera-controller.gni")
+import("${chip_root}/src/data-model-providers/codegen/model.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
 assert(chip_build_tools)
@@ -47,6 +48,8 @@ config("config") {
 
 static_library("camera-controller-utils") {
   sources = [
+    "${chip_root}/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp",
+    "${chip_root}/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h",
     "${chip_root}/src/controller/ExamplePersistentStorage.cpp",
     "${chip_root}/src/controller/ExamplePersistentStorage.h",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
@@ -75,6 +78,8 @@ static_library("camera-controller-utils") {
     "webrtc_manager/WebRTCManager.h",
     "webrtc_manager/WebRTCProviderClient.cpp",
     "webrtc_manager/WebRTCProviderClient.h",
+    "webrtc_manager/WebRTCRequestorDelegate.cpp",
+    "webrtc_manager/WebRTCRequestorDelegate.h",
   ]
 
   deps = [ "${chip_root}/src/app:events" ]
@@ -93,7 +98,6 @@ static_library("camera-controller-utils") {
     "${chip_root}/examples/common/tracing:commandline",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/tests/suites/commands/interaction_model",
-    "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:file_attestation_trust_store",
     "${chip_root}/src/lib",
     "${chip_root}/src/lib/core:types",
@@ -102,6 +106,19 @@ static_library("camera-controller-utils") {
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",
   ]
+
+  defines = [ "CHIP_CONFIG_SKIP_APP_SPECIFIC_GENERATED_HEADER_INCLUDES=1" ]
+
+  deps += [ "${chip_root}/src/controller:nodatamodel" ]
+
+  # Temporary dependency: InteractionModelEngine NEEDS a codegen data model instance
+  # defined and application is supposed to provide it. This adds the sources
+  # in the same way "data_model" implementations do
+  #
+  # DynamicDispatcher in src/app:interaction-model implements the actual required
+  # ember callbacks in this case...
+  sources += codegen_data_model_SOURCES
+  public_deps += codegen_data_model_PUBLIC_DEPS
 
   public_configs = [ ":config" ]
 

--- a/examples/camera-controller/args.gni
+++ b/examples/camera-controller/args.gni
@@ -32,3 +32,5 @@ matter_log_json_payload_decode_full = true
 # make camera-controller very strict by default
 chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true
+
+chip_build_controller_dynamic_server = true

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -18,22 +18,10 @@
 
 #include "WebRTCManager.h"
 
-#include <app-common/zap-generated/ids/Attributes.h>
-#include <app-common/zap-generated/ids/Clusters.h>
-#include <app/AttributeAccessInterfaceRegistry.h>
-#include <app/ConcreteAttributePath.h>
-#include <app/EventLogging.h>
 #include <app/dynamic_server/AccessControl.h>
-#include <app/reporting/reporting.h>
-#include <app/server/Server.h>
-#include <app/util/af-types.h>
-#include <app/util/attribute-storage.h>
-#include <app/util/endpoint-config-api.h>
-#include <app/util/util.h>
 #include <commands/interactive/InteractiveCommands.h>
 #include <crypto/RandUtils.h>
 #include <lib/support/StringBuilder.h>
-#include <lib/support/ZclString.h>
 
 #include <cstdio>
 #include <string>
@@ -42,7 +30,7 @@ using namespace chip;
 using namespace chip::app;
 using namespace std::chrono_literals;
 
-WebRTCManager::WebRTCManager() {}
+WebRTCManager::WebRTCManager() : mWebRTCRequestorServer(kWebRTCRequesterDynamicEndpointId, mWebRTCRequestorDelegate) {}
 
 WebRTCManager::~WebRTCManager()
 {
@@ -62,7 +50,8 @@ WebRTCManager::~WebRTCManager()
 
 void WebRTCManager::Init()
 {
-    // TODO:: mWebRTCRequestorServer.Init();
+    dynamic_server::InitAccessControl();
+    mWebRTCRequestorServer.Init();
 }
 
 CHIP_ERROR WebRTCManager::SetRemoteDescription(uint16_t webRTCSessionID, const std::string & sdp)
@@ -209,6 +198,9 @@ void WebRTCManager::HandleCommandResponse(const ConcreteCommandPath & path, TLV:
 {
     ChipLogProgress(NotSpecified, "Command Response received.");
 
+    // TODO: Upon receiving, the client SHALL create a new WebRTCSessionStruct populated with the values from this command, along
+    // with the accessing Peer Node ID and Local Fabric Index entries stored in the Secure Session Context, as the PeerNodeID and
+    // FabricIndex values, and store in the Requestor clusters CurrentSessions.
     if (path.mClusterId == Clusters::WebRTCTransportProvider::Id &&
         path.mCommandId == Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::Id)
     {

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.h
@@ -22,6 +22,7 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <rtc/rtc.hpp>
 #include <webrtc_manager/WebRTCProviderClient.h>
+#include <webrtc_manager/WebRTCRequestorDelegate.h>
 
 class WebRTCManager
 {
@@ -52,7 +53,10 @@ private:
 
     void HandleProvideOfferResponse(chip::TLV::TLVReader & data);
 
+    chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer mWebRTCRequestorServer;
+
     WebRTCProviderClient mWebRTCProviderClient;
+    WebRTCRequestorDelegate mWebRTCRequestorDelegate;
 
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
     std::shared_ptr<rtc::DataChannel> mDataChannel;

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
     CASESessionManager * caseSessionMgr = engine->GetCASESessionManager();
     VerifyOrReturnError(caseSessionMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
 
     return CHIP_NO_ERROR;
 }
@@ -80,7 +80,7 @@ CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, 
     CASESessionManager * caseSessionMgr = engine->GetCASESessionManager();
     VerifyOrReturnError(caseSessionMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
 
     return CHIP_NO_ERROR;
 }
@@ -139,11 +139,11 @@ CHIP_ERROR WebRTCProviderClient::SendCommandForType(Messaging::ExchangeManager &
     }
 }
 
-void WebRTCProviderClient::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr,
-                                               const SessionHandle & sessionHandle)
+void WebRTCProviderClient::OnDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
+                                             const SessionHandle & sessionHandle)
 {
     WebRTCProviderClient * self = reinterpret_cast<WebRTCProviderClient *>(context);
-    VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
+    VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnDeviceConnected: context is null"));
 
     ChipLogProgress(NotSpecified, "CASE session established, sending WebRTCTransportProvider command...");
     CHIP_ERROR sendErr = self->SendCommandForType(exchangeMgr, sessionHandle, self->mCommandType);
@@ -153,10 +153,10 @@ void WebRTCProviderClient::OnDeviceConnectedFn(void * context, Messaging::Exchan
     }
 }
 
-void WebRTCProviderClient::OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR err)
+void WebRTCProviderClient::OnDeviceConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR err)
 {
     LogErrorOnFailure(err);
     WebRTCProviderClient * self = reinterpret_cast<WebRTCProviderClient *>(context);
-    VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
+    VerifyOrReturn(self != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectionFailure: context is null"));
     self->OnDone(nullptr);
 }

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
@@ -38,7 +38,7 @@ public:
      * for device connection success/failure events.
      */
     WebRTCProviderClient() :
-        mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
+        mOnConnectedCallback(OnDeviceConnected, this), mOnConnectionFailureCallback(OnDeviceConnectionFailure, this)
     {}
 
     /**
@@ -136,9 +136,9 @@ private:
     CHIP_ERROR SendCommandForType(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
                                   CommandType commandType);
 
-    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
-                                    const chip::SessionHandle & sessionHandle);
-    static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
+    static void OnDeviceConnected(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                                  const chip::SessionHandle & sessionHandle);
+    static void OnDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
     // Private data members
     chip::ScopedNodeId mPeerId;
@@ -153,6 +153,6 @@ private:
     // We store the SDP here so that mProvideOfferData.sdp points to a stable buffer.
     std::string mSdpString;
 
-    chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
-    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
+    chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;
+    chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectionFailureCallback;
 };

--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
@@ -1,0 +1,51 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "WebRTCRequestorDelegate.h"
+#include "WebRTCManager.h"
+
+#include <lib/support/logging/CHIPLogging.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::WebRTCTransportRequestor;
+
+CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferArgs & args, WebRTCSessionTypeStruct & outSession)
+{
+    ChipLogProgress(NotSpecified, "WebRTCRequestorDelegate::HandleOffer");
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer)
+{
+    ChipLogProgress(NotSpecified, "WebRTCRequestorDelegate::HandleAnswer");
+    return WebRTCManager::Instance().SetRemoteDescription(sessionId, sdpAnswer);
+}
+
+CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates)
+{
+    ChipLogProgress(NotSpecified, "WebRTCRequestorDelegate::HandleICECandidates");
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WebRTCRequestorDelegate::HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode)
+{
+    ChipLogProgress(NotSpecified, "WebRTCRequestorDelegate::HandleEnd");
+    return CHIP_NO_ERROR;
+}

--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.h
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-enums.h>
+#include <app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h>
+
+class WebRTCRequestorDelegate : public chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorDelegate
+{
+public:
+    WebRTCRequestorDelegate()  = default;
+    ~WebRTCRequestorDelegate() = default;
+
+    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args,
+                           chip::app::Clusters::WebRTCTransportRequestor::WebRTCSessionTypeStruct & outSession) override;
+
+    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
+
+    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates) override;
+
+    CHIP_ERROR HandleEnd(uint16_t sessionId,
+                         chip::app::Clusters::WebRTCTransportRequestor::WebRTCEndReasonEnum reasonCode) override;
+};


### PR DESCRIPTION
This is the initial end-to-end WebRTC Normal Flow. This PR enable the dynamic server on the controller side, which allows by-directional communication.

In this flow, the controller starts the signaling sequence by providing an SDP Offer to the camera via ProvideOffer. If the camera is successful in starting a session, it SHALL send a ProvideOfferResponse with the allocated WebRTC session ID, the allocated video stream ID, and the allocated audio stream ID.  

Subsequently, the camera SHALL follow up with an SDP Answer. The second phase is the trickle ICE candidate exchange, where both peers determine their ICE candidates and exchange them via ProvideICECandidates and ICECandidates. In the third phase, the actual connection is established and the WebRTC session becomes active.

#### Testing

 **Launch the Camera Application:** 
Open a terminal console.
Execute the command: ./chip-camera-app

 **Launch the Camera Controller:**
Open a separate terminal console.
Execute the command: ./chip-camera-controller

**Commission the Camera Device:**
In the controller console, initiate the commissioning process using the pairing code.
`>>> pairing code 1 34970312332`

**Initiate WebRTC Connection and SDP Offer:**
In the controller console, start the normal flow to establish a WebRTC connection.
Execute the commands sequentially:
```
>>> webrtc connect 1 1
>>> webrtc provide-offer 2
```
