### PR TITLE
Minor fixups in Identify cluster.

### DIFF
--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -41,14 +41,14 @@ static Identify * firstIdentify = nullptr;
 
 static void onIdentifyClusterTick(chip::System::Layer * systemLayer, void * appState);
 
-// The Q quality rules for the Identify cluster is:
+// The Q quality rules for the Identify cluster are:
 // 1. When it changes from 0 to any other value and vice versa, or
 // 2. When it is written by a client, or
 // 3. When the value (identifytime) is set by an Identify command.
 //
 // Changes to identifytime by either a write or a command will result
-// in the attribute being set and marked dirty. This covers rule 2 and 3.
-// Rule 1 is archived by not marking the regular conutdown changes as dirty
+// in the attribute being set and marked dirty. This covers rules 2 and 3.
+// Rule 1 is handled by not marking the regular countdown changes as dirty
 // in the onIdentifyClusterTick function and only marking the attribute dirty
 // when the identifytime is set to 0.
 
@@ -104,19 +104,19 @@ void emberAfIdentifyClusterServerInitCallback(EndpointId endpoint)
 
 static void onIdentifyClusterTick(chip::System::Layer * systemLayer, void * appState)
 {
-    uint16_t identifyTime = 0;
-    Identify * identify   = reinterpret_cast<Identify *>(appState);
+    Identify * identify = reinterpret_cast<Identify *>(appState);
 
     if (nullptr != identify)
     {
         EndpointId endpoint = identify->mEndpoint;
 
+        uint16_t identifyTime = 0;
         if (Status::Success == Attributes::IdentifyTime::Get(endpoint, &identifyTime) && 0 != identifyTime)
         {
             auto markDirty = MarkAttributeDirty::kNo;
-            identifyTime   = static_cast<uint16_t>(identifyTime == 0 ? 0 : identifyTime - 1);
+            identifyTime   = static_cast<uint16_t>(identifyTime - 1);
 
-            // If the identify time is 0, we need to mark the attribute dirty so that
+            // If the new identify time is 0, we need to mark the attribute dirty so that
             // the attribute change is reported
             if (identifyTime == 0)
             {


### PR DESCRIPTION
1) Fixes some grammar/spelling issues in comments.
2) Removes a redundant check for identifyTime == 0, because we are in a block
   that has that check as part of its entry condition.

#### Testing

No behavior changes.