### PR TITLE
[Fix] Fix for CADMIN_1_5 DNS-SD commissionable device discovery issue #38538

### DIFF
--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -88,10 +88,9 @@ class TC_CADMIN_1_5(MatterBaseTest):
                     return parsed_service.service  # Return the original service object
 
             # Log what we found for debugging purposes
-            if services:
-                logging.info(f"Found {len(services)} services, but none match CM={expected_cm_value}, D={expected_discriminator}")
-                for service in services:
-                    logging.info(f"  {service}")
+            logging.info(f"Found {len(services)} services, but none match CM={expected_cm_value}, D={expected_discriminator}")
+            for service in services:
+                logging.info(f"{service}")
             else:
                 logging.info("No services found in this attempt")
 
@@ -182,7 +181,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         # Wait for DNS-SD advertisement with correct CM value and discriminator
         # This will either return a valid service or assert failure
         service = await self.wait_for_correct_cm_value(
-            expected_cm_value=2,
+            expected_cm_value=4,
             expected_discriminator=params.randomDiscriminator
         )
         logging.info(f"Successfully found service with CM={service.txt_record.get('CM')}, D={service.txt_record.get('D')}")

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -54,8 +54,23 @@ class TC_CADMIN_1_5(MatterBaseTest):
         d: Optional[int] = None
 
         def __post_init__(self):
-            self.cm = int(self.service.txt_record.get('CM', None))
-            self.d = int(self.service.txt_record.get('D', None))
+            # Safely convert CM value to int if present
+            cm_value = self.service.txt_record.get('CM')
+            if cm_value is not None:
+                try:
+                    self.cm = int(cm_value)
+                except (ValueError, TypeError):
+                    logging.warning(f"Could not convert CM value '{cm_value}' to integer")
+                    self.cm = None
+            
+            # Safely convert D value to int if present
+            d_value = self.service.txt_record.get('D')
+            if d_value is not None:
+                try:
+                    self.d = int(d_value)
+                except (ValueError, TypeError):
+                    logging.warning(f"Could not convert discriminator value '{d_value}' to integer")
+                    self.d = None
 
         def __str__(self) -> str:
             return f"Service CM={self.cm}, D={self.d}"

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -34,6 +34,8 @@
 import asyncio.exceptions as ae
 import logging
 from time import sleep
+from dataclasses import dataclass
+from typing import Optional
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
@@ -45,59 +47,64 @@ from mobly import asserts
 
 
 class TC_CADMIN_1_5(MatterBaseTest):
+    @dataclass
+    class ParsedService:
+        service: mdns_discovery.MdnsServiceInfo
+        cm: Optional[int] = None
+        d: Optional[int] = None
+
+        def __post_init__(self):
+            self.cm = int(self.service.txt_record.get('CM', None))
+            self.d = int(self.service.txt_record.get('D', None))
+    
+        def __str__(self) -> str:     
+            return f"Service CM={self.cm}, D={self.d}"
+
+        def matches(self, expected_cm: int, expected_d: int) -> bool:
+            """Check if this service matches the expected CM and discriminator values."""
+            cm_match = self.cm == expected_cm
+            d_match = self.d == expected_d
+            return cm_match and d_match
+
     async def get_all_txt_records(self):
         discovery = mdns_discovery.MdnsDiscovery(verbose_logging=True)
         discovery._service_types = [mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         await discovery._discover(discovery_timeout_sec=240, log_output=False)
-
+        
         if mdns_discovery.MdnsServiceType.COMMISSIONABLE.value in discovery._discovered_services:
             return discovery._discovered_services[mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         return []
 
-    async def wait_for_correct_cm_value(self, expected_cm_value, expected_discriminator, max_attempts=5, delay_sec=5):
+    async def wait_for_correct_cm_value(self, expected_cm_value: int, expected_discriminator: int, max_attempts: int = 5, delay_sec: int = 5):
         """Wait for the correct CM value and discriminator in DNS-SD with retries."""
         for attempt in range(max_attempts):
-            services = await self.get_all_txt_records()
+            raw_services = await self.get_all_txt_records()
+            services = [self.ParsedService(service) for service in raw_services]
 
             # Look through all services for a match
-            for service in services:
-                cm_value = service.txt_record.get('CM')
-                d_value = service.txt_record.get('D')
-
-                # Convert to strings for comparison
-                if str(cm_value) == str(expected_cm_value) and str(d_value) == str(expected_discriminator):
-                    logging.info(f"Found matching service: CM={cm_value}, D={d_value}")
-                    return service
+            for parsed_service in services:
+                if parsed_service.matches(expected_cm_value, expected_discriminator):
+                    logging.info(f"Found matching service: {parsed_service}")
+                    return parsed_service.service  # Return the original service object
 
             # Log what we found for debugging purposes
             if services:
                 logging.info(f"Found {len(services)} services, but none match CM={expected_cm_value}, D={expected_discriminator}")
                 for service in services:
-                    logging.info(f"  Service: CM={service.txt_record.get('CM')} (type: {type(service.txt_record.get('CM'))}), "
-                                 f"D={service.txt_record.get('D')} (type: {type(service.txt_record.get('D'))})")
+                    logging.info(f"  {service}")
             else:
                 logging.info("No services found in this attempt")
 
+            # Not on last attempt, wait and retry
             if attempt < max_attempts - 1:
                 logging.info(f"Waiting for service with CM={expected_cm_value} and D={expected_discriminator}, "
-                             f"attempt {attempt+1}/{max_attempts}")
+                            f"attempt {attempt+1}/{max_attempts}")
                 sleep(delay_sec)
-
             else:
-                # Final retry attempt failed, format services for display and fail
-                found_services = []
-                for svc in services:
-                    # Convert values to strings to ensure consistent comparison
-                    cm = str(svc.txt_record.get('CM', 'MISSING'))
-                    d = str(svc.txt_record.get('D', 'MISSING'))
-                    found_services.append(f"Service with CM={cm}, D={d}")
-
-                # Log the expected types for comparison
-                logging.info(f"Expected: CM={expected_cm_value}, D={expected_discriminator}")
-
+                # Final retry attempt failed
                 asserts.fail(f"Failed to find DNS-SD advertisement with CM={expected_cm_value} and "
-                             f"discriminator={expected_discriminator} after {max_attempts} attempts. "
-                             f"Found services: {found_services}")
+                            f"discriminator={expected_discriminator} after {max_attempts} attempts. "
+                            f"Found services: {[str(s) for s in services]}")
 
     async def commission_on_network(self, setup_code: int, discriminator: int, expected_error: int = 0):
         # This is expected to error as steps 4 and 7 expects timeout issue or pase connection error to occur due to commissioning window being closed already
@@ -175,7 +182,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         # Wait for DNS-SD advertisement with correct CM value and discriminator
         # This will either return a valid service or assert failure
         service = await self.wait_for_correct_cm_value(
-            expected_cm_value="2",
+            expected_cm_value=2,
             expected_discriminator=params.randomDiscriminator
         )
         logging.info(f"Successfully found service with CM={service.txt_record.get('CM')}, D={service.txt_record.get('D')}")

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -181,7 +181,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         # Wait for DNS-SD advertisement with correct CM value and discriminator
         # This will either return a valid service or assert failure
         service = await self.wait_for_correct_cm_value(
-            expected_cm_value=4,
+            expected_cm_value=2,
             expected_discriminator=params.randomDiscriminator
         )
         logging.info(f"Successfully found service with CM={service.txt_record.get('CM')}, D={service.txt_record.get('D')}")

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -49,7 +49,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         discovery = mdns_discovery.MdnsDiscovery(verbose_logging=True)
         discovery._service_types = [mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         await discovery._discover(discovery_timeout_sec=240, log_output=False)
-        
+
         if mdns_discovery.MdnsServiceType.COMMISSIONABLE.value in discovery._discovered_services:
             return discovery._discovered_services[mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         return []
@@ -58,26 +58,26 @@ class TC_CADMIN_1_5(MatterBaseTest):
         """Wait for the correct CM value and discriminator in DNS-SD with retries."""
         for attempt in range(max_attempts):
             services = await self.get_all_txt_records()
-            
+
             # Look through all services for a match
             for service in services:
                 cm_value = service.txt_record.get('CM')
                 d_value = service.txt_record.get('D')
-                
+
                 # Convert to strings for comparison
                 if str(cm_value) == str(expected_cm_value) and str(d_value) == str(expected_discriminator):
                     logging.info(f"Found matching service: CM={cm_value}, D={d_value}")
                     return service
-            
+
             # Log what we found for debugging purposes
             if services:
                 logging.info(f"Found {len(services)} services, but none match CM={expected_cm_value}, D={expected_discriminator}")
                 for service in services:
                     logging.info(f"  Service: CM={service.txt_record.get('CM')} (type: {type(service.txt_record.get('CM'))}), "
-                                f"D={service.txt_record.get('D')} (type: {type(service.txt_record.get('D'))})")
+                                 f"D={service.txt_record.get('D')} (type: {type(service.txt_record.get('D'))})")
             else:
                 logging.info("No services found in this attempt")
-            
+
             if attempt < max_attempts - 1:
                 logging.info(f"Waiting for service with CM={expected_cm_value} and D={expected_discriminator}, "
                              f"attempt {attempt+1}/{max_attempts}")
@@ -91,10 +91,10 @@ class TC_CADMIN_1_5(MatterBaseTest):
                     cm = str(svc.txt_record.get('CM', 'MISSING'))
                     d = str(svc.txt_record.get('D', 'MISSING'))
                     found_services.append(f"Service with CM={cm}, D={d}")
-                
+
                 # Log the expected types for comparison
                 logging.info(f"Expected: CM={expected_cm_value}, D={expected_discriminator}")
-                
+
                 asserts.fail(f"Failed to find DNS-SD advertisement with CM={expected_cm_value} and "
                              f"discriminator={expected_discriminator} after {max_attempts} attempts. "
                              f"Found services: {found_services}")
@@ -175,7 +175,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         # Wait for DNS-SD advertisement with correct CM value and discriminator
         # This will either return a valid service or assert failure
         service = await self.wait_for_correct_cm_value(
-            expected_cm_value="2", 
+            expected_cm_value="2",
             expected_discriminator=params.randomDiscriminator
         )
         logging.info(f"Successfully found service with CM={service.txt_record.get('CM')}, D={service.txt_record.get('D')}")

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -62,7 +62,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
                 except (ValueError, TypeError):
                     logging.warning(f"Could not convert CM value '{cm_value}' to integer")
                     self.cm = None
-            
+
             # Safely convert D value to int if present
             d_value = self.service.txt_record.get('D')
             if d_value is not None:

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -56,8 +56,8 @@ class TC_CADMIN_1_5(MatterBaseTest):
         def __post_init__(self):
             self.cm = int(self.service.txt_record.get('CM', None))
             self.d = int(self.service.txt_record.get('D', None))
-    
-        def __str__(self) -> str:     
+
+        def __str__(self) -> str:
             return f"Service CM={self.cm}, D={self.d}"
 
         def matches(self, expected_cm: int, expected_d: int) -> bool:
@@ -70,7 +70,7 @@ class TC_CADMIN_1_5(MatterBaseTest):
         discovery = mdns_discovery.MdnsDiscovery(verbose_logging=True)
         discovery._service_types = [mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         await discovery._discover(discovery_timeout_sec=240, log_output=False)
-        
+
         if mdns_discovery.MdnsServiceType.COMMISSIONABLE.value in discovery._discovered_services:
             return discovery._discovered_services[mdns_discovery.MdnsServiceType.COMMISSIONABLE.value]
         return []
@@ -98,13 +98,13 @@ class TC_CADMIN_1_5(MatterBaseTest):
             # Not on last attempt, wait and retry
             if attempt < max_attempts - 1:
                 logging.info(f"Waiting for service with CM={expected_cm_value} and D={expected_discriminator}, "
-                            f"attempt {attempt+1}/{max_attempts}")
+                             f"attempt {attempt+1}/{max_attempts}")
                 sleep(delay_sec)
             else:
                 # Final retry attempt failed
                 asserts.fail(f"Failed to find DNS-SD advertisement with CM={expected_cm_value} and "
-                            f"discriminator={expected_discriminator} after {max_attempts} attempts. "
-                            f"Found services: {[str(s) for s in services]}")
+                             f"discriminator={expected_discriminator} after {max_attempts} attempts. "
+                             f"Found services: {[str(s) for s in services]}")
 
     async def commission_on_network(self, setup_code: int, discriminator: int, expected_error: int = 0):
         # This is expected to error as steps 4 and 7 expects timeout issue or pase connection error to occur due to commissioning window being closed already

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -33,8 +33,8 @@
 
 import asyncio.exceptions as ae
 import logging
-from time import sleep
 from dataclasses import dataclass
+from time import sleep
 from typing import Optional
 
 import chip.clusters as Clusters

--- a/src/python_testing/TC_CADMIN_1_5.py
+++ b/src/python_testing/TC_CADMIN_1_5.py
@@ -32,8 +32,8 @@
 # === END CI TEST ARGUMENTS ===
 
 import asyncio.exceptions as ae
-from time import sleep
 import logging
+from time import sleep
 
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl


### PR DESCRIPTION
**Reason**
- Fix for congested commissionable discovery issue #[38538](https://github.com/project-chip/connectedhomeip/issues/38538) reported by Kishok
- Issue reported to be noticed when running in a congested testing environment when multiple test devices were in commissionable mode

**Resolution**
Improved TC_CADMIN_1_5 test reliability by changing the service discovery approach to handle discovery in the event of multiple commissionable devices. 

The test now:
1. Gathers all discoverable service records rather than just the first one as was done previously
2. Filters through all commissionable services discovered to find the correct match based on both CM value and discriminator

This makes the test more reliable in congested test environments where multiple devices might be in commissioning mode simultaneously, avoiding false failures when the correct device isn't the first one discovered.

#### Testing
- WSL