### PR TITLE
[Silabs] Init the OTA Requestor based on the DNS-SD event

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -940,6 +940,15 @@ void BaseApplication::OnPlatformEvent(const ChipDeviceEvent * event, intptr_t)
     }
     break;
 
+    case DeviceEventType::kDnssdInitialized: {
+#if SILABS_OTA_ENABLED
+        ChipLogProgress(AppServer, "DNS-SD initialized, scheduling OTA Requestor initialization");
+        chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds32(OTAConfig::kInitOTARequestorDelaySec),
+                                                    InitOTARequestorHandler, nullptr);
+#endif // SILABS_OTA_ENABLED
+    }
+    break;
+
     case DeviceEventType::kCommissioningComplete: {
 #if SL_WIFI && CHIP_CONFIG_ENABLE_ICD_SERVER
         WifiSleepManager::GetInstance().VerifyAndTransitionToLowPowerMode(WifiSleepManager::PowerEvent::kCommissioningComplete);


### PR DESCRIPTION
### Problem
In some cases (most often seen in ICDs) BaseApplication::OnPlatformEvent() does not get registered in time to receive the DeviceEventType::kThreadConnectivityChange event when the device joins the Thread network. As a result the OTA Requestor does not get initialized.

### Solution
Add another OTA Requestor initialization call from DeviceEventType::kDnssdInitialized event handling. 

### Testing
Verified that OTA Requestor init is invoked even if DeviceEventType::kThreadConnectivityChange event is missed. 

