### PR TITLE
Add data model dependencies to metadata and elements

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/AllItemsBuild.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/AllItemsBuild.jinja
@@ -17,7 +17,9 @@ template("declare_all_items_target") {
   }
 }
 
-declare_all_items_target("all-ids") { target = ":ids" }
+declare_all_items_target("all-elements") { target = ":elements" }
 declare_all_items_target("all-enums") { target = ":enums" }
 declare_all_items_target("all-headers") { target = ":headers" }
+declare_all_items_target("all-ids") { target = ":ids" }
+declare_all_items_target("all-metadata") { target = ":metadata" }
 

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -516,6 +516,8 @@ template("chip_data_model") {
       "${chip_root}/src/lib/core",
       "${chip_root}/src/lib/support",
       "${chip_root}/src/protocols/secure_channel",
+      "${chip_root}/zzz_generated/app-common/clusters:all-elements",
+      "${chip_root}/zzz_generated/app-common/clusters:all-metadata",
 
       # TODO: Embedded example apps currently build with chip_build_controller = false, and so get a libCHIP without controller support,
       # but nevertheless expect to have access to some of the "controller" code to implement bindings and related functionality.

--- a/zzz_generated/app-common/clusters/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BUILD.gn
@@ -152,7 +152,9 @@ template("declare_all_items_target") {
   }
 }
 
-declare_all_items_target("all-ids") { target = ":ids" }
+declare_all_items_target("all-elements") { target = ":elements" }
 declare_all_items_target("all-enums") { target = ":enums" }
 declare_all_items_target("all-headers") { target = ":headers" }
+declare_all_items_target("all-ids") { target = ":ids" }
+declare_all_items_target("all-metadata") { target = ":metadata" }
 


### PR DESCRIPTION
This is so that any cluster implementation can import cluster metadata and settings.


#### Testing

CI should continue to build