### PR TITLE
Add handling for DPTZ commands to Camera App

### DIFF
--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -34,9 +34,10 @@ using chip::app::Clusters::CameraAvStreamManagement::ViewportStruct;
 struct VideoStream
 {
     VideoStreamStruct videoStreamParams;
-    bool isAllocated;    // Flag to indicate if the stream is allocated.
-    void * videoContext; // Platform-specific context object associated with
-                         // video stream;
+    bool isAllocated;        // Flag to indicate if the stream is allocated.
+    ViewportStruct viewport; // Stream specific viewport, defaults to the camera viewport
+    void * videoContext;     // Platform-specific context object associated with
+                             // video stream;
 
     bool IsCompatible(const VideoStreamStruct & inputParams) const
     {
@@ -207,6 +208,9 @@ public:
         // Get the current camera viewport.
         virtual const ViewportStruct & GetViewport() = 0;
 
+        // Set the viewport for a specific stream
+        virtual CameraError SetViewport(VideoStream & stream, const ViewportStruct & viewPort) = 0;
+
         // Mute/Unmute speaker.
         virtual CameraError SetSpeakerMuted(bool muteSpeaker) = 0;
 
@@ -232,14 +236,16 @@ public:
         virtual uint8_t GetMicrophoneMaxLevel() = 0;
         virtual uint8_t GetMicrophoneMinLevel() = 0;
 
+        // Set Pan, Tilt, and Zoom
+        virtual CameraError SetPan(int16_t aPan) = 0;
+        virtual CameraError SetTilt(int16_t aTilt) = 0;
+        virtual CameraError SetZoom(uint8_t aZoom) = 0;
+
+        // Get device defined limits for Pan, Tilt, and Zoom
         virtual int16_t GetPanMin() = 0;
-
         virtual int16_t GetPanMax() = 0;
-
         virtual int16_t GetTiltMin() = 0;
-
         virtual int16_t GetTiltMax() = 0;
-
         virtual uint8_t GetZoomMax() = 0;
     };
 

--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -237,13 +237,13 @@ public:
         virtual uint8_t GetMicrophoneMinLevel() = 0;
 
         // Set Pan, Tilt, and Zoom
-        virtual CameraError SetPan(int16_t aPan) = 0;
+        virtual CameraError SetPan(int16_t aPan)   = 0;
         virtual CameraError SetTilt(int16_t aTilt) = 0;
         virtual CameraError SetZoom(uint8_t aZoom) = 0;
 
         // Get device defined limits for Pan, Tilt, and Zoom
-        virtual int16_t GetPanMin() = 0;
-        virtual int16_t GetPanMax() = 0;
+        virtual int16_t GetPanMin()  = 0;
+        virtual int16_t GetPanMax()  = 0;
         virtual int16_t GetTiltMin() = 0;
         virtual int16_t GetTiltMax() = 0;
         virtual uint8_t GetZoomMax() = 0;

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -122,8 +122,6 @@ void CameraApp::InitCameraDeviceClusters()
 
     mChimeServerPtr->Init();
 
-    mAVStreamMgmtServerPtr->Init();
-
     mAVSettingsUserLevelMgmtServerPtr->Init();
 
     InitializeCameraAVStreamMgmt();

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -40,8 +40,18 @@
 #define MICROPHONE_MIN_LEVEL (1)
 #define MICROPHONE_MAX_LEVEL (254)
 #define INVALID_SPKR_LEVEL (0)
+#define DEFAULT_PAN (0)
+#define DEFAULT_TILT (0)
+#define DEFAULT_ZOOM (1)
 
 namespace Camera {
+
+// Camera defined constants for Pan, Tilt, Zoom bounding values
+constexpr int16_t kMyMinPanValue  = -90;
+constexpr int16_t kMyMaxPanValue  = 90;
+constexpr int16_t kMyMinTiltValue = -90;
+constexpr int16_t kMyMaxTiltValue = 90;
+constexpr uint8_t kMyMaxZoomValue = 75;
 
 class CameraDevice : public CameraDeviceInterface, public CameraDeviceInterface::CameraHALInterface
 {
@@ -102,8 +112,12 @@ public:
     CameraError SetHDRMode(bool hdrMode);
     bool GetHDRMode() { return mHDREnabled; }
 
+    // Sets the Default Camera Viewport
     CameraError SetViewport(const ViewportStruct & viewPort);
     const ViewportStruct & GetViewport() { return mViewport; }
+
+    // Sets the Viewport for a specific stream
+    CameraError SetViewport(VideoStream & stream, const ViewportStruct & viewPort);
 
     // Currently, defaulting to not supporting speaker.
     bool HasSpeaker() { return false; }
@@ -142,6 +156,10 @@ public:
     int16_t GetTiltMax();
 
     uint8_t GetZoomMax();
+
+    CameraError SetPan(int16_t aPan);
+    CameraError SetTilt(int16_t aTilt);
+    CameraError SetZoom(uint8_t aZoom);
 
     std::vector<VideoStream> & GetAvailableVideoStreams() { return videoStreams; }
 
@@ -183,7 +201,11 @@ private:
     uint8_t mMicrophoneMinLevel                                             = MICROPHONE_MIN_LEVEL;
     uint8_t mMicrophoneMaxLevel                                             = MICROPHONE_MAX_LEVEL;
     uint8_t mMicrophoneVol                                                  = MICROPHONE_MIN_LEVEL;
-    chip::app::Clusters::CameraAvStreamManagement::ViewportStruct mViewport = { 325, 585, 2244, 1664 };
+    uint16_t mPan                                                           = DEFAULT_PAN;
+    uint16_t mTilt                                                          = DEFAULT_TILT;
+    int8_t mZoom                                                            = DEFAULT_ZOOM;
+    // Use a standard 1080p aspect ratio
+    chip::app::Clusters::CameraAvStreamManagement::ViewportStruct mViewport = { 320, 585, 2240, 1665 };
 };
 
 } // namespace Camera

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -115,13 +115,13 @@ public:
 
     /**
      * Sets the Viewport for a specific stream. The implementation of this HAL API is responsible
-     * for updating the stream identified with the provided viewport. The invoker of this 
+     * for updating the stream identified with the provided viewport. The invoker of this
      * API shall have already ensured that the provided viewport conforms to the specification
      * requirements on size and aspect ratio.
      *
      * @param stream   the currently allocated video stream on which the viewport is being set
      * @param viewport the viewport to be set on the stream
-     */ 
+     */
     CameraError SetViewport(VideoStream & stream, const ViewportStruct & viewport);
 
     // Currently, defaulting to not supporting speaker.

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -40,18 +40,15 @@
 #define MICROPHONE_MIN_LEVEL (1)
 #define MICROPHONE_MAX_LEVEL (254)
 #define INVALID_SPKR_LEVEL (0)
-#define DEFAULT_PAN (0)
-#define DEFAULT_TILT (0)
-#define DEFAULT_ZOOM (1)
 
 namespace Camera {
 
 // Camera defined constants for Pan, Tilt, Zoom bounding values
-constexpr int16_t kMyMinPanValue  = -90;
-constexpr int16_t kMyMaxPanValue  = 90;
-constexpr int16_t kMyMinTiltValue = -90;
-constexpr int16_t kMyMaxTiltValue = 90;
-constexpr uint8_t kMyMaxZoomValue = 75;
+constexpr int16_t kMinPanValue  = -90;
+constexpr int16_t kMaxPanValue  = 90;
+constexpr int16_t kMinTiltValue = -90;
+constexpr int16_t kMaxTiltValue = 90;
+constexpr uint8_t kMaxZoomValue = 75;
 
 class CameraDevice : public CameraDeviceInterface, public CameraDeviceInterface::CameraHALInterface
 {
@@ -201,9 +198,9 @@ private:
     uint8_t mMicrophoneMinLevel     = MICROPHONE_MIN_LEVEL;
     uint8_t mMicrophoneMaxLevel     = MICROPHONE_MAX_LEVEL;
     uint8_t mMicrophoneVol          = MICROPHONE_MIN_LEVEL;
-    uint16_t mPan                   = DEFAULT_PAN;
-    uint16_t mTilt                  = DEFAULT_TILT;
-    int8_t mZoom                    = DEFAULT_ZOOM;
+    uint16_t mPan                   = chip::app::Clusters::CameraAvSettingsUserLevelManagement::kDefaultPan;
+    uint16_t mTilt                  = chip::app::Clusters::CameraAvSettingsUserLevelManagement::kDefaultTilt;
+    int8_t mZoom                    = chip::app::Clusters::CameraAvSettingsUserLevelManagement::kDefaultZoom;
     // Use a standard 1080p aspect ratio
     chip::app::Clusters::CameraAvStreamManagement::ViewportStruct mViewport = { 320, 585, 2240, 1665 };
 };

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -113,8 +113,16 @@ public:
     CameraError SetViewport(const ViewportStruct & viewPort);
     const ViewportStruct & GetViewport() { return mViewport; }
 
-    // Sets the Viewport for a specific stream
-    CameraError SetViewport(VideoStream & stream, const ViewportStruct & viewPort);
+    /**
+     * Sets the Viewport for a specific stream. The implementation of this HAL API is responsible
+     * for updating the stream identified with the provided viewport. The invoker of this 
+     * API shall have already ensured that the provided viewport conforms to the specification
+     * requirements on size and aspect ratio.
+     *
+     * @param stream   the currently allocated video stream on which the viewport is being set
+     * @param viewport the viewport to be set on the stream
+     */ 
+    CameraError SetViewport(VideoStream & stream, const ViewportStruct & viewport);
 
     // Currently, defaulting to not supporting speaker.
     bool HasSpeaker() { return false; }

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -195,15 +195,15 @@ private:
 
     DefaultMediaController mMediaController;
 
-    uint16_t mCurrentVideoFrameRate                                         = 0;
-    bool mHDREnabled                                                        = false;
-    bool mMicrophoneMuted                                                   = false;
-    uint8_t mMicrophoneMinLevel                                             = MICROPHONE_MIN_LEVEL;
-    uint8_t mMicrophoneMaxLevel                                             = MICROPHONE_MAX_LEVEL;
-    uint8_t mMicrophoneVol                                                  = MICROPHONE_MIN_LEVEL;
-    uint16_t mPan                                                           = DEFAULT_PAN;
-    uint16_t mTilt                                                          = DEFAULT_TILT;
-    int8_t mZoom                                                            = DEFAULT_ZOOM;
+    uint16_t mCurrentVideoFrameRate = 0;
+    bool mHDREnabled                = false;
+    bool mMicrophoneMuted           = false;
+    uint8_t mMicrophoneMinLevel     = MICROPHONE_MIN_LEVEL;
+    uint8_t mMicrophoneMaxLevel     = MICROPHONE_MAX_LEVEL;
+    uint8_t mMicrophoneVol          = MICROPHONE_MIN_LEVEL;
+    uint16_t mPan                   = DEFAULT_PAN;
+    uint16_t mTilt                  = DEFAULT_TILT;
+    int8_t mZoom                    = DEFAULT_ZOOM;
     // Use a standard 1080p aspect ratio
     chip::app::Clusters::CameraAvStreamManagement::ViewportStruct mViewport = { 320, 585, 2240, 1665 };
 };

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -638,7 +638,7 @@ CameraError CameraDevice::SetViewport(const ViewportStruct & viewPort)
 CameraError CameraDevice::SetViewport(VideoStream & stream, const ViewportStruct & viewport)
 {
     ChipLogDetail(Camera,"Setting per stream viewport for stream %d.", stream.videoStreamParams.videoStreamID);
-    ChipLogDetail(Camera,"New viewport. x1=%d, x2=%d, y1=%d, y2=%d.", 
+    ChipLogDetail(Camera,"New viewport. x1=%d, x2=%d, y1=%d, y2=%d.",
                           viewport.x1, viewport.x2, viewport.y1, viewport.y2);
     stream.viewport = viewport;
     return CameraError::SUCCESS;

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -661,27 +661,27 @@ CameraError CameraDevice::SetMicrophoneVolume(uint8_t microphoneVol)
 
 int16_t CameraDevice::GetPanMin()
 {
-    return kMyMinPanValue;
+    return kMinPanValue;
 }
 
 int16_t CameraDevice::GetPanMax()
 {
-    return kMyMaxPanValue;
+    return kMaxPanValue;
 }
 
 int16_t CameraDevice::GetTiltMin()
 {
-    return kMyMinTiltValue;
+    return kMinTiltValue;
 }
 
 int16_t CameraDevice::GetTiltMax()
 {
-    return kMyMaxTiltValue;
+    return kMaxTiltValue;
 }
 
 uint8_t CameraDevice::GetZoomMax()
 {
-    return kMyMaxZoomValue;
+    return kMaxZoomValue;
 }
 
 // Set the Pan level

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -637,9 +637,8 @@ CameraError CameraDevice::SetViewport(const ViewportStruct & viewPort)
 
 CameraError CameraDevice::SetViewport(VideoStream & stream, const ViewportStruct & viewport)
 {
-    ChipLogDetail(Camera,"Setting per stream viewport for stream %d.", stream.videoStreamParams.videoStreamID);
-    ChipLogDetail(Camera,"New viewport. x1=%d, x2=%d, y1=%d, y2=%d.",
-                          viewport.x1, viewport.x2, viewport.y1, viewport.y2);
+    ChipLogDetail(Camera, "Setting per stream viewport for stream %d.", stream.videoStreamParams.videoStreamID);
+    ChipLogDetail(Camera, "New viewport. x1=%d, x2=%d, y1=%d, y2=%d.", viewport.x1, viewport.x2, viewport.y1, viewport.y2);
     stream.viewport = viewport;
     return CameraError::SUCCESS;
 }

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -635,6 +635,15 @@ CameraError CameraDevice::SetViewport(const ViewportStruct & viewPort)
     return CameraError::SUCCESS;
 }
 
+CameraError CameraDevice::SetViewport(VideoStream & stream, const ViewportStruct & viewport)
+{
+    ChipLogDetail(Camera,"Setting per stream viewport for stream %d.", stream.videoStreamParams.videoStreamID);
+    ChipLogDetail(Camera,"New viewport. x1=%d, x2=%d, y1=%d, y2=%d.", 
+                          viewport.x1, viewport.x2, viewport.y1, viewport.y2);
+    stream.viewport = viewport;
+    return CameraError::SUCCESS;
+}
+
 // Mute/Unmute microphone.
 CameraError CameraDevice::SetMicrophoneMuted(bool muteMicrophone)
 {
@@ -653,27 +662,48 @@ CameraError CameraDevice::SetMicrophoneVolume(uint8_t microphoneVol)
 
 int16_t CameraDevice::GetPanMin()
 {
-    return -90;
+    return kMyMinPanValue;
 }
 
 int16_t CameraDevice::GetPanMax()
 {
-    return 90;
+    return kMyMaxPanValue;
 }
 
 int16_t CameraDevice::GetTiltMin()
 {
-    return -90;
+    return kMyMinTiltValue;
 }
 
 int16_t CameraDevice::GetTiltMax()
 {
-    return 90;
+    return kMyMaxTiltValue;
 }
 
 uint8_t CameraDevice::GetZoomMax()
 {
-    return 75;
+    return kMyMaxZoomValue;
+}
+
+// Set the Pan level
+CameraError CameraDevice::SetPan(int16_t aPan)
+{
+    mPan = aPan;
+    return CameraError::SUCCESS;
+}
+
+// Set the Tilt level
+CameraError CameraDevice::SetTilt(int16_t aTilt)
+{
+    mTilt = aTilt;
+    return CameraError::SUCCESS;
+}
+
+// Set the Zoom level
+CameraError CameraDevice::SetZoom(uint8_t aZoom)
+{
+    mZoom = aZoom;
+    return CameraError::SUCCESS;
 }
 
 void CameraDevice::InitializeVideoStreams()
@@ -694,6 +724,7 @@ void CameraDevice::InitializeVideoStreams()
                                   chip::MakeOptional(static_cast<bool>(false)) /* OSD */,
                                   0 /* RefCount */ },
                                 false,
+                                { mViewport.x1, mViewport.y1, mViewport.x2, mViewport.y2 },
                                 nullptr };
 
     videoStreams.push_back(videoStream);

--- a/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
@@ -150,7 +150,7 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
     // The application needs to interact with iHAL to access the stream, validate the viewport
     // and set the new viewport value.
     //
-    Status status = Status::Success;
+    Status status    = Status::Success;
     bool streamFound = false;
 
     for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
@@ -164,31 +164,31 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
             // Esnure width does not exceed sensor width
             // Ensure height does not exceed sensor height
             //
-            uint16_t requestedWidth = aViewport.x2 - aViewport.x1;
-            uint16_t requestedHeight = aViewport.y2 - aViewport.y1;
+            uint16_t requestedWidth             = aViewport.x2 - aViewport.x1;
+            uint16_t requestedHeight            = aViewport.y2 - aViewport.y1;
             VideoResolutionStruct minResolution = mCameraDeviceHAL->GetMinViewport();
             VideoSensorParamsStruct sensorParms = mCameraDeviceHAL->GetVideoSensorParams();
-            if ((requestedWidth < minResolution.width) ||
-                (requestedHeight < minResolution.height) ||
-                (requestedWidth > sensorParms.sensorWidth) ||
-                (requestedHeight > sensorParms.sensorHeight))
+            if ((requestedWidth < minResolution.width) || (requestedHeight < minResolution.height) ||
+                (requestedWidth > sensorParms.sensorWidth) || (requestedHeight > sensorParms.sensorHeight))
             {
-                ChipLogError(Camera,"CameraApp: DPTZSetViewport with invalid viewport dimensions");
+                ChipLogError(Camera, "CameraApp: DPTZSetViewport with invalid viewport dimensions");
                 status = Status::ConstraintError;
                 break;
             }
 
             // Get the ARs to no more than 2DP.  Otherwise you get mismatches e.g. 16:9 ratio calculation for 480p isn't the same as
             // 1080p beyond 2DP.
-            float requestedAR = floorf((static_cast<float>(requestedWidth)/requestedHeight)*100)/100;
-            float streamAR    = floorf((static_cast<float>(stream.videoStreamParams.maxResolution.width)/
-                                                    stream.videoStreamParams.maxResolution.height)*100)/100;
+            float requestedAR = floorf((static_cast<float>(requestedWidth) / requestedHeight) * 100) / 100;
+            float streamAR    = floorf((static_cast<float>(stream.videoStreamParams.maxResolution.width) /
+                                     stream.videoStreamParams.maxResolution.height) *
+                                       100) /
+                100;
 
-            ChipLogDetail(Camera,"DPTZSetViewpoort. AR of viewport %f, AR of stream %f.", requestedAR, streamAR);
+            ChipLogDetail(Camera, "DPTZSetViewpoort. AR of viewport %f, AR of stream %f.", requestedAR, streamAR);
             // Ensure that the aspect ration of the viewport matches the aspect ratio of the stream
             if (requestedAR != streamAR)
             {
-                ChipLogError(Camera,"CameraApp: DPTZSetViewport with mismatching aspect ratio.");
+                ChipLogError(Camera, "CameraApp: DPTZSetViewport with mismatching aspect ratio.");
                 status = Status::ConstraintError;
                 break;
             }
@@ -202,7 +202,6 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
     }
 
     return status;
-
 }
 
 Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamID, Optional<int16_t> aDeltaX,
@@ -212,14 +211,14 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
     // The application needs to interact with its instance of AVStreamManagement to access the stream, validate the viewport
     // and set the new values for the viewpoort based on the pixel movement requested
     //
-    Status status = Status::Success;
+    Status status    = Status::Success;
     bool streamFound = false;
 
     for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
     {
         if (stream.videoStreamParams.videoStreamID == aVideoStreamID && stream.isAllocated)
         {
-            ViewportStruct viewport = stream.viewport;
+            ViewportStruct viewport             = stream.viewport;
             VideoResolutionStruct minResolution = mCameraDeviceHAL->GetMinViewport();
             VideoSensorParamsStruct sensorParms = mCameraDeviceHAL->GetVideoSensorParams();
 
@@ -230,11 +229,11 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
                 {
                     // if the delta would move us out of the cartesian plane of the sensor, limit to the left hand edge
                     //
-                    uint16_t x1Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x1))? -viewport.x1: deltaX;
-                    viewport.x1 = static_cast<uint16_t>(viewport.x1 + x1Movement);
+                    uint16_t x1Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x1)) ? -viewport.x1 : deltaX;
+                    viewport.x1         = static_cast<uint16_t>(viewport.x1 + x1Movement);
 
-                    uint16_t x2Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x2))? -viewport.x2: deltaX;
-                    viewport.x2 = static_cast<uint16_t>(viewport.x2 + x2Movement);
+                    uint16_t x2Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x2)) ? -viewport.x2 : deltaX;
+                    viewport.x2         = static_cast<uint16_t>(viewport.x2 + x2Movement);
                 }
             }
 
@@ -245,11 +244,11 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
                 {
                     // if the delta would move us out of the cartesian plane of the sensor, limit to the top hand edge
                     //
-                    uint16_t y1Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y1))? -viewport.y1: deltaY;
-                    viewport.y1 = static_cast<uint16_t>(viewport.y1 + y1Movement);
+                    uint16_t y1Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y1)) ? -viewport.y1 : deltaY;
+                    viewport.y1         = static_cast<uint16_t>(viewport.y1 + y1Movement);
 
-                    uint16_t y2Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y2))? -viewport.y2: deltaY;
-                    viewport.y2 = static_cast<uint16_t>(viewport.y2 + y2Movement);
+                    uint16_t y2Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y2)) ? -viewport.y2 : deltaY;
+                    viewport.y2         = static_cast<uint16_t>(viewport.y2 + y2Movement);
                 }
             }
 
@@ -260,11 +259,11 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
                 {
                     // Scale the current values by the given zoom
                     //
-                    uint16_t originalWidth = viewport.x2 - viewport.x1;
-                    uint16_t originalHeight = viewport.y2 - viewport.y1;
-                    uint32_t originalSize = originalWidth * originalHeight;
-                    uint32_t zoomDeltaInPixels = static_cast<uint32_t>(originalSize * abs(zoomDelta)/100);
-                    uint32_t newSize = (zoomDelta < 0)? originalSize - zoomDeltaInPixels: originalSize + zoomDeltaInPixels;
+                    uint16_t originalWidth     = viewport.x2 - viewport.x1;
+                    uint16_t originalHeight    = viewport.y2 - viewport.y1;
+                    uint32_t originalSize      = originalWidth * originalHeight;
+                    uint32_t zoomDeltaInPixels = static_cast<uint32_t>(originalSize * abs(zoomDelta) / 100);
+                    uint32_t newSize = (zoomDelta < 0) ? originalSize - zoomDeltaInPixels : originalSize + zoomDeltaInPixels;
 
                     // If the new viewport after zoom would be less than the min, scale it to the min
                     //
@@ -276,9 +275,9 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
                     // The new width of a rectangle with a defined aspect ratio is the square root of the new size
                     // of that rectangle multiplied by the aspect ratio
                     //
-                    double viewportAR = floorf((static_cast<float>(originalWidth)/originalHeight)*100)/100;
+                    double viewportAR = floorf((static_cast<float>(originalWidth) / originalHeight) * 100) / 100;
 
-                    uint16_t newWidth = static_cast<uint16_t>(round(sqrt(newSize * viewportAR)));
+                    uint16_t newWidth  = static_cast<uint16_t>(round(sqrt(newSize * viewportAR)));
                     uint16_t newHeight = static_cast<uint16_t>(newWidth / viewportAR);
 
                     viewport.x1 = static_cast<uint16_t>(viewport.x1 - (newWidth - originalWidth));
@@ -289,7 +288,7 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
             }
             // Is the requested viewport smaller than the minimum, if yes scale to the minimum size, starting at x1, y1.
             //
-            if (((viewport.x2 - viewport.x1) < minResolution.width) || ((viewport.y2-viewport.y1) < minResolution.height))
+            if (((viewport.x2 - viewport.x1) < minResolution.width) || ((viewport.y2 - viewport.y1) < minResolution.height))
             {
                 viewport.x2 = viewport.x1 + minResolution.width;
                 viewport.y2 = viewport.y1 + minResolution.height;

--- a/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
@@ -17,7 +17,9 @@
  */
 
 #include <app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h>
+#include <app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h>
 #include <camera-avsettingsuserlevel-manager.h>
+#include <cmath>
 
 using namespace chip;
 using namespace chip::app;
@@ -43,7 +45,15 @@ bool CameraAVSettingsUserLevelManager::IsValidVideoStreamID(uint16_t aVideoStrea
     // The server needs to verify that the provided Video Stream ID is valid and known and subject to digital modification
     // The camera app needs to also have an instance of AV Stream Management, querying that to determine validity of the provided
     // id.
-    return true;
+    for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
+    {
+        if (stream.videoStreamParams.videoStreamID == aVideoStreamID && stream.isAllocated)
+        {
+            return true;
+        }
+    }
+    
+    return false;
 }
 
 Status CameraAVSettingsUserLevelManager::MPTZSetPosition(Optional<int16_t> aPan, Optional<int16_t> aTilt, Optional<uint8_t> aZoom)
@@ -52,6 +62,21 @@ Status CameraAVSettingsUserLevelManager::MPTZSetPosition(Optional<int16_t> aPan,
     // hardware interactions to actually set the camera to the new values of PTZ.  Then return a Status response. The server itself
     // will persist the new values.
     //
+    if (aPan.HasValue())
+    {
+        mCameraDeviceHAL->SetPan(aPan.Value());
+    }
+
+    if (aTilt.HasValue())
+    {
+        mCameraDeviceHAL->SetTilt(aTilt.Value());
+    }
+
+    if (aZoom.HasValue()) 
+    {
+        mCameraDeviceHAL->SetZoom(aZoom.Value());
+    }
+    
     return Status::Success;
 }
 
@@ -61,6 +86,21 @@ Status CameraAVSettingsUserLevelManager::MPTZRelativeMove(Optional<int16_t> aPan
     // hardware interactions to actually set the camera to the new values of PTZ.  Then return a Status response. The server itself
     // will persist the new values.
     //
+    if (aPan.HasValue())
+    {
+        mCameraDeviceHAL->SetPan(aPan.Value());
+    }
+
+    if (aTilt.HasValue())
+    {
+        mCameraDeviceHAL->SetTilt(aTilt.Value());
+    }
+
+    if (aZoom.HasValue()) 
+    {
+        mCameraDeviceHAL->SetZoom(aZoom.Value());
+    }
+    
     return Status::Success;
 }
 
@@ -70,6 +110,21 @@ Status CameraAVSettingsUserLevelManager::MPTZMoveToPreset(uint8_t aPreset, Optio
     // The Cluster implementation has validated the preset is valid, and provided the MPTZ values associated with that preset.
     // Do any needed hardware interactions to actually set the camera to the new values of PTZ.  Then return a Status response.
     //
+    if (aPan.HasValue())
+    {
+        mCameraDeviceHAL->SetPan(aPan.Value());
+    }
+
+    if (aTilt.HasValue())
+    {
+        mCameraDeviceHAL->SetTilt(aTilt.Value());
+    }
+
+    if (aZoom.HasValue()) 
+    {
+        mCameraDeviceHAL->SetZoom(aZoom.Value());
+    }
+
     return Status::Success;
 }
 
@@ -92,10 +147,62 @@ Status CameraAVSettingsUserLevelManager::MPTZRemovePreset(uint8_t aPreset)
 Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID, Structs::ViewportStruct::Type aViewport)
 {
     // The Cluster implementation has ensured that the videoStreamID represents a valid stream.
-    // The application needs to interact with its instance of AVStreamManagement to access the stream, validate the viewport
-    // and set the new vieport value.
+    // The application needs to interact with iHAL to access the stream, validate the viewport
+    // and set the new viewport value.
     //
-    return Status::Success;
+    Status status = Status::Success;
+    bool streamFound = false;
+
+    for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
+    {
+        if (stream.videoStreamParams.videoStreamID == aVideoStreamID && stream.isAllocated)
+        {
+            streamFound = true;
+            // Validate the received viewport dimensions
+            // 
+            // Ensure pixel count is > min pixels
+            // Esnure width does not exceed sensor width
+            // Ensure height does not exceed sensor height
+            //
+            uint16_t requestedWidth = aViewport.x2 - aViewport.x1;
+            uint16_t requestedHeight = aViewport.y2 - aViewport.y1; 
+            VideoResolutionStruct minResolution = mCameraDeviceHAL->GetMinViewport();
+            VideoSensorParamsStruct sensorParms = mCameraDeviceHAL->GetVideoSensorParams();
+            if ((requestedWidth < minResolution.width) ||
+                (requestedHeight < minResolution.height) || 
+                (requestedWidth > sensorParms.sensorWidth) ||
+                (requestedHeight > sensorParms.sensorHeight))
+            {
+                ChipLogError(Camera,"CameraApp: DPTZSetViewport with invalid viewport dimensions");
+                status = Status::ConstraintError;
+                break;
+            }
+
+            // Get the ARs to no more than 2DP.  Otherwise you get mismatches e.g. 16:9 ratio calculation for 480p isn't the same as 
+            // 1080p beyond 2DP.
+            float requestedAR = floorf((static_cast<float>(requestedWidth)/requestedHeight)*100)/100;
+            float streamAR    = floorf((static_cast<float>(stream.videoStreamParams.maxResolution.width)/
+                                                    stream.videoStreamParams.maxResolution.height)*100)/100;
+
+            ChipLogDetail(Camera,"DPTZSetViewpoort. AR of viewport %f, AR of stream %f.", requestedAR, streamAR);
+            // Ensure that the aspect ration of the viewport matches the aspect ratio of the stream
+            if (requestedAR != streamAR)
+            {
+                ChipLogError(Camera,"CameraApp: DPTZSetViewport with mismatching aspect ratio.");
+                status = Status::ConstraintError;
+                break;
+            }
+            mCameraDeviceHAL->SetViewport(stream, aViewport);
+        }
+    }
+
+    if (!streamFound) 
+    {
+        status = Status::InvalidCommand;
+    }
+
+    return status;
+
 }
 
 Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamID, Optional<int16_t> aDeltaX,
@@ -105,7 +212,109 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
     // The application needs to interact with its instance of AVStreamManagement to access the stream, validate the viewport
     // and set the new values for the viewpoort based on the pixel movement requested
     //
-    return Status::Success;
+    Status status = Status::Success;
+    bool streamFound = false;
+
+    for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
+    {
+        if (stream.videoStreamParams.videoStreamID == aVideoStreamID && stream.isAllocated)
+        {
+            ViewportStruct viewport = stream.viewport;
+            VideoResolutionStruct minResolution = mCameraDeviceHAL->GetMinViewport();
+            VideoSensorParamsStruct sensorParms = mCameraDeviceHAL->GetVideoSensorParams();
+
+            if (aDeltaX.HasValue())
+            {
+                int16_t deltaX = aDeltaX.Value();
+                if (deltaX != 0) 
+                {
+                    // if the delta would move us out of the cartesian plane of the sensor, limit to the left hand edge
+                    // 
+                    uint16_t x1Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x1))? -viewport.x1: deltaX;
+                    viewport.x1 = static_cast<uint16_t>(viewport.x1 + x1Movement);
+
+                    uint16_t x2Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x2))? -viewport.x2: deltaX;
+                    viewport.x2 = static_cast<uint16_t>(viewport.x2 + x2Movement);
+                }
+            }
+
+            if (aDeltaY.HasValue())
+            {
+                int16_t deltaY = aDeltaY.Value();
+                if (deltaY != 0) 
+                {
+                    // if the delta would move us out of the cartesian plane of the sensor, limit to the top hand edge
+                    // 
+                    uint16_t y1Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y1))? -viewport.y1: deltaY;
+                    viewport.y1 = static_cast<uint16_t>(viewport.y1 + y1Movement);
+
+                    uint16_t y2Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y2))? -viewport.y2: deltaY;
+                    viewport.y2 = static_cast<uint16_t>(viewport.y2 + y2Movement);
+                }
+            }
+
+            if (aZoomDelta.HasValue())
+            {
+                int8_t zoomDelta = aZoomDelta.Value();
+                if (zoomDelta != 0) 
+                {
+                    // Scale the current values by the given zoom
+                    // 
+                    uint16_t originalWidth = viewport.x2 - viewport.x1;
+                    uint16_t originalHeight = viewport.y2 - viewport.y1;
+                    uint32_t originalSize = originalWidth * originalHeight;
+                    uint32_t zoomDeltaInPixels = static_cast<uint32_t>(originalSize * abs(zoomDelta)/100);
+                    uint32_t newSize = (zoomDelta < 0)? originalSize - zoomDeltaInPixels: originalSize + zoomDeltaInPixels;
+
+                    // If the new viewport after zoom would be less than the min, scale it to the min
+                    //
+                    if (newSize < (minResolution.width * minResolution.height))
+                    {
+                        newSize = minResolution.width * minResolution.height;
+                    }
+
+                    // The new width of a rectangle with a defined aspect ratio is the square root of the new size
+                    // of that rectangle multiplied by the aspect ratio
+                    //
+                    double viewportAR = floorf((static_cast<float>(originalWidth)/originalHeight)*100)/100;
+
+                    uint16_t newWidth = static_cast<uint16_t>(round(sqrt(newSize * viewportAR)));
+                    uint16_t newHeight = static_cast<uint16_t>(newWidth / viewportAR);
+
+                    viewport.x1 = static_cast<uint16_t>(viewport.x1 - (newWidth - originalWidth));
+                    viewport.x2 = static_cast<uint16_t>(viewport.x2 + (newWidth - originalWidth));
+                    viewport.y1 = static_cast<uint16_t>(viewport.y1 - (newHeight - originalHeight));
+                    viewport.y2 = static_cast<uint16_t>(viewport.y2 + (newHeight - originalHeight));
+                }
+            }
+            // Is the requested viewport smaller than the minimum, if yes scale to the minimum size, starting at x1, y1.
+            //
+            if (((viewport.x2 - viewport.x1) < minResolution.width) || ((viewport.y2-viewport.y1) < minResolution.height))
+            {
+                viewport.x2 = viewport.x1 + minResolution.width;
+                viewport.y2 = viewport.y1 + minResolution.height;
+            }
+
+            // Is the requested viewport greater than the sensor size, if yes, scale to the sensor
+            //
+            if (((viewport.x2 - viewport.x1) > sensorParms.sensorWidth) || ((viewport.y2 - viewport.y1) > sensorParms.sensorHeight))
+            {
+                viewport.x1 = 0;
+                viewport.y1 = 0;
+                viewport.x2 = sensorParms.sensorWidth;
+                viewport.y2 = sensorParms.sensorHeight;
+            }
+            streamFound = true;
+            mCameraDeviceHAL->SetViewport(stream, viewport);
+        }
+    }
+
+    if (!streamFound)
+    {
+        status = Status::InvalidCommand;
+    }
+
+    return status;
 }
 
 CHIP_ERROR CameraAVSettingsUserLevelManager::LoadMPTZPresets(std::vector<MPTZPresetHelper> & mptzPresetHelpers)
@@ -122,5 +331,6 @@ CHIP_ERROR CameraAVSettingsUserLevelManager::LoadDPTZRelativeMove(std::vector<ui
 
 CHIP_ERROR CameraAVSettingsUserLevelManager::PersistentAttributesLoadedCallback()
 {
+    ChipLogDetail(Camera, "CameraAvSettingsUserLevelManagement: Persistent attributes loaded");
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
@@ -176,7 +176,8 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
             float requestedAR = floorf((static_cast<float>(requestedWidth) / requestedHeight) * 100) / 100;
             float streamAR    = floorf((static_cast<float>(stream.videoStreamParams.maxResolution.width) /
                                      stream.videoStreamParams.maxResolution.height) *
-                                       100) / 100;
+                                       100) /
+                100;
 
             ChipLogDetail(Camera, "DPTZSetViewpoort. AR of viewport %f, AR of stream %f.", requestedAR, streamAR);
             // Ensure that the aspect ration of the viewport matches the aspect ratio of the stream
@@ -287,8 +288,8 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
             {
                 viewport.x1 = 0;
                 viewport.y1 = 0;
-                viewport.x2 = sensorParms.sensorWidth-1;
-                viewport.y2 = sensorParms.sensorHeight-1;
+                viewport.x2 = sensorParms.sensorWidth - 1;
+                viewport.y2 = sensorParms.sensorHeight - 1;
             }
             mCameraDeviceHAL->SetViewport(stream, viewport);
             return Status::Success;

--- a/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
@@ -52,7 +52,7 @@ bool CameraAVSettingsUserLevelManager::IsValidVideoStreamID(uint16_t aVideoStrea
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -72,11 +72,11 @@ Status CameraAVSettingsUserLevelManager::MPTZSetPosition(Optional<int16_t> aPan,
         mCameraDeviceHAL->SetTilt(aTilt.Value());
     }
 
-    if (aZoom.HasValue()) 
+    if (aZoom.HasValue())
     {
         mCameraDeviceHAL->SetZoom(aZoom.Value());
     }
-    
+
     return Status::Success;
 }
 
@@ -96,11 +96,11 @@ Status CameraAVSettingsUserLevelManager::MPTZRelativeMove(Optional<int16_t> aPan
         mCameraDeviceHAL->SetTilt(aTilt.Value());
     }
 
-    if (aZoom.HasValue()) 
+    if (aZoom.HasValue())
     {
         mCameraDeviceHAL->SetZoom(aZoom.Value());
     }
-    
+
     return Status::Success;
 }
 
@@ -120,7 +120,7 @@ Status CameraAVSettingsUserLevelManager::MPTZMoveToPreset(uint8_t aPreset, Optio
         mCameraDeviceHAL->SetTilt(aTilt.Value());
     }
 
-    if (aZoom.HasValue()) 
+    if (aZoom.HasValue())
     {
         mCameraDeviceHAL->SetZoom(aZoom.Value());
     }
@@ -159,17 +159,17 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
         {
             streamFound = true;
             // Validate the received viewport dimensions
-            // 
+            //
             // Ensure pixel count is > min pixels
             // Esnure width does not exceed sensor width
             // Ensure height does not exceed sensor height
             //
             uint16_t requestedWidth = aViewport.x2 - aViewport.x1;
-            uint16_t requestedHeight = aViewport.y2 - aViewport.y1; 
+            uint16_t requestedHeight = aViewport.y2 - aViewport.y1;
             VideoResolutionStruct minResolution = mCameraDeviceHAL->GetMinViewport();
             VideoSensorParamsStruct sensorParms = mCameraDeviceHAL->GetVideoSensorParams();
             if ((requestedWidth < minResolution.width) ||
-                (requestedHeight < minResolution.height) || 
+                (requestedHeight < minResolution.height) ||
                 (requestedWidth > sensorParms.sensorWidth) ||
                 (requestedHeight > sensorParms.sensorHeight))
             {
@@ -178,7 +178,7 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
                 break;
             }
 
-            // Get the ARs to no more than 2DP.  Otherwise you get mismatches e.g. 16:9 ratio calculation for 480p isn't the same as 
+            // Get the ARs to no more than 2DP.  Otherwise you get mismatches e.g. 16:9 ratio calculation for 480p isn't the same as
             // 1080p beyond 2DP.
             float requestedAR = floorf((static_cast<float>(requestedWidth)/requestedHeight)*100)/100;
             float streamAR    = floorf((static_cast<float>(stream.videoStreamParams.maxResolution.width)/
@@ -196,7 +196,7 @@ Status CameraAVSettingsUserLevelManager::DPTZSetViewport(uint16_t aVideoStreamID
         }
     }
 
-    if (!streamFound) 
+    if (!streamFound)
     {
         status = Status::InvalidCommand;
     }
@@ -226,10 +226,10 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
             if (aDeltaX.HasValue())
             {
                 int16_t deltaX = aDeltaX.Value();
-                if (deltaX != 0) 
+                if (deltaX != 0)
                 {
                     // if the delta would move us out of the cartesian plane of the sensor, limit to the left hand edge
-                    // 
+                    //
                     uint16_t x1Movement = ((deltaX < 0) && (abs(deltaX) > viewport.x1))? -viewport.x1: deltaX;
                     viewport.x1 = static_cast<uint16_t>(viewport.x1 + x1Movement);
 
@@ -241,10 +241,10 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
             if (aDeltaY.HasValue())
             {
                 int16_t deltaY = aDeltaY.Value();
-                if (deltaY != 0) 
+                if (deltaY != 0)
                 {
                     // if the delta would move us out of the cartesian plane of the sensor, limit to the top hand edge
-                    // 
+                    //
                     uint16_t y1Movement = ((deltaY < 0) && (abs(deltaY) > viewport.y1))? -viewport.y1: deltaY;
                     viewport.y1 = static_cast<uint16_t>(viewport.y1 + y1Movement);
 
@@ -256,10 +256,10 @@ Status CameraAVSettingsUserLevelManager::DPTZRelativeMove(uint16_t aVideoStreamI
             if (aZoomDelta.HasValue())
             {
                 int8_t zoomDelta = aZoomDelta.Value();
-                if (zoomDelta != 0) 
+                if (zoomDelta != 0)
                 {
                     // Scale the current values by the given zoom
-                    // 
+                    //
                     uint16_t originalWidth = viewport.x2 - viewport.x1;
                     uint16_t originalHeight = viewport.y2 - viewport.y1;
                     uint32_t originalSize = originalWidth * originalHeight;


### PR DESCRIPTION
Add handling for DPTZ commands to Camera App
Add HAL API for PTZ setting.
Cleanup some default values to align with actual Aspect Ratios


#### Testing
- build camera app
- build chip tool
- allocate a video stream
- using chip-tool invoke setting of viewport with unknown stream id, viewports under sized, viewports with incorrect aspect ratio
- using chip-tool invoke setting of relative move with + and -zoom values.  + and - deltaX and deltaY values
- repeat with values that would force a resize to minimum, and with values that would force alignment on the left hand edge