### PR TITLE
[Server::Shutdown] Fix the matter server shutdown sequence, introduced few APIs to do *ClusterServerShutdown so that we can reinitialise the matter server without reboot on embedded platforms.

### DIFF
--- a/src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.cpp
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.cpp
@@ -1302,3 +1302,10 @@ void CameraAvSettingsUserLevelMgmtServer::HandleDPTZRelativeMove(HandlerContext 
  *
  */
 void MatterCameraAvSettingsUserLevelManagementPluginServerInitCallback() {}
+
+/** @brief Camera AV Settings User Level Management Cluster Server Shutdown
+ *
+ * Server Shutdown
+ *
+ */
+void MatterCameraAvSettingsUserLevelManagementPluginServerShutdownCallback() {}

--- a/src/app/clusters/scenes-server/scenes-server.cpp
+++ b/src/app/clusters/scenes-server/scenes-server.cpp
@@ -1153,12 +1153,15 @@ void emberAfScenesManagementClusterServerInitCallback(EndpointId endpoint)
 
 void MatterScenesManagementClusterServerShutdownCallback(EndpointId endpoint)
 {
-    uint16_t endpointTableSize = 0;
-    VerifyOrReturn(Status::Success == Attributes::SceneTableSize::Get(endpoint, &endpointTableSize));
+    // TODO: Remove the commented code.
+    // MatterScenesManagementClusterServerShutdownCallback was not being called before and in the sceneTable->RemoveEndpoint();
+    // it removes the SceneTableEntry from the persistent storage.
+    // uint16_t endpointTableSize = 0;
+    // VerifyOrReturn(Status::Success == Attributes::SceneTableSize::Get(endpoint, &endpointTableSize));
 
-    // Get Scene Table Instance
-    SceneTable * sceneTable = scenes::GetSceneTableImpl(endpoint, endpointTableSize);
-    sceneTable->RemoveEndpoint();
+    // // Get Scene Table Instance
+    // SceneTable * sceneTable = scenes::GetSceneTableImpl(endpoint, endpointTableSize);
+    // sceneTable->RemoveEndpoint();
 }
 
 void MatterScenesManagementPluginServerInitCallback()

--- a/src/app/clusters/scenes-server/scenes-server.h
+++ b/src/app/clusters/scenes-server/scenes-server.h
@@ -106,7 +106,12 @@ public:
 
 private:
     ScenesServer() : CommandHandlerInterface(Optional<EndpointId>(), Id), AttributeAccessInterface(Optional<EndpointId>(), Id) {}
-    ~ScenesServer() { Shutdown(); }
+    ~ScenesServer()
+    {
+        // TODO: Remove the commented code.
+        // ScenesServer::Shutdown is being called from MatterScenesManagementPluginServerShutdownCallback.
+        // Shutdown();
+    }
 
     bool mIsInitialized = false;
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -652,6 +652,12 @@ void Server::Shutdown()
     app::DnssdServer::Instance().SetICDManager(nullptr);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
+    /** Shutdown all active read handlers to ensure a clean shutdown of the Interaction Model.
+     * This is required before resetting the DataModelProvider, as ongoing reads may access it
+     * and lead to crashes or undefined behavior.
+     **/
+    app::InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+
     app::InteractionModelEngine::GetInstance()->SetDataModelProvider(nullptr);
     app::DnssdServer::Instance().SetCommissioningModeProvider(nullptr);
     Dnssd::ServiceAdvertiser::Instance().Shutdown();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -651,6 +651,8 @@ void Server::Shutdown()
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     app::DnssdServer::Instance().SetICDManager(nullptr);
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+    app::InteractionModelEngine::GetInstance()->SetDataModelProvider(nullptr);
     app::DnssdServer::Instance().SetCommissioningModeProvider(nullptr);
     Dnssd::ServiceAdvertiser::Instance().Shutdown();
 
@@ -681,11 +683,13 @@ void Server::Shutdown()
     mCommissioningWindowManager.Shutdown();
     mMessageCounterManager.Shutdown();
     mExchangeMgr.Shutdown();
+    mFabrics.RemoveFabricDelegate(&mFabricDelegate);
     mSessions.Shutdown();
     mTransports.Close();
     mAccessControl.Finish();
     Access::ResetAccessControlToDefault();
     Credentials::SetGroupDataProvider(nullptr);
+    app::EventManagement::GetInstance().DestroyEventManagement();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     // Remove Test Event Trigger Handler
     if (mTestEventTriggerDelegate != nullptr)
@@ -695,6 +699,7 @@ void Server::Shutdown()
     mICDManager.Shutdown();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER
 
+    mFabrics.Shutdown();
     // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryShutdown();
 }

--- a/src/app/tests/test-ember-api.cpp
+++ b/src/app/tests/test-ember-api.cpp
@@ -35,5 +35,6 @@ uint16_t emberAfGetClusterServerEndpointIndex(chip::EndpointId endpoint, chip::C
     return endpoint;
 }
 
-// Mock function for linking
+// Mock functions for linking
 void InitDataModelHandler() {}
+void ShutdownDataModelHandler() {}

--- a/src/app/util/DataModelHandler.cpp
+++ b/src/app/util/DataModelHandler.cpp
@@ -28,3 +28,8 @@ void InitDataModelHandler()
     emberAfEndpointConfigure();
     emberAfInit();
 }
+
+void ShutdownDataModelHandler()
+{
+    emberAfShutdown();
+}

--- a/src/app/util/DataModelHandler.h
+++ b/src/app/util/DataModelHandler.h
@@ -21,3 +21,8 @@
  * data model messages.
  */
 void InitDataModelHandler();
+
+/**
+ * Shutdown the data model.
+ */
+void ShutdownDataModelHandler();

--- a/src/app/util/attribute-storage-detail.h
+++ b/src/app/util/attribute-storage-detail.h
@@ -32,6 +32,8 @@ extern uint8_t attributeData[]; // main storage bucket for all attributes
 
 void emAfCallInits();
 
+void emAfCallShutdowns();
+
 chip::Protocols::InteractionModel::Status emAfReadOrWriteAttribute(const EmberAfAttributeSearchRecord * attRecord,
                                                                    const EmberAfAttributeMetadata ** metadata, uint8_t * buffer,
                                                                    uint16_t readLength, bool write);

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -478,7 +478,7 @@ static void shutdownEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     const EmberAfEndpointType * epType = definedEndpoint->endpointType;
     for (clusterIndex = 0; clusterIndex < epType->clusterCount; clusterIndex++)
     {
-        const EmberAfCluster * cluster  = &(epType->cluster[clusterIndex]);
+        const EmberAfCluster * cluster = &(epType->cluster[clusterIndex]);
         emberAfClusterShutdownCallback(definedEndpoint->endpoint, cluster->clusterId);
         EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, MATTER_CLUSTER_FLAG_SHUTDOWN_FUNCTION);
         if (f != nullptr)

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -479,6 +479,7 @@ static void shutdownEndpoint(EmberAfDefinedEndpoint * definedEndpoint)
     for (clusterIndex = 0; clusterIndex < epType->clusterCount; clusterIndex++)
     {
         const EmberAfCluster * cluster  = &(epType->cluster[clusterIndex]);
+        emberAfClusterShutdownCallback(definedEndpoint->endpoint, cluster->clusterId);
         EmberAfGenericClusterFunction f = emberAfFindClusterFunction(cluster, MATTER_CLUSTER_FLAG_SHUTDOWN_FUNCTION);
         if (f != nullptr)
         {
@@ -499,6 +500,19 @@ void emAfCallInits()
         if (emberAfEndpointIndexIsEnabled(index))
         {
             initializeEndpoint(&(emAfEndpoints[index]));
+        }
+    }
+}
+
+// Calls the shutdown functions.
+void emAfCallShutdowns()
+{
+    uint16_t index;
+    for (index = 0; index < emberAfEndpointCount(); index++)
+    {
+        if (emberAfEndpointIndexIsEnabled(index))
+        {
+            shutdownEndpoint(&(emAfEndpoints[index]));
         }
     }
 }

--- a/src/app/util/generic-callbacks.h
+++ b/src/app/util/generic-callbacks.h
@@ -35,6 +35,17 @@
  */
 void emberAfClusterInitCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
 
+/** @brief Cluster Shutdown
+ *
+ * This function is called when a specific cluster is shutdown. It gives the
+ * application an opportunity to take care of cluster shutdown procedures.
+ * It is called exactly once for each endpoint where cluster is present.
+ *
+ * @param endpoint   Ver.: always
+ * @param clusterId   Ver.: always
+ */
+void emberAfClusterShutdownCallback(chip::EndpointId endpoint, chip::ClusterId clusterId);
+
 /** @brief Attribute Read Access
  *
  * This function is called whenever the Application Framework needs to check

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -84,6 +84,15 @@ void emberAfInit()
     emAfCallInits();
 }
 
+// ****************************************
+// Shutdown Clusters
+// ****************************************
+void emberAfShutdown()
+{
+    emAfCallShutdowns();
+    MATTER_PLUGINS_SHUTDOWN
+}
+
 // Cluster init functions that don't have a cluster implementation to define
 // them in.
 void MatterBallastConfigurationPluginServerInitCallback() {}
@@ -142,6 +151,63 @@ void MatterWaterHeaterModePluginServerInitCallback() {}
 void MatterCommodityPricePluginServerInitCallback() {}
 void MatterElectricalGridConditionsPluginServerInitCallback() {}
 void MatterSoilMeasurementPluginServerInitCallback() {}
+
+// Cluster shutdown functions that don't have a cluster implementation to define
+// them in.
+void MatterBallastConfigurationPluginServerShutdownCallback() {}
+void MatterBooleanStatePluginServerShutdownCallback() {}
+void MatterRelativeHumidityMeasurementPluginServerShutdownCallback() {}
+void MatterIlluminanceMeasurementPluginServerShutdownCallback() {}
+void MatterBinaryInputBasicPluginServerShutdownCallback() {}
+void MatterPressureMeasurementPluginServerShutdownCallback() {}
+void MatterTemperatureMeasurementPluginServerShutdownCallback() {}
+void MatterFlowMeasurementPluginServerShutdownCallback() {}
+void MatterThermostatUserInterfaceConfigurationPluginServerShutdownCallback() {}
+void MatterBridgedDeviceBasicInformationPluginServerShutdownCallback() {}
+void MatterPowerConfigurationPluginServerShutdownCallback() {}
+void MatterPowerProfilePluginServerShutdownCallback() {}
+void MatterPulseWidthModulationPluginServerShutdownCallback() {}
+void MatterAlarmsPluginServerShutdownCallback() {}
+void MatterTimePluginServerShutdownCallback() {}
+void MatterAclPluginServerShutdownCallback() {}
+void MatterPollControlPluginServerShutdownCallback() {}
+void MatterUnitLocalizationPluginServerShutdownCallback() {}
+void MatterProxyValidPluginServerShutdownCallback() {}
+void MatterProxyDiscoveryPluginServerShutdownCallback() {}
+void MatterProxyConfigurationPluginServerShutdownCallback() {}
+void MatterFanControlPluginServerShutdownCallback() {}
+void MatterActivatedCarbonFilterMonitoringPluginServerShutdownCallback() {}
+void MatterHepaFilterMonitoringPluginServerShutdownCallback() {}
+void MatterAirQualityPluginServerShutdownCallback() {}
+void MatterCarbonMonoxideConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterCarbonDioxideConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterFormaldehydeConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterNitrogenDioxideConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterOzoneConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterPm10ConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterPm1ConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterPm25ConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterRadonConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterTotalVolatileOrganicCompoundsConcentrationMeasurementPluginServerShutdownCallback() {}
+void MatterRvcRunModePluginServerShutdownCallback() {}
+void MatterRvcCleanModePluginServerShutdownCallback() {}
+void MatterDishwasherModePluginServerShutdownCallback() {}
+void MatterLaundryWasherModePluginServerShutdownCallback() {}
+void MatterRefrigeratorAndTemperatureControlledCabinetModePluginServerShutdownCallback() {}
+void MatterOperationalStatePluginServerShutdownCallback() {}
+void MatterRvcOperationalStatePluginServerShutdownCallback() {}
+void MatterOvenModePluginServerShutdownCallback() {}
+void MatterOvenCavityOperationalStatePluginServerShutdownCallback() {}
+void MatterDishwasherAlarmPluginServerShutdownCallback() {}
+void MatterMicrowaveOvenModePluginServerShutdownCallback() {}
+void MatterDeviceEnergyManagementModePluginServerShutdownCallback() {}
+void MatterEnergyEvseModePluginServerShutdownCallback() {}
+void MatterPowerTopologyPluginServerShutdownCallback() {}
+void MatterElectricalEnergyMeasurementPluginServerShutdownCallback() {}
+void MatterElectricalPowerMeasurementPluginServerShutdownCallback() {}
+void MatterServiceAreaPluginServerShutdownCallback() {}
+void MatterWaterHeaterManagementPluginServerShutdownCallback() {}
+void MatterWaterHeaterModePluginServerShutdownCallback() {}
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -211,6 +211,7 @@ void MatterMeterIdentificationPluginServerShutdownCallback() {}
 void MatterClosureDimensionPluginServerShutdownCallback() {}
 void MatterElectricalGridConditionsPluginServerShutdownCallback() {}
 void MatterCommodityPricePluginServerShutdownCallback() {}
+void MatterSoilMeasurementPluginServerShutdownCallback() {}
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -207,6 +207,10 @@ void MatterElectricalPowerMeasurementPluginServerShutdownCallback() {}
 void MatterServiceAreaPluginServerShutdownCallback() {}
 void MatterWaterHeaterManagementPluginServerShutdownCallback() {}
 void MatterWaterHeaterModePluginServerShutdownCallback() {}
+void MatterMeterIdentificationPluginServerShutdownCallback() {}
+void MatterClosureDimensionPluginServerShutdownCallback() {}
+void MatterElectricalGridConditionsPluginServerShutdownCallback() {}
+void MatterCommodityPricePluginServerShutdownCallback() {}
 
 bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId)
 {

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -171,7 +171,6 @@ void MatterAlarmsPluginServerShutdownCallback() {}
 void MatterTimePluginServerShutdownCallback() {}
 void MatterAclPluginServerShutdownCallback() {}
 void MatterPollControlPluginServerShutdownCallback() {}
-void MatterUnitLocalizationPluginServerShutdownCallback() {}
 void MatterProxyValidPluginServerShutdownCallback() {}
 void MatterProxyDiscoveryPluginServerShutdownCallback() {}
 void MatterProxyConfigurationPluginServerShutdownCallback() {}

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -25,6 +25,7 @@
 
 void emberAfInit();
 
+void emberAfShutdown();
 /**
  * Retrieves the difference between the two passed values.
  * This function assumes that the two values have the same endianness.

--- a/src/controller/EmptyDataModelHandler.cpp
+++ b/src/controller/EmptyDataModelHandler.cpp
@@ -25,3 +25,4 @@
 #include <app/util/DataModelHandler.h>
 
 void InitDataModelHandler() {}
+void ShutdownDataModelHandler() {}

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -149,8 +149,10 @@ public:
 
 protected:
     // Since the current unit tests do not involve any cluster implementations, we override InitDataModelForTesting
-    // to do nothing, thereby preventing calls to the Ember-specific InitDataModelHandler.
+    // ShutdownDataModelForTesting to do nothing, thereby preventing calls to the Ember-specific InitDataModelHandler
+    // and ShutdownDataModelHandler.
     void InitDataModelForTesting() override {}
+    void ShutdownDataModelForTesting() override {}
 };
 
 class TestServerCommandDispatch : public chip::Test::AppContext

--- a/src/controller/tests/data_model/DataModelFixtures.cpp
+++ b/src/controller/tests/data_model/DataModelFixtures.cpp
@@ -40,8 +40,9 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::UnitTesting;
 using namespace chip::Protocols;
 
-// Mock function for linking
+// Mock functions for linking
 void InitDataModelHandler() {}
+void ShutdownDataModelHandler() {}
 
 namespace chip {
 namespace app {

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1169,6 +1169,7 @@ void FabricTable::Shutdown()
         delegate->next               = nullptr;
         delegate                     = temp;
     }
+    mDelegateListRoot = nullptr;
 
     RevertPendingFabricData();
     for (FabricInfo & fabricInfo : mStates)

--- a/src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/ServerEndpoint/MTRIMDispatch.mm
@@ -73,6 +73,14 @@ void emberAfClusterInitCallback(EndpointId endpoint, ClusterId clusterId)
     // clusters dont use it.
 }
 
+void emberAfClusterShutdownCallback(EndpointId endpoint, ClusterId clusterId)
+{
+    assertChipStackLockedByCurrentThread();
+
+    // No-op: Descriptor and OTA do not need this, and our client-defined
+    // clusters dont use it.
+}
+
 Protocols::InteractionModel::Status emAfWriteAttributeExternal(const ConcreteAttributePath & path,
     const EmberAfWriteDataInput & input)
 {

--- a/src/darwin/Framework/CHIP/app/PluginApplicationCallbacks.h
+++ b/src/darwin/Framework/CHIP/app/PluginApplicationCallbacks.h
@@ -23,5 +23,7 @@
  */
 
 void MatterDescriptorPluginServerInitCallback();
+void MatterDescriptorPluginServerShutdownCallback();
 
 #define MATTER_PLUGINS_INIT MatterDescriptorPluginServerInitCallback();
+#define MATTER_PLUGINS_SHUTDOWN MatterDescriptorPluginServerShutdownCallback();

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.cpp
@@ -129,6 +129,7 @@ DefaultAttributePersistenceProvider gDefaultAttributePersistence;
 CHIP_ERROR CodegenDataModelProvider::Shutdown()
 {
     Reset();
+    ShutdownDataModelForTesting();
     mRegistry.ClearContext();
     return CHIP_NO_ERROR;
 }
@@ -594,6 +595,12 @@ void CodegenDataModelProvider::InitDataModelForTesting()
 {
     // Call the Ember-specific InitDataModelHandler
     InitDataModelHandler();
+}
+
+void CodegenDataModelProvider::ShutdownDataModelForTesting()
+{
+    // Call the Ember-specific ShutdownDataModelHandler
+    ShutdownDataModelHandler();
 }
 
 CHIP_ERROR CodegenDataModelProvider::DeviceTypes(EndpointId endpointId, ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & builder)

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -87,8 +87,8 @@ public:
 
 protected:
     // Temporary hack for a test: Initializes the data model for testing purposes only.
-    // This method serves as a placeholder and should NOT be used outside of specific tests.
-    // It is expected to be removed or replaced with a proper implementation in the future.TODO:(#36837).
+    // These methods serve as placeholders and should NOT be used outside of specific tests.
+    // They are expected to be removed or replaced with a proper implementation in the future.TODO:(#36837).
     virtual void InitDataModelForTesting();
     virtual void ShutdownDataModelForTesting();
 

--- a/src/data-model-providers/codegen/CodegenDataModelProvider.h
+++ b/src/data-model-providers/codegen/CodegenDataModelProvider.h
@@ -90,6 +90,7 @@ protected:
     // This method serves as a placeholder and should NOT be used outside of specific tests.
     // It is expected to be removed or replaced with a proper implementation in the future.TODO:(#36837).
     virtual void InitDataModelForTesting();
+    virtual void ShutdownDataModelForTesting();
 
 private:
     // Iteration is often done in a tight loop going through all values.

--- a/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
+++ b/src/data-model-providers/codegen/tests/TestCodegenModelViaMocks.cpp
@@ -80,8 +80,9 @@ using namespace chip::app::Clusters::Globals::Attributes;
 
 using chip::Protocols::InteractionModel::Status;
 
-// Mock function for linking
+// Mock functions for linking
 void InitDataModelHandler() {}
+void ShutdownDataModelHandler() {}
 
 namespace {
 


### PR DESCRIPTION
#### Problem

- Fixes a part of https://github.com/project-chip/connectedhomeip/issues/38092.
- There were multiple crash when we try to Shutdown the Matter server and Re-initialise it without actually having a power cycle reason for that was we have `VerifyOrDie` checks at the time of emberAfClusterInitCallbacks for almost every cluster.
- Missing `SetDataModelProvider(nullptr)` and cluster shutdown callbacks were not being called at all.
- We have check for active IM read handlers in the `SetDataModelProvider` API and the API to close active read handlers was private for unit testing but it should happen before we `SetDataModelProvider(nullptr)` in the `Server::Shutdown()`.
- In Scenes cluster shutdown callback we were removing the scene endpoint that leads to loss of persistent scene storage but scenes should be persistent.

#### Changes

- Adds `ShutdownDataModelForTesting` which consumes `Matter*PluginServerShutdownCallback` to `Unregister the AAI and CHI from the cluster itself and also remove the registered fabric delegate` and `emberAf*ClusterShutdownCallback` to delete the cluster instance/delegate pointers so that we can reinit it on next server initialisation sequence and device will not crash on `VerifyOrDie`.
- Added `SetDataModelProvider(nullptr)` in the `Server::Shutdown()` so that actual cluster shutdown APIs being called.
- Expose `ShutdownActiveReads()` publicly and integrate into standard shutdown sequence.
- Removed the `RemoveEndpoint()` from scenes cluster shutdown callback so that we can have persistent scenes across devices power cycle.

#### Testing

- Locally tested `Server::Shutdown` API by having multiple Shutdown and Init cycles in the application using ESP32 to verify device do not crash at the time of initialisations due to any reason.
- There are some integrated tests (TestBasicInformation, TestGeneralCommissioning, TestIcdManagementCluster.yaml, Test_TC_ACL_2_10, Test_TC_BINFO_2_2, Test_TC_DGETH_2_1, Test_TC_OO_2_4, Test_TC_S_2_2, etc) which does reboot on device and test commands and attributes after the reboot, green CI verifies that those tests were successful.