### PR TITLE
Handle link-local IPs that claim the kDNSServiceInterfaceIndexLocalOnly interface.

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -683,15 +683,6 @@ CHIP_ERROR ResolveContext::OnNewAddress(const InterfaceKey & interfaceKey, const
                     addrStr);
 #endif // CHIP_PROGRESS_LOGGING
 
-    if (ip.IsIPv6LinkLocal() && interfaceId == kDNSServiceInterfaceIndexLocalOnly)
-    {
-        // We need a real interface to use a link-local address.  Just ignore
-        // this one, because trying to use it will simply lead to "No route to
-        // host" errors.
-        ChipLogProgress(Discovery, "Mdns: Ignoring link-local address with no usable interface");
-        return CHIP_NO_ERROR;
-    }
-
     interfaces[interfaceKey].addresses.push_back(ip);
 
     return CHIP_NO_ERROR;
@@ -753,8 +744,9 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
 
     if (kDNSServiceInterfaceIndexLocalOnly == interfaceId)
     {
-        // Set interface to ANY (0) - network stack can decide how to route this.
-        interface.service.mInterface = Inet::InterfaceId(0);
+        // Set interface to local loopback.  This should also work for
+        // link-local IPs that we resolve on the local-only interface.
+        interface.service.mInterface = Inet::InterfaceId(if_nametoindex("lo0"));
     }
     else
     {


### PR DESCRIPTION
There are some situations where DNSServiceGetAddrInfo is not handing us back a loopback IP before it unsets the kDNSServiceFlagsMoreComing flag.  In those cases we _might_ have already gotten some link-local IPs, but we used to ignore them when the interface index is kDNSServiceInterfaceIndexLocalOnly. This can lead to failures to resolve a useful PeerAddress at all.

The fix is that instead of ignoring link-local results on kDNSServiceInterfaceIndexLocalOnly and treating
kDNSServiceInterfaceIndexLocalOnly as "try all interfaces", which leads to errors because there is no way to figure out how to route to a link-local on "all interfaces", we keep the results, and treat that interface index as "use the lo0 interface", which is local loopback.

Fixes https://github.com/project-chip/connectedhomeip/issues/38341

#### Testing

Should be covered by our existing tests, and fixes a random-fail in them.