### PR TITLE
Add LargePayload flags to session establishment for WebRTC commands

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -226,7 +226,12 @@ void WebRTCProviderManager::ScheduleAnswerSend()
         CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
         VerifyOrDie(caseSessionMgr != nullptr);
 
-        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+        // WebRTC Answer requires a large payload session establishment.
+        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                               1, nullptr,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                               TransportPayloadCapability::kLargePayload);
     });
 }
 

--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -228,9 +228,6 @@ void WebRTCProviderManager::ScheduleAnswerSend()
 
         // WebRTC Answer requires a large payload session establishment.
         caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
-#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
-                                               1, nullptr,
-#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                                TransportPayloadCapability::kLargePayload);
     });
 }

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -76,7 +76,12 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
 
     MoveToState(State::Connecting);
 
-    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    // WebRTC ProvideOffer requires a large payload session establishment
+    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                           1, nullptr,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                           TransportPayloadCapability::kLargePayload);
 
     return CHIP_NO_ERROR;
 }
@@ -105,7 +110,12 @@ CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, 
 
     MoveToState(State::Connecting);
 
-    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    // WebRTC ProvideOffer requires a large payload session establishment
+    caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                           1, nullptr,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                           TransportPayloadCapability::kLargePayload);
 
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -78,9 +78,6 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
 
     // WebRTC ProvideOffer requires a large payload session establishment
     caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
-#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
-                                           1, nullptr,
-#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                            TransportPayloadCapability::kLargePayload);
 
     return CHIP_NO_ERROR;
@@ -112,9 +109,6 @@ CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, 
 
     // WebRTC ProvideOffer requires a large payload session establishment
     caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
-#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
-                                           1, nullptr,
-#endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                            TransportPayloadCapability::kLargePayload);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
All webrtc commands require a LargePayload session, so it is mandatory for all commands.
Ensure WebRTC Session establishment sets up a LargePayload secure session in camera-controller and chip-camera-app.

#### Testing
Local testing between chip-camera-app and camera-controller:
* Pair chip-camera-app
* Send WebRTC ProvideOffer command from controller over TCP based session.