### PR TITLE
[ACL][WriteClient] Encoding non-empty ReplaceAll when writing to AccessControl Cluster

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -234,7 +234,7 @@ CHIP_ERROR AccessControl::CreateEntry(const SubjectDescriptor * subjectDescripto
 
     VerifyOrReturnError((count + 1) <= maxCount, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
 
     size_t i = 0;
     ReturnErrorOnFailure(mDelegate->CreateEntry(&i, entry, &fabric));
@@ -252,7 +252,7 @@ CHIP_ERROR AccessControl::UpdateEntry(const SubjectDescriptor * subjectDescripto
                                       const Entry & entry)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
     ReturnErrorOnFailure(mDelegate->UpdateEntry(index, entry, &fabric));
     NotifyEntryChanged(subjectDescriptor, fabric, index, &entry, EntryListener::ChangeType::kUpdated);
     return CHIP_NO_ERROR;
@@ -626,7 +626,7 @@ exit:
 }
 #endif
 
-bool AccessControl::IsValid(const Entry & entry)
+bool AccessControl::Entry::IsValid() const
 {
     const char * log = "unexpected error";
     IgnoreUnusedVariable(log); // logging may be disabled
@@ -638,11 +638,11 @@ bool AccessControl::IsValid(const Entry & entry)
     size_t targetCount      = 0;
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    SuccessOrExit(err = entry.GetAuthMode(authMode));
-    SuccessOrExit(err = entry.GetFabricIndex(fabricIndex));
-    SuccessOrExit(err = entry.GetPrivilege(privilege));
-    SuccessOrExit(err = entry.GetSubjectCount(subjectCount));
-    SuccessOrExit(err = entry.GetTargetCount(targetCount));
+    SuccessOrExit(err = GetAuthMode(authMode));
+    SuccessOrExit(err = GetFabricIndex(fabricIndex));
+    SuccessOrExit(err = GetPrivilege(privilege));
+    SuccessOrExit(err = GetSubjectCount(subjectCount));
+    SuccessOrExit(err = GetTargetCount(targetCount));
 
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
     ChipLogProgress(DataManagement, "AccessControl: validating f=%u p=%c a=%c s=%d t=%d", fabricIndex,
@@ -665,7 +665,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < subjectCount; ++i)
     {
         NodeId subject;
-        SuccessOrExit(err = entry.GetSubject(i, subject));
+        SuccessOrExit(err = GetSubject(i, subject));
         const bool kIsCase  = authMode == AuthMode::kCase;
         const bool kIsGroup = authMode == AuthMode::kGroup;
 #if CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY > 1
@@ -677,7 +677,7 @@ bool AccessControl::IsValid(const Entry & entry)
     for (size_t i = 0; i < targetCount; ++i)
     {
         Entry::Target target;
-        SuccessOrExit(err = entry.GetTarget(i, target));
+        SuccessOrExit(err = GetTarget(i, target));
         const bool kHasCluster    = target.flags & Entry::Target::kCluster;
         const bool kHasEndpoint   = target.flags & Entry::Target::kEndpoint;
         const bool kHasDeviceType = target.flags & Entry::Target::kDeviceType;

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -233,6 +233,13 @@ public:
             mDelegate = &mDefaultDelegate.get();
         }
 
+        /**
+         * Validate whether an ACL Entry is valid and complies with all defined constraints.
+         *
+         * @retval true if all the fields within the Entry are valid and compliant.
+         */
+        bool IsValid() const;
+
     private:
         static Global<Delegate> mDefaultDelegate;
         Delegate * mDelegate = &mDefaultDelegate.get();
@@ -501,7 +508,7 @@ public:
      */
     CHIP_ERROR CreateEntry(size_t * index, const Entry & entry, FabricIndex * fabricIndex = nullptr)
     {
-        VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->CreateEntry(index, entry, fabricIndex);
     }
@@ -551,7 +558,7 @@ public:
      */
     CHIP_ERROR UpdateEntry(size_t index, const Entry & entry, const FabricIndex * fabricIndex = nullptr)
     {
-        VerifyOrReturnError(IsValid(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(entry.IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
         VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
         return mDelegate->UpdateEntry(index, entry, fabricIndex);
     }
@@ -668,8 +675,6 @@ public:
 
 private:
     bool IsInitialized() const { return (mDelegate != nullptr); }
-
-    bool IsValid(const Entry & entry);
 
     void NotifyEntryChanged(const SubjectDescriptor * subjectDescriptor, FabricIndex fabric, size_t index, const Entry * entry,
                             EntryListener::ChangeType changeType);

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -105,6 +105,17 @@ public:
      */
     CHIP_ERROR EndOfAttributeDataIB();
 
+    /**
+     *  @brief Get number of bytes required in the buffer to reserve the EndOfContainer of EndOfAttributeDataIB()
+     *
+     *  @return Expected number of bytes required in the buffer to reserve the EndOfContainer of EndOfAttributeDataIB()
+     */
+    static constexpr uint16_t GetSizeToEndAttributeDataIB()
+    {
+        uint16_t kEndOfAttributeDataIBSize = 1;
+        return kEndOfAttributeDataIBSize;
+    };
+
 private:
     AttributePathIB::Builder mPath;
 };

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -106,9 +106,9 @@ public:
     CHIP_ERROR EndOfAttributeDataIB();
 
     /**
-     *  @brief Get number of bytes required in the buffer to reserve the EndOfContainer of EndOfAttributeDataIB()
+     *  @brief Get number of bytes required in the buffer to allow EndOfAttributeDataIB() to succeed.
      *
-     *  @return Expected number of bytes required in the buffer to reserve the EndOfContainer of EndOfAttributeDataIB()
+     *  @return Expected number of bytes required in the buffer to successfully execute EndOfAttributeDataIB()
      */
     static constexpr uint16_t GetSizeToEndAttributeDataIB()
     {

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -304,8 +304,8 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
         // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
         // list operation.
-        // TODO: Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all clusters
-        // to support it in testing and in certification.
+        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all
+        // clusters to support it in testing and in certification.
         bool encodeEmptyListAsReplaceAll =
             !(path.mClusterId == Clusters::AccessControl::Id && path.mAttributeId == Clusters::AccessControl::Attributes::Acl::Id);
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -169,7 +169,6 @@ CHIP_ERROR WriteClient::StartNewMessage()
     if (mState == State::AddAttribute)
     {
         ReturnErrorOnFailure(FinalizeMessage(true));
-        mIsWriteRequestChunked = true;
     }
 
     // Do not allow timed request with chunks.

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -169,6 +169,7 @@ CHIP_ERROR WriteClient::StartNewMessage()
     if (mState == State::AddAttribute)
     {
         ReturnErrorOnFailure(FinalizeMessage(true));
+        mIsWriteRequestChunked = true;
     }
 
     // Do not allow timed request with chunks.
@@ -247,29 +248,112 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     return err;
 }
 
+CHIP_ERROR
+WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
+                                                           TLV::TLVReader & valueReader, bool & outChunkingNeeded,
+                                                           ListIndex & outEncodedItemCount)
+{
+
+    ReturnErrorOnFailure(EnsureListStarted(attributePath));
+
+    chip::TLV::TLVWriter * writer = nullptr;
+    VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    TLV::TLVWriter backupWriter;
+    CHIP_ERROR err      = CHIP_NO_ERROR;
+    outEncodedItemCount = 0;
+
+    while ((err = valueReader.Next()) == CHIP_NO_ERROR)
+    {
+        mWriteRequestBuilder.GetWriteRequests().Checkpoint(backupWriter);
+        err = writer->CopyElement(TLV::AnonymousTag(), valueReader);
+
+        if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+        {
+            mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
+            outChunkingNeeded = true;
+            err               = CHIP_NO_ERROR;
+            break;
+        }
+        ReturnErrorOnFailure(err);
+        outEncodedItemCount++;
+    }
+    VerifyOrReturnError(err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR, err);
+
+    return EnsureListEnded();
+}
+
+// TODO Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
-    ReturnErrorOnFailure(EnsureMessage());
 
     // ListIndex is missing and the data is an array -- we are writing a whole list.
     if (!attributePath.IsListOperation() && data.GetType() == TLV::TLVType::kTLVType_Array)
     {
+
         TLV::TLVReader dataReader;
         TLV::TLVReader valueReader;
-        CHIP_ERROR err = CHIP_NO_ERROR;
-
+        uint16_t encodedItemCount      = 0;
         ConcreteDataAttributePath path = attributePath;
 
+        // By convention, and as tested against all cluster servers, clients have historically encoded an empty list as a
+        // ReplaceAll, (i.e. the entire attribute contents are cleared before appending the new list’s items). However, this
+        // behavior can be problematic, especially for the ACL attribute; sending an empty ReplaceAll list can cause clients to be
+        // locked out. This is because the empty list first deletes all existing ACL entries, and if the new (malformed) ACL is
+        // rejected, the server is left without valid (or with incomplete) ACLs.
+        // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
+        // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
+        // list operation.
+        // TODO: Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all clusters
+        // to support it in testing and in certification.
+        bool encodeEmptyListAsReplaceAll =
+            !(path.mClusterId == Clusters::AccessControl::Id && path.mAttributeId == Clusters::AccessControl::Attributes::Acl::Id);
+
+        if (encodeEmptyListAsReplaceAll)
+        {
+            ReturnErrorOnFailure(EnsureMessage());
+            ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+            encodedItemCount = 0;
+        }
+        else
+        {
+            // We will always start a new chunk when we have a new Attribute to Encode. This might be more efficient since this
+            // first chunk contains the "ReplaceAll List" which will pack as many list items as possible into a single
+            // AttributeDataIB.
+            ReturnErrorOnFailure(StartNewMessage());
+
+            dataReader.Init(data);
+            dataReader.OpenContainer(valueReader);
+            bool chunkingNeeded = false;
+
+            // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
+            // WriteRequestMessage chunk
+            ReturnErrorOnFailure(
+                TryPutPreencodedAttributeWritePayloadIntoList(path, valueReader, chunkingNeeded, encodedItemCount));
+
+            // If all list items fit perfectly into a single AttributeDataIB, there is no need for any `append-item` or chunking,
+            // and we can exit early
+            VerifyOrReturnError(chunkingNeeded, CHIP_NO_ERROR);
+
+            // Start a new WriteRequest chunk, as there are still remaining list items to encode. These remaining items will be
+            // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
+            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it
+            ReturnErrorOnFailure(StartNewMessage());
+        }
+        path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
+
+        // We will restart iterating on ValueReader, only appending the items we need to append.
         dataReader.Init(data);
         dataReader.OpenContainer(valueReader);
 
-        // Encode an empty list for the chunking protocol.
-        ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
+        CHIP_ERROR err            = CHIP_NO_ERROR;
+        uint16_t currentItemCount = 0;
 
-        if (err == CHIP_NO_ERROR)
+        while ((err = valueReader.Next()) == CHIP_NO_ERROR)
         {
-            path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
-            while ((err = valueReader.Next()) == CHIP_NO_ERROR)
+            currentItemCount++;
+
+            if (currentItemCount > encodedItemCount)
             {
                 ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
             }
@@ -281,7 +365,9 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         }
         return err;
     }
+
     // We are writing a non-list attribute, or we are writing a single element of a list.
+    ReturnErrorOnFailure(EnsureMessage());
     return PutSinglePreencodedAttributeWritePayload(attributePath, data);
 }
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -290,7 +290,6 @@ WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::Conc
 // TODO #38287 Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList.
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
-
     // ListIndex is missing and the data is an array -- we are writing a whole list.
     if (!attributePath.IsListOperation() && data.GetType() == TLV::TLVType::kTLVType_Array)
     {
@@ -316,7 +315,6 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         {
             ReturnErrorOnFailure(EnsureMessage());
             ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
-            encodedItemCount = 0;
         }
         else
         {

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -283,7 +283,7 @@ WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::Conc
     return EnsureListEnded();
 }
 
-// TODO Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList
+// TODO #38287 Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList.
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
 
@@ -327,17 +327,17 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
             bool chunkingNeeded = false;
 
             // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
-            // WriteRequestMessage chunk
+            // WriteRequestMessage chunk.
             ReturnErrorOnFailure(
                 TryPutPreencodedAttributeWritePayloadIntoList(path, valueReader, chunkingNeeded, encodedItemCount));
 
             // If all list items fit perfectly into a single AttributeDataIB, there is no need for any `append-item` or chunking,
-            // and we can exit early
+            // and we can exit early.
             VerifyOrReturnError(chunkingNeeded, CHIP_NO_ERROR);
 
             // Start a new WriteRequest chunk, as there are still remaining list items to encode. These remaining items will be
             // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
-            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it
+            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it.
             ReturnErrorOnFailure(StartNewMessage());
         }
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -256,7 +256,6 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
     // ListIndex is missing and the data is an array -- we are writing a whole list.
     if (!attributePath.IsListOperation() && data.GetType() == TLV::TLVType::kTLVType_Array)
     {
-
         TLV::TLVReader dataReader;
         TLV::TLVReader valueReader;
         uint16_t encodedItemCount      = 0;
@@ -398,12 +397,7 @@ WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const ConcreteDataAtt
             err               = CHIP_NO_ERROR;
             break;
         }
-        // Make sure that we undo the buffer reservation made in EnsureListStarted()
-        if (err != CHIP_NO_ERROR)
-        {
-            ReturnErrorOnFailure(EnsureListEnded());
-            return err;
-        }
+        ReturnErrorOnFailure(err);
         outEncodedItemCount++;
     }
     VerifyOrReturnError(err == CHIP_END_OF_TLV || err == CHIP_NO_ERROR, err);

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -274,6 +274,8 @@ WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::Conc
 
         if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
         {
+            // Rollback through the attributeDataIB, which also resets the Builder's error state.
+            // This returns the object to the state it was in before attempting to copy the element.
             attributeDataIB.Rollback(backupWriter);
             outChunkingNeeded = true;
             err               = CHIP_NO_ERROR;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -306,8 +306,7 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
         // list operation.
         // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all
         // clusters to support it in testing and in certification.
-        bool encodeEmptyListAsReplaceAll =
-            !(path.mClusterId == Clusters::AccessControl::Id && path.mAttributeId == Clusters::AccessControl::Attributes::Acl::Id);
+        bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
 
         if (encodeEmptyListAsReplaceAll)
         {

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -248,6 +248,37 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     return err;
 }
 
+CHIP_ERROR WriteClient::EnsureListStarted(const ConcreteDataAttributePath & attributePath)
+{
+    chip::TLV::TLVWriter * writer = nullptr;
+
+    TLV::TLVType outerType;
+
+    ReturnErrorOnFailure(mMessageWriter.ReserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB));
+
+    ReturnErrorOnFailure(PrepareAttributeIB(attributePath));
+    VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(
+        writer->StartContainer(chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), TLV::kTLVType_Array, outerType));
+
+    VerifyOrReturnError(outerType == kAttributeDataIBType, CHIP_ERROR_INCORRECT_STATE);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WriteClient::EnsureListEnded()
+{
+    chip::TLV::TLVWriter * writer = nullptr;
+    VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // In the event of Chunking (we have a CHIP_ERROR_NO_MEMORY), we need to Unreserve two more Bytes in order to be able to
+    // Append EndOfContainer of the List + EndOfContainer of the AttributeDataIB.
+    ReturnErrorOnFailure(writer->UnreserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB));
+    ReturnErrorOnFailure(writer->EndContainer(kAttributeDataIBType));
+
+    return FinishAttributeIB();
+}
+
 CHIP_ERROR
 WriteClient::TryPutPreencodedAttributeWritePayloadIntoList(const chip::app::ConcreteDataAttributePath & attributePath,
                                                            TLV::TLVReader & valueReader, bool & outChunkingNeeded,
@@ -354,12 +385,13 @@ CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath &
 
         while ((err = valueReader.Next()) == CHIP_NO_ERROR)
         {
-            currentItemCount++;
-
-            if (currentItemCount > encodedItemCount)
+            if (currentItemCount++ < encodedItemCount)
             {
-                ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
+                // Element already encoded via `TryPutPreencodedAttributeWritePayloadIntoList`
+                continue;
             }
+
+            ReturnErrorOnFailure(PutSinglePreencodedAttributeWritePayload(path, valueReader));
         }
 
         if (err == CHIP_END_OF_TLV)

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributePathParams.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/InteractionModelTimeout.h>
@@ -41,8 +43,6 @@
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
 
-#include <app-common/zap-generated/ids/Attributes.h>
-#include <app-common/zap-generated/ids/Clusters.h>
 namespace chip {
 namespace app {
 
@@ -165,8 +165,8 @@ public:
     /**
      *  Encode a possibly-chunked list attribute value.  Will create a new chunk when necessary.
      *
-     * This method will attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
-     * cluster server as a ReplaceAll Item operation.
+     *  Note: As an exception, for attributes in the AccessControl Clusters, this method will attempt to encode as many list items
+     * as possible into a SingleAttributeDataIB, which will be handled by cluster server as a ReplaceAll Item operation.
      * If the list is too large, the WriteRequest will be chunked and remaining items will be encoded as AppendItem operations,
      chunking them as needed.
      *
@@ -180,9 +180,9 @@ public:
             ConcreteDataAttributePath(attributePath.HasWildcardEndpointId() ? kInvalidEndpointId : attributePath.mEndpointId,
                                       attributePath.mClusterId, attributePath.mAttributeId, aDataVersion);
 
-        ListIndex nextItemToAppendIndex = kInvalidListIndex;
-        uint16_t encodedItemCount       = 0;
-        bool chunkingNeeded             = false;
+        ListIndex firstItemToAppendIndex = 0;
+        uint16_t encodedItemCount        = 0;
+        bool chunkingNeeded              = false;
 
         // By convention, and as tested against all cluster servers, clients have historically encoded an empty list as a
         // ReplaceAll, (i.e. the entire attribute contents are cleared before appending the new list’s items). However, this
@@ -196,18 +196,14 @@ public:
         // enforce all clusters to support it in testing and in certification.
         bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
 
+        ReturnErrorOnFailure(EnsureMessage());
+
         if (encodeEmptyListAsReplaceAll)
         {
-            ReturnErrorOnFailure(EnsureMessage());
             ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, DataModel::List<uint8_t>()));
         }
         else
         {
-            // We will always start a new chunk when we have a new Attribute to Encode. This might be more efficient since this
-            // first chunk contains the "ReplaceAll List" which will pack as many list items as possible into a single
-            // AttributeDataIB.
-            ReturnErrorOnFailure(StartNewMessage());
-
             // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
             // WriteRequestMessage chunk.
             ReturnErrorOnFailure(TryEncodeListIntoSingleAttributeDataIB(path, listValue, chunkingNeeded, encodedItemCount));
@@ -220,14 +216,12 @@ public:
             // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
             // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it.
             ReturnErrorOnFailure(StartNewMessage());
-            nextItemToAppendIndex = encodedItemCount;
+            firstItemToAppendIndex = encodedItemCount;
         }
 
         path.mListOp = ConcreteDataAttributePath::ListOperation::AppendItem;
 
-        ListIndex startIndex = encodeEmptyListAsReplaceAll ? 0 : nextItemToAppendIndex;
-
-        for (ListIndex i = startIndex; i < listValue.size(); i++)
+        for (ListIndex i = firstItemToAppendIndex; i < listValue.size(); i++)
         {
             ReturnErrorOnFailure(EncodeSingleAttributeDataIB(path, listValue[i]));
         }
@@ -303,7 +297,22 @@ private:
     CHIP_ERROR ProcessWriteResponseMessage(System::PacketBufferHandle && payload);
     CHIP_ERROR ProcessAttributeStatusIB(AttributeStatusIB::Parser & aAttributeStatusIB);
     const char * GetStateStr() const;
+
+    /**
+     * Prepare the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *
+     * @note Must always be followed by a call to EnsureListEnded(), to undo buffer reservation that took place within
+     * it, and properly close TLV Containers.
+     */
+
     CHIP_ERROR EnsureListStarted(const ConcreteDataAttributePath & attributePath);
+    /**
+     * Complete the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *
+     * @note Must always be called after EnsureListStarted(), even in cases of encoding failures; to undo buffer reservation that
+     * took place in EnsureListStarted.
+     */
+
     CHIP_ERROR EnsureListEnded();
 
     /**
@@ -341,30 +350,26 @@ private:
                                                       const DataModel::List<T> & list, bool & outChunkingNeeded,
                                                       uint16_t & outEncodedItemCount)
     {
-        CHIP_ERROR err = CHIP_NO_ERROR;
-        TLV::TLVWriter backupWriter;
-
         ReturnErrorOnFailure(EnsureListStarted(attributePath));
 
-        chip::TLV::TLVWriter * attributeDataIBWriter = nullptr;
-        VerifyOrReturnError((attributeDataIBWriter = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
         AttributeDataIB::Builder & attributeDataIB = mWriteRequestBuilder.GetWriteRequests().GetAttributeDataIBBuilder();
-
+        TLV::TLVWriter backupWriter;
+        CHIP_ERROR err      = CHIP_NO_ERROR;
         outEncodedItemCount = 0;
 
         for (auto & item : list)
         {
-            // We essentially write List items to the Data Container within the first AttributeDataIB. We checkpoint the
-            // AttributeDataIB Builder in case there's not enough space to encode a list item.
+            // Try to put all the list items into the list we just started, until we either run out of items
+            // or run out of space.
+            // Make sure that if we run out of space we don't leave a partially-encoded list item around.
             attributeDataIB.Checkpoint(backupWriter);
             if constexpr (DataModel::IsFabricScoped<T>::value)
             {
-                err = DataModel::EncodeForWrite(*attributeDataIBWriter, TLV::AnonymousTag(), item);
+                err = DataModel::EncodeForWrite(*attributeDataIB.GetWriter(), TLV::AnonymousTag(), item);
             }
             else
             {
-                err = DataModel::Encode(*attributeDataIBWriter, TLV::AnonymousTag(), item);
+                err = DataModel::Encode(*attributeDataIB.GetWriter(), TLV::AnonymousTag(), item);
             }
 
             if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
@@ -375,7 +380,11 @@ private:
                 outChunkingNeeded = true;
                 break;
             }
-            ReturnErrorOnFailure(err);
+            else if (err != CHIP_NO_ERROR)
+            {
+                ReturnErrorOnFailure(EnsureListEnded());
+                ReturnErrorOnFailure(err);
+            }
             outEncodedItemCount++;
         }
 
@@ -384,7 +393,11 @@ private:
 
     /**
      * A wrapper for TryEncodeSingleAttributeDataIB which will start a new chunk when failed with CHIP_ERROR_NO_MEMORY or
-     * CHIP_ERROR_BUFFER_TOO_SMALL. This will not be used for Lists. For Lists, use TryEncodeListIntoSingleAttributeDataIB instead.
+     * CHIP_ERROR_BUFFER_TOO_SMALL.
+     *
+     * NOTE: This method must not be used for encoding non-empty lists, even if the template accepts a list type.
+     * For such cases, use TryEncodeListIntoSingleAttributeDataIB as part of a suitable encoding strategy,
+     * since it has a different contract and has different usage expectations.
      */
     template <class T>
     CHIP_ERROR EncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -301,16 +301,23 @@ private:
     CHIP_ERROR ProcessAttributeStatusIB(AttributeStatusIB::Parser & aAttributeStatusIB);
     const char * GetStateStr() const;
 
-    // TODO (#38453) Clarify and fix the API contract of EnsureListStarted and EnsureListEnded; in the case of encoding failure,
-    // should we just undo buffer reservation? rollback to a checkpoint that we create within EnsureListStarted? or just leave the
-    // WriteClient in a bad state.
+    // TODO (#38453) Clarify and fix the API contract of EnsureListStarted, TryToStartList and EnsureListEnded; in the case of
+    // encoding failure, should we just undo buffer reservation? rollback to a checkpoint that we create within EnsureListStarted?
+    // or just leave the WriteClient in a bad state.
     /**
-     * Prepare the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *     A wrapper for TryToStartList which will start a new chunk when TryToStartList fails with CHIP_ERROR_NO_MEMORY or
+     * CHIP_ERROR_BUFFER_TOO_SMALL.
      *
      * @note Must always be followed by a call to EnsureListEnded(), to undo buffer reservation that took place within
      * it, and properly close TLV Containers.
      */
     CHIP_ERROR EnsureListStarted(const ConcreteDataAttributePath & attributePath);
+
+    /**
+     * Prepare the Encoding of an Attribute with List DataType into an AttributeDataIB.
+     *
+     */
+    CHIP_ERROR TryToStartList(const ConcreteDataAttributePath & attributePath);
 
     /**
      * Complete the Encoding of an Attribute with List DataType into an AttributeDataIB.

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -165,10 +165,10 @@ public:
     /**
      *  Encode a possibly-chunked list attribute value.  Will create a new chunk when necessary.
      *
-     * This function will Attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
-     cluster server as a ReplaceAll Item operation
+     * This method will Attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
+     * cluster server as a ReplaceAll Item operation.
      * If the list is too large, the WriteRequest will be chunked and remaining items will be encoded as AppendItem operations,
-     chunking them as needed
+     chunking them as needed.
      *
      */
     template <class T>
@@ -210,16 +210,16 @@ public:
             ReturnErrorOnFailure(StartNewMessage());
 
             // Encode as many list-items as possible into a single AttributeDataIB, which will be included in a single
-            // WriteRequestMessage chunk
+            // WriteRequestMessage chunk.
             ReturnErrorOnFailure(TryEncodeListIntoSingleAttributeDataIB(path, listValue, chunkingNeeded, encodedItemCount));
 
             // If all list items fit perfectly into a single AttributeDataIB, there is no need for any `append-item` or chunking,
-            // and we can exit early
+            // and we can exit early.
             VerifyOrReturnError(chunkingNeeded, CHIP_NO_ERROR);
 
             // Start a new WriteRequest chunk, as there are still remaining list items to encode. These remaining items will be
             // appended one by one, each into its own AttributeDataIB. Unlike the first chunk (which contains only one
-            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it
+            // AttributeDataIB), subsequent chunks may contain multiple AttributeDataIBs if space allows it.
             ReturnErrorOnFailure(StartNewMessage());
             nextItemToAppendIndex = encodedItemCount;
         }
@@ -360,7 +360,7 @@ private:
         VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         // In the event of Chunking (we have a CHIP_ERROR_NO_MEMORY), we need to Unreserve two more Bytes in order to be able to
-        // Append EndOfContainer of the List + EndOfContainer of the AttributeDataIB
+        // Append EndOfContainer of the List + EndOfContainer of the AttributeDataIB.
         VerifyOrDie(writer->UnreserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB) ==
                     CHIP_NO_ERROR);
         ReturnErrorOnFailure(writer->EndContainer(kAttributeDataIBType));
@@ -371,7 +371,7 @@ private:
 
     template <class T>
     CHIP_ERROR TryEncodeListIntoSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath,
-                                                      const DataModel::List<T> & list, bool & chunkingNeeded,
+                                                      const DataModel::List<T> & list, bool & outChunkingNeeded,
                                                       uint16_t & outEncodedItemCount)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
@@ -399,7 +399,7 @@ private:
             if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
             {
                 mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
-                chunkingNeeded = true;
+                outChunkingNeeded = true;
                 break;
             }
             ReturnErrorOnFailure(err);
@@ -411,7 +411,7 @@ private:
 
     /**
      * A wrapper for TryEncodeSingleAttributeDataIB which will start a new chunk when failed with CHIP_ERROR_NO_MEMORY or
-     * CHIP_ERROR_BUFFER_TOO_SMALL. This will not be used for Lists
+     * CHIP_ERROR_BUFFER_TOO_SMALL. This will not be used for Lists. For Lists, use TryEncodeListIntoSingleAttributeDataIB instead.
      */
     template <class T>
     CHIP_ERROR EncodeSingleAttributeDataIB(const ConcreteDataAttributePath & attributePath, const T & value)

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -192,8 +192,8 @@ public:
         // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
         // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
         // list operation.
-        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all
-        // clusters to support it in testing and in certification.
+        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in a later Matter version and
+        // enforce all clusters to support it in testing and in certification.
         bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
 
         if (encodeEmptyListAsReplaceAll)
@@ -377,26 +377,30 @@ private:
 
         ReturnErrorOnFailure(EnsureListStarted(attributePath));
 
-        chip::TLV::TLVWriter * writer = nullptr;
-        VerifyOrReturnError((writer = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        chip::TLV::TLVWriter * attributeDataIBWriter = nullptr;
+        VerifyOrReturnError((attributeDataIBWriter = GetAttributeDataIBTLVWriter()) != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        AttributeDataIB::Builder & attributeDataIB = mWriteRequestBuilder.GetWriteRequests().GetAttributeDataIBBuilder();
 
         outEncodedItemCount = 0;
 
         for (auto & item : list)
         {
-            mWriteRequestBuilder.GetWriteRequests().Checkpoint(backupWriter);
+            // We essentially write List items to the Data Container within the first AttributeDataIB. We checkpoint the
+            // AttributeDataIB Builder in case there's not enough space to encode a list item.
+            attributeDataIB.Checkpoint(backupWriter);
             if constexpr (DataModel::IsFabricScoped<T>::value)
             {
-                err = DataModel::EncodeForWrite(*writer, TLV::AnonymousTag(), item);
+                err = DataModel::EncodeForWrite(*attributeDataIBWriter, TLV::AnonymousTag(), item);
             }
             else
             {
-                err = DataModel::Encode(*writer, TLV::AnonymousTag(), item);
+                err = DataModel::Encode(*attributeDataIBWriter, TLV::AnonymousTag(), item);
             }
 
             if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
             {
-                mWriteRequestBuilder.GetWriteRequests().Rollback(backupWriter);
+                attributeDataIB.Rollback(backupWriter);
                 outChunkingNeeded = true;
                 break;
             }

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -380,10 +380,11 @@ private:
                 outChunkingNeeded = true;
                 break;
             }
-            else if (err != CHIP_NO_ERROR)
+            // Make sure that we undo the buffer reservation made in EnsureListStarted()
+            if (err != CHIP_NO_ERROR)
             {
                 ReturnErrorOnFailure(EnsureListEnded());
-                ReturnErrorOnFailure(err);
+                return err;
             }
             outEncodedItemCount++;
         }
@@ -547,10 +548,8 @@ private:
         kReservedSizeForEndOfContainer + kReservedSizeForEndOfContainer;
     bool mHasDataVersion = false;
 
-    // These were not added to kReservedSizeForTLVEncodingOverhead since they will only be Reserved and Unreserved when Encoding
-    // Attributes that use a list Data Type
-    static constexpr uint32_t kReservedSizeForEndOfListContainer   = 1;
-    static constexpr uint32_t kReservedSizeForEndOfAttributeDataIB = 1;
+    static constexpr uint16_t kReservedSizeForEndOfListAttributeIB =
+        kReservedSizeForEndOfContainer + AttributeDataIB::Builder::GetSizeToEndAttributeDataIB();
 
     static constexpr TLV::TLVType kAttributeDataIBType = TLV::kTLVType_Structure;
 };

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -165,7 +165,7 @@ public:
     /**
      *  Encode a possibly-chunked list attribute value.  Will create a new chunk when necessary.
      *
-     * This method will Attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
+     * This method will attempt to to encode as many list items as possible into a SingleAttributeDataIB, which will be handled by
      * cluster server as a ReplaceAll Item operation.
      * If the list is too large, the WriteRequest will be chunked and remaining items will be encoded as AppendItem operations,
      chunking them as needed.

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -129,7 +129,7 @@ public:
                 bool aSuppressResponse = false) :
         mpExchangeMgr(apExchangeMgr),
         mExchangeCtx(*this), mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs),
-        mSuppressResponse(aSuppressResponse), mIsWriteRequestChunked(false)
+        mSuppressResponse(aSuppressResponse)
     {
         assertChipStackLockedByCurrentThread();
     }
@@ -273,8 +273,11 @@ public:
 
     /**
      *  Returns true if the WriteRequest is Chunked.
+     *  WARNING: This method is only used for UnitTests. It should only be called AFTER a call
+     * EncodeAttribute/PutPreencodedAttribute AND BEFORE a call to SendWriteRequest(); only during this window does
+     * "!mChunks.IsNull()" reliably indicate that the WriteRequest is chunked.
      */
-    bool IsWriteRequestChunked() const { return mIsWriteRequestChunked; };
+    bool IsWriteRequestChunked() const { return !mChunks.IsNull(); };
 
 private:
     friend class TestWriteInteraction;
@@ -497,8 +500,6 @@ private:
 
     // A list of buffers, one buffer for each chunk.
     System::PacketBufferHandle mChunks;
-
-    bool mIsWriteRequestChunked = false;
 
     // TODO: This file might be compiled with different build flags on Darwin platform (when building WriteClient.cpp and
     // CHIPClustersObjc.mm), which will cause undefined behavior when building write requests. Uncomment the #if and #endif after

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -194,8 +194,7 @@ public:
         // list operation.
         // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all
         // clusters to support it in testing and in certification.
-        bool encodeEmptyListAsReplaceAll =
-            !(path.mClusterId == Clusters::AccessControl::Id && path.mAttributeId == Clusters::AccessControl::Attributes::Acl::Id);
+        bool encodeEmptyListAsReplaceAll = !(path.mClusterId == Clusters::AccessControl::Id);
 
         if (encodeEmptyListAsReplaceAll)
         {
@@ -349,7 +348,7 @@ private:
         ReturnErrorOnFailure(
             writer->StartContainer(chip::TLV::ContextTag(chip::app::AttributeDataIB::Tag::kData), TLV::kTLVType_Array, outerType));
 
-        VerifyOrDie(outerType == kAttributeDataIBType);
+        VerifyOrReturnError(outerType == kAttributeDataIBType, CHIP_ERROR_INCORRECT_STATE);
 
         return CHIP_NO_ERROR;
     }
@@ -361,8 +360,7 @@ private:
 
         // In the event of Chunking (we have a CHIP_ERROR_NO_MEMORY), we need to Unreserve two more Bytes in order to be able to
         // Append EndOfContainer of the List + EndOfContainer of the AttributeDataIB.
-        VerifyOrDie(writer->UnreserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB) ==
-                    CHIP_NO_ERROR);
+        ReturnErrorOnFailure(writer->UnreserveBuffer(kReservedSizeForEndOfListContainer + kReservedSizeForEndOfAttributeDataIB));
         ReturnErrorOnFailure(writer->EndContainer(kAttributeDataIBType));
         ReturnErrorOnFailure(FinishAttributeIB());
 

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -400,6 +400,8 @@ private:
 
             if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
             {
+                // Rollback through the attributeDataIB, which also resets the Builder's error state.
+                // This returns the object to the state it was in before attempting to encode the list item.
                 attributeDataIB.Rollback(backupWriter);
                 outChunkingNeeded = true;
                 break;

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -192,8 +192,8 @@ public:
         // SOLUTION: we treat ACL as an exception and avoid encoding an empty ReplaceAll list. Instead, we pack as many ACL entries
         // as possible into the ReplaceAll list, and send  any remaining entries in subsequent chunks are part of the AppendItem
         // list operation.
-        // TODO: Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all clusters
-        // to support it in testing and in certification.
+        // TODO (#38270): Generalize this behavior; send a non-empty ReplaceAll list for all clusters in Matter 1.5 and enforce all
+        // clusters to support it in testing and in certification.
         bool encodeEmptyListAsReplaceAll =
             !(path.mClusterId == Clusters::AccessControl::Id && path.mAttributeId == Clusters::AccessControl::Attributes::Acl::Id);
 

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -297,7 +297,8 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         // Validating all ACL entries in the ReplaceAll list before Updating or Deleting any entries. If any of the entries has an
         // invalid field, the whole "ReplaceAll" list will be rejected.
-        ReturnErrorOnFailure(IsValidAclEntryList(list));
+        CHIP_ERROR err = IsValidAclEntryList(list);
+        VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
         auto iterator = list.begin();
         size_t i      = 0;

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -102,8 +102,11 @@ private:
     CHIP_ERROR ReadExtension(AttributeValueEncoder & aEncoder);
     CHIP_ERROR WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder);
     CHIP_ERROR WriteExtension(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder);
+    CHIP_ERROR IsValidAclEntryList(const DataModel::DecodableList<AclStorage::DecodableEntry> & list);
+
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-    CHIP_ERROR ReadCommissioningArl(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR
+    ReadCommissioningArl(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadArl(AttributeValueEncoder & aEncoder);
 #endif
 } sAttribute;
@@ -262,6 +265,18 @@ CHIP_ERROR AccessControlAttribute::WriteImpl(const ConcreteDataAttributePath & a
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR AccessControlAttribute::IsValidAclEntryList(const DataModel::DecodableList<AclStorage::DecodableEntry> & list)
+{
+    auto validationIterator = list.begin();
+    while (validationIterator.Next())
+    {
+        VerifyOrReturnError(validationIterator.GetValue().GetEntry().IsValid(), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    ReturnErrorOnFailure(validationIterator.GetStatus());
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)
 {
     FabricIndex accessingFabricIndex = aDecoder.AccessingFabricIndex();
@@ -280,6 +295,10 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
         ReturnErrorOnFailure(list.ComputeSize(&newCount));
 
         VerifyOrReturnError(newCount <= maxCount, CHIP_IM_GLOBAL_STATUS(ResourceExhausted));
+
+        // Validating all ACL entries in the ReplaceAll list before Updating or Deleting any entries. If any of the entries has an
+        // invalid field, the whole "ReplaceAll" list will be rejected.
+        ReturnErrorOnFailure(IsValidAclEntryList(list));
 
         auto iterator = list.begin();
         size_t i      = 0;

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -105,8 +105,7 @@ private:
     CHIP_ERROR IsValidAclEntryList(const DataModel::DecodableList<AclStorage::DecodableEntry> & list);
 
 #if CHIP_CONFIG_USE_ACCESS_RESTRICTIONS
-    CHIP_ERROR
-    ReadCommissioningArl(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadCommissioningArl(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadArl(AttributeValueEncoder & aEncoder);
 #endif
 } sAttribute;

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -297,8 +297,7 @@ CHIP_ERROR AccessControlAttribute::WriteAcl(const ConcreteDataAttributePath & aP
 
         // Validating all ACL entries in the ReplaceAll list before Updating or Deleting any entries. If any of the entries has an
         // invalid field, the whole "ReplaceAll" list will be rejected.
-        CHIP_ERROR err = IsValidAclEntryList(list);
-        VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(ConstraintError));
+        ReturnErrorOnFailure(IsValidAclEntryList(list));
 
         auto iterator = list.begin();
         size_t i      = 0;

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -627,13 +627,17 @@ TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteHandlerReceiveInvalidMessage)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 60 bytes, so that we make sure to chunk. it was empirically determined that with a list of 10
+    // ByteSpan items, we will be able to fit 5/6 list items into the initial ReplaceAll list; thus triggering chunking.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 60) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(writeClient.IsWriteRequestChunked());
 
     GetLoopback().mSentMessageCount                 = 0;
     GetLoopback().mNumMessagesToDrop                = 1;
@@ -692,13 +696,17 @@ TEST_F(TestWriteInteraction, TestWriteHandlerInvalidateFabric)
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
 
-    // Reserve all except the last 128 bytes, so that we make sure to chunk.
+    // Reserve all except the last 60 bytes, so that we make sure to chunk. it was empirically determined that with a list of 10
+    // ByteSpan items, we will be able to fit 5/6 list items into the initial ReplaceAll list; thus triggering chunking.
     app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
-                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 128) /* reserved buffer size */);
+                                 static_cast<uint16_t>(kMaxSecureSduLengthBytes - 60) /* reserved buffer size */);
 
-    ByteSpan list[5];
+    constexpr uint8_t kTestListLength = 10;
+    ByteSpan list[kTestListLength];
 
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, 5)), CHIP_NO_ERROR);
+    EXPECT_EQ(writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength)), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(writeClient.IsWriteRequestChunked());
 
     GetLoopback().mDroppedMessageCount              = 0;
     GetLoopback().mSentMessageCount                 = 0;

--- a/src/app/tests/suites/TestAccessControlCluster.yaml
+++ b/src/app/tests/suites/TestAccessControlCluster.yaml
@@ -215,6 +215,14 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid auth mode"
@@ -248,6 +256,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -289,6 +304,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry invalid target"
@@ -323,6 +345,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -386,6 +415,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Write entry too many targets"
@@ -441,6 +477,13 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 1, # view
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
@@ -520,54 +563,21 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value: [
+          value: # Since the writeAttribute failed, the entire list was rejected, and the previous ACL values remained unchanged
+              [
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
                       AuthMode: 2, # case
                       Subjects: null,
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 0, DeviceType: null },
-                              { Cluster: 1, Endpoint: null, DeviceType: null },
-                              { Cluster: 2, Endpoint: 3, DeviceType: null },
-                          ],
+                      Targets: null,
                   },
                   {
                       FabricIndex: 1,
                       Privilege: 1, # view
                       AuthMode: 2, # case
-                      Subjects: [4, 5, 6, 7],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 8, DeviceType: null },
-                              { Cluster: 9, Endpoint: null, DeviceType: null },
-                              { Cluster: 10, Endpoint: 11, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 3, # operate
-                      AuthMode: 3, # group
-                      Subjects: [12, 13, 14, 15],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 16, DeviceType: null },
-                              { Cluster: 17, Endpoint: null, DeviceType: null },
-                              { Cluster: 18, Endpoint: 19, DeviceType: null },
-                          ],
-                  },
-                  {
-                      FabricIndex: 1,
-                      Privilege: 1, # view
-                      AuthMode: 2, # case
-                      Subjects: [20, 21, 22, 23],
-                      Targets:
-                          [
-                              { Cluster: null, Endpoint: 24, DeviceType: null },
-                              { Cluster: 25, Endpoint: null, DeviceType: null },
-                              { Cluster: 26, Endpoint: 27, DeviceType: null },
-                          ],
+                      Subjects: null,
+                      Targets: null,
                   },
               ]
 
@@ -584,6 +594,13 @@ tests:
                       Subjects: null,
                       Targets: null,
                   },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
               ]
 
     - label: "Verify"
@@ -594,6 +611,107 @@ tests:
                   {
                       FabricIndex: 1,
                       Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in first ACL Entry, with 2nd ACL Entry completely
+          valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Even though a malformed entry was sent, nothing has changed and we still retain the Valid ACLs from previous step
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+              ]
+
+    - label:
+          "Write invalid field in second ACL Entry, with 1st ACL Entry being
+          Valid"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  {
+                      FabricIndex: 0,
+                      Privilege: 1, # view
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 0,
+                      Privilege: 0, # invalid privilege
+                      AuthMode: 2, # case
+                      Subjects: [12, 13, 14, 15],
+                      Targets: null,
+                  },
+              ]
+      response:
+          error: CONSTRAINT_ERROR
+
+    # Test: If second ACL Entry had invalid field, even 1st ACL Entry should be rejected. While retaining the previous Valid ACLs
+    - label: "Verify"
+      command: "readAttribute"
+      attribute: "ACL"
+      response:
+          value: [
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
+                      Subjects: null,
+                      Targets: null,
+                  },
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3, # operate
                       AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
@@ -257,7 +257,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
+          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 19: TH1 writes DUT Endpoint 0 AccessControl cluster Extension

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_3.yaml
@@ -257,7 +257,7 @@ tests:
       command: "readAttribute"
       attribute: "Extension"
       response:
-          value: [{ Data: D_OK_EMPTY, FabricIndex: CurrentFabricIndexValue }]
+          value: [{ Data: D_OK_FULL, FabricIndex: CurrentFabricIndexValue }]
 
     - label:
           "Step 19: TH1 writes DUT Endpoint 0 AccessControl cluster Extension

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -1101,12 +1101,19 @@ tests:
       command: "readAttribute"
       attribute: "ACL"
       response:
-          value:
-              [
+          value: [
                   {
                       Privilege: 5,
                       AuthMode: 2,
                       Subjects: [CommissionerNodeId],
+                      Targets: null,
+                      FabricIndex: CurrentFabricIndexValue,
+                  },
+                  # We are retaining the ACLs from Step 21 and Step 22
+                  {
+                      Privilege: 3,
+                      AuthMode: 2,
+                      Subjects: [CAT1, CAT2, CAT3, CAT4],
                       Targets: null,
                       FabricIndex: CurrentFabricIndexValue,
                   },

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_4.yaml
@@ -23,17 +23,17 @@ config:
     cluster: "Access Control"
     endpoint: 0
     CAT1:
-        type: int64u
-        defaultValue: 65520
+        type: node_id
+        defaultValue: 0xFFFFFFFDABCD0001
     CAT2:
-        type: int64u
-        defaultValue: 65521
+        type: node_id
+        defaultValue: 0xFFFFFFFDFFFF0001
     CAT3:
-        type: int64u
-        defaultValue: 65522
+        type: node_id
+        defaultValue: 0xFFFFFFFD071C1074
     CAT4:
-        type: int64u
-        defaultValue: 65523
+        type: node_id
+        defaultValue: 0xFFFFFFFDAB120003
 
 tests:
     - label: "Step 1:Wait for the commissioned device to be retrieved"

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -140,7 +140,20 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 0,
+                          ChangeType: 2,
+                          LatestValue:
+                              {
+                                  Data: D_OK_EMPTY,
+                                  FabricIndex: CurrentFabricIndexValue,
+                              },
+                          FabricIndex: CurrentFabricIndexValue,
+                      }
+          - values:
+                - value:
+                      {
+                          AdminNodeID: CommissionerNodeId,
+                          AdminPasscodeID: null,
+                          ChangeType: 1,
                           LatestValue:
                               {
                                   Data: D_OK_SINGLE,
@@ -161,17 +174,26 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
-      # Since a CONSTRAINT_ERROR was triggered in Step 8, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
-      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      PICS: ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value: {}
+          value:
+              {
+                  AdminNodeID: CommissionerNodeId,
+                  AdminPasscodeID: null,
+                  ChangeType: 2,
+                  LatestValue:
+                      {
+                          Data: D_OK_SINGLE,
+                          FabricIndex: CurrentFabricIndexValue,
+                      },
+                  FabricIndex: CurrentFabricIndexValue,
+              }
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -189,17 +211,26 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
-      # Since a CONSTRAINT_ERROR was triggered in Step 10, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
-      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 11: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      PICS: ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value: {}
+          value:
+              {
+                  AdminNodeID: CommissionerNodeId,
+                  AdminPasscodeID: null,
+                  ChangeType: 1,
+                  LatestValue:
+                      {
+                          Data: D_OK_EMPTY,
+                          FabricIndex: CurrentFabricIndexValue,
+                      },
+                  FabricIndex: CurrentFabricIndexValue,
+              }
 
     - label:
           "Step 12: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -223,9 +254,9 @@ tests:
                   AdminNodeID: CommissionerNodeId,
                   AdminPasscodeID: null,
                   ChangeType: 2,
-                  LatestValue: {
-                          # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed
-                          Data: D_OK_SINGLE,
+                  LatestValue:
+                      {
+                          Data: D_OK_EMPTY,
                           FabricIndex: CurrentFabricIndexValue,
                       },
                   FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -167,6 +167,8 @@ tests:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
       PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      disabled: true
+
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
@@ -195,6 +197,8 @@ tests:
           "Step 11: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
       PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
+      disabled: true
+
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_5.yaml
@@ -140,20 +140,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Data: D_OK_EMPTY,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Data: D_OK_SINGLE,
@@ -174,26 +161,17 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 8, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 9: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 2,
-                  LatestValue:
-                      {
-                          Data: D_OK_SINGLE,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+          value: {}
 
     - label:
           "Step 10: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -211,26 +189,17 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since a CONSTRAINT_ERROR was triggered in Step 10, no change will happen to the already-existing "Extension", and thus no AccessControlExtensionChanged event will be generated
+      # SKIP for Now, as there is currently no way to check that AccessControlExtensionChanged value is an empty list
     - label:
           "Step 11: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlExtensionChanged event"
-      PICS: ACL.S.E01
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E01
       command: "readEvent"
       event: "AccessControlExtensionChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
-          value:
-              {
-                  AdminNodeID: CommissionerNodeId,
-                  AdminPasscodeID: null,
-                  ChangeType: 1,
-                  LatestValue:
-                      {
-                          Data: D_OK_EMPTY,
-                          FabricIndex: CurrentFabricIndexValue,
-                      },
-                  FabricIndex: CurrentFabricIndexValue,
-              }
+          value: {}
 
     - label:
           "Step 12: TH1 writes DUT Endpoint 0 AccessControl cluster Extension
@@ -254,9 +223,9 @@ tests:
                   AdminNodeID: CommissionerNodeId,
                   AdminPasscodeID: null,
                   ChangeType: 2,
-                  LatestValue:
-                      {
-                          Data: D_OK_EMPTY,
+                  LatestValue: {
+                          # The Extension data D_OK_SINGLE that was "Changed" in Step in 7 will be removed
+                          Data: D_OK_SINGLE,
                           FabricIndex: CurrentFabricIndexValue,
                       },
                   FabricIndex: CurrentFabricIndexValue,

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -114,23 +114,7 @@ tests:
                       {
                           AdminNodeID: CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -190,59 +174,21 @@ tests:
       response:
           error: CONSTRAINT_ERROR
 
+      # Since in Step 6 one of the ACL List Entries had an invalid item, then the whole ACL Entries List was rejected, As such no change will happen to the already-existing AccessControl Entries, and thus no AccessControlEntryChanged event will be generated
+      # SKIP for Now, as YAML does not provide a way to check that the received ReportDataMessage does NOT contain an EventReportIB
+      # Example of Output of this Step
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] ReportDataMessage =
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] {
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	SuppressResponse = true,
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] 	InteractionModelRevision = 12
+      # 2025-03-25 16:36:59.453 ERROR   16:36:59.296 - TEST OUT  : 		    [DMG] }
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
-      PICS: ACL.S.E00
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"
       response:
           - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 3,
-                                  AuthMode: 3,
-                                  Subjects: null,
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: CurrentFabricIndexValue,
-                              },
-                          FabricIndex: CurrentFabricIndexValue,
-                      }
+                - value: {}

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -186,6 +186,7 @@ tests:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
       PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
+      disabled: true
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -185,7 +185,8 @@ tests:
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
-      PICS: ACL.S.E00
+      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
+      disabled: true
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_6.yaml
@@ -185,8 +185,7 @@ tests:
     - label:
           "Step 7: TH1 reads DUT Endpoint 0 AccessControl cluster
           AccessControlEntryChanged event"
-      PICS: PICS_SKIP_SAMPLE_APP && ACL.S.E00
-      disabled: true
+      PICS: ACL.S.E00
       command: "readEvent"
       event: "AccessControlEntryChanged"
       eventNumber: "LastReceivedEventNumber + 1"

--- a/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ACL_2_8.yaml
@@ -378,23 +378,7 @@ tests:
                       {
                           AdminNodeID: TH1CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH1CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH1FabricIndex,
-                              },
-                          FabricIndex: TH1FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH1CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,
@@ -435,23 +419,7 @@ tests:
                       {
                           AdminNodeID: TH2CommissionerNodeId,
                           AdminPasscodeID: null,
-                          ChangeType: 2,
-                          LatestValue:
-                              {
-                                  Privilege: 5,
-                                  AuthMode: 2,
-                                  Subjects: [TH2CommissionerNodeId],
-                                  Targets: null,
-                                  FabricIndex: TH2FabricIndex,
-                              },
-                          FabricIndex: TH2FabricIndex,
-                      }
-          - values:
-                - value:
-                      {
-                          AdminNodeID: TH2CommissionerNodeId,
-                          AdminPasscodeID: null,
-                          ChangeType: 1,
+                          ChangeType: 0,
                           LatestValue:
                               {
                                   Privilege: 5,

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -384,7 +384,7 @@ TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
 
         ChipLogDetail(DataManagement, "Running iteration %d\n", static_cast<int>(reservationReduction));
 
-        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, NullOptional,
                                      static_cast<uint16_t>(maxReservationSize - reservationReduction) /* reserved buffer size */);
 
         ByteSpan list[kTestListLength2];
@@ -546,7 +546,7 @@ TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
 
         ChipLogDetail(DataManagement, "Running iteration with OCTET_STRING length = %d\n", bufferSize);
 
-        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, NullOptional);
 
         ByteSpan list[kTestListLengthBadChunking];
         for (auto & item : list)
@@ -706,12 +706,10 @@ TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
     ByteSpan list[kTestListLength2];
 
     TestWriteCallback writeCallback1;
-    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
-                                  static_cast<uint16_t>(kReserveSize));
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, NullOptional, static_cast<uint16_t>(kReserveSize));
 
     TestWriteCallback writeCallback2;
-    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
-                                  static_cast<uint16_t>(kReserveSize));
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, NullOptional, static_cast<uint16_t>(kReserveSize));
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -855,12 +853,10 @@ TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
     constexpr uint8_t kTestListLength2 = 10;
 
     TestWriteCallback writeCallback1;
-    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
-                                  static_cast<uint16_t>(kReserveSize));
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, NullOptional, static_cast<uint16_t>(kReserveSize));
 
     TestWriteCallback writeCallback2;
-    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
-                                  static_cast<uint16_t>(kReserveSize));
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, NullOptional, static_cast<uint16_t>(kReserveSize));
 
     ByteSpan list[kTestListLength2];
 
@@ -1104,7 +1100,7 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
 
     TestWriteCallback writeCallback;
     std::unique_ptr<WriteClient> writeClient = std::make_unique<WriteClient>(
-        &GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
+        &GetExchangeManager(), &writeCallback, NullOptional,
         static_cast<uint16_t>(kMaxSecureSduLengthBytes -
                               66) /* use a smaller chunk so we only need a few attributes in the write request. */);
 

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -1284,6 +1284,30 @@ TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
         .expectedStatus = { false },
     });
 
+    // This TestCase tests corner cases when we Encode many attributes into the same WriteRequest, up to 10 Attributes will be
+    // Encoded.
+    for (int nullableListCount = 1; nullableListCount <= 10; nullableListCount++)
+    {
+        ChipLogProgress(Zcl, "Test 10.%d: Encoding %d nullable lists following a single non-nullable list", nullableListCount,
+                        nullableListCount);
+
+        Instructions test;
+
+        // Add the single non-nullable list
+        test.paths.push_back(ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id));
+        test.data.push_back(ListData::kList);
+
+        // Add the nullable lists
+        for (int i = 0; i < nullableListCount; i++)
+        {
+            test.paths.push_back(ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id));
+            test.data.push_back(ListData::kNull);
+        }
+
+        test.expectedStatus = { true };
+        RunTest_NonEmptyReplaceAll(test);
+    }
+
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 
     emberAfClearDynamicEndpoint(0);

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -381,8 +381,6 @@ TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
 
         ChipLogDetail(DataManagement, "Running iteration %d\n", static_cast<int>(i));
 
-        gIterationCount = i;
-
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
                                      static_cast<uint16_t>(minReservationSize + i) /* reserved buffer size */);
 
@@ -513,7 +511,7 @@ TEST_F(TestWriteChunking, TestBadChunking)
 
 /*
  * A Variant of TestBadChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
- * happens with the ACL Attribute
+ * happens with the ACL Attribute.
  */
 TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
 {
@@ -536,21 +534,19 @@ TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
 
     constexpr uint8_t kTestListLengthBadChunking = 5;
 
-    for (int i = 850; i < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); i++)
+    for (int msgSize = 850; msgSize < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); msgSize++)
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
         TestWriteCallback writeCallback;
 
-        ChipLogDetail(DataManagement, "Running iteration with OCTET_STRING length = %d\n", i);
-
-        gIterationCount = (uint32_t) i;
+        ChipLogDetail(DataManagement, "Running iteration with OCTET_STRING length = %d\n", msgSize);
 
         app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
 
         ByteSpan list[kTestListLengthBadChunking];
         for (auto & item : list)
         {
-            item = ByteSpan(sByteSpanData, static_cast<uint32_t>(i));
+            item = ByteSpan(sByteSpanData, static_cast<uint32_t>(msgSize));
         }
 
         err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLengthBadChunking));
@@ -678,7 +674,7 @@ TEST_F(TestWriteChunking, TestConflictWrite)
 
 /*
  * A Variant of TestConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
- * happens with the ACL Attribute
+ * happens with the ACL Attribute.
  */
 TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
 {
@@ -828,7 +824,7 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
 
 /*
  * A Variant of TestNonConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
- * happens with the ACL Attribute
+ * happens with the ACL Attribute.
  */
 TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
 {
@@ -1094,7 +1090,7 @@ TEST_F(TestWriteChunking, TestTransactionalList)
 
 /*
  * A Variant of RunTest above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
- * happens with the ACL Attribute
+ * happens with the ACL Attribute.
  */
 void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
 {
@@ -1192,7 +1188,7 @@ void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
 
 TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
 {
-    // Initialize the ember side server logic
+    // Initialize the ember side server logic.
     app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
     InitDataModelHandler();
 

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -54,7 +54,7 @@ uint32_t gIterationCount = 0;
 // already used in the fixed endpoint set of size 1. Consequently, let's use the next
 // number higher than that for our dynamic test endpoint.
 //
-constexpr EndpointId kTestEndpointId      = 2;
+constexpr EndpointId kTestEndpointId      = 0;
 constexpr AttributeId kTestListAttribute  = 6;
 constexpr AttributeId kTestListAttribute2 = 7;
 constexpr uint32_t kTestListLength        = 5;
@@ -94,9 +94,11 @@ protected:
     };
 
     void RunTest(Instructions instructions);
+    void RunTest_NonEmptyReplaceAll(Instructions instructions);
 };
 
 //clang-format off
+
 DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrsOnEndpoint)
 DECLARE_DYNAMIC_ATTRIBUTE(kTestListAttribute, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE),
     DECLARE_DYNAMIC_ATTRIBUTE(kTestListAttribute2, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE), DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
@@ -107,7 +109,22 @@ DECLARE_DYNAMIC_CLUSTER(Clusters::UnitTesting::Id, testClusterAttrsOnEndpoint, Z
 
 DECLARE_DYNAMIC_ENDPOINT(testEndpoint, testEndpointClusters);
 
+// Second Endpoint to Test Chunking when we send non-empty initial ReplaceAll List, which is used for ACL, see
+// WriteClient::EncodeAttribute()
+
+DECLARE_DYNAMIC_ATTRIBUTE_LIST_BEGIN(testClusterAttrsOnEndpoint2)
+DECLARE_DYNAMIC_ATTRIBUTE(Clusters::AccessControl::Attributes::Acl::Id, ARRAY, 8, MATTER_ATTRIBUTE_FLAG_WRITABLE),
+    DECLARE_DYNAMIC_ATTRIBUTE(Clusters::AccessControl::Attributes::Extension::Id, ARRAY, 1, MATTER_ATTRIBUTE_FLAG_WRITABLE),
+    DECLARE_DYNAMIC_ATTRIBUTE_LIST_END();
+
+DECLARE_DYNAMIC_CLUSTER_LIST_BEGIN(testEndpointClusters2)
+DECLARE_DYNAMIC_CLUSTER(Clusters::AccessControl::Id, testClusterAttrsOnEndpoint2, ZAP_CLUSTER_MASK(SERVER), nullptr, nullptr),
+    DECLARE_DYNAMIC_CLUSTER_LIST_END;
+
+DECLARE_DYNAMIC_ENDPOINT(testEndpointAcl, testEndpointClusters2);
+
 DataVersion dataVersionStorage[MATTER_ARRAY_SIZE(testEndpointClusters)];
+DataVersion dataVersionStorageAcl[MATTER_ARRAY_SIZE(testEndpointClusters2)];
 
 //clang-format on
 
@@ -183,14 +200,69 @@ CHIP_ERROR TestAttrAccess::Write(const app::ConcreteDataAttributePath & aPath, a
     {
         app::DataModel::Nullable<app::DataModel::DecodableList<ByteSpan>> list;
         CHIP_ERROR err = aDecoder.Decode(list);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "NotList/ReplaceAll: Decode result: %s", err.AsString());
         return err;
     }
     if (aPath.mListOp == app::ConcreteDataAttributePath::ListOperation::AppendItem)
     {
         ByteSpan listItem;
         CHIP_ERROR err = aDecoder.Decode(listItem);
-        ChipLogError(Zcl, "Decode result: %s", err.AsString());
+        ChipLogError(Zcl, "AppendItem: Decode result: %s", err.AsString());
+        return err;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+class TestAttrAccessAcl : public app::AttributeAccessInterface
+{
+public:
+    // Register for the Test Cluster cluster on all endpoints.
+    TestAttrAccessAcl() : AttributeAccessInterface(Optional<EndpointId>::Missing(), AccessControl::Id) {}
+
+    CHIP_ERROR Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder) override;
+    CHIP_ERROR Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder) override;
+
+    void OnListWriteBegin(const app::ConcreteAttributePath & aPath) override
+    {
+        if (mOnListWriteBegin)
+        {
+            mOnListWriteBegin(aPath);
+        }
+    }
+
+    void OnListWriteEnd(const app::ConcreteAttributePath & aPath, bool aWriteWasSuccessful) override
+    {
+        if (mOnListWriteEnd)
+        {
+            mOnListWriteEnd(aPath, aWriteWasSuccessful);
+        }
+    }
+
+    std::function<void(const app::ConcreteAttributePath & path)> mOnListWriteBegin;
+    std::function<void(const app::ConcreteAttributePath & path, bool wasSuccessful)> mOnListWriteEnd;
+} testServerAcl;
+
+CHIP_ERROR TestAttrAccessAcl::Read(const app::ConcreteReadAttributePath & aPath, app::AttributeValueEncoder & aEncoder)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR TestAttrAccessAcl::Write(const app::ConcreteDataAttributePath & aPath, app::AttributeValueDecoder & aDecoder)
+{
+    // We only care about the number of attribute data.
+    if (!aPath.IsListItemOperation())
+    {
+        app::DataModel::Nullable<app::DataModel::DecodableList<ByteSpan>> list;
+        CHIP_ERROR err = aDecoder.Decode(list);
+        ChipLogError(Zcl, "NotList/ReplaceAll: Decode result: %s", err.AsString());
+        return err;
+    }
+    if (aPath.mListOp == app::ConcreteDataAttributePath::ListOperation::AppendItem)
+    {
+        ByteSpan listItem;
+        CHIP_ERROR err = aDecoder.Decode(listItem);
+        ChipLogError(Zcl, "AppendItem: Decode result: %s", err.AsString());
         return err;
     }
 
@@ -259,6 +331,88 @@ TEST_F(TestWriteChunking, TestListChunking)
         }
 
         EXPECT_EQ(writeCallback.mSuccessCount, kTestListLength + 1 /* an extra item for the empty list at the beginning */);
+        EXPECT_EQ(writeCallback.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
+
+        EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+        //
+        // Stop the test if we detected an error. Otherwise, it'll be difficult to read the logs.
+        //
+        if (HasFailure())
+        {
+            break;
+        }
+    }
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of TestListChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Attribute
+ */
+TEST_F(TestWriteChunking, TestListChunking_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    // We've empirically determined that by reserving all but 65 bytes in the packet buffer, we can fit 1
+    // AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of 20 items, our
+    // initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t minReservationSize = kMaxSecureSduLengthBytes - 65 - 20;
+
+    constexpr uint8_t kTestListLength2 = 20;
+
+    for (uint32_t i = 20; i > 0; i--)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        TestWriteCallback writeCallback;
+
+        ChipLogDetail(DataManagement, "Running iteration %d\n", static_cast<int>(i));
+
+        gIterationCount = i;
+
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
+                                     static_cast<uint16_t>(minReservationSize + i) /* reserved buffer size */);
+
+        ByteSpan list[kTestListLength2];
+
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        err = writeClient.SendWriteRequest(sessionHandle);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Service the IO + Engine till we get a ReportEnd callback on the client.
+        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
+        // times this can run without seeing expected results.
+        //
+        for (int j = 0; j < 10 && writeCallback.mOnDoneCount == 0; j++)
+        {
+            DrainAndServiceIO();
+        }
+
+        // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+        // This check guarantees that the test is validating chunked behavior as intended.
+        EXPECT_TRUE(writeClient.IsWriteRequestChunked());
+
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List, before
+        // starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into the initial
+        // ReplaceAll List.
+        // However, we know for sure that writeCallback should NEVER fail.
         EXPECT_EQ(writeCallback.mErrorCount, 0u);
         EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
 
@@ -358,6 +512,96 @@ TEST_F(TestWriteChunking, TestBadChunking)
 }
 
 /*
+ * A Variant of TestBadChunking above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Attribute
+ */
+TEST_F(TestWriteChunking, TestBadChunking_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    bool atLeastOneRequestSent   = false;
+    bool atLeastOneRequestFailed = false;
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    constexpr uint8_t kTestListLengthBadChunking = 5;
+
+    for (int i = 850; i < static_cast<int>(chip::app::kMaxSecureSduLengthBytes); i++)
+    {
+        CHIP_ERROR err = CHIP_NO_ERROR;
+        TestWriteCallback writeCallback;
+
+        ChipLogDetail(DataManagement, "Running iteration with OCTET_STRING length = %d\n", i);
+
+        gIterationCount = (uint32_t) i;
+
+        app::WriteClient writeClient(&GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing());
+
+        ByteSpan list[kTestListLengthBadChunking];
+        for (auto & item : list)
+        {
+            item = ByteSpan(sByteSpanData, static_cast<uint32_t>(i));
+        }
+
+        err = writeClient.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLengthBadChunking));
+        if (err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL)
+        {
+            // This kind of error is expected.
+            atLeastOneRequestFailed = true;
+            continue;
+        }
+
+        atLeastOneRequestSent = true;
+
+        // If we successfully encoded the attribute, then we must be able to send the message.
+        err = writeClient.SendWriteRequest(sessionHandle);
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Service the IO + Engine till we get a ReportEnd callback on the client.
+        // Since bugs can happen, we don't want this test to never stop, so create a ceiling for how many
+        // times this can run without seeing expected results.
+        //
+        for (int j = 0; j < 10 && writeCallback.mOnDoneCount == 0; j++)
+        {
+            DrainAndServiceIO();
+        }
+
+        // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+        // This check guarantees that the test is validating chunked behavior as intended.
+        EXPECT_TRUE(writeClient.IsWriteRequestChunked());
+
+        // Due to the way Write Chunking is done, it is difficult to predict mSuccessCount. It all depends on how much was
+        // packed into the initial ReplaceAll List.
+        EXPECT_EQ(writeCallback.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback.mOnDoneCount, 1u);
+
+        EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+        //
+        // Stop the test if we detected an error. Otherwise, it'll be difficult to read the logs.
+        //
+        if (HasFailure())
+        {
+            break;
+        }
+    }
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+    EXPECT_TRUE(atLeastOneRequestSent && atLeastOneRequestFailed);
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
  * When chunked write is enabled, it is dangerious to handle multiple write requests at the same time. In this case, we will reject
  * the latter write requests to the same attribute.
  */
@@ -433,6 +677,92 @@ TEST_F(TestWriteChunking, TestConflictWrite)
 }
 
 /*
+ * A Variant of TestConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Attribute
+ */
+TEST_F(TestWriteChunking, TestConflictWrite_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet buffer,
+    // we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of
+    // 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize      = kMaxSecureSduLengthBytes - 60;
+    constexpr uint8_t kTestListLength2 = 10;
+
+    ByteSpan list[kTestListLength2];
+
+    TestWriteCallback writeCallback1;
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
+                                  static_cast<uint16_t>(kReserveSize));
+
+    TestWriteCallback writeCallback2;
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
+                                  static_cast<uint16_t>(kReserveSize));
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = writeClient1.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    err = writeClient2.EncodeAttribute(attributePath, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient1.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient2.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    {
+        const TestWriteCallback * writeCallbackRef1 = &writeCallback1;
+        const TestWriteCallback * writeCallbackRef2 = &writeCallback2;
+
+        // Exactly one of WriteClient1 and WriteClient2 should success, not both.
+
+        if (writeCallback1.mSuccessCount == 0)
+        {
+            writeCallbackRef2 = &writeCallback1;
+            writeCallbackRef1 = &writeCallback2;
+        }
+
+        // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+        // This check guarantees that the test is validating chunked behavior as intended.
+        EXPECT_TRUE(writeClient1.IsWriteRequestChunked());
+        EXPECT_TRUE(writeClient2.IsWriteRequestChunked());
+
+        // Due to Write Chunking being done dynamically (fitting as many items as possible into an initial ReplaceAll List, before
+        // starting to chunk), it is fragile to try to predict mSuccessCount. It all depends on how much was packed into the initial
+        // ReplaceAll List. However, we know for sure that writeCallbackRef1 should NEVER fail, and that writeCallbackRef2 should
+        // NEVER Succeed.
+        EXPECT_EQ(writeCallbackRef1->mErrorCount, 0u);
+        EXPECT_EQ(writeCallbackRef2->mSuccessCount, 0u);
+
+        EXPECT_EQ(writeCallbackRef2->mLastErrorReason.mStatus, Protocols::InteractionModel::Status::Busy);
+
+        EXPECT_EQ(writeCallbackRef1->mOnDoneCount, 1u);
+        EXPECT_EQ(writeCallbackRef2->mOnDoneCount, 1u);
+    }
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
  * When chunked write is enabled, it is dangerious to handle multiple write requests at the same time. However, we will allow such
  * change when writing to different attributes in parallel.
  */
@@ -486,6 +816,80 @@ TEST_F(TestWriteChunking, TestNonConflictWrite)
         EXPECT_EQ(writeCallback1.mSuccessCount, kTestListLength + 1);
         EXPECT_EQ(writeCallback2.mErrorCount, 0u);
         EXPECT_EQ(writeCallback2.mSuccessCount, kTestListLength + 1);
+
+        EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
+        EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
+    }
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of TestNonConflictWrite above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Attribute
+ */
+TEST_F(TestWriteChunking, TestNonConflictWrite_NonEmptyReplaceAllList)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    app::AttributePathParams attributePath1(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id);
+    app::AttributePathParams attributePath2(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id);
+
+    // To ensure that chunking is triggered: We've empirically determined that by reserving all but 60 bytes in the packet buffer,
+    // we can fit 1 AttributeDataIB into the packet with a List of 5/6 ByteSpans with empty items. So if we have a ByteSpan List of
+    // 10 items, our initial ReplaceAll list will contain 5/6 items, and the remaining items are chunked.
+    constexpr size_t kReserveSize      = kMaxSecureSduLengthBytes - 65;
+    constexpr uint8_t kTestListLength2 = 10;
+
+    TestWriteCallback writeCallback1;
+    app::WriteClient writeClient1(&GetExchangeManager(), &writeCallback1, Optional<uint16_t>::Missing(),
+                                  static_cast<uint16_t>(kReserveSize));
+
+    TestWriteCallback writeCallback2;
+    app::WriteClient writeClient2(&GetExchangeManager(), &writeCallback2, Optional<uint16_t>::Missing(),
+                                  static_cast<uint16_t>(kReserveSize));
+
+    ByteSpan list[kTestListLength2];
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = writeClient1.EncodeAttribute(attributePath1, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+    err = writeClient2.EncodeAttribute(attributePath2, app::DataModel::List<ByteSpan>(list, kTestListLength2));
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient1.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    err = writeClient2.SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    DrainAndServiceIO();
+
+    {
+
+        // Ensure that chunking actually occurred. Since chunking is dynamic, it's easy to unintentionally avoid it.
+        // This check guarantees that the test is validating chunked behavior as intended.
+        EXPECT_TRUE(writeClient1.IsWriteRequestChunked());
+        EXPECT_TRUE(writeClient2.IsWriteRequestChunked());
+
+        // Due to Write Chunking being done dynamically, it is fragile to try to predict mSuccessCount. It all depends on how much
+        // was packed into the initial ReplaceAll List.
+        // However, we know for sure that writeCallback1 and writeCallback2 should NEVER fail.
+        EXPECT_EQ(writeCallback1.mErrorCount, 0u);
+        EXPECT_EQ(writeCallback2.mErrorCount, 0u);
 
         EXPECT_EQ(writeCallback1.mOnDoneCount, 1u);
         EXPECT_EQ(writeCallback2.mOnDoneCount, 1u);
@@ -679,6 +1083,204 @@ TEST_F(TestWriteChunking, TestTransactionalList)
                     "during processing the requests");
     RunTest(Instructions{
         .paths          = { ConcreteAttributePath(kTestEndpointId, Clusters::UnitTesting::Id, kTestListAttribute) },
+        .data           = { ListData::kBadValue },
+        .expectedStatus = { false },
+    });
+
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+
+    emberAfClearDynamicEndpoint(0);
+}
+
+/*
+ * A Variant of RunTest above, that tests the Code Path where we encode a Non-Replace All List in WriteRequests, this
+ * happens with the ACL Attribute
+ */
+void TestWriteChunking::RunTest_NonEmptyReplaceAll(Instructions instructions)
+{
+    CHIP_ERROR err     = CHIP_NO_ERROR;
+    auto sessionHandle = GetSessionBobToAlice();
+
+    TestWriteCallback writeCallback;
+    std::unique_ptr<WriteClient> writeClient = std::make_unique<WriteClient>(
+        &GetExchangeManager(), &writeCallback, Optional<uint16_t>::Missing(),
+        static_cast<uint16_t>(kMaxSecureSduLengthBytes -
+                              66) /* use a smaller chunk so we only need a few attributes in the write request. */);
+
+    ConcreteAttributePath onGoingPath = ConcreteAttributePath();
+    std::vector<PathStatus> status;
+
+    testServerAcl.mOnListWriteBegin = [&](const ConcreteAttributePath & aPath) {
+        EXPECT_EQ(onGoingPath, ConcreteAttributePath());
+        onGoingPath = aPath;
+        ChipLogProgress(Zcl, "OnListWriteBegin endpoint=%u Cluster=" ChipLogFormatMEI " attribute=" ChipLogFormatMEI,
+                        aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
+        if (instructions.onListWriteBeginActions)
+        {
+            switch (instructions.onListWriteBeginActions(aPath))
+            {
+            case Operations::kNoop:
+                break;
+            case Operations::kShutdownWriteClient:
+                // By setting writeClient to nullptr, we actually shutdown the write interaction to simulate a timeout.
+                writeClient = nullptr;
+            }
+        }
+    };
+    testServerAcl.mOnListWriteEnd = [&](const ConcreteAttributePath & aPath, bool aWasSuccessful) {
+        EXPECT_EQ(onGoingPath, aPath);
+        status.push_back(PathStatus(aPath, aWasSuccessful));
+        onGoingPath = ConcreteAttributePath();
+        ChipLogProgress(Zcl, "OnListWriteEnd endpoint=%u Cluster=" ChipLogFormatMEI " attribute=" ChipLogFormatMEI,
+                        aPath.mEndpointId, ChipLogValueMEI(aPath.mClusterId), ChipLogValueMEI(aPath.mAttributeId));
+    };
+
+    constexpr uint8_t kTestListLength2 = 10;
+
+    ByteSpan list[kTestListLength2];
+    uint8_t badList[kTestListLength2];
+
+    if (instructions.data.size() == 0)
+    {
+        instructions.data = std::vector<ListData>(instructions.paths.size(), ListData::kList);
+    }
+    EXPECT_EQ(instructions.paths.size(), instructions.data.size());
+
+    for (size_t i = 0; i < instructions.paths.size(); i++)
+    {
+        const auto & p = instructions.paths[i];
+        switch (instructions.data[i])
+        {
+        case ListData::kNull: {
+            DataModel::Nullable<uint8_t> null; // The actual type is not important since we will only put a null value.
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId), null);
+            break;
+        }
+        case ListData::kList: {
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
+                                               DataModel::List<ByteSpan>(list, kTestListLength2));
+            break;
+        }
+        case ListData::kBadValue: {
+            err = writeClient->EncodeAttribute(AttributePathParams(p.mEndpointId, p.mClusterId, p.mAttributeId),
+                                               DataModel::List<uint8_t>(badList, kTestListLength2));
+            break;
+        }
+        }
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+    }
+
+    err = writeClient->SendWriteRequest(sessionHandle);
+    EXPECT_EQ(err, CHIP_NO_ERROR);
+
+    GetIOContext().DriveIOUntil(
+        sessionHandle->ComputeRoundTripTimeout(app::kExpectedIMProcessingTime, true /*isFirstMessageOnExchange*/) +
+            System::Clock::Seconds16(1),
+        [&]() { return GetExchangeManager().GetNumActiveExchanges() == 0; });
+
+    EXPECT_EQ(onGoingPath, app::ConcreteAttributePath());
+    EXPECT_EQ(status.size(), instructions.expectedStatus.size());
+
+    for (size_t i = 0; i < status.size(); i++)
+    {
+        EXPECT_EQ(status[i], PathStatus(instructions.paths[i], instructions.expectedStatus[i]));
+    }
+
+    testServerAcl.mOnListWriteBegin = nullptr;
+    testServerAcl.mOnListWriteEnd   = nullptr;
+}
+
+TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
+{
+    // Initialize the ember side server logic
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(CodegenDataModelProviderInstance(nullptr /* delegate */));
+    InitDataModelHandler();
+
+    // Register our fake dynamic endpoint.
+    emberAfSetDynamicEndpoint(0, kTestEndpointId, &testEndpointAcl, Span<DataVersion>(dataVersionStorageAcl));
+
+    // Register our fake attribute access interface.
+    AttributeAccessInterfaceRegistry::Instance().Register(&testServerAcl);
+
+    // Test 1: we should receive transaction notifications
+    ChipLogProgress(Zcl, "Test 1: we should receive transaction notifications");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl, "Test 2: we should receive transaction notifications for incomplete list operations");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .onListWriteBeginActions = [&](const app::ConcreteAttributePath & aPath) { return Operations::kShutdownWriteClient; },
+        .expectedStatus          = { false },
+    });
+
+    ChipLogProgress(Zcl, "Test 3: we should receive transaction notifications for every list in the transaction");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id) },
+        .expectedStatus = { true, true },
+    });
+
+    ChipLogProgress(Zcl, "Test 4: we should receive transaction notifications with the status of each list");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                   ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Extension::Id) },
+        .onListWriteBeginActions =
+            [&](const app::ConcreteAttributePath & aPath) {
+                if (aPath.mAttributeId == AccessControl::Attributes::Extension::Id)
+                {
+                    return Operations::kShutdownWriteClient;
+                }
+                return Operations::kNoop;
+            },
+        .expectedStatus = { true, false },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 5: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value before non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kNull, ListData::kList },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 6: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value after non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kList, ListData::kNull },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 7: transactional list callbacks will be called for nullable lists, test if it is handled correctly for "
+                    "null value between non null values");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id),
+                            ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kList, ListData::kNull, ListData::kList },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl, "Test 8: transactional list callbacks will be called for nullable lists");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
+        .data           = { ListData::kNull },
+        .expectedStatus = { true },
+    });
+
+    ChipLogProgress(Zcl,
+                    "Test 9: for nullable lists, we should receive notifications for unsuccessful writes when non-fatal occurred "
+                    "during processing the requests");
+    RunTest_NonEmptyReplaceAll(Instructions{
+        .paths          = { ConcreteAttributePath(kTestEndpointId, AccessControl::Id, AccessControl::Attributes::Acl::Id) },
         .data           = { ListData::kBadValue },
         .expectedStatus = { false },
     });


### PR DESCRIPTION
- Fix for https://github.com/project-chip/connectedhomeip/issues/36535

Modifying how ACL (and Extensions) Attribute is written: making it use a non-empty initial ReplaceAll list.

### Cause of Issue

- Basically, The issue is related to how Clients Encode Attribute Lists (not only ACLs) into WriteRequests.
- `ReplaceAll List Operation`: Currently, an Empty List is always Encoded first, This triggers a clearing of all Entries on the server side.
- `AppendItem List Operation` Followed by all the Items that are meant to be written; Those Items are Appended one by one on the Server's side.
- If an ACL Entry is malformed, we would have already cleared out all ACL entries, before Validating that ACL is malformed, and thus staying with incomplete or no ACLs.

### The Fix

1. Modify how the `WriteClient` Encodes an ACL List 
2. Instead of Encoding and sending an Empty Initial List (the `ReplaceAll` list that used to clear all List Entries), and then following it up with Items sent seperately.
3. We will now encode the maximum number of items possible into the initial `ReplaceAll` List, and will only chunk if needed.
4. Added a Check in ACL Cluster Server that all List Entries in that initial `ReplaceAll` list are valid, before starting to Update or Delete any Entries.

### Scope of Fix

- The main two methods impacted are:
  1. `WriteClient::EncodeAttribute()`: used by Linux-based WriteClients
  2. `WriteClient::PutPreencodedAttribute()`: used by Python and Android WriteClients


#### Testing

- Modified ACL-based YAML Tests 
- Tested Manually against All-Clusters and TV-App from Matter 1.0.2
- Added Unit Test Cases related to this Exception (TestWriteChunking)
- - Added TestCases to the integration test `AccessControlCluster.yaml`