### PR TITLE
[ESP32] Add a menuconfig option to enable access restrictions from the application.

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -248,6 +248,10 @@ if (CONFIG_ENABLE_OTA_REQUESTOR)
     chip_gn_arg_append("chip_enable_ota_requestor"                 "true")
 endif()
 
+if (CONFIG_ENABLE_ACCESS_RESTRICTIONS)
+    chip_gn_arg_append("chip_enable_access_restrictions"                 "true")
+endif()
+
 if (CONFIG_ENABLE_ROTATING_DEVICE_ID)
     chip_gn_arg_append("chip_enable_additional_data_advertising"   "true")
     chip_gn_arg_append("chip_enable_rotating_device_id"            "true")

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1252,4 +1252,12 @@ menu "CHIP Device Layer"
 
     endmenu
 
+    menu "Cluster Configuration Options"
+        config ENABLE_ACCESS_RESTRICTIONS
+            bool "Enable Access Restrictions of Access Control Cluster"
+            default n
+            help
+                Enable this option to enable Access Restrictions on the device.
+
+    endmenu
 endmenu


### PR DESCRIPTION
#### Problem

-  There is no way to enable Access Restrictions feature for esp32.

#### Changes

- Added a `menuconfig` option to enable access restrictions feature.

#### Testing

- Manually tested the esp32 examples by enabling Access Restrictions feature in the `.zap` and read the corresponding attributes using `chip-tool`.
