### PR TITLE
Update ZAP.

### DIFF
--- a/scripts/setup/zap.json
+++ b/scripts/setup/zap.json
@@ -8,13 +8,13 @@
                 "mac-amd64",
                 "windows-amd64"
             ],
-            "tags": ["version:2@v2025.04.03-nightly.1"]
+            "tags": ["version:2@v2025.04.08-nightly.1"]
         },
         {
             "_comment": "Always get the amd64 version on mac until usable arm64 zap build is available",
             "path": "fuchsia/third_party/3pp/zap/mac-amd64",
             "platforms": ["mac-arm64"],
-            "tags": ["version:2@v2025.04.03-nightly.1"]
+            "tags": ["version:2@v2025.04.08-nightly.1"]
         }
     ]
 }

--- a/scripts/setup/zap.version
+++ b/scripts/setup/zap.version
@@ -1,1 +1,1 @@
-v2025.04.03-nightly
+v2025.04.08-nightly

--- a/scripts/tools/zap/zap_execution.py
+++ b/scripts/tools/zap/zap_execution.py
@@ -23,7 +23,7 @@ from typing import Tuple
 # Use scripts/tools/zap/version_update.py to manage ZAP versioning as many
 # files may need updating for versions
 #
-MIN_ZAP_VERSION = '2025.4.3'
+MIN_ZAP_VERSION = '2025.4.8'
 
 
 class ZapTool:


### PR DESCRIPTION
Pulls in fixes for the case when a global and cluster-specific struct have the same name.

#### Testing

CI should check that things work.