### PR TITLE
Use a smaller BDX block size for Thread networks

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -225,7 +225,7 @@ CHIP_ERROR MTROTAImageTransferHandler::OnTransferSessionBegin(const TransferSess
 
     dispatch_async(delegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector
-                (handleBDXTransferSessionBeginForNodeID:controller:fileDesignator:offset:completion:)]) {
+                            (handleBDXTransferSessionBeginForNodeID:controller:fileDesignator:offset:completion:)]) {
             [strongDelegate handleBDXTransferSessionBeginForNodeID:nodeId
                                                         controller:controller
                                                     fileDesignator:fileDesignator

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -65,7 +65,7 @@ constexpr uint16_t kMaxBdxBlockSize = 1024;
 
 constexpr uint8_t kMaxThreadFramesPerBdxBlock = 6;
 
-static uint16_t ComputeBdxBlockSizeForThread(uint8_t framesPerBlock)
+static constexpr uint16_t ComputeBDXBlockSizeForThread(uint8_t framesPerBlock)
 {
     return 74 + (framesPerBlock - 1) * 95 - 38;
 }
@@ -136,7 +136,7 @@ CHIP_ERROR MTROTAImageTransferHandler::Init(Messaging::ExchangeContext * exchang
 
     uint16_t blockSize;
     if (mIsPeerNodeAKnownThreadDevice) {
-        blockSize = ComputeBdxBlockSizeForThread(Platform::GetUserDefaultBDXThreadFramesPerBlock().value_or(kMaxThreadFramesPerBdxBlock));
+        blockSize = ComputeBDXBlockSizeForThread(Platform::GetUserDefaultBDXThreadFramesPerBlock().value_or(kMaxThreadFramesPerBdxBlock));
     } else {
         blockSize = kMaxBdxBlockSize;
     }

--- a/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
+++ b/src/darwin/Framework/CHIPTests/MTROTAProviderTests.m
@@ -411,7 +411,6 @@ static MTROTAProviderDelegateImpl * sOTAProviderDelegate;
         NSNumber * blockIndex, NSNumber * bytesToSkip, BlockQueryCompletion completion) {
         XCTAssertEqualObjects(nodeID, nodeID);
         XCTAssertEqual(controller, sController);
-        XCTAssertEqualObjects(blockSize, @(1024)); // Seems to always be 1024.
         XCTAssertEqualObjects(blockIndex, @(lastBlockIndex + 1));
         XCTAssertEqualObjects(bytesToSkip, @(0)); // Don't expect to see skips here.
         // Make sure we actually end up with multiple blocks.
@@ -1099,7 +1098,6 @@ static BOOL sStackInitRan = NO;
         NSNumber * blockIndex, NSNumber * bytesToSkip, BlockQueryCompletion completion) {
         XCTAssertEqualObjects(nodeID, @(kDeviceId1));
         XCTAssertEqual(controller, sController);
-        XCTAssertEqualObjects(blockSize, @(1024)); // Seems to always be 1024.
         XCTAssertEqualObjects(blockIndex, @(lastBlockIndex + 1));
         XCTAssertEqualObjects(bytesToSkip, @(0)); // Don't expect to see skips here.
         // Make sure we actually end up with multiple blocks.
@@ -1178,7 +1176,6 @@ static BOOL sStackInitRan = NO;
             NSNumber * blockIndex, NSNumber * bytesToSkip, BlockQueryCompletion completion) {
             XCTAssertEqualObjects(nodeID, @(kDeviceId2));
             XCTAssertEqual(controller, sController);
-            XCTAssertEqualObjects(blockSize, @(1024)); // Seems to always be 1024.
             XCTAssertEqualObjects(blockIndex, @(lastBlockIndex + 1));
             XCTAssertEqualObjects(bytesToSkip, @(0)); // Don't expect to see skips here.
             // Make sure we actually end up with multiple blocks.

--- a/src/platform/Darwin/UserDefaults.h
+++ b/src/platform/Darwin/UserDefaults.h
@@ -27,5 +27,7 @@ std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs();
 
 std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread();
 
+std::optional<uint8_t> GetUserDefaultBDXThreadFramesPerBlock();
+
 } // namespace Platform
 } // namespace chip

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -25,35 +25,67 @@ static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOv
 
 static NSString * const kBDXThrottleIntervalInMsecsUserDefaultKey = @"BDXThrottleIntervalForThreadDevicesInMSecs";
 
+static NSString * const kBDXThreadFramesPerBlockDefaultKey = @"BDXThreadFramesPerBlock";
+
 namespace chip {
 namespace Platform {
 
+    namespace {
+
+        enum ZeroDefault {
+            kAcceptZero,
+            kDontAcceptZero,
+        };
+
+        // Returns a std::optional containing the value for the user default.
+        // Returns std::nullopt in the following cases:
+        //   - kDontAcceptZero is passed and no user default is found
+        //   - a user default is found, but it can't fit into the requested
+        //     integer type (for example it's either too big, or it's negative)
+        //   - kDontAcceptZero is passed and a user default with value 0 is
+        //     found
+        template <typename T>
+        static std::optional<T> GetUserDefault(NSString * key, ZeroDefault acceptZero)
+        {
+            NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
+            NSInteger value = [defaults integerForKey:key];
+            if (CanCastTo<T>(value) && (acceptZero == kAcceptZero || value != 0)) {
+                return std::make_optional(static_cast<T>(value));
+            }
+            return std::nullopt;
+        }
+
+    } // namespace
+
     std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs()
     {
-        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-        NSInteger srpTimeoutValue = [defaults integerForKey:kSRPTimeoutInMsecsUserDefaultKey];
-        if (CanCastTo<uint16_t>(srpTimeoutValue)) {
-            uint16_t timeoutinMsecs = static_cast<uint16_t>(srpTimeoutValue);
-            ChipLogProgress(Discovery, "Got a user default value for Dnssd SRP timeout - %d msecs", timeoutinMsecs);
-            return std::make_optional(timeoutinMsecs);
+        std::optional timeoutinMsecs = GetUserDefault<uint16_t>(kSRPTimeoutInMsecsUserDefaultKey, kAcceptZero);
+        if (timeoutinMsecs.has_value()) {
+            ChipLogProgress(Discovery, "Got a user default value for Dnssd SRP timeout - %d msecs", timeoutinMsecs.value());
         }
-        return std::nullopt;
+        return timeoutinMsecs;
     }
 
     std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread()
     {
-        NSUserDefaults * defaults = [NSUserDefaults standardUserDefaults];
-        NSInteger bdxThrottleIntervalInMsecs = [defaults integerForKey:kBDXThrottleIntervalInMsecsUserDefaultKey];
-
-        if (bdxThrottleIntervalInMsecs > 0 && CanCastTo<uint16_t>(bdxThrottleIntervalInMsecs)) {
-            uint16_t intervalInMsecs = static_cast<uint16_t>(bdxThrottleIntervalInMsecs);
-            ChipLogProgress(BDX, "Got a user default value for BDX Throttle Interval for Thread devices - %d msecs", intervalInMsecs);
-            return std::make_optional(System::Clock::Milliseconds16(intervalInMsecs));
+        std::optional intervalInMsecs = GetUserDefault<uint16_t>(kBDXThrottleIntervalInMsecsUserDefaultKey, kDontAcceptZero);
+        if (intervalInMsecs.has_value()) {
+            ChipLogProgress(BDX, "Got a user default value for BDX Throttle Interval for Thread devices - %d msecs", intervalInMsecs.value());
+            return std::make_optional(System::Clock::Milliseconds16(intervalInMsecs.value()));
         }
 
         // For now return NullOptional if value returned in bdxThrottleIntervalInMsecs is 0, since that either means the key was not found or value was zero.
         // Since 0 is not a feasible value for this interval for now, we will treat that as not being set.
         return std::nullopt;
+    }
+
+    std::optional<uint8_t> GetUserDefaultBDXThreadFramesPerBlock()
+    {
+        std::optional numberOfFrames = GetUserDefault<uint8_t>(kBDXThreadFramesPerBlockDefaultKey, kDontAcceptZero);
+        if (numberOfFrames.has_value()) {
+            ChipLogProgress(BDX, "Got a user default value for thread frames per block - %d", numberOfFrames.value());
+        }
+        return numberOfFrames;
     }
 
 } // namespace Platform


### PR DESCRIPTION
Use a smaller BDX block size for Thread networks, to reduce number of fragments needed per block.


#### Testing

Manually enabled all the tests in `MTROTAProviderTests`, and ran the Matter Framework Tests.
