### PR TITLE
Fix unit test static analyzer warning in TestChipCryptoPAL

### DIFF
--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -1558,14 +1558,14 @@ TEST_F(TestChipCryptoPAL, TestCSR_GenByKeypair)
 
     Test_P256Keypair keypair;
     EXPECT_EQ(keypair.Initialize(ECPKeyTarget::ECDSA), CHIP_NO_ERROR);
-    EXPECT_EQ(keypair.NewCertificateSigningRequest(csr, length), CHIP_NO_ERROR);
-    EXPECT_GT(length, 0u);
+    ASSERT_EQ(keypair.NewCertificateSigningRequest(csr, length), CHIP_NO_ERROR);
+    ASSERT_GT(length, 2u);
 
     P256PublicKey pubkey;
     CHIP_ERROR err = VerifyCertificateSigningRequest(csr, length, pubkey);
     if (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
     {
-        EXPECT_EQ(err, CHIP_NO_ERROR);
+        ASSERT_EQ(err, CHIP_NO_ERROR);
         EXPECT_EQ(pubkey.Length(), kP256_PublicKey_Length);
         EXPECT_EQ(memcmp(pubkey.ConstBytes(), keypair.Pubkey().ConstBytes(), pubkey.Length()), 0);
 


### PR DESCRIPTION

#### Changes done

Error was:
```
../../src/crypto/tests/TestChipCryptoPAL.cpp:1573:38: note: Access of 'csr' at negative byte offset -2
 1573 |         csr[length - 2] = (uint8_t) (csr[length - 2] + 1);
      |                                      ^~~~~~~~~~~~~~~

WARNING TIDY ../../src/crypto/tests/TestChipCryptoPAL.cpp: 1 warning treated as error
WARNING Tidy ../../src/crypto/tests/TestChipCryptoPAL.cpp ended with code 1
```

Cause was that a EXPECT was used where ASSERT should be used, which leads to an access in mbedTLS unit test version, that should not have run.

#### Testing
Unit tests still pass, but clang tidy not unhappy on Darwin.