### PR TITLE
Simplify local-only DNS-SD registration on Darwin.

### DIFF
--- a/src/platform/Darwin/DnssdHostNameRegistrar.cpp
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.cpp
@@ -290,24 +290,12 @@ CHIP_ERROR HostNameRegistrar::Register()
     {
         ReturnErrorOnFailure(ResetSharedConnection());
 
-        InetInterfacesVector inetInterfaces;
-        Inet6InterfacesVector inet6Interfaces;
-        // Instead of mInterfaceId (which will not match any actual interface),
-        // use kDNSServiceInterfaceIndexAny and restrict to loopback interfaces.
-        GetInterfaceAddresses(kDNSServiceInterfaceIndexAny, mAddressType, inetInterfaces, inet6Interfaces,
-                              true /* searchLoopbackOnly */);
+        // Just register the loopback IPv6 address, on mInterfaceId so that the
+        // resolution code finds it there.
+        auto loopbackIPAddress = Inet::IPAddress::Loopback(Inet::IPAddressType::kIPv6);
+        in6_addr loopbackAddr  = loopbackIPAddress.ToIPv6();
 
-        // But we register the IPs with mInterfaceId, not the actual interface
-        // IDs, so that resolution code that is grouping addresses by interface
-        // ends up doing the right thing, since we registered our SRV record on
-        // mInterfaceId.
-        //
-        // And only register the IPv6 ones, for simplicity.
-        for (auto & interface : inet6Interfaces)
-        {
-            ReturnErrorOnFailure(RegisterInterface(mInterfaceId, interface.second, kDNSServiceType_AAAA));
-        }
-        return CHIP_NO_ERROR;
+        return RegisterInterface(mInterfaceId, loopbackAddr, kDNSServiceType_AAAA);
     }
 
     return StartMonitorInterfaces(^(InetInterfacesVector inetInterfaces, Inet6InterfacesVector inet6Interfaces) {


### PR DESCRIPTION
We were trying to register all loopback interface IPs, which included some link-local IPs, which we then could not use during resolution (because when resolving we were using kDNSServiceInterfaceIndexLocalOnly as the interface index, so could not use LLAs).

And for some reason mDNSResponder sometimes was not handing back the ::1 loopback IP, only the link-local addresses, before it cleared the "has more coming" flag, which would lead to CI failures due to not being able to resolve a usable IP for the server.

Try to avoid that by only registering ::1, not all the addresses associated with loopback interfaces.

#### Testing

Tested locally and CI will test as well, and we'll see whether this improves CI failure rates.