### PR TITLE
[NXP] Update border router name in the TBRM cluster

### DIFF
--- a/examples/platform/nxp/common/app_task/include/AppTaskBase.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskBase.h
@@ -204,6 +204,11 @@ private:
     static void StartCommissioning(intptr_t arg);
     static void StopCommissioning(intptr_t arg);
     static void SwitchCommissioningState(intptr_t arg);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+    static constexpr EndpointId kThreadBRMgmtEndpoint = 2;
+    bool mTbrmClusterEnabled = false;
+#endif
 };
 
 /**

--- a/examples/platform/nxp/common/app_task/include/AppTaskBase.h
+++ b/examples/platform/nxp/common/app_task/include/AppTaskBase.h
@@ -207,7 +207,7 @@ private:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_TBR
     static constexpr EndpointId kThreadBRMgmtEndpoint = 2;
-    bool mTbrmClusterEnabled = false;
+    bool mTbrmClusterEnabled                          = false;
 #endif
 };
 

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -482,12 +482,12 @@ void chip::NXP::App::AppTaskBase::EnableTbrManagementCluster()
 {
     if (mTbrmClusterEnabled == false)
     {
-        mTbrmClusterEnabled = true;
+        mTbrmClusterEnabled      = true;
         auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
 
         static ThreadBorderRouterManagement::GenericOpenThreadBorderRouterDelegate sThreadBRDelegate(persistentStorage);
         static ThreadBorderRouterManagement::ServerInstance sThreadBRMgmtInstance(kThreadBRMgmtEndpoint, &sThreadBRDelegate,
-                                                                                Server::GetInstance().GetFailSafeContext());
+                                                                                  Server::GetInstance().GetFailSafeContext());
 
         // Initialize TBR name
         CharSpan brName(baseServiceInstanceName, strlen(baseServiceInstanceName));

--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -129,8 +129,7 @@ app::Clusters::NetworkCommissioning::Instance
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_TBR
-static constexpr EndpointId kThreadBRMgmtEndpoint = 2;
-static CharSpan sBrName("NXP-BR", strlen("NXP-BR"));
+extern char baseServiceInstanceName[];
 #endif
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER || (CONFIG_CHIP_TEST_EVENT && CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR)
@@ -220,10 +219,6 @@ void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 
 #if CONFIG_CHIP_APP_WIFI_CONNECT_AT_BOOT
     VerifyOrDie(WifiConnectAtboot(chip::NXP::App::GetAppTask().GetWifiDriverInstance()) == CHIP_NO_ERROR);
-#endif
-
-#if CHIP_DEVICE_CONFIG_ENABLE_TBR
-    GetAppTask().EnableTbrManagementCluster();
 #endif
 }
 
@@ -485,15 +480,20 @@ void chip::NXP::App::AppTaskBase::PrintCurrentVersion()
 #if CHIP_DEVICE_CONFIG_ENABLE_TBR
 void chip::NXP::App::AppTaskBase::EnableTbrManagementCluster()
 {
-    auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
+    if (mTbrmClusterEnabled == false)
+    {
+        mTbrmClusterEnabled = true;
+        auto * persistentStorage = &Server::GetInstance().GetPersistentStorage();
 
-    static ThreadBorderRouterManagement::GenericOpenThreadBorderRouterDelegate sThreadBRDelegate(persistentStorage);
-    static ThreadBorderRouterManagement::ServerInstance sThreadBRMgmtInstance(kThreadBRMgmtEndpoint, &sThreadBRDelegate,
-                                                                              Server::GetInstance().GetFailSafeContext());
+        static ThreadBorderRouterManagement::GenericOpenThreadBorderRouterDelegate sThreadBRDelegate(persistentStorage);
+        static ThreadBorderRouterManagement::ServerInstance sThreadBRMgmtInstance(kThreadBRMgmtEndpoint, &sThreadBRDelegate,
+                                                                                Server::GetInstance().GetFailSafeContext());
 
-    // Initialize TBR name
-    sThreadBRDelegate.SetThreadBorderRouterName(sBrName);
-    // Initialize TBR cluster
-    sThreadBRMgmtInstance.Init();
+        // Initialize TBR name
+        CharSpan brName(baseServiceInstanceName, strlen(baseServiceInstanceName));
+        sThreadBRDelegate.SetThreadBorderRouterName(brName);
+        // Initialize TBR cluster
+        sThreadBRMgmtInstance.Init();
+    }
 }
 #endif

--- a/examples/platform/nxp/common/device_callbacks/source/CommonDeviceCallbacks.cpp
+++ b/examples/platform/nxp/common/device_callbacks/source/CommonDeviceCallbacks.cpp
@@ -133,6 +133,12 @@ void chip::NXP::App::CommonDeviceCallbacks::OnInternetConnectivityChange(const C
         ChipLogProgress(DeviceLayer, "IPv6 Server ready at: [%s]:%d", ip_addr, CHIP_PORT);
 
         chip::app::DnssdServer::Instance().StartServer();
+
+#if CHIP_DEVICE_CONFIG_ENABLE_TBR
+        // Start the TBRM cluster after we are connected to local network. At this point the Open Thread
+        // Border Router management is up and running and the Border Router Service Name is created.
+        GetAppTask().EnableTbrManagementCluster();
+#endif
     }
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {


### PR DESCRIPTION
Update border router name in TBRM cluster to be consistent with the Border Router service name present in MeshCop service.

#### Testing

Tested on RW612 Matter over WIFI with Border Router support. Read TBRM border router name attribute and compared with Openthread Meshcop service name.