### PR TITLE
Update the boot reason to BootReasonEnum::kSoftwareUpdateCompleted wh…

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -38,8 +38,8 @@ using chip::OTAImageProcessorImpl;
 using chip::PeerId;
 using chip::Server;
 using chip::VendorId;
-using chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
 using chip::app::Clusters::GeneralDiagnostics::BootReasonEnum;
+using chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
 using chip::Callback::Callback;
 using chip::System::Layer;
 using chip::Transport::PeerAddress;
@@ -315,7 +315,8 @@ int main(int argc, char * argv[])
             return -1;
         }
 
-        // Set the boot reason to SoftwareUpdateCompleted since the OTA requestor is going to boot into the new image after applying the firmware update.
+        // Set the boot reason to SoftwareUpdateCompleted since the OTA requestor is going to boot into the new image after applying
+        // the firmware update.
         CHIP_ERROR err = ConfigurationMgr().StoreBootReason(static_cast<uint32_t>(BootReasonEnum::kSoftwareUpdateCompleted));
         if (err != CHIP_NO_ERROR)
         {

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -39,6 +39,7 @@ using chip::PeerId;
 using chip::Server;
 using chip::VendorId;
 using chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
+using chip::app::Clusters::GeneralDiagnostics::BootReasonEnum;
 using chip::Callback::Callback;
 using chip::System::Layer;
 using chip::Transport::PeerAddress;
@@ -312,6 +313,13 @@ int main(int argc, char * argv[])
         {
             ChipLogError(SoftwareUpdate, "Buffer too small for the new image file path: %s", kImageExecPath);
             return -1;
+        }
+
+        // Set the boot reason to SoftwareUpdateCompleted since the OTA requestor is going to boot into the new image after applying the firmware update.
+        CHIP_ERROR err = ConfigurationMgr().StoreBootReason(static_cast<uint32_t>(BootReasonEnum::kSoftwareUpdateCompleted));
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(SoftwareUpdate, "Failed to store boot reason - SoftwareUpdateCompleted");
         }
 
         argv[0] = kImageExecPath;

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -317,7 +317,7 @@ int main(int argc, char * argv[])
 
         // Set the boot reason to SoftwareUpdateCompleted since the OTA requestor is going to boot into the new image after applying
         // the firmware update.
-        CHIP_ERROR err = ConfigurationMgr().StoreBootReason(static_cast<uint32_t>(BootReasonEnum::kSoftwareUpdateCompleted));
+        CHIP_ERROR err = ConfigurationMgr().StoreBootReason(to_underlying(BootReasonEnum::kSoftwareUpdateCompleted));
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(SoftwareUpdate, "Failed to store boot reason - SoftwareUpdateCompleted");


### PR DESCRIPTION
…en the OTA requestor boots into the new image after applying the update

Fixes: #37882 

#### Testing
 ran the steps described in #37882 

and see the boot reason being reported correctly.

[1745353645.584] [5875:21405159:chip] [EM] Found matching exchange: 53233i, Delegate: 0x13e813f50
[1745353645.584] [5875:21405159:chip] [EM] Rxd Ack; Removing MessageCounter:40408833 from Retrans Table on exchange 53233i
[1745353645.584] [5875:21405159:chip] [DMG] ReportDataMessage =
[1745353645.584] [5875:21405159:chip] [DMG] {
[1745353645.584] [5875:21405159:chip] [DMG] 	AttributeReportIBs =
[1745353645.584] [5875:21405159:chip] [DMG] 	[
[1745353645.584] [5875:21405159:chip] [DMG] 		AttributeReportIB =
[1745353645.584] [5875:21405159:chip] [DMG] 		{
[1745353645.584] [5875:21405159:chip] [DMG] 			AttributeDataIB =
[1745353645.584] [5875:21405159:chip] [DMG] 			{
[1745353645.584] [5875:21405159:chip] [DMG] 				DataVersion = 0x8b9ced46,
[1745353645.584] [5875:21405159:chip] [DMG] 				AttributePathIB =
[1745353645.584] [5875:21405159:chip] [DMG] 				{
[1745353645.584] [5875:21405159:chip] [DMG] 					Endpoint = 0x0,
[1745353645.584] [5875:21405159:chip] [DMG] 					Cluster = 0x33,
[1745353645.584] [5875:21405159:chip] [DMG] 					Attribute = 0x0000_0004,
[1745353645.584] [5875:21405159:chip] [DMG] 				}
[1745353645.584] [5875:21405159:chip] [DMG] 					
[1745353645.584] [5875:21405159:chip] [DMG] 				Data = 5 (unsigned), 
[1745353645.584] [5875:21405159:chip] [DMG] 			},
[1745353645.584] [5875:21405159:chip] [DMG] 			
[1745353645.584] [5875:21405159:chip] [DMG] 		},
[1745353645.584] [5875:21405159:chip] [DMG] 		
[1745353645.584] [5875:21405159:chip] [DMG] 	],
[1745353645.584] [5875:21405159:chip] [DMG] 	
[1745353645.584] [5875:21405159:chip] [DMG] 	SuppressResponse = true, 
[1745353645.584] [5875:21405159:chip] [DMG] 	InteractionModelRevision = 11
[1745353645.584] [5875:21405159:chip] [DMG] }
[1745353645.584] [5875:21405159:chip] [TOO] Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0004 DataVersion: 2342317382
[1745353645.585] [5875:21405159:chip] [TOO]   BootReason: 5

