### PR TITLE
Define LogModule enum using CHIP_LOGMODULES_ENUMERATE x-macros helper

### DIFF
--- a/src/lib/support/logging/Constants.h
+++ b/src/lib/support/logging/Constants.h
@@ -7,6 +7,8 @@ namespace Logging {
 
 // X-Macro style enumeration of log modules and associated short names
 // Note: For any module added here, a CHIP_CONFIG_LOG_MODULE_* macro needs to be defined below.
+// This list is used to generate the array of strings backing GetModuleName(), and can also
+// be used by platform-specific code, e.g. Darwin generates an array of non-abbreviated names.
 #define CHIP_LOGMODULES_ENUMERATE(X)                                                                                               \
     X(NotSpecified, "-")                                                                                                           \
     X(Inet, "IN")                                                                                                                  \

--- a/src/lib/support/logging/Constants.h
+++ b/src/lib/support/logging/Constants.h
@@ -5,6 +5,53 @@
 namespace chip {
 namespace Logging {
 
+// X-Macro style enumeration of log modules and associated short names
+// Note: For any module added here, a CHIP_CONFIG_LOG_MODULE_* macro needs to be defined below.
+#define CHIP_LOGMODULES_ENUMERATE(X)                                                                                               \
+    X(NotSpecified, "-")                                                                                                           \
+    X(Inet, "IN")                                                                                                                  \
+    X(Ble, "BLE")                                                                                                                  \
+    X(MessageLayer, "ML")                                                                                                          \
+    X(SecurityManager, "SM")                                                                                                       \
+    X(ExchangeManager, "EM")                                                                                                       \
+    X(TLV, "TLV")                                                                                                                  \
+    X(ASN1, "ASN")                                                                                                                 \
+    X(Crypto, "CR")                                                                                                                \
+    X(Controller, "CTL")                                                                                                           \
+    X(Alarm, "AL")                                                                                                                 \
+    X(SecureChannel, "SC")                                                                                                         \
+    X(BDX, "BDX")                                                                                                                  \
+    X(DataManagement, "DMG")                                                                                                       \
+    X(DeviceControl, "DC")                                                                                                         \
+    X(DeviceDescription, "DD")                                                                                                     \
+    X(Echo, "ECH")                                                                                                                 \
+    X(FabricProvisioning, "FP")                                                                                                    \
+    X(NetworkProvisioning, "NP")                                                                                                   \
+    X(ServiceDirectory, "SD")                                                                                                      \
+    X(ServiceProvisioning, "SP")                                                                                                   \
+    X(SoftwareUpdate, "SWU")                                                                                                       \
+    X(FailSafe, "FS")                                                                                                              \
+    X(TimeService, "TS")                                                                                                           \
+    X(Heartbeat, "HB")                                                                                                             \
+    X(chipSystemLayer, "CSL")                                                                                                      \
+    X(EventLogging, "EVL")                                                                                                         \
+    X(Support, "SPT")                                                                                                              \
+    X(chipTool, "TOO")                                                                                                             \
+    X(Zcl, "ZCL")                                                                                                                  \
+    X(Shell, "SH")                                                                                                                 \
+    X(DeviceLayer, "DL")                                                                                                           \
+    X(SetupPayload, "SPL")                                                                                                         \
+    X(AppServer, "SVR")                                                                                                            \
+    X(Discovery, "DIS")                                                                                                            \
+    X(InteractionModel, "IM")                                                                                                      \
+    X(Test, "TST")                                                                                                                 \
+    X(OperationalSessionSetup, "OSS")                                                                                              \
+    X(Automation, "ATM")                                                                                                           \
+    X(CASESessionManager, "CSM")                                                                                                   \
+    X(ICD, "ICD")                                                                                                                  \
+    X(FabricSync, "FS")                                                                                                            \
+    X(WiFiPAF, "PAF")
+
 /**
  *  @enum LogModule
  *
@@ -18,52 +65,9 @@ namespace Logging {
  */
 enum LogModule
 {
-    kLogModule_NotSpecified = 0,
-
-    kLogModule_Inet,
-    kLogModule_Ble,
-    kLogModule_MessageLayer,
-    kLogModule_SecurityManager,
-    kLogModule_ExchangeManager,
-    kLogModule_TLV,
-    kLogModule_ASN1,
-    kLogModule_Crypto,
-    kLogModule_Controller,
-    kLogModule_Alarm,
-    kLogModule_SecureChannel,
-    kLogModule_BDX,
-    kLogModule_DataManagement,
-    kLogModule_DeviceControl,
-    kLogModule_DeviceDescription,
-    kLogModule_Echo,
-    kLogModule_FabricProvisioning,
-    kLogModule_NetworkProvisioning,
-    kLogModule_ServiceDirectory,
-    kLogModule_ServiceProvisioning,
-    kLogModule_SoftwareUpdate,
-    kLogModule_FailSafe,
-    kLogModule_TimeService,
-    kLogModule_Heartbeat,
-    kLogModule_chipSystemLayer,
-    kLogModule_EventLogging,
-    kLogModule_Support,
-    kLogModule_chipTool,
-    kLogModule_Zcl,
-    kLogModule_Shell,
-    kLogModule_DeviceLayer,
-    kLogModule_SetupPayload,
-    kLogModule_AppServer,
-    kLogModule_Discovery,
-    kLogModule_InteractionModel,
-    kLogModule_Test,
-    kLogModule_OperationalSessionSetup,
-    kLogModule_Automation,
-    kLogModule_CASESessionManager,
-    kLogModule_ICD,
-    kLogModule_FabricSync,
-    kLogModule_WiFiPAF,
-
-    kLogModule_Max
+#define _CHIP_LOGMODULE_ENUM_DECL(MOD, ...) kLogModule_##MOD,
+    CHIP_LOGMODULES_ENUMERATE(_CHIP_LOGMODULE_ENUM_DECL) //
+    kLogModule_Max                                       // marker value
 };
 
 /* Log modules enablers. Those definitions can be overwritten with 0 to disable

--- a/src/lib/support/logging/TextOnlyLogging.cpp
+++ b/src/lib/support/logging/TextOnlyLogging.cpp
@@ -104,54 +104,11 @@ namespace {
 std::atomic<LogRedirectCallback_t> sLogRedirectCallback{ nullptr };
 
 /*
- * Array of strings containing the names for each of the chip log modules.
- *
- * NOTE: The names must be in the order defined in the LogModule enumeration.
+ * Array of strings containing the short names for each of the chip log modules.
  */
 static const char ModuleNames[kLogModule_Max][kMaxModuleNameLen + 1] = {
-    "-",   // None
-    "IN",  // Inet
-    "BLE", // BLE
-    "ML",  // MessageLayer
-    "SM",  // SecurityManager
-    "EM",  // ExchangeManager
-    "TLV", // TLV
-    "ASN", // ASN1
-    "CR",  // Crypto
-    "CTL", // Controller
-    "AL",  // Alarm
-    "SC",  // SecureChannel
-    "BDX", // BulkDataTransfer
-    "DMG", // DataManagement
-    "DC",  // DeviceControl
-    "DD",  // DeviceDescription
-    "ECH", // Echo
-    "FP",  // FabricProvisioning
-    "NP",  // NetworkProvisioning
-    "SD",  // ServiceDirectory
-    "SP",  // ServiceProvisioning
-    "SWU", // SoftwareUpdate
-    "FS",  // FailSafe
-    "TS",  // TimeService
-    "HB",  // Heartbeat
-    "CSL", // chipSystemLayer
-    "EVL", // Event Logging
-    "SPT", // Support
-    "TOO", // chipTool
-    "ZCL", // Zcl
-    "SH",  // Shell
-    "DL",  // DeviceLayer
-    "SPL", // SetupPayload
-    "SVR", // AppServer
-    "DIS", // Discovery
-    "IM",  // InteractionModel
-    "TST", // Test
-    "OSS", // OperationalSessionSetup
-    "ATM", // Automation
-    "CSM", // CASESessionManager
-    "ICD", // ICD
-    "FS",  // FabricSync
-    "PAF", // WiFiPAF
+#define _CHIP_LOGMODULE_NAME_INIT(MOD, NAME, ...) NAME,
+    CHIP_LOGMODULES_ENUMERATE(_CHIP_LOGMODULE_NAME_INIT)
 };
 
 } // namespace


### PR DESCRIPTION
This avoids having to maintain the list of names separately, and lets platform logging code use CHIP_LOGMODULES_ENUMERATE to generate similar lists.

#### Testing

Existing CI tests.