### PR TITLE
Revert "[TC-TSTAT-2.2] Adding test steps 13b and 15b (#38555)"

### DIFF
--- a/src/python_testing/TC_TSTAT_2_2.py
+++ b/src/python_testing/TC_TSTAT_2_2.py
@@ -89,11 +89,9 @@ class TC_TSTAT_2_2(MatterBaseTest):
             TestStep("11b", "Test Harness Writes the value below MinSetpointDeadBand"),
             TestStep("11c", "Test Harness Writes the min limit of MinSetpointDeadBand"),
             TestStep("12", "Test Harness Reads ControlSequenceOfOperation from Server DUT, if TSTAT.S.F01 is true"),
-            TestStep("13a", "Sets OccupiedCoolingSetpoint to default value"),
-            TestStep("13b", "Sets SetpointRaiseLower set to Heat (0x00), and the amount set to 0xE2 (-30 units = -3 degrees)."),
+            TestStep("13", "Sets OccupiedCoolingSetpoint to default value"),
             TestStep("14", "Sets OccupiedHeatingSetpoint to default value"),
-            TestStep("15a", "Test Harness Sends SetpointRaise Command Cool Only"),
-            TestStep("15b", "Sets SetpointRaiseLower set to Cool (0x01), and the amount set to 0xE2 (-30 units = -3 degrees)."),
+            TestStep("15", "Test Harness Sends SetpointRaise Command Cool Only"),
             TestStep("16", "Sets OccupiedCoolingSetpoint to default value"),
             TestStep("17", "Sets OccupiedCoolingSetpoint to default value"),
             TestStep("18", "Sets OccupiedCoolingSetpoint to default value"),
@@ -676,7 +674,7 @@ class TC_TSTAT_2_2(MatterBaseTest):
             if val != ControlSequenceOfOperation:
                 asserts.assert_equal(val, 4)
 
-        self.step("13a")
+        self.step("13")
 
         if self.pics_guard(hasCoolingFeature):
             # Sets OccupiedCoolingSetpoint to default value
@@ -693,13 +691,6 @@ class TC_TSTAT_2_2(MatterBaseTest):
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.OccupiedHeatingSetpoint)
             asserts.assert_equal(val, OccupiedHeatingSetpointValue - 30 * 10)
 
-        self.step("13b")
-
-        if self.pics_guard(not hasHeatingFeature):
-            # Sends SetpointRaise Command Heat Only
-            await self.send_single_cmd(cmd=Clusters.Objects.Thermostat.Commands.SetpointRaiseLower(mode=Clusters.Objects.Thermostat.Enums.SetpointRaiseLowerModeEnum.kHeat, amount=-30), endpoint=endpoint)
-            asserts.assert_equal(status, Status.InvalidCommand)
-
         self.step("14")
 
         if self.pics_guard(hasHeatingFeature):
@@ -713,7 +704,7 @@ class TC_TSTAT_2_2(MatterBaseTest):
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.OccupiedHeatingSetpoint)
             asserts.assert_equal(val, OccupiedHeatingSetpointValue + 30 * 10)
 
-        self.step("15a")
+        self.step("15")
 
         if self.pics_guard(hasCoolingFeature):
             # Test Harness Sends SetpointRaise Command Cool Only
@@ -722,13 +713,6 @@ class TC_TSTAT_2_2(MatterBaseTest):
             # Test Harness Reads back OccupiedCoolingSetpoint to confirm the success of the write
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.OccupiedCoolingSetpoint)
             asserts.assert_equal(val, OccupiedCoolingSetpointValue - 30 * 10)
-
-        self.step("15b")
-
-        if self.pics_guard(not hasCoolingFeature):
-            # Test Harness Sends SetpointRaise Command Cool Only
-            await self.send_single_cmd(cmd=Clusters.Objects.Thermostat.Commands.SetpointRaiseLower(mode=Clusters.Objects.Thermostat.Enums.SetpointRaiseLowerModeEnum.kCool, amount=-30), endpoint=endpoint)
-            asserts.assert_equal(status, Status.InvalidCommand)
 
         self.step("16")
 


### PR DESCRIPTION
This reverts commit dc44c00559ec2257fa64117a19ca472a44e436b6.

PR was failing with `UnboundLocalError: cannot access local variable 'status' where it is not associated with a value`.
If trying locally to actually set the value, we seem to get `None` which seems to indicate that the command succeeds rather than fail.

#### Testing

Revert only
