### PR TITLE
[Telink] config for precompiled OpenThread lib

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -635,6 +635,20 @@ jobs:
             - name: clean out build output
               run: rm -rf ./out
 
+            - name: Build example Telink (B92) lighting with precompiled OpenThread library
+              # Run test for s07641069 PRs
+              if: github.event.pull_request.head.repo.full_name == 's07641069/connectedhomeip'
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --target 'telink-tlsr9528a-light-precompiled-ot' build"
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    telink tlsr9528a light-precompiled-ot \
+                    out/telink-tlsr9528a-light-precompiled-ot/zephyr/zephyr.elf \
+                    /tmp/bloat_reports/
+
+            - name: clean out build output
+              run: rm -rf ./out
+
             - name: Build example Telink (B91) Thermostat App
               # Run test for master and s07641069 PRs
               if: github.event.pull_request.number == null || github.event.pull_request.head.repo.full_name == 's07641069/connectedhomeip'

--- a/config/telink/chip-module/CMakeLists.txt
+++ b/config/telink/chip-module/CMakeLists.txt
@@ -69,6 +69,11 @@ matter_add_flags(-DMBEDTLS_USER_CONFIG_FILE=<${CONFIG_MBEDTLS_CFG_FILE}>)
 
 # Set up custom OpenThread configuration
 
+if (CONFIG_OPENTHREAD_TELINK_LIBRARY)
+    set(ZEPHYR_OPENTHREAD_MODULE_DIR ${ZEPHYR_BASE}/../modules/lib/openthread_telink_lib CACHE STRING INTERNAL)
+	message(STATUS "OpenThread used as precompiled Telink library, path: ${ZEPHYR_OPENTHREAD_MODULE_DIR}")
+endif()
+
 if (CONFIG_CHIP_OPENTHREAD_CONFIG)
     get_filename_component(CHIP_OPENTHREAD_CONFIG
         ${CONFIG_CHIP_OPENTHREAD_CONFIG}

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -817,6 +817,7 @@ def BuildTelinkTarget():
     target.AppendModifier('usb', usb_board_config=True)
     target.AppendModifier('compress-lzma', compress_lzma_config=True)
     target.AppendModifier('thread-analyzer', thread_analyzer_config=True)
+    target.AppendModifier('precompiled-ot', precompiled_ot_config=True)
 
     return target
 

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -162,6 +162,7 @@ class TelinkBuilder(Builder):
                  usb_board_config: bool = False,
                  compress_lzma_config: bool = False,
                  thread_analyzer_config: bool = False,
+                 precompiled_ot_config: bool = False,
                  ):
         super(TelinkBuilder, self).__init__(root, runner)
         self.app = app
@@ -176,6 +177,7 @@ class TelinkBuilder(Builder):
         self.usb_board_config = usb_board_config
         self.compress_lzma_config = compress_lzma_config
         self.thread_analyzer_config = thread_analyzer_config
+        self.precompiled_ot_config = precompiled_ot_config
 
     def get_cmd_prefixes(self):
         if not self._runner.dry_run:
@@ -225,6 +227,9 @@ class TelinkBuilder(Builder):
 
         if self.thread_analyzer_config:
             flags.append("-DCONFIG_THREAD_ANALYZER=y")
+
+        if self.precompiled_ot_config:
+            flags.append("-DCONFIG_OPENTHREAD_TELINK_LIBRARY=y -DCONFIG_LOG_MODE_DEFERRED=y")
 
         if self.options.pregen_dir:
             flags.append(f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -23,5 +23,5 @@ qpg-qpg6105-{lock,light,shell,persistent-storage,light-switch,thermostat}[-updat
 realtek-rtl8777g-{lighting,light-switch,lock,window}
 stm32-stm32wb5mm-dk-light
 tizen-{arm,arm64}-{all-clusters,chip-tool,light,tests}[-no-ble][-no-thread][-no-wifi][-asan][-ubsan][-coverage][-with-ui]
-telink-{tlsr9118bdk40d,tlsr9518adk80d,tlsr9528a,tlsr9528a_retention,tl3218x,tl3218x_retention,tl7218x,tl7218x_retention}-{air-quality-sensor,all-clusters,all-clusters-minimal,bridge,contact-sensor,light,light-switch,lock,ota-requestor,pump,pump-controller,shell,smoke-co-alarm,temperature-measurement,thermostat,window-covering}[-ota][-dfu][-shell][-rpc][-factory-data][-4mb][-mars][-usb][-compress-lzma][-thread-analyzer]
+telink-{tlsr9118bdk40d,tlsr9518adk80d,tlsr9528a,tlsr9528a_retention,tl3218x,tl3218x_retention,tl7218x,tl7218x_retention}-{air-quality-sensor,all-clusters,all-clusters-minimal,bridge,contact-sensor,light,light-switch,lock,ota-requestor,pump,pump-controller,shell,smoke-co-alarm,temperature-measurement,thermostat,window-covering}[-ota][-dfu][-shell][-rpc][-factory-data][-4mb][-mars][-usb][-compress-lzma][-thread-analyzer][-precompiled-ot]
 openiotsdk-{shell,lock}[-mbedtls][-psa]


### PR DESCRIPTION
Github CI job for pre-built OpenThread library config added for B92 lighting target

#### Testing
Tested manually:
`west build -b tlsr9528a -- -DCONFIG_OPENTHREAD_TELINK_LIBRARY=y -DCONFIG_LOG_MODE_DEFERRED=y`
alternatively, script run:
`./scripts/run_in_build_env.sh   "./scripts/build/build_examples.py --target 'telink-tlsr9528a-light-precompiled-ot' build"`