### PR TITLE
ThreadNetworkDiagnostics: Encode the Extended address as an big-endian integer

### DIFF
--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -684,13 +684,8 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
         {
             // This attribute's value is composed by taking the 8 octets of the extended address EUI-64 and
             // treating them as a big-endian integer.
-            uint64_t extAddrBigEndian = 0;
-            for (size_t index = 0; index < sizeof(extAddress->m8); ++index)
-            {
-                extAddrBigEndian = extAddrBigEndian << 8;
-                extAddrBigEndian += extAddress->m8[index];
-            }
-            err = encoder.Encode(extAddrBigEndian);
+            static_assert(sizeof(extAddress->m8) == sizeof(uint64_t), "Unexpected buffer size");
+            err = encoder.Encode(Encoding::BigEndian::Get64(extAddress->m8));
         }
     }
     break;

--- a/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
+++ b/src/app/clusters/thread-network-diagnostics-server/thread-network-diagnostics-provider.cpp
@@ -682,7 +682,15 @@ CHIP_ERROR WriteThreadNetworkDiagnosticAttributeToTlv(AttributeId attributeId, a
         }
         else
         {
-            err = encoder.Encode(*(uint64_t *) extAddress->m8);
+            // This attribute's value is composed by taking the 8 octets of the extended address EUI-64 and
+            // treating them as a big-endian integer.
+            uint64_t extAddrBigEndian = 0;
+            for (size_t index = 0; index < sizeof(extAddress->m8); ++index)
+            {
+                extAddrBigEndian = extAddrBigEndian << 8;
+                extAddrBigEndian += extAddress->m8[index];
+            }
+            err = encoder.Encode(extAddrBigEndian);
         }
     }
     break;


### PR DESCRIPTION
Encode the ExtendedAddress attribute in ThreadNetworkDiagnostics cluster following the SPEC change in https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/11513

#### Testing

Tested on ESP32-H2, using chip-tool to read the extended address and get the value 483378320754432673(0x06b54e058cb15aa1) and using openthread cli to get the extended address which is an octet string `06b54e058cb15aa1`