### PR TITLE
Add check in InteractionModelEngine for Commands having the LargePayload flag.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1832,6 +1832,14 @@ Protocols::InteractionModel::Status InteractionModelEngine::CheckCommandFlags(co
         }
     }
 
+    // Command that is marked as having a large payload must be sent over a
+    // session that supports it.
+    if (entry.flags.Has(DataModel::CommandQualityFlags::kLargeMessage) &&
+        !CurrentExchange()->GetSessionHandle()->AllowsLargePayload())
+    {
+        return Status::InvalidAction;
+    }
+
     return Status::Success;
 }
 


### PR DESCRIPTION
Before dispatching for payload processing, ensure that a received command that is flagged with the `L` quality is on an Exchange over a LargePayload session.
Fixes #37779

#### Testing
Issue CaptureSnapshot command in CameraAVStreamMgmt cluster from chip-tool to chip-camera-app after snapshot stream allocation.
* Command is processed and succeeds when over TCP
* Fails with InvalidAction over MRP session.