### PR TITLE
Add some test coverage for downloadLogOfType.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -496,8 +496,9 @@ MTR_DIRECT_MEMBERS
     if (allowInvalid) {
         // Encoding should always work if invalid payloads are allowed
         VerifyOrDieWithMsg(err == CHIP_NO_ERROR, NotSpecified, "Internal error: %" CHIP_ERROR_FORMAT, err.Format());
-    } else {
-        VerifyOrReturnValue(err == CHIP_NO_ERROR, nil);
+    } else if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("Failed to generate QR code string for payload: %" CHIP_ERROR_FORMAT, err.Format());
+        return nil;
     }
     return [NSString stringWithUTF8String:result.c_str()];
 }

--- a/src/darwin/Framework/CHIPTests/MTRDiagnosticLogDownloadTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDiagnosticLogDownloadTests.m
@@ -1,0 +1,169 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+// module headers
+#import <Matter/Matter.h>
+
+#import "MTRTestCase+ServerAppRunner.h"
+#import "MTRTestCase.h"
+#import "MTRTestDeclarations.h"
+
+static const uint64_t kDeviceId = 0x12344321;
+static MTRDeviceController * sDeviceController = nil;
+static const uint16_t kTimeoutInSeconds = 10;
+static NSString * shortLogContent = @"This is a short log\n";
+static NSString * longLogContent = nil;
+
+@interface MTRDiagnosticLogDownloadTests : MTRTestCase
+
+@end
+
+@implementation MTRDiagnosticLogDownloadTests
+
++ (void)setUp
+{
+    [super setUp];
+
+    // TODO: Once we have a way to startCommissionedAppWithName with explicit
+    // per-suite scope, do that in the instance setUp method, with a "have we
+    // already done it?" guard.
+
+    // Ensure that our long log content is long enough that it can't fit in a
+    // 1280-byte packet, so has to be sent via BDX.  In particular, ensure we
+    // have at least 2KB of log.
+    NSUInteger neededSize = 2048;
+
+    NSUInteger expectedCopies = (neededSize - 1) / shortLogContent.length + 1;
+    NSUInteger expectedSize = expectedCopies * shortLogContent.length;
+    NSMutableString * mutableLongLogContent = [NSMutableString stringWithCapacity:expectedSize];
+    while (mutableLongLogContent.length < neededSize) {
+        [mutableLongLogContent appendString:shortLogContent];
+    }
+    longLogContent = mutableLongLogContent;
+
+    NSString * endUserSupportLog = [self _createLogFile:shortLogContent];
+    NSString * networkDiagnosticsLog = [self _createLogFile:longLogContent];
+    NSString * crashLog = [self _createLogFile:longLogContent];
+
+    sDeviceController = [self startCommissionedAppWithName:@"all-clusters"
+                                                 arguments:@[
+                                                     @("--end_user_support_log"),
+                                                     endUserSupportLog,
+                                                     @("--network_diagnostics_log"),
+                                                     networkDiagnosticsLog,
+                                                     @("--crash_log"),
+                                                     crashLog
+                                                 ]
+                                                    nodeID:@(kDeviceId)];
+    XCTAssertNotNil(sDeviceController);
+}
+
++ (NSString *)_createLogFile:(NSString *)logContent
+{
+    NSString * uniqueName = [[NSUUID UUID] UUIDString];
+    NSString * logFilePath = [NSTemporaryDirectory() stringByAppendingPathComponent:uniqueName];
+    BOOL created = [[NSFileManager defaultManager] createFileAtPath:logFilePath
+                                                           contents:[logContent dataUsingEncoding:NSUTF8StringEncoding]
+                                                         attributes:nil];
+    XCTAssertTrue(created);
+    return logFilePath;
+}
+
+- (void)setUp
+{
+    [super setUp];
+    [self setContinueAfterFailure:NO];
+}
+
+- (void)_testDownloadLogWithContent:(NSString *)expectedLogContent type:(MTRDiagnosticLogType)type testName:(NSString *)testName
+{
+
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"Downloaded the end user support log"];
+
+    MTRDevice * device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sDeviceController];
+    XCTAssertNotNil(device, "%@", testName);
+
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device downloadLogOfType:type
+                      timeout:kTimeoutInSeconds
+                        queue:queue
+                   completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                       NSLog(@"downloadLogOfType: url: %@, error: %@", url, error);
+                       XCTAssertNil(error, "%@", testName);
+
+                       XCTAssertNotNil(url, "%@", testName);
+
+                       NSError * readError;
+                       NSString * fileContent = [NSString stringWithContentsOfURL:url encoding:NSUTF8StringEncoding error:&readError];
+                       XCTAssertNil(readError, "%@", testName);
+                       XCTAssertEqualObjects(fileContent, expectedLogContent, "%@", testName);
+                       [expectation fulfill];
+                   }];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+
+    // TODO: BDXDiagnosticLogsProvider.cpp has a 50ms lag between receiving the
+    // BlockAckEOF message and actually treating the transfer as done, because
+    // it does the 50ms poll thing.  Wait 100ms to make sure it has time to
+    // process the message.
+    usleep(100 * 1000);
+}
+
+- (void)test001_UserSupportLog
+{
+    [self _testDownloadLogWithContent:shortLogContent type:MTRDiagnosticLogTypeEndUserSupport testName:@("test001_UserSupportLog")];
+}
+
+- (void)test002_NetworkDiagnosticsLog
+{
+    [self _testDownloadLogWithContent:longLogContent type:MTRDiagnosticLogTypeNetworkDiagnostics testName:@("test002_NetworkDiagnosticsLog")];
+}
+
+- (void)test003_CrashLog
+{
+    [self _testDownloadLogWithContent:longLogContent type:MTRDiagnosticLogTypeCrash testName:@("test003_CrashLog")];
+}
+
+- (void)test004_CanceledDownload
+{
+    XCTestExpectation * expectation =
+        [self expectationWithDescription:@"Canceled download completed"];
+
+    MTRDevice * device = [MTRDevice deviceWithNodeID:@(kDeviceId) controller:sDeviceController];
+    XCTAssertNotNil(device);
+
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    [device downloadLogOfType:MTRDiagnosticLogTypeEndUserSupport
+                      timeout:kTimeoutInSeconds
+                        queue:queue
+                   completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
+                       XCTAssertNil(url);
+                       XCTAssertNotNil(error);
+
+                       XCTAssertEqual(error.domain, MTRErrorDomain);
+                       XCTAssertEqual(error.code, MTRErrorCodeCancelled);
+                       [expectation fulfill];
+                   }];
+
+    [self _testDownloadLogWithContent:shortLogContent type:MTRDiagnosticLogTypeEndUserSupport testName:@("test004_CanceledDownload")];
+
+    [self waitForExpectations:@[ expectation ] timeout:kTimeoutInSeconds];
+}
+
+@end

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
@@ -46,13 +46,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Same thing as startAppWithName, but also starts a controller on a test fabric, commissions the
- * application with the provided node ID and returns the controller.
+ * application with the provided node ID and returns the controller.  The app
+ * and controller will be killed at the end of the current suite.
  */
 + (nullable MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments payload:(NSString *)payload nodeID:(NSNumber *)nodeID;
 
 /**
  * Same thing, but will decide on a commissioning payload itself instead of
- * making the caller provide one.
+ * making the caller provide one.  The app and controller will be killed at the
+ * end of the current suite.
  */
 + (nullable MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments nodeID:(NSNumber *)nodeID;
 

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */; };
 		511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */; };
 		511FAD1B2DA59A7000E75D18 /* MTRTestControllerDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 511FAD1A2DA59A7000E75D18 /* MTRTestControllerDelegate.mm */; };
+		511FAD1D2DA82E5900E75D18 /* MTRDiagnosticLogDownloadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 511FAD1C2DA82E5900E75D18 /* MTRDiagnosticLogDownloadTests.m */; };
 		512431252BA0C8B7000BC136 /* Commands.h in Headers */ = {isa = PBXBuildFile; fileRef = 512431182BA0C09A000BC136 /* Commands.h */; };
 		512431262BA0C8BA000BC136 /* ResetMRPParametersCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 512431192BA0C09A000BC136 /* ResetMRPParametersCommand.h */; };
 		512431272BA0C8BF000BC136 /* SetMRPParametersCommand.h in Headers */ = {isa = PBXBuildFile; fileRef = 5124311B2BA0C09A000BC136 /* SetMRPParametersCommand.h */; };
@@ -754,6 +755,7 @@
 		511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseSubscriptionCallback.h; sourceTree = "<group>"; };
 		511FAD192DA59A7000E75D18 /* MTRTestControllerDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRTestControllerDelegate.h; sourceTree = "<group>"; };
 		511FAD1A2DA59A7000E75D18 /* MTRTestControllerDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRTestControllerDelegate.mm; sourceTree = "<group>"; };
+		511FAD1C2DA82E5900E75D18 /* MTRDiagnosticLogDownloadTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDiagnosticLogDownloadTests.m; sourceTree = "<group>"; };
 		512431182BA0C09A000BC136 /* Commands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Commands.h; sourceTree = "<group>"; };
 		512431192BA0C09A000BC136 /* ResetMRPParametersCommand.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResetMRPParametersCommand.h; sourceTree = "<group>"; };
 		5124311A2BA0C09A000BC136 /* ResetMRPParametersCommand.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ResetMRPParametersCommand.mm; sourceTree = "<group>"; };
@@ -1869,6 +1871,7 @@
 				75B326A12BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m */,
 				5109E9B62CB8B83D0006884B /* MTRDeviceTypeTests.m */,
 				3D9F2FC22D10E207003CA2BB /* MTRDeviceTypeRevisionTests.m */,
+				511FAD1C2DA82E5900E75D18 /* MTRDiagnosticLogDownloadTests.m */,
 				51D9CB0A2BA37DCE0049D6DB /* MTRDSTOffsetTests.m */,
 				3D9F2FCF2D11FE90003CA2BB /* MTREndpointInfoTests.m */,
 				3D0C484A29DA4FA0006D811F /* MTRErrorTests.m */,
@@ -2689,6 +2692,7 @@
 				5109E9B72CB8B83D0006884B /* MTRDeviceTypeTests.m in Sources */,
 				51E24E73274E0DAC007CCF6E /* MTRErrorTestUtils.mm in Sources */,
 				519498322A25581C00B3BABE /* MTRSetupPayloadInitializationTests.m in Sources */,
+				511FAD1D2DA82E5900E75D18 /* MTRDiagnosticLogDownloadTests.m in Sources */,
 				51A2F1322A00402A00F03298 /* MTRDataValueParserTests.m in Sources */,
 				5165A4B32C5AB978002B9799 /* MTRClusterNamesTests.m in Sources */,
 				51E95DF82A78110900A434F0 /* MTRPerControllerStorageTests.m in Sources */,


### PR DESCRIPTION
Some other issues that were discovered in the process:

* MTRSetupPayload did not log the error on failure to generate a QR code.
* startCommissionedAppWithName did not set up the payload properly, so generating a QR code failed.

#### Testing

Test changes only, except for logging.