### PR TITLE
[1.4] python: Fix bootstrap on python 3.13 (#38258)

### DIFF
--- a/scripts/setup/constraints.txt
+++ b/scripts/setup/constraints.txt
@@ -141,7 +141,7 @@ packaging==23.0
     #   ghapi
     #   idf-component-manager
     #   west
-pandas==2.1.4 ; platform_machine != "aarch64" and platform_machine != "arm64"
+pandas==2.2.3 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.memory.txt
 parso==0.8.3
     # via jedi


### PR DESCRIPTION
Fix Python 3.13 boostrap.

Cherry-picked https://github.com/project-chip/connectedhomeip/pull/38258 to v1.4-branch.