### PR TITLE
Fix checks for fabric-scoped vs timed invoke to have an order matching spec.

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -1814,11 +1814,6 @@ Protocols::InteractionModel::Status InteractionModelEngine::CheckCommandFlags(co
     const bool commandNeedsTimedInvoke = entry.flags.Has(DataModel::CommandQualityFlags::kTimed);
     const bool commandIsFabricScoped   = entry.flags.Has(DataModel::CommandQualityFlags::kFabricScoped);
 
-    if (commandNeedsTimedInvoke && !aRequest.invokeFlags.Has(DataModel::InvokeFlags::kTimed))
-    {
-        return Status::NeedsTimedInteraction;
-    }
-
     if (commandIsFabricScoped)
     {
         // SPEC: Else if the command in the path is fabric-scoped and there is no accessing fabric,
@@ -1830,6 +1825,11 @@ Protocols::InteractionModel::Status InteractionModelEngine::CheckCommandFlags(co
         {
             return Status::UnsupportedAccess;
         }
+    }
+
+    if (commandNeedsTimedInvoke && !aRequest.invokeFlags.Has(DataModel::InvokeFlags::kTimed))
+    {
+        return Status::NeedsTimedInteraction;
     }
 
     // Command that is marked as having a large payload must be sent over a


### PR DESCRIPTION
In the spec, the check for "he command in the path is fabric-scoped" is done before the check for "the command in the path requires a Timed Invoke transaction".

Fix the SDK to match that order.

#### Testing

Code inspection.