### PR TITLE
Add overloaded FindOrEstablishSession API to internally use defaults for CASE retries.

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -76,6 +76,17 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
                                  transportPayloadCapability);
 }
 
+void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                                                Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                                TransportPayloadCapability transportPayloadCapability)
+{
+    FindOrEstablishSessionHelper(peerId, onConnection, onFailure, nullptr,
+#if CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
+                                 1 /* attemptCount */, nullptr /* onRetry */,
+#endif
+                                 transportPayloadCapability);
+}
+
 void CASESessionManager::FindOrEstablishSessionHelper(const ScopedNodeId & peerId,
                                                       Callback::Callback<OnDeviceConnected> * onConnection,
                                                       Callback::Callback<OnDeviceConnectionFailure> * onFailure,

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -142,6 +142,29 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_AUTOMATIC_CASE_RETRIES
                                 TransportPayloadCapability transportPayloadCapability = TransportPayloadCapability::kMRPPayload);
 
+    /**
+     * Find an existing session for the given node ID or trigger a new session request.
+     *
+     * The caller can optionally provide `onConnection`
+     * callback objects. If provided, these will be used to inform the caller about successful connection establishment.
+     *
+     * If the connection is already established, the `onConnection` callback will be immediately called,
+     * before `FindOrEstablishSession` returns.
+     *
+     * The `onFailure` callback may be called before the FindOrEstablishSession
+     * call returns, for error cases that are detected synchronously.
+     *
+     * @note This API uses default values for automatic CASE retries, if enabled.
+     *
+     * @param peerId The node ID to find or establish a session with.
+     * @param onConnection A callback to be called upon successful connection establishment.
+     * @param onSetupFailure A callback to be called upon an extended device connection failure.
+     * @param transportPayloadCapability An indicator of what payload types the session needs to be able to transport.
+     */
+    void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+                                Callback::Callback<OnDeviceConnectionFailure> * onFailure,
+                                TransportPayloadCapability transportPayloadCapability);
+
     void ReleaseSession(const ScopedNodeId & peerId);
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 


### PR DESCRIPTION
This is for users of that API who care about changing the TransportPayload type but can use defaults for the CASE automatic retries.

#### Testing
Local build and run basic interaction between chip-tool and all-clusters-app