### PR TITLE
Python framework : Removed on-network-ip from commisioning and CLI arguments.

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
@@ -117,10 +117,6 @@ async def commission_device(
     Returns:
         True if the commissioning process completes successfully. False otherwise,
         except in case of an error which logs the exception details.
-
-    Note:
-        The "on-network-ip" method is deprecated as it's not supported in long-term
-        environments.
     """
 
     if commissioning_info.tc_version_to_simulate is not None and commissioning_info.tc_user_response_to_simulate is not None:
@@ -160,18 +156,6 @@ async def commission_device(
                 node_id,
                 commissioning_info.thread_operational_dataset,
                 isShortDiscriminator=(info.filter_type == DiscoveryFilterType.SHORT_DISCRIMINATOR),
-            )
-            return True
-        except ChipStackError as e:
-            logging.error("Commissioning failed: %s" % e)
-            return False
-    elif commissioning_info.commissioning_method == "on-network-ip":
-        try:
-            logging.warning("==== USING A DIRECT IP COMMISSIONING METHOD NOT SUPPORTED IN THE LONG TERM ====")
-            await dev_ctrl.CommissionIP(
-                ipaddr=commissioning_info.commissionee_ip_address_just_for_testing,
-                setupPinCode=info.passcode,
-                nodeid=node_id,
             )
             return True
         except ChipStackError as e:

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1923,11 +1923,11 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
 
     commission_group.add_argument('-m', '--commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
+                                  choices=["on-network", "ble-wifi", "ble-thread"],
                                   help='Name of commissioning method to use')
     commission_group.add_argument('--in-test-commissioning-method', type=str,
                                   metavar='METHOD_NAME',
-                                  choices=["on-network", "ble-wifi", "ble-thread", "on-network-ip"],
+                                  choices=["on-network", "ble-wifi", "ble-thread"],
                                   help='Name of commissioning method to use, for commissioning tests')
     commission_group.add_argument('-d', '--discriminator', type=int_decimal_or_hex,
                                   metavar='LONG_DISCRIMINATOR',
@@ -1939,9 +1939,6 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
                                   dest='passcodes',
                                   default=[],
                                   help='PAKE passcode to use', nargs="+")
-    commission_group.add_argument('-i', '--ip-addr', type=str,
-                                  metavar='RAW_IP_ADDRESS',
-                                  help='IP address to use (only for method "on-network-ip". ONLY FOR LOCAL TESTING!', nargs="+")
 
     commission_group.add_argument('--wifi-ssid', type=str,
                                   metavar='SSID',


### PR DESCRIPTION
Remove on-network-ip form commissioning and CLI arguments.

#### Testing


Removed the option **on-network-ip** from the mattertesting CLI arguments.
Removed on-network-ip code block wich call the on-network-ip commissioning.

For this change I prefer to first remove the commissioning from the matterbasetesting.

A new issue and PR must be created to remove from the ip commissioning from the connectedhomeip/src/controller/python/chip/ChipDeviceCtrl.py file, this will lead to remove and adjust the other files that will  affect the Cirque tests.


###Fixes https://github.com/project-chip/matter-test-scripts/issues/532


