### PR TITLE
[Energy-Management-App] Add cluster shutdown APIs for the clusters which are enabled in all-clusters-app.

### DIFF
--- a/examples/energy-management-app/energy-management-common/device-energy-management/src/device-energy-management-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/device-energy-management/src/device-energy-management-mode.cpp
@@ -110,6 +110,15 @@ void emberAfDeviceEnergyManagementModeClusterInitCallback(chip::EndpointId endpo
     gDeviceEnergyManagementModeInstance->Init();
 }
 
+void emberAfDeviceEnergyManagementModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gDeviceEnergyManagementModeInstance)
+    {
+        gDeviceEnergyManagementModeInstance->Shutdown();
+    }
+    DeviceEnergyManagementMode::Shutdown();
+}
+
 void MatterDeviceEnergyManagementModeClusterServerShutdownCallback(chip::EndpointId endpoint)
 {
     DeviceEnergyManagementMode::Shutdown();

--- a/examples/energy-management-app/energy-management-common/device-energy-management/src/device-energy-management-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/device-energy-management/src/device-energy-management-mode.cpp
@@ -112,6 +112,11 @@ void emberAfDeviceEnergyManagementModeClusterInitCallback(chip::EndpointId endpo
 
 void emberAfDeviceEnergyManagementModeClusterShutdownCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     if (gDeviceEnergyManagementModeInstance)
     {
         gDeviceEnergyManagementModeInstance->Shutdown();
@@ -119,7 +124,12 @@ void emberAfDeviceEnergyManagementModeClusterShutdownCallback(chip::EndpointId e
     DeviceEnergyManagementMode::Shutdown();
 }
 
-void MatterDeviceEnergyManagementModeClusterServerShutdownCallback(chip::EndpointId endpoint)
+void MatterDeviceEnergyManagementModeClusterServerShutdownCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     DeviceEnergyManagementMode::Shutdown();
 }

--- a/examples/energy-management-app/energy-management-common/energy-evse/include/EnergyEvseTargetsStore.h
+++ b/examples/energy-management-app/energy-management-common/energy-evse/include/EnergyEvseTargetsStore.h
@@ -42,6 +42,7 @@ public:
     ~EvseTargetsDelegate();
 
     CHIP_ERROR Init(PersistentStorageDelegate * targetStore);
+    void Shutdown();
 
     /**
      * @brief Delegate should implement a handler for LoadTargets

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseMain.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseMain.cpp
@@ -146,6 +146,11 @@ CHIP_ERROR EnergyEvseShutdown()
         gEvseDelegate.reset();
     }
 
+    if (gEvseTargetsDelegate)
+    {
+        gEvseTargetsDelegate.reset();
+    }
+
     return CHIP_NO_ERROR;
 }
 

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseManager.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseManager.cpp
@@ -134,9 +134,11 @@ CHIP_ERROR EnergyEvseManager::Init()
 void EnergyEvseManager::Shutdown()
 {
     EnergyEvseDelegate * dg = GetDelegate();
-    if(dg) {
+    if (dg)
+    {
         EvseTargetsDelegate * targetsStore = dg->GetEvseTargetsDelegate();
-        if(targetsStore) {
+        if (targetsStore)
+        {
             targetsStore->Shutdown();
         }
     }

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseManager.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseManager.cpp
@@ -133,5 +133,12 @@ CHIP_ERROR EnergyEvseManager::Init()
 
 void EnergyEvseManager::Shutdown()
 {
+    EnergyEvseDelegate * dg = GetDelegate();
+    if(dg) {
+        EvseTargetsDelegate * targetsStore = dg->GetEvseTargetsDelegate();
+        if(targetsStore) {
+            targetsStore->Shutdown();
+        }
+    }
     Instance::Shutdown();
 }

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseTargetsStore.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseTargetsStore.cpp
@@ -48,6 +48,12 @@ CHIP_ERROR EvseTargetsDelegate::Init(PersistentStorageDelegate * targetStore)
     return CHIP_NO_ERROR;
 }
 
+void EvseTargetsDelegate::Shutdown()
+{
+    // Remove FabricDelegate
+    chip::Server::GetInstance().GetFabricTable().RemoveFabricDelegate(this);
+}
+
 const DataModel::List<const Structs::ChargingTargetScheduleStruct::Type> & EvseTargetsDelegate::GetTargets()
 {
     return mChargingTargetSchedulesList;

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/energy-evse-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/energy-evse-mode.cpp
@@ -94,3 +94,12 @@ void emberAfEnergyEvseModeClusterInitCallback(chip::EndpointId endpointId)
     gEnergyEvseModeInstance = std::make_unique<ModeBase::Instance>(gEnergyEvseModeDelegate.get(), 0x1, EnergyEvseMode::Id, 0);
     gEnergyEvseModeInstance->Init();
 }
+
+void emberAfEnergyEvseModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gEnergyEvseModeInstance)
+    {
+        gEnergyEvseModeInstance->Shutdown();
+    }
+    EnergyEvseMode::Shutdown();
+}

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/energy-evse-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/energy-evse-mode.cpp
@@ -16,6 +16,7 @@
  *    limitations under the License.
  */
 
+#include <EnergyManagementAppCommonMain.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <energy-evse-modes.h>
 
@@ -89,6 +90,11 @@ void EnergyEvseMode::Shutdown()
 
 void emberAfEnergyEvseModeClusterInitCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     VerifyOrDie(!gEnergyEvseModeDelegate && !gEnergyEvseModeInstance);
     gEnergyEvseModeDelegate = std::make_unique<EnergyEvseMode::EnergyEvseModeDelegate>();
     gEnergyEvseModeInstance = std::make_unique<ModeBase::Instance>(gEnergyEvseModeDelegate.get(), 0x1, EnergyEvseMode::Id, 0);
@@ -97,6 +103,11 @@ void emberAfEnergyEvseModeClusterInitCallback(chip::EndpointId endpointId)
 
 void emberAfEnergyEvseModeClusterShutdownCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     if (gEnergyEvseModeInstance)
     {
         gEnergyEvseModeInstance->Shutdown();

--- a/examples/energy-management-app/energy-management-common/water-heater/src/water-heater-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/water-heater/src/water-heater-mode.cpp
@@ -105,3 +105,12 @@ void emberAfWaterHeaterModeClusterInitCallback(chip::EndpointId endpointId)
     gWaterHeaterModeInstance = new ModeBase::Instance(gWaterHeaterModeDelegate, endpointId, WaterHeaterMode::Id, 0);
     gWaterHeaterModeInstance->Init();
 }
+
+void emberAfWaterHeaterModeClusterShutdownCallback(chip::EndpointId endpointId)
+{
+    if (gWaterHeaterModeInstance)
+    {
+        gWaterHeaterModeInstance->Shutdown();
+    }
+    WaterHeaterMode::Shutdown();
+}

--- a/examples/energy-management-app/energy-management-common/water-heater/src/water-heater-mode.cpp
+++ b/examples/energy-management-app/energy-management-common/water-heater/src/water-heater-mode.cpp
@@ -15,6 +15,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+#include <EnergyManagementAppCommonMain.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <water-heater-mode.h>
 
@@ -100,6 +101,11 @@ void WaterHeaterMode::Shutdown()
 
 void emberAfWaterHeaterModeClusterInitCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     VerifyOrDie(gWaterHeaterModeDelegate == nullptr && gWaterHeaterModeInstance == nullptr);
     gWaterHeaterModeDelegate = new WaterHeaterMode::ExampleWaterHeaterModeDelegate;
     gWaterHeaterModeInstance = new ModeBase::Instance(gWaterHeaterModeDelegate, endpointId, WaterHeaterMode::Id, 0);
@@ -108,6 +114,11 @@ void emberAfWaterHeaterModeClusterInitCallback(chip::EndpointId endpointId)
 
 void emberAfWaterHeaterModeClusterShutdownCallback(chip::EndpointId endpointId)
 {
+    if (endpointId != GetEnergyDeviceEndpointId())
+    {
+        return;
+    }
+
     if (gWaterHeaterModeInstance)
     {
         gWaterHeaterModeInstance->Shutdown();


### PR DESCRIPTION
#### Problem
> A part of https://github.com/project-chip/connectedhomeip/issues/38092

#### Changes
> Add cluster shutdown APIs.
> Add `EvseTargetsDelegate::Shutdown()` to remove registered fabric delegate.

#### Testing

> CI should be green.
