### PR TITLE
[IM] Relocate InternalEventOptions into private section of EventManagement

### DIFF
--- a/src/app/EventLoggingTypes.h
+++ b/src/app/EventLoggingTypes.h
@@ -134,14 +134,6 @@ public:
     FabricIndex mFabricIndex = kUndefinedFabricIndex;
 };
 
-class InternalEventOptions : public EventOptions
-{
-public:
-    InternalEventOptions() {}
-    InternalEventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp) {}
-    Timestamp mTimestamp;
-};
-
 /**
  * @brief
  *   Structure for copying event lists on output.

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -390,6 +390,14 @@ public:
                              EventNumber & generatedEventNumber) override;
 
 private:
+    class InternalEventOptions : public EventOptions
+    {
+    public:
+        InternalEventOptions() {}
+        InternalEventOptions(Timestamp aTimestamp) : mTimestamp(aTimestamp) {}
+        Timestamp mTimestamp;
+    };
+
     /**
      * @brief
      *  Internal structure for traversing events.


### PR DESCRIPTION
Relocate InternalEventOptions into private section of EventManagement since this InternalEventOptions is not for public, and is only used inside EventManagement
#### Testing
Existing test covers
