### PR TITLE
Reset state before Step 8 in SWTCH 2.6 test

### DIFF
--- a/src/python_testing/TC_SWTCH.py
+++ b/src/python_testing/TC_SWTCH.py
@@ -924,6 +924,8 @@ class TC_SwitchTests(MatterBaseTest):
         # subscription is already established
         self.step("7b")
 
+        self._ask_for_switch_idle(endpoint_id)
+
         test_multi_press_sequence("8a", count=2, short_long=True)
 
         self.step("9a")


### PR DESCRIPTION
#### Testing

Switch test 2.6 Step 6 is doing more switch actions then configured leading into the "cancelled" state which means that no more event should be send

(from spec 1.13.5.3. MultiPressMax Attribute)
> until the switch has become
fully idle (i.e. no longer in the process of counting presses within the multipress).

The test is starting step 8 directly after receiving the MultiPressComplete event from step 6 and not giving the Switch the time to finish multi switch actions.

This PR adds a reset after Step 6 before Step 8 to ensure this is cleared

I am not sure if there is a bug in the SDK implementation of the special case for
> The server for cluster revision >= 2 SHALL generate a MultiPressComplete event with the TotalNumberOfPressesCounted
field set to zero (indicating an aborted sequence), and SHALL NOT
generate any further InitialPress and MultiPressOngoing events until the switch has become
fully idle (i.e. no longer in the process of counting presses within the multipress).

because I would assume that also the SDK implementation would have needed to run into this.

The reason for this issue is that the Switch Simulator in Chip CI test app is putting the Switch into idle state as soon as the "cancel event" is sent out ... see https://github.com/project-chip/connectedhomeip/blob/8968e083d621a81014df35c342119847c2ac7663/examples/all-clusters-app/linux/ButtonEventsSimulator.cpp#L277-L289 ... other CI relevant implementations (like matter.js) that use a real timed state engine also in CI is actibng different, so after sync in Slack it makes sense to reset the state as proposed in this PR.