### PR TITLE
Fix path to py_matter_idl

### DIFF
--- a/.github/workflows/protocol_compatibility.yaml
+++ b/.github/workflows/protocol_compatibility.yaml
@@ -35,6 +35,7 @@ jobs:
          run: |
            python3 -m venv venv
            venv/bin/pip3 install click coloredlogs lark
+           venv/bin/pip3 install -e scripts/py_matter_idl
        - name: Create old/new copies
          run: |
            mkdir -p out


### PR DESCRIPTION
#### Testing

This should fix the Backwards Compatibility action; it worked on a separate PR.