### PR TITLE
CASE: move busy wait time parsing in status report module

### DIFF
--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -183,25 +183,11 @@ protected:
         }
 
         Optional<uintptr_t> protocolData;
-        if (report.GetGeneralCode() == Protocols::SecureChannel::GeneralStatusCode::kBusy &&
-            report.GetProtocolCode() == Protocols::SecureChannel::kProtocolCodeBusy)
+        if (report.IsBusy() && report.GetMinimumWaitTime().HasValue())
         {
-            if (!report.GetProtocolData().IsNull())
-            {
-                Encoding::LittleEndian::Reader reader(report.GetProtocolData()->Start(), report.GetProtocolData()->DataLength());
-
-                uint16_t minimumWaitTime = 0;
-                CHIP_ERROR waitTimeErr   = reader.Read16(&minimumWaitTime).StatusCode();
-                if (waitTimeErr != CHIP_NO_ERROR)
-                {
-                    ChipLogError(SecureChannel, "Failed to read the minimum wait time: %" CHIP_ERROR_FORMAT, waitTimeErr.Format());
-                }
-                else
-                {
-                    ChipLogProgress(SecureChannel, "Received busy status report with minimum wait time: %u ms", minimumWaitTime);
-                    protocolData.Emplace(minimumWaitTime);
-                }
-            }
+            System::Clock::Milliseconds16 minimumWaitTime = report.GetMinimumWaitTime().Value();
+            ChipLogProgress(SecureChannel, "Received busy status report with minimum wait time: %u ms", minimumWaitTime.count());
+            protocolData.Emplace(minimumWaitTime.count());
         }
 
         // It's very important that we propagate the return value from

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -183,9 +183,9 @@ protected:
         }
 
         Optional<uintptr_t> protocolData;
-        if (report.IsBusy() && report.GetMinimumWaitTime().HasValue())
+        if (report.IsBusy() && report.GetMinimumWaitTime().has_value())
         {
-            System::Clock::Milliseconds16 minimumWaitTime = report.GetMinimumWaitTime().Value();
+            System::Clock::Milliseconds16 minimumWaitTime = report.GetMinimumWaitTime().value();
             ChipLogProgress(SecureChannel, "Received busy status report with minimum wait time: %u ms", minimumWaitTime.count());
             protocolData.Emplace(minimumWaitTime.count());
         }

--- a/src/protocols/secure_channel/StatusReport.cpp
+++ b/src/protocols/secure_channel/StatusReport.cpp
@@ -70,6 +70,14 @@ CHIP_ERROR StatusReport::Parse(System::PacketBufferHandle buf)
         {
             return CHIP_ERROR_NO_MEMORY;
         }
+
+        if (IsBusy())
+        {
+            Encoding::LittleEndian::Reader reader(mProtocolData->Start(), mProtocolData->DataLength());
+            uint16_t tmpMinimumWaitTime = 0;
+            ReturnErrorOnFailure(reader.Read16(&tmpMinimumWaitTime).StatusCode());
+            mMinimumWaitTime.SetValue(System::Clock::Milliseconds16(tmpMinimumWaitTime));
+        }
     }
     else
     {
@@ -95,6 +103,11 @@ size_t StatusReport::Size() const
     return WriteToBuffer(emptyBuf).Needed();
 }
 
+bool StatusReport::IsBusy() const
+{
+    return (mGeneralCode == GeneralStatusCode::kBusy && mProtocolCode == kProtocolCodeBusy);
+}
+
 System::PacketBufferHandle StatusReport::MakeBusyStatusReportMessage(System::Clock::Milliseconds16 minimumWaitTime)
 {
     using namespace Protocols::SecureChannel;
@@ -113,6 +126,7 @@ System::PacketBufferHandle StatusReport::MakeBusyStatusReportMessage(System::Clo
 
     // Build a busy status report
     StatusReport statusReport(GeneralStatusCode::kBusy, Protocols::SecureChannel::Id, kProtocolCodeBusy, std::move(handle));
+    statusReport.mMinimumWaitTime.SetValue(minimumWaitTime);
 
     // Build the status report message
     handle = System::PacketBufferHandle::New(statusReport.Size());

--- a/src/protocols/secure_channel/StatusReport.cpp
+++ b/src/protocols/secure_channel/StatusReport.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <optional>
 #include <protocols/secure_channel/Constants.h>
 #include <protocols/secure_channel/StatusReport.h>
 
@@ -76,7 +77,7 @@ CHIP_ERROR StatusReport::Parse(System::PacketBufferHandle buf)
             Encoding::LittleEndian::Reader reader(mProtocolData->Start(), mProtocolData->DataLength());
             uint16_t tmpMinimumWaitTime = 0;
             ReturnErrorOnFailure(reader.Read16(&tmpMinimumWaitTime).StatusCode());
-            mMinimumWaitTime.SetValue(System::Clock::Milliseconds16(tmpMinimumWaitTime));
+            mMinimumWaitTime = std::make_optional<System::Clock::Milliseconds16>(tmpMinimumWaitTime);
         }
     }
     else
@@ -126,7 +127,7 @@ System::PacketBufferHandle StatusReport::MakeBusyStatusReportMessage(System::Clo
 
     // Build a busy status report
     StatusReport statusReport(GeneralStatusCode::kBusy, Protocols::SecureChannel::Id, kProtocolCodeBusy, std::move(handle));
-    statusReport.mMinimumWaitTime.SetValue(minimumWaitTime);
+    statusReport.mMinimumWaitTime = std::make_optional<System::Clock::Milliseconds16>(minimumWaitTime);
 
     // Build the status report message
     handle = System::PacketBufferHandle::New(statusReport.Size());

--- a/src/protocols/secure_channel/StatusReport.h
+++ b/src/protocols/secure_channel/StatusReport.h
@@ -20,6 +20,7 @@
 
 #include <lib/core/Optional.h>
 #include <lib/support/BufferWriter.h>
+#include <optional>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
 #include <system/SystemClock.h>
@@ -99,9 +100,8 @@ public:
     /**
      * Returns the minimum wait time if the status report is of type busy.
      * If status report is not busy, then this is an empty optional.
-     * If parsing the minimum wait time fails, then this is an empty optional.
      */
-    Optional<System::Clock::Milliseconds16> GetMinimumWaitTime() const { return mMinimumWaitTime; }
+    std::optional<System::Clock::Milliseconds16> GetMinimumWaitTime() const { return mMinimumWaitTime; }
 
     /**
      *  Returns true if the status report is of type busy.
@@ -121,7 +121,7 @@ private:
     GeneralStatusCode mGeneralCode;
     Protocols::Id mProtocolId;
     uint16_t mProtocolCode;
-    Optional<System::Clock::Milliseconds16> mMinimumWaitTime = Optional<System::Clock::Milliseconds16>::Missing();
+    std::optional<System::Clock::Milliseconds16> mMinimumWaitTime;
     System::PacketBufferHandle mProtocolData;
 };
 

--- a/src/protocols/secure_channel/StatusReport.h
+++ b/src/protocols/secure_channel/StatusReport.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <lib/core/Optional.h>
 #include <lib/support/BufferWriter.h>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
@@ -96,6 +97,18 @@ public:
     const System::PacketBufferHandle & GetProtocolData() const { return mProtocolData; }
 
     /**
+     * Returns the minimum wait time if the status report is of type busy.
+     * If status report is not busy, then this is an empty optional.
+     * If parsing the minimum wait time fails, then this is an empty optional.
+     */
+    Optional<System::Clock::Milliseconds16> GetMinimumWaitTime() const { return mMinimumWaitTime; }
+
+    /**
+     *  Returns true if the status report is of type busy.
+     */
+    bool IsBusy() const;
+
+    /**
      * Builds a busy status report with protocol data containing the minimum wait time.
      *
      * @param[in] minimumWaitTime Time in milliseconds before initiator retries the request
@@ -108,7 +121,7 @@ private:
     GeneralStatusCode mGeneralCode;
     Protocols::Id mProtocolId;
     uint16_t mProtocolCode;
-
+    Optional<System::Clock::Milliseconds16> mMinimumWaitTime = Optional<System::Clock::Milliseconds16>::Missing();
     System::PacketBufferHandle mProtocolData;
 };
 

--- a/src/protocols/secure_channel/tests/TestStatusReport.cpp
+++ b/src/protocols/secure_channel/tests/TestStatusReport.cpp
@@ -125,8 +125,8 @@ TEST_F(TestStatusReport, TestMakeBusyStatusReport)
     EXPECT_EQ(reportToParse.GetProtocolId(), protocolId);
     EXPECT_EQ(reportToParse.GetProtocolCode(), protocolCode);
     EXPECT_TRUE(reportToParse.IsBusy());
-    EXPECT_TRUE(reportToParse.GetMinimumWaitTime().HasValue());
-    EXPECT_EQ(reportToParse.GetMinimumWaitTime().Value(), minimumWaitTime);
+    EXPECT_TRUE(reportToParse.GetMinimumWaitTime().has_value());
+    EXPECT_EQ(reportToParse.GetMinimumWaitTime().value(), minimumWaitTime);
 }
 
 // Test Suite

--- a/src/protocols/secure_channel/tests/TestStatusReport.cpp
+++ b/src/protocols/secure_channel/tests/TestStatusReport.cpp
@@ -125,8 +125,12 @@ TEST_F(TestStatusReport, TestMakeBusyStatusReport)
     EXPECT_EQ(reportToParse.GetProtocolId(), protocolId);
     EXPECT_EQ(reportToParse.GetProtocolCode(), protocolCode);
     EXPECT_TRUE(reportToParse.IsBusy());
-    EXPECT_TRUE(reportToParse.GetMinimumWaitTime().has_value());
-    EXPECT_EQ(reportToParse.GetMinimumWaitTime().value(), minimumWaitTime);
+    auto tmpMinimumWaitTime = reportToParse.GetMinimumWaitTime();
+    EXPECT_TRUE(tmpMinimumWaitTime.has_value());
+    if (tmpMinimumWaitTime.has_value())
+    {
+        EXPECT_EQ(tmpMinimumWaitTime.value(), minimumWaitTime);
+    }
 }
 
 // Test Suite

--- a/src/protocols/secure_channel/tests/TestStatusReport.cpp
+++ b/src/protocols/secure_channel/tests/TestStatusReport.cpp
@@ -124,15 +124,9 @@ TEST_F(TestStatusReport, TestMakeBusyStatusReport)
     EXPECT_EQ(reportToParse.GetGeneralCode(), generalCode);
     EXPECT_EQ(reportToParse.GetProtocolId(), protocolId);
     EXPECT_EQ(reportToParse.GetProtocolCode(), protocolCode);
-
-    const System::PacketBufferHandle & rcvData = reportToParse.GetProtocolData();
-    ASSERT_FALSE(rcvData.IsNull());
-    EXPECT_EQ(rcvData->DataLength(), sizeof(minimumWaitTime));
-
-    uint16_t readMinimumWaitTime = 0;
-    Encoding::LittleEndian::Reader reader(rcvData->Start(), rcvData->DataLength());
-    EXPECT_EQ(reader.Read16(&readMinimumWaitTime).StatusCode(), CHIP_NO_ERROR);
-    EXPECT_EQ(System::Clock::Milliseconds16(readMinimumWaitTime), minimumWaitTime);
+    EXPECT_TRUE(reportToParse.IsBusy());
+    EXPECT_TRUE(reportToParse.GetMinimumWaitTime().HasValue());
+    EXPECT_EQ(reportToParse.GetMinimumWaitTime().Value(), minimumWaitTime);
 }
 
 // Test Suite


### PR DESCRIPTION
Fixes #28487

- Wait time is being parsed separately in PairingSession. Moved this parsing to StatusReport.
- Adjusted unit tests

#### Testing

- Unit tests pass

- Manually tested with light-switch-app/esp32 and chip-tool
```
# Commissioning and access control
./chip-tool pairing ble-wifi 1 (SSID) (PSK) 20202021 3840
./chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode":2, "subjects": [ 112233, 1213], "targets": null}]' 1 0x0

# Simultaneously sent below two commands from two different terminals
./chip-tool basicinformation read node-label 1 0
./chip-tool basicinformation read node-label 1 0 --commissioner-nodeid 1213
```

On chip-tool with node-id 1213, it does 3 retries and failes 
```
[1745222031.995] [20290:127465:chip] [SC] Received busy status report with minimum wait time: 5000 ms
[1745222031.995] [20290:127465:chip] [SC] Received error (protocol code 4) during pairing process: src/protocols/secure_channel/CASESession.cpp:2349: CHIP Error 0x000000DB: The Resource is busy and cannot process the request
```

On ESP32
```
I (112763) chip[IN]: Already in the middle of CASE handshake, sending busy status report
```