### PR TITLE
python: Fix bootstrap on python 3.13

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -141,7 +141,7 @@ packaging==23.0
     #   ghapi
     #   idf-component-manager
     #   west
-pandas==2.1.4 ; platform_machine != "aarch64" and platform_machine != "arm64"
+pandas==2.2.3 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.memory.txt
 parso==0.8.3
     # via jedi


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/37712

#### Testing

Tested on fedora:41 container and the ubuntu devcontainer with the following commands:

```shell
$ source scripts/bootstrap.sh 
$ source scripts/activate.sh
$ scripts/build_python.sh -b true -d true -m minimal -i venv -j
$ venv/bin/python3
>>> import chip
>>>
```
