### PR TITLE
[camera-controller] Create a new WebRTCSessionStruct upon receiving ProvideOfferResponse command

### DIFF
--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -85,7 +85,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
 
     chip::ScopedNodeId peerId(nodeId, fabricIndex);
 
-    mWebRTCProviderClient.Init(peerId, endpointId);
+    mWebRTCProviderClient.Init(peerId, endpointId, &mWebRTCRequestorServer);
 
     rtc::InitLogger(rtc::LogLevel::Warning);
 
@@ -185,24 +185,4 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t webRTCSessionID)
     }
 
     return err;
-}
-
-void WebRTCManager::HandleProvideOfferResponse(TLV::TLVReader & data)
-{
-    ChipLogProgress(Camera, "WebRTCManager::HandleProvideOfferResponse.");
-}
-
-void WebRTCManager::HandleCommandResponse(const ConcreteCommandPath & path, TLV::TLVReader & data)
-{
-    ChipLogProgress(Camera, "Command Response received.");
-
-    // TODO: Upon receiving, the client SHALL create a new WebRTCSessionStruct populated with the values from this command, along
-    // with the accessing Peer Node ID and Local Fabric Index entries stored in the Secure Session Context, as the PeerNodeID and
-    // FabricIndex values, and store in the Requestor clusters CurrentSessions.
-    if (path.mClusterId == Clusters::WebRTCTransportProvider::Id &&
-        path.mCommandId == Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::Id)
-    {
-        VerifyOrDie(path.mEndpointId == kWebRTCRequesterDynamicEndpointId);
-        HandleProvideOfferResponse(data);
-    }
 }

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.h
@@ -44,14 +44,10 @@ public:
 
     CHIP_ERROR ProvideICECandidates(uint16_t webRTCSessionID);
 
-    void HandleCommandResponse(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader & data);
-
 private:
     // Make the constructor private to enforce the singleton pattern
     WebRTCManager();
     ~WebRTCManager();
-
-    void HandleProvideOfferResponse(chip::TLV::TLVReader & data);
 
     chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer mWebRTCRequestorServer;
 

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -104,7 +104,7 @@ void WebRTCProviderClient::OnResponse(CommandSender * client, const ConcreteComm
     {
         if (data == nullptr)
         {
-            ChipLogError(NotSpecified, "Response Failure: data is null");
+            ChipLogError(Camera, "Response Failure: data is null");
             return;
         }
 
@@ -171,13 +171,13 @@ void WebRTCProviderClient::OnDeviceConnectionFailure(void * context, const Scope
 
 void WebRTCProviderClient::HandleProvideOfferResponse(TLV::TLVReader & data)
 {
-    ChipLogProgress(NotSpecified, "WebRTCProviderClient::HandleProvideOfferResponse.");
+    ChipLogProgress(Camera, "WebRTCProviderClient::HandleProvideOfferResponse.");
 
     Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::DecodableType value;
     CHIP_ERROR error = app::DataModel::Decode(data, value);
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(NotSpecified, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
+        ChipLogError(Camera, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
         return;
     }
 
@@ -188,7 +188,7 @@ void WebRTCProviderClient::HandleProvideOfferResponse(TLV::TLVReader & data)
     session.fabricIndex    = mPeerId.GetFabricIndex();
     session.peerEndpointID = mEndpointId;
 
-    //TODO:: spec needs to clarify how to set streamUsage here
+    // TODO:: spec needs to clarify how to set streamUsage here
 
     // Populate optional fields for video/audio stream IDs if present; set them to Null otherwise
     if (value.videoStreamID.HasValue())
@@ -211,7 +211,7 @@ void WebRTCProviderClient::HandleProvideOfferResponse(TLV::TLVReader & data)
 
     if (mRequestorServer == nullptr)
     {
-        ChipLogError(NotSpecified, "WebRTCProviderClient is not initialized");
+        ChipLogError(Camera, "WebRTCProviderClient is not initialized");
         return;
     }
 

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
@@ -20,6 +20,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandSender.h>
+#include <app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h>
 #include <controller/CHIPDeviceController.h>
 
 /**
@@ -42,11 +43,15 @@ public:
     {}
 
     /**
-     * @brief Initializes the WebRTCProviderClient with a ScopedNodeId, and EndpointId.
-     * @param peerId         The PeerId (fabric + nodeId) for the remote device.
-     * @param endpointId     The Matter endpoint on the remote device for WebRTCTransportProvider cluster.
+     * @brief Initializes the WebRTCProviderClient with a ScopedNodeId, an EndpointId, and an optional
+     *        pointer to the WebRTCTransportRequestorServer.
+     *
+     * @param peerId              The PeerId (fabric + nodeId) for the remote device.
+     * @param endpointId          The Matter endpoint on the remote device for WebRTCTransportProvider cluster.
+     * @param requestorServer     Pointer to a WebRTCTransportRequestorServer instance.
      */
-    void Init(const chip::ScopedNodeId & peerId, chip::EndpointId endpointId);
+    void Init(const chip::ScopedNodeId & peerId, chip::EndpointId endpointId,
+              chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer * requestorServer);
 
     /**
      * @brief Sends a ProvideOffer command to the remote device.
@@ -140,11 +145,15 @@ private:
                                   const chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
+    void HandleProvideOfferResponse(chip::TLV::TLVReader & data);
+
     // Private data members
     chip::ScopedNodeId mPeerId;
     chip::EndpointId mEndpointId = chip::kInvalidEndpointId;
     CommandType mCommandType     = CommandType::kUndefined;
     std::unique_ptr<chip::app::CommandSender> mCommandSender;
+
+    chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorServer * mRequestorServer = nullptr;
 
     // Data needed to send the WebRTCTransportProvider commands
     chip::app::Clusters::WebRTCTransportProvider::Commands::ProvideOffer::Type mProvideOfferData;

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp
@@ -257,12 +257,6 @@ void WebRTCTransportRequestorServer::HandleAnswer(HandlerContext & ctx, const Co
     uint16_t sessionId = req.webRTCSessionID;
     auto sdpSpan       = req.sdp;
 
-    // BUG: https://github.com/project-chip/connectedhomeip/issues/38212
-    // FIXME: This Bug has been raised to discuss with dev team about how to handle this issue.
-    // WebRTCRequestorServer shall provide an API to update mCurrentSessions, but whether delegate
-    // can have write access to WebRTCRequestorServer's mCurrentSessions is still under discussion.
-    // For now, we just validate the sdp as mentioned in the specification.
-
     // Check if the session, NodeID are valid
     if (!IsPeerNodeSessionValid(sessionId, ctx))
     {

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h
@@ -107,6 +107,12 @@ public:
 class WebRTCTransportRequestorServer : private AttributeAccessInterface, private CommandHandlerInterface
 {
 public:
+    enum class UpsertResultEnum : uint8_t
+    {
+        kInserted = 0x00,
+        kUpdated  = 0x01,
+    };
+
     /**
      * @brief
      *  Creates a WebRTCTransportRequestorServer instance with a given endpoint and delegate.
@@ -144,13 +150,16 @@ public:
      */
     std::vector<WebRTCSessionTypeStruct> GetCurrentSessions() const { return mCurrentSessions; }
 
-private:
-    enum class UpsertResultEnum : uint8_t
-    {
-        kInserted = 0x00,
-        kUpdated  = 0x01,
-    };
+    /**
+     * @brief
+     * Inserts a new session or updates an existing one based on session ID.
+     *
+     * @param session The session data to insert or update.
+     * @return kInserted if a new session was added, kUpdated if an existing one was modified.
+     */
+    UpsertResultEnum UpsertSession(const WebRTCSessionTypeStruct & session); // Now public
 
+private:
     WebRTCTransportRequestorDelegate & mDelegate;
     std::vector<WebRTCSessionTypeStruct> mCurrentSessions;
 
@@ -162,7 +171,6 @@ private:
 
     // Helper functions
     WebRTCSessionTypeStruct * FindSession(uint16_t sessionId);
-    UpsertResultEnum UpsertSession(const WebRTCSessionTypeStruct & session);
     uint16_t GenerateSessionId();
     void RemoveSession(uint16_t sessionId);
     bool IsPeerNodeSessionValid(uint16_t sessionId, HandlerContext & ctx);


### PR DESCRIPTION
```
11.5.6.4. ProvideOfferResponse Command
This command contains information about the session and streams created as a response to the requestor’s offer.

Upon receiving, the client SHALL create a new WebRTCSessionStruct populated with the values from this command, along with the accessing Peer Node ID and Local Fabric Index entries stored in the Secure Session Context, as the PeerNodeID and FabricIndex values, and store in the Requestor clusters CurrentSessions.
```
Per spec, camera-controller need to create a new WebRTCSessionStruct upon receiving ProvideOfferResponse command and store in the Requestor clusters CurrentSessions.

Fix: #38212

#### Testing

 **Launch the Camera Application:** 
Open a terminal console.
Execute the command: ./chip-camera-app

 **Launch the Camera Controller:**
Open a separate terminal console.
Execute the command: ./chip-camera-controller

**Commission the Camera Device:**
In the controller console, initiate the commissioning process using the pairing code.
`>>> pairing code 1 34970312332`

**Initiate WebRTC Connection and SDP Offer:**
In the controller console, start the normal flow to establish a WebRTC connection.
Execute the commands sequentially:
```
>>> webrtc connect
>>> webrtc provide-offer
```
