### PR TITLE
Remove test steps deleted in #38377

### DIFF
--- a/src/python_testing/TC_TCCM_1_2.py
+++ b/src/python_testing/TC_TCCM_1_2.py
@@ -58,8 +58,6 @@ class TC_TCCM_1_2(MatterBaseTest, ModeBaseClusterChecks):
             TestStep(1, "Commissioning, already done", is_commissioning=True),
             TestStep(2, "TH reads from the DUT the SupportedModes attribute."),
             TestStep(3, "TH reads from the DUT the CurrentMode attribute."),
-            TestStep(4, "TH reads from the DUT the OnMode attribute."),
-            TestStep(5, "TH reads from the DUT the StartUpMode attribute.")
         ]
         return steps
 


### PR DESCRIPTION
Removes test steps as well, since the other PR just removed the execution

#### Testing

Obvious change, CI will validate

This passed locally: `./scripts/tests/local.py python-tests --test-filter 'CCM_1_2' --fail-log-dir out `
