### PR TITLE
[ESP32]: Fix the build failure with esp32 ble controller enabled.

### DIFF
--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -25,6 +25,11 @@
 
 #pragma once
 #include <sdkconfig.h>
+#include <string>
+
+#if CONFIG_BT_NIMBLE_ENABLED
+#include <vector>
+#endif
 
 #include <lib/core/Optional.h>
 


### PR DESCRIPTION
#### Problem
- The lighting-app esp32 build was failing when `CONFIG_ENABLE_ESP32_BLE_CONTROLLER` was enabled in the firmware post https://github.com/project-chip/connectedhomeip/pull/38067.

#### Change Overview
- Added the missing string header to fix the compilation.

#### Testing
- Tested the lighting-app esp32 with `CONFIG_ENABLE_ESP32_BLE_CONTROLLER=y` in menuconfig.
- Verified the resolution of compilation failure with the changes.
Steps:
```
cd /path/to/examples/lighting-app/esp32
idf.py set-target esp32s3
idf.py menuconfig --> Enable CONFIG_ENABLE_ESP32_BLE_CONTROLLER=y in menuconfig. Save and exit.
idf.py build
idf.py flash monitor
```