### PR TITLE
[Silabs] Adding the Custom UI for the window app

### DIFF
--- a/examples/window-app/silabs/include/WindowManager.h
+++ b/examples/window-app/silabs/include/WindowManager.h
@@ -127,7 +127,11 @@ public:
 
     static void ButtonEventHandler(uint8_t button, uint8_t btnAction);
     void UpdateLED();
+
+#ifdef DISPLAY_ENABLED
+    static void DrawUI(GLIB_Context_t * glibContext);
     void UpdateLCD();
+#endif // DISPLAY_ENABLED
 
     static void GeneralEventHandler(AppEvent * aEvent);
 

--- a/examples/window-app/silabs/src/AppTask.cpp
+++ b/examples/window-app/silabs/src/AppTask.cpp
@@ -85,7 +85,9 @@ void AppTask::AppTaskMain(void * pvParameter)
     SILABS_LOG("App Task started");
 
     WindowManager::sWindow.UpdateLED();
+#ifdef DISPLAY_ENABLED
     WindowManager::sWindow.UpdateLCD();
+#endif // DISPLAY_ENABLED
 
     while (true)
     {

--- a/examples/window-app/silabs/src/WindowManager.cpp
+++ b/examples/window-app/silabs/src/WindowManager.cpp
@@ -171,7 +171,9 @@ void WindowManager::DispatchEventAttributeChange(chip::EndpointId endpoint, chip
     case Attributes::CurrentPositionLiftPercent100ths::Id:
     case Attributes::CurrentPositionTiltPercent100ths::Id:
         UpdateLED();
+#ifdef DISPLAY_ENABLED
         UpdateLCD();
+#endif // DISPLAY_ENABLED
         break;
     default:
         break;
@@ -554,7 +556,7 @@ void WindowManager::OnIconTimeout(WindowManager::Timer & timer)
 #ifdef DISPLAY_ENABLED
     sWindow.mIcon = LcdIcon::None;
     sWindow.UpdateLCD();
-#endif
+#endif // DISPLAY_ENABLED
 }
 
 CHIP_ERROR WindowManager::Init()
@@ -632,10 +634,15 @@ void WindowManager::UpdateLED()
     }
 }
 
+#ifdef DISPLAY_ENABLED
+void WindowManager::DrawUI(GLIB_Context_t * glibContext)
+{
+    sWindow.UpdateLCD();
+}
+
 void WindowManager::UpdateLCD()
 {
     // Update LCD
-#ifdef DISPLAY_ENABLED
     if (BaseApplication::GetProvisionStatus())
     {
         Cover & cover = GetCover();
@@ -654,8 +661,8 @@ void WindowManager::UpdateLCD()
             LcdPainter::Paint(AppTask::GetAppTask().GetLCD(), type, lift.Value(), tilt.Value(), mIcon);
         }
     }
-#endif // DISPLAY_ENABLED
 }
+#endif // DISPLAY_ENABLED
 
 // Silabs button callback from button event ISR
 void WindowManager::ButtonEventHandler(uint8_t button, uint8_t btnAction)
@@ -792,7 +799,7 @@ void WindowManager::GeneralEventHandler(AppEvent * aEvent)
         window->mIcon = window->mTiltMode ? LcdIcon::Tilt : LcdIcon::Lift;
         window->UpdateLCD();
         break;
-#endif
+#endif // DISPLAY_ENABLED
 
     default:
         break;


### PR DESCRIPTION
#### Testing

The window app QR code doesn't exists hence once commissioning is done the LCD display shows, no image found.
Adding the window app LCD display as a custom UI so the LCD is updated based on the UI.

Tested getting the window screen after commissioning
