### PR TITLE
[Telink] W91 WiFiManager fix to pass TC-CNET-4.4

### DIFF
--- a/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
+++ b/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
@@ -179,6 +179,27 @@ CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCal
     mWiFiState          = WIFI_STATE_SCANNING;
     mSsidFound          = false;
 
+    if (!ssid.empty()) // Directed Scanning, Main Spec, 11.9.7.1. "ScanNetworks Command"
+    {
+        if (!mInternalScan) // don't erase in the middle of Connect procedure
+        {
+            Instance().mDirectedScanning = true;
+            if (ssid.size() <= DeviceLayer::Internal::kMaxWiFiSSIDLength)
+            {
+                mWantedNetwork.Erase();
+                memcpy(mWantedNetwork.ssid, ssid.data(), ssid.size());
+                mWantedNetwork.ssidLen = ssid.size();
+                ChipLogProgress(DeviceLayer, "Directed Scanning, looking for: %.*s", static_cast<int>(ssid.size()), ssid.data());
+            }
+            else
+            {
+                ChipLogError(DeviceLayer, "SSID too long: %d bytes, max allowed is %d", ssid.size(),
+                             DeviceLayer::Internal::kMaxWiFiSSIDLength);
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+        }
+    }
+
     if (0 != net_mgmt(NET_REQUEST_WIFI_SCAN, mNetIf, NULL, 0))
     {
         ChipLogError(DeviceLayer, "Scan request failed");
@@ -293,6 +314,13 @@ void WiFiManager::ScanResultHandler(Platform::UniquePtr<uint8_t> data, size_t le
     // Contrary to other handlers, offload accumulating of the scan results from the CHIP thread to the caller's thread
     const wifi_scan_result * scanResult = reinterpret_cast<const wifi_scan_result *>(data.get());
 
+    ChipLogDetail(DeviceLayer, "Found SSID: %.*s", scanResult->ssid_length, scanResult->ssid);
+
+    if (Instance().mDirectedScanning)
+    {
+        VerifyOrReturn(Instance().mWantedNetwork.GetSsidSpan().data_equal(ByteSpan(scanResult->ssid, scanResult->ssid_length)));
+    }
+
     if (Instance().mInternalScan &&
         Instance().mWantedNetwork.GetSsidSpan().data_equal(ByteSpan(scanResult->ssid, scanResult->ssid_length)))
     {
@@ -337,6 +365,8 @@ void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data, size_t leng
 {
     // Validate that input data size matches the expected one.
     VerifyOrReturn(length == sizeof(wifi_status));
+
+    Instance().mDirectedScanning = false;
 
     CHIP_ERROR err = SystemLayer().ScheduleLambda([capturedData = data.get()] {
         Platform::UniquePtr<uint8_t> safePtr(capturedData);

--- a/src/platform/telink/wifi/3.3.99.0/WiFiManager.h
+++ b/src/platform/telink/wifi/3.3.99.0/WiFiManager.h
@@ -232,6 +232,7 @@ private:
     ScanDoneCallback mScanDoneCallback{ nullptr };
     WiFiNetwork mWantedNetwork{};
     bool mInternalScan{ false };
+    bool mDirectedScanning{ false };
     uint8_t mRouterSolicitationCounter = 0;
     bool mSsidFound{ false };
     uint32_t mConnectionRecoveryCounter{ 0 };

--- a/src/platform/telink/wifi/3.7.99.0/WiFiManager.h
+++ b/src/platform/telink/wifi/3.7.99.0/WiFiManager.h
@@ -246,6 +246,7 @@ private:
     ScanDoneCallback mScanDoneCallback{ nullptr };
     WiFiNetwork mWantedNetwork{};
     bool mInternalScan{ false };
+    bool mDirectedScanning{ false };
     uint8_t mRouterSolicitationCounter = 0;
     bool mSsidFound{ false };
     uint32_t mConnectionRecoveryCounter{ 0 };


### PR DESCRIPTION
Directed scanning handled for certification TC to pass
Applies for both 3.3 and 3.7 Zephyr versions

Our Zephyr WiFi driver doesn't distinguish directed scans (just returns list of all SSID's nearby) so for now we'll handle that on Matter's side.

#### Testing

Tested manually with chip-tool and python controller.

Now for step 4:
`./chip-tool networkcommissioning scan-networks {$NODE_ID} 0 --Ssid null --Breadcrumb 1`
DUT returns list of all available SSIDs

For step 6:
`./chip-tool networkcommissioning scan-networks {$NODE_ID} 0 --Ssid hex:{$KNOWN_SSID} --Breadcrumb 2`
returns `{$KNOWN_SSID}` if found.

> [1744275604.998] [189340:189342] [DMG] Received Command Response Data, Endpoint=0 Cluster=0x0000_0031 Command=0x0000_0001
> [1744275604.998] [189340:189342] [TOO] Endpoint: 0 Cluster: 0x0000_0031 Command 0x0000_0001
> [1744275604.998] [189340:189342] [TOO]   ScanNetworksResponse: {
> [1744275604.998] [189340:189342] [TOO]     networkingStatus: 0
> [1744275604.998] [189340:189342] [TOO]     wiFiScanResults: 1 entries
> [1744275604.998] [189340:189342] [TOO]       [1]: {
> [1744275604.998] [189340:189342] [TOO]         Security: 4
> [1744275604.998] [189340:189342] [TOO]         Ssid: 486F6D654E6574
> [1744275604.998] [189340:189342] [TOO]         Bssid: 000000000000
> [1744275604.998] [189340:189342] [TOO]         Channel: 1
> [1744275604.998] [189340:189342] [TOO]         WiFiBand: 0
> [1744275604.998] [189340:189342] [TOO]         Rssi: -61
> [1744275604.998] [189340:189342] [TOO]        }
> [1744275604.998] [189340:189342] [TOO]    }
> [1744275604.998] [189340:189342] [DMG] ICR moving to [AwaitingDe]

And for step 8:
`./chip-tool networkcommissioning scan-networks 1 0 --Ssid ${UNKNOWN_SSID} --Breadcrumb 2`
returns `NetworkNotFound` 

> [1744272426.362] [184677:184679] [TOO] Endpoint: 0 Cluster: 0x0000_0031 Command 0x0000_0001
> [1744272426.362] [184677:184679] [TOO]   ScanNetworksResponse: {
> [1744272426.362] [184677:184679] [TOO]     networkingStatus: 5
> [1744272426.362] [184677:184679] [TOO]     wiFiScanResults: 0 entries
> [1744272426.362] [184677:184679] [TOO]    }
