### PR TITLE
OpenThread: Guard ClearAllSrpHostAndServices with CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT.

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -179,3 +179,6 @@ jobs:
 
             - name: Build example Lock App (Target:ESP32C6)
               run: scripts/examples/esp_example.sh lock-app sdkconfig.defaults esp32c6
+
+            - name: Build example thread-br-app (Target:ESP32S3)
+              run: scripts/examples/esp_example.sh thread-br-app sdkconfig.defaults esp32s3

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -119,7 +119,9 @@ CHIP_ERROR GenericThreadDriver::RevertConfiguration()
     // since the fail-safe was armed, so return with no error.
     VerifyOrReturnError(error != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     ThreadStackMgrImpl().ClearAllSrpHostAndServices();
+#endif
 
     if (!GetEnabled())
     {


### PR DESCRIPTION
#### Problem
- The guard for` ClearAllSrpHostAndServices` was missing post #38053 as done in #36284. 
- The thread br app esp32 build was failing due to missing guard.

#### Change Overview
-  Added the guard for `ClearAllSrpHostAndServices` with `CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT.`
-  Added the `thread-br-app esp32 `in CI testing for `esp32s3 `target.

#### Testing
- Tested the thread br app esp32 for resolution of compilation failure post the changes.
- Steps:
```
cd /path/to/examples/thread-br-app/esp32
idf.py set target esp32s3
idf.py build
```

