### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-128 : Upgrading Silabs docker - sisdk 2024.12.2, Wiseconnect SDK 3.4.2, WC BT 2.11.4
+129 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=c02df4a2bf7598d0a62b4d98f7f274bcbc1af4af
+ARG ZEPHYR_REVISION=2f112696a24c8921bcb196a3c4b90c4f8a37f710
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.7.0; branch: develop
-ARG ZEPHYR_REVISION=eff83ae8b6e5bfdda87bcdb96760a938317e8c3c
+ARG ZEPHYR_REVISION=ed037d7de7c23eb14c908453d2d481cdf782796a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- soc: telink: telink_w9x: Get rid of DLM section
    - Introduced auxiliary RAM (zephyr,aux_ram)
    - Moved all blocking core to ILM
- telink: scripts: Migrate Telink binaries
- telink: drivers: add ability to read/write blocks in serial driver for W91
- kconfig: update N22 binary revision
- telink: telink_w9x: openthread: Add IEEE 802.15.4 driver
- telink: telink_w9x: openthread: Fix memory leak
    - Free RCP response data after processing.
    - Valid ACK data for driver.
- telink: drivers: kconfig: add updates after moving freertos to SCM-1.2.9
- samples: net: openthread: cli: Fix COAPS feature
- kconfig: update N22 binary revision
- telink: telink_w9x: openthread: Enhanced-ack linkmetrics
- west.yml: Update Telink HAL hash
- telink: telink_w9x: openthread: MAC keys
- telink: telink_w9x: openthread: Cleanup IEEE802.15.4 driver
    - Warning for not supported features.
    - Support LOG_MODE_MINIMAL for openthread application (all platforms)
- telink: soc: update functions in spinel driver
- telink: config: use nvs lookup cache in cli sample for W91
- telink: tl3218x: fix gpio interrupts
- kconfig: update N22 binary revision

**Changes of N22 binary:**

(latest hash c8397b726468c1c63b098bc06eec2d9acad4887d)
- Migrate binaries
- Add ability to read and write blocks in serial driver
- Set serial CTS pin in pull-down mode
- Fix setting tx_done flag
- [refactor]:sync with SCM-1.2.8
- [refactor]:Sync with SDK-1.2.9
- Update tlsr_i2s.h
- Fix issues after updating to SCM-1.2.9
- Extend serial rx buffer size
- Telink w91 ram optimization

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully
