### PR TITLE
[Chef] Artifacts generation for ICD cloud builder

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -43,7 +43,8 @@ _CD_STAGING_DIR = os.path.join(_CHEF_SCRIPT_PATH, "staging")
 _EXCLUDE_DEVICE_FROM_LINUX_CI = [  # These do not compile / deprecated.
     "noip_rootnode_dimmablelight_bCwGYSDpoe",
 ]
-_ICD_DEVICE_PATTERN = "^icd_"  # Pattern to filter (based on device-name) devices that need ICD support.
+# Pattern to filter (based on device-name) devices that need ICD support.
+_ICD_DEVICE_PATTERN = "^icd_"
 
 gen_dir = ""  # Filled in after sample app type is read from args.
 
@@ -910,7 +911,8 @@ def main() -> int:
                 linux_args.append("chip_enable_icd_dsls = true")
                 if options.icd_subscription_resumption:
                     options.icd_persist_subscription = True
-                    linux_args.append("chip_subscription_timeout_resumption = true")
+                    linux_args.append(
+                        "chip_subscription_timeout_resumption = true")
                 if options.icd_persist_subscription:
                     linux_args.append("chip_persist_subscriptions = true")
 

--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -42,9 +42,8 @@ _CICD_CONFIG_FILE_NAME = os.path.join(_CHEF_SCRIPT_PATH, "cicd_config.json")
 _CD_STAGING_DIR = os.path.join(_CHEF_SCRIPT_PATH, "staging")
 _EXCLUDE_DEVICE_FROM_LINUX_CI = [  # These do not compile / deprecated.
     "noip_rootnode_dimmablelight_bCwGYSDpoe",
-    "icd_rootnode_contactsensor_ed3b19ec55",
-    "rootnode_refrigerator_temperaturecontrolledcabinet_temperaturecontrolledcabinet_ffdb696680",
 ]
+_ICD_DEVICE_PATTERN = "^icd_"  # Pattern to filter (based on device-name) devices that need ICD support.
 
 gen_dir = ""  # Filled in after sample app type is read from args.
 
@@ -904,7 +903,7 @@ def main() -> int:
             else:
                 linux_args.append("chip_inet_config_enable_ipv4=false")
 
-            if options.enable_lit_icd:
+            if options.enable_lit_icd or re.search(_ICD_DEVICE_PATTERN, options.sample_device_type_name):
                 linux_args.append("chip_enable_icd_server = true")
                 linux_args.append("chip_icd_report_on_active_mode = true")
                 linux_args.append("chip_enable_icd_lit = true")

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -29,7 +29,7 @@ steps:
       args:
           - >-
               perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt &&
-              ./examples/chef/chef.py --build_all --build_exclude "noip|temperaturecontrolledcabinet|icd"
+              ./examples/chef/chef.py --build_all --build_exclude "noip|icd"
       id: CompileAll
       waitFor:
           - Bootstrap
@@ -44,7 +44,7 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
-          - ./examples/chef/chef.py -cbrI -d icd_rootnode_contactsensor_ed3b19ec55 -t linux
+          - ./examples/chef/chef.py --build_all --build_include linux_x86-icd
       allowFailure: true # TODO: Remove this once compilation stability is established.
       id: CompileICDLinux
       waitFor:


### PR DESCRIPTION
* Cloud build artefacts are only generated when `--build_all` flag is used.
* Add ICD compile flags if device_name matches ICD pattern.
* Enable devices with temperaturecontrolledcabinet in cloud build.

#### Testing

ICD devices no longer need the `-I` flag:
```
./chef.py -br -d icd_rootnode_contactsensor_ed3b19ec55 -t linux
```
Dry run -
```
./chef.py --build_all --build_include linux_x86-icd
```
Print output showed only Linux ICD device compiled.