### PR TITLE
[HOTFIX] Fix hermeticity of TC-CGEN scripts in CI

### DIFF
--- a/src/python_testing/TC_CGEN_2_10.py
+++ b/src/python_testing/TC_CGEN_2_10.py
@@ -31,7 +31,7 @@
 #           --tc-user-response-to-simulate 1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_11.py
+++ b/src/python_testing/TC_CGEN_2_11.py
@@ -32,7 +32,7 @@
 #           --int-arg PIXIT.CGEN.TCRevision:1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_5.py
+++ b/src/python_testing/TC_CGEN_2_5.py
@@ -32,7 +32,7 @@
 #           --int-arg PIXIT.CGEN.TCRevision:1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_6.py
+++ b/src/python_testing/TC_CGEN_2_6.py
@@ -29,7 +29,7 @@
 #           --in-test-commissioning-method on-network
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_7.py
+++ b/src/python_testing/TC_CGEN_2_7.py
@@ -32,7 +32,7 @@
 #           --int-arg PIXIT.CGEN.TCRevision:1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_8.py
+++ b/src/python_testing/TC_CGEN_2_8.py
@@ -32,7 +32,7 @@
 #           --int-arg PIXIT.CGEN.TCRevision:1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -36,6 +36,8 @@
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 
+import logging
+
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.commissioning import ROOT_ENDPOINT_ID
@@ -53,12 +55,14 @@ class TC_CGEN_2_9(MatterBaseTest):
             node_id=self.dut_node_id,
             endpoint=ROOT_ENDPOINT_ID,
             attribute=Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)
+        logging.info(f"Commissioner's fabricIndex on DUT: {commissioner_fabric_index_on_dut}")
         
         fabrics: list[Clusters.OperationalCredentials.Structs.FabricDescriptorStruct] = await self.read_single_attribute(
             dev_ctrl=commissioner,
             node_id=self.dut_node_id,
             endpoint=ROOT_ENDPOINT_ID,
             attribute=Clusters.OperationalCredentials.Attributes.Fabrics)
+        logging.info(f"Fabrics table on DUT: {commissioner_fabric_index_on_dut}")
 
         # Re-order the list of fabrics so that the test harness admin fabric is removed last
         commissioner_fabric = next((fabric for fabric in fabrics if fabric.fabricIndex == commissioner_fabric_index_on_dut), None)
@@ -66,6 +70,7 @@ class TC_CGEN_2_9(MatterBaseTest):
         fabrics.append(commissioner_fabric)
 
         for fabric in fabrics:
+            logging.info(f"Removing fabric at fabricIndex {fabric.fabricIndex}")
             response: Clusters.OperationalCredentials.Commands.NOCResponse = await commissioner.SendCommand(
                 nodeid=self.dut_node_id,
                 endpoint=ROOT_ENDPOINT_ID,

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -56,7 +56,7 @@ class TC_CGEN_2_9(MatterBaseTest):
             endpoint=ROOT_ENDPOINT_ID,
             attribute=Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)
         logging.info(f"Commissioner's fabricIndex on DUT: {commissioner_fabric_index_on_dut}")
-        
+
         fabrics: list[Clusters.OperationalCredentials.Structs.FabricDescriptorStruct] = await self.read_single_attribute(
             dev_ctrl=commissioner,
             node_id=self.dut_node_id,

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -62,7 +62,7 @@ class TC_CGEN_2_9(MatterBaseTest):
             node_id=self.dut_node_id,
             endpoint=ROOT_ENDPOINT_ID,
             attribute=Clusters.OperationalCredentials.Attributes.Fabrics)
-        logging.info(f"Fabrics table on DUT: {commissioner_fabric_index_on_dut}")
+        logging.info(f"Fabrics table on DUT: {fabrics}")
 
         # Re-order the list of fabrics so that the test harness admin fabric is removed last
         commissioner_fabric = next((fabric for fabric in fabrics if fabric.fabricIndex == commissioner_fabric_index_on_dut), None)

--- a/src/python_testing/TC_CGEN_2_9.py
+++ b/src/python_testing/TC_CGEN_2_9.py
@@ -32,7 +32,7 @@
 #           --int-arg PIXIT.CGEN.TCRevision:1
 #           --qr-code MT:-24J0AFN00KA0648G00
 #           --trace-to json:log
-#       factoryreset: True
+#       factory-reset: true
 #       quiet: True
 # === END CI TEST ARGUMENTS ===
 
@@ -48,6 +48,12 @@ class TC_CGEN_2_9(MatterBaseTest):
     async def remove_commissioner_fabric(self):
         commissioner: ChipDeviceCtrl.ChipDeviceController = self.default_controller
 
+        commissioner_fabric_index_on_dut = await self.read_single_attribute(
+            dev_ctrl=commissioner,
+            node_id=self.dut_node_id,
+            endpoint=ROOT_ENDPOINT_ID,
+            attribute=Clusters.OperationalCredentials.Attributes.CurrentFabricIndex)
+        
         fabrics: list[Clusters.OperationalCredentials.Structs.FabricDescriptorStruct] = await self.read_single_attribute(
             dev_ctrl=commissioner,
             node_id=self.dut_node_id,
@@ -55,7 +61,7 @@ class TC_CGEN_2_9(MatterBaseTest):
             attribute=Clusters.OperationalCredentials.Attributes.Fabrics)
 
         # Re-order the list of fabrics so that the test harness admin fabric is removed last
-        commissioner_fabric = next((fabric for fabric in fabrics if fabric.fabricIndex == commissioner.fabricId), None)
+        commissioner_fabric = next((fabric for fabric in fabrics if fabric.fabricIndex == commissioner_fabric_index_on_dut), None)
         fabrics.remove(commissioner_fabric)
         fabrics.append(commissioner_fabric)
 


### PR DESCRIPTION
#### Changes

- The scripts did not factory reset properly so they were
  impacted by lack of hermeticity, causing a failure of CGEN-2.9
  after unrelated master changes.
- The method to find "commissioner's fabric" before some fabric
  removal was wrong in CGEN-2.9. Fixed the method to use CurrentFabricIndex

#### Testing

- Tests all still pass, but CGEN-2.9 no longer fails
