### PR TITLE
Add zap app template generation delendency on config-data.yaml

### DIFF
--- a/build/chip/chip_codegen.gni
+++ b/build/chip/chip_codegen.gni
@@ -149,6 +149,9 @@ template("_chip_build_time_zapgen") {
       "${_template_dir}/endpoint_config.zapt",
       "${_template_dir}/gen_config.zapt",
       "${_template_dir}/im-cluster-command-handler.zapt",
+
+      # config data controls template contents (specifically command handling)
+      "${chip_root}/src/app/common/templates/config-data.yaml",
     ]
 
     _output_subdir = "zap-generated"


### PR DESCRIPTION
config-data contains settings on what callbacks are being generated/used. 

#### Testing

Compile still works. Change is trivial.
