### PR TITLE
Update binary diff demangling to be lenient to names that cannot be demangled

### DIFF
--- a/scripts/tools/binary_elf_size_diff.py
+++ b/scripts/tools/binary_elf_size_diff.py
@@ -93,7 +93,11 @@ def get_sizes(p: Path, no_demangle: bool):
         size = int(size, 10)
 
         if not no_demangle:
-            name = cxxfilt.demangle(name)
+            try:
+                name = cxxfilt.demangle(name)
+            except cxxfilt.InvalidName:
+                # Keep non-demangled name if we cannot have a nice name
+                pass
 
         result[name] = Symbol(symbol_type=t, name=name, size=size)
 


### PR DESCRIPTION
Demangle is for human read, but it should not be a critical error.

#### Testing

Ran `binary_elf_size_diff.py` on a file that did contain mangling errors. It ran successfully after the change.