### PR TITLE
Fix the logs for the case where we do not need to start subscription …

### DIFF
--- a/restyle.patch
+++ b/restyle.patch
@@ -1,0 +1,24 @@
+From e02e5779525502c582f99ab24b11acdd67ef2af4 Mon Sep 17 00:00:00 2001
+From: "Restyled.io" <commits@restyled.io>
+Date: Tue, 22 Apr 2025 23:26:10 +0000
+Subject: [PATCH] Restyled by clang-format
+
+---
+ src/darwin/Framework/CHIP/MTRDevice_Concrete.mm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+index 5edb4e03..0a3c08d3 100644
+--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
++++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+@@ -2786,7 +2786,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
+ 
+     // for now just subscribe once
+     if (!NeedToStartSubscriptionSetup(_internalDeviceState)) {
+-        MTR_LOG("%@ setupSubscription: No need to subscribe due to internal state %@ (reason: %@)", self,  InternalDeviceStateString(_internalDeviceState), reason);
++        MTR_LOG("%@ setupSubscription: No need to subscribe due to internal state %@ (reason: %@)", self, InternalDeviceStateString(_internalDeviceState), reason);
+         [self _clearSubscriptionPoolWork];
+         return;
+     }
+-- 
+2.49.0

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -969,7 +969,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                 VerifyOrReturn(self, MTR_LOG_DEBUG("_ensureSubscriptionForExistingDelegates asyncDispatchToMatterQueue called back with nil MTRDevice"));
 
                 std::lock_guard lock(self->_lock);
-                [self _setupSubscriptionWithReason:[NSString stringWithFormat:@"%@ and subscription is needed", reason]];
+                [self _setupSubscriptionWithReason:[NSString stringWithFormat:@"%@ and subscription is allowed", reason]];
             } errorHandler:nil];
         }
     }
@@ -2786,7 +2786,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     // for now just subscribe once
     if (!NeedToStartSubscriptionSetup(_internalDeviceState)) {
-        MTR_LOG("%@ setupSubscription: no need to subscribe due to internal state %lu (reason: %@)", self, static_cast<unsigned long>(_internalDeviceState), reason);
+        MTR_LOG("%@ setupSubscription: No need to subscribe due to internal state %@ (reason: %@)", self,  InternalDeviceStateString(_internalDeviceState), reason);
         [self _clearSubscriptionPoolWork];
         return;
     }

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -2786,7 +2786,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
     // for now just subscribe once
     if (!NeedToStartSubscriptionSetup(_internalDeviceState)) {
-        MTR_LOG("%@ setupSubscription: No need to subscribe due to internal state %@ (reason: %@)", self,  InternalDeviceStateString(_internalDeviceState), reason);
+        MTR_LOG("%@ setupSubscription: No need to subscribe due to internal state %@ (reason: %@)", self, InternalDeviceStateString(_internalDeviceState), reason);
         [self _clearSubscriptionPoolWork];
         return;
     }


### PR DESCRIPTION
…setup since one is already established


#### Testing

Built Matter framework and ran darwin tests.
