### PR TITLE
ESP32: USE_BLE_ONLY_FOR_COMMISSIONING should depend on ENABLE_CHIPOBLE

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -712,7 +712,7 @@ menu "CHIP Device Layer"
                 should not start advertising automatically after power-up.
 
         config USE_BLE_ONLY_FOR_COMMISSIONING
-            depends on BT_ENABLED
+            depends on ENABLE_CHIPOBLE
             bool "Use BLE only for commissioning"
             default y
             help


### PR DESCRIPTION
USE_BLE_ONLY_FOR_COMMISSIONING depends on BT_ENABLED, but it should depend on ENABLE_CHIPOBLE.

#### Testing

`idf.py menuconfig` hide/unhide the option on toggling ENABLE_CHIPOBLE