### PR TITLE
[Darwin] CI test testMTRDeviceDealloc flake fix

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -3692,6 +3692,11 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         XCTAssertEqual(controller.devices.count, 1);
     }
 
+    // Wait for the report processing to finish, so the MTRDevice object may dealloc
+    [controller syncRunOnWorkQueue:^{
+        ;
+    } error:nil];
+
     // report should still be ongoing
     XCTAssertFalse(subscriptionReportEnd1);
     XCTAssertEqual(controller.devices.count, 0);


### PR DESCRIPTION
Thanks to @bzbarsky-apple for identifying this issue. I believe this should fix the flake. Will be running CI a few times to test.

#### Testing

Will be force-pushing this a few times to test that this flak is not happening again.