### PR TITLE
Factor out a common MTRDeviceControllerDelegate implementation for Matter.framework tests.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateValidityTests.m
@@ -21,6 +21,7 @@
 #import "MTRErrorTestUtils.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestControllerDelegate.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
@@ -36,43 +37,6 @@ static MTRBaseDevice * sConnectedDevice;
 
 // Singleton controller we use.
 static MTRDeviceController * sController = nil;
-
-@interface MTRCertificateValidityTestControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, readonly) XCTestExpectation * expectation;
-@property (nonatomic, readonly) NSNumber * commissioneeNodeID;
-@end
-
-@implementation MTRCertificateValidityTestControllerDelegate
-- (id)initWithExpectation:(XCTestExpectation *)expectation commissioneeNodeID:(NSNumber *)nodeID
-{
-    self = [super init];
-    if (self) {
-        _expectation = expectation;
-        _commissioneeNodeID = nodeID;
-    }
-    return self;
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
-{
-    XCTAssertEqual(error.code, 0);
-
-    NSError * commissionError = nil;
-    [sController commissionNodeWithID:self.commissioneeNodeID
-                  commissioningParams:[[MTRCommissioningParameters alloc] init]
-                                error:&commissionError];
-    XCTAssertNil(commissionError);
-
-    // Keep waiting for onCommissioningComplete
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
-}
-@end
 
 @interface MTRTestCertificateIssuer : NSObject <MTROperationalCertificateIssuer>
 
@@ -216,8 +180,8 @@ static MTRDeviceController * sController = nil;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"Commissioning Complete for %@", nodeID]];
-    __auto_type * deviceControllerDelegate = [[MTRCertificateValidityTestControllerDelegate alloc] initWithExpectation:expectation
-                                                                                                    commissioneeNodeID:nodeID];
+    __auto_type * deviceControllerDelegate = [[MTRTestControllerDelegate alloc] initWithExpectation:expectation
+                                                                                          newNodeID:nodeID];
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.device_controller_delegate", DISPATCH_QUEUE_SERIAL);
 
     [sController setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -34,6 +34,7 @@
 #import "MTRErrorTestUtils.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestControllerDelegate.h"
 #import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
@@ -76,53 +77,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
     XCTAssertNotNil(mConnectedDevice);
     return mConnectedDevice;
 }
-
-@interface MTRDeviceTestDeviceControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, strong) XCTestExpectation * expectation;
-@end
-
-@implementation MTRDeviceTestDeviceControllerDelegate
-- (id)initWithExpectation:(XCTestExpectation *)expectation
-{
-    self = [super init];
-    if (self) {
-        _expectation = expectation;
-    }
-    return self;
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-
-    NSError * getDeviceError = nil;
-    __auto_type * device = [controller deviceBeingCommissionedWithNodeID:@(kDeviceId) error:&getDeviceError];
-    XCTAssertNil(getDeviceError);
-    XCTAssertNotNil(device);
-
-    // Now check that getting with some other random id fails.
-    device = [controller deviceBeingCommissionedWithNodeID:@(kDeviceId + 1) error:&getDeviceError];
-    XCTAssertNil(device);
-    XCTAssertNotNil(getDeviceError);
-
-    __auto_type * params = [[MTRCommissioningParameters alloc] init];
-    params.countryCode = @("au");
-
-    NSError * commissionError = nil;
-    [sController commissionNodeWithID:@(kDeviceId) commissioningParams:params error:&commissionError];
-    XCTAssertNil(commissionError);
-
-    // Keep waiting for controller:commissioningComplete:
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
-}
-
-@end
 
 @interface MTRDeviceTests : MTRTestCase
 
@@ -171,8 +125,9 @@ static BOOL slocalTestStorageEnabledBeforeUnitTest;
 
     sController = controller;
 
-    MTRDeviceTestDeviceControllerDelegate * deviceControllerDelegate =
-        [[MTRDeviceTestDeviceControllerDelegate alloc] initWithExpectation:pairingExpectation];
+    MTRTestControllerDelegate * deviceControllerDelegate =
+        [[MTRTestControllerDelegate alloc] initWithExpectation:pairingExpectation newNodeID:@(kDeviceId)];
+    deviceControllerDelegate.countryCode = @("au");
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.device_controller_delegate", DISPATCH_QUEUE_SERIAL);
 
     [controller setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];

--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -22,6 +22,7 @@
 #import "MTRErrorTestUtils.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestControllerDelegate.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
@@ -115,44 +116,6 @@ static NSString * kUpdatedSoftwareVersionString_10 = @"10.0";
     _downloadFilePath = downloadFilePath;
 
     return self;
-}
-
-@end
-
-@interface MTROTAProviderTestControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, readonly) XCTestExpectation * expectation;
-@property (nonatomic, readonly) NSNumber * commissioneeNodeID;
-@end
-
-@implementation MTROTAProviderTestControllerDelegate
-- (id)initWithExpectation:(XCTestExpectation *)expectation commissioneeNodeID:(NSNumber *)nodeID
-{
-    self = [super init];
-    if (self) {
-        _expectation = expectation;
-        _commissioneeNodeID = nodeID;
-    }
-    return self;
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
-{
-    XCTAssertEqual(error.code, 0);
-
-    NSError * commissionError = nil;
-    [sController commissionNodeWithID:self.commissioneeNodeID
-                  commissioningParams:[[MTRCommissioningParameters alloc] init]
-                                error:&commissionError];
-    XCTAssertNil(commissionError);
-
-    // Keep waiting for onCommissioningComplete
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
 }
 
 @end
@@ -587,8 +550,8 @@ static BOOL sStackInitRan = NO;
 {
     XCTestExpectation * expectation =
         [self expectationWithDescription:[NSString stringWithFormat:@"Commissioning Complete for %@", nodeID]];
-    __auto_type * deviceControllerDelegate = [[MTROTAProviderTestControllerDelegate alloc] initWithExpectation:expectation
-                                                                                            commissioneeNodeID:nodeID];
+    __auto_type * deviceControllerDelegate = [[MTRTestControllerDelegate alloc] initWithExpectation:expectation
+                                                                                          newNodeID:nodeID];
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.device_controller_delegate", DISPATCH_QUEUE_SERIAL);
 
     [sController setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -29,6 +29,7 @@
 #import "MTRFabricInfoChecker.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestControllerDelegate.h"
 #import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestPerControllerStorage.h"
@@ -40,44 +41,6 @@ static const uint16_t kSubscriptionTimeoutInSeconds = 60;
 static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kTestVendorId = 0xFFF1u;
 static const uint16_t kSubscriptionPoolBaseTimeoutInSeconds = 30;
-
-@interface MTRPerControllerStorageTestsControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, strong) XCTestExpectation * expectation;
-@property (nonatomic, strong) NSNumber * deviceID;
-@end
-
-@implementation MTRPerControllerStorageTestsControllerDelegate
-- (id)initWithExpectation:(XCTestExpectation *)expectation newNodeID:(NSNumber *)newNodeID
-{
-    self = [super init];
-    if (self) {
-        _expectation = expectation;
-        _deviceID = newNodeID;
-    }
-    return self;
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-
-    __auto_type * params = [[MTRCommissioningParameters alloc] init];
-
-    NSError * commissionError = nil;
-    [controller commissionNodeWithID:self.deviceID commissioningParams:params error:&commissionError];
-    XCTAssertNil(commissionError);
-
-    // Keep waiting for controller:commissioningComplete:
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
-}
-
-@end
 
 @interface MTRPerControllerStorageTestsSuspensionDelegate : NSObject <MTRDeviceControllerDelegate>
 @property (nonatomic, strong) XCTestExpectation * expectation;
@@ -398,8 +361,8 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
 
-    __auto_type * deviceControllerDelegate = [[MTRPerControllerStorageTestsControllerDelegate alloc] initWithExpectation:expectation
-                                                                                                               newNodeID:newNodeID];
+    __auto_type * deviceControllerDelegate = [[MTRTestControllerDelegate alloc] initWithExpectation:expectation
+                                                                                          newNodeID:newNodeID];
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.device_controller_delegate", DISPATCH_QUEUE_SERIAL);
 
     [controller setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -25,6 +25,7 @@
 #import "MTRErrorTestUtils.h"
 #import "MTRTestCase+ServerAppRunner.h"
 #import "MTRTestCase.h"
+#import "MTRTestControllerDelegate.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
@@ -435,41 +436,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
     return mConnectedDevice;
 }
 
-@interface MTRRemoteDeviceSampleTestDeviceControllerDelegate : NSObject <MTRDeviceControllerDelegate>
-@property (nonatomic, strong) XCTestExpectation * expectation;
-@end
-
-@implementation MTRRemoteDeviceSampleTestDeviceControllerDelegate
-- (id)initWithExpectation:(XCTestExpectation *)expectation
-{
-    self = [super init];
-    if (self) {
-        _expectation = expectation;
-    }
-    return self;
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    NSError * commissionError = nil;
-    [sController commissionNodeWithID:@(kDeviceId)
-                  commissioningParams:[[MTRCommissioningParameters alloc] init]
-                                error:&commissionError];
-    XCTAssertNil(commissionError);
-
-    // Keep waiting for controller:commissioningComplete
-}
-
-- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
-{
-    XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
-}
-
-@end
-
 typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *, id> *> *);
 
 @interface MTRXPCDeviceTestDelegate : NSObject <MTRDeviceDelegate>
@@ -589,8 +555,8 @@ static BOOL sStackInitRan = NO;
 
     sController = controller;
 
-    MTRRemoteDeviceSampleTestDeviceControllerDelegate * deviceControllerDelegate =
-        [[MTRRemoteDeviceSampleTestDeviceControllerDelegate alloc] initWithExpectation:expectation];
+    MTRTestControllerDelegate * deviceControllerDelegate =
+        [[MTRTestControllerDelegate alloc] initWithExpectation:expectation newNodeID:@(kDeviceId)];
     dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.device_controller_delegate", DISPATCH_QUEUE_SERIAL);
 
     [controller setDeviceControllerDelegate:deviceControllerDelegate queue:callbackQueue];

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestControllerDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestControllerDelegate.h
@@ -1,0 +1,31 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRTestControllerDelegate : NSObject <MTRDeviceControllerDelegate>
+- (instancetype)initWithExpectation:(XCTestExpectation *)expectation newNodeID:(NSNumber *)newNodeID;
+
+@property (nonatomic, strong, readonly) XCTestExpectation * expectation;
+@property (nonatomic, strong, readonly) NSNumber * deviceID;
+@property (nonatomic, nullable, strong) NSString * countryCode;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestControllerDelegate.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestControllerDelegate.mm
@@ -1,0 +1,62 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRTestControllerDelegate.h"
+
+@implementation MTRTestControllerDelegate
+- (id)initWithExpectation:(XCTestExpectation *)expectation newNodeID:(NSNumber *)newNodeID
+{
+    self = [super init];
+    if (self) {
+        _expectation = expectation;
+        _deviceID = newNodeID;
+        _countryCode = nil;
+    }
+    return self;
+}
+
+- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+
+    NSError * getDeviceError = nil;
+    __auto_type * device = [controller deviceBeingCommissionedWithNodeID:self.deviceID error:&getDeviceError];
+    XCTAssertNil(getDeviceError);
+    XCTAssertNotNil(device);
+
+    // Now check that getting with some other random id fails.
+    device = [controller deviceBeingCommissionedWithNodeID:@(self.deviceID.unsignedLongLongValue + 1) error:&getDeviceError];
+    XCTAssertNil(device);
+    XCTAssertNotNil(getDeviceError);
+
+    __auto_type * params = [[MTRCommissioningParameters alloc] init];
+    params.countryCode = self.countryCode;
+
+    NSError * commissionError = nil;
+    [controller commissionNodeWithID:self.deviceID commissioningParams:params error:&commissionError];
+    XCTAssertNil(commissionError);
+
+    // Keep waiting for controller:commissioningComplete:
+}
+
+- (void)controller:(MTRDeviceController *)controller commissioningComplete:(NSError *)error
+{
+    XCTAssertEqual(error.code, 0);
+    [_expectation fulfill];
+    _expectation = nil;
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		5117DD3929A931AE00FFA1AA /* MTROperationalBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */; };
 		511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */; };
 		511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */; };
+		511FAD1B2DA59A7000E75D18 /* MTRTestControllerDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511FAD1A2DA59A7000E75D18 /* MTRTestControllerDelegate.mm */; };
 		512431252BA0C8B7000BC136 /* Commands.h in Headers */ = {isa = PBXBuildFile; fileRef = 512431182BA0C09A000BC136 /* Commands.h */; };
 		512431262BA0C8BA000BC136 /* ResetMRPParametersCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 512431192BA0C09A000BC136 /* ResetMRPParametersCommand.h */; };
 		512431272BA0C8BF000BC136 /* SetMRPParametersCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 5124311B2BA0C09A000BC136 /* SetMRPParametersCommand.h */; };
@@ -735,6 +736,8 @@
 		5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTROperationalBrowser.h; sourceTree = "<group>"; };
 		511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRBaseSubscriptionCallback.mm; sourceTree = "<group>"; };
 		511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseSubscriptionCallback.h; sourceTree = "<group>"; };
+		511FAD192DA59A7000E75D18 /* MTRTestControllerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRTestControllerDelegate.h; sourceTree = "<group>"; };
+		511FAD1A2DA59A7000E75D18 /* MTRTestControllerDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRTestControllerDelegate.mm; sourceTree = "<group>"; };
 		512431182BA0C09A000BC136 /* Commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Commands.h; sourceTree = "<group>"; };
 		512431192BA0C09A000BC136 /* ResetMRPParametersCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResetMRPParametersCommand.h; sourceTree = "<group>"; };
 		5124311A2BA0C09A000BC136 /* ResetMRPParametersCommand.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResetMRPParametersCommand.mm; sourceTree = "<group>"; };
@@ -1476,6 +1479,8 @@
 				5131BF642BE2E1B000D5D6BC /* MTRTestCase.mm */,
 				D437613F285BDC0D0051FEA2 /* MTRTestKeys.h */,
 				51C8E3F72825CDB600D47D00 /* MTRTestKeys.m */,
+				511FAD192DA59A7000E75D18 /* MTRTestControllerDelegate.h */,
+				511FAD1A2DA59A7000E75D18 /* MTRTestControllerDelegate.mm */,
 				51F9F9D32BF7A9EE00FEA0E2 /* MTRTestCase+ServerAppRunner.h */,
 				51F9F9D42BF7A9EE00FEA0E2 /* MTRTestCase+ServerAppRunner.m */,
 				D4376140285BDC0D0051FEA2 /* MTRTestStorage.h */,
@@ -2600,6 +2605,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BC9E5872D3099FF00784A21 /* MTRSwiftCertificateTests.swift in Sources */,
+				511FAD1B2DA59A7000E75D18 /* MTRTestControllerDelegate.mm in Sources */,
 				51742B4E29CB6B88009974FE /* MTRPairingTests.m in Sources */,
 				5131BF662BE2E1B000D5D6BC /* MTRTestCase.mm in Sources */,
 				51669AF02913204400F4AA36 /* MTRBackwardsCompatTests.m in Sources */,


### PR DESCRIPTION
#### Testing

Test changes only.