### PR TITLE
Prevent the Matter task from remaining locked for too long

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -244,7 +244,11 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
         while (eventReceived == pdTRUE)
         {
             Impl()->DispatchEvent(&event);
-            eventReceived = xQueueReceive(mChipEventQueue, &event, 0);
+            {
+                // Unlock the CHIP stack, to prevent the Matter task from remaining locked for too long
+                StackUnlock unlock;
+                eventReceived = xQueueReceive(mChipEventQueue, &event, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Description

During the Freertos _RunEventLoop process, the Matter task is locked  and will dispatch events until the queue is empty without unlocking the task during this process. This could lock the Matter task for a long time and lead to issues.

Scenario identified:
![chip_task_priority_inheritance](https://github.com/user-attachments/assets/e9dafc1e-caad-41aa-9f19-e646ce22069e)

The Matter task will have priority 8 (due to priority inheritance) until the queue of the run event loop will be empty (chip mutex is unlock once the queue is empty). During this time other tasks with lower priority will never be executed like the timer task (p 7). If the ethernet interrupt add multiple entries into the Timer queue, the Timer task will not be able to process this queue and the ethernet interrupt will get an error when the Timer queue will be full.

#### Proposal

Unlock the Matter task between each event processed to allow other task to be executed

#### Testing

Tested locally with rw61x NXP board with ethernet connectivity, the bug is no more reproduceable 

