### PR TITLE
Fix FreeRTOS _Shutdown and _StopEventLoopTask APIs

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -269,8 +269,13 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::EventLoopTaskMain(void * ar
     GenericPlatformManagerImpl_FreeRTOS<ImplClass> * platformManager =
         static_cast<GenericPlatformManagerImpl_FreeRTOS<ImplClass> *>(arg);
     platformManager->Impl()->RunEventLoop();
+    ChipLogDetail(DeviceLayer, "CHIP event task stopped");
+
+    // Notify any waiting tasks that we're about to exit
+    TaskHandle_t currentTask = xTaskGetCurrentTaskHandle();
+    xTaskNotifyGive(currentTask);
+
     vTaskDelete(NULL);
-    platformManager->mEventLoopTask = NULL;
 }
 
 template <class ImplClass>
@@ -410,6 +415,19 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
 template <class ImplClass>
 void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 {
+    // If event loop task exists, wait for it to exit
+    if (mEventLoopTask != NULL)
+    {
+        // Wait for notification from the event loop task with a timeout
+        const TickType_t xMaxBlockTime = pdMS_TO_TICKS(2000); // 2 second timeout
+        if (ulTaskNotifyTake(pdTRUE, xMaxBlockTime) == 0)
+        {
+            ChipLogError(DeviceLayer, "Event loop task failed to exit within timeout");
+        }
+
+        mEventLoopTask = NULL;
+    }
+
     if (mChipEventQueue)
     {
         vQueueDelete(mChipEventQueue);
@@ -422,15 +440,29 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
         mBackgroundEventQueue = NULL;
     }
 #endif
-    vSemaphoreDelete(mChipStackLock);
-    mChipStackLock = NULL;
+    if (mChipStackLock)
+    {
+        vSemaphoreDelete(mChipStackLock);
+        mChipStackLock = NULL;
+    }
     GenericPlatformManagerImpl<ImplClass>::_Shutdown();
 }
 
 template <class ImplClass>
 CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_StopEventLoopTask(void)
 {
-    mShouldRunEventLoop.store(false);
+    if (mEventLoopTask != NULL)
+    {
+        // Signal the event loop to stop
+        mShouldRunEventLoop.store(false);
+
+        // Post a no-op event to wake up the event loop if it's blocked on queue receive
+        ChipDeviceEvent noop{ .Type = DeviceEventType::kNoOp };
+        if (mChipEventQueue != NULL)
+        {
+            xQueueSend(mChipEventQueue, &noop, 0);
+        }
+    }
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem

- https://github.com/project-chip/connectedhomeip/pull/37489 was deleting `mChipEventQueue` before the queue was empty this leads to a crash as jobs in the queue may try to acquire lock which is deleted in the `_Shutdown`.

#### Changes

-  `_Shutdown` waits for some time before setting mEventLoopTask to NULL.
-  `_StopEventLoopTask` unsets the `mShouldRunEventLoop` flag to break the RunEventLoop and post no-op event to wake up the event loop.

#### Testing

- Tested the APIs by stopping event loop and restarting it.
