### PR TITLE
ESP32: disable debug mode when compiler optimization assertions are d…

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -35,9 +35,9 @@ set(CHIP_REQUIRE_COMPONENTS esp_eth freertos lwip bt mbedtls fatfs app_update co
 
 if (NOT CMAKE_BUILD_EARLY_EXPANSION)
     if (CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)
-        set(is_debug TRUE)
-    else()
         set(is_debug FALSE)
+    else()
+        set(is_debug TRUE)
     endif()
 endif()
 


### PR DESCRIPTION
…isabled

Earlier we were setting is_debug to TRUE when assertions were disabled and it is incorrect.

All components would be built using cmake build system would honour the `CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS....` configuration. But sources compiled using gn will have `-NDEBUG` flag by default. This would create a mismatch. 

A simple test would be add an assert in file built by gn. eg: `src/platform/ESP32/ESP32Utils.cpp` and build/flash with default config, assert will be optimized out. With change it will hit. And after configuring with `CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLED` it won't hit the assert.

Also can be verified with grepping in the build directory of the app.
After building any app, this would list all files being built using gn build system and they would have `-NDEBUG` flag.
```
idf.py build
grep -r --exclude-dir pigweed NDEBUG build | grep -v COMPILER_ASSERT_NDEBUG_EVALUATE | grep NDEBUG
```

After this change, 

#### Testing

Verified manually by `idf.py build` with assertion enabled and disabled.

```
# build with default (assertions enabled) config
> idf.py build

# make sure that NDEBUG is not present in compile commands
> grep -q NDEBUG build/compile_commands.json && echo 0 || echo 1
1
```

- Disabled assertions using idf.py menuconfig and build app and check NDEBUG is present
```
# make sure that NDEBUG is present
> grep -q NDEBUG build/compile_commands.json && echo 0 || echo 1
0
```

- Also, verified by adding assert and make sure it crashes when assertions are enabled and not when disabled.