### PR TITLE
[ESP32]: Fixed the crash due to the format specifier on enabling newlib_nano_format.

### DIFF
--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
         localtime_r(&timep, &calendar);
         char time_str[64];
         strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S UTC", &calendar);
-        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%s)", static_cast<long long>(tv.tv_sec), time_str);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %ld (%s)", static_cast<long>(tv.tv_sec), time_str);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;


### PR DESCRIPTION
**Problem**
- The lighting-app esp32 when built with esp32c3 with `CONFIG_NEWLIB_NANO_FORMAT=y` enabled in the sdkconfig
crashed due to unsupported format specifier %lld.

**Change Overview**
- Fixed the log with %ld instead of %lld in SystemTimeSupport.cpp.

#### Testing
- Built the lighting-app esp32 with and without `CONFIG_NEWLIB_NANO_FORMAT` menconfig option.
- Verified for the crash resolution in case of nano_format enabled with the changes.
- Tested for any discrepancies to the loggged statement in the output.
- In all the below cases, the print `'Real time clock set to 946684800 (2000-01-01 00:00:00 UTC)` remains unchanged with %ld change as well.

<!-- START: Memory Header -->
#### Test results 
<!-- END: Memory Header -->

<!-- START: -->
<details><summary><b> With nano format enabled</b></summary>

```Executing action: erase-flash
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP32-C3
Running esptool.py in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32/build
Executing "/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/esptool_py/esptool/esptool.py -p /dev/ttyUSB0 -b 460800 --before default_reset --after hard_reset --chip esp32c3 erase_flash"...
esptool.py v4.8.1
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C3 (QFN32) (revision v0.3)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 70:04:1d:14:f7:8c
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Erasing flash (this may take a while)...
Chip erase completed successfully in 18.9s
Hard resetting via RTS pin...
Executing action: flash
Running ninja in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32/build
Executing "ninja flash"...
[1/10] Performing build step for 'bootloader'
[1/1] cd /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/bootloader/esp-idf/esptool_py && /home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/partition_table/check_sizes.py --offset 0x8000 bootloader 0x0 /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/bootloader/bootloader.bin
Bootloader binary size 0x5160 bytes. 0x2ea0 bytes (36%) free.
[2/8] Performing build step for 'chip_gn'
ninja: no work to do.
[3/4] cd /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/esptool_py && /home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/partition_table/check_sizes.py --offset 0x8000 partition --type app /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/partition_table/partition-table.bin /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.bin
chip-lighting-app.bin binary size 0x160b10 bytes. Smallest app partition is 0x1e0000 bytes. 0x7f4f0 bytes (27%) free.
[3/4] cd /home/shripad/esp/esp-idf/components/esptool_py && /usr/bin/cmake -D IDF_PATH=/home/shripad/esp/esp-idf -D "SERIAL_TOOL=/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python;;/home/shripad/esp/esp-idf/components/esptool_py/esptool/esptool.py;--chip;esp32c3" -D "SERIAL_TOOL_ARGS=--before=default_reset;--after=hard_reset;write_flash;@flash_args" -D WORKING_DIRECTORY=/home/shripad/connectedhomeip/examples/lighting-app/esp32/build -P /home/shripad/esp/esp-idf/components/esptool_py/run_serial_tool.cmake
esptool.py --chip esp32c3 -p /dev/ttyUSB0 -b 460800 --before=default_reset --after=hard_reset write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0 bootloader/bootloader.bin 0x20000 chip-lighting-app.bin 0x8000 partition_table/partition-table.bin 0x1d000 ota_data_initial.bin
esptool.py v4.8.1
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C3 (QFN32) (revision v0.3)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 70:04:1d:14:f7:8c
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Flash will be erased from 0x00000000 to 0x00005fff...
Flash will be erased from 0x00020000 to 0x00180fff...
Flash will be erased from 0x00008000 to 0x00008fff...
Flash will be erased from 0x0001d000 to 0x0001efff...
SHA digest in image updated
Compressed 20832 bytes to 13061...
Writing at 0x00000000... (100 %)
Wrote 20832 bytes (13061 compressed) at 0x00000000 in 1.0 seconds (effective 173.3 kbit/s)...
Hash of data verified.
Compressed 1444624 bytes to 879628...
Writing at 0x00020000... (1 %)
Writing at 0x0002c094... (3 %)
Writing at 0x00038a88... (5 %)
Writing at 0x00044291... (7 %)
Writing at 0x0004ca85... (9 %)
Writing at 0x00055ba4... (11 %)
Writing at 0x0005c79c... (12 %)
Writing at 0x000626fc... (14 %)
Writing at 0x00068db5... (16 %)
Writing at 0x0006f60e... (18 %)
Writing at 0x000753ac... (20 %)
Writing at 0x0007cbb7... (22 %)
Writing at 0x00083098... (24 %)
Writing at 0x0008901b... (25 %)
Writing at 0x0008efeb... (27 %)
Writing at 0x00095006... (29 %)
Writing at 0x0009acbc... (31 %)
Writing at 0x000a142a... (33 %)
Writing at 0x000a71c7... (35 %)
Writing at 0x000ad578... (37 %)
Writing at 0x000b3d00... (38 %)
Writing at 0x000b98c4... (40 %)
Writing at 0x000bf4d2... (42 %)
Writing at 0x000c56c9... (44 %)
Writing at 0x000cbf0f... (46 %)
Writing at 0x000d21fc... (48 %)
Writing at 0x000d8595... (50 %)
Writing at 0x000decf8... (51 %)
Writing at 0x000e501f... (53 %)
Writing at 0x000ebf0c... (55 %)
Writing at 0x000f3560... (57 %)
Writing at 0x000f9568... (59 %)
Writing at 0x000ff73a... (61 %)
Writing at 0x00105c64... (62 %)
Writing at 0x0010c0b2... (64 %)
Writing at 0x00111ebd... (66 %)
Writing at 0x00117f3f... (68 %)
Writing at 0x0011dadc... (70 %)
Writing at 0x00123c4c... (72 %)
Writing at 0x00129772... (74 %)
Writing at 0x0012f63b... (75 %)
Writing at 0x001358d4... (77 %)
Writing at 0x0013c0d8... (79 %)
Writing at 0x001420a7... (81 %)
Writing at 0x0014822a... (83 %)
Writing at 0x0014e21e... (85 %)
Writing at 0x0015388d... (87 %)
Writing at 0x00159128... (88 %)
Writing at 0x0015efa5... (90 %)
Writing at 0x00164fbc... (92 %)
Writing at 0x0016a9d7... (94 %)
Writing at 0x0017060e... (96 %)
Writing at 0x001766f7... (98 %)
Writing at 0x0017c740... (100 %)
Wrote 1444624 bytes (879628 compressed) at 0x00020000 in 26.6 seconds (effective 434.1 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 180...
Writing at 0x00008000... (100 %)
Wrote 3072 bytes (180 compressed) at 0x00008000 in 0.1 seconds (effective 269.0 kbit/s)...
Hash of data verified.
Compressed 8192 bytes to 31...
Writing at 0x0001d000... (100 %)
Wrote 8192 bytes (31 compressed) at 0x0001d000 in 0.2 seconds (effective 403.3 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
Executing action: monitor
Running idf_monitor in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32
Executing "/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix riscv32-esp-elf- --target esp32c3 --revision 3 --decode-panic backtrace /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.elf -m '/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python' '/home/shripad/esp/esp-idf/tools/idf.py'"...
� � �x���x� � � � � � � �x� � � �x �xx�x)�J����  5 ota_ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5820,len:0x1574
load:0x403cc710,len:0xc30
load:0x403ce710,len:0x2f64
entry 0x403cc71a
[0;32mI (30) boot: ESP-IDF v5.4.1-dirty 2nd stage bootloader[0m
[0;32mI (30) boot: compile time Apr  2 2025 14:35:22[0m
[0;32mI (30) boot: chip revision: v0.3[0m
[0;32mI (31) boot: efuse block revision: v1.2[0m
[0;32mI (34) boot.esp32c3: SPI Speed      : 80MHz[0m
[0;32mI (38) boot.esp32c3: SPI Mode       : DIO[0m
[0;32mI (42) boot.esp32c3: SPI Flash Size : 4MB[0m
[0;32mI (46) boot: Enabling RNG early entropy source...[0m
[0;32mI (50) boot: Partition Table:[0m
[0;32mI (53) boot: ## Label            Usage          Type ST Offset   Length[0m
[0;32mI (59) boot:  0 esp_secure_cert  unknown          3f 06 0000d000 00002000[0m
[0;32mI (66) boot:  1 nvs              WiFi data        01 02 00010000 0000c000[0m
[0;32mI (72) boot:  2 nvs_keys         NVS keys         01 04 0001c000 00001000[0m
[0;32mI (79) boot:  3 otadata          OTA data         01 00 0001d000 00002000[0m
[0;32mI (85) boot:  4 phy_init         RF data          01 01 0001f000 00001000[0m
[0;32mI (92) boot:  5 ota_0            OTA app          00 10 00020000 001e0000[0m
[0;32mI (98) boot:  6 ota_1            OTA app          00 11 00200000 001e0000[0m
[0;32mI (105) boot:  7 fctry            WiFi data        01 02 003e0000 00006000[0m
[0;32mI (111) boot: End of partition table[0m
[0;32mI (115) boot: No factory image, trying OTA 0[0m
[0;32mI (119) esp_image: segment 0: paddr=00020020 vaddr=3c120020 size=3412ch (213292) map[0m
[0;32mI (160) esp_image: segment 1: paddr=00054154 vaddr=3fc98a00 size=03b58h ( 15192) load[0m
[0;32mI (163) esp_image: segment 2: paddr=00057cb4 vaddr=40380000 size=08364h ( 33636) load[0m
[0;32mI (170) esp_image: segment 3: paddr=00060020 vaddr=42000020 size=11046ch (1115244) map[0m
[0;32mI (349) esp_image: segment 4: paddr=00170494 vaddr=40388364 size=10630h ( 67120) load[0m
[0;32mI (362) esp_image: segment 5: paddr=00180acc vaddr=50000200 size=0001ch (    28) load[0m
[0;32mI (370) boot: Loaded app from partition at offset 0x20000[0m
[0;32mI (446) boot: Set actual ota_seq=1 in otadata[0][0m
[0;32mI (446) boot: Disabling RNG early entropy source...[0m
[0;32mI (455) cpu_start: Unicore app[0m
[0;32mI (464) cpu_start: Pro cpu start user code[0m
[0;32mI (464) cpu_start: cpu freq: 160000000 Hz[0m
[0;32mI (464) app_init: Application information:[0m
[0;32mI (464) app_init: Project name:     chip-lighting-app[0m
[0;32mI (469) app_init: App version:      v1.0[0m
[0;32mI (472) app_init: Compile time:     Apr  2 2025 14:35:18[0m
[0;32mI (477) app_init: ELF file SHA256:  6468c0a61...[0m
[0;32mI (482) app_init: ESP-IDF:          v5.4.1-dirty[0m
[0;32mI (486) efuse_init: Min chip rev:     v0.3[0m
[0;32mI (490) efuse_init: Max chip rev:     v1.99 [0m
[0;32mI (494) efuse_init: Chip rev:         v0.3[0m
[0;32mI (498) heap_init: Initializing. RAM available for dynamic allocation:[0m
[0;32mI (504) heap_init: At 3FCAF900 len 00010700 (65 KiB): RAM[0m
[0;32mI (509) heap_init: At 3FCC0000 len 0001C710 (113 KiB): Retention RAM[0m
[0;32mI (515) heap_init: At 3FCDC710 len 00002950 (10 KiB): Retention RAM[0m
[0;32mI (521) heap_init: At 5000021C len 00001DCC (7 KiB): RTCRAM[0m
[0;32mI (527) spi_flash: detected chip: generic[0m
[0;32mI (530) spi_flash: flash io: dio[0m
[0;33mW (533) rmt(legacy): legacy driver is deprecated, please migrate to `driver/rmt_tx.h` and/or `driver/rmt_rx.h`[0m
[0;32mI (544) sleep_gpio: Configure to isolate all GPIO pins in sleep state[0m
[0;32mI (549) sleep_gpio: Enable automatic switching of GPIO sleep configuration[0m
[0;32mI (556) coexist: coex firmware version: e727207[0m
[0;32mI (577) coexist: coexist rom version 9387209[0m
[0;32mI (577) main_task: Started on CPU0[0m
[0;32mI (577) main_task: Calling app_main()[0m
[0;32mI (577) light-app: ==================================================[0m
[0;32mI (577) light-app: chip-esp32-light-example starting[0m
[0;32mI (577) light-app: ==================================================[0m
[5n[6n I (677) pp: pp rom version: 9387209
[0;32mI (677) net80211: net80211 rom version: 9387209[0m
[0;32mI (687) wifi:wifi driver task: 3fcbaee4, prio:23, stack:6144, core=0[0m
[0;32mI (687) wifi:wifi firmware version: 79fa3f41ba[0m
[0;32mI (687) wifi:wifi certification version: v7.0[0m
[0;32mI (687) wifi:config NVS flash: enabled[0m
[0;32mI (697) wifi:config nano formatting: enabled[0m
[0;32mI (697) wifi:Init data frame dynamic rx buffer num: 32[0m
[0;32mI (697) wifi:Init static rx mgmt buffer num: 5[0m
[0;32mI (707) wifi:Init management short buffer num: 32[0m
[0;32mI (707) wifi:Init dynamic tx buffer num: 32[0m
[0;32mI (717) wifi:Init static tx FG buffer num: 2[0m
[0;32mI (717) wifi:Init static rx buffer size: 1600[0m
[0;32mI (717) wifi:Init static rx buffer num: 10[0m
[0;32mI (727) wifi:Init dynamic rx buffer num: 32[0m
[999C [6n I (737) wifi_init: rx ba win: 6
[0;32mI (737) wifi_init: accept mbox: 6[0m
[0;32mI (737) wifi_init: tcpip mbox: 32[0m
[0;32mI (737) wifi_init: udp mbox: 6[0m
[0;32mI (737) wifi_init: tcp mbox: 6[0m
[0;32mI (747) wifi_init: tcp tx win: 5760[0m
[0;32mI (747) wifi_init: tcp rx win: 5760[0m
[0;32mI (747) wifi_init: tcp mss: 1440[0m
[0;32mI (747) wifi_init: WiFi IRAM OP enabled[0m
[0;32mI (767) wifi_init: WiFi RX IRAM OP enabled[0m
[0;32mI (767) chip[DL]: NVS set: chip-counters/reboot-count = 1 (0x1)[0m
[0;32mI (767) chip[DL]: NVS set: chip-config/unique-id = "EF1A5A5E4EDB51EA"[0m
[0;32mI (767) chip[DL]: Real time clock set to 946684800 (2000-01-01 00:00:00 UTC)[0m
[130D> I (787) BLE_INIT: BT controller compile version [d74042a]
[0;32mI (787) BLE_INIT: Bluetooth MAC: 70:04:1d:14:f7:8e[0m
[0;32mI (797) app-task: App Task started[0m
[0;32mI (797) main_task: Returned from app_main()[0m
[0;32mI (797) phy_init: phy_version 1200,2b7123f9,Feb 18 2025,15:22:21[0m
[0;33mW (807) phy_init: failed to load RF calibration data (0x1102), falling back to full calibration[0m
[0;32mI (847) phy_init: Saving new calibration data due to checksum failure or outdated calibration data, mode(2)[0m
[0;32mI (857) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (857) CHIP[DL]: BLE host-controller synced[0m
[0;32mI (1357) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1357) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1357) NimBLE: disc_mode=2[0m
[0;32mI (1367) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1367) NimBLE: [0m

[0;32mI (1377) chip[DL]: CHIPoBLE advertising started[0m
[0;32mI (1377) chip[DL]: Starting ESP WiFi layer[0m
[0;32mI (1377) wifi:mode : sta (70:04:1d:14:f7:8c)[0m
[0;32mI (1377) wifi:enable tsf[0m
[0;32mI (1377) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 43[0m
[0;32mI (1397) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 2[0m
[0;33mW (1397) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1407) chip[DL]: Done driving station state, nothing else to do...[0m
[0;33mW (1417) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1417) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1417) chip[SVR]: SetupQRCode: [MT:Y.K9042C00KA0648G00][0m
[0;32mI (1427) chip[SVR]: Copy/paste the below URL in a browser to see the QR Code:[0m
[0;32mI (1427) chip[SVR]: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AY.K9042C00KA0648G00[0m
[0;32mI (1437) chip[SVR]: Manual pairing code: [34970112332][0m
[0;32mI (1447) chip[SVR]: Initializing subscription resumption storage...[0m
[0;32mI (1457) chip[SVR]: Server initializing...[0m
[0;32mI (1457) chip[TS]: Last Known Good Time: [unknown][0m
[0;32mI (1467) chip[TS]: Setting Last Known Good Time to firmware build time 2023-10-14T01:16:48[0m
[0;32mI (1467) chip[DMG]: AccessControl: initializing[0m
[0;32mI (1477) chip[DMG]: Examples::AccessControlDelegate::Init[0m
[0;32mI (1477) chip[DMG]: AccessControl: setting[0m
[0;32mI (1477) chip[DMG]: DefaultAclStorage: initializing[0m
[0;32mI (1487) chip[DMG]: DefaultAclStorage: 0 entries loaded[0m
[0;32mI (1497) chip[ZCL]: Using ZAP configuration...[0m
[0;32mI (1497) chip[DMG]: AccessControlCluster: initializing[0m
[0;32mI (1497) chip[ZCL]: Initiating Admin Commissioning cluster.[0m
[0;32mI (1517) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x2b', EndPoint ID: '0x0', Attribute ID: '0x0'[0m
[0;32mI (1517) light-app-callbacks: Unhandled cluster ID: 43[0m
[0;32mI (1527) light-app-callbacks: Current free heap: 51976[0m

[0;32mI (1527) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0x0'[0m
[0;32mI (1537) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1547) light-app-callbacks: Current free heap: 51976[0m

[0;32mI (1547) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0xfffc'[0m
[0;32mI (1557) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1557) light-app-callbacks: Current free heap: 51976[0m

[0;32mI (1567) light-app-callbacks: emberAfOnOffClusterInitCallback[0m
[0;32mI (1567) app-task: Writing to OnOff cluster[0m
[0;32mI (1577) app-task: Writing to Current Level cluster[0m
[1;31mE (1587) app-task: Updating level cluster failed: 87[0m
[0;32mI (1587) chip[ZCL]: Endpoint 1 On/off already set to new value[0m
[0;32mI (1597) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x300', EndPoint ID: '0x1', Attribute ID: '0x8'[0m
[0;32mI (1607) light-app-callbacks: Unhandled AttributeId ID: '0x8'[0m
[0;32mI (1607) light-app-callbacks: Current free heap: 51976[0m

[0;32mI (1617) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x300', EndPoint ID: '0x1', Attribute ID: '0x4001'[0m
[0;32mI (1617) light-app-callbacks: Unhandled AttributeId ID: '0x4001'[0m
[0;32mI (1627) light-app-callbacks: Current free heap: 51844[0m

[0;32mI (1637) chip[DIS]: Updating services using commissioning mode 1[0m
[0;32mI (1647) chip[DIS]: CHIP minimal mDNS started advertising.[0m
[0;32mI (1647) chip[DIS]: Advertise commission parameter vendorID=65521 productID=32768 discriminator=3840/15 cm=1 cp=0[0m
[0;32mI (1657) chip[DIS]: CHIP minimal mDNS configured as 'Commissionable node device'; instance name: 593F0B27F94216B9.[0m
[0;32mI (1667) chip[DIS]: mDNS service published: _matterc._udp[0m
[0;32mI (1667) chip[IN]: CASE Server enabling CASE session setups[0m
[0;32mI (1677) chip[SVR]: Joining Multicast groups[0m
[0;32mI (1687) chip[SVR]: Server Listening...[0m
[0;32mI (1687) app-devicecallbacks: Current free heap: Internal: 51076/202028 External: 0/0[0m
[0;32mI (1697) app-devicecallbacks: Current free heap: Internal: 51076/202028 External: 0/0[0m
[0;32mI (1697) chip[DL]: WIFI_EVENT_STA_START[0m
[0;33mW (1697) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1707) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1707) app-devicecallbacks: Current free heap: Internal: 51076/202028 External: 0/0[0m
[0;32mI (1727) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1737) chip[DL]: Device already advertising, stop active advertisement and restart[0m
[0;32mI (1737) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (1747) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1747) NimBLE: disc_mode=2[0m
[0;32mI (1747) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1757) NimBLE: [0m

Done

```
</details>
<!-- END: Memory Results for esp32c2 -->

<!-- START: Memory Results for esp32h2 -->
<details><summary><b>Without nano format enabled</b></summary>

```Executing action: erase-flash
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP32-C3
Running esptool.py in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32/build
Executing "/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/esptool_py/esptool/esptool.py -p /dev/ttyUSB0 -b 460800 --before default_reset --after hard_reset --chip esp32c3 erase_flash"...
esptool.py v4.8.1
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C3 (QFN32) (revision v0.3)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 70:04:1d:14:f7:8c
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Erasing flash (this may take a while)...
Chip erase completed successfully in 18.9s
Hard resetting via RTS pin...
Executing action: flash
Running ninja in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32/build
Executing "ninja flash"...
[1/10] Performing build step for 'bootloader'
[1/1] cd /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/bootloader/esp-idf/esptool_py && /home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/partition_table/check_sizes.py --offset 0x8000 bootloader 0x0 /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/bootloader/bootloader.bin
Bootloader binary size 0x5160 bytes. 0x2ea0 bytes (36%) free.
[2/8] Performing build step for 'chip_gn'
ninja: no work to do.
[3/4] cd /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/esptool_py && /home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/partition_table/check_sizes.py --offset 0x8000 partition --type app /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/partition_table/partition-table.bin /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.bin
chip-lighting-app.bin binary size 0x16c3d0 bytes. Smallest app partition is 0x1e0000 bytes. 0x73c30 bytes (24%) free.
[3/4] cd /home/shripad/esp/esp-idf/components/esptool_py && /usr/bin/cmake -D IDF_PATH=/home/shripad/esp/esp-idf -D "SERIAL_TOOL=/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python;;/home/shripad/esp/esp-idf/components/esptool_py/esptool/esptool.py;--chip;esp32c3" -D "SERIAL_TOOL_ARGS=--before=default_reset;--after=hard_reset;write_flash;@flash_args" -D WORKING_DIRECTORY=/home/shripad/connectedhomeip/examples/lighting-app/esp32/build -P /home/shripad/esp/esp-idf/components/esptool_py/run_serial_tool.cmake
esptool.py --chip esp32c3 -p /dev/ttyUSB0 -b 460800 --before=default_reset --after=hard_reset write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x0 bootloader/bootloader.bin 0x20000 chip-lighting-app.bin 0x8000 partition_table/partition-table.bin 0x1d000 ota_data_initial.bin
esptool.py v4.8.1
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C3 (QFN32) (revision v0.3)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 70:04:1d:14:f7:8c
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Flash will be erased from 0x00000000 to 0x00005fff...
Flash will be erased from 0x00020000 to 0x0018cfff...
Flash will be erased from 0x00008000 to 0x00008fff...
Flash will be erased from 0x0001d000 to 0x0001efff...
SHA digest in image updated
Compressed 20832 bytes to 13063...
Writing at 0x00000000... (100 %)
Wrote 20832 bytes (13063 compressed) at 0x00000000 in 1.0 seconds (effective 171.1 kbit/s)...
Hash of data verified.
Compressed 1491920 bytes to 902740...
Writing at 0x00020000... (1 %)
Writing at 0x0002c073... (3 %)
Writing at 0x00038a75... (5 %)
Writing at 0x0004426e... (7 %)
Writing at 0x0004ca9a... (8 %)
Writing at 0x0005591a... (10 %)
Writing at 0x0005cf0b... (12 %)
Writing at 0x00062dff... (14 %)
Writing at 0x00069561... (16 %)
Writing at 0x0006fddf... (17 %)
Writing at 0x00075b3d... (19 %)
Writing at 0x0007d567... (21 %)
Writing at 0x000837ec... (23 %)
Writing at 0x0008993b... (25 %)
Writing at 0x0008f858... (26 %)
Writing at 0x000957b5... (28 %)
Writing at 0x0009b46c... (30 %)
Writing at 0x000a1bfd... (32 %)
Writing at 0x000a7949... (33 %)
Writing at 0x000adf42... (35 %)
Writing at 0x000b4417... (37 %)
Writing at 0x000ba0f6... (39 %)
Writing at 0x000bfc36... (41 %)
Writing at 0x000c5e58... (42 %)
Writing at 0x000cc6a9... (44 %)
Writing at 0x000d2a26... (46 %)
Writing at 0x000d8d16... (48 %)
Writing at 0x000df4b9... (50 %)
Writing at 0x000e5a5c... (51 %)
Writing at 0x000ec9e6... (53 %)
Writing at 0x000f3d12... (55 %)
Writing at 0x000f9df0... (57 %)
Writing at 0x000fffd4... (58 %)
Writing at 0x00106587... (60 %)
Writing at 0x0010c8c6... (62 %)
Writing at 0x001127a8... (64 %)
Writing at 0x001188ae... (66 %)
Writing at 0x0011e2d1... (67 %)
Writing at 0x0012445e... (69 %)
Writing at 0x00129e83... (71 %)
Writing at 0x0012fe2f... (73 %)
Writing at 0x001361b4... (75 %)
Writing at 0x0013c929... (76 %)
Writing at 0x0014295d... (78 %)
Writing at 0x00148b87... (80 %)
Writing at 0x0014e982... (82 %)
Writing at 0x00154056... (83 %)
Writing at 0x001599c2... (85 %)
Writing at 0x0015f7ac... (87 %)
Writing at 0x00166237... (89 %)
Writing at 0x0016c67a... (91 %)
Writing at 0x0017406f... (92 %)
Writing at 0x00179854... (94 %)
Writing at 0x0017f657... (96 %)
Writing at 0x001859fa... (98 %)
Writing at 0x0018b86a... (100 %)
Wrote 1491920 bytes (902740 compressed) at 0x00020000 in 27.7 seconds (effective 431.2 kbit/s)...
Hash of data verified.
Compressed 3072 bytes to 180...
Writing at 0x00008000... (100 %)
Wrote 3072 bytes (180 compressed) at 0x00008000 in 0.1 seconds (effective 267.7 kbit/s)...
Hash of data verified.
Compressed 8192 bytes to 31...
Writing at 0x0001d000... (100 %)
Wrote 8192 bytes (31 compressed) at 0x0001d000 in 0.2 seconds (effective 366.6 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
Executing action: monitor
Running idf_monitor in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32
Executing "/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix riscv32-esp-elf- --target esp32c3 --revision 3 --decode-panic backtrace /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.elf -m '/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python' '/home/shripad/esp/esp-idf/tools/idf.py'"...
x��xx �� x�x�x�x�� ���x�x��V�ѽ���imagESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5820,len:0x1574
load:0x403cc710,len:0xc30
load:0x403ce710,len:0x2f64
entry 0x403cc71a
[0;32mI (30) boot: ESP-IDF v5.4.1-dirty 2nd stage bootloader[0m
[0;32mI (30) boot: compile time Apr  2 2025 14:46:24[0m
[0;32mI (30) boot: chip revision: v0.3[0m
[0;32mI (31) boot: efuse block revision: v1.2[0m
[0;32mI (34) boot.esp32c3: SPI Speed      : 80MHz[0m
[0;32mI (38) boot.esp32c3: SPI Mode       : DIO[0m
[0;32mI (42) boot.esp32c3: SPI Flash Size : 4MB[0m
[0;32mI (46) boot: Enabling RNG early entropy source...[0m
[0;32mI (50) boot: Partition Table:[0m
[0;32mI (53) boot: ## Label            Usage          Type ST Offset   Length[0m
[0;32mI (59) boot:  0 esp_secure_cert  unknown          3f 06 0000d000 00002000[0m
[0;32mI (66) boot:  1 nvs              WiFi data        01 02 00010000 0000c000[0m
[0;32mI (72) boot:  2 nvs_keys         NVS keys         01 04 0001c000 00001000[0m
[0;32mI (79) boot:  3 otadata          OTA data         01 00 0001d000 00002000[0m
[0;32mI (85) boot:  4 phy_init         RF data          01 01 0001f000 00001000[0m
[0;32mI (92) boot:  5 ota_0            OTA app          00 10 00020000 001e0000[0m
[0;32mI (98) boot:  6 ota_1            OTA app          00 11 00200000 001e0000[0m
[0;32mI (105) boot:  7 fctry            WiFi data        01 02 003e0000 00006000[0m
[0;32mI (111) boot: End of partition table[0m
[0;32mI (115) boot: No factory image, trying OTA 0[0m
[0;32mI (119) esp_image: segment 0: paddr=00020020 vaddr=3c120020 size=34eb4h (216756) map[0m
[0;32mI (161) esp_image: segment 1: paddr=00054edc vaddr=3fc98a00 size=03b58h ( 15192) load[0m
[0;32mI (164) esp_image: segment 2: paddr=00058a3c vaddr=40380000 size=075dch ( 30172) load[0m
[0;32mI (170) esp_image: segment 3: paddr=00060020 vaddr=42000020 size=11af9ch (1159068) map[0m
[0;32mI (357) esp_image: segment 4: paddr=0017afc4 vaddr=403875dc size=113b8h ( 70584) load[0m
[0;32mI (370) esp_image: segment 5: paddr=0018c384 vaddr=50000200 size=0001ch (    28) load[0m
[0;32mI (378) boot: Loaded app from partition at offset 0x20000[0m
[0;32mI (445) boot: Set actual ota_seq=1 in otadata[0][0m
[0;32mI (445) boot: Disabling RNG early entropy source...[0m
[0;32mI (455) cpu_start: Unicore app[0m
[0;32mI (463) cpu_start: Pro cpu start user code[0m
[0;32mI (463) cpu_start: cpu freq: 160000000 Hz[0m
[0;32mI (463) app_init: Application information:[0m
[0;32mI (463) app_init: Project name:     chip-lighting-app[0m
[0;32mI (468) app_init: App version:      v1.0[0m
[0;32mI (472) app_init: Compile time:     Apr  2 2025 14:46:22[0m
[0;32mI (477) app_init: ELF file SHA256:  815a87900...[0m
[0;32mI (481) app_init: ESP-IDF:          v5.4.1-dirty[0m
[0;32mI (486) efuse_init: Min chip rev:     v0.3[0m
[0;32mI (489) efuse_init: Max chip rev:     v1.99 [0m
[0;32mI (493) efuse_init: Chip rev:         v0.3[0m
[0;32mI (497) heap_init: Initializing. RAM available for dynamic allocation:[0m
[0;32mI (503) heap_init: At 3FCAF900 len 00010700 (65 KiB): RAM[0m
[0;32mI (509) heap_init: At 3FCC0000 len 0001C710 (113 KiB): Retention RAM[0m
[0;32mI (515) heap_init: At 3FCDC710 len 00002950 (10 KiB): Retention RAM[0m
[0;32mI (521) heap_init: At 5000021C len 00001DCC (7 KiB): RTCRAM[0m
[0;32mI (527) spi_flash: detected chip: generic[0m
[0;32mI (530) spi_flash: flash io: dio[0m
[0;33mW (533) rmt(legacy): legacy driver is deprecated, please migrate to `driver/rmt_tx.h` and/or `driver/rmt_rx.h`[0m
[0;32mI (544) sleep_gpio: Configure to isolate all GPIO pins in sleep state[0m
[0;32mI (549) sleep_gpio: Enable automatic switching of GPIO sleep configuration[0m
[0;32mI (555) coexist: coex firmware version: e727207[0m
[0;32mI (576) coexist: coexist rom version 9387209[0m
[0;32mI (577) main_task: Started on CPU0[0m
[0;32mI (577) main_task: Calling app_main()[0m
[0;32mI (577) light-app: ==================================================[0m
[0;32mI (577) light-app: chip-esp32-light-example starting[0m
[0;32mI (577) light-app: ==================================================[0m
[5n[6n I (657) pp: pp rom version: 9387209
[0;32mI (657) net80211: net80211 rom version: 9387209[0m
[0;32mI (667) wifi:wifi driver task: 3fcbb8e4, prio:23, stack:6656, core=0[0m
[0;32mI (667) wifi:wifi firmware version: 79fa3f41ba[0m
[0;32mI (667) wifi:wifi certification version: v7.0[0m
[0;32mI (667) wifi:config NVS flash: enabled[0m
[0;32mI (677) wifi:config nano formatting: disabled[0m
[0;32mI (677) wifi:Init data frame dynamic rx buffer num: 32[0m
[0;32mI (677) wifi:Init static rx mgmt buffer num: 5[0m
[0;32mI (687) wifi:Init management short buffer num: 32[0m
[0;32mI (687) wifi:Init dynamic tx buffer num: 32[0m
[0;32mI (697) wifi:Init static tx FG buffer num: 2[0m
[0;32mI (697) wifi:Init static rx buffer size: 1600[0m
[0;32mI (697) wifi:Init static rx buffer num: 10[0m
[0;32mI (707) wifi:Init dynamic rx buffer num: 32[0m
[999C [6n I (717) wifi_init: rx ba win: 6
[0;32mI (717) wifi_init: accept mbox: 6[0m
[0;32mI (717) wifi_init: tcpip mbox: 32[0m
[0;32mI (717) wifi_init: udp mbox: 6[0m
[0;32mI (717) wifi_init: tcp mbox: 6[0m
[0;32mI (727) wifi_init: tcp tx win: 5760[0m
[0;32mI (727) wifi_init: tcp rx win: 5760[0m
[0;32mI (727) wifi_init: tcp mss: 1440[0m
[0;32mI (727) wifi_init: WiFi IRAM OP enabled[0m
[0;32mI (747) wifi_init: WiFi RX IRAM OP enabled[0m
[0;32mI (747) chip[DL]: NVS set: chip-counters/reboot-count = 1 (0x1)[0m
[0;32mI (747) chip[DL]: NVS set: chip-config/unique-id = "7ED4E0E071278B36"[0m
[0;32mI (757) chip[DL]: Real time clock set to 946684800 (2000-01-01 00:00:00 UTC)[0m
[130D> I (767) BLE_INIT: BT controller compile version [d74042a]
[0;32mI (767) BLE_INIT: Bluetooth MAC: 70:04:1d:14:f7:8e[0m
[0;32mI (777) app-task: App Task started[0m
[0;32mI (777) main_task: Returned from app_main()[0m
[0;32mI (777) phy_init: phy_version 1200,2b7123f9,Feb 18 2025,15:22:21[0m
[0;33mW (787) phy_init: failed to load RF calibration data (0x1102), falling back to full calibration[0m
[0;32mI (827) phy_init: Saving new calibration data due to checksum failure or outdated calibration data, mode(2)[0m
[0;32mI (837) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (837) CHIP[DL]: BLE host-controller synced[0m
[0;32mI (1337) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1337) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1337) NimBLE: disc_mode=2[0m
[0;32mI (1347) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1347) NimBLE: [0m

[0;32mI (1357) chip[DL]: CHIPoBLE advertising started[0m
[0;32mI (1357) chip[DL]: Starting ESP WiFi layer[0m
[0;32mI (1357) wifi:mode : sta (70:04:1d:14:f7:8c)[0m
[0;32mI (1357) wifi:enable tsf[0m
[0;32mI (1357) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 43[0m
[0;32mI (1377) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 2[0m
[0;33mW (1377) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1387) chip[DL]: Done driving station state, nothing else to do...[0m
[0;33mW (1387) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1397) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1397) chip[SVR]: SetupQRCode: [MT:Y.K9042C00KA0648G00][0m
[0;32mI (1407) chip[SVR]: Copy/paste the below URL in a browser to see the QR Code:[0m
[0;32mI (1407) chip[SVR]: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AY.K9042C00KA0648G00[0m
[0;32mI (1417) chip[SVR]: Manual pairing code: [34970112332][0m
[0;32mI (1437) chip[SVR]: Initializing subscription resumption storage...[0m
[0;32mI (1437) chip[SVR]: Server initializing...[0m
[0;32mI (1437) chip[TS]: Last Known Good Time: [unknown][0m
[0;32mI (1447) chip[TS]: Setting Last Known Good Time to firmware build time 2023-10-14T01:16:48[0m
[0;32mI (1447) chip[DMG]: AccessControl: initializing[0m
[0;32mI (1447) chip[DMG]: Examples::AccessControlDelegate::Init[0m
[0;32mI (1457) chip[DMG]: AccessControl: setting[0m
[0;32mI (1457) chip[DMG]: DefaultAclStorage: initializing[0m
[0;32mI (1477) chip[DMG]: DefaultAclStorage: 0 entries loaded[0m
[0;32mI (1477) chip[ZCL]: Using ZAP configuration...[0m
[0;32mI (1477) chip[DMG]: AccessControlCluster: initializing[0m
[0;32mI (1487) chip[ZCL]: Initiating Admin Commissioning cluster.[0m
[0;32mI (1487) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x2b', EndPoint ID: '0x0', Attribute ID: '0x0'[0m
[0;32mI (1497) light-app-callbacks: Unhandled cluster ID: 43[0m
[0;32mI (1507) light-app-callbacks: Current free heap: 49420[0m

[0;32mI (1507) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0x0'[0m
[0;32mI (1517) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1517) light-app-callbacks: Current free heap: 49420[0m

[0;32mI (1527) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0xfffc'[0m
[0;32mI (1537) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1547) light-app-callbacks: Current free heap: 49420[0m

[0;32mI (1557) light-app-callbacks: emberAfOnOffClusterInitCallback[0m
[0;32mI (1557) app-task: Writing to OnOff cluster[0m
[0;32mI (1557) app-task: Writing to Current Level cluster[0m
[1;31mE (1567) app-task: Updating level cluster failed: 87[0m
[0;32mI (1567) chip[ZCL]: Endpoint 1 On/off already set to new value[0m
[0;32mI (1577) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x300', EndPoint ID: '0x1', Attribute ID: '0x8'[0m
[0;32mI (1577) light-app-callbacks: Unhandled AttributeId ID: '0x8'[0m
[0;32mI (1587) light-app-callbacks: Current free heap: 49420[0m

[0;32mI (1597) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x300', EndPoint ID: '0x1', Attribute ID: '0x4001'[0m
[0;32mI (1607) light-app-callbacks: Unhandled AttributeId ID: '0x4001'[0m
[0;32mI (1617) light-app-callbacks: Current free heap: 49288[0m

[0;32mI (1617) chip[DIS]: Updating services using commissioning mode 1[0m
[0;32mI (1617) chip[DIS]: CHIP minimal mDNS started advertising.[0m
[0;32mI (1627) chip[DIS]: Advertise commission parameter vendorID=65521 productID=32768 discriminator=3840/15 cm=1 cp=0[0m
[0;32mI (1637) chip[DIS]: CHIP minimal mDNS configured as 'Commissionable node device'; instance name: D6520C3F03D8AFAE.[0m
[0;32mI (1647) chip[DIS]: mDNS service published: _matterc._udp[0m
[0;32mI (1657) chip[IN]: CASE Server enabling CASE session setups[0m
[0;32mI (1657) chip[SVR]: Joining Multicast groups[0m
[0;32mI (1657) chip[SVR]: Server Listening...[0m
[0;32mI (1657) app-devicecallbacks: Current free heap: Internal: 48520/202028 External: 0/0[0m
[0;32mI (1667) app-devicecallbacks: Current free heap: Internal: 48520/202028 External: 0/0[0m
[0;32mI (1677) chip[DL]: WIFI_EVENT_STA_START[0m
[0;33mW (1687) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1687) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1697) app-devicecallbacks: Current free heap: Internal: 48520/202028 External: 0/0[0m
[0;32mI (1707) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1707) chip[DL]: Device already advertising, stop active advertisement and restart[0m
[0;32mI (1717) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (1717) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1727) NimBLE: disc_mode=2[0m
[0;32mI (1727) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1747) NimBLE: [0m

Done

```
</details>
<!-- END: Memory Results for esp32h2 -->

<!-- START: Memory Results for esp32c2 -->
<details><summary><b>Without changes and nano format disabled</b></summary>

```Executing action: app-flash
Serial port /dev/ttyUSB0
Connecting....
Detecting chip type... ESP32-C3
Running ninja in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32/build
Executing "ninja app-flash"...
[1/7] Performing build step for 'chip_gn'
[1/3] c++ obj/third_party/connectedhomeip/src/platform/ESP32/ESP32.SystemTimeSupport.cpp.o
[2/3] ar ESP32.a
[3/3] ar libCHIP.a
[2/5] Linking CXX executable chip-lighting-app.elf
[3/5] Generating binary image from built executable
esptool.py v4.8.1
Creating esp32c3 image...
Merged 1 ELF section
Successfully created esp32c3 image.
Generated /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.bin
[4/5] cd /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/esp-idf/esptool_py && /home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/components/partition_table/check_sizes.py --offset 0x8000 partition --type app /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/partition_table/partition-table.bin /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.bin
chip-lighting-app.bin binary size 0x16c3d0 bytes. Smallest app partition is 0x1e0000 bytes. 0x73c30 bytes (24%) free.
[4/5] cd /home/shripad/esp/esp-idf/components/esptool_py && /usr/bin/cmake -D IDF_PATH=/home/shripad/esp/esp-idf -D "SERIAL_TOOL=/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python;;/home/shripad/esp/esp-idf/components/esptool_py/esptool/esptool.py;--chip;esp32c3" -D "SERIAL_TOOL_ARGS=--before=default_reset;--after=hard_reset;write_flash;@app-flash_args" -D WORKING_DIRECTORY=/home/shripad/connectedhomeip/examples/lighting-app/esp32/build -P /home/shripad/esp/esp-idf/components/esptool_py/run_serial_tool.cmake
esptool.py --chip esp32c3 -p /dev/ttyUSB0 -b 460800 --before=default_reset --after=hard_reset write_flash --flash_mode dio --flash_freq 80m --flash_size 4MB 0x20000 chip-lighting-app.bin
esptool.py v4.8.1
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-C3 (QFN32) (revision v0.3)
Features: WiFi, BLE, Embedded Flash 4MB (XMC)
Crystal is 40MHz
MAC: 70:04:1d:14:f7:8c
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 460800
Changed.
Configuring flash size...
Flash will be erased from 0x00020000 to 0x0018cfff...
Compressed 1491920 bytes to 902761...
Writing at 0x00020000... (1 %)
Writing at 0x0002c098... (3 %)
Writing at 0x00038a80... (5 %)
Writing at 0x0004427e... (7 %)
Writing at 0x0004caa2... (8 %)
Writing at 0x00055938... (10 %)
Writing at 0x0005cf13... (12 %)
Writing at 0x00062e0e... (14 %)
Writing at 0x00069567... (16 %)
Writing at 0x0006fdf1... (17 %)
Writing at 0x00075b4a... (19 %)
Writing at 0x0007d567... (21 %)
Writing at 0x000837ec... (23 %)
Writing at 0x0008993b... (25 %)
Writing at 0x0008f855... (26 %)
Writing at 0x000957ac... (28 %)
Writing at 0x0009b478... (30 %)
Writing at 0x000a1bff... (32 %)
Writing at 0x000a7945... (33 %)
Writing at 0x000adf41... (35 %)
Writing at 0x000b440e... (37 %)
Writing at 0x000ba0fa... (39 %)
Writing at 0x000bfc39... (41 %)
Writing at 0x000c5e54... (42 %)
Writing at 0x000cc69e... (44 %)
Writing at 0x000d2a13... (46 %)
Writing at 0x000d8d15... (48 %)
Writing at 0x000df4b4... (50 %)
Writing at 0x000e5a56... (51 %)
Writing at 0x000ec9e6... (53 %)
Writing at 0x000f3d14... (55 %)
Writing at 0x000f9df3... (57 %)
Writing at 0x000fffc5... (58 %)
Writing at 0x0010657b... (60 %)
Writing at 0x0010c8bc... (62 %)
Writing at 0x001127a6... (64 %)
Writing at 0x001188ab... (66 %)
Writing at 0x0011e2d0... (67 %)
Writing at 0x0012445a... (69 %)
Writing at 0x00129e7d... (71 %)
Writing at 0x0012fe2a... (73 %)
Writing at 0x001361b2... (75 %)
Writing at 0x0013c927... (76 %)
Writing at 0x0014295f... (78 %)
Writing at 0x00148b88... (80 %)
Writing at 0x0014e97c... (82 %)
Writing at 0x00154048... (83 %)
Writing at 0x001599bb... (85 %)
Writing at 0x0015f783... (87 %)
Writing at 0x0016621e... (89 %)
Writing at 0x0016c66b... (91 %)
Writing at 0x0017405f... (92 %)
Writing at 0x00179841... (94 %)
Writing at 0x0017f646... (96 %)
Writing at 0x001859df... (98 %)
Writing at 0x0018b84a... (100 %)
Wrote 1491920 bytes (902761 compressed) at 0x00020000 in 27.7 seconds (effective 431.3 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...
Executing action: monitor
Running idf_monitor in directory /home/shripad/connectedhomeip/examples/lighting-app/esp32
Executing "/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python /home/shripad/esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix riscv32-esp-elf- --target esp32c3 --revision 3 --decode-panic backtrace /home/shripad/connectedhomeip/examples/lighting-app/esp32/build/chip-lighting-app.elf -m '/home/shripad/.espressif/python_env/idf5.4_py3.10_env/bin/python' '/home/shripad/esp/esp-idf/tools/idf.py'"...
x�x��x�x� � � � � � � � ���x� x� �x x�x��         01 ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0x1 (POWERON),boot:0xc (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5820,len:0x1574
load:0x403cc710,len:0xc30
load:0x403ce710,len:0x2f64
entry 0x403cc71a
[0;32mI (30) boot: ESP-IDF v5.4.1-dirty 2nd stage bootloader[0m
[0;32mI (30) boot: compile time Apr  2 2025 14:46:24[0m
[0;32mI (30) boot: chip revision: v0.3[0m
[0;32mI (31) boot: efuse block revision: v1.2[0m
[0;32mI (34) boot.esp32c3: SPI Speed      : 80MHz[0m
[0;32mI (38) boot.esp32c3: SPI Mode       : DIO[0m
[0;32mI (42) boot.esp32c3: SPI Flash Size : 4MB[0m
[0;32mI (46) boot: Enabling RNG early entropy source...[0m
[0;32mI (50) boot: Partition Table:[0m
[0;32mI (53) boot: ## Label            Usage          Type ST Offset   Length[0m
[0;32mI (59) boot:  0 esp_secure_cert  unknown          3f 06 0000d000 00002000[0m
[0;32mI (66) boot:  1 nvs              WiFi data        01 02 00010000 0000c000[0m
[0;32mI (72) boot:  2 nvs_keys         NVS keys         01 04 0001c000 00001000[0m
[0;32mI (79) boot:  3 otadata          OTA data         01 00 0001d000 00002000[0m
[0;32mI (85) boot:  4 phy_init         RF data          01 01 0001f000 00001000[0m
[0;32mI (92) boot:  5 ota_0            OTA app          00 10 00020000 001e0000[0m
[0;32mI (98) boot:  6 ota_1            OTA app          00 11 00200000 001e0000[0m
[0;32mI (105) boot:  7 fctry            WiFi data        01 02 003e0000 00006000[0m
[0;32mI (111) boot: End of partition table[0m
[0;32mI (115) esp_image: segment 0: paddr=00020020 vaddr=3c120020 size=34ebch (216764) map[0m
[0;32mI (157) esp_image: segment 1: paddr=00054ee4 vaddr=3fc98a00 size=03b58h ( 15192) load[0m
[0;32mI (160) esp_image: segment 2: paddr=00058a44 vaddr=40380000 size=075d4h ( 30164) load[0m
[0;32mI (166) esp_image: segment 3: paddr=00060020 vaddr=42000020 size=11afa0h (1159072) map[0m
[0;32mI (353) esp_image: segment 4: paddr=0017afc8 vaddr=403875d4 size=113c0h ( 70592) load[0m
[0;32mI (366) esp_image: segment 5: paddr=0018c390 vaddr=50000200 size=0001ch (    28) load[0m
[0;32mI (374) boot: Loaded app from partition at offset 0x20000[0m
[0;32mI (374) boot: Disabling RNG early entropy source...[0m
[0;32mI (385) cpu_start: Unicore app[0m
[0;32mI (393) cpu_start: Pro cpu start user code[0m
[0;32mI (393) cpu_start: cpu freq: 160000000 Hz[0m
[0;32mI (393) app_init: Application information:[0m
[0;32mI (393) app_init: Project name:     chip-lighting-app[0m
[0;32mI (398) app_init: App version:      v1.0[0m
[0;32mI (401) app_init: Compile time:     Apr  2 2025 14:46:22[0m
[0;32mI (406) app_init: ELF file SHA256:  0448820df...[0m
[0;32mI (411) app_init: ESP-IDF:          v5.4.1-dirty[0m
[0;32mI (415) efuse_init: Min chip rev:     v0.3[0m
[0;32mI (419) efuse_init: Max chip rev:     v1.99 [0m
[0;32mI (423) efuse_init: Chip rev:         v0.3[0m
[0;32mI (427) heap_init: Initializing. RAM available for dynamic allocation:[0m
[0;32mI (433) heap_init: At 3FCAF900 len 00010700 (65 KiB): RAM[0m
[0;32mI (438) heap_init: At 3FCC0000 len 0001C710 (113 KiB): Retention RAM[0m
[0;32mI (444) heap_init: At 3FCDC710 len 00002950 (10 KiB): Retention RAM[0m
[0;32mI (450) heap_init: At 5000021C len 00001DCC (7 KiB): RTCRAM[0m
[0;32mI (456) spi_flash: detected chip: generic[0m
[0;32mI (459) spi_flash: flash io: dio[0m
[0;33mW (462) rmt(legacy): legacy driver is deprecated, please migrate to `driver/rmt_tx.h` and/or `driver/rmt_rx.h`[0m
[0;32mI (473) sleep_gpio: Configure to isolate all GPIO pins in sleep state[0m
[0;32mI (478) sleep_gpio: Enable automatic switching of GPIO sleep configuration[0m
[0;32mI (485) coexist: coex firmware version: e727207[0m
[0;32mI (506) coexist: coexist rom version 9387209[0m
[0;32mI (506) main_task: Started on CPU0[0m
[0;32mI (506) main_task: Calling app_main()[0m
[0;32mI (516) light-app: ==================================================[0m
[0;32mI (516) light-app: chip-esp32-light-example starting[0m
[0;32mI (516) light-app: ==================================================[0m
[5n[6n I (586) pp: pp rom version: 9387209
[0;32mI (586) net80211: net80211 rom version: 9387209[0m
[0;32mI (596) wifi:wifi driver task: 3fcbba24, prio:23, stack:6656, core=0[0m
[0;32mI (596) wifi:wifi firmware version: 79fa3f41ba[0m
[0;32mI (596) wifi:wifi certification version: v7.0[0m
[0;32mI (596) wifi:config NVS flash: enabled[0m
[0;32mI (606) wifi:config nano formatting: disabled[0m
[0;32mI (606) wifi:Init data frame dynamic rx buffer num: 32[0m
[0;32mI (606) wifi:Init static rx mgmt buffer num: 5[0m
[0;32mI (616) wifi:Init management short buffer num: 32[0m
[0;32mI (616) wifi:Init dynamic tx buffer num: 32[0m
[0;32mI (626) wifi:Init static tx FG buffer num: 2[0m
[0;32mI (626) wifi:Init static rx buffer size: 1600[0m
[0;32mI (626) wifi:Init static rx buffer num: 10[0m
[0;32mI (636) wifi:Init dynamic rx buffer num: 32[0m
[999C [6n I (646) wifi_init: rx ba win: 6
[0;32mI (646) wifi_init: accept mbox: 6[0m
[0;32mI (646) wifi_init: tcpip mbox: 32[0m
[0;32mI (646) wifi_init: udp mbox: 6[0m
[0;32mI (646) wifi_init: tcp mbox: 6[0m
[0;32mI (656) wifi_init: tcp tx win: 5760[0m
[0;32mI (656) wifi_init: tcp rx win: 5760[0m
[0;32mI (656) wifi_init: tcp mss: 1440[0m
[0;32mI (656) wifi_init: WiFi IRAM OP enabled[0m
[0;32mI (676) wifi_init: WiFi RX IRAM OP enabled[0m
[0;32mI (686) chip[DL]: NVS set: chip-counters/reboot-count = 2 (0x2)[0m
[130DI (686) chip[DL]: > Real time clock set to 946684800 (2000-01-01 00:00:00 UTC)
[0;32mI (696) BLE_INIT: BT controller compile version [d74042a][0m
[0;32mI (696) app-task: App Task started[0m
[0;32mI (696) main_task: Returned from app_main()[0m
[0;32mI (696) BLE_INIT: Bluetooth MAC: 70:04:1d:14:f7:8e[0m
[0;32mI (706) phy_init: phy_version 1200,2b7123f9,Feb 18 2025,15:22:21[0m
[0;32mI (736) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (746) CHIP[DL]: BLE host-controller synced[0m
[0;32mI (1246) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1246) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1246) NimBLE: disc_mode=2[0m
[0;32mI (1256) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1256) NimBLE: [0m

[0;32mI (1266) chip[DL]: CHIPoBLE advertising started[0m
[0;32mI (1266) chip[DL]: Starting ESP WiFi layer[0m
[0;32mI (1266) wifi:mode : sta (70:04:1d:14:f7:8c)[0m
[0;32mI (1266) wifi:enable tsf[0m
[0;32mI (1266) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 43[0m
[0;32mI (1286) chip[DL]: Posting ESPSystemEvent: Wifi Event with eventId : 2[0m
[0;33mW (1286) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1296) chip[DL]: Done driving station state, nothing else to do...[0m
[0;33mW (1296) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1306) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1306) chip[SVR]: SetupQRCode: [MT:Y.K9042C00KA0648G00][0m
[0;32mI (1316) chip[SVR]: Copy/paste the below URL in a browser to see the QR Code:[0m
[0;32mI (1316) chip[SVR]: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AY.K9042C00KA0648G00[0m
[0;32mI (1326) chip[SVR]: Manual pairing code: [34970112332][0m
[0;32mI (1346) chip[SVR]: Initializing subscription resumption storage...[0m
[0;32mI (1346) chip[SVR]: Server initializing...[0m
[0;32mI (1346) chip[TS]: Last Known Good Time: 2023-10-14T01:16:48[0m
[0;32mI (1356) chip[DMG]: AccessControl: initializing[0m
[0;32mI (1356) chip[DMG]: Examples::AccessControlDelegate::Init[0m
[0;32mI (1356) chip[DMG]: AccessControl: setting[0m
[0;32mI (1366) chip[DMG]: DefaultAclStorage: initializing[0m
[0;32mI (1366) chip[DMG]: DefaultAclStorage: 0 entries loaded[0m
[0;32mI (1396) chip[ZCL]: Using ZAP configuration...[0m
[0;32mI (1406) chip[DMG]: AccessControlCluster: initializing[0m
[0;32mI (1406) chip[ZCL]: Initiating Admin Commissioning cluster.[0m
[0;32mI (1406) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x2b', EndPoint ID: '0x0', Attribute ID: '0x0'[0m
[0;32mI (1416) light-app-callbacks: Unhandled cluster ID: 43[0m
[0;32mI (1416) light-app-callbacks: Current free heap: 49300[0m

[0;32mI (1426) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0x0'[0m
[0;32mI (1436) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1436) light-app-callbacks: Current free heap: 49300[0m

[0;32mI (1446) light-app-callbacks: PostAttributeChangeCallback - Cluster ID: '0x4', EndPoint ID: '0x1', Attribute ID: '0xfffc'[0m
[0;32mI (1466) light-app-callbacks: Unhandled cluster ID: 4[0m
[0;32mI (1466) light-app-callbacks: Current free heap: 49300[0m

[0;32mI (1466) light-app-callbacks: emberAfOnOffClusterInitCallback[0m
[0;32mI (1476) app-task: Writing to OnOff cluster[0m
[0;32mI (1476) app-task: Writing to Current Level cluster[0m
[1;31mE (1486) app-task: Updating level cluster failed: 87[0m
[0;32mI (1486) chip[ZCL]: Endpoint 1 On/off already set to new value[0m
[0;32mI (1496) chip[DIS]: Updating services using commissioning mode 1[0m
[0;32mI (1496) chip[DIS]: CHIP minimal mDNS started advertising.[0m
[0;32mI (1506) chip[DIS]: Advertise commission parameter vendorID=65521 productID=32768 discriminator=3840/15 cm=1 cp=0[0m
[0;32mI (1516) chip[DIS]: CHIP minimal mDNS configured as 'Commissionable node device'; instance name: 4019A71F28BA20B8.[0m
[0;32mI (1526) chip[DIS]: mDNS service published: _matterc._udp[0m
[0;32mI (1526) chip[IN]: CASE Server enabling CASE session setups[0m
[0;32mI (1536) chip[SVR]: Joining Multicast groups[0m
[0;32mI (1536) chip[SVR]: Server Listening...[0m
[0;32mI (1536) app-devicecallbacks: Current free heap: Internal: 48536/202028 External: 0/0[0m
[0;32mI (1556) app-devicecallbacks: Current free heap: Internal: 48536/202028 External: 0/0[0m
[0;32mI (1556) chip[DL]: WIFI_EVENT_STA_START[0m
[0;33mW (1566) wifi:Haven't to connect to a suitable AP now![0m
[0;32mI (1566) chip[DL]: Done driving station state, nothing else to do...[0m
[0;32mI (1576) app-devicecallbacks: Current free heap: Internal: 48536/202028 External: 0/0[0m
[0;32mI (1576) chip[DL]: Configuring CHIPoBLE advertising (interval 25 ms, connectable)[0m
[0;32mI (1586) chip[DL]: Device already advertising, stop active advertisement and restart[0m
[0;32mI (1586) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (1606) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (1606) NimBLE: disc_mode=2[0m
[0;32mI (1606) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=40 adv_itvl_max=40[0m
[0;32mI (1616) NimBLE: [0m

[0;32mI (31496) chip[DL]: bleAdv Timeout : Start slow advertisement[0m
[0;32mI (31496) chip[DL]: Configuring CHIPoBLE advertising (interval 500 ms, connectable)[0m
[0;32mI (31506) chip[DL]: Device already advertising, stop active advertisement and restart[0m
[0;32mI (31516) NimBLE: GAP procedure initiated: stop advertising.[0m

[0;32mI (31526) NimBLE: GAP procedure initiated: advertise; [0m
[0;32mI (31526) NimBLE: disc_mode=2[0m
[0;32mI (31526) NimBLE:  adv_channel_map=0 own_addr_type=1 adv_filter_policy=0 adv_itvl_min=800 adv_itvl_max=800[0m
[0;32mI (31536) NimBLE: [0m

Done
```
</details>
<!-- END: Memory Results for esp32c2 -->






