### PR TITLE
[Basic Information] Add TC-BINFO-3.2 and command to bump ConfigurationVersion on CI

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -555,6 +555,17 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
     {
         SetRefrigeratorDoorStatusHandler(self->mJsonValue);
     }
+    else if (name == "SimulateConfigurationVersionChange")
+    {
+        uint32_t configurationVersion = 0;
+        ConfigurationMgr().GetConfigurationVersion(configurationVersion);
+        configurationVersion++;
+
+        if (ConfigurationMgr().StoreConfigurationVersion(configurationVersion + 1) != CHIP_NO_ERROR)
+        {
+            ChipLogError(NotSpecified, "Failed to store configuration version:%d", configurationVersion);
+        }
+    }
     else
     {
         ChipLogError(NotSpecified, "Unhandled command '%s': this should never happen", name.c_str());

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -25,6 +25,8 @@
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --endpoint 0
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #     factory-reset: true
@@ -95,12 +97,12 @@ class TC_BINFO_3_2(MatterBaseTest):
         asserts.assert_greater_equal(initialConfigurationVersion, 1, "ConfigurationVersion attribute is out of range")
 
         self.step(3)
-        if not self.is_pics_sdk_ci_only:
-            self.wait_for_user_input(
-                prompt_msg="Change the configuration version in a way which results in functionality to be added or removed, then continue")
-        else:
+        if self.is_pics_sdk_ci_only:
             command_dict = {"Name": "SimulateConfigurationVersionChange"}
             self._send_named_pipe_command(command_dict)
+        else:
+            self.wait_for_user_input(
+                prompt_msg="Change the configuration version in a way which results in functionality to be added or removed, then continue")
 
         self.step(4)
         newConfigurationVersion = await self.read_binfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -49,7 +49,7 @@ class TC_BINFO_3_2(MatterBaseTest):
         return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     def desc_TC_BINFO_3_2(self) -> str:
-        return "[TC-BOOLCFG-3.2] Attributes with DUT as Server"
+        return "[TC-BINFO-3.2] Attributes with DUT as Server"
 
     def steps_TC_BINFO_3_2(self) -> list[TestStep]:
         steps = [

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -85,7 +85,7 @@ class TC_BINFO_3_2(MatterBaseTest):
     @async_test_body
     async def test_TC_BINFO_3_2(self):
 
-        endpoint = self.get_endpoint(default=1)
+        endpoint = self.get_endpoint(default=0)
 
         self.step(1)
         attributes = Clusters.BasicInformation.Attributes

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -53,11 +53,10 @@ class TC_BINFO_3_2(MatterBaseTest):
 
     def steps_TC_BINFO_3_2(self) -> list[TestStep]:
         steps = [
-            TestStep(1, "Commissioning, already done", is_commissioning=True),
-            TestStep(2, "TH reads ConfigurationVersion from the DUT and stores the value as initialConfigurationVersion",
+            TestStep(1, "TH reads ConfigurationVersion from the DUT and stores the value as initialConfigurationVersion",
                      "Verify that the value is in the inclusive range of 1 to 4294967295"),
-            TestStep(3, "Change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
-            TestStep(4, "TH reads ConfigurationVersion from the DUT",
+            TestStep(2, "Change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
+            TestStep(3, "TH reads ConfigurationVersion from the DUT",
                      "Verify that the value is higher than the value of initialConfigurationVersion"),
         ]
         return steps
@@ -88,15 +87,13 @@ class TC_BINFO_3_2(MatterBaseTest):
     async def test_TC_BINFO_3_2(self):
 
         endpoint = self.get_endpoint(default=0)
-
-        self.step(1)
         attributes = Clusters.BasicInformation.Attributes
 
-        self.step(2)
+        self.step(1)
         initialConfigurationVersion = await self.read_binfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)
         asserts.assert_greater_equal(initialConfigurationVersion, 1, "ConfigurationVersion attribute is out of range")
 
-        self.step(3)
+        self.step(2)
         if self.is_pics_sdk_ci_only:
             command_dict = {"Name": "SimulateConfigurationVersionChange"}
             self._send_named_pipe_command(command_dict)
@@ -104,7 +101,7 @@ class TC_BINFO_3_2(MatterBaseTest):
             self.wait_for_user_input(
                 prompt_msg="Change the configuration version in a way which results in functionality to be added or removed, then continue")
 
-        self.step(4)
+        self.step(3)
         newConfigurationVersion = await self.read_binfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)
         asserts.assert_greater(newConfigurationVersion, initialConfigurationVersion,
                                "ConfigurationVersion attribute not grater than initialConfigurationVersion")

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -33,9 +33,10 @@
 
 import json
 import logging
-import chip.clusters as Clusters
 from time import sleep
 from typing import Any
+
+import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
 

--- a/src/python_testing/TC_BINFO_3_2.py
+++ b/src/python_testing/TC_BINFO_3_2.py
@@ -1,0 +1,111 @@
+#
+#    Copyright (c) 2023 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import json
+import logging
+import chip.clusters as Clusters
+from time import sleep
+from typing import Any
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_BINFO_3_2(MatterBaseTest):
+    async def read_binfo_attribute_expect_success(self, endpoint, attribute):
+        cluster = Clusters.Objects.BasicInformation
+        return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
+
+    def desc_TC_BINFO_3_2(self) -> str:
+        return "[TC-BOOLCFG-3.2] Attributes with DUT as Server"
+
+    def steps_TC_BINFO_3_2(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "TH reads ConfigurationVersion from the DUT and stores the value as initialConfigurationVersion",
+                     "Verify that the value is in the inclusive range of 1 to 4294967295"),
+            TestStep(3, "Change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
+            TestStep(4, "TH reads ConfigurationVersion from the DUT",
+                     "Verify that the value is higher than the value of initialConfigurationVersion"),
+        ]
+        return steps
+
+    def pics_TC_BINFO_3_2(self) -> list[str]:
+        pics = [
+            "BINFO.S",
+            "BINFO.S.M.DeviceConfigurationChange",
+        ]
+        return pics
+
+    def _send_named_pipe_command(self, command_dict: dict[str, Any]):
+        app_pid = self.matter_test_config.app_pid
+        if app_pid == 0:
+            asserts.fail("The --app-pid flag must be set when usage of door state simulation named pipe is required (e.g. CI)")
+
+        app_pipe = f"/tmp/chip_all_clusters_fifo_{app_pid}"
+        command = json.dumps(command_dict)
+
+        # Sends an out-of-band command to the sample app
+        with open(app_pipe, "w") as outfile:
+            logging.info(f"Sending named pipe command to {app_pipe}: '{command}'")
+            outfile.write(command + "\n")
+        # Delay for pipe command to be processed (otherwise tests may be flaky).
+        sleep(0.1)
+
+    @async_test_body
+    async def test_TC_BINFO_3_2(self):
+
+        endpoint = self.get_endpoint(default=1)
+
+        self.step(1)
+        attributes = Clusters.BasicInformation.Attributes
+
+        self.step(2)
+        initialConfigurationVersion = await self.read_binfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)
+        asserts.assert_greater_equal(initialConfigurationVersion, 1, "ConfigurationVersion attribute is out of range")
+
+        self.step(3)
+        if not self.is_pics_sdk_ci_only:
+            self.wait_for_user_input(
+                prompt_msg="Change the configuration version in a way which results in functionality to be added or removed, then continue")
+        else:
+            command_dict = {"Name": "SimulateConfigurationVersionChange"}
+            self._send_named_pipe_command(command_dict)
+
+        self.step(4)
+        newConfigurationVersion = await self.read_binfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)
+        asserts.assert_greater(newConfigurationVersion, initialConfigurationVersion,
+                               "ConfigurationVersion attribute not grater than initialConfigurationVersion")
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
This PR adds the test script for TC-BINFO-3.2 as well as a basic named pipe command to bump the ConfigirationVersion, in order to allow the test to pass on CI.

Once we have a more automated way to bump the config version, then I will follow up and improve the command implementation.

#### Testing

Executed test against all-cluster locally and passed test case.