### PR TITLE
TC-FAN-4.1: Fan cluster interaction with on/off cluster + app implementation

### DIFF
--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.matter
@@ -326,6 +326,78 @@ cluster Identify = 3 {
   command access(invoke: manage) TriggerEffect(TriggerEffectRequest): DefaultSuccess = 64;
 }
 
+/** Attributes and commands for switching devices between 'On' and 'Off' states. */
+cluster OnOff = 6 {
+  revision 6;
+
+  enum DelayedAllOffEffectVariantEnum : enum8 {
+    kDelayedOffFastFade = 0;
+    kNoFade = 1;
+    kDelayedOffSlowFade = 2;
+  }
+
+  enum DyingLightEffectVariantEnum : enum8 {
+    kDyingLightFadeOff = 0;
+  }
+
+  enum EffectIdentifierEnum : enum8 {
+    kDelayedAllOff = 0;
+    kDyingLight = 1;
+  }
+
+  enum StartUpOnOffEnum : enum8 {
+    kOff = 0;
+    kOn = 1;
+    kToggle = 2;
+  }
+
+  bitmap Feature : bitmap32 {
+    kLighting = 0x1;
+    kDeadFrontBehavior = 0x2;
+    kOffOnly = 0x4;
+  }
+
+  bitmap OnOffControlBitmap : bitmap8 {
+    kAcceptOnlyWhenOn = 0x1;
+  }
+
+  readonly attribute boolean onOff = 0;
+  readonly attribute optional boolean globalSceneControl = 16384;
+  attribute optional int16u onTime = 16385;
+  attribute optional int16u offWaitTime = 16386;
+  attribute access(write: manage) optional nullable StartUpOnOffEnum startUpOnOff = 16387;
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute event_id eventList[] = 65530;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+
+  request struct OffWithEffectRequest {
+    EffectIdentifierEnum effectIdentifier = 0;
+    enum8 effectVariant = 1;
+  }
+
+  request struct OnWithTimedOffRequest {
+    OnOffControlBitmap onOffControl = 0;
+    int16u onTime = 1;
+    int16u offWaitTime = 2;
+  }
+
+  /** On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0. */
+  command Off(): DefaultSuccess = 0;
+  /** On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. */
+  command On(): DefaultSuccess = 1;
+  /** On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’ state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0. */
+  command Toggle(): DefaultSuccess = 2;
+  /** The OffWithEffect command allows devices to be turned off using enhanced ways of fading. */
+  command OffWithEffect(OffWithEffectRequest): DefaultSuccess = 64;
+  /** The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off. */
+  command OnWithRecallGlobalScene(): DefaultSuccess = 65;
+  /** The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off duration so that SHOULD the device be subsequently switched off, further OnWithTimedOff commands, received during this time, are prevented from turning the devices back on. */
+  command OnWithTimedOff(OnWithTimedOffRequest): DefaultSuccess = 66;
+}
+
 /** The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints and clusters. */
 cluster Descriptor = 29 {
   revision 2;
@@ -2837,6 +2909,19 @@ endpoint 1 {
 
     handle command Identify;
     handle command TriggerEffect;
+  }
+
+  server cluster OnOff {
+    ram      attribute onOff default = 0;
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute attributeList;
+    ram      attribute featureMap default = 0;
+    ram      attribute clusterRevision default = 6;
+
+    handle command Off;
+    handle command On;
+    handle command Toggle;
   }
 
   server cluster Descriptor {

--- a/examples/air-purifier-app/air-purifier-common/air-purifier-app.zap
+++ b/examples/air-purifier-app/air-purifier-common/air-purifier-app.zap
@@ -2290,6 +2290,138 @@
           ]
         },
         {
+          "name": "On/Off",
+          "code": 6,
+          "mfgCode": null,
+          "define": "ON_OFF_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "Off",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "On",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "Toggle",
+              "code": 2,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "OnOff",
+              "code": 0,
+              "mfgCode": null,
+              "side": "server",
+              "type": "boolean",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "6",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
           "name": "Descriptor",
           "code": 29,
           "mfgCode": null,

--- a/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
@@ -101,9 +101,6 @@ private:
 
     EndpointId mEndpointId;
 
-    uint8_t percentCurrent;
-    uint8_t speedCurrent;
-
     // Set up for Activated Carbon Filter Monitoring
     ActivatedCarbonFilterMonitoringDelegate activatedCarbonFilterDelegate;
     ResourceMonitoring::Instance activatedCarbonFilterInstance;
@@ -119,7 +116,7 @@ private:
     ThermostatManager mThermostatManager;
 
     // This gets initialized properly in the init function from the On/Off cluster
-    bool mOnOffClusterOn = True;
+    bool mOnOffClusterOn = true;
 
     // Fan Mode Limits
     static constexpr int FAN_MODE_LOW_LOWER_BOUND    = 1;

--- a/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
@@ -135,7 +135,8 @@ private:
      */
     AirPurifierManager(EndpointId aEndpointId, EndpointId aAirQualitySensorEndpointId, EndpointId aTemperatureSensorEndpointId,
                        EndpointId aHumiditySensorEndpointId, EndpointId aThermostatEndpointId) :
-        FanControl::Delegate(aEndpointId), mEndpointId(aEndpointId),
+        FanControl::Delegate(aEndpointId),
+        mEndpointId(aEndpointId),
         activatedCarbonFilterInstance(&activatedCarbonFilterDelegate, mEndpointId, ActivatedCarbonFilterMonitoring::Id,
                                       static_cast<uint32_t>(gActivatedCarbonFeatureMap.to_ulong()),
                                       ResourceMonitoring::DegradationDirectionEnum::kDown, true),

--- a/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
@@ -135,8 +135,7 @@ private:
      */
     AirPurifierManager(EndpointId aEndpointId, EndpointId aAirQualitySensorEndpointId, EndpointId aTemperatureSensorEndpointId,
                        EndpointId aHumiditySensorEndpointId, EndpointId aThermostatEndpointId) :
-        FanControl::Delegate(aEndpointId),
-        mEndpointId(aEndpointId),
+        FanControl::Delegate(aEndpointId), mEndpointId(aEndpointId),
         activatedCarbonFilterInstance(&activatedCarbonFilterDelegate, mEndpointId, ActivatedCarbonFilterMonitoring::Id,
                                       static_cast<uint32_t>(gActivatedCarbonFeatureMap.to_ulong()),
                                       ResourceMonitoring::DegradationDirectionEnum::kDown, true),
@@ -164,6 +163,7 @@ private:
     void SetSpeedSetting(DataModel::Nullable<uint8_t> aNewSpeedSetting);
     DataModel::Nullable<uint8_t> GetSpeedSetting();
     DataModel::Nullable<Percent> GetPercentSetting();
+    uint8_t GetSpeedMax();
 
     void HandleThermostatAttributeChange(AttributeId attributeId, uint8_t type, uint16_t size, uint8_t * value);
     void ThermostatHeatingSetpointWriteCallback(int16_t aNewHeatingSetpoint);

--- a/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
+++ b/examples/air-purifier-app/air-purifier-common/include/air-purifier-manager.h
@@ -118,6 +118,9 @@ private:
     RelativeHumiditySensorManager mHumiditySensorManager;
     ThermostatManager mThermostatManager;
 
+    // This gets initialized properly in the init function from the On/Off cluster
+    bool mOnOffClusterOn = True;
+
     // Fan Mode Limits
     static constexpr int FAN_MODE_LOW_LOWER_BOUND    = 1;
     static constexpr int FAN_MODE_LOW_UPPER_BOUND    = 3;
@@ -135,8 +138,7 @@ private:
      */
     AirPurifierManager(EndpointId aEndpointId, EndpointId aAirQualitySensorEndpointId, EndpointId aTemperatureSensorEndpointId,
                        EndpointId aHumiditySensorEndpointId, EndpointId aThermostatEndpointId) :
-        FanControl::Delegate(aEndpointId),
-        mEndpointId(aEndpointId),
+        FanControl::Delegate(aEndpointId), mEndpointId(aEndpointId),
         activatedCarbonFilterInstance(&activatedCarbonFilterDelegate, mEndpointId, ActivatedCarbonFilterMonitoring::Id,
                                       static_cast<uint32_t>(gActivatedCarbonFeatureMap.to_ulong()),
                                       ResourceMonitoring::DegradationDirectionEnum::kDown, true),
@@ -168,6 +170,8 @@ private:
     void HandleThermostatAttributeChange(AttributeId attributeId, uint8_t type, uint16_t size, uint8_t * value);
     void ThermostatHeatingSetpointWriteCallback(int16_t aNewHeatingSetpoint);
     void ThermostatSystemModeWriteCallback(uint8_t aNewSystemMode);
+
+    void HandleOnOff(AttributeId attributeId, uint8_t type, uint16_t size, uint8_t * value);
 };
 
 } // namespace Clusters

--- a/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
@@ -209,8 +209,9 @@ void AirPurifierManager::HandleOnOff(AttributeId attributeId, uint8_t type, uint
         // If either of these come back as NULL, that should mean the fan is operating in auto mode.
         // I have no idea what that means for this case, so I'll just set them to high because this
         // is just an example.
-        // In theory these should always be NULL together or not at all, so hopefully the last
-        // error is more theoretical than practical.
+        // In theory these should always be NULL together or not at all, so hopefully
+        // the checks for only percent.IsNull() or only speed.IsNull() are more theoretical
+        // than practical.
         DataModel::Nullable<Percent> percent = GetPercentSetting();
         DataModel::Nullable<uint8_t> speed   = GetSpeedSetting();
         uint8_t speedMax                     = 100;
@@ -251,8 +252,8 @@ void AirPurifierManager::HandleOnOff(AttributeId attributeId, uint8_t type, uint
         new_percent = 0;
         new_speed   = 0;
     }
-    FanControl::Attributes::SpeedCurrent::Set(mEndpointId, new_speed, MarkAttributeDirty::kYes);
-    FanControl::Attributes::PercentCurrent::Set(mEndpointId, new_percent, MarkAttributeDirty::kYes);
+    FanControl::Attributes::SpeedCurrent::Set(mEndpointId, new_speed);
+    FanControl::Attributes::PercentCurrent::Set(mEndpointId, new_percent);
     mOnOffClusterOn = on;
 }
 
@@ -287,19 +288,19 @@ void AirPurifierManager::SpeedSettingWriteCallback(uint8_t aNewSpeedSetting)
     // Determine if the speed change should also change the fan mode
     if (aNewSpeedSetting == 0)
     {
-        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kOff, MarkAttributeDirty::kIfChanged);
+        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kOff);
     }
     else if (aNewSpeedSetting <= FAN_MODE_LOW_UPPER_BOUND)
     {
-        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kLow, MarkAttributeDirty::kIfChanged);
+        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kLow);
     }
     else if (aNewSpeedSetting <= FAN_MODE_MEDIUM_UPPER_BOUND)
     {
-        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kMedium, MarkAttributeDirty::kIfChanged);
+        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kMedium);
     }
     else if (aNewSpeedSetting <= FAN_MODE_HIGH_UPPER_BOUND)
     {
-        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kHigh, MarkAttributeDirty::kIfChanged);
+        FanControl::Attributes::FanMode::Set(mEndpointId, FanControl::FanModeEnum::kHigh);
     }
 }
 
@@ -363,7 +364,7 @@ void AirPurifierManager::SetSpeedSetting(DataModel::Nullable<uint8_t> aNewSpeedS
         return;
     }
 
-    Status status = FanControl::Attributes::SpeedSetting::Set(mEndpointId, aNewSpeedSetting, MarkAttributeDirty::kIfChanged);
+    Status status = FanControl::Attributes::SpeedSetting::Set(mEndpointId, aNewSpeedSetting);
     if (status != Status::Success)
     {
         ChipLogError(NotSpecified, "AirPurifierManager::SetSpeedSetting: failed to set SpeedSetting attribute: %d",

--- a/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
@@ -435,7 +435,7 @@ void AirPurifierManager::HeatingCallback()
     if (speedSetting.IsNull() || speedSetting.Value() == 0)
     {
         DataModel::Nullable<uint8_t> newSpeedSetting(5);
-        // TODO: what causes this to happen? Seems like ther other ones also need updating.
+        // TODO: what causes this to happen? Seems like the other ones also need updating.
         SetSpeedSetting(newSpeedSetting);
     }
 }

--- a/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
+++ b/examples/air-purifier-app/air-purifier-common/src/air-purifier-manager.cpp
@@ -209,7 +209,7 @@ void AirPurifierManager::HandleOnOff(AttributeId attributeId, uint8_t type, uint
         // If either of these come back as NULL, that should mean the fan is operating in auto mode.
         // I have no idea what that means for this case, so I'll just set them to high because this
         // is just an example.
-        // In theory these should always be NULL together or not all all, so hopefully the last
+        // In theory these should always be NULL together or not at all, so hopefully the last
         // error is more theoretical than practical.
         DataModel::Nullable<Percent> percent = GetPercentSetting();
         DataModel::Nullable<uint8_t> speed   = GetSpeedSetting();

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -35,6 +35,10 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+import logging
+import time
+from typing import Optional
+
 import chip.clusters as Clusters
 from chip.interaction_model import Status
 from matter_testing_infrastructure.chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, default_matter_test_main,
@@ -46,29 +50,82 @@ class TC_FAN_2_4(MatterBaseTest):
     def desc_TC_FAN_4_1(self) -> str:
         return "[TC-FAN-4.1] Fan interaction with On/Off cluster"
 
-    def steps_TC_FAN_4_1(self):
-        return [TestStep(1, "TH Commissions DUT.", is_commissioning=True),
-                TestStep(2, "TH subscribes to the Fan control cluster"),
+    def get_fan_modes(self, fan_mode_sequence: Clusters.FanControl.Enums.FanModeSequenceEnum):
+        # TODO: put this in a common location once all the fan stuff is landed
+        sequence = Clusters.FanControl.Enums.FanModeSequenceEnum
+        mode = Clusters.FanControl.Enums.FanModeEnum
 
-                TestStep(3, "TH sends the On command to the On/Off cluster", "DUT returns SUCCESS"),
-                TestStep(4, "TH sets the FanMode attribute on the Fan Control cluster to High", "DUT returns SUCCESS"),
+        if fan_mode_sequence == sequence.kOffLowMedHigh:
+            return [mode.kOff, mode.kLow, mode.kMedium, mode.kHigh]
+        if fan_mode_sequence == sequence.kOffLowHigh:
+            return [mode.kOff, mode.kLow, mode.kHigh]
+        if fan_mode_sequence == sequence.kOffLowMedHighAuto:
+            return [mode.kOff, mode.kLow, mode.kMedium, mode.kHigh, mode.kAuto]
+        if fan_mode_sequence == sequence.kOffLowHighAuto:
+            return [mode.kOff, mode.kLow, mode.kHigh, mode.kAuto]
+        if fan_mode_sequence == sequence.kOffHighAuto:
+            return [mode.kOff, mode.kHigh, mode.kAuto]
+        if fan_mode_sequence == sequence.kOffHigh:
+            return [mode.kOff, mode.kHigh]
 
-                TestStep(5, "TH reads the PercentSetting attribute from the Fan Control cluster and saves as `percent_setting_original`", "SUCCESS"),
-                TestStep(6, "If the SPD feature is supported, TH reads the SpeedSetting attribute from the Fan Control cluster and saves as `speed_setting_original`", "SUCCESS"),
-                TestStep(7, "TH reads the PercentCurrent attribute from the Fan Control cluster", "SUCCESS"),
-                TestStep(8, "If PercentCurrent is not equal to PercentSetting, TH awaits an attribute report for the PercentCurrent matching PercentSetting", "Report is received"),
+        asserts.fail(f"Unknown FanModeSequence {fan_mode_sequence}")
 
-                TestStep(9, "TH sends the Off command to the On/Off cluster", "DUT returns SUCCESS"),
-                TestStep(10, "TH awaits the following attribute reports (order does not matter): PercentCurrent is 0, SpeedCurrent is 0 (if SPD feature is supported)", "Report(s) are received"),
-                TestStep(11, "TH reads the FanMode attribute", "FanMode is set to HIGH"),
-                TestStep(12, "TH reads the PercentSetting attribute", "PercentSetting matches `percent_setting_original"),
-                TestStep(13, "If the SPD feature is supported, TH reads the SpeedSetting",
-                         "SpeedSetting matches `speed_setting_original`"),
-
-                TestStep(14, "TH sends On command to the On/Off cluster", "DUT returns SUCCESS"),
-                TestStep(15, "TH awaits the following attribute reports (order does not matter): PercentCurrent is `percent_setting_original`, SpeedCurrent is `speed_setting_original` (if SPD feature is supported)", "Reports are received"),
-
+    def _sub_step(self, start_step: int, attribute_to_set: str, value: str, verify_mode: str, verify_percent: str, verify_speed: str, spd_check: bool = False):
+        spd = ""
+        if spd_check:
+            spd = "If SPD is not supported, skip this step and the next 6 steps. "
+        return [TestStep(start_step, f"{spd}Set the {attribute_to_set} to {value}. If the write returns INVALID_IN_STATE, skip the next three steps", "INVALID_IN_STATE or SUCCESS"),
+                TestStep(start_step + 1, "Read the FanMode", f"Verify FanMode is set to {verify_mode}"),
+                TestStep(start_step + 2, "Read PercentSetting", f"Verify PercentSetting is {verify_percent}"),
+                TestStep(start_step + 3, "Wait for PIXIT.FanStartTime seconds"),
+                TestStep(start_step + 4, "Read PercentCurrent", "PercentCurrent is 0"),
+                TestStep(start_step + 5, "If SPD is supported, Read SpeedSetting", f"Verify SpeedSetting is {verify_speed}"),
+                TestStep(start_step + 6, "If SPD is supported, Read SpeedCurrent", "SpeedCurrent is 0")
                 ]
+
+    def steps_TC_FAN_4_1(self):
+        steps = [TestStep(1, "TH Commissions DUT.", is_commissioning=True),
+                 TestStep(2, "TH subscribes to the Fan control cluster", "SUCCESS"),
+                 TestStep(3, "TH reads the supported fan modes", "SUCCESS"),
+                 TestStep(4, "If SPD is supported, TH reads SpeedMax", "SUCCESS"),
+
+                 TestStep(5, "TH sends the On command to the On/Off cluster", "DUT returns SUCCESS"),
+                 TestStep(6, "TH sets the FanMode attribute on the Fan Control cluster to High", "DUT returns SUCCESS"),
+
+                 TestStep(7, "TH reads the PercentSetting attribute from the Fan Control cluster and saves as `percent_setting_original`", "SUCCESS"),
+                 TestStep(8, "If the SPD feature is supported, TH reads the SpeedSetting attribute from the Fan Control cluster and saves as `speed_setting_original`", "SUCCESS"),
+                 TestStep(9, "TH reads the PercentCurrent attribute from the Fan Control cluster", "SUCCESS"),
+                 TestStep(10, "If PercentCurrent is not equal to PercentSetting, TH awaits an attribute report for the PercentCurrent matching PercentSetting", "Report is received"),
+
+                 TestStep(11, "TH sends the Off command to the On/Off cluster", "DUT returns SUCCESS"),
+                 TestStep(12, "TH awaits the following attribute reports (order does not matter): PercentCurrent is 0, SpeedCurrent is 0 (if SPD feature is supported)", "Report(s) are received"),
+                 TestStep(13, "TH reads the FanMode attribute", "FanMode is set to HIGH"),
+                 TestStep(14, "TH reads the PercentSetting attribute", "PercentSetting matches `percent_setting_original"),
+                 TestStep(15, "If the SPD feature is supported, TH reads the SpeedSetting",
+                          "SpeedSetting matches `speed_setting_original`"),
+                 ]
+        num = 16
+        num_substeps = 7
+        steps.extend(self._sub_step(num, "PercentSetting", "1", "lowest supported mode above Off", "1", "1"))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "PercentSetting", "0", "Off", "0", "0"))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "FanMode", "High", "High", "not 0", "not 0"))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "FanMode", "Off", "Off", "0", "0"))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "SpeedSetting", "SpeedMax", "High", "not 0", "SpeedMax", spd_check=True))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "SpeedSetting", "0", "Off", "0", "0", spd_check=True))
+        num += num_substeps
+        steps.extend(self._sub_step(num, "PercentSetting", "100", "High", "100", "SpeedMax"))
+        num += num_substeps
+
+        steps.append(TestStep(num, "TH sends On command to the On/Off cluster", "DUT returns SUCCESS"))
+        steps.append(TestStep(num + 1, "TH awaits the following attribute reports (order does not matter): PercentCurrent is 100, SpeedCurrent is SpeedMax (if SPD feature is supported)", "Reports are received"))
+        steps.append(TestStep(num + 2, "TH sets PercentSetting to 50", "Response is SUCCESS or INVALID_IN_STATE"))
+        steps.append(TestStep(num + 3, "If the response was SUCCESS, TH awaits the following attribute reports (order does not matter): PercentCurrent is 50, PercentSetting is 50", "Report(s) are received"))
+        return steps
 
     def pics_TC_FAN_4_1(self) -> list[str]:
         return ["FAN.S", "OO.S"]
@@ -82,83 +139,174 @@ class TC_FAN_2_4(MatterBaseTest):
         # Wait for the entire duration of the test because this valve may be slow. The test will time out before this does. That's fine.
         timeout = self.matter_test_config.timeout if self.matter_test_config.timeout is not None else self.default_timeout
 
+        # TODO: make this a pixit
+        wait_s = 1
+
         self.step(2)
         sub = ClusterAttributeChangeAccumulator(Clusters.FanControl)
         await sub.start(self.default_controller, node_id=self.dut_node_id, endpoint=self.get_endpoint())
 
         self.step(3)
-        await self.send_single_cmd(cmd=Clusters.OnOff.Commands.On())
+        supported_fan_modes = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.FanModeSequence)
 
         self.step(4)
+        if has_spd:
+            speed_max = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedMax)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(5)
+        await self.send_single_cmd(cmd=Clusters.OnOff.Commands.On())
+
+        self.step(6)
         attr = Clusters.FanControl.Attributes.FanMode(Clusters.FanControl.Enums.FanModeEnum.kHigh)
         resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
         asserts.assert_equal(resp[0].Status, Status.Success, "Unexpected error writing FanMode attribute")
 
-        self.step(5)
+        self.step(7)
         percent_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
 
-        self.step(6)
+        self.step(8)
         if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
             speed_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
 
-        self.step(7)
+        self.step(9)
         percent_current = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentCurrent)
 
-        self.step(8)
+        self.step(10)
         if percent_current != percent_setting_original:
             sub.await_all_final_values_reported(
                 expected_final_values=[fan.Attributes.PercentCurrent(percent_setting_original)], timeout_sec=timeout)
         else:
             self.mark_current_step_skipped()
 
-        self.step(9)
+        self.step(11)
         await self.send_single_cmd(cmd=Clusters.OnOff.Commands.Off())
 
-        self.step(10)
+        self.step(12)
         awaiting = [AttributeValue(endpoint_id=self.get_endpoint(), attribute=fan.Attributes.PercentCurrent, value=0)]
         if has_spd:
             awaiting.append(AttributeValue(endpoint_id=self.get_endpoint(), attribute=fan.Attributes.SpeedCurrent, value=0))
         sub.await_all_final_values_reported(expected_final_values=awaiting, timeout_sec=timeout)
         sub.reset()
 
-        self.step(11)
+        self.step(13)
         mode = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.FanMode)
         asserts.assert_equal(mode, fan.Enums.FanModeEnum.kHigh, "FanMode was changed when on/off cluster was changed")
 
-        self.step(12)
+        self.step(14)
         percent_setting_new = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
         asserts.assert_equal(percent_setting_new, percent_setting_original,
                              "PercentSetting was changed when on/off cluster was changed")
 
-        self.step(13)
+        self.step(15)
         if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
             speed_setting_new = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
             asserts.assert_equal(speed_setting_new, speed_setting_original,
                                  "SpeedSetting was changed when on/off cluster was changed")
+        step_num = 16
+        num_substeps = 7
 
-        # Changing the percent while the fan is off should change the percent setting, but not the percent current or speed current
-        attr = Clusters.FanControl.Attributes.PercentSetting(1)
-        resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
+        async def verify_onoff_off(attr: Clusters.ClusterObjects.ClusterAttributeDescriptor, expected_mode: Clusters.FanControl.Enums.FanModeEnum, expected_percent_setting: Optional[int], expected_speed_setting: Optional[int]):
+            """ Writes specified attribute and checks expected results for On/Off cluster in Off mode
+                None on PercentSetting or SpeedSetting just verifies the values are not 0.
+            """
+            nonlocal step_num
+            self.step(step_num)
+            resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
+            asserts.assert_in(resp[0].Status, [Status.Success, Status.InvalidInState], "Unexpected status returned")
+            if resp[0].Status != Status.Success:
+                self.skip_step(step_num + 1)
+                self.skip_step(step_num + 2)
+                self.skip_step(step_num + 3)
+                self.skip_step(step_num + 4)
+                self.skip_step(step_num + 5)
+                self.skip_step(step_num + 6)
+                step_num += num_substeps
+                return
 
-        self.step(14)
+            self.step(step_num + 1)
+            fan_mode = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.FanMode)
+            asserts.assert_equal(fan_mode, expected_mode, "Incorrect FanMode")
+
+            self.step(step_num + 2)
+            percent_setting = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
+            if expected_percent_setting is not None:
+                asserts.assert_equal(percent_setting, expected_percent_setting, "Incorrect percent setting")
+            else:
+                asserts.assert_not_equal(percent_setting, 0, "Incorrect percent setting")
+
+            self.step(step_num + 3)
+            logging.info(f"Waiting for {wait_s} seconds to give the fan a chance to respond")
+            time.sleep(wait_s)
+
+            self.step(step_num + 4)
+            percent_current = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentCurrent)
+            asserts.assert_equal(percent_current, 0, "Fan turned on while On/Off cluster was set to off")
+
+            if has_spd:
+                self.step(step_num + 5)
+                speed_setting = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
+                if expected_speed_setting is not None:
+                    asserts.assert_equal(speed_setting, expected_speed_setting,
+                                         "Speed was not adjusted when percent was adjusted while fan was off")
+                else:
+                    asserts.assert_not_equal(speed_setting, 0, "Incorrect speed setting")
+
+                self.step(step_num + 6)
+                speed_current = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedCurrent)
+                asserts.assert_equal(speed_current, 0, "Current speed is not 0 even though the fan is off")
+            else:
+                self.skip_step(step_num + 5)
+                self.skip_step(step_num + 6)
+            step_num += num_substeps
+
+        lowest_mode = self.get_fan_modes(supported_fan_modes)[1]
+        await verify_onoff_off(fan.Attributes.PercentSetting(1), lowest_mode, 1, 1)
+        await verify_onoff_off(fan.Attributes.PercentSetting(0), fan.Enums.FanModeEnum.kOff, 0, 0)
+        await verify_onoff_off(fan.Attributes.FanMode(fan.Enums.FanModeEnum.kHigh), fan.Enums.FanModeEnum.kHigh, None, None)
+        await verify_onoff_off(fan.Attributes.FanMode(fan.Enums.FanModeEnum.kOff), fan.Enums.FanModeEnum.kOff, 0, 0)
+        if has_spd:
+            await verify_onoff_off(fan.Attributes.SpeedSetting(speed_max), fan.Enums.FanModeEnum.kHigh, None, speed_max)
+            await verify_onoff_off(fan.Attributes.SpeedSetting(0), fan.Enums.FanModeEnum.kOff, 0, 0)
+        else:
+            for i in range(2*num_substeps + 1):
+                self.skip_step(step_num + i)
+            step_num += 2 * num_substeps
+
+        await verify_onoff_off(fan.Attributes.PercentSetting(100), fan.Enums.FanModeEnum.kHigh, 100, speed_max)
+
+        self.step(step_num)
         await self.send_single_cmd(cmd=Clusters.OnOff.Commands.On())
+        step_num += 1
 
-        self.step(15)
-        awaiting = [AttributeValue(endpoint_id=self.get_endpoint(
-        ), attribute=fan.Attributes.PercentCurrent, value=percent_setting_original)]
+        self.step(step_num)
+        awaiting = [AttributeValue(endpoint_id=self.get_endpoint(), attribute=fan.Attributes.PercentCurrent, value=100)]
         if has_spd:
             awaiting.append(AttributeValue(endpoint_id=self.get_endpoint(),
-                            attribute=fan.Attributes.SpeedCurrent, value=speed_setting_original))
-        sub.await_all_final_values_reported(expected_final_values=awaiting, timeout_sec=timeout)
-
+                            attribute=fan.Attributes.SpeedCurrent, value=speed_max))
+        sub.await_all_final_values_reported(expected_final_values=awaiting, timeout_sec=5)
         sub.reset()
+        step_num += 1
 
         # Make sure that we can still adjust the Percent values now that it's back on
-        attr = Clusters.FanControl.Attributes.PercentSetting(1)
+        self.step(step_num)
+        attr = Clusters.FanControl.Attributes.PercentSetting(50)
         resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
-        # we want to see a change on percent setting and percent current to 1
-        sub.await_all_final_values_reported()
+        asserts.assert_in(resp[0].Status, [Status.Success, Status.InvalidInState], "Invalid response from writing PercentSetting")
+        step_num += 1
 
+        # we want to see a change on percent setting and percent current to 1
+        self.step(step_num)
+        if resp[0].Status == Status.Success:
+            sub.await_all_final_values_reported([AttributeValue(self.get_endpoint(), fan.Attributes.PercentSetting, 50), AttributeValue(
+                self.get_endpoint(), fan.Attributes.PercentCurrent, 50)], timeout_sec=timeout)
+        else:
+            self.mark_current_step_skipped()
+
+
+# TODO: need to add tests and probably handlers to check what happens when the step command is given when the on/off cluster is off
+# Also what happens when the on/off cluster is turned of while the step is a-steppin'
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -139,8 +139,7 @@ class TC_FAN_2_4(MatterBaseTest):
         # Wait for the entire duration of the test because this valve may be slow. The test will time out before this does. That's fine.
         timeout = self.matter_test_config.timeout if self.matter_test_config.timeout is not None else self.default_timeout
 
-        # TODO: make this a pixit
-        wait_s = 1
+        wait_s = self.user_params.get('pixit_fan_start_time', 1)
 
         self.step(2)
         sub = ClusterAttributeChangeAccumulator(Clusters.FanControl)

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -41,7 +41,8 @@ from typing import Optional
 
 import chip.clusters as Clusters
 from chip.interaction_model import Status
-from matter_testing_infrastructure.chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, default_matter_test_main,
+from matter_testing_infrastructure.chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator,
+                                                                       MatterBaseTest, TestStep, default_matter_test_main,
                                                                        has_cluster, run_if_endpoint_matches)
 from mobly import asserts
 

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -1,0 +1,164 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${AIR_PURIFIER_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace_file json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --endpoint 1
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import chip.clusters as Clusters
+from chip.interaction_model import Status
+from matter_testing_infrastructure.chip.testing.matter_testing import (AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest, TestStep, default_matter_test_main,
+                                                                       has_cluster, run_if_endpoint_matches)
+from mobly import asserts
+
+
+class TC_FAN_2_4(MatterBaseTest):
+    def desc_TC_FAN_4_1(self) -> str:
+        return "[TC-FAN-4.1] Fan interaction with On/Off cluster"
+
+    def steps_TC_FAN_4_1(self):
+        return [TestStep(1, "TH Commissions DUT.", is_commissioning=True),
+                TestStep(2, "TH subscribes to the Fan control cluster"),
+
+                TestStep(3, "TH sends the On command to the On/Off cluster", "DUT returns SUCCESS"),
+                TestStep(4, "TH sets the FanMode attribute on the Fan Control cluster to High", "DUT returns SUCCESS"),
+
+                TestStep(5, "TH reads the PercentSetting attribute from the Fan Control cluster and saves as `percent_setting_original`", "SUCCESS"),
+                TestStep(6, "If the SPD feature is supported, TH reads the SpeedSetting attribute from the Fan Control cluster and saves as `speed_setting_original`", "SUCCESS"),
+                TestStep(7, "TH reads the PercentCurrent attribute from the Fan Control cluster", "SUCCESS"),
+                TestStep(8, "If PercentCurrent is not equal to PercentSetting, TH awaits an attribute report for the PercentCurrent matching PercentSetting", "Report is received"),
+
+                TestStep(9, "TH sends the Off command to the On/Off cluster", "DUT returns SUCCESS"),
+                TestStep(10, "TH awaits the following attribute reports (order does not matter): PercentCurrent is 0, SpeedCurrent is 0 (if SPD feature is supported)", "Report(s) are received"),
+                TestStep(11, "TH reads the FanMode attribute", "FanMode is set to HIGH"),
+                TestStep(12, "TH reads the PercentSetting attribute", "PercentSetting matches `percent_setting_original"),
+                TestStep(13, "If the SPD feature is supported, TH reads the SpeedSetting",
+                         "SpeedSetting matches `speed_setting_original`"),
+
+                TestStep(14, "TH sends On command to the On/Off cluster", "DUT returns SUCCESS"),
+                TestStep(15, "TH awaits the following attribute reports (order does not matter): PercentCurrent is `percent_setting_original`, SpeedCurrent is `speed_setting_original` (if SPD feature is supported)", "Reports are received"),
+
+                ]
+
+    def pics_TC_FAN_4_1(self) -> list[str]:
+        return ["FAN.S", "OO.S"]
+
+    @run_if_endpoint_matches(has_cluster(Clusters.FanControl) and has_cluster(Clusters.OnOff))
+    async def test_TC_FAN_4_1(self):
+        self.step(1)
+        fan = Clusters.FanControl
+        features = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.FeatureMap)
+        has_spd = (features & fan.Bitmaps.Feature.kMultiSpeed) != 0
+        # Wait for the entire duration of the test because this valve may be slow. The test will time out before this does. That's fine.
+        timeout = self.matter_test_config.timeout if self.matter_test_config.timeout is not None else self.default_timeout
+
+        self.step(2)
+        sub = ClusterAttributeChangeAccumulator(Clusters.FanControl)
+        await sub.start(self.default_controller, node_id=self.dut_node_id, endpoint=self.get_endpoint())
+
+        self.step(3)
+        await self.send_single_cmd(cmd=Clusters.OnOff.Commands.On())
+
+        self.step(4)
+        attr = Clusters.FanControl.Attributes.FanMode(Clusters.FanControl.Enums.FanModeEnum.kHigh)
+        resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
+        asserts.assert_equal(resp[0].Status, Status.Success, "Unexpected error writing FanMode attribute")
+
+        self.step(5)
+        percent_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
+
+        self.step(6)
+        if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
+            speed_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
+
+        self.step(7)
+        percent_current = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentCurrent)
+
+        self.step(8)
+        if percent_current != percent_setting_original:
+            sub.await_all_final_values_reported(
+                expected_final_values=[fan.Attributes.PercentCurrent(percent_setting_original)], timeout_sec=timeout)
+        else:
+            self.mark_current_step_skipped()
+
+        self.step(9)
+        await self.send_single_cmd(cmd=Clusters.OnOff.Commands.Off())
+
+        self.step(10)
+        awaiting = [AttributeValue(endpoint_id=self.get_endpoint(), attribute=fan.Attributes.PercentCurrent, value=0)]
+        if has_spd:
+            awaiting.append(AttributeValue(endpoint_id=self.get_endpoint(), attribute=fan.Attributes.SpeedCurrent, value=0))
+        sub.await_all_final_values_reported(expected_final_values=awaiting, timeout_sec=timeout)
+        sub.reset()
+
+        self.step(11)
+        mode = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.FanMode)
+        asserts.assert_equal(mode, fan.Enums.FanModeEnum.kHigh, "FanMode was changed when on/off cluster was changed")
+
+        self.step(12)
+        percent_setting_new = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
+        asserts.assert_equal(percent_setting_new, percent_setting_original,
+                             "PercentSetting was changed when on/off cluster was changed")
+
+        self.step(13)
+        if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
+            speed_setting_new = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
+            asserts.assert_equal(speed_setting_new, speed_setting_original,
+                                 "SpeedSetting was changed when on/off cluster was changed")
+
+        # Changing the percent while the fan is off should change the percent setting, but not the percent current or speed current
+        attr = Clusters.FanControl.Attributes.PercentSetting(1)
+        resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
+
+        self.step(14)
+        await self.send_single_cmd(cmd=Clusters.OnOff.Commands.On())
+
+        self.step(15)
+        awaiting = [AttributeValue(endpoint_id=self.get_endpoint(
+        ), attribute=fan.Attributes.PercentCurrent, value=percent_setting_original)]
+        if has_spd:
+            awaiting.append(AttributeValue(endpoint_id=self.get_endpoint(),
+                            attribute=fan.Attributes.SpeedCurrent, value=speed_setting_original))
+        sub.await_all_final_values_reported(expected_final_values=awaiting, timeout_sec=timeout)
+
+        sub.reset()
+
+        # Make sure that we can still adjust the Percent values now that it's back on
+        attr = Clusters.FanControl.Attributes.PercentSetting(1)
+        resp = await self.default_controller.WriteAttribute(nodeid=self.dut_node_id, attributes=[(self.get_endpoint(), attr)])
+        # we want to see a change on percent setting and percent current to 1
+        sub.await_all_final_values_reported()
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
App Changes
- Added an On/Off cluster to the air purifier app so we can test the fan interaction with the on off cluster.
- Removed the two class variables speedCurrent and percentCurrent because these were actually speedSetting and percentSetting and it just so happened that the current and setting always matched.
- Added an on/off handler for the on/off cluster and handling for changes to the settings and fan mode variables when the fan is off

Tests:
- added TC-FAN-4.1 to check for fan cluster interaction with the on/off cluster

#### Testing
Please see added cert/integration test in this PR - TC-FAN-4.1. Unit tests on this cluster are not done since this cluster uses an ember implementation.


