### PR TITLE
[v1.4] fix: missing field initializer build error (#38069)

### DIFF
--- a/src/app/data-model-provider/Context.h
+++ b/src/app/data-model-provider/Context.h
@@ -31,9 +31,9 @@ namespace DataModel {
 /// as well as fetching current state (via actionContext)
 struct InteractionModelContext
 {
-    EventsGenerator * eventsGenerator;
-    ProviderChangeListener * dataModelChangeListener;
-    ActionContext * actionContext;
+    EventsGenerator * eventsGenerator                = nullptr;
+    ProviderChangeListener * dataModelChangeListener = nullptr;
+    ActionContext * actionContext                    = nullptr;
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -116,7 +116,7 @@ public:
                                                      CommandHandler * handler) = 0;
 
 private:
-    InteractionModelContext mContext = { nullptr };
+    InteractionModelContext mContext = {};
 };
 
 } // namespace DataModel

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -116,7 +116,7 @@ public:
                                                      CommandHandler * handler) = 0;
 
 private:
-    InteractionModelContext mContext = {};
+    InteractionModelContext mContext;
 };
 
 } // namespace DataModel


### PR DESCRIPTION
Backporting #38069

#### Testing

- build without change using `idf.py build`
```
/Users/shubhampatil/esp/connectedhomeip/src/app/data-model-provider/Provider.h:119:50: warning: missing initializer for member 'chip::app::DataModel::InteractionModelContext::dataModelChangeListener' [-Wmissing-field-initializers]
  119 |     InteractionModelContext mContext = { nullptr };
      |                                                  ^
```

- After fix this warning goes off