### PR TITLE
for cluster enums, use `next_larger` mode for `kUnknownEnumValue`

### DIFF
--- a/src/app/zap-templates/partials/cluster-enums-enum.zapt
+++ b/src/app/zap-templates/partials/cluster-enums-enum.zapt
@@ -8,7 +8,7 @@ k{{asUpperCamelCase label}} = {{asHex value 2}},
 // to kUnknownEnumValue. This is a helper enum value that should only
 // be used by code to process how it handles receiving and unknown
 // enum value. This specific should never be transmitted.
-kUnknownEnumValue = {{first_unused_enum_value mode="first_unused"}},
+kUnknownEnumValue = {{first_unused_enum_value mode="next_larger"}},
 {{else}}
 // kUnknownEnumValue intentionally not defined. This enum never goes
 // through DataModel::Decode, likely because it is a part of a derived

--- a/zzz_generated/app-common/clusters/AccessControl/Enums.h
+++ b/zzz_generated/app-common/clusters/AccessControl/Enums.h
@@ -36,7 +36,7 @@ enum class AccessControlEntryAuthModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for AccessControlEntryPrivilegeEnum
@@ -51,7 +51,7 @@ enum class AccessControlEntryPrivilegeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 6,
 };
 
 // Enum for AccessRestrictionTypeEnum

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/Enums.h
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/Enums.h
@@ -49,7 +49,7 @@ enum class StatusCode : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 5,
 };
 
 // Bitmap for Feature

--- a/zzz_generated/app-common/clusters/ColorControl/Enums.h
+++ b/zzz_generated/app-common/clusters/ColorControl/Enums.h
@@ -117,7 +117,7 @@ enum class MoveModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for StepModeEnum
@@ -129,7 +129,7 @@ enum class StepModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 4,
 };
 
 // Bitmap for ColorCapabilitiesBitmap

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Enums.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Enums.h
@@ -104,7 +104,7 @@ enum class ESATypeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 14,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for ForecastUpdateReasonEnum

--- a/zzz_generated/app-common/clusters/DoorLock/Enums.h
+++ b/zzz_generated/app-common/clusters/DoorLock/Enums.h
@@ -41,7 +41,7 @@ enum class AlarmCodeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 9,
 };
 
 // Enum for CredentialRuleEnum
@@ -139,7 +139,7 @@ enum class DlStatus : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 4,
+    kUnknownEnumValue = 140,
 };
 
 // Enum for DoorLockOperationEventCode
@@ -209,7 +209,7 @@ enum class DoorLockUserStatus : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for DoorLockUserType
@@ -225,7 +225,7 @@ enum class DoorLockUserType : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 5,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for DoorStateEnum
@@ -344,7 +344,7 @@ enum class UserStatusEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for UserTypeEnum

--- a/zzz_generated/app-common/clusters/EnergyEvse/Enums.h
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Enums.h
@@ -63,7 +63,7 @@ enum class FaultStateEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 16,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for StateEnum

--- a/zzz_generated/app-common/clusters/Identify/Enums.h
+++ b/zzz_generated/app-common/clusters/Identify/Enums.h
@@ -39,7 +39,7 @@ enum class EffectIdentifierEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 3,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for EffectVariantEnum

--- a/zzz_generated/app-common/clusters/KeypadInput/Enums.h
+++ b/zzz_generated/app-common/clusters/KeypadInput/Enums.h
@@ -119,7 +119,7 @@ enum class CECKeyCodeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 14,
+    kUnknownEnumValue = 119,
 };
 
 // Enum for StatusEnum

--- a/zzz_generated/app-common/clusters/MicrowaveOvenMode/Enums.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenMode/Enums.h
@@ -45,7 +45,7 @@ enum class ModeTag : uint16_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 10,
+    kUnknownEnumValue = 16386,
 };
 
 // Bitmap for Feature

--- a/zzz_generated/app-common/clusters/OperationalCredentials/Enums.h
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/Enums.h
@@ -35,7 +35,7 @@ enum class CertificateChainTypeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for NodeOperationalCertStatusEnum
@@ -55,7 +55,7 @@ enum class NodeOperationalCertStatusEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 7,
+    kUnknownEnumValue = 12,
 };
 } // namespace OperationalCredentials
 } // namespace Clusters

--- a/zzz_generated/app-common/clusters/OvenMode/Enums.h
+++ b/zzz_generated/app-common/clusters/OvenMode/Enums.h
@@ -52,7 +52,7 @@ enum class ModeTag : uint16_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 10,
+    kUnknownEnumValue = 16393,
 };
 
 // Bitmap for Feature

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Enums.h
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Enums.h
@@ -39,7 +39,7 @@ enum class ControlModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 4,
+    kUnknownEnumValue = 8,
 };
 
 // Enum for OperationModeEnum

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Enums.h
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Enums.h
@@ -64,7 +64,7 @@ enum class StatusCodeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 17,
 };
 
 // Enum for StreamMultiplexingEnum

--- a/zzz_generated/app-common/clusters/Thermostat/Enums.h
+++ b/zzz_generated/app-common/clusters/Thermostat/Enums.h
@@ -63,7 +63,7 @@ enum class ACLouverPositionEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 6,
 };
 
 // Enum for ACRefrigerantTypeEnum
@@ -125,7 +125,7 @@ enum class PresetScenarioEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 255,
 };
 
 // Enum for SetpointChangeSourceEnum
@@ -187,7 +187,7 @@ enum class SystemModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 10,
 };
 
 // Enum for TemperatureSetpointHoldEnum
@@ -212,7 +212,7 @@ enum class ThermostatRunningModeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 1,
+    kUnknownEnumValue = 5,
 };
 
 // Bitmap for ACErrorCodeBitmap

--- a/zzz_generated/app-common/clusters/TimeFormatLocalization/Enums.h
+++ b/zzz_generated/app-common/clusters/TimeFormatLocalization/Enums.h
@@ -46,7 +46,7 @@ enum class CalendarTypeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 12,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for HourFormatEnum
@@ -59,7 +59,7 @@ enum class HourFormatEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 2,
+    kUnknownEnumValue = 256,
 };
 
 // Bitmap for Feature

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Enums.h
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Enums.h
@@ -49,7 +49,7 @@ enum class StatusCode : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for TimeSourceEnum

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Enums.h
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Enums.h
@@ -34,7 +34,7 @@ enum class StatusCodeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for ValveStateEnum

--- a/zzz_generated/app-common/clusters/WindowCovering/Enums.h
+++ b/zzz_generated/app-common/clusters/WindowCovering/Enums.h
@@ -58,7 +58,7 @@ enum class EndProductType : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 24,
+    kUnknownEnumValue = 256,
 };
 
 // Enum for Type
@@ -79,7 +79,7 @@ enum class Type : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 10,
+    kUnknownEnumValue = 256,
 };
 
 // Bitmap for ConfigStatus

--- a/zzz_generated/app-common/clusters/ZoneManagement/Enums.h
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Enums.h
@@ -35,7 +35,7 @@ enum class StatusCodeEnum : uint8_t
     // to kUnknownEnumValue. This is a helper enum value that should only
     // be used by code to process how it handles receiving and unknown
     // enum value. This specific should never be transmitted.
-    kUnknownEnumValue = 0,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for ZoneEventStoppedReasonEnum


### PR DESCRIPTION
avoids reuse of reserved/deprecated values

An issue was observed in #38288 where the `kUnknownEnumValue` was set to a reserved/deprecated value rather than the next value after all known enums.

**Testing revealed that several enums use maximum values in the type (0xFF, 0xFFFF), so attempting to use `next_larger` overflows the enum storage type, which won't compile.**

#### Testing

- [ ] Will re-run codegen with this patch against #38288 to ensure `kUnknownEnumValue` is replaced with the first value after the highest-valued enum.
- [ ] 
