### PR TITLE
Expose this internal SPI so the framework can use it

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -185,6 +185,10 @@ MTR_DIRECT_MEMBERS
 
 @end
 
+@interface MTRDevice (MatterPrivateForInternalDragonsDoNotFeed)
+- (void)_deviceMayBeReachable;
+@end
+
 #pragma mark - MTRDevice internal state monitoring
 @protocol MTRDeviceInternalStateDelegate
 - (void)devicePrivateInternalStateChanged:(MTRDevice *)device internalState:(NSDictionary *)state;


### PR DESCRIPTION
#### Summary

Adding a header so we can call this internally where needed

#### Testing

Not required, internal header exposed, build is sufficient