### PR TITLE
python: Drop run_in_python_env.sh where applicable

### DIFF
--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -88,8 +88,8 @@ jobs:
             - name: Build Java Matter Controller and all clusters app
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
-                  out/venv/pip install -r scripts/setup/requirements.build.txt
-                  out/venv/pip install colorama
+                  out/venv/bin/pip install -r scripts/setup/requirements.build.txt
+                  out/venv/bin/pip install colorama
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test \

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -88,8 +88,8 @@ jobs:
             - name: Build Java Matter Controller and all clusters app
               run: |
                   scripts/run_in_build_env.sh './scripts/build_python.sh --install_virtual_env out/venv'
-                  scripts/run_in_python_env.sh out/venv 'pip install -r scripts/setup/requirements.build.txt'
-                  scripts/run_in_python_env.sh out/venv 'pip install colorama'
+                  out/venv/pip install -r scripts/setup/requirements.build.txt
+                  out/venv/pip install colorama
                   ./scripts/run_in_build_env.sh \
                    "./scripts/build/build_examples.py \
                       --target linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test \
@@ -109,247 +109,247 @@ jobs:
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "discover" \
                      --tool-args "commissionables" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run IM Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run IM Extendable Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-extendable-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run IM Read Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run IM Write Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run IM Subscribe Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing AlreadyDiscovered Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing Address-PaseOnly Test
               # Disabled due to failure: https://github.com/project-chip/connectedhomeip/issues/27361
               if: false
               run: |
-                 scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                 out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing SetupQRCode Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "code --nodeid 1 --setup-payload MT:-24J0AFN00KA0648G00 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing ManualCode Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "code --nodeid 1 --setup-payload 34970112332 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing ICD Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-lit-icd-ipv6only/lit-icd-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing ICD Onnetwork and OTA test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-ota-requestor/chip-ota-requestor-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "ota" \
                      --tool-args "onnetwork-long-ota-over-bdx  --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing Onnetwork and get diagnostic log Test
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_java_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_java_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "bdx" \
                      --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Pairing Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_kotlin_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_kotlin_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Kotlin IM Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_kotlin_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_kotlin_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Kotlin IM Read Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_kotlin_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_kotlin_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Kotlin IM Write Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_kotlin_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_kotlin_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Run Kotlin IM Subscribe Test
               # Generally completes in seconds
               timeout-minutes: 2
               run: |
-                  scripts/run_in_python_env.sh out/venv \
-                  './scripts/tests/run_kotlin_test.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_kotlin_test.py \
                      --app out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
                      --factoryreset \
-                  '
+                     ''
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -116,8 +116,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "discover" \
                      --tool-args "commissionables" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -129,8 +128,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run IM Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -142,8 +140,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run IM Extendable Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -155,8 +152,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-extendable-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run IM Read Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -168,8 +164,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run IM Write Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -181,8 +176,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run IM Subscribe Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -194,8 +188,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing AlreadyDiscovered Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -207,8 +200,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing Address-PaseOnly Test
               # Disabled due to failure: https://github.com/project-chip/connectedhomeip/issues/27361
               if: false
@@ -220,8 +212,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing SetupQRCode Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -233,8 +224,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "code --nodeid 1 --setup-payload MT:-24J0AFN00KA0648G00 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing ManualCode Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -246,8 +236,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "code --nodeid 1 --setup-payload 34970112332 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing ICD Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -259,8 +248,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing ICD Onnetwork and OTA test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -272,8 +260,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "ota" \
                      --tool-args "onnetwork-long-ota-over-bdx  --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing Onnetwork and get diagnostic log Test
               run: |
                   out/venv/bin/python \
@@ -283,8 +270,7 @@ jobs:
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "bdx" \
                      --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Pairing Onnetwork Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -296,8 +282,7 @@ jobs:
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "pairing" \
                      --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Kotlin IM Invoke Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -309,8 +294,7 @@ jobs:
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Kotlin IM Read Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -322,8 +306,7 @@ jobs:
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Kotlin IM Write Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -335,8 +318,7 @@ jobs:
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Run Kotlin IM Subscribe Test
               # Generally completes in seconds
               timeout-minutes: 2
@@ -348,8 +330,7 @@ jobs:
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
                      --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
-                     --factoryreset \
-                     ''
+                     --factoryreset
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/mypy-validation.yml
+++ b/.github/workflows/mypy-validation.yml
@@ -57,8 +57,7 @@ jobs:
             src/python_testing/matter_testing_infrastructure/chip/testing/apps.py \
             src/python_testing/matter_testing_infrastructure/chip/testing/tasks.py \
             src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py \
-            src/python_testing/matter_testing_infrastructure/chip/testing/pics.py \
-            ''
+            src/python_testing/matter_testing_infrastructure/chip/testing/pics.py
           
           # Print a reminder about expanding coverage
           echo "⚠️ NOTE: Currently only checking a subset of files. Remember to expand coverage!" 

--- a/.github/workflows/mypy-validation.yml
+++ b/.github/workflows/mypy-validation.yml
@@ -53,11 +53,12 @@ jobs:
           # TODO: Expand this list to include more files once they are mypy-compatible
           # Eventually we should just check all files in the chip/testing directory
           
-          ./scripts/run_in_python_env.sh out/venv "mypy --config-file=src/python_testing/matter_testing_infrastructure/mypy.ini \
+          out/venv/bin/mypy --config-file=src/python_testing/matter_testing_infrastructure/mypy.ini \
             src/python_testing/matter_testing_infrastructure/chip/testing/apps.py \
             src/python_testing/matter_testing_infrastructure/chip/testing/tasks.py \
             src/python_testing/matter_testing_infrastructure/chip/testing/taglist_and_topology_test.py \
-            src/python_testing/matter_testing_infrastructure/chip/testing/pics.py"
+            src/python_testing/matter_testing_infrastructure/chip/testing/pics.py \
+            ''
           
           # Print a reminder about expanding coverage
           echo "⚠️ NOTE: Currently only checking a subset of files. Remember to expand coverage!" 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -284,8 +284,8 @@ jobs:
             - name: Run Tests using chip-repl (skip slow)
               if: github.event_name == 'pull_request'
               run: |
-                  ./scripts/run_in_python_env.sh out/venv \
-                  "./scripts/tests/run_test_suite.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_test_suite.py \
                      --runner chip_repl_python \
                      --exclude-tags MANUAL \
                      --exclude-tags FLAKY \
@@ -306,12 +306,12 @@ jobs:
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
                      --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-                  "
+                     ''
             - name: Run Tests using chip-repl (including slow)
               if: github.event_name == 'push'
               run: |
-                  ./scripts/run_in_python_env.sh out/venv \
-                  "./scripts/tests/run_test_suite.py \
+                  out/venv/bin/python \
+                  ./scripts/tests/run_test_suite.py \
                      --runner chip_repl_python \
                      run \
                      --iterations 1 \
@@ -326,7 +326,7 @@ jobs:
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
                      --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-                  "
+                     ''
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}
@@ -540,26 +540,26 @@ jobs:
 
             - name: Verify Testing Support
               run: |
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_IDM_10_4.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/test_TC_SC_7_1.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/test_testing/TestDecorators.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestChoiceConformanceSupport.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestConformanceSupport.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestConformanceTest.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestIdChecks.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestMatterTestingSupport.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestSpecParsingDeviceType.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestSpecParsingSelection.py'
-                  scripts/run_in_python_env.sh out/venv 'python3 src/python_testing/TestSpecParsingSupport.py'
+                  out/venv/bin/python src/python_testing/test_testing/test_IDM_10_4.py
+                  out/venv/bin/python src/python_testing/test_testing/test_TC_ICDM_2_1_full_pics.py
+                  out/venv/bin/python src/python_testing/test_testing/test_TC_ICDM_2_1_min_pics.py
+                  out/venv/bin/python src/python_testing/test_testing/test_TC_SC_7_1.py
+                  out/venv/bin/python src/python_testing/test_testing/TestDecorators.py
+                  out/venv/bin/python src/python_testing/TestChoiceConformanceSupport.py
+                  out/venv/bin/python src/python_testing/TestConformanceSupport.py
+                  out/venv/bin/python src/python_testing/TestConformanceTest.py
+                  out/venv/bin/python src/python_testing/TestIdChecks.py
+                  out/venv/bin/python src/python_testing/TestMatterTestingSupport.py
+                  out/venv/bin/python src/python_testing/TestSpecParsingDeviceType.py
+                  out/venv/bin/python src/python_testing/TestSpecParsingSelection.py
+                  out/venv/bin/python src/python_testing/TestSpecParsingSupport.py
 
             - name: Run Tests
               run: |
                   mkdir -p out/trace_data
-                  scripts/run_in_python_env.sh out/venv 'scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/controller/python/test/test_scripts/mobile-device-test.py'
-                  scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py --env-file /tmp/test_env.yaml --search-directory src/python_testing'
-                  scripts/run_in_python_env.sh out/venv 'scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py --all-clusters out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app'
+                  out/venv/bin/python scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/controller/python/test/test_scripts/mobile-device-test.py
+                  out/venv/bin/python src/python_testing/execute_python_tests.py --env-file /tmp/test_env.yaml --search-directory src/python_testing
+                  out/venv/bin/python scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py --all-clusters out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app
 
             - name: Execute Jupyter Notebooks
               run: |
@@ -570,12 +570,12 @@ jobs:
                       build \
                       --copy-artifacts-to objdir-clone \
                    "
-                  scripts/run_in_python_env.sh out/venv \
-                  "jupyter execute docs/development_controllers/chip-repl/Matter_REPL_Intro.ipynb \
+                  out/venv/bin/jupyter \
+                  jupyter execute docs/development_controllers/chip-repl/Matter_REPL_Intro.ipynb \
                   docs/development_controllers/chip-repl/Matter_Basic_Interactions.ipynb \
                   docs/development_controllers/chip-repl/Matter_Access_Control.ipynb \
                   docs/development_controllers/chip-repl/Matter_Multi_Fabric_Commissioning.ipynb \
-                  "
+                  ''
 
             - name: Uploading core files
               uses: actions/upload-artifact@v4
@@ -637,7 +637,7 @@ jobs:
                    "
             - name: Run Tests
               run: |
-                  scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --app out/darwin-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factory-reset --quiet --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
+                  out/venv/bin/python ./scripts/tests/run_python_test.py --app out/darwin-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factory-reset --quiet --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -305,8 +305,7 @@ jobs:
                      --lit-icd-app ./out/linux-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
-                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-                     ''
+                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app
             - name: Run Tests using chip-repl (including slow)
               if: github.event_name == 'push'
               run: |
@@ -325,8 +324,7 @@ jobs:
                      --lit-icd-app ./out/linux-x64-lit-icd-${BUILD_VARIANT}/lit-icd-app \
                      --microwave-oven-app ./out/linux-x64-microwave-oven-${BUILD_VARIANT}/chip-microwave-oven-app \
                      --rvc-app ./out/linux-x64-rvc-${BUILD_VARIANT}/chip-rvc-app \
-                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app \
-                     ''
+                     --network-manager-app ./out/linux-x64-network-manager-${BUILD_VARIANT}/matter-network-manager-app
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}
@@ -574,8 +572,7 @@ jobs:
                   jupyter execute docs/development_controllers/chip-repl/Matter_REPL_Intro.ipynb \
                   docs/development_controllers/chip-repl/Matter_Basic_Interactions.ipynb \
                   docs/development_controllers/chip-repl/Matter_Access_Control.ipynb \
-                  docs/development_controllers/chip-repl/Matter_Multi_Fabric_Commissioning.ipynb \
-                  ''
+                  docs/development_controllers/chip-repl/Matter_Multi_Fabric_Commissioning.ipynb
 
             - name: Uploading core files
               uses: actions/upload-artifact@v4

--- a/docs/testing/python.md
+++ b/docs/testing/python.md
@@ -652,7 +652,7 @@ using structured comments at the top of the test file. To use this structured
 format, use the `--load-from-env` flag with the `run_python_tests.py` runner.
 
 Ex:
-`scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_ICDM_2_1.py'`
+`out/venv/bin/python ./scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/python_testing/TC_ICDM_2_1.py`
 
 ## Running ALL or a subset of tests when changing application code
 

--- a/scripts/tests/local.py
+++ b/scripts/tests/local.py
@@ -860,8 +860,7 @@ def python_tests(
             for script in to_run:
                 bar.text(script)
                 cmd = [
-                    "scripts/run_in_python_env.sh",
-                    "out/venv",
+                    "out/venv/bin/python",
                     f"./scripts/tests/run_python_test.py --load-from-env out/test_env.yaml --script {script}",
                 ]
 


### PR DESCRIPTION
Using the run_in_python_env.sh script is often not required as python or mypy can be run straight from inside of the venv.

#### Testing

Nothing should change, all CI jobs should pass.