### PR TITLE
Pass the right cluster name for struct field types in Darwin codegen.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -15,12 +15,12 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_command_arguments}}
 
 {{#if (isSupported ../cluster command=../command commandField=(asStructPropertyName label))}}
-{{> struct_field_decl cluster=parent.parent.name type=type label=label}} {{availability ../cluster command=../command commandField=(asStructPropertyName label) deprecationMessage=(concat "The " (asStructPropertyName label) " field will be removed")}};
+{{> struct_field_decl cluster=parent.parent.name originalCluster=parent.parent.name type=type label=label}} {{availability ../cluster command=../command commandField=(asStructPropertyName label) deprecationMessage=(concat "The " (asStructPropertyName label) " field will be removed")}};
 {{/if}}
 {{#*inline "oldNameFieldDecl"}}
 
 {{#if (isSupported ../cluster command=../command commandField=commandField)}}
-{{> struct_field_decl cluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{> struct_field_decl cluster=parent.parent.name originalCluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
 {{/if}}
 {{/inline}}
 {{#if (and includeRenamedProperties
@@ -120,7 +120,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#zcl_command_arguments}}
 {{#*inline "oldNameFieldDecl"}}
 
-{{> struct_field_decl cluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{> struct_field_decl cluster=parent.parent.name originalCluster=parent.parent.name type=type label=commandField}} {{availability ../cluster command=../command commandField=commandField deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
 {{/inline}}
 {{#if (hasOldName ../cluster command=../command commandField=(asStructPropertyName label))}}
 {{> oldNameFieldDecl commandField=(oldName ../cluster command=../command commandField=(asStructPropertyName label))}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -39,11 +39,11 @@ NS_ASSUME_NONNULL_BEGIN
 {{#*inline "interfaceDecl"}}
 {{#zcl_event_fields}}
 {{#if (isSupported ../cluster event=../event eventField=(asStructPropertyName name))}}
-{{> struct_field_decl cluster=../cluster type=type label=name}} {{availability ../cluster event=../event eventField=(asStructPropertyName name) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true) "Event")}};
+{{> struct_field_decl cluster=../cluster originalCluster=../originalCluster type=type label=name}} {{availability ../cluster event=../event eventField=(asStructPropertyName name) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../../name preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true) "Event")}};
 {{/if}}
 {{#if (hasOldName ../cluster event=../event eventField=(asStructPropertyName name))}}
 {{#if (isSupported ../cluster event=../event eventField=(oldName ../cluster event=../event eventField=(asStructPropertyName name)))}}
-{{> struct_field_decl cluster=../cluster type=type label=(oldName ../cluster event=../event eventField=(asStructPropertyName name))}} {{availability ../cluster event=../event eventField=(oldName ../cluster event=../event eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
+{{> struct_field_decl cluster=../cluster originalCluster=../originalCluster type=type label=(oldName ../cluster event=../event eventField=(asStructPropertyName name))}} {{availability ../cluster event=../event eventField=(oldName ../cluster event=../event eventField=(asStructPropertyName name)) deprecationMessage=(concat "Please use " (asStructPropertyName name))}};
 {{/if}}
 {{/if}}
 {{/zcl_event_fields}}
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true))}}
 {{availability (asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
 @interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
-{{> interfaceDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) event=(asUpperCamelCase name preserveAcronyms=true)}}
+{{> interfaceDecl cluster=(asUpperCamelCase parent.name preserveAcronyms=true) originalCluster=parent.name event=(asUpperCamelCase name preserveAcronyms=true)}}
 @end
 
 {{/if}}
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (compatClusterNameRemapping parent.name) event=eventName)}}
 {{availability (compatClusterNameRemapping parent.name) event=eventName deprecationMessage=(concat "Please use MTR" (asUpperCamelCase parent.name preserveAcronyms=true) "Cluster" (asUpperCamelCase name preserveAcronyms=true) "Event")}}
 @interface MTR{{compatClusterNameRemapping parent.name}}Cluster{{eventName}}Event : MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
-{{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) event=eventName}}
+{{> interfaceDecl cluster=(compatClusterNameRemapping parent.name) originalCluster=parent.name event=eventName}}
 @end
 
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/partials/struct_field_decl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/struct_field_decl.zapt
@@ -1,3 +1,11 @@
 {{! Override the getter name because some of our properties start with things
     like "new" or "init" }}
-@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type cluster}} {{asStructPropertyName label}} {{! Caller provides availability~}}
+@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}})
+{{~! If our cluster is just the upper-camel-case version of originalCluster,
+     then use originalCluster, with its spaces, etc, as the cluster name for
+     the type, since that's what's stored in the database. }}
+{{~#if (isStrEqual cluster (asUpperCamelCase originalCluster preserveAcronyms=true))~}}
+{{~asObjectiveCType type originalCluster~}}
+{{~else~}}
+{{~asObjectiveCType type cluster~}}
+{{~/if}} {{asStructPropertyName label}} {{! Caller provides availability~}}

--- a/src/darwin/Framework/CHIP/templates/partials/struct_interface_decl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/struct_interface_decl.zapt
@@ -12,11 +12,11 @@
 {{~/if}}
 {{#zcl_struct_items}}
 {{#if (isSupported ../cluster struct=../struct structField=(asStructPropertyName label))}}
-{{> struct_field_decl cluster=../cluster type=type label=label}} {{availability ../cluster struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../originalCluster preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
+{{> struct_field_decl cluster=../cluster originalCluster=../originalCluster type=type label=label}} {{availability ../cluster struct=../struct structField=(asStructPropertyName label) deprecationMessage=(concat "Please use MTR" (asUpperCamelCase ../originalCluster preserveAcronyms=true) "Cluster" (asUpperCamelCase ../name preserveAcronyms=true))}};
 {{/if}}
 {{#if (hasOldName ../cluster struct=../struct structField=(asStructPropertyName label))}}
 {{#if (isSupported ../cluster struct=../struct structField=(oldName ../cluster struct=../struct structField=(asStructPropertyName label)))}}
-{{> struct_field_decl cluster=../cluster type=type label=(oldName ../cluster struct=../struct structField=(asStructPropertyName label))}} {{availability ../cluster struct=../struct structField=(oldName ../cluster struct=../struct structField=(asStructPropertyName label)) deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
+{{> struct_field_decl cluster=../cluster originalCluster=../originalCluster type=type label=(oldName ../cluster struct=../struct structField=(asStructPropertyName label))}} {{availability ../cluster struct=../struct structField=(oldName ../cluster struct=../struct structField=(asStructPropertyName label)) deprecationMessage=(concat "Please use " (asStructPropertyName label))}};
 {{/if}}
 {{/if}}
 {{/zcl_struct_items}}

--- a/src/darwin/Framework/CHIP/templates/partials/struct_interface_impl.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/struct_interface_impl.zapt
@@ -3,7 +3,7 @@
     originalCluster, and struct, where cluster and struct are uppercased }}
 {{#*inline "interfaceImpl"}}
 {{#if (isSupported cluster struct=struct)}}
-@implementation {{asObjectiveCClass struct cluster}}
+@implementation {{asObjectiveCClass struct originalCluster}}
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -18,7 +18,7 @@
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-  auto other = [[{{asObjectiveCClass struct cluster}} alloc] init];
+  auto other = [[{{asObjectiveCClass struct originalCluster}} alloc] init];
 
   {{#zcl_struct_items}}
   {{#if (isSupported ../cluster struct=../struct structField=(asStructPropertyName label))}}


### PR DESCRIPTION
We were upper-camel-casing cluster names for convenience in some cases, but asObjectiveCType/asObjectiveCClass really do want the original cluster name. Except in cases when we've done a compat rename, in which case we should keep using the munged name.

#### Testing

No changes in codegen; this will matter more with updated ZAP bits.