### PR TITLE
restyle-diff: Don't keep containers and force AMD64 images on ARM Macs

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -42,6 +42,7 @@ restyle-paths() {
     image=restyled/restyler:edge
 
     docker run \
+        --rm \
         --env LOG_LEVEL \
         --env LOG_DESTINATION \
         --env LOG_FORMAT \
@@ -75,6 +76,11 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Use AMD64 images on Apple Silicon since restyler doesn't provide ARM64 images
+if [[ -z "$DOCKER_DEFAULT_PLATFORM" && "$(uname -sm)" == "Darwin arm64" ]]; then
+    export DOCKER_DEFAULT_PLATFORM=linux/amd64
+fi
 
 if [[ -z "$ref" ]]; then
     ref="master"


### PR DESCRIPTION
restyle-diff: Don't keep containers and force AMD64 images on ARM Macs

#### Testing

Manually tested on Mac OS
