### PR TITLE
Make MTRServerEndpoint threadsafe.

### DIFF
--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A representation of an endpoint implemented by an MTRDeviceController.
+ *
+ * MTRServerEndpoint's API can be accessed from any thread.
  */
 NS_SWIFT_SENDABLE
 MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
@@ -62,9 +64,9 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  */
 - (BOOL)addServerCluster:(MTRServerCluster *)serverCluster;
 
-@property (nonatomic, copy, readonly) NSNumber * endpointID;
+@property (atomic, copy, readonly) NSNumber * endpointID;
 
-@property (nonatomic, copy, readonly) NSArray<MTRDeviceTypeRevision *> * deviceTypes;
+@property (atomic, copy, readonly) NSArray<MTRDeviceTypeRevision *> * deviceTypes;
 
 /**
  * The list of entities that are allowed to access all clusters on this
@@ -73,7 +75,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  *
  * Defaults to empty list, which means no access granted.
  */
-@property (nonatomic, copy, readonly) NSArray<MTRAccessGrant *> * accessGrants;
+@property (atomic, copy, readonly) NSArray<MTRAccessGrant *> * accessGrants;
 
 /**
  * A list of server clusters supported on this endpoint.  The Descriptor cluster
@@ -82,7 +84,7 @@ MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))
  * grants.  If not included, the Descriptor cluster will be generated
  * automatically.
  */
-@property (nonatomic, copy, readonly) NSArray<MTRServerCluster *> * serverClusters;
+@property (atomic, copy, readonly) NSArray<MTRServerCluster *> * serverClusters;
 
 @end
 

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint_Internal.h
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRServerEndpoint_Internal.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The access grants the Matter stack can observe.  Only modified while in
  * Initializing state or on the Matter queue.
  */
-@property (nonatomic, strong, readonly) NSSet<MTRAccessGrant *> * matterAccessGrants;
+@property (atomic, copy, readonly) NSArray<MTRAccessGrant *> * matterAccessGrants;
 
 @end
 


### PR DESCRIPTION
If two API clients are both touching the same instance of MTRServerEndpoint on different threads, we should handle that correctly.

Fixes https://github.com/project-chip/connectedhomeip/issues/31756

#### Testing

Covered by existing unit tests.