### PR TITLE
ESP32: remove redundant and unused config for IM pretty prints

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -173,10 +173,6 @@ if (CONFIG_BUILD_CHIP_TESTS)
     chip_gn_arg_bool("chip_build_tests"     "true")
 endif()
 
-if (CONFIG_IM_PRETTY_PRINT)
-    chip_gn_arg_bool("enable_im_pretty_print"	"true")
-endif()
-
 if (NOT CONFIG_USE_MINIMAL_MDNS)
     chip_gn_arg_append("chip_mdns"                          "\"platform\"")
 else()


### PR DESCRIPTION
CONFIG_CHIP_CONFIG_IM_PRETTY_PRINT should be used and not CONFIG_IM_PRETTY_PRINT, so removed it.


#### Testing

- Enable debug logging (`CONFIG_LOG_DEFAULT_LEVEL_DEBUG=y`)
- `idf.py build flash monitor` and commission the device and verified that IM prints are visible.

<details> <summary>Logs when on/off command is received on esp32</summary>

```
D (63460) chip[EM]: Handling via exchange: 11314r, Delegate: 0x3fca04bc
D (63470) chip[DMG]: InvokeRequestMessage =
D (63480) chip[DMG]: {
D (63480) chip[DMG]: 	suppressResponse = false,
D (63480) chip[DMG]: 	timedRequest = false,
D (63490) chip[DMG]: 	InvokeRequests =
D (63490) chip[DMG]: 	[
D (63490) chip[DMG]: 		CommandDataIB =
D (63490) chip[DMG]: 		{
D (63500) chip[DMG]: 			CommandPathIB =
D (63500) chip[DMG]: 			{
D (63500) chip[DMG]: 				EndpointId = 0x1,
D (63500) chip[DMG]: 				ClusterId = 0x6,
D (63510) chip[DMG]: 				CommandId = 0x2,
D (63510) chip[DMG]: 			},
D (63510) chip[DMG]:
D (63510) chip[DMG]: 			CommandFields =
D (63530) chip[DMG]: 			{
D (63530) chip[DMG]: 			},
D (63530) chip[DMG]: 		},
D (63530) chip[DMG]:
D (63530) chip[DMG]: 	],
D (63540) chip[DMG]:
D (63540) chip[DMG]: 	InteractionModelRevision = 12
D (63540) chip[DMG]: },
```

</details>