### PR TITLE
fix: do not store each error source_location by default

### DIFF
--- a/src/lib/core/BUILD.gn
+++ b/src/lib/core/BUILD.gn
@@ -72,6 +72,7 @@ buildconfig_header("chip_buildconfig") {
     "CHIP_CONFIG_COMMAND_SENDER_BUILTIN_SUPPORT_FOR_BATCHED_COMMANDS=${chip_enable_sending_batch_commands}",
     "CHIP_CONFIG_TEST_GOOGLETEST=${chip_build_tests_googletest}",
     "CHIP_CONFIG_MRP_ANALYTICS_ENABLED=${chip_enable_mrp_analytics}",
+    "CHIP_CONFIG_ERROR_SOURCE_FULL=${chip_enable_error_source_full}",
   ]
 
   visibility = [ ":chip_config_header" ]

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -509,11 +509,21 @@
 /**
  *  @def CHIP_CONFIG_ERROR_SOURCE
  *
- *  If asserted (1), then CHIP_ERROR constants will include the source location of their expansion.
+ *  If asserted (1), then CHIP_ERROR constants will include the minimum source location (file, line) of their expansion.
  */
 #ifndef CHIP_CONFIG_ERROR_SOURCE
 #define CHIP_CONFIG_ERROR_SOURCE 0
 #endif // CHIP_CONFIG_ERROR_SOURCE
+
+/**
+ *  @def CHIP_CONFIG_ERROR_SOURCE_FULL
+ *
+ *  If asserted (1), then CHIP_ERROR constants will include the std::source_location of their expansion.
+ *  Note: this option significantly increases output binary size
+ */
+#ifndef CHIP_CONFIG_ERROR_SOURCE_FULL
+#define CHIP_CONFIG_ERROR_SOURCE_FULL 0
+#endif // CHIP_CONFIG_ERROR_SOURCE_FULL
 
 /**
  *  @def CHIP_CONFIG_ERROR_SOURCE_NO_ERROR

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -36,13 +36,7 @@
 #include <type_traits>
 
 #if CHIP_CONFIG_ERROR_SOURCE_FULL
-
-#if __cplusplus < 202002L
-#error "std::source_location requires C++20"
-#endif // __cplusplus < 202002L
-
 #include <source_location>
-
 #endif // CHIP_CONFIG_ERROR_SOURCE_FULL
 
 namespace chip {

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -130,6 +130,11 @@ declare_args() {
   chip_enable_mrp_analytics =
       current_os == "linux" || current_os == "android" || current_os == "mac" ||
       current_os == "ios"
+
+  # Store CHIPError source_location and add API to get it.
+  # Increases target binary size.
+  # Requires at least C++20.
+  chip_enable_error_source_full = false
 }
 
 if (chip_target_style == "") {

--- a/src/lib/core/tests/TestCHIPError.cpp
+++ b/src/lib/core/tests/TestCHIPError.cpp
@@ -28,44 +28,55 @@ namespace {
 TEST(ChipErrorTest, RangeConstructor)
 {
     ChipError error(ChipError::Range::kSDK, /*value=*/1, __FILE__, __LINE__);
+
+    EXPECT_EQ(error.AsInteger(), 1u);
+
 #if CHIP_CONFIG_ERROR_SOURCE
     EXPECT_EQ(error.GetFile(), __FILE__);
     EXPECT_EQ(error.GetLine(), 30u);
-#if __cplusplus >= 202002L
+#endif // CHIP_CONFIG_ERROR_SOURCE
+
+#if CHIP_CONFIG_ERROR_SOURCE_FULL
     std::source_location location = error.GetSourceLocation();
     EXPECT_EQ(location.line(), 30u);
     EXPECT_EQ(location.file_name(), __FILE__);
-#endif // __cplusplus >= 202002L
-#endif // CHIP_CONFIG_ERROR_SOURCE
+#endif // CHIP_CONFIG_ERROR_SOURCE_FULL
 }
 
 TEST(ChipErrorTest, SdkPartConstructor)
 {
     ChipError error(ChipError::SdkPart::kCore, /*code=*/1, __FILE__, __LINE__);
+
+    EXPECT_EQ(error.AsInteger(), 1u);
+
 #if CHIP_CONFIG_ERROR_SOURCE
     EXPECT_EQ(error.GetFile(), __FILE__);
-    EXPECT_EQ(error.GetLine(), 44u);
-#if __cplusplus >= 202002L
-    std::source_location location = error.GetSourceLocation();
-    EXPECT_EQ(location.line(), 44u);
-    EXPECT_EQ(location.file_name(), __FILE__);
-#endif // __cplusplus >= 202002L
+    EXPECT_EQ(error.GetLine(), 48u);
 #endif // CHIP_CONFIG_ERROR_SOURCE
+
+#if CHIP_CONFIG_ERROR_SOURCE_FULL
+    std::source_location location = error.GetSourceLocation();
+    EXPECT_EQ(location.line(), 48u);
+    EXPECT_EQ(location.file_name(), __FILE__);
+#endif // CHIP_CONFIG_ERROR_SOURCE_FULL
 }
 
 TEST(ChipErrorTest, StorageTypeConstructor)
 {
     ChipError error(/*error=*/1, __FILE__, __LINE__);
+
     EXPECT_EQ(error.AsInteger(), 1u);
+
 #if CHIP_CONFIG_ERROR_SOURCE
     EXPECT_EQ(error.GetFile(), __FILE__);
-    EXPECT_EQ(error.GetLine(), 58u);
-#if __cplusplus >= 202002L
-    std::source_location location = error.GetSourceLocation();
-    EXPECT_EQ(location.line(), 58u);
-    EXPECT_EQ(location.file_name(), __FILE__);
-#endif // __cplusplus >= 202002L
+    EXPECT_EQ(error.GetLine(), 66u);
 #endif // CHIP_CONFIG_ERROR_SOURCE
+
+#if CHIP_CONFIG_ERROR_SOURCE_FULL
+    std::source_location location = error.GetSourceLocation();
+    EXPECT_EQ(location.line(), 66u);
+    EXPECT_EQ(location.file_name(), __FILE__);
+#endif // CHIP_CONFIG_ERROR_SOURCE_FULL
 }
 
 } // namespace


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/32935 leads to substantial increase of binary size (for about 300Kb) because std::source_location stores in .rodata semantic of each function where error is created (that is almost all functions in CHIP).

This PR makes it possible to disable source_location storage but leave base location with file/line. Disable by default as it looks like regression

#### Testing

Updated unit tests
