### PR TITLE
Add some comments to disambiguate default cases in generated switches.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeSpecifiedCheck-src.zapt
@@ -22,6 +22,7 @@ static BOOL AttributeIsSpecifiedIn{{asUpperCamelCase name preserveAcronyms=true}
         {{/if}}
         {{/zcl_attributes_server}}
         default: {
+            // Not a known {{asUpperCamelCase name preserveAcronyms=true}} attribute.
             return NO;
         }
     }

--- a/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRAttributeTLVValueDecoder-src.zapt
@@ -73,6 +73,7 @@ static id _Nullable DecodeAttributeValueFor{{asUpperCamelCase name preserveAcron
         {{/if}}
         {{/zcl_attributes_server}}
         default: {
+            // Not a known {{asUpperCamelCase name preserveAcronyms=true}} attribute.
             break;
         }
     }

--- a/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterNames-src.zapt
@@ -72,6 +72,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
 
 {{#if (isSupported (asUpperCamelCase label preserveAcronyms=true) isForIds=true)}}
             default:
+                // Not a known {{asUpperCamelCase name preserveAcronyms=true}} attribute.
                 result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
                 break;
         }

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -52,6 +52,7 @@ static id _Nullable DecodeEventPayloadFor{{asUpperCamelCase name preserveAcronym
         {{/if}}
         {{/zcl_events}}
         default: {
+            // Not a known {{asUpperCamelCase name preserveAcronyms=true}} event.
             break;
         }
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeSpecifiedCheck.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeSpecifiedCheck.mm
@@ -49,6 +49,7 @@ static BOOL AttributeIsSpecifiedInIdentifyCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Identify attribute.
         return NO;
     }
     }
@@ -76,6 +77,7 @@ static BOOL AttributeIsSpecifiedInGroupsCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Groups attribute.
         return NO;
     }
     }
@@ -115,6 +117,7 @@ static BOOL AttributeIsSpecifiedInOnOffCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known OnOff attribute.
         return NO;
     }
     }
@@ -181,6 +184,7 @@ static BOOL AttributeIsSpecifiedInLevelControlCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known LevelControl attribute.
         return NO;
     }
     }
@@ -205,6 +209,7 @@ static BOOL AttributeIsSpecifiedInPulseWidthModulationCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known PulseWidthModulation attribute.
         return NO;
     }
     }
@@ -244,6 +249,7 @@ static BOOL AttributeIsSpecifiedInDescriptorCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Descriptor attribute.
         return NO;
     }
     }
@@ -271,6 +277,7 @@ static BOOL AttributeIsSpecifiedInBindingCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Binding attribute.
         return NO;
     }
     }
@@ -316,6 +323,7 @@ static BOOL AttributeIsSpecifiedInAccessControlCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known AccessControl attribute.
         return NO;
     }
     }
@@ -349,6 +357,7 @@ static BOOL AttributeIsSpecifiedInActionsCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Actions attribute.
         return NO;
     }
     }
@@ -445,6 +454,7 @@ static BOOL AttributeIsSpecifiedInBasicInformationCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known BasicInformation attribute.
         return NO;
     }
     }
@@ -469,6 +479,7 @@ static BOOL AttributeIsSpecifiedInOTASoftwareUpdateProviderCluster(AttributeId a
         return YES;
     }
     default: {
+        // Not a known OTASoftwareUpdateProvider attribute.
         return NO;
     }
     }
@@ -505,6 +516,7 @@ static BOOL AttributeIsSpecifiedInOTASoftwareUpdateRequestorCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known OTASoftwareUpdateRequestor attribute.
         return NO;
     }
     }
@@ -535,6 +547,7 @@ static BOOL AttributeIsSpecifiedInLocalizationConfigurationCluster(AttributeId a
         return YES;
     }
     default: {
+        // Not a known LocalizationConfiguration attribute.
         return NO;
     }
     }
@@ -568,6 +581,7 @@ static BOOL AttributeIsSpecifiedInTimeFormatLocalizationCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known TimeFormatLocalization attribute.
         return NO;
     }
     }
@@ -595,6 +609,7 @@ static BOOL AttributeIsSpecifiedInUnitLocalizationCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known UnitLocalization attribute.
         return NO;
     }
     }
@@ -622,6 +637,7 @@ static BOOL AttributeIsSpecifiedInPowerSourceConfigurationCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known PowerSourceConfiguration attribute.
         return NO;
     }
     }
@@ -742,6 +758,7 @@ static BOOL AttributeIsSpecifiedInPowerSourceCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known PowerSource attribute.
         return NO;
     }
     }
@@ -796,6 +813,7 @@ static BOOL AttributeIsSpecifiedInGeneralCommissioningCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known GeneralCommissioning attribute.
         return NO;
     }
     }
@@ -853,6 +871,7 @@ static BOOL AttributeIsSpecifiedInNetworkCommissioningCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known NetworkCommissioning attribute.
         return NO;
     }
     }
@@ -877,6 +896,7 @@ static BOOL AttributeIsSpecifiedInDiagnosticLogsCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known DiagnosticLogs attribute.
         return NO;
     }
     }
@@ -928,6 +948,7 @@ static BOOL AttributeIsSpecifiedInGeneralDiagnosticsCluster(AttributeId aAttribu
         return YES;
     }
     default: {
+        // Not a known GeneralDiagnostics attribute.
         return NO;
     }
     }
@@ -964,6 +985,7 @@ static BOOL AttributeIsSpecifiedInSoftwareDiagnosticsCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known SoftwareDiagnostics attribute.
         return NO;
     }
     }
@@ -1183,6 +1205,7 @@ static BOOL AttributeIsSpecifiedInThreadNetworkDiagnosticsCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known ThreadNetworkDiagnostics attribute.
         return NO;
     }
     }
@@ -1246,6 +1269,7 @@ static BOOL AttributeIsSpecifiedInWiFiNetworkDiagnosticsCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known WiFiNetworkDiagnostics attribute.
         return NO;
     }
     }
@@ -1297,6 +1321,7 @@ static BOOL AttributeIsSpecifiedInEthernetNetworkDiagnosticsCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known EthernetNetworkDiagnostics attribute.
         return NO;
     }
     }
@@ -1360,6 +1385,7 @@ static BOOL AttributeIsSpecifiedInTimeSynchronizationCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known TimeSynchronization attribute.
         return NO;
     }
     }
@@ -1438,6 +1464,7 @@ static BOOL AttributeIsSpecifiedInBridgedDeviceBasicInformationCluster(Attribute
         return YES;
     }
     default: {
+        // Not a known BridgedDeviceBasicInformation attribute.
         return NO;
     }
     }
@@ -1471,6 +1498,7 @@ static BOOL AttributeIsSpecifiedInSwitchCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Switch attribute.
         return NO;
     }
     }
@@ -1504,6 +1532,7 @@ static BOOL AttributeIsSpecifiedInAdministratorCommissioningCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known AdministratorCommissioning attribute.
         return NO;
     }
     }
@@ -1546,6 +1575,7 @@ static BOOL AttributeIsSpecifiedInOperationalCredentialsCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known OperationalCredentials attribute.
         return NO;
     }
     }
@@ -1582,6 +1612,7 @@ static BOOL AttributeIsSpecifiedInGroupKeyManagementCluster(AttributeId aAttribu
         return YES;
     }
     default: {
+        // Not a known GroupKeyManagement attribute.
         return NO;
     }
     }
@@ -1609,6 +1640,7 @@ static BOOL AttributeIsSpecifiedInFixedLabelCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known FixedLabel attribute.
         return NO;
     }
     }
@@ -1636,6 +1668,7 @@ static BOOL AttributeIsSpecifiedInUserLabelCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known UserLabel attribute.
         return NO;
     }
     }
@@ -1663,6 +1696,7 @@ static BOOL AttributeIsSpecifiedInBooleanStateCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known BooleanState attribute.
         return NO;
     }
     }
@@ -1717,6 +1751,7 @@ static BOOL AttributeIsSpecifiedInICDManagementCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known ICDManagement attribute.
         return NO;
     }
     }
@@ -1750,6 +1785,7 @@ static BOOL AttributeIsSpecifiedInTimerCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Timer attribute.
         return NO;
     }
     }
@@ -1792,6 +1828,7 @@ static BOOL AttributeIsSpecifiedInOvenCavityOperationalStateCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known OvenCavityOperationalState attribute.
         return NO;
     }
     }
@@ -1822,6 +1859,7 @@ static BOOL AttributeIsSpecifiedInOvenModeCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known OvenMode attribute.
         return NO;
     }
     }
@@ -1852,6 +1890,7 @@ static BOOL AttributeIsSpecifiedInLaundryDryerControlsCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known LaundryDryerControls attribute.
         return NO;
     }
     }
@@ -1894,6 +1933,7 @@ static BOOL AttributeIsSpecifiedInModeSelectCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known ModeSelect attribute.
         return NO;
     }
     }
@@ -1924,6 +1964,7 @@ static BOOL AttributeIsSpecifiedInLaundryWasherModeCluster(AttributeId aAttribut
         return YES;
     }
     default: {
+        // Not a known LaundryWasherMode attribute.
         return NO;
     }
     }
@@ -1954,6 +1995,7 @@ static BOOL AttributeIsSpecifiedInRefrigeratorAndTemperatureControlledCabinetMod
         return YES;
     }
     default: {
+        // Not a known RefrigeratorAndTemperatureControlledCabinetMode attribute.
         return NO;
     }
     }
@@ -1990,6 +2032,7 @@ static BOOL AttributeIsSpecifiedInLaundryWasherControlsCluster(AttributeId aAttr
         return YES;
     }
     default: {
+        // Not a known LaundryWasherControls attribute.
         return NO;
     }
     }
@@ -2020,6 +2063,7 @@ static BOOL AttributeIsSpecifiedInRVCRunModeCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known RVCRunMode attribute.
         return NO;
     }
     }
@@ -2050,6 +2094,7 @@ static BOOL AttributeIsSpecifiedInRVCCleanModeCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known RVCCleanMode attribute.
         return NO;
     }
     }
@@ -2092,6 +2137,7 @@ static BOOL AttributeIsSpecifiedInTemperatureControlCluster(AttributeId aAttribu
         return YES;
     }
     default: {
+        // Not a known TemperatureControl attribute.
         return NO;
     }
     }
@@ -2125,6 +2171,7 @@ static BOOL AttributeIsSpecifiedInRefrigeratorAlarmCluster(AttributeId aAttribut
         return YES;
     }
     default: {
+        // Not a known RefrigeratorAlarm attribute.
         return NO;
     }
     }
@@ -2155,6 +2202,7 @@ static BOOL AttributeIsSpecifiedInDishwasherModeCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known DishwasherMode attribute.
         return NO;
     }
     }
@@ -2182,6 +2230,7 @@ static BOOL AttributeIsSpecifiedInAirQualityCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known AirQuality attribute.
         return NO;
     }
     }
@@ -2245,6 +2294,7 @@ static BOOL AttributeIsSpecifiedInSmokeCOAlarmCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known SmokeCOAlarm attribute.
         return NO;
     }
     }
@@ -2281,6 +2331,7 @@ static BOOL AttributeIsSpecifiedInDishwasherAlarmCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known DishwasherAlarm attribute.
         return NO;
     }
     }
@@ -2311,6 +2362,7 @@ static BOOL AttributeIsSpecifiedInMicrowaveOvenModeCluster(AttributeId aAttribut
         return YES;
     }
     default: {
+        // Not a known MicrowaveOvenMode attribute.
         return NO;
     }
     }
@@ -2362,6 +2414,7 @@ static BOOL AttributeIsSpecifiedInMicrowaveOvenControlCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known MicrowaveOvenControl attribute.
         return NO;
     }
     }
@@ -2404,6 +2457,7 @@ static BOOL AttributeIsSpecifiedInOperationalStateCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known OperationalState attribute.
         return NO;
     }
     }
@@ -2446,6 +2500,7 @@ static BOOL AttributeIsSpecifiedInRVCOperationalStateCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known RVCOperationalState attribute.
         return NO;
     }
     }
@@ -2476,6 +2531,7 @@ static BOOL AttributeIsSpecifiedInScenesManagementCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known ScenesManagement attribute.
         return NO;
     }
     }
@@ -2518,6 +2574,7 @@ static BOOL AttributeIsSpecifiedInHEPAFilterMonitoringCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known HEPAFilterMonitoring attribute.
         return NO;
     }
     }
@@ -2560,6 +2617,7 @@ static BOOL AttributeIsSpecifiedInActivatedCarbonFilterMonitoringCluster(Attribu
         return YES;
     }
     default: {
+        // Not a known ActivatedCarbonFilterMonitoring attribute.
         return NO;
     }
     }
@@ -2608,6 +2666,7 @@ static BOOL AttributeIsSpecifiedInBooleanStateConfigurationCluster(AttributeId a
         return YES;
     }
     default: {
+        // Not a known BooleanStateConfiguration attribute.
         return NO;
     }
     }
@@ -2665,6 +2724,7 @@ static BOOL AttributeIsSpecifiedInValveConfigurationAndControlCluster(AttributeI
         return YES;
     }
     default: {
+        // Not a known ValveConfigurationAndControl attribute.
         return NO;
     }
     }
@@ -2746,6 +2806,7 @@ static BOOL AttributeIsSpecifiedInElectricalPowerMeasurementCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known ElectricalPowerMeasurement attribute.
         return NO;
     }
     }
@@ -2788,6 +2849,7 @@ static BOOL AttributeIsSpecifiedInElectricalEnergyMeasurementCluster(AttributeId
         return YES;
     }
     default: {
+        // Not a known ElectricalEnergyMeasurement attribute.
         return NO;
     }
     }
@@ -2830,6 +2892,7 @@ static BOOL AttributeIsSpecifiedInWaterHeaterManagementCluster(AttributeId aAttr
         return YES;
     }
     default: {
+        // Not a known WaterHeaterManagement attribute.
         return NO;
     }
     }
@@ -2866,6 +2929,7 @@ static BOOL AttributeIsSpecifiedInCommodityPriceCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known CommodityPrice attribute.
         return NO;
     }
     }
@@ -2914,6 +2978,7 @@ static BOOL AttributeIsSpecifiedInDemandResponseLoadControlCluster(AttributeId a
         return YES;
     }
     default: {
+        // Not a known DemandResponseLoadControl attribute.
         return NO;
     }
     }
@@ -2944,6 +3009,7 @@ static BOOL AttributeIsSpecifiedInMessagesCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Messages attribute.
         return NO;
     }
     }
@@ -2992,6 +3058,7 @@ static BOOL AttributeIsSpecifiedInDeviceEnergyManagementCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known DeviceEnergyManagement attribute.
         return NO;
     }
     }
@@ -3085,6 +3152,7 @@ static BOOL AttributeIsSpecifiedInEnergyEVSECluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known EnergyEVSE attribute.
         return NO;
     }
     }
@@ -3124,6 +3192,7 @@ static BOOL AttributeIsSpecifiedInEnergyPreferenceCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known EnergyPreference attribute.
         return NO;
     }
     }
@@ -3154,6 +3223,7 @@ static BOOL AttributeIsSpecifiedInPowerTopologyCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known PowerTopology attribute.
         return NO;
     }
     }
@@ -3184,6 +3254,7 @@ static BOOL AttributeIsSpecifiedInEnergyEVSEModeCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known EnergyEVSEMode attribute.
         return NO;
     }
     }
@@ -3214,6 +3285,7 @@ static BOOL AttributeIsSpecifiedInWaterHeaterModeCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known WaterHeaterMode attribute.
         return NO;
     }
     }
@@ -3244,6 +3316,7 @@ static BOOL AttributeIsSpecifiedInDeviceEnergyManagementModeCluster(AttributeId 
         return YES;
     }
     default: {
+        // Not a known DeviceEnergyManagementMode attribute.
         return NO;
     }
     }
@@ -3277,6 +3350,7 @@ static BOOL AttributeIsSpecifiedInElectricalGridConditionsCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known ElectricalGridConditions attribute.
         return NO;
     }
     }
@@ -3436,6 +3510,7 @@ static BOOL AttributeIsSpecifiedInDoorLockCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known DoorLock attribute.
         return NO;
     }
     }
@@ -3526,6 +3601,7 @@ static BOOL AttributeIsSpecifiedInWindowCoveringCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known WindowCovering attribute.
         return NO;
     }
     }
@@ -3565,6 +3641,7 @@ static BOOL AttributeIsSpecifiedInClosureControlCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known ClosureControl attribute.
         return NO;
     }
     }
@@ -3622,6 +3699,7 @@ static BOOL AttributeIsSpecifiedInClosureDimensionCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known ClosureDimension attribute.
         return NO;
     }
     }
@@ -3664,6 +3742,7 @@ static BOOL AttributeIsSpecifiedInServiceAreaCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known ServiceArea attribute.
         return NO;
     }
     }
@@ -3757,6 +3836,7 @@ static BOOL AttributeIsSpecifiedInPumpConfigurationAndControlCluster(AttributeId
         return YES;
     }
     default: {
+        // Not a known PumpConfigurationAndControl attribute.
         return NO;
     }
     }
@@ -3961,6 +4041,7 @@ static BOOL AttributeIsSpecifiedInThermostatCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Thermostat attribute.
         return NO;
     }
     }
@@ -4021,6 +4102,7 @@ static BOOL AttributeIsSpecifiedInFanControlCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known FanControl attribute.
         return NO;
     }
     }
@@ -4054,6 +4136,7 @@ static BOOL AttributeIsSpecifiedInThermostatUserInterfaceConfigurationCluster(At
         return YES;
     }
     default: {
+        // Not a known ThermostatUserInterfaceConfiguration attribute.
         return NO;
     }
     }
@@ -4234,6 +4317,7 @@ static BOOL AttributeIsSpecifiedInColorControlCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known ColorControl attribute.
         return NO;
     }
     }
@@ -4300,6 +4384,7 @@ static BOOL AttributeIsSpecifiedInBallastConfigurationCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known BallastConfiguration attribute.
         return NO;
     }
     }
@@ -4339,6 +4424,7 @@ static BOOL AttributeIsSpecifiedInIlluminanceMeasurementCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known IlluminanceMeasurement attribute.
         return NO;
     }
     }
@@ -4375,6 +4461,7 @@ static BOOL AttributeIsSpecifiedInTemperatureMeasurementCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known TemperatureMeasurement attribute.
         return NO;
     }
     }
@@ -4426,6 +4513,7 @@ static BOOL AttributeIsSpecifiedInPressureMeasurementCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known PressureMeasurement attribute.
         return NO;
     }
     }
@@ -4462,6 +4550,7 @@ static BOOL AttributeIsSpecifiedInFlowMeasurementCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known FlowMeasurement attribute.
         return NO;
     }
     }
@@ -4498,6 +4587,7 @@ static BOOL AttributeIsSpecifiedInRelativeHumidityMeasurementCluster(AttributeId
         return YES;
     }
     default: {
+        // Not a known RelativeHumidityMeasurement attribute.
         return NO;
     }
     }
@@ -4564,6 +4654,7 @@ static BOOL AttributeIsSpecifiedInOccupancySensingCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known OccupancySensing attribute.
         return NO;
     }
     }
@@ -4621,6 +4712,7 @@ static BOOL AttributeIsSpecifiedInCarbonMonoxideConcentrationMeasurementCluster(
         return YES;
     }
     default: {
+        // Not a known CarbonMonoxideConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4678,6 +4770,7 @@ static BOOL AttributeIsSpecifiedInCarbonDioxideConcentrationMeasurementCluster(A
         return YES;
     }
     default: {
+        // Not a known CarbonDioxideConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4735,6 +4828,7 @@ static BOOL AttributeIsSpecifiedInNitrogenDioxideConcentrationMeasurementCluster
         return YES;
     }
     default: {
+        // Not a known NitrogenDioxideConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4792,6 +4886,7 @@ static BOOL AttributeIsSpecifiedInOzoneConcentrationMeasurementCluster(Attribute
         return YES;
     }
     default: {
+        // Not a known OzoneConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4849,6 +4944,7 @@ static BOOL AttributeIsSpecifiedInPM25ConcentrationMeasurementCluster(AttributeI
         return YES;
     }
     default: {
+        // Not a known PM25ConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4906,6 +5002,7 @@ static BOOL AttributeIsSpecifiedInFormaldehydeConcentrationMeasurementCluster(At
         return YES;
     }
     default: {
+        // Not a known FormaldehydeConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -4963,6 +5060,7 @@ static BOOL AttributeIsSpecifiedInPM1ConcentrationMeasurementCluster(AttributeId
         return YES;
     }
     default: {
+        // Not a known PM1ConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -5020,6 +5118,7 @@ static BOOL AttributeIsSpecifiedInPM10ConcentrationMeasurementCluster(AttributeI
         return YES;
     }
     default: {
+        // Not a known PM10ConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -5077,6 +5176,7 @@ static BOOL AttributeIsSpecifiedInTotalVolatileOrganicCompoundsConcentrationMeas
         return YES;
     }
     default: {
+        // Not a known TotalVolatileOrganicCompoundsConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -5134,6 +5234,7 @@ static BOOL AttributeIsSpecifiedInRadonConcentrationMeasurementCluster(Attribute
         return YES;
     }
     default: {
+        // Not a known RadonConcentrationMeasurement attribute.
         return NO;
     }
     }
@@ -5164,6 +5265,7 @@ static BOOL AttributeIsSpecifiedInWiFiNetworkManagementCluster(AttributeId aAttr
         return YES;
     }
     default: {
+        // Not a known WiFiNetworkManagement attribute.
         return NO;
     }
     }
@@ -5206,6 +5308,7 @@ static BOOL AttributeIsSpecifiedInThreadBorderRouterManagementCluster(AttributeI
         return YES;
     }
     default: {
+        // Not a known ThreadBorderRouterManagement attribute.
         return NO;
     }
     }
@@ -5239,6 +5342,7 @@ static BOOL AttributeIsSpecifiedInThreadNetworkDirectoryCluster(AttributeId aAtt
         return YES;
     }
     default: {
+        // Not a known ThreadNetworkDirectory attribute.
         return NO;
     }
     }
@@ -5269,6 +5373,7 @@ static BOOL AttributeIsSpecifiedInWakeOnLANCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known WakeOnLAN attribute.
         return NO;
     }
     }
@@ -5302,6 +5407,7 @@ static BOOL AttributeIsSpecifiedInChannelCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Channel attribute.
         return NO;
     }
     }
@@ -5332,6 +5438,7 @@ static BOOL AttributeIsSpecifiedInTargetNavigatorCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known TargetNavigator attribute.
         return NO;
     }
     }
@@ -5389,6 +5496,7 @@ static BOOL AttributeIsSpecifiedInMediaPlaybackCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known MediaPlayback attribute.
         return NO;
     }
     }
@@ -5419,6 +5527,7 @@ static BOOL AttributeIsSpecifiedInMediaInputCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known MediaInput attribute.
         return NO;
     }
     }
@@ -5443,6 +5552,7 @@ static BOOL AttributeIsSpecifiedInLowPowerCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known LowPower attribute.
         return NO;
     }
     }
@@ -5467,6 +5577,7 @@ static BOOL AttributeIsSpecifiedInKeypadInputCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known KeypadInput attribute.
         return NO;
     }
     }
@@ -5497,6 +5608,7 @@ static BOOL AttributeIsSpecifiedInContentLauncherCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known ContentLauncher attribute.
         return NO;
     }
     }
@@ -5527,6 +5639,7 @@ static BOOL AttributeIsSpecifiedInAudioOutputCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known AudioOutput attribute.
         return NO;
     }
     }
@@ -5557,6 +5670,7 @@ static BOOL AttributeIsSpecifiedInApplicationLauncherCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known ApplicationLauncher attribute.
         return NO;
     }
     }
@@ -5605,6 +5719,7 @@ static BOOL AttributeIsSpecifiedInApplicationBasicCluster(AttributeId aAttribute
         return YES;
     }
     default: {
+        // Not a known ApplicationBasic attribute.
         return NO;
     }
     }
@@ -5629,6 +5744,7 @@ static BOOL AttributeIsSpecifiedInAccountLoginCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known AccountLogin attribute.
         return NO;
     }
     }
@@ -5677,6 +5793,7 @@ static BOOL AttributeIsSpecifiedInContentControlCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known ContentControl attribute.
         return NO;
     }
     }
@@ -5701,6 +5818,7 @@ static BOOL AttributeIsSpecifiedInContentAppObserverCluster(AttributeId aAttribu
         return YES;
     }
     default: {
+        // Not a known ContentAppObserver attribute.
         return NO;
     }
     }
@@ -5737,6 +5855,7 @@ static BOOL AttributeIsSpecifiedInZoneManagementCluster(AttributeId aAttributeId
         return YES;
     }
     default: {
+        // Not a known ZoneManagement attribute.
         return NO;
     }
     }
@@ -5884,6 +6003,7 @@ static BOOL AttributeIsSpecifiedInCameraAVStreamManagementCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known CameraAVStreamManagement attribute.
         return NO;
     }
     }
@@ -5935,6 +6055,7 @@ static BOOL AttributeIsSpecifiedInCameraAVSettingsUserLevelManagementCluster(Att
         return YES;
     }
     default: {
+        // Not a known CameraAVSettingsUserLevelManagement attribute.
         return NO;
     }
     }
@@ -5962,6 +6083,7 @@ static BOOL AttributeIsSpecifiedInWebRTCTransportProviderCluster(AttributeId aAt
         return YES;
     }
     default: {
+        // Not a known WebRTCTransportProvider attribute.
         return NO;
     }
     }
@@ -5989,6 +6111,7 @@ static BOOL AttributeIsSpecifiedInWebRTCTransportRequestorCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known WebRTCTransportRequestor attribute.
         return NO;
     }
     }
@@ -6022,6 +6145,7 @@ static BOOL AttributeIsSpecifiedInPushAVStreamTransportCluster(AttributeId aAttr
         return YES;
     }
     default: {
+        // Not a known PushAVStreamTransport attribute.
         return NO;
     }
     }
@@ -6055,6 +6179,7 @@ static BOOL AttributeIsSpecifiedInChimeCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known Chime attribute.
         return NO;
     }
     }
@@ -6136,6 +6261,7 @@ static BOOL AttributeIsSpecifiedInCommodityTariffCluster(AttributeId aAttributeI
         return YES;
     }
     default: {
+        // Not a known CommodityTariff attribute.
         return NO;
     }
     }
@@ -6166,6 +6292,7 @@ static BOOL AttributeIsSpecifiedInEcosystemInformationCluster(AttributeId aAttri
         return YES;
     }
     default: {
+        // Not a known EcosystemInformation attribute.
         return NO;
     }
     }
@@ -6193,6 +6320,7 @@ static BOOL AttributeIsSpecifiedInCommissionerControlCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known CommissionerControl attribute.
         return NO;
     }
     }
@@ -6229,6 +6357,7 @@ static BOOL AttributeIsSpecifiedInTLSCertificateManagementCluster(AttributeId aA
         return YES;
     }
     default: {
+        // Not a known TLSCertificateManagement attribute.
         return NO;
     }
     }
@@ -6259,6 +6388,7 @@ static BOOL AttributeIsSpecifiedInTLSClientManagementCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known TLSClientManagement attribute.
         return NO;
     }
     }
@@ -6298,6 +6428,7 @@ static BOOL AttributeIsSpecifiedInMeterIdentificationCluster(AttributeId aAttrib
         return YES;
     }
     default: {
+        // Not a known MeterIdentification attribute.
         return NO;
     }
     }
@@ -6331,6 +6462,7 @@ static BOOL AttributeIsSpecifiedInCommodityMeteringCluster(AttributeId aAttribut
         return YES;
     }
     default: {
+        // Not a known CommodityMetering attribute.
         return NO;
     }
     }
@@ -6622,6 +6754,7 @@ static BOOL AttributeIsSpecifiedInUnitTestingCluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known UnitTesting attribute.
         return NO;
     }
     }
@@ -6649,6 +6782,7 @@ static BOOL AttributeIsSpecifiedInSampleMEICluster(AttributeId aAttributeId)
         return YES;
     }
     default: {
+        // Not a known SampleMEI attribute.
         return NO;
     }
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -172,6 +172,7 @@ static id _Nullable DecodeAttributeValueForIdentifyCluster(AttributeId aAttribut
         return value;
     }
     default: {
+        // Not a known Identify attribute.
         break;
     }
     }
@@ -195,6 +196,7 @@ static id _Nullable DecodeAttributeValueForGroupsCluster(AttributeId aAttributeI
         return value;
     }
     default: {
+        // Not a known Groups attribute.
         break;
     }
     }
@@ -266,6 +268,7 @@ static id _Nullable DecodeAttributeValueForOnOffCluster(AttributeId aAttributeId
         return value;
     }
     default: {
+        // Not a known OnOff attribute.
         break;
     }
     }
@@ -456,6 +459,7 @@ static id _Nullable DecodeAttributeValueForLevelControlCluster(AttributeId aAttr
         return value;
     }
     default: {
+        // Not a known LevelControl attribute.
         break;
     }
     }
@@ -468,6 +472,7 @@ static id _Nullable DecodeAttributeValueForPulseWidthModulationCluster(Attribute
     using namespace Clusters::PulseWidthModulation;
     switch (aAttributeId) {
     default: {
+        // Not a known PulseWidthModulation attribute.
         break;
     }
     }
@@ -633,6 +638,7 @@ static id _Nullable DecodeAttributeValueForDescriptorCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known Descriptor attribute.
         break;
     }
     }
@@ -692,6 +698,7 @@ static id _Nullable DecodeAttributeValueForBindingCluster(AttributeId aAttribute
         return value;
     }
     default: {
+        // Not a known Binding attribute.
         break;
     }
     }
@@ -950,6 +957,7 @@ static id _Nullable DecodeAttributeValueForAccessControlCluster(AttributeId aAtt
         return value;
     }
     default: {
+        // Not a known AccessControl attribute.
         break;
     }
     }
@@ -1065,6 +1073,7 @@ static id _Nullable DecodeAttributeValueForActionsCluster(AttributeId aAttribute
         return value;
     }
     default: {
+        // Not a known Actions attribute.
         break;
     }
     }
@@ -1409,6 +1418,7 @@ static id _Nullable DecodeAttributeValueForBasicInformationCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known BasicInformation attribute.
         break;
     }
     }
@@ -1421,6 +1431,7 @@ static id _Nullable DecodeAttributeValueForOTASoftwareUpdateProviderCluster(Attr
     using namespace Clusters::OtaSoftwareUpdateProvider;
     switch (aAttributeId) {
     default: {
+        // Not a known OTASoftwareUpdateProvider attribute.
         break;
     }
     }
@@ -1499,6 +1510,7 @@ static id _Nullable DecodeAttributeValueForOTASoftwareUpdateRequestorCluster(Att
         return value;
     }
     default: {
+        // Not a known OTASoftwareUpdateRequestor attribute.
         break;
     }
     }
@@ -1558,6 +1570,7 @@ static id _Nullable DecodeAttributeValueForLocalizationConfigurationCluster(Attr
         return value;
     }
     default: {
+        // Not a known LocalizationConfiguration attribute.
         break;
     }
     }
@@ -1618,6 +1631,7 @@ static id _Nullable DecodeAttributeValueForTimeFormatLocalizationCluster(Attribu
         return value;
     }
     default: {
+        // Not a known TimeFormatLocalization attribute.
         break;
     }
     }
@@ -1641,6 +1655,7 @@ static id _Nullable DecodeAttributeValueForUnitLocalizationCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known UnitLocalization attribute.
         break;
     }
     }
@@ -1679,6 +1694,7 @@ static id _Nullable DecodeAttributeValueForPowerSourceConfigurationCluster(Attri
         return value;
     }
     default: {
+        // Not a known PowerSourceConfiguration attribute.
         break;
     }
     }
@@ -2155,6 +2171,7 @@ static id _Nullable DecodeAttributeValueForPowerSourceCluster(AttributeId aAttri
         return value;
     }
     default: {
+        // Not a known PowerSource attribute.
         break;
     }
     }
@@ -2283,6 +2300,7 @@ static id _Nullable DecodeAttributeValueForGeneralCommissioningCluster(Attribute
         return value;
     }
     default: {
+        // Not a known GeneralCommissioning attribute.
         break;
     }
     }
@@ -2478,6 +2496,7 @@ static id _Nullable DecodeAttributeValueForNetworkCommissioningCluster(Attribute
         return value;
     }
     default: {
+        // Not a known NetworkCommissioning attribute.
         break;
     }
     }
@@ -2490,6 +2509,7 @@ static id _Nullable DecodeAttributeValueForDiagnosticLogsCluster(AttributeId aAt
     using namespace Clusters::DiagnosticLogs;
     switch (aAttributeId) {
     default: {
+        // Not a known DiagnosticLogs attribute.
         break;
     }
     }
@@ -2712,6 +2732,7 @@ static id _Nullable DecodeAttributeValueForGeneralDiagnosticsCluster(AttributeId
         return value;
     }
     default: {
+        // Not a known GeneralDiagnostics attribute.
         break;
     }
     }
@@ -2809,6 +2830,7 @@ static id _Nullable DecodeAttributeValueForSoftwareDiagnosticsCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known SoftwareDiagnostics attribute.
         break;
     }
     }
@@ -3708,6 +3730,7 @@ static id _Nullable DecodeAttributeValueForThreadNetworkDiagnosticsCluster(Attri
         return value;
     }
     default: {
+        // Not a known ThreadNetworkDiagnostics attribute.
         break;
     }
     }
@@ -3915,6 +3938,7 @@ static id _Nullable DecodeAttributeValueForWiFiNetworkDiagnosticsCluster(Attribu
         return value;
     }
     default: {
+        // Not a known WiFiNetworkDiagnostics attribute.
         break;
     }
     }
@@ -4038,6 +4062,7 @@ static id _Nullable DecodeAttributeValueForEthernetNetworkDiagnosticsCluster(Att
         return value;
     }
     default: {
+        // Not a known EthernetNetworkDiagnostics attribute.
         break;
     }
     }
@@ -4266,6 +4291,7 @@ static id _Nullable DecodeAttributeValueForTimeSynchronizationCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known TimeSynchronization attribute.
         break;
     }
     }
@@ -4537,6 +4563,7 @@ static id _Nullable DecodeAttributeValueForBridgedDeviceBasicInformationCluster(
         return value;
     }
     default: {
+        // Not a known BridgedDeviceBasicInformation attribute.
         break;
     }
     }
@@ -4582,6 +4609,7 @@ static id _Nullable DecodeAttributeValueForSwitchCluster(AttributeId aAttributeI
         return value;
     }
     default: {
+        // Not a known Switch attribute.
         break;
     }
     }
@@ -4635,6 +4663,7 @@ static id _Nullable DecodeAttributeValueForAdministratorCommissioningCluster(Att
         return value;
     }
     default: {
+        // Not a known AdministratorCommissioning attribute.
         break;
     }
     }
@@ -4786,6 +4815,7 @@ static id _Nullable DecodeAttributeValueForOperationalCredentialsCluster(Attribu
         return value;
     }
     default: {
+        // Not a known OperationalCredentials attribute.
         break;
     }
     }
@@ -4903,6 +4933,7 @@ static id _Nullable DecodeAttributeValueForGroupKeyManagementCluster(AttributeId
         return value;
     }
     default: {
+        // Not a known GroupKeyManagement attribute.
         break;
     }
     }
@@ -4953,6 +4984,7 @@ static id _Nullable DecodeAttributeValueForFixedLabelCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known FixedLabel attribute.
         break;
     }
     }
@@ -5003,6 +5035,7 @@ static id _Nullable DecodeAttributeValueForUserLabelCluster(AttributeId aAttribu
         return value;
     }
     default: {
+        // Not a known UserLabel attribute.
         break;
     }
     }
@@ -5026,6 +5059,7 @@ static id _Nullable DecodeAttributeValueForBooleanStateCluster(AttributeId aAttr
         return value;
     }
     default: {
+        // Not a known BooleanState attribute.
         break;
     }
     }
@@ -5172,6 +5206,7 @@ static id _Nullable DecodeAttributeValueForICDManagementCluster(AttributeId aAtt
         return value;
     }
     default: {
+        // Not a known ICDManagement attribute.
         break;
     }
     }
@@ -5217,6 +5252,7 @@ static id _Nullable DecodeAttributeValueForTimerCluster(AttributeId aAttributeId
         return value;
     }
     default: {
+        // Not a known Timer attribute.
         break;
     }
     }
@@ -5374,6 +5410,7 @@ static id _Nullable DecodeAttributeValueForOvenCavityOperationalStateCluster(Att
         return value;
     }
     default: {
+        // Not a known OvenCavityOperationalState attribute.
         break;
     }
     }
@@ -5452,6 +5489,7 @@ static id _Nullable DecodeAttributeValueForOvenModeCluster(AttributeId aAttribut
         return value;
     }
     default: {
+        // Not a known OvenMode attribute.
         break;
     }
     }
@@ -5505,6 +5543,7 @@ static id _Nullable DecodeAttributeValueForLaundryDryerControlsCluster(Attribute
         return value;
     }
     default: {
+        // Not a known LaundryDryerControls attribute.
         break;
     }
     }
@@ -5640,6 +5679,7 @@ static id _Nullable DecodeAttributeValueForModeSelectCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known ModeSelect attribute.
         break;
     }
     }
@@ -5718,6 +5758,7 @@ static id _Nullable DecodeAttributeValueForLaundryWasherModeCluster(AttributeId 
         return value;
     }
     default: {
+        // Not a known LaundryWasherMode attribute.
         break;
     }
     }
@@ -5796,6 +5837,7 @@ static id _Nullable DecodeAttributeValueForRefrigeratorAndTemperatureControlledC
         return value;
     }
     default: {
+        // Not a known RefrigeratorAndTemperatureControlledCabinetMode attribute.
         break;
     }
     }
@@ -5891,6 +5933,7 @@ static id _Nullable DecodeAttributeValueForLaundryWasherControlsCluster(Attribut
         return value;
     }
     default: {
+        // Not a known LaundryWasherControls attribute.
         break;
     }
     }
@@ -5969,6 +6012,7 @@ static id _Nullable DecodeAttributeValueForRVCRunModeCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known RVCRunMode attribute.
         break;
     }
     }
@@ -6047,6 +6091,7 @@ static id _Nullable DecodeAttributeValueForRVCCleanModeCluster(AttributeId aAttr
         return value;
     }
     default: {
+        // Not a known RVCCleanMode attribute.
         break;
     }
     }
@@ -6145,6 +6190,7 @@ static id _Nullable DecodeAttributeValueForTemperatureControlCluster(AttributeId
         return value;
     }
     default: {
+        // Not a known TemperatureControl attribute.
         break;
     }
     }
@@ -6190,6 +6236,7 @@ static id _Nullable DecodeAttributeValueForRefrigeratorAlarmCluster(AttributeId 
         return value;
     }
     default: {
+        // Not a known RefrigeratorAlarm attribute.
         break;
     }
     }
@@ -6268,6 +6315,7 @@ static id _Nullable DecodeAttributeValueForDishwasherModeCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known DishwasherMode attribute.
         break;
     }
     }
@@ -6291,6 +6339,7 @@ static id _Nullable DecodeAttributeValueForAirQualityCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known AirQuality attribute.
         break;
     }
     }
@@ -6446,6 +6495,7 @@ static id _Nullable DecodeAttributeValueForSmokeCOAlarmCluster(AttributeId aAttr
         return value;
     }
     default: {
+        // Not a known SmokeCOAlarm attribute.
         break;
     }
     }
@@ -6502,6 +6552,7 @@ static id _Nullable DecodeAttributeValueForDishwasherAlarmCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known DishwasherAlarm attribute.
         break;
     }
     }
@@ -6580,6 +6631,7 @@ static id _Nullable DecodeAttributeValueForMicrowaveOvenModeCluster(AttributeId 
         return value;
     }
     default: {
+        // Not a known MicrowaveOvenMode attribute.
         break;
     }
     }
@@ -6706,6 +6758,7 @@ static id _Nullable DecodeAttributeValueForMicrowaveOvenControlCluster(Attribute
         return value;
     }
     default: {
+        // Not a known MicrowaveOvenControl attribute.
         break;
     }
     }
@@ -6863,6 +6916,7 @@ static id _Nullable DecodeAttributeValueForOperationalStateCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known OperationalState attribute.
         break;
     }
     }
@@ -7020,6 +7074,7 @@ static id _Nullable DecodeAttributeValueForRVCOperationalStateCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known RVCOperationalState attribute.
         break;
     }
     }
@@ -7075,6 +7130,7 @@ static id _Nullable DecodeAttributeValueForScenesManagementCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known ScenesManagement attribute.
         break;
     }
     }
@@ -7179,6 +7235,7 @@ static id _Nullable DecodeAttributeValueForHEPAFilterMonitoringCluster(Attribute
         return value;
     }
     default: {
+        // Not a known HEPAFilterMonitoring attribute.
         break;
     }
     }
@@ -7283,6 +7340,7 @@ static id _Nullable DecodeAttributeValueForActivatedCarbonFilterMonitoringCluste
         return value;
     }
     default: {
+        // Not a known ActivatedCarbonFilterMonitoring attribute.
         break;
     }
     }
@@ -7383,6 +7441,7 @@ static id _Nullable DecodeAttributeValueForBooleanStateConfigurationCluster(Attr
         return value;
     }
     default: {
+        // Not a known BooleanStateConfiguration attribute.
         break;
     }
     }
@@ -7548,6 +7607,7 @@ static id _Nullable DecodeAttributeValueForValveConfigurationAndControlCluster(A
         return value;
     }
     default: {
+        // Not a known ValveConfigurationAndControl attribute.
         break;
     }
     }
@@ -7996,6 +8056,7 @@ static id _Nullable DecodeAttributeValueForElectricalPowerMeasurementCluster(Att
         return value;
     }
     default: {
+        // Not a known ElectricalPowerMeasurement attribute.
         break;
     }
     }
@@ -8266,6 +8327,7 @@ static id _Nullable DecodeAttributeValueForElectricalEnergyMeasurementCluster(At
         return value;
     }
     default: {
+        // Not a known ElectricalEnergyMeasurement attribute.
         break;
     }
     }
@@ -8344,6 +8406,7 @@ static id _Nullable DecodeAttributeValueForWaterHeaterManagementCluster(Attribut
         return value;
     }
     default: {
+        // Not a known WaterHeaterManagement attribute.
         break;
     }
     }
@@ -8551,6 +8614,7 @@ static id _Nullable DecodeAttributeValueForCommodityPriceCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known CommodityPrice attribute.
         break;
     }
     }
@@ -8922,6 +8986,7 @@ static id _Nullable DecodeAttributeValueForDemandResponseLoadControlCluster(Attr
         return value;
     }
     default: {
+        // Not a known DemandResponseLoadControl attribute.
         break;
     }
     }
@@ -9040,6 +9105,7 @@ static id _Nullable DecodeAttributeValueForMessagesCluster(AttributeId aAttribut
         return value;
     }
     default: {
+        // Not a known Messages attribute.
         break;
     }
     }
@@ -9306,6 +9372,7 @@ static id _Nullable DecodeAttributeValueForDeviceEnergyManagementCluster(Attribu
         return value;
     }
     default: {
+        // Not a known DeviceEnergyManagement attribute.
         break;
     }
     }
@@ -9636,6 +9703,7 @@ static id _Nullable DecodeAttributeValueForEnergyEVSECluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known EnergyEVSE attribute.
         break;
     }
     }
@@ -9770,6 +9838,7 @@ static id _Nullable DecodeAttributeValueForEnergyPreferenceCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known EnergyPreference attribute.
         break;
     }
     }
@@ -9834,6 +9903,7 @@ static id _Nullable DecodeAttributeValueForPowerTopologyCluster(AttributeId aAtt
         return value;
     }
     default: {
+        // Not a known PowerTopology attribute.
         break;
     }
     }
@@ -9912,6 +9982,7 @@ static id _Nullable DecodeAttributeValueForEnergyEVSEModeCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known EnergyEVSEMode attribute.
         break;
     }
     }
@@ -9990,6 +10061,7 @@ static id _Nullable DecodeAttributeValueForWaterHeaterModeCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known WaterHeaterMode attribute.
         break;
     }
     }
@@ -10068,6 +10140,7 @@ static id _Nullable DecodeAttributeValueForDeviceEnergyManagementModeCluster(Att
         return value;
     }
     default: {
+        // Not a known DeviceEnergyManagementMode attribute.
         break;
     }
     }
@@ -10156,6 +10229,7 @@ static id _Nullable DecodeAttributeValueForElectricalGridConditionsCluster(Attri
         return value;
     }
     default: {
+        // Not a known ElectricalGridConditions attribute.
         break;
     }
     }
@@ -10718,6 +10792,7 @@ static id _Nullable DecodeAttributeValueForDoorLockCluster(AttributeId aAttribut
         return value;
     }
     default: {
+        // Not a known DoorLock attribute.
         break;
     }
     }
@@ -11004,6 +11079,7 @@ static id _Nullable DecodeAttributeValueForWindowCoveringCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known WindowCovering attribute.
         break;
     }
     }
@@ -11149,6 +11225,7 @@ static id _Nullable DecodeAttributeValueForClosureControlCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known ClosureControl attribute.
         break;
     }
     }
@@ -11328,6 +11405,7 @@ static id _Nullable DecodeAttributeValueForClosureDimensionCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known ClosureDimension attribute.
         break;
     }
     }
@@ -11540,6 +11618,7 @@ static id _Nullable DecodeAttributeValueForServiceAreaCluster(AttributeId aAttri
         return value;
     }
     default: {
+        // Not a known ServiceArea attribute.
         break;
     }
     }
@@ -11877,6 +11956,7 @@ static id _Nullable DecodeAttributeValueForPumpConfigurationAndControlCluster(At
         return value;
     }
     default: {
+        // Not a known PumpConfigurationAndControl attribute.
         break;
     }
     }
@@ -12774,6 +12854,7 @@ static id _Nullable DecodeAttributeValueForThermostatCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known Thermostat attribute.
         break;
     }
     }
@@ -12926,6 +13007,7 @@ static id _Nullable DecodeAttributeValueForFanControlCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known FanControl attribute.
         break;
     }
     }
@@ -12971,6 +13053,7 @@ static id _Nullable DecodeAttributeValueForThermostatUserInterfaceConfigurationC
         return value;
     }
     default: {
+        // Not a known ThermostatUserInterfaceConfiguration attribute.
         break;
     }
     }
@@ -13604,6 +13687,7 @@ static id _Nullable DecodeAttributeValueForColorControlCluster(AttributeId aAttr
         return value;
     }
     default: {
+        // Not a known ColorControl attribute.
         break;
     }
     }
@@ -13800,6 +13884,7 @@ static id _Nullable DecodeAttributeValueForBallastConfigurationCluster(Attribute
         return value;
     }
     default: {
+        // Not a known BallastConfiguration attribute.
         break;
     }
     }
@@ -13883,6 +13968,7 @@ static id _Nullable DecodeAttributeValueForIlluminanceMeasurementCluster(Attribu
         return value;
     }
     default: {
+        // Not a known IlluminanceMeasurement attribute.
         break;
     }
     }
@@ -13951,6 +14037,7 @@ static id _Nullable DecodeAttributeValueForTemperatureMeasurementCluster(Attribu
         return value;
     }
     default: {
+        // Not a known TemperatureMeasurement attribute.
         break;
     }
     }
@@ -14086,6 +14173,7 @@ static id _Nullable DecodeAttributeValueForPressureMeasurementCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known PressureMeasurement attribute.
         break;
     }
     }
@@ -14154,6 +14242,7 @@ static id _Nullable DecodeAttributeValueForFlowMeasurementCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known FlowMeasurement attribute.
         break;
     }
     }
@@ -14222,6 +14311,7 @@ static id _Nullable DecodeAttributeValueForRelativeHumidityMeasurementCluster(At
         return value;
     }
     default: {
+        // Not a known RelativeHumidityMeasurement attribute.
         break;
     }
     }
@@ -14391,6 +14481,7 @@ static id _Nullable DecodeAttributeValueForOccupancySensingCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known OccupancySensing attribute.
         break;
     }
     }
@@ -14544,6 +14635,7 @@ static id _Nullable DecodeAttributeValueForCarbonMonoxideConcentrationMeasuremen
         return value;
     }
     default: {
+        // Not a known CarbonMonoxideConcentrationMeasurement attribute.
         break;
     }
     }
@@ -14697,6 +14789,7 @@ static id _Nullable DecodeAttributeValueForCarbonDioxideConcentrationMeasurement
         return value;
     }
     default: {
+        // Not a known CarbonDioxideConcentrationMeasurement attribute.
         break;
     }
     }
@@ -14850,6 +14943,7 @@ static id _Nullable DecodeAttributeValueForNitrogenDioxideConcentrationMeasureme
         return value;
     }
     default: {
+        // Not a known NitrogenDioxideConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15003,6 +15097,7 @@ static id _Nullable DecodeAttributeValueForOzoneConcentrationMeasurementCluster(
         return value;
     }
     default: {
+        // Not a known OzoneConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15156,6 +15251,7 @@ static id _Nullable DecodeAttributeValueForPM25ConcentrationMeasurementCluster(A
         return value;
     }
     default: {
+        // Not a known PM25ConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15309,6 +15405,7 @@ static id _Nullable DecodeAttributeValueForFormaldehydeConcentrationMeasurementC
         return value;
     }
     default: {
+        // Not a known FormaldehydeConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15462,6 +15559,7 @@ static id _Nullable DecodeAttributeValueForPM1ConcentrationMeasurementCluster(At
         return value;
     }
     default: {
+        // Not a known PM1ConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15615,6 +15713,7 @@ static id _Nullable DecodeAttributeValueForPM10ConcentrationMeasurementCluster(A
         return value;
     }
     default: {
+        // Not a known PM10ConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15768,6 +15867,7 @@ static id _Nullable DecodeAttributeValueForTotalVolatileOrganicCompoundsConcentr
         return value;
     }
     default: {
+        // Not a known TotalVolatileOrganicCompoundsConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15921,6 +16021,7 @@ static id _Nullable DecodeAttributeValueForRadonConcentrationMeasurementCluster(
         return value;
     }
     default: {
+        // Not a known RadonConcentrationMeasurement attribute.
         break;
     }
     }
@@ -15963,6 +16064,7 @@ static id _Nullable DecodeAttributeValueForWiFiNetworkManagementCluster(Attribut
         return value;
     }
     default: {
+        // Not a known WiFiNetworkManagement attribute.
         break;
     }
     }
@@ -16054,6 +16156,7 @@ static id _Nullable DecodeAttributeValueForThreadBorderRouterManagementCluster(A
         return value;
     }
     default: {
+        // Not a known ThreadBorderRouterManagement attribute.
         break;
     }
     }
@@ -16127,6 +16230,7 @@ static id _Nullable DecodeAttributeValueForThreadNetworkDirectoryCluster(Attribu
         return value;
     }
     default: {
+        // Not a known ThreadNetworkDirectory attribute.
         break;
     }
     }
@@ -16166,6 +16270,7 @@ static id _Nullable DecodeAttributeValueForWakeOnLANCluster(AttributeId aAttribu
         return value;
     }
     default: {
+        // Not a known WakeOnLAN attribute.
         break;
     }
     }
@@ -16355,6 +16460,7 @@ static id _Nullable DecodeAttributeValueForChannelCluster(AttributeId aAttribute
         return value;
     }
     default: {
+        // Not a known Channel attribute.
         break;
     }
     }
@@ -16411,6 +16517,7 @@ static id _Nullable DecodeAttributeValueForTargetNavigatorCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known TargetNavigator attribute.
         break;
     }
     }
@@ -16740,6 +16847,7 @@ static id _Nullable DecodeAttributeValueForMediaPlaybackCluster(AttributeId aAtt
         return value;
     }
     default: {
+        // Not a known MediaPlayback attribute.
         break;
     }
     }
@@ -16803,6 +16911,7 @@ static id _Nullable DecodeAttributeValueForMediaInputCluster(AttributeId aAttrib
         return value;
     }
     default: {
+        // Not a known MediaInput attribute.
         break;
     }
     }
@@ -16815,6 +16924,7 @@ static id _Nullable DecodeAttributeValueForLowPowerCluster(AttributeId aAttribut
     using namespace Clusters::LowPower;
     switch (aAttributeId) {
     default: {
+        // Not a known LowPower attribute.
         break;
     }
     }
@@ -16827,6 +16937,7 @@ static id _Nullable DecodeAttributeValueForKeypadInputCluster(AttributeId aAttri
     using namespace Clusters::KeypadInput;
     switch (aAttributeId) {
     default: {
+        // Not a known KeypadInput attribute.
         break;
     }
     }
@@ -16881,6 +16992,7 @@ static id _Nullable DecodeAttributeValueForContentLauncherCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known ContentLauncher attribute.
         break;
     }
     }
@@ -16938,6 +17050,7 @@ static id _Nullable DecodeAttributeValueForAudioOutputCluster(AttributeId aAttri
         return value;
     }
     default: {
+        // Not a known AudioOutput attribute.
         break;
     }
     }
@@ -17004,6 +17117,7 @@ static id _Nullable DecodeAttributeValueForApplicationLauncherCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known ApplicationLauncher attribute.
         break;
     }
     }
@@ -17141,6 +17255,7 @@ static id _Nullable DecodeAttributeValueForApplicationBasicCluster(AttributeId a
         return value;
     }
     default: {
+        // Not a known ApplicationBasic attribute.
         break;
     }
     }
@@ -17153,6 +17268,7 @@ static id _Nullable DecodeAttributeValueForAccountLoginCluster(AttributeId aAttr
     using namespace Clusters::AccountLogin;
     switch (aAttributeId) {
     default: {
+        // Not a known AccountLogin attribute.
         break;
     }
     }
@@ -17325,6 +17441,7 @@ static id _Nullable DecodeAttributeValueForContentControlCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known ContentControl attribute.
         break;
     }
     }
@@ -17337,6 +17454,7 @@ static id _Nullable DecodeAttributeValueForContentAppObserverCluster(AttributeId
     using namespace Clusters::ContentAppObserver;
     switch (aAttributeId) {
     default: {
+        // Not a known ContentAppObserver attribute.
         break;
     }
     }
@@ -17450,6 +17568,7 @@ static id _Nullable DecodeAttributeValueForZoneManagementCluster(AttributeId aAt
         return value;
     }
     default: {
+        // Not a known ZoneManagement attribute.
         break;
     }
     }
@@ -18193,6 +18312,7 @@ static id _Nullable DecodeAttributeValueForCameraAVStreamManagementCluster(Attri
         return value;
     }
     default: {
+        // Not a known CameraAVStreamManagement attribute.
         break;
     }
     }
@@ -18372,6 +18492,7 @@ static id _Nullable DecodeAttributeValueForCameraAVSettingsUserLevelManagementCl
         return value;
     }
     default: {
+        // Not a known CameraAVSettingsUserLevelManagement attribute.
         break;
     }
     }
@@ -18426,6 +18547,7 @@ static id _Nullable DecodeAttributeValueForWebRTCTransportProviderCluster(Attrib
         return value;
     }
     default: {
+        // Not a known WebRTCTransportProvider attribute.
         break;
     }
     }
@@ -18480,6 +18602,7 @@ static id _Nullable DecodeAttributeValueForWebRTCTransportRequestorCluster(Attri
         return value;
     }
     default: {
+        // Not a known WebRTCTransportRequestor attribute.
         break;
     }
     }
@@ -18540,6 +18663,7 @@ static id _Nullable DecodeAttributeValueForPushAVStreamTransportCluster(Attribut
         return value;
     }
     default: {
+        // Not a known PushAVStreamTransport attribute.
         break;
     }
     }
@@ -18607,6 +18731,7 @@ static id _Nullable DecodeAttributeValueForChimeCluster(AttributeId aAttributeId
         return value;
     }
     default: {
+        // Not a known Chime attribute.
         break;
     }
     }
@@ -19498,6 +19623,7 @@ static id _Nullable DecodeAttributeValueForCommodityTariffCluster(AttributeId aA
         return value;
     }
     default: {
+        // Not a known CommodityTariff attribute.
         break;
     }
     }
@@ -19645,6 +19771,7 @@ static id _Nullable DecodeAttributeValueForEcosystemInformationCluster(Attribute
         return value;
     }
     default: {
+        // Not a known EcosystemInformation attribute.
         break;
     }
     }
@@ -19668,6 +19795,7 @@ static id _Nullable DecodeAttributeValueForCommissionerControlCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known CommissionerControl attribute.
         break;
     }
     }
@@ -19786,6 +19914,7 @@ static id _Nullable DecodeAttributeValueForTLSCertificateManagementCluster(Attri
         return value;
     }
     default: {
+        // Not a known TLSCertificateManagement attribute.
         break;
     }
     }
@@ -19845,6 +19974,7 @@ static id _Nullable DecodeAttributeValueForTLSClientManagementCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known TLSClientManagement attribute.
         break;
     }
     }
@@ -19962,6 +20092,7 @@ static id _Nullable DecodeAttributeValueForMeterIdentificationCluster(AttributeI
         return value;
     }
     default: {
+        // Not a known MeterIdentification attribute.
         break;
     }
     }
@@ -20051,6 +20182,7 @@ static id _Nullable DecodeAttributeValueForCommodityMeteringCluster(AttributeId 
         return value;
     }
     default: {
+        // Not a known CommodityMetering attribute.
         break;
     }
     }
@@ -21617,6 +21749,7 @@ static id _Nullable DecodeAttributeValueForUnitTestingCluster(AttributeId aAttri
         return value;
     }
     default: {
+        // Not a known UnitTesting attribute.
         break;
     }
     }
@@ -21640,6 +21773,7 @@ static id _Nullable DecodeAttributeValueForSampleMEICluster(AttributeId aAttribu
         return value;
     }
     default: {
+        // Not a known SampleMEI attribute.
         break;
     }
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterNames.mm
@@ -480,6 +480,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Identify attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -515,6 +516,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Groups attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -566,6 +568,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OnOff attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -653,6 +656,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LevelControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -684,6 +688,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PulseWidthModulation attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -735,6 +740,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Descriptor attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -770,6 +776,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Binding attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -829,6 +836,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known AccessControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -872,6 +880,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Actions attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -999,6 +1008,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known BasicInformation attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1030,6 +1040,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OTASoftwareUpdateProvider attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1077,6 +1088,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OTASoftwareUpdateRequestor attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1116,6 +1128,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LocalizationConfiguration attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1159,6 +1172,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TimeFormatLocalization attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1194,6 +1208,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known UnitLocalization attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1229,6 +1244,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PowerSourceConfiguration attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1388,6 +1404,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PowerSource attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1459,6 +1476,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known GeneralCommissioning attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1534,6 +1552,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known NetworkCommissioning attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1565,6 +1584,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DiagnosticLogs attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1632,6 +1652,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known GeneralDiagnostics attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1679,6 +1700,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known SoftwareDiagnostics attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -1970,6 +1992,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ThreadNetworkDiagnostics attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2053,6 +2076,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WiFiNetworkDiagnostics attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2120,6 +2144,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known EthernetNetworkDiagnostics attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2203,6 +2228,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TimeSynchronization attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2306,6 +2332,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known BridgedDeviceBasicInformation attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2349,6 +2376,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Switch attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2392,6 +2420,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known AdministratorCommissioning attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2447,6 +2476,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OperationalCredentials attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2494,6 +2524,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known GroupKeyManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2529,6 +2560,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known FixedLabel attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2564,6 +2596,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known UserLabel attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2599,6 +2632,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known BooleanState attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2670,6 +2704,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ICDManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2713,6 +2748,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Timer attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2768,6 +2804,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OvenCavityOperationalState attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2807,6 +2844,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OvenMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2846,6 +2884,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LaundryDryerControls attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2901,6 +2940,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ModeSelect attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2940,6 +2980,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LaundryWasherMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -2979,6 +3020,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RefrigeratorAndTemperatureControlledCabinetMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3026,6 +3068,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LaundryWasherControls attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3065,6 +3108,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RVCRunMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3104,6 +3148,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RVCCleanMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3159,6 +3204,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TemperatureControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3202,6 +3248,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RefrigeratorAlarm attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3241,6 +3288,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DishwasherMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3276,6 +3324,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known AirQuality attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3359,6 +3408,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known SmokeCOAlarm attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3406,6 +3456,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DishwasherAlarm attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3445,6 +3496,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known MicrowaveOvenMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3512,6 +3564,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known MicrowaveOvenControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3567,6 +3620,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OperationalState attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3622,6 +3676,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RVCOperationalState attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3661,6 +3716,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ScenesManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3716,6 +3772,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known HEPAFilterMonitoring attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3771,6 +3828,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ActivatedCarbonFilterMonitoring attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3834,6 +3892,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known BooleanStateConfiguration attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -3909,6 +3968,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ValveConfigurationAndControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4016,6 +4076,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ElectricalPowerMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4071,6 +4132,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ElectricalEnergyMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4126,6 +4188,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WaterHeaterManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4173,6 +4236,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CommodityPrice attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4236,6 +4300,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DemandResponseLoadControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4275,6 +4340,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Messages attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4338,6 +4404,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DeviceEnergyManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4461,6 +4528,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known EnergyEVSE attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4512,6 +4580,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known EnergyPreference attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4551,6 +4620,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PowerTopology attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4590,6 +4660,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known EnergyEVSEMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4629,6 +4700,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WaterHeaterMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4668,6 +4740,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DeviceEnergyManagementMode attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4711,6 +4784,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ElectricalGridConditions attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -4922,6 +4996,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known DoorLock attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5041,6 +5116,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WindowCovering attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5092,6 +5168,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ClosureControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5167,6 +5244,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ClosureDimension attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5222,6 +5300,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ServiceArea attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5345,6 +5424,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PumpConfigurationAndControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5616,6 +5696,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Thermostat attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5695,6 +5776,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known FanControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5738,6 +5820,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ThermostatUserInterfaceConfiguration attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -5977,6 +6060,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ColorControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6064,6 +6148,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known BallastConfiguration attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6115,6 +6200,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known IlluminanceMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6162,6 +6248,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TemperatureMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6229,6 +6316,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PressureMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6276,6 +6364,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known FlowMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6323,6 +6412,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RelativeHumidityMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6410,6 +6500,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OccupancySensing attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6485,6 +6576,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CarbonMonoxideConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6560,6 +6652,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CarbonDioxideConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6635,6 +6728,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known NitrogenDioxideConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6710,6 +6804,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known OzoneConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6785,6 +6880,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PM25ConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6860,6 +6956,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known FormaldehydeConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -6935,6 +7032,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PM1ConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7010,6 +7108,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PM10ConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7085,6 +7184,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TotalVolatileOrganicCompoundsConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7160,6 +7260,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known RadonConcentrationMeasurement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7199,6 +7300,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WiFiNetworkManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7254,6 +7356,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ThreadBorderRouterManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7297,6 +7400,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ThreadNetworkDirectory attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7336,6 +7440,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WakeOnLAN attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7379,6 +7484,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Channel attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7418,6 +7524,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TargetNavigator attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7493,6 +7600,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known MediaPlayback attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7532,6 +7640,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known MediaInput attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7563,6 +7672,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known LowPower attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7594,6 +7704,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known KeypadInput attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7633,6 +7744,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ContentLauncher attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7672,6 +7784,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known AudioOutput attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7711,6 +7824,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ApplicationLauncher attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7774,6 +7888,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ApplicationBasic attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7805,6 +7920,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known AccountLogin attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7868,6 +7984,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ContentControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7899,6 +8016,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ContentAppObserver attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -7946,6 +8064,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known ZoneManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8141,6 +8260,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CameraAVStreamManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8208,6 +8328,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CameraAVSettingsUserLevelManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8243,6 +8364,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WebRTCTransportProvider attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8278,6 +8400,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known WebRTCTransportRequestor attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8321,6 +8444,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known PushAVStreamTransport attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8364,6 +8488,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known Chime attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8471,6 +8596,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CommodityTariff attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8510,6 +8636,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known EcosystemInformation attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8545,6 +8672,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CommissionerControl attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8592,6 +8720,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TLSCertificateManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8631,6 +8760,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known TLSClientManagement attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8682,6 +8812,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known MeterIdentification attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -8725,6 +8856,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known CommodityMetering attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -9112,6 +9244,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known UnitTesting attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }
@@ -9147,6 +9280,7 @@ NSString * MTRAttributeNameForID(MTRClusterIDType clusterID, MTRAttributeIDType 
             break;
 
         default:
+            // Not a known SampleMEI attribute.
             result = [NSString stringWithFormat:@"<Unknown attributeID %u>", attributeID];
             break;
         }

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -39,6 +39,7 @@ static id _Nullable DecodeEventPayloadForIdentifyCluster(EventId aEventId, TLV::
     using namespace Clusters::Identify;
     switch (aEventId) {
     default: {
+        // Not a known Identify event.
         break;
     }
     }
@@ -51,6 +52,7 @@ static id _Nullable DecodeEventPayloadForGroupsCluster(EventId aEventId, TLV::TL
     using namespace Clusters::Groups;
     switch (aEventId) {
     default: {
+        // Not a known Groups event.
         break;
     }
     }
@@ -63,6 +65,7 @@ static id _Nullable DecodeEventPayloadForOnOffCluster(EventId aEventId, TLV::TLV
     using namespace Clusters::OnOff;
     switch (aEventId) {
     default: {
+        // Not a known OnOff event.
         break;
     }
     }
@@ -75,6 +78,7 @@ static id _Nullable DecodeEventPayloadForLevelControlCluster(EventId aEventId, T
     using namespace Clusters::LevelControl;
     switch (aEventId) {
     default: {
+        // Not a known LevelControl event.
         break;
     }
     }
@@ -87,6 +91,7 @@ static id _Nullable DecodeEventPayloadForPulseWidthModulationCluster(EventId aEv
     using namespace Clusters::PulseWidthModulation;
     switch (aEventId) {
     default: {
+        // Not a known PulseWidthModulation event.
         break;
     }
     }
@@ -99,6 +104,7 @@ static id _Nullable DecodeEventPayloadForDescriptorCluster(EventId aEventId, TLV
     using namespace Clusters::Descriptor;
     switch (aEventId) {
     default: {
+        // Not a known Descriptor event.
         break;
     }
     }
@@ -111,6 +117,7 @@ static id _Nullable DecodeEventPayloadForBindingCluster(EventId aEventId, TLV::T
     using namespace Clusters::Binding;
     switch (aEventId) {
     default: {
+        // Not a known Binding event.
         break;
     }
     }
@@ -331,6 +338,7 @@ static id _Nullable DecodeEventPayloadForAccessControlCluster(EventId aEventId, 
         return value;
     }
     default: {
+        // Not a known AccessControl event.
         break;
     }
     }
@@ -402,6 +410,7 @@ static id _Nullable DecodeEventPayloadForActionsCluster(EventId aEventId, TLV::T
         return value;
     }
     default: {
+        // Not a known Actions event.
         break;
     }
     }
@@ -476,6 +485,7 @@ static id _Nullable DecodeEventPayloadForBasicInformationCluster(EventId aEventI
         return value;
     }
     default: {
+        // Not a known BasicInformation event.
         break;
     }
     }
@@ -488,6 +498,7 @@ static id _Nullable DecodeEventPayloadForOTASoftwareUpdateProviderCluster(EventI
     using namespace Clusters::OtaSoftwareUpdateProvider;
     switch (aEventId) {
     default: {
+        // Not a known OTASoftwareUpdateProvider event.
         break;
     }
     }
@@ -598,6 +609,7 @@ static id _Nullable DecodeEventPayloadForOTASoftwareUpdateRequestorCluster(Event
         return value;
     }
     default: {
+        // Not a known OTASoftwareUpdateRequestor event.
         break;
     }
     }
@@ -610,6 +622,7 @@ static id _Nullable DecodeEventPayloadForLocalizationConfigurationCluster(EventI
     using namespace Clusters::LocalizationConfiguration;
     switch (aEventId) {
     default: {
+        // Not a known LocalizationConfiguration event.
         break;
     }
     }
@@ -622,6 +635,7 @@ static id _Nullable DecodeEventPayloadForTimeFormatLocalizationCluster(EventId a
     using namespace Clusters::TimeFormatLocalization;
     switch (aEventId) {
     default: {
+        // Not a known TimeFormatLocalization event.
         break;
     }
     }
@@ -634,6 +648,7 @@ static id _Nullable DecodeEventPayloadForUnitLocalizationCluster(EventId aEventI
     using namespace Clusters::UnitLocalization;
     switch (aEventId) {
     default: {
+        // Not a known UnitLocalization event.
         break;
     }
     }
@@ -646,6 +661,7 @@ static id _Nullable DecodeEventPayloadForPowerSourceConfigurationCluster(EventId
     using namespace Clusters::PowerSourceConfiguration;
     switch (aEventId) {
     default: {
+        // Not a known PowerSourceConfiguration event.
         break;
     }
     }
@@ -814,6 +830,7 @@ static id _Nullable DecodeEventPayloadForPowerSourceCluster(EventId aEventId, TL
         return value;
     }
     default: {
+        // Not a known PowerSource event.
         break;
     }
     }
@@ -826,6 +843,7 @@ static id _Nullable DecodeEventPayloadForGeneralCommissioningCluster(EventId aEv
     using namespace Clusters::GeneralCommissioning;
     switch (aEventId) {
     default: {
+        // Not a known GeneralCommissioning event.
         break;
     }
     }
@@ -838,6 +856,7 @@ static id _Nullable DecodeEventPayloadForNetworkCommissioningCluster(EventId aEv
     using namespace Clusters::NetworkCommissioning;
     switch (aEventId) {
     default: {
+        // Not a known NetworkCommissioning event.
         break;
     }
     }
@@ -850,6 +869,7 @@ static id _Nullable DecodeEventPayloadForDiagnosticLogsCluster(EventId aEventId,
     using namespace Clusters::DiagnosticLogs;
     switch (aEventId) {
     default: {
+        // Not a known DiagnosticLogs event.
         break;
     }
     }
@@ -1035,6 +1055,7 @@ static id _Nullable DecodeEventPayloadForGeneralDiagnosticsCluster(EventId aEven
         return value;
     }
     default: {
+        // Not a known GeneralDiagnostics event.
         break;
     }
     }
@@ -1087,6 +1108,7 @@ static id _Nullable DecodeEventPayloadForSoftwareDiagnosticsCluster(EventId aEve
         return value;
     }
     default: {
+        // Not a known SoftwareDiagnostics event.
         break;
     }
     }
@@ -1168,6 +1190,7 @@ static id _Nullable DecodeEventPayloadForThreadNetworkDiagnosticsCluster(EventId
         return value;
     }
     default: {
+        // Not a known ThreadNetworkDiagnostics event.
         break;
     }
     }
@@ -1236,6 +1259,7 @@ static id _Nullable DecodeEventPayloadForWiFiNetworkDiagnosticsCluster(EventId a
         return value;
     }
     default: {
+        // Not a known WiFiNetworkDiagnostics event.
         break;
     }
     }
@@ -1248,6 +1272,7 @@ static id _Nullable DecodeEventPayloadForEthernetNetworkDiagnosticsCluster(Event
     using namespace Clusters::EthernetNetworkDiagnostics;
     switch (aEventId) {
     default: {
+        // Not a known EthernetNetworkDiagnostics event.
         break;
     }
     }
@@ -1341,6 +1366,7 @@ static id _Nullable DecodeEventPayloadForTimeSynchronizationCluster(EventId aEve
         return value;
     }
     default: {
+        // Not a known TimeSynchronization event.
         break;
     }
     }
@@ -1426,6 +1452,7 @@ static id _Nullable DecodeEventPayloadForBridgedDeviceBasicInformationCluster(Ev
         return value;
     }
     default: {
+        // Not a known BridgedDeviceBasicInformation event.
         break;
     }
     }
@@ -1567,6 +1594,7 @@ static id _Nullable DecodeEventPayloadForSwitchCluster(EventId aEventId, TLV::TL
         return value;
     }
     default: {
+        // Not a known Switch event.
         break;
     }
     }
@@ -1579,6 +1607,7 @@ static id _Nullable DecodeEventPayloadForAdministratorCommissioningCluster(Event
     using namespace Clusters::AdministratorCommissioning;
     switch (aEventId) {
     default: {
+        // Not a known AdministratorCommissioning event.
         break;
     }
     }
@@ -1591,6 +1620,7 @@ static id _Nullable DecodeEventPayloadForOperationalCredentialsCluster(EventId a
     using namespace Clusters::OperationalCredentials;
     switch (aEventId) {
     default: {
+        // Not a known OperationalCredentials event.
         break;
     }
     }
@@ -1603,6 +1633,7 @@ static id _Nullable DecodeEventPayloadForGroupKeyManagementCluster(EventId aEven
     using namespace Clusters::GroupKeyManagement;
     switch (aEventId) {
     default: {
+        // Not a known GroupKeyManagement event.
         break;
     }
     }
@@ -1615,6 +1646,7 @@ static id _Nullable DecodeEventPayloadForFixedLabelCluster(EventId aEventId, TLV
     using namespace Clusters::FixedLabel;
     switch (aEventId) {
     default: {
+        // Not a known FixedLabel event.
         break;
     }
     }
@@ -1627,6 +1659,7 @@ static id _Nullable DecodeEventPayloadForUserLabelCluster(EventId aEventId, TLV:
     using namespace Clusters::UserLabel;
     switch (aEventId) {
     default: {
+        // Not a known UserLabel event.
         break;
     }
     }
@@ -1656,6 +1689,7 @@ static id _Nullable DecodeEventPayloadForBooleanStateCluster(EventId aEventId, T
         return value;
     }
     default: {
+        // Not a known BooleanState event.
         break;
     }
     }
@@ -1668,6 +1702,7 @@ static id _Nullable DecodeEventPayloadForICDManagementCluster(EventId aEventId, 
     using namespace Clusters::IcdManagement;
     switch (aEventId) {
     default: {
+        // Not a known ICDManagement event.
         break;
     }
     }
@@ -1680,6 +1715,7 @@ static id _Nullable DecodeEventPayloadForTimerCluster(EventId aEventId, TLV::TLV
     using namespace Clusters::Timer;
     switch (aEventId) {
     default: {
+        // Not a known Timer event.
         break;
     }
     }
@@ -1773,6 +1809,7 @@ static id _Nullable DecodeEventPayloadForOvenCavityOperationalStateCluster(Event
         return value;
     }
     default: {
+        // Not a known OvenCavityOperationalState event.
         break;
     }
     }
@@ -1785,6 +1822,7 @@ static id _Nullable DecodeEventPayloadForOvenModeCluster(EventId aEventId, TLV::
     using namespace Clusters::OvenMode;
     switch (aEventId) {
     default: {
+        // Not a known OvenMode event.
         break;
     }
     }
@@ -1797,6 +1835,7 @@ static id _Nullable DecodeEventPayloadForLaundryDryerControlsCluster(EventId aEv
     using namespace Clusters::LaundryDryerControls;
     switch (aEventId) {
     default: {
+        // Not a known LaundryDryerControls event.
         break;
     }
     }
@@ -1809,6 +1848,7 @@ static id _Nullable DecodeEventPayloadForModeSelectCluster(EventId aEventId, TLV
     using namespace Clusters::ModeSelect;
     switch (aEventId) {
     default: {
+        // Not a known ModeSelect event.
         break;
     }
     }
@@ -1821,6 +1861,7 @@ static id _Nullable DecodeEventPayloadForLaundryWasherModeCluster(EventId aEvent
     using namespace Clusters::LaundryWasherMode;
     switch (aEventId) {
     default: {
+        // Not a known LaundryWasherMode event.
         break;
     }
     }
@@ -1833,6 +1874,7 @@ static id _Nullable DecodeEventPayloadForRefrigeratorAndTemperatureControlledCab
     using namespace Clusters::RefrigeratorAndTemperatureControlledCabinetMode;
     switch (aEventId) {
     default: {
+        // Not a known RefrigeratorAndTemperatureControlledCabinetMode event.
         break;
     }
     }
@@ -1845,6 +1887,7 @@ static id _Nullable DecodeEventPayloadForLaundryWasherControlsCluster(EventId aE
     using namespace Clusters::LaundryWasherControls;
     switch (aEventId) {
     default: {
+        // Not a known LaundryWasherControls event.
         break;
     }
     }
@@ -1857,6 +1900,7 @@ static id _Nullable DecodeEventPayloadForRVCRunModeCluster(EventId aEventId, TLV
     using namespace Clusters::RvcRunMode;
     switch (aEventId) {
     default: {
+        // Not a known RVCRunMode event.
         break;
     }
     }
@@ -1869,6 +1913,7 @@ static id _Nullable DecodeEventPayloadForRVCCleanModeCluster(EventId aEventId, T
     using namespace Clusters::RvcCleanMode;
     switch (aEventId) {
     default: {
+        // Not a known RVCCleanMode event.
         break;
     }
     }
@@ -1881,6 +1926,7 @@ static id _Nullable DecodeEventPayloadForTemperatureControlCluster(EventId aEven
     using namespace Clusters::TemperatureControl;
     switch (aEventId) {
     default: {
+        // Not a known TemperatureControl event.
         break;
     }
     }
@@ -1925,6 +1971,7 @@ static id _Nullable DecodeEventPayloadForRefrigeratorAlarmCluster(EventId aEvent
         return value;
     }
     default: {
+        // Not a known RefrigeratorAlarm event.
         break;
     }
     }
@@ -1937,6 +1984,7 @@ static id _Nullable DecodeEventPayloadForDishwasherModeCluster(EventId aEventId,
     using namespace Clusters::DishwasherMode;
     switch (aEventId) {
     default: {
+        // Not a known DishwasherMode event.
         break;
     }
     }
@@ -1949,6 +1997,7 @@ static id _Nullable DecodeEventPayloadForAirQualityCluster(EventId aEventId, TLV
     using namespace Clusters::AirQuality;
     switch (aEventId) {
     default: {
+        // Not a known AirQuality event.
         break;
     }
     }
@@ -2112,6 +2161,7 @@ static id _Nullable DecodeEventPayloadForSmokeCOAlarmCluster(EventId aEventId, T
         return value;
     }
     default: {
+        // Not a known SmokeCOAlarm event.
         break;
     }
     }
@@ -2156,6 +2206,7 @@ static id _Nullable DecodeEventPayloadForDishwasherAlarmCluster(EventId aEventId
         return value;
     }
     default: {
+        // Not a known DishwasherAlarm event.
         break;
     }
     }
@@ -2168,6 +2219,7 @@ static id _Nullable DecodeEventPayloadForMicrowaveOvenModeCluster(EventId aEvent
     using namespace Clusters::MicrowaveOvenMode;
     switch (aEventId) {
     default: {
+        // Not a known MicrowaveOvenMode event.
         break;
     }
     }
@@ -2180,6 +2232,7 @@ static id _Nullable DecodeEventPayloadForMicrowaveOvenControlCluster(EventId aEv
     using namespace Clusters::MicrowaveOvenControl;
     switch (aEventId) {
     default: {
+        // Not a known MicrowaveOvenControl event.
         break;
     }
     }
@@ -2273,6 +2326,7 @@ static id _Nullable DecodeEventPayloadForOperationalStateCluster(EventId aEventI
         return value;
     }
     default: {
+        // Not a known OperationalState event.
         break;
     }
     }
@@ -2366,6 +2420,7 @@ static id _Nullable DecodeEventPayloadForRVCOperationalStateCluster(EventId aEve
         return value;
     }
     default: {
+        // Not a known RVCOperationalState event.
         break;
     }
     }
@@ -2378,6 +2433,7 @@ static id _Nullable DecodeEventPayloadForScenesManagementCluster(EventId aEventI
     using namespace Clusters::ScenesManagement;
     switch (aEventId) {
     default: {
+        // Not a known ScenesManagement event.
         break;
     }
     }
@@ -2390,6 +2446,7 @@ static id _Nullable DecodeEventPayloadForHEPAFilterMonitoringCluster(EventId aEv
     using namespace Clusters::HepaFilterMonitoring;
     switch (aEventId) {
     default: {
+        // Not a known HEPAFilterMonitoring event.
         break;
     }
     }
@@ -2402,6 +2459,7 @@ static id _Nullable DecodeEventPayloadForActivatedCarbonFilterMonitoringCluster(
     using namespace Clusters::ActivatedCarbonFilterMonitoring;
     switch (aEventId) {
     default: {
+        // Not a known ActivatedCarbonFilterMonitoring event.
         break;
     }
     }
@@ -2457,6 +2515,7 @@ static id _Nullable DecodeEventPayloadForBooleanStateConfigurationCluster(EventI
         return value;
     }
     default: {
+        // Not a known BooleanStateConfiguration event.
         break;
     }
     }
@@ -2512,6 +2571,7 @@ static id _Nullable DecodeEventPayloadForValveConfigurationAndControlCluster(Eve
         return value;
     }
     default: {
+        // Not a known ValveConfigurationAndControl event.
         break;
     }
     }
@@ -2599,6 +2659,7 @@ static id _Nullable DecodeEventPayloadForElectricalPowerMeasurementCluster(Event
         return value;
     }
     default: {
+        // Not a known ElectricalPowerMeasurement event.
         break;
     }
     }
@@ -2755,6 +2816,7 @@ static id _Nullable DecodeEventPayloadForElectricalEnergyMeasurementCluster(Even
         return value;
     }
     default: {
+        // Not a known ElectricalEnergyMeasurement event.
         break;
     }
     }
@@ -2821,6 +2883,7 @@ static id _Nullable DecodeEventPayloadForWaterHeaterManagementCluster(EventId aE
         return value;
     }
     default: {
+        // Not a known WaterHeaterManagement event.
         break;
     }
     }
@@ -3016,6 +3079,7 @@ static id _Nullable DecodeEventPayloadForCommodityPriceCluster(EventId aEventId,
         return value;
     }
     default: {
+        // Not a known CommodityPrice event.
         break;
     }
     }
@@ -3174,6 +3238,7 @@ static id _Nullable DecodeEventPayloadForDemandResponseLoadControlCluster(EventI
         return value;
     }
     default: {
+        // Not a known DemandResponseLoadControl event.
         break;
     }
     }
@@ -3277,6 +3342,7 @@ static id _Nullable DecodeEventPayloadForMessagesCluster(EventId aEventId, TLV::
         return value;
     }
     default: {
+        // Not a known Messages event.
         break;
     }
     }
@@ -3355,6 +3421,7 @@ static id _Nullable DecodeEventPayloadForDeviceEnergyManagementCluster(EventId a
         return value;
     }
     default: {
+        // Not a known DeviceEnergyManagement event.
         break;
     }
     }
@@ -3555,6 +3622,7 @@ static id _Nullable DecodeEventPayloadForEnergyEVSECluster(EventId aEventId, TLV
         return value;
     }
     default: {
+        // Not a known EnergyEVSE event.
         break;
     }
     }
@@ -3567,6 +3635,7 @@ static id _Nullable DecodeEventPayloadForEnergyPreferenceCluster(EventId aEventI
     using namespace Clusters::EnergyPreference;
     switch (aEventId) {
     default: {
+        // Not a known EnergyPreference event.
         break;
     }
     }
@@ -3579,6 +3648,7 @@ static id _Nullable DecodeEventPayloadForPowerTopologyCluster(EventId aEventId, 
     using namespace Clusters::PowerTopology;
     switch (aEventId) {
     default: {
+        // Not a known PowerTopology event.
         break;
     }
     }
@@ -3591,6 +3661,7 @@ static id _Nullable DecodeEventPayloadForEnergyEVSEModeCluster(EventId aEventId,
     using namespace Clusters::EnergyEvseMode;
     switch (aEventId) {
     default: {
+        // Not a known EnergyEVSEMode event.
         break;
     }
     }
@@ -3603,6 +3674,7 @@ static id _Nullable DecodeEventPayloadForWaterHeaterModeCluster(EventId aEventId
     using namespace Clusters::WaterHeaterMode;
     switch (aEventId) {
     default: {
+        // Not a known WaterHeaterMode event.
         break;
     }
     }
@@ -3615,6 +3687,7 @@ static id _Nullable DecodeEventPayloadForDeviceEnergyManagementModeCluster(Event
     using namespace Clusters::DeviceEnergyManagementMode;
     switch (aEventId) {
     default: {
+        // Not a known DeviceEnergyManagementMode event.
         break;
     }
     }
@@ -3704,6 +3777,7 @@ static id _Nullable DecodeEventPayloadForElectricalGridConditionsCluster(EventId
         return value;
     }
     default: {
+        // Not a known ElectricalGridConditions event.
         break;
     }
     }
@@ -3976,6 +4050,7 @@ static id _Nullable DecodeEventPayloadForDoorLockCluster(EventId aEventId, TLV::
         return value;
     }
     default: {
+        // Not a known DoorLock event.
         break;
     }
     }
@@ -3988,6 +4063,7 @@ static id _Nullable DecodeEventPayloadForWindowCoveringCluster(EventId aEventId,
     using namespace Clusters::WindowCovering;
     switch (aEventId) {
     default: {
+        // Not a known WindowCovering event.
         break;
     }
     }
@@ -4077,6 +4153,7 @@ static id _Nullable DecodeEventPayloadForClosureControlCluster(EventId aEventId,
         return value;
     }
     default: {
+        // Not a known ClosureControl event.
         break;
     }
     }
@@ -4089,6 +4166,7 @@ static id _Nullable DecodeEventPayloadForClosureDimensionCluster(EventId aEventI
     using namespace Clusters::ClosureDimension;
     switch (aEventId) {
     default: {
+        // Not a known ClosureDimension event.
         break;
     }
     }
@@ -4101,6 +4179,7 @@ static id _Nullable DecodeEventPayloadForServiceAreaCluster(EventId aEventId, TL
     using namespace Clusters::ServiceArea;
     switch (aEventId) {
     default: {
+        // Not a known ServiceArea event.
         break;
     }
     }
@@ -4300,6 +4379,7 @@ static id _Nullable DecodeEventPayloadForPumpConfigurationAndControlCluster(Even
         return value;
     }
     default: {
+        // Not a known PumpConfigurationAndControl event.
         break;
     }
     }
@@ -4312,6 +4392,7 @@ static id _Nullable DecodeEventPayloadForThermostatCluster(EventId aEventId, TLV
     using namespace Clusters::Thermostat;
     switch (aEventId) {
     default: {
+        // Not a known Thermostat event.
         break;
     }
     }
@@ -4324,6 +4405,7 @@ static id _Nullable DecodeEventPayloadForFanControlCluster(EventId aEventId, TLV
     using namespace Clusters::FanControl;
     switch (aEventId) {
     default: {
+        // Not a known FanControl event.
         break;
     }
     }
@@ -4336,6 +4418,7 @@ static id _Nullable DecodeEventPayloadForThermostatUserInterfaceConfigurationClu
     using namespace Clusters::ThermostatUserInterfaceConfiguration;
     switch (aEventId) {
     default: {
+        // Not a known ThermostatUserInterfaceConfiguration event.
         break;
     }
     }
@@ -4348,6 +4431,7 @@ static id _Nullable DecodeEventPayloadForColorControlCluster(EventId aEventId, T
     using namespace Clusters::ColorControl;
     switch (aEventId) {
     default: {
+        // Not a known ColorControl event.
         break;
     }
     }
@@ -4360,6 +4444,7 @@ static id _Nullable DecodeEventPayloadForBallastConfigurationCluster(EventId aEv
     using namespace Clusters::BallastConfiguration;
     switch (aEventId) {
     default: {
+        // Not a known BallastConfiguration event.
         break;
     }
     }
@@ -4372,6 +4457,7 @@ static id _Nullable DecodeEventPayloadForIlluminanceMeasurementCluster(EventId a
     using namespace Clusters::IlluminanceMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known IlluminanceMeasurement event.
         break;
     }
     }
@@ -4384,6 +4470,7 @@ static id _Nullable DecodeEventPayloadForTemperatureMeasurementCluster(EventId a
     using namespace Clusters::TemperatureMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known TemperatureMeasurement event.
         break;
     }
     }
@@ -4396,6 +4483,7 @@ static id _Nullable DecodeEventPayloadForPressureMeasurementCluster(EventId aEve
     using namespace Clusters::PressureMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known PressureMeasurement event.
         break;
     }
     }
@@ -4408,6 +4496,7 @@ static id _Nullable DecodeEventPayloadForFlowMeasurementCluster(EventId aEventId
     using namespace Clusters::FlowMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known FlowMeasurement event.
         break;
     }
     }
@@ -4420,6 +4509,7 @@ static id _Nullable DecodeEventPayloadForRelativeHumidityMeasurementCluster(Even
     using namespace Clusters::RelativeHumidityMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known RelativeHumidityMeasurement event.
         break;
     }
     }
@@ -4449,6 +4539,7 @@ static id _Nullable DecodeEventPayloadForOccupancySensingCluster(EventId aEventI
         return value;
     }
     default: {
+        // Not a known OccupancySensing event.
         break;
     }
     }
@@ -4461,6 +4552,7 @@ static id _Nullable DecodeEventPayloadForCarbonMonoxideConcentrationMeasurementC
     using namespace Clusters::CarbonMonoxideConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known CarbonMonoxideConcentrationMeasurement event.
         break;
     }
     }
@@ -4473,6 +4565,7 @@ static id _Nullable DecodeEventPayloadForCarbonDioxideConcentrationMeasurementCl
     using namespace Clusters::CarbonDioxideConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known CarbonDioxideConcentrationMeasurement event.
         break;
     }
     }
@@ -4485,6 +4578,7 @@ static id _Nullable DecodeEventPayloadForNitrogenDioxideConcentrationMeasurement
     using namespace Clusters::NitrogenDioxideConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known NitrogenDioxideConcentrationMeasurement event.
         break;
     }
     }
@@ -4497,6 +4591,7 @@ static id _Nullable DecodeEventPayloadForOzoneConcentrationMeasurementCluster(Ev
     using namespace Clusters::OzoneConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known OzoneConcentrationMeasurement event.
         break;
     }
     }
@@ -4509,6 +4604,7 @@ static id _Nullable DecodeEventPayloadForPM25ConcentrationMeasurementCluster(Eve
     using namespace Clusters::Pm25ConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known PM25ConcentrationMeasurement event.
         break;
     }
     }
@@ -4521,6 +4617,7 @@ static id _Nullable DecodeEventPayloadForFormaldehydeConcentrationMeasurementClu
     using namespace Clusters::FormaldehydeConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known FormaldehydeConcentrationMeasurement event.
         break;
     }
     }
@@ -4533,6 +4630,7 @@ static id _Nullable DecodeEventPayloadForPM1ConcentrationMeasurementCluster(Even
     using namespace Clusters::Pm1ConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known PM1ConcentrationMeasurement event.
         break;
     }
     }
@@ -4545,6 +4643,7 @@ static id _Nullable DecodeEventPayloadForPM10ConcentrationMeasurementCluster(Eve
     using namespace Clusters::Pm10ConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known PM10ConcentrationMeasurement event.
         break;
     }
     }
@@ -4557,6 +4656,7 @@ static id _Nullable DecodeEventPayloadForTotalVolatileOrganicCompoundsConcentrat
     using namespace Clusters::TotalVolatileOrganicCompoundsConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known TotalVolatileOrganicCompoundsConcentrationMeasurement event.
         break;
     }
     }
@@ -4569,6 +4669,7 @@ static id _Nullable DecodeEventPayloadForRadonConcentrationMeasurementCluster(Ev
     using namespace Clusters::RadonConcentrationMeasurement;
     switch (aEventId) {
     default: {
+        // Not a known RadonConcentrationMeasurement event.
         break;
     }
     }
@@ -4581,6 +4682,7 @@ static id _Nullable DecodeEventPayloadForWiFiNetworkManagementCluster(EventId aE
     using namespace Clusters::WiFiNetworkManagement;
     switch (aEventId) {
     default: {
+        // Not a known WiFiNetworkManagement event.
         break;
     }
     }
@@ -4593,6 +4695,7 @@ static id _Nullable DecodeEventPayloadForThreadBorderRouterManagementCluster(Eve
     using namespace Clusters::ThreadBorderRouterManagement;
     switch (aEventId) {
     default: {
+        // Not a known ThreadBorderRouterManagement event.
         break;
     }
     }
@@ -4605,6 +4708,7 @@ static id _Nullable DecodeEventPayloadForThreadNetworkDirectoryCluster(EventId a
     using namespace Clusters::ThreadNetworkDirectory;
     switch (aEventId) {
     default: {
+        // Not a known ThreadNetworkDirectory event.
         break;
     }
     }
@@ -4617,6 +4721,7 @@ static id _Nullable DecodeEventPayloadForWakeOnLANCluster(EventId aEventId, TLV:
     using namespace Clusters::WakeOnLan;
     switch (aEventId) {
     default: {
+        // Not a known WakeOnLAN event.
         break;
     }
     }
@@ -4629,6 +4734,7 @@ static id _Nullable DecodeEventPayloadForChannelCluster(EventId aEventId, TLV::T
     using namespace Clusters::Channel;
     switch (aEventId) {
     default: {
+        // Not a known Channel event.
         break;
     }
     }
@@ -4690,6 +4796,7 @@ static id _Nullable DecodeEventPayloadForTargetNavigatorCluster(EventId aEventId
         return value;
     }
     default: {
+        // Not a known TargetNavigator event.
         break;
     }
     }
@@ -4769,6 +4876,7 @@ static id _Nullable DecodeEventPayloadForMediaPlaybackCluster(EventId aEventId, 
         return value;
     }
     default: {
+        // Not a known MediaPlayback event.
         break;
     }
     }
@@ -4781,6 +4889,7 @@ static id _Nullable DecodeEventPayloadForMediaInputCluster(EventId aEventId, TLV
     using namespace Clusters::MediaInput;
     switch (aEventId) {
     default: {
+        // Not a known MediaInput event.
         break;
     }
     }
@@ -4793,6 +4902,7 @@ static id _Nullable DecodeEventPayloadForLowPowerCluster(EventId aEventId, TLV::
     using namespace Clusters::LowPower;
     switch (aEventId) {
     default: {
+        // Not a known LowPower event.
         break;
     }
     }
@@ -4805,6 +4915,7 @@ static id _Nullable DecodeEventPayloadForKeypadInputCluster(EventId aEventId, TL
     using namespace Clusters::KeypadInput;
     switch (aEventId) {
     default: {
+        // Not a known KeypadInput event.
         break;
     }
     }
@@ -4817,6 +4928,7 @@ static id _Nullable DecodeEventPayloadForContentLauncherCluster(EventId aEventId
     using namespace Clusters::ContentLauncher;
     switch (aEventId) {
     default: {
+        // Not a known ContentLauncher event.
         break;
     }
     }
@@ -4829,6 +4941,7 @@ static id _Nullable DecodeEventPayloadForAudioOutputCluster(EventId aEventId, TL
     using namespace Clusters::AudioOutput;
     switch (aEventId) {
     default: {
+        // Not a known AudioOutput event.
         break;
     }
     }
@@ -4841,6 +4954,7 @@ static id _Nullable DecodeEventPayloadForApplicationLauncherCluster(EventId aEve
     using namespace Clusters::ApplicationLauncher;
     switch (aEventId) {
     default: {
+        // Not a known ApplicationLauncher event.
         break;
     }
     }
@@ -4853,6 +4967,7 @@ static id _Nullable DecodeEventPayloadForApplicationBasicCluster(EventId aEventI
     using namespace Clusters::ApplicationBasic;
     switch (aEventId) {
     default: {
+        // Not a known ApplicationBasic event.
         break;
     }
     }
@@ -4891,6 +5006,7 @@ static id _Nullable DecodeEventPayloadForAccountLoginCluster(EventId aEventId, T
         return value;
     }
     default: {
+        // Not a known AccountLogin event.
         break;
     }
     }
@@ -4914,6 +5030,7 @@ static id _Nullable DecodeEventPayloadForContentControlCluster(EventId aEventId,
         return value;
     }
     default: {
+        // Not a known ContentControl event.
         break;
     }
     }
@@ -4926,6 +5043,7 @@ static id _Nullable DecodeEventPayloadForContentAppObserverCluster(EventId aEven
     using namespace Clusters::ContentAppObserver;
     switch (aEventId) {
     default: {
+        // Not a known ContentAppObserver event.
         break;
     }
     }
@@ -5012,6 +5130,7 @@ static id _Nullable DecodeEventPayloadForZoneManagementCluster(EventId aEventId,
         return value;
     }
     default: {
+        // Not a known ZoneManagement event.
         break;
     }
     }
@@ -5024,6 +5143,7 @@ static id _Nullable DecodeEventPayloadForCameraAVStreamManagementCluster(EventId
     using namespace Clusters::CameraAvStreamManagement;
     switch (aEventId) {
     default: {
+        // Not a known CameraAVStreamManagement event.
         break;
     }
     }
@@ -5036,6 +5156,7 @@ static id _Nullable DecodeEventPayloadForCameraAVSettingsUserLevelManagementClus
     using namespace Clusters::CameraAvSettingsUserLevelManagement;
     switch (aEventId) {
     default: {
+        // Not a known CameraAVSettingsUserLevelManagement event.
         break;
     }
     }
@@ -5048,6 +5169,7 @@ static id _Nullable DecodeEventPayloadForWebRTCTransportProviderCluster(EventId 
     using namespace Clusters::WebRTCTransportProvider;
     switch (aEventId) {
     default: {
+        // Not a known WebRTCTransportProvider event.
         break;
     }
     }
@@ -5060,6 +5182,7 @@ static id _Nullable DecodeEventPayloadForWebRTCTransportRequestorCluster(EventId
     using namespace Clusters::WebRTCTransportRequestor;
     switch (aEventId) {
     default: {
+        // Not a known WebRTCTransportRequestor event.
         break;
     }
     }
@@ -5134,6 +5257,7 @@ static id _Nullable DecodeEventPayloadForPushAVStreamTransportCluster(EventId aE
         return value;
     }
     default: {
+        // Not a known PushAVStreamTransport event.
         break;
     }
     }
@@ -5146,6 +5270,7 @@ static id _Nullable DecodeEventPayloadForChimeCluster(EventId aEventId, TLV::TLV
     using namespace Clusters::Chime;
     switch (aEventId) {
     default: {
+        // Not a known Chime event.
         break;
     }
     }
@@ -5158,6 +5283,7 @@ static id _Nullable DecodeEventPayloadForCommodityTariffCluster(EventId aEventId
     using namespace Clusters::CommodityTariff;
     switch (aEventId) {
     default: {
+        // Not a known CommodityTariff event.
         break;
     }
     }
@@ -5170,6 +5296,7 @@ static id _Nullable DecodeEventPayloadForEcosystemInformationCluster(EventId aEv
     using namespace Clusters::EcosystemInformation;
     switch (aEventId) {
     default: {
+        // Not a known EcosystemInformation event.
         break;
     }
     }
@@ -5214,6 +5341,7 @@ static id _Nullable DecodeEventPayloadForCommissionerControlCluster(EventId aEve
         return value;
     }
     default: {
+        // Not a known CommissionerControl event.
         break;
     }
     }
@@ -5226,6 +5354,7 @@ static id _Nullable DecodeEventPayloadForTLSCertificateManagementCluster(EventId
     using namespace Clusters::TlsCertificateManagement;
     switch (aEventId) {
     default: {
+        // Not a known TLSCertificateManagement event.
         break;
     }
     }
@@ -5238,6 +5367,7 @@ static id _Nullable DecodeEventPayloadForTLSClientManagementCluster(EventId aEve
     using namespace Clusters::TlsClientManagement;
     switch (aEventId) {
     default: {
+        // Not a known TLSClientManagement event.
         break;
     }
     }
@@ -5250,6 +5380,7 @@ static id _Nullable DecodeEventPayloadForMeterIdentificationCluster(EventId aEve
     using namespace Clusters::MeterIdentification;
     switch (aEventId) {
     default: {
+        // Not a known MeterIdentification event.
         break;
     }
     }
@@ -5262,6 +5393,7 @@ static id _Nullable DecodeEventPayloadForCommodityMeteringCluster(EventId aEvent
     using namespace Clusters::CommodityMetering;
     switch (aEventId) {
     default: {
+        // Not a known CommodityMetering event.
         break;
     }
     }
@@ -5416,6 +5548,7 @@ static id _Nullable DecodeEventPayloadForUnitTestingCluster(EventId aEventId, TL
         return value;
     }
     default: {
+        // Not a known UnitTesting event.
         break;
     }
     }
@@ -5450,6 +5583,7 @@ static id _Nullable DecodeEventPayloadForSampleMEICluster(EventId aEventId, TLV:
         return value;
     }
     default: {
+        // Not a known SampleMEI event.
         break;
     }
     }


### PR DESCRIPTION
Makes the code a bit more readable when you're in the middle of it somewhere.

#### Testing

Adds comments only.