### PR TITLE
[Matter.framework][xctests] Ensure xctests advertising the controller…

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2097,12 +2097,6 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 // startControllerWithRootKeys into a test helper.
 - (void)testControllerServer
 {
-#ifdef DEBUG
-    // Force our controllers to only advertise on localhost, to avoid DNS-SD
-    // crosstalk.
-    [MTRDeviceController forceLocalhostAdvertisingOnly];
-#endif // DEBUG
-
     __auto_type queue = dispatch_get_main_queue();
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -17,6 +17,7 @@
 #import "MTRTestCase.h"
 
 #import "MTRMockCB.h"
+#import "MTRTestDeclarations.h"
 #import "MTRTestKeys.h"
 #import "MTRTestStorage.h"
 
@@ -68,6 +69,12 @@ static NSMutableSet<MTRDeviceController *> * sStartedControllers;
 
     sMockCB = [[MTRMockCB alloc] init];
     sStartedControllers = [[NSMutableSet alloc] init];
+
+#ifdef DEBUG
+    // Force our controllers to only advertise on localhost, to avoid DNS-SD
+    // crosstalk.
+    [MTRDeviceController forceLocalhostAdvertisingOnly];
+#endif // DEBUG
 
 #if HAVE_NSTASK
     sRunningCrossTestTasks = [[NSMutableSet alloc] init];


### PR DESCRIPTION
… advertise locally

The `xctests` keeps advertising on interface `0` - which is basically all interfaces. This seems to confused `mdns`.

Fix #38341

#### Testing
CI is running - hopefully it will reduce the flakiness.
