### PR TITLE
examples, docs: Harmonize --ble-controller in all examples and documentation

### DIFF
--- a/docs/development_controllers/chip-repl/python_chip_controller_advanced_usage.md
+++ b/docs/development_controllers/chip-repl/python_chip_controller_advanced_usage.md
@@ -7,9 +7,9 @@ tool or Matter accessories on Linux.
 
 <hr>
 
--   [Using Python CHIP Controller advanced features](#using-python-chip-controller-advanced-features)
-    -   [Bluetooth LE virtualization on Linux](#bluetooth-le-virtualization-on-linux)
-    -   [Debugging with gdb](#debugging-with-gdb)
+- [Using Python CHIP Controller advanced features](#using-python-chip-controller-advanced-features)
+  - [Bluetooth LE virtualization on Linux](#bluetooth-le-virtualization-on-linux)
+  - [Debugging with gdb](#debugging-with-gdb)
 
 <hr>
 
@@ -66,11 +66,11 @@ interfaces working as Bluetooth LE central and peripheral, respectively.
 4. Run the Python CHIP Controller REPL with Bluetooth LE adapter defined from a
    command line:
 
-    For example, add `--ble-adapter=2` to use the virtual interface `hci2`
+    For example, add `--ble-controller=2` to use the virtual interface `hci2`
     listed above.
 
     ```
-    chip-repl --ble-adapter=2
+    chip-repl --ble-controller=2
     ```
 
 <hr>

--- a/docs/development_controllers/chip-repl/python_chip_controller_advanced_usage.md
+++ b/docs/development_controllers/chip-repl/python_chip_controller_advanced_usage.md
@@ -7,9 +7,9 @@ tool or Matter accessories on Linux.
 
 <hr>
 
-- [Using Python CHIP Controller advanced features](#using-python-chip-controller-advanced-features)
-  - [Bluetooth LE virtualization on Linux](#bluetooth-le-virtualization-on-linux)
-  - [Debugging with gdb](#debugging-with-gdb)
+-   [Using Python CHIP Controller advanced features](#using-python-chip-controller-advanced-features)
+    -   [Bluetooth LE virtualization on Linux](#bluetooth-le-virtualization-on-linux)
+    -   [Debugging with gdb](#debugging-with-gdb)
 
 <hr>
 

--- a/docs/development_controllers/chip-tool/chip_tool_guide.md
+++ b/docs/development_controllers/chip-tool/chip_tool_guide.md
@@ -649,7 +649,7 @@ $ ./chip-tool onoff on
 ```bash
 [1647417976.556313][404456:404456] CHIP:TOO: InitArgs: Wrong arguments number: 0 instead of 2
 Usage:
-  ./chip-tool onoff on node-id/group-id endpoint-id-ignored-for-group-commands [--paa-trust-store-path] [--commissioner-name] [--trace_file] [--trace_log] [--ble-adapter] [--timedInteractionTimeoutMs] [--suppressResponse]
+  ./chip-tool onoff on node-id/group-id endpoint-id-ignored-for-group-commands [--paa-trust-store-path] [--commissioner-name] [--trace_file] [--trace_log] [--ble-controller] [--timedInteractionTimeoutMs] [--suppressResponse]
 [1647417976.556362][404456:404456] CHIP:TOO: Run command failure: ../../examples/chip-tool/commands/common/Commands.cpp:135: Error 0x0000002F
 
 ```
@@ -661,21 +661,15 @@ command.
 
 ##### Choosing the Bluetooth adapter
 
-To choose the Bluetooth adapter used by the CHIP Tool, use the following command
-pattern:
-
-```
---ble-adapter <id>
-```
-
-In this command:
-
--   _<id\>_ is the ID of HCI device.
+To choose the Bluetooth adapter used by the CHIP Tool, use the
+`--ble-controller <selector>` switch where selector syntax is platform-specific.
+For Linux it's documented in
+[Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 **Example of usage:**
 
 ```
-$ ./chip-tool pairing ble-thread 1 hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 20202021 3840 --ble-adapter 0
+$ ./chip-tool pairing ble-thread 1 hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 20202021 3840 --ble-controller 2
 ```
 
 ##### Using message tracing

--- a/docs/platforms/index.md
+++ b/docs/platforms/index.md
@@ -10,6 +10,7 @@ asr/index
 bouffalolab/index
 esp32/index
 infineon/index
+linux/index
 mbedos/index
 nrf/index
 nxp/index
@@ -25,6 +26,7 @@ ti/index
 -   [Bouffalo Lab](./bouffalolab)
 -   [ESP32](./esp32/)
 -   [Infineon](./infineon/)
+-   [Linux](./linux/)
 -   [MbedOS](./mbedos/)
 -   [NRF](./nrf/)
 -   [NXP](./nxp/)

--- a/docs/platforms/linux/ble_settings.md
+++ b/docs/platforms/linux/ble_settings.md
@@ -1,0 +1,29 @@
+# Bluetooth Low Energy (BLE)
+
+For Linux systems that use the bluez Bluetooth stack the
+`--ble-controller <selector>` CLI argument expects a single integer to identify
+Bluetooth controllers connected to the system. Specifically, the number after
+`hci` is the selector. For example, when `hciconfig` returns the following:
+
+```
+$ hciconfig
+hci0:	Type: Primary  Bus: UART
+    BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+    UP RUNNING PSCAN ISCAN
+    RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
+    TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+
+hci1:	Type: Primary  Bus: USB
+    BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
+    UP RUNNING PSCAN ISCAN
+    RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
+    TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+```
+
+`hci0` will be selected by default or when `--ble-controller 0` is specified,
+`hci1` will be selected when `--ble-controller 1` is specified on the command
+line. For example when using chip-tool:
+
+```
+$ out/linux-x64-light/chip-lighting-app --ble-controller 1  # Select hci1
+```

--- a/docs/platforms/linux/index.md
+++ b/docs/platforms/linux/index.md
@@ -1,0 +1,11 @@
+# Linux
+
+```{toctree}
+:glob:
+:maxdepth: 1
+:hidden:
+
+*
+```
+
+[BLE Settings](ble_settings.md)

--- a/docs/platforms/nxp/nxp_imx8m_linux_examples.md
+++ b/docs/platforms/nxp/nxp_imx8m_linux_examples.md
@@ -23,10 +23,10 @@ Linux OS development. For more information about this project, see the
 
 <hr>
 
--   [Building and Running CHIP Linux Examples for i.MX 8M Mini EVK](#building-and-running-chip-linux-examples-for-imx-8m-mini-evk)
-    -   [Building](#building)
-    -   [Commandline arguments](#commandline-arguments)
-    -   [Running the Examples on i.MX 8M Mini EVK](#running-the-examples-on-imx-8m-mini-evk)
+- [Building and Running CHIP Linux Examples for i.MX 8M Mini EVK](#building-and-running-chip-linux-examples-for-imx-8m-mini-evk)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Examples on i.MX 8M Mini EVK](#running-the-examples-on-imx-8m-mini-evk)
 
 <hr>
 
@@ -190,13 +190,11 @@ The generated executable files supports to work with below commandline argument:
     The Wi-Fi device on **i.MX 8M Mini EVK** is a module based on the NXP
     88W8987 Wi-Fi/Bluetooth SoC.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use the specific Bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces using the
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
     The BLE device on **i.MX 8M Mini EVK** is a module based on the NXP 88W8987
     Wi-Fi/Bluetooth SoC.
@@ -264,23 +262,13 @@ Thermostat-app is used as an example below.
               hciattach /dev/ttymxc0 any 115200 flow              # Initialize the BT device
               ```
 
-    -   Find the Bluetooth device id for **i.MX 8M Mini EVK** by executing the
-        command below. The number following string `hci` is the Bluetooth device
-        id, `0` in this example.
-
-              ```
-              $ hciconfig
-              hci0:   Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:DA:71:13  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING
-                      RX bytes:73311 acl:1527 sco:0 events:3023 errors:0
-                      TX bytes:48805 acl:1459 sco:0 commands:704 errors:0
-              ```
+    -   Find the Bluetooth controller selector for **i.MX 8M Mini EVK**
+        according to [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
     -   Run the Linux Example App
 
               ```
-              /home/root/thermostat-app --ble-device 0 --wifi  # The bluetooth device used is hci0 and support wifi network
+              /home/root/thermostat-app --ble-controller 1 --wifi  # The bluetooth controller used is hci1 and support wifi network
               ```
 
     -   Run [ChipDeviceController](../../../src/controller/python) on the

--- a/docs/platforms/nxp/nxp_imx8m_linux_examples.md
+++ b/docs/platforms/nxp/nxp_imx8m_linux_examples.md
@@ -23,10 +23,10 @@ Linux OS development. For more information about this project, see the
 
 <hr>
 
-- [Building and Running CHIP Linux Examples for i.MX 8M Mini EVK](#building-and-running-chip-linux-examples-for-imx-8m-mini-evk)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Examples on i.MX 8M Mini EVK](#running-the-examples-on-imx-8m-mini-evk)
+-   [Building and Running CHIP Linux Examples for i.MX 8M Mini EVK](#building-and-running-chip-linux-examples-for-imx-8m-mini-evk)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Examples on i.MX 8M Mini EVK](#running-the-examples-on-imx-8m-mini-evk)
 
 <hr>
 

--- a/examples/air-purifier-app/linux/README.md
+++ b/examples/air-purifier-app/linux/README.md
@@ -16,10 +16,10 @@ details.
 
 <hr>
 
--   [CHIP Linux Air Purifier Example](#chip-linux-air-purifier-example)
-    -   [Building](#building)
-    -   [Commandline arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+- [CHIP Linux Air Purifier Example](#chip-linux-air-purifier-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 
@@ -53,13 +53,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -84,28 +82,15 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Air Purifier Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/air-purifier-app/linux
+              $ sudo out/debug/chip-air-purifier-app --ble-controller [bluetooth controller number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-air-purifier-app --ble-controller 1
 
-        -   Run Linux Air Purifier Example App
-
-                  $ cd ~/connectedhomeip/examples/air-purifier-app/linux
-                  $ sudo out/debug/chip-air-purifier-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-air-purifier-app --ble-device 1
-
-        -   Test the device using ChipTool on your laptop / workstation etc.
+    -   Test the device using ChipTool on your laptop / workstation etc.

--- a/examples/air-purifier-app/linux/README.md
+++ b/examples/air-purifier-app/linux/README.md
@@ -16,10 +16,10 @@ details.
 
 <hr>
 
-- [CHIP Linux Air Purifier Example](#chip-linux-air-purifier-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+-   [CHIP Linux Air Purifier Example](#chip-linux-air-purifier-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 

--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -12,15 +12,15 @@ details.
 
 <hr>
 
-- [Matter Linux Air Quality Example](#matter-linux-air-quality-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Trigger event using air-quality-sensor-app event named pipe](#trigger-event-using-air-quality-sensor-app-event-named-pipe)
-    - [Trigger air quality change event](#trigger-air-quality-change-event)
-    - [Trigger Temperature change event](#trigger-temperature-change-event)
-    - [Trigger Humidity change event](#trigger-humidity-change-event)
-    - [Trigger concentration change event](#trigger-concentration-change-event)
+-   [Matter Linux Air Quality Example](#matter-linux-air-quality-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Trigger event using air-quality-sensor-app event named pipe](#trigger-event-using-air-quality-sensor-app-event-named-pipe)
+        -   [Trigger air quality change event](#trigger-air-quality-change-event)
+        -   [Trigger Temperature change event](#trigger-temperature-change-event)
+        -   [Trigger Humidity change event](#trigger-humidity-change-event)
+        -   [Trigger concentration change event](#trigger-concentration-change-event)
 
 <hr>
 

--- a/examples/air-quality-sensor-app/linux/README.md
+++ b/examples/air-quality-sensor-app/linux/README.md
@@ -12,11 +12,15 @@ details.
 
 <hr>
 
--   [Matter Linux Air Quality Example](#matter-linux-air-quality-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Trigger event using air-quality-sensor-app event named pipe](#trigger-event-using-air-quality-sensor-app-event-named-pipe)
+- [Matter Linux Air Quality Example](#matter-linux-air-quality-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Trigger event using air-quality-sensor-app event named pipe](#trigger-event-using-air-quality-sensor-app-event-named-pipe)
+    - [Trigger air quality change event](#trigger-air-quality-change-event)
+    - [Trigger Temperature change event](#trigger-temperature-change-event)
+    - [Trigger Humidity change event](#trigger-humidity-change-event)
+    - [Trigger concentration change event](#trigger-concentration-change-event)
 
 <hr>
 
@@ -58,13 +62,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -87,32 +89,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Air Quality Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/air-quality-sensor-app/linux
+              $ sudo out/debug/chip-air-quality-sensor-app --ble-controller [bluetooth controller number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-air-quality-sensor-app --ble-controller 1
 
-        -   Run Linux Air Quality Example App
-
-                  $ cd ~/connectedhomeip/examples/air-quality-sensor-app/linux
-                  $ sudo out/debug/chip-air-quality-sensor-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-air-quality-sensor-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Trigger event using air-quality-sensor-app event named pipe
 

--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -8,10 +8,13 @@ Raspberry Pi Desktop 20.10 (aarch64)**
 
 <hr>
 
--   [Matter Linux Bridge Example](#matter-linux-bridge-example)
-    -   [Theory of Operation](#theory-of-operation)
-    -   [Building](#building)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+- [Matter Linux Bridge Example](#matter-linux-bridge-example)
+  - [Theory of Operation](#theory-of-operation)
+    - [Dynamic Endpoints](#dynamic-endpoints)
+    - [Limitations](#limitations)
+    - [Bridge Implementation Example](#bridge-implementation-example)
+  - [Building](#building)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 
@@ -147,33 +150,18 @@ is simulated with the value/label pair `"room"`/`[light name]`.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-            ```sh
-            $ hciconfig
-            hci1:	Type: Primary  Bus: USB
-                BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                UP RUNNING PSCAN ISCAN
-                RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Bridge Example App
 
-            hci0:	Type: Primary  Bus: UART
-                BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                UP RUNNING PSCAN ISCAN
-                RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
-            ```
+        ```sh
+        cd ~/connectedhomeip/examples/bridge-app/linux
+        sudo out/debug/chip-bridge-app --ble-controller [bluetooth controller number]
+        # In this example, the device we want to use is hci1
+        sudo out/debug/chip-bridge-app --ble-controller 1
+        ```
 
-        -   Run Linux Bridge Example App
-
-            ```sh
-            cd ~/connectedhomeip/examples/bridge-app/linux
-            sudo out/debug/chip-bridge-app --ble-device [bluetooth device number]
-            # In this example, the device we want to use is hci1
-            sudo out/debug/chip-bridge-app --ble-device 1
-            ```
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.

--- a/examples/bridge-app/linux/README.md
+++ b/examples/bridge-app/linux/README.md
@@ -8,13 +8,13 @@ Raspberry Pi Desktop 20.10 (aarch64)**
 
 <hr>
 
-- [Matter Linux Bridge Example](#matter-linux-bridge-example)
-  - [Theory of Operation](#theory-of-operation)
-    - [Dynamic Endpoints](#dynamic-endpoints)
-    - [Limitations](#limitations)
-    - [Bridge Implementation Example](#bridge-implementation-example)
-  - [Building](#building)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+-   [Matter Linux Bridge Example](#matter-linux-bridge-example)
+    -   [Theory of Operation](#theory-of-operation)
+        -   [Dynamic Endpoints](#dynamic-endpoints)
+        -   [Limitations](#limitations)
+        -   [Bridge Implementation Example](#bridge-implementation-example)
+    -   [Building](#building)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 

--- a/examples/camera-controller/commands/common/CHIPCommand.h
+++ b/examples/camera-controller/commands/common/CHIPCommand.h
@@ -93,7 +93,7 @@ public:
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace-to", &mTraceTo, "Trace destinations, comma-separated (" SUPPORTED_COMMAND_LINE_TRACING_TARGETS ")");
-        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId);
+        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId, "Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.");
         AddArgument("storage-directory", &mStorageDirectory,
                     "Directory to place camera-controller's storage files in.  Defaults to $TMPDIR, with fallback to /tmp");
         AddArgument("commissioner-vendor-id", 0, UINT16_MAX, &mCommissionerVendorId,

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -96,7 +96,8 @@ public:
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace-to", &mTraceTo, "Trace destinations, comma-separated (" SUPPORTED_COMMAND_LINE_TRACING_TARGETS ")");
-        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId, "Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.");
+        AddArgument("ble-controller", 0, UINT16_MAX, &mBleAdapterId,
+                    "BLE controller selector, see example or platform docs for details");
         AddArgument("storage-directory", &mStorageDirectory,
                     "Directory to place chip-tool's storage files in.  Defaults to $TMPDIR, with fallback to /tmp");
         AddArgument(

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -96,7 +96,7 @@ public:
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace-to", &mTraceTo, "Trace destinations, comma-separated (" SUPPORTED_COMMAND_LINE_TRACING_TARGETS ")");
-        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId);
+        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId, "Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.");
         AddArgument("storage-directory", &mStorageDirectory,
                     "Directory to place chip-tool's storage files in.  Defaults to $TMPDIR, with fallback to /tmp");
         AddArgument(

--- a/examples/contact-sensor-app/linux/README.md
+++ b/examples/contact-sensor-app/linux/README.md
@@ -12,12 +12,12 @@ details.
 
 <hr>
 
--   [Matter Linux Contact Sensor Example](#matter-linux-contact-sensor-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
+- [Matter Linux Contact Sensor Example](#matter-linux-contact-sensor-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -59,13 +59,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -85,32 +83,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Contact Sensor App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/contact-sensor-app/linux
+              $ sudo out/debug/chip-contact-sensor-app --ble-controller [bluetooth controller number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/contact-sensor-app --ble-controller 1
 
-        -   Run Linux Contact Sensor App
-
-                  $ cd ~/connectedhomeip/examples/contact-sensor-app/linux
-                  $ sudo out/debug/chip-contact-sensor-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/contact-sensor-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Running RPC Console
 

--- a/examples/contact-sensor-app/linux/README.md
+++ b/examples/contact-sensor-app/linux/README.md
@@ -12,12 +12,12 @@ details.
 
 <hr>
 
-- [Matter Linux Contact Sensor Example](#matter-linux-contact-sensor-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
+-   [Matter Linux Contact Sensor Example](#matter-linux-contact-sensor-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 

--- a/examples/dishwasher-app/linux/README.md
+++ b/examples/dishwasher-app/linux/README.md
@@ -12,13 +12,13 @@ details.
 
 <hr>
 
-- [Matter Linux Dishwasher Example](#matter-linux-dishwasher-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Control](#control)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
+-   [Matter Linux Dishwasher Example](#matter-linux-dishwasher-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Control](#control)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 

--- a/examples/dishwasher-app/linux/README.md
+++ b/examples/dishwasher-app/linux/README.md
@@ -12,12 +12,13 @@ details.
 
 <hr>
 
--   [Matter Linux Dishwasher Example](#matter-linux-dishwasher-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
+- [Matter Linux Dishwasher Example](#matter-linux-dishwasher-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Control](#control)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -59,13 +60,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -90,32 +89,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Dishwasher Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/dishwasher-app/linux
+              $ sudo out/debug/chip-dishwasher-app --ble-controller [bluetooth controller number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-dishwasher-app --ble-controller 1
 
-        -   Run Linux Dishwasher Example App
-
-                  $ cd ~/connectedhomeip/examples/dishwasher-app/linux
-                  $ sudo out/debug/chip-dishwasher-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-dishwasher-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Control
 

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -4,13 +4,13 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 
 <hr>
 
-- [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
-  - [Introduction](#introduction)
-  - [Building](#building)
-  - [Flashing the Application](#flashing-the-application)
-  - [Viewing Logging Output](#viewing-logging-output)
-  - [Running the Complete Example](#running-the-complete-example)
-    - [Commissioning](#commissioning)
+-   [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
+    -   [Introduction](#introduction)
+    -   [Building](#building)
+    -   [Flashing the Application](#flashing-the-application)
+    -   [Viewing Logging Output](#viewing-logging-output)
+    -   [Running the Complete Example](#running-the-complete-example)
+        -   [Commissioning](#commissioning)
 
 <hr>
 

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -4,13 +4,13 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
 
 <hr>
 
--   [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
-    -   [Introduction](#introduction)
-    -   [Building](#building)
-    -   [Flashing the Application](#flashing-the-application)
-    -   [Viewing Logging Output](#viewing-logging-output)
-    -   [Running the Complete Example](#running-the-complete-example)
-        -   [Commissioning](#commissioning)
+- [Matter Silabs dishwasher Example](#matter-silabs-dishwasher-example)
+  - [Introduction](#introduction)
+  - [Building](#building)
+  - [Flashing the Application](#flashing-the-application)
+  - [Viewing Logging Output](#viewing-logging-output)
+  - [Running the Complete Example](#running-the-complete-example)
+    - [Commissioning](#commissioning)
 
 <hr>
 
@@ -241,5 +241,5 @@ Pi image. For more info on using `chip-tool`, see
 
 Here is an example using `chip-tool`:
 
-    $ chip-tool pairing ble-thread 1 hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 20202021 3840 --ble-adapter 0
+    $ chip-tool pairing ble-thread 1 hex:0e080000000000010000000300001335060004001fffe002084fe76e9a8b5edaf50708fde46f999f0698e20510d47f5027a414ffeebaefa92285cc84fa030f4f70656e5468726561642d653439630102e49c0410b92f8c7fbb4f9f3e08492ee3915fbd2f0c0402a0fff8 20202021 3840 --ble-controller 0
     $ chip-tool operationalstate start 1 1

--- a/examples/energy-management-app/linux/README.md
+++ b/examples/energy-management-app/linux/README.md
@@ -12,19 +12,19 @@ details.
 
 <hr>
 
--   [Matter Linux Energy Management Example](#matter-linux-energy-management-example)
-    -   [Building](#building)
-    -   [Commandline arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Device Tracing](#device-tracing)
-    -   [Python Test Cases](#python-test-cases)
-        -   [Running the test cases:](#running-the-test-cases)
-    -   [CHIP-REPL Interaction](#chip-repl-interaction)
-        -   [Building chip-repl:](#building-chip-repl)
-        -   [Activating python virtual env](#activating-python-virtual-env)
-        -   [Interacting with CHIP-REPL and the example app](#interacting-with-chip-repl-and-the-example-app)
-        -   [Using chip-repl to Fake a charging session](#using-chip-repl-to-fake-a-charging-session)
-    -   [Water Heater App: Interaction using the chip-tool and TestEventTriggers](#water-heater-app-interaction-using-the-chip-tool-and-testeventtriggers)
+- [Matter Linux Energy Management Example](#matter-linux-energy-management-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Device Tracing](#device-tracing)
+  - [Python Test Cases](#python-test-cases)
+    - [Running the test cases:](#running-the-test-cases)
+  - [CHIP-REPL Interaction](#chip-repl-interaction)
+    - [Building chip-repl:](#building-chip-repl)
+    - [Activating python virtual env](#activating-python-virtual-env)
+    - [Interacting with CHIP-REPL and the example app](#interacting-with-chip-repl-and-the-example-app)
+    - [Using chip-repl to Fake a charging session](#using-chip-repl-to-fake-a-charging-session)
+  - [Water Heater App: Interaction using the chip-tool and TestEventTriggers](#water-heater-app-interaction-using-the-chip-tool-and-testeventtriggers)
 
 <hr>
 
@@ -66,13 +66,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 -   `--application <evse | water-heater>`
 
@@ -110,32 +108,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Energy Management Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/energy-management-app/linux
+              $ sudo out/debug/chip-energy-management-app --ble-controller [bluetooth controller number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-energy-management-app --ble-controller 1
 
-        -   Run Linux Energy Management Example App
-
-                  $ cd ~/connectedhomeip/examples/energy-management-app/linux
-                  $ sudo out/debug/chip-energy-management-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-energy-management-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Device Tracing
 

--- a/examples/energy-management-app/linux/README.md
+++ b/examples/energy-management-app/linux/README.md
@@ -12,19 +12,19 @@ details.
 
 <hr>
 
-- [Matter Linux Energy Management Example](#matter-linux-energy-management-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Device Tracing](#device-tracing)
-  - [Python Test Cases](#python-test-cases)
-    - [Running the test cases:](#running-the-test-cases)
-  - [CHIP-REPL Interaction](#chip-repl-interaction)
-    - [Building chip-repl:](#building-chip-repl)
-    - [Activating python virtual env](#activating-python-virtual-env)
-    - [Interacting with CHIP-REPL and the example app](#interacting-with-chip-repl-and-the-example-app)
-    - [Using chip-repl to Fake a charging session](#using-chip-repl-to-fake-a-charging-session)
-  - [Water Heater App: Interaction using the chip-tool and TestEventTriggers](#water-heater-app-interaction-using-the-chip-tool-and-testeventtriggers)
+-   [Matter Linux Energy Management Example](#matter-linux-energy-management-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Device Tracing](#device-tracing)
+    -   [Python Test Cases](#python-test-cases)
+        -   [Running the test cases:](#running-the-test-cases)
+    -   [CHIP-REPL Interaction](#chip-repl-interaction)
+        -   [Building chip-repl:](#building-chip-repl)
+        -   [Activating python virtual env](#activating-python-virtual-env)
+        -   [Interacting with CHIP-REPL and the example app](#interacting-with-chip-repl-and-the-example-app)
+        -   [Using chip-repl to Fake a charging session](#using-chip-repl-to-fake-a-charging-session)
+    -   [Water Heater App: Interaction using the chip-tool and TestEventTriggers](#water-heater-app-interaction-using-the-chip-tool-and-testeventtriggers)
 
 <hr>
 

--- a/examples/fabric-admin/commands/common/CHIPCommand.h
+++ b/examples/fabric-admin/commands/common/CHIPCommand.h
@@ -95,7 +95,8 @@ public:
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace-to", &mTraceTo, "Trace destinations, comma-separated (" SUPPORTED_COMMAND_LINE_TRACING_TARGETS ")");
-        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId, "Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.");
+        AddArgument("ble-controller", 0, UINT16_MAX, &mBleAdapterId,
+                    "BLE controller selector, see example or platform docs for details");
         AddArgument("storage-directory", &mStorageDirectory,
                     "Directory to place fabric-admin's storage files in.  Defaults to $TMPDIR, with fallback to /tmp");
         AddArgument(

--- a/examples/fabric-admin/commands/common/CHIPCommand.h
+++ b/examples/fabric-admin/commands/common/CHIPCommand.h
@@ -95,7 +95,7 @@ public:
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace-to", &mTraceTo, "Trace destinations, comma-separated (" SUPPORTED_COMMAND_LINE_TRACING_TARGETS ")");
-        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId);
+        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId, "Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.");
         AddArgument("storage-directory", &mStorageDirectory,
                     "Directory to place fabric-admin's storage files in.  Defaults to $TMPDIR, with fallback to /tmp");
         AddArgument(

--- a/examples/lighting-app-data-mode-no-unique-id/linux/README.md
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/README.md
@@ -17,16 +17,16 @@ details.
 
 <hr>
 
-- [CHIP Linux Lighting Example (Data Mode, No Unique ID)](#chip-linux-lighting-example-data-mode-no-unique-id)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
-  - [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
-    - [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
-    - [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
-    - [Trigger Switch events](#trigger-switch-events)
+-   [CHIP Linux Lighting Example (Data Mode, No Unique ID)](#chip-linux-lighting-example-data-mode-no-unique-id)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
+    -   [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
+        -   [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
+        -   [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
+        -   [Trigger Switch events](#trigger-switch-events)
 
 <hr>
 

--- a/examples/lighting-app-data-mode-no-unique-id/linux/README.md
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/README.md
@@ -17,16 +17,16 @@ details.
 
 <hr>
 
--   [CHIP Linux Lighting Example (Data Mode, No Unique ID)](#chip-linux-lighting-example-data-mode-no-unique-id)
-    -   [Building](#building)
-    -   [Commandline arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC Console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
-    -   [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
-        -   [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
-        -   [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
-        -   [Trigger Switch events](#trigger-switch-events)
+- [CHIP Linux Lighting Example (Data Mode, No Unique ID)](#chip-linux-lighting-example-data-mode-no-unique-id)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
+  - [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
+    - [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
+    - [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
+    - [Trigger Switch events](#trigger-switch-events)
 
 <hr>
 
@@ -68,13 +68,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -99,32 +97,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Lighting Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/lighting-app/linux
+              $ sudo out/debug/chip-lighting-app-data-mode-no-unique-id --ble-controller [bluetooth device number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-lighting-app-data-mode-no-unique-id --ble-controller 1
 
-        -   Run Linux Lighting Example App
-
-                  $ cd ~/connectedhomeip/examples/lighting-app/linux
-                  $ sudo out/debug/chip-lighting-app-data-mode-no-unique-id --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-lighting-app-data-mode-no-unique-id --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Running RPC Console
 

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -12,12 +12,16 @@ details.
 
 <hr>
 
--   [CHIP Linux Lighting Example](#chip-linux-lighting-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
+- [CHIP Linux Lighting Example](#chip-linux-lighting-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
+  - [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
+    - [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
+    - [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
+    - [Trigger Switch events](#trigger-switch-events)
 
 <hr>
 
@@ -59,13 +63,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -90,32 +92,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Lighting Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/lighting-app/linux
+              $ sudo out/debug/chip-lighting-app --ble-controller [bluetooth device number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-lighting-app --ble-controller 1
 
-        -   Run Linux Lighting Example App
-
-                  $ cd ~/connectedhomeip/examples/lighting-app/linux
-                  $ sudo out/debug/chip-lighting-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-lighting-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Running RPC Console
 

--- a/examples/lighting-app/linux/README.md
+++ b/examples/lighting-app/linux/README.md
@@ -12,16 +12,16 @@ details.
 
 <hr>
 
-- [CHIP Linux Lighting Example](#chip-linux-lighting-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
-  - [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
-    - [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
-    - [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
-    - [Trigger Switch events](#trigger-switch-events)
+-   [CHIP Linux Lighting Example](#chip-linux-lighting-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
+    -   [Trigger event using lighting-app event named pipe](#trigger-event-using-lighting-app-event-named-pipe)
+        -   [Trigger `SoftwareFault` events](#trigger-softwarefault-events)
+        -   [Trigger `HardwareFault` events](#trigger-hardwarefault-events)
+        -   [Trigger Switch events](#trigger-switch-events)
 
 <hr>
 

--- a/examples/microwave-oven-app/linux/README.md
+++ b/examples/microwave-oven-app/linux/README.md
@@ -7,12 +7,12 @@ doc is tested on **Ubuntu for Raspberry Pi Server 20.04 LTS (aarch64)** and
 
 <hr>
 
--   [Matter Linux Microwave Oven Example](#matter-linux-microwave-oven-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
+- [Matter Linux Microwave Oven Example](#matter-linux-microwave-oven-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -54,13 +54,11 @@ doc is tested on **Ubuntu for Raspberry Pi Server 20.04 LTS (aarch64)** and
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -85,32 +83,19 @@ doc is tested on **Ubuntu for Raspberry Pi Server 20.04 LTS (aarch64)** and
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Lighting Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/microwave-oven-app/linux
+              $ sudo out/debug/chip-microwave-oven-app --ble-controller [bluetooth device number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-microwave-oven-app --ble-controller 1
 
-        -   Run Linux Lighting Example App
-
-                  $ cd ~/connectedhomeip/examples/microwave-oven-app/linux
-                  $ sudo out/debug/chip-microwave-oven-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-microwave-oven-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Running RPC Console
 

--- a/examples/microwave-oven-app/linux/README.md
+++ b/examples/microwave-oven-app/linux/README.md
@@ -7,12 +7,12 @@ doc is tested on **Ubuntu for Raspberry Pi Server 20.04 LTS (aarch64)** and
 
 <hr>
 
-- [Matter Linux Microwave Oven Example](#matter-linux-microwave-oven-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
+-   [Matter Linux Microwave Oven Example](#matter-linux-microwave-oven-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -143,7 +143,7 @@ constexpr unsigned kAppUsageLength = 64;
 
 OptionDef sDeviceOptionDefs[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
+    { "ble-controller", kArgumentRequired, kDeviceOption_BleDevice },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     { "wifi", kNoArgument, kDeviceOption_WiFi },
@@ -226,8 +226,8 @@ OptionDef sDeviceOptionDefs[] = {
 
 const char * sDeviceOptionHelp =
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    "  --ble-device <number>\n"
-    "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
+    "  --ble-controller <selector>\n"
+    "       BLE controller selector, see example or platform docs for details\n"
 #endif // CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
     "\n"

--- a/examples/platform/tizen/OptionsProxy.cpp
+++ b/examples/platform/tizen/OptionsProxy.cpp
@@ -39,7 +39,7 @@ struct Option
 //       from examples/platform/linux/Options.cpp
 static constexpr Option sOptions[] = {
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
-    { "ble-device", false },
+    { "ble-controller", false },
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     { "wifi", true },

--- a/examples/refrigerator-app/linux/README.md
+++ b/examples/refrigerator-app/linux/README.md
@@ -12,12 +12,12 @@ details.
 
 <hr>
 
-- [CHIP Linux Refrigerator Example](#chip-linux-refrigerator-example)
-  - [Building](#building)
-  - [Commandline arguments](#commandline-arguments)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-  - [Running RPC Console](#running-rpc-console)
-  - [Device Tracing](#device-tracing)
+-   [CHIP Linux Refrigerator Example](#chip-linux-refrigerator-example)
+    -   [Building](#building)
+    -   [Commandline arguments](#commandline-arguments)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+    -   [Running RPC Console](#running-rpc-console)
+    -   [Device Tracing](#device-tracing)
 
 <hr>
 

--- a/examples/refrigerator-app/linux/README.md
+++ b/examples/refrigerator-app/linux/README.md
@@ -12,12 +12,12 @@ details.
 
 <hr>
 
--   [CHIP Linux Refrigerator Example](#chip-linux-refrigerator-example)
-    -   [Building](#building)
-    -   [Commandline Arguments](#commandline-arguments)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
-    -   [Running RPC console](#running-rpc-console)
-    -   [Device Tracing](#device-tracing)
+- [CHIP Linux Refrigerator Example](#chip-linux-refrigerator-example)
+  - [Building](#building)
+  - [Commandline arguments](#commandline-arguments)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+  - [Running RPC Console](#running-rpc-console)
+  - [Device Tracing](#device-tracing)
 
 <hr>
 
@@ -59,13 +59,11 @@ details.
     Enables Thread management feature, requires ot-br-posix dbus daemon running.
     Required for Thread commissioning.
 
--   `--ble-device <interface id>`
+-   `--ble-controller <selector>`
 
-    Use specific bluetooth interface for BLE advertisement and connections.
-
-    `interface id`: the number after `hci` when listing BLE interfaces by
-    `hciconfig` command, for example, `--ble-device 1` means using `hci1`
-    interface. Default: `0`.
+    Use the specific Bluetooth controller for BLE advertisement and connections.
+    For details on controller selection refer to
+    [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
 ## Running the Complete Example on Raspberry Pi 4
 
@@ -90,32 +88,19 @@ details.
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run Linux Refrigerator Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/refrigerator-app/linux
+              $ sudo out/debug/chip-refrigerator-app --ble-controller [bluetooth device number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-refrigerator-app --ble-controller 1
 
-        -   Run Linux Refrigerator Example App
-
-                  $ cd ~/connectedhomeip/examples/refrigerator-app/linux
-                  $ sudo out/debug/chip-refrigerator-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-refrigerator-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.
 
 ## Running RPC Console
 

--- a/examples/tv-app/linux/README.md
+++ b/examples/tv-app/linux/README.md
@@ -7,12 +7,12 @@ Raspberry Pi Desktop 20.10 (aarch64)**
 
 <hr>
 
--   [Matter TV Example](#matter-tv-example)
-    -   [Building](#building)
-    -   [Exercising Commissioning](#exercising-commissioning)
-    -   [App Platform commands](#app-platform-commands)
-    -   [Casting](#casting)
-    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+- [Matter TV Example](#matter-tv-example)
+  - [Building](#building)
+  - [Exercising Commissioning](#exercising-commissioning)
+  - [App Platform commands](#app-platform-commands)
+  - [Casting](#casting)
+  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 
@@ -214,29 +214,16 @@ TODO
 
     -   [Optional] Plug USB Bluetooth dongle
 
-        -   Plug USB Bluetooth dongle and find its bluetooth device number. The
-            number after `hci` is the bluetooth device number, `1` in this
-            example.
+        -   Plug USB Bluetooth dongle and find its bluetooth controller selector
+            as described in
+            [Linux BLE Settings](/platforms/linux/ble_settings.md).
 
-                  $ hciconfig
-                  hci1:	Type: Primary  Bus: USB
-                      BD Address: 00:1A:7D:AA:BB:CC  ACL MTU: 310:10  SCO MTU: 64:8
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:20942 acl:1023 sco:0 events:1140 errors:0
-                      TX bytes:16559 acl:1011 sco:0 commands:121 errors:0
+    -   Run TV Example App
 
-                  hci0:	Type: Primary  Bus: UART
-                      BD Address: B8:27:EB:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
-                      UP RUNNING PSCAN ISCAN
-                      RX bytes:8609495 acl:14 sco:0 events:217484 errors:0
-                      TX bytes:92185 acl:20 sco:0 commands:5259 errors:0
+              $ cd ~/connectedhomeip/examples/tv-app/linux
+              $ sudo out/debug/chip-tv-app --ble-controller [bluetooth device number]
+              # In this example, the device we want to use is hci1
+              $ sudo out/debug/chip-tv-app --ble-controller 1
 
-        -   Run TV Example App
-
-                  $ cd ~/connectedhomeip/examples/tv-app/linux
-                  $ sudo out/debug/chip-tv-app --ble-device [bluetooth device number]
-                  # In this example, the device we want to use is hci1
-                  $ sudo out/debug/chip-tv-app --ble-device 1
-
-        -   Test the device using ChipDeviceController on your laptop /
-            workstation etc.
+    -   Test the device using ChipDeviceController on your laptop / workstation
+        etc.

--- a/examples/tv-app/linux/README.md
+++ b/examples/tv-app/linux/README.md
@@ -7,12 +7,12 @@ Raspberry Pi Desktop 20.10 (aarch64)**
 
 <hr>
 
-- [Matter TV Example](#matter-tv-example)
-  - [Building](#building)
-  - [Exercising Commissioning](#exercising-commissioning)
-  - [App Platform commands](#app-platform-commands)
-  - [Casting](#casting)
-  - [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
+-   [Matter TV Example](#matter-tv-example)
+    -   [Building](#building)
+    -   [Exercising Commissioning](#exercising-commissioning)
+    -   [App Platform commands](#app-platform-commands)
+    -   [Casting](#casting)
+    -   [Running the Complete Example on Raspberry Pi 4](#running-the-complete-example-on-raspberry-pi-4)
 
 <hr>
 

--- a/scripts/helpers/bash-completion.sh
+++ b/scripts/helpers/bash-completion.sh
@@ -34,7 +34,7 @@ _chip_app() {
     _init_completion -s || return
 
     case "$prev" in
-        --ble-device)
+        --ble-controller)
             readarray -t words < <(ls -I '*:*' /sys/class/bluetooth)
             # Get the list of Bluetooth devices without the 'hci' prefix.
             readarray -t COMPREPLY < <(compgen -W "${words[*]#hci}" -- "$cur")

--- a/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
@@ -70,7 +70,7 @@ tests:
           Use a Commissionee with a QR code that has the Custom Flow field set to 0, supports BLE for its Discovery Capability, and
           ensures the Version bit string follows the current Matter specification. Pass the QR code into the DUT during the commissioning process.
 
-            ./chip-all-clusters-app --custom-flow 0 --capabilities 2 --ble-device 1
+            ./chip-all-clusters-app --custom-flow 0 --capabilities 2 --ble-controller 1
           On the TH (All-Clusters App), verify that the user has a QR code available to pass into the DUT
 
           [1667888323.966941][3151:3151] CHIP:DL: Device Configuration:

--- a/src/app/tests/suites/certification/Test_TC_DD_3_12.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_12.yaml
@@ -71,7 +71,7 @@ tests:
           Use a Commissionee with a QR code that has the Custom Flow field set to 1, supports BLE for its Discovery Capability,
           and ensures the Version bit string follows the current Matter specification. Pass the QR code into the DUT during the commissioning process.
 
-          ./chip-all-clusters-app --capabilities 2 --custom-flow 1 --ble-device 1
+          ./chip-all-clusters-app --capabilities 2 --custom-flow 1 --ble-controller 1
           On the TH (All-Clusters App), verify that the user has a QR code available to pass into the DUT
 
           [1657234110.765249][370717:370717] CHIP:SVR: SetupQRCode: [MT:-24J0YXE00KA0648G00]

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -148,7 +148,7 @@ or run `os.chdir` to the root of your CHIP repository checkout.
         # nothing we can do ... things will NOT work
         return
 
-    chip.native.Init(bluetoothAdapter=args.ble_adapter)
+    chip.native.Init(bluetoothAdapter=args.ble_controller)
 
     global certificateAuthorityManager
     global chipStack

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -111,7 +111,7 @@ def main():
     parser.add_argument(
         "-t", "--trust-store", help="Path to the PAA trust store.", action="store", default="./credentials/development/paa-root-certs")
     parser.add_argument(
-        "-b", "--ble-adapter", help="Set the Bluetooth adapter index.", type=int, default=None)
+        "-b", "--ble-controller", help="BLE controller selector, see example or platform docs for details", type=int, default=None)
     parser.add_argument(
         "-s", "--server-interactions", help="Enable server interactions.", action="store_true")
     args = parser.parse_args()

--- a/src/controller/python/chip/server/Options.cpp
+++ b/src/controller/python/chip/server/Options.cpp
@@ -37,7 +37,7 @@ enum
     kDeviceOption_Thread    = 0x1002,
 };
 
-OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOption_BleDevice },
+OptionDef sDeviceOptionDefs[] = { { "ble-controller", kArgumentRequired, kDeviceOption_BleDevice },
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
                                   { "wifi", kNoArgument, kDeviceOption_WiFi },
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -46,8 +46,8 @@ OptionDef sDeviceOptionDefs[] = { { "ble-device", kArgumentRequired, kDeviceOpti
 #endif // CHIP_ENABLE_OPENTHREAD
                                   {} };
 
-const char sDeviceOptionHelp[] = "  --ble-device <number>\n"
-                                 "       The device number for CHIPoBLE, without 'hci' prefix, can be found by hciconfig.\n"
+const char sDeviceOptionHelp[] = "  --ble-controller <selector>\n"
+                                 "       BLE controller selector, see example or platform docs for details\n"
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
                                  "\n"
                                  "  --wifi\n"

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1904,8 +1904,8 @@ def parse_matter_test_args(argv: Optional[List[str]] = None) -> MatterTestConfig
                              help="PAA trust store path (default: %s)" % str(paa_path_default))
     basic_group.add_argument('--dac-revocation-set-path', action="store", type=pathlib.Path, metavar="PATH",
                              help="Path to JSON file containing the device attestation revocation set.")
-    basic_group.add_argument('--ble-interface-id', action="store", type=int,
-                             metavar="INTERFACE_ID", help="ID of BLE adapter (from hciconfig)")
+    basic_group.add_argument('--ble-controller', action="store", type=int,
+                             metavar="CONTROLLER_ID", help="BLE controller selector, see example or platform docs for details")
     basic_group.add_argument('-N', '--controller-node-id', type=int_decimal_or_hex,
                              metavar='NODE_ID',
                              default=_DEFAULT_CONTROLLER_NODE_ID,

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -547,7 +547,7 @@ class MatterTestConfig:
     storage_path: pathlib.Path = pathlib.Path(".")
     logs_path: pathlib.Path = pathlib.Path(".")
     paa_trust_store_path: Optional[pathlib.Path] = None
-    ble_interface_id: Optional[int] = None
+    ble_controller: Optional[int] = None
     commission_only: bool = False
 
     admin_vendor_id: int = _DEFAULT_ADMIN_VENDOR_ID
@@ -773,7 +773,7 @@ class MatterStackState:
         self._config = config
 
         if not hasattr(builtins, "chipStack"):
-            chip.native.Init(bluetoothAdapter=config.ble_interface_id)
+            chip.native.Init(bluetoothAdapter=config.ble_controller)
             if config.storage_path is None:
                 raise ValueError("Must have configured a MatterTestConfig.storage_path")
             self._init_stack(already_initialized=False, persistentStoragePath=config.storage_path)
@@ -1853,7 +1853,7 @@ def convert_args_to_matter_config(args: argparse.Namespace) -> MatterTestConfig:
     config.storage_path = pathlib.Path(_DEFAULT_STORAGE_PATH) if args.storage_path is None else args.storage_path
     config.logs_path = pathlib.Path(_DEFAULT_LOG_PATH) if args.logs_path is None else args.logs_path
     config.paa_trust_store_path = args.paa_trust_store_path
-    config.ble_interface_id = args.ble_interface_id
+    config.ble_controller = args.ble_controller
     config.pics = {} if args.PICS is None else read_pics_from_file(args.PICS)
     config.tests = list(chain.from_iterable(args.tests or []))
     config.timeout = args.timeout  # This can be none, we pull the default from the test if it's unspecified


### PR DESCRIPTION
#### Testing

Manual test of new help text:

```
$ out/linux-x64-chip-tool/chip-tool pairing ble-wifi --help
[…]
[--ble-adapter]:
  Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.
```

```
$ out/linux-x64-camera-controller/chip-camera-controller --help
[…]
[--ble-adapter]:
  Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.
```

```
$ out/linux-x64-fabric-admin-rpc/fabric-admin --help  
[…]
[--ble-adapter]:
  Bluetooth adapter index. 0 -> hci0, 1 -> hci1, etc.
```
