### PR TITLE
Enhancements to TC-DA-1-9 certification test

### DIFF
--- a/src/python_testing/TC_DA_1_9.py
+++ b/src/python_testing/TC_DA_1_9.py
@@ -205,7 +205,7 @@ class TC_DA_1_9(MatterBaseTest):
                             discoveryType=ChipDeviceCtrl.DiscoveryType.DISCOVERY_NETWORK_ONLY,
                         )
                         resp = 'Y'
-                    except Exception as e:
+                    except Exception:
                         resp = 'N'
                 else:
                     resp = self.wait_for_user_input(prompt_msg)

--- a/src/python_testing/TC_DA_1_9.py
+++ b/src/python_testing/TC_DA_1_9.py
@@ -48,6 +48,7 @@ import os
 import signal
 import subprocess
 
+from chip import ChipDeviceCtrl
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 
@@ -184,23 +185,35 @@ class TC_DA_1_9(MatterBaseTest):
                 # Run the all-clusters-app in background
                 app_process = subprocess.Popen(app_cmd.split(), stdout=app_log_file, stderr=app_log_file)
 
+                revocation_set = os.path.join(self.revocation_set_base_path, test_case['revocation_set'])
                 # Prompt user with instructions
                 prompt_msg = (
                     f"\nPlease commission the DUT with:\n"
                     f"  Manual Pairing Code: '{test_case['manual_pairing_code']}'\n"
-                    f"  Revocation Set: {os.path.join(self.revocation_set_base_path, test_case['revocation_set'])}\n\n"
+                    f"  Revocation Set: {revocation_set}\n\n"
                     f"Input 'Y' if DUT successfully commissions without any warnings\n"
                     f"Input 'N' if commissioner warns about commissioning the non-genuine device, "
                     f"Or Commissioning fails with device appropriate attestation error\n"
                 )
 
-                # TODO: Run Python commissioner, commission the DUT, and check the return code
                 if self.is_pics_sdk_ci_only:
-                    resp = 'Y' if test_case['expects_commissioning_success'] else 'N'
+                    try:
+                        self.default_controller.SetDACRevocationSetPath(revocation_set)
+                        await self.default_controller.CommissionWithCode(
+                            setupPayload=test_case['manual_pairing_code'],
+                            nodeid=1,
+                            discoveryType=ChipDeviceCtrl.DiscoveryType.DISCOVERY_NETWORK_ONLY,
+                        )
+                        resp = 'Y'
+                    except Exception as e:
+                        resp = 'N'
                 else:
                     resp = self.wait_for_user_input(prompt_msg)
 
                 commissioning_success = resp.lower() == 'y'
+
+                app_process.send_signal(signal.SIGTERM.value)
+                app_process.wait()
 
                 # Verify results
                 asserts.assert_equal(
@@ -208,9 +221,6 @@ class TC_DA_1_9(MatterBaseTest):
                     test_case['expects_commissioning_success'],
                     f"Commissioning {'succeeded' if commissioning_success else 'failed'} when it should have {'succeeded' if test_case['expects_commissioning_success'] else 'failed'}"
                 )
-
-                app_process.send_signal(signal.SIGTERM.value)
-                app_process.wait()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Problems
- CI does not validate the controller's implementation in Matter SDK
- If script asserts with failure, it keeps the app running

Fixes (1) in #38411

#### Change overview
- commissioning the app in the CI using python controller
- Move killing app before asserting for cleanup, if any step asserts

#### Testing

- CI validation
- Ran the test manually with and without CI option
```
> python3 src/python_testing/TC_DA_1_9.py \
    --string-arg app_path:out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app \
    --string-arg dac_provider_base_path:credentials/test/revoked-attestation-certificates/dac-provider-test-vectors \
    --string-arg revocation_set_base_path:credentials/test/revoked-attestation-certificates/revocation-sets \
    --PICS src/app/tests/suites/certification/ci-pics-values
```