### PR TITLE
[Telink] Fixed TC-CNET-4.12 for ble-thread devices

### DIFF
--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -160,6 +160,7 @@ BLEManagerImpl BLEManagerImpl::sInstance;
 CHIP_ERROR BLEManagerImpl::_Init(void)
 {
     mBLERadioInitialized  = false;
+    mReadyToAttachThread  = false;
     mconId                = NULL;
     mInternalScanCallback = new InternalScanCallback(this);
 
@@ -921,13 +922,35 @@ CHIP_ERROR BLEManagerImpl::HandleOperationalNetworkEnabled(const ChipDeviceEvent
 {
     ChipLogDetail(DeviceLayer, "HandleOperationalNetworkEnabled");
 
-    int error = bt_conn_disconnect(BLEMgrImpl().mconId, BT_HCI_ERR_LOCALHOST_TERM_CONN);
-    if (error)
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    /* On first commissioning BLE disconnects before switching to Thread operational network.
+       All subsequent Thread operational network changes are handled in a bit different way */
+    if (!mReadyToAttachThread)
     {
-        ChipLogError(DeviceLayer, "Close BLEConn err: %d", error);
+        error = MapErrorZephyr(bt_conn_disconnect(BLEMgrImpl().mconId, BT_HCI_ERR_LOCALHOST_TERM_CONN));
+        if (error != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Close BLEConn err: %" CHIP_ERROR_FORMAT, error.Format());
+        }
+        mReadyToAttachThread = true;
+    }
+    else
+    {
+        ThreadStackMgrImpl().SetThreadEnabled(false);
+        SwitchToIeee802154();
+
+        ChipDeviceEvent attachEvent;
+        attachEvent.Type                            = DeviceEventType::kThreadConnectivityChange;
+        attachEvent.ThreadConnectivityChange.Result = kConnectivity_Established;
+
+        error = PlatformMgr().PostEvent(&attachEvent);
+        VerifyOrExit(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "PostEvent err: %" CHIP_ERROR_FORMAT, error.Format()));
+
+        ThreadStackMgrImpl().CommitConfiguration();
     }
 
-    return MapErrorZephyr(error);
+exit:
+    return error;
 }
 
 CHIP_ERROR BLEManagerImpl::HandleThreadStateChange(const ChipDeviceEvent * event)

--- a/src/platform/telink/BLEManagerImpl.h
+++ b/src/platform/telink/BLEManagerImpl.h
@@ -108,6 +108,7 @@ private:
     PacketBufferHandle c3CharDataBufferHandle;
 #endif
     bool mBLERadioInitialized;
+    bool mReadyToAttachThread;
 
     void DriveBLEState(void);
     CHIP_ERROR PrepareAdvertisingRequest(void);

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -62,6 +62,7 @@ public:
     void SetRadioBlocked(bool state) { mRadioBlocked = state; }
     bool IsReadyToAttach(void) const { return mReadyToAttach; }
     void Finalize(void);
+    CHIP_ERROR CommitConfiguration(void);
 
 protected:
     // ===== Methods that implement the ThreadStackManager abstract interface.


### PR DESCRIPTION
Migration to another Thread network handled, step 7 passes.

As Zephyr supports single OT instance, on Telink platform we receive new network credentials with `add-or-update-thread-network`, then mark as provisioned on `connect-network` and just after succesful result callback is returned, connect to new Thread network.

#### Testing
Tested manually with chip-tool on tlsr9528a