### PR TITLE
ClusterMetadataHeader: Fix/remove unnecessary namespace prefix

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/ClusterMetadataHeader.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/ClusterMetadataHeader.jinja
@@ -46,7 +46,7 @@ namespace Commands {
 {% for command in cluster.commands -%}
 namespace {{command.name | upfirst}} {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = {{cluster.name | upfirst}}::Commands::{{command.name | upfirst}}::Id,
+    .commandId       = {{command.name | upfirst}}::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ {{ command | extract_command_quality_flags | join(", ") }} },
     .invokePrivilege = {{ command.invokeacl | as_privilege}},
 };

--- a/zzz_generated/app-common/clusters/AccessControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/AccessControl/Metadata.h
@@ -81,7 +81,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ReviewFabricRestrictions {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AccessControl::Commands::ReviewFabricRestrictions::Id,
+    .commandId       = ReviewFabricRestrictions::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/AccountLogin/Metadata.h
+++ b/zzz_generated/app-common/clusters/AccountLogin/Metadata.h
@@ -23,7 +23,7 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace GetSetupPIN {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AccountLogin::Commands::GetSetupPIN::Id,
+    .commandId       = GetSetupPIN::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped,
                                                                  DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
@@ -31,7 +31,7 @@ inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
 } // namespace GetSetupPIN
 namespace Login {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AccountLogin::Commands::Login::Id,
+    .commandId       = Login::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped,
                                                                  DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
@@ -39,7 +39,7 @@ inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
 } // namespace Login
 namespace Logout {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AccountLogin::Commands::Logout::Id,
+    .commandId       = Logout::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped,
                                                                  DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,

--- a/zzz_generated/app-common/clusters/Actions/Metadata.h
+++ b/zzz_generated/app-common/clusters/Actions/Metadata.h
@@ -49,84 +49,84 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace InstantAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::InstantAction::Id,
+    .commandId       = InstantAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace InstantAction
 namespace InstantActionWithTransition {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::InstantActionWithTransition::Id,
+    .commandId       = InstantActionWithTransition::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace InstantActionWithTransition
 namespace StartAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::StartAction::Id,
+    .commandId       = StartAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StartAction
 namespace StartActionWithDuration {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::StartActionWithDuration::Id,
+    .commandId       = StartActionWithDuration::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StartActionWithDuration
 namespace StopAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::StopAction::Id,
+    .commandId       = StopAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StopAction
 namespace PauseAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::PauseAction::Id,
+    .commandId       = PauseAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace PauseAction
 namespace PauseActionWithDuration {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::PauseActionWithDuration::Id,
+    .commandId       = PauseActionWithDuration::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace PauseActionWithDuration
 namespace ResumeAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::ResumeAction::Id,
+    .commandId       = ResumeAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ResumeAction
 namespace EnableAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::EnableAction::Id,
+    .commandId       = EnableAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnableAction
 namespace EnableActionWithDuration {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::EnableActionWithDuration::Id,
+    .commandId       = EnableActionWithDuration::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnableActionWithDuration
 namespace DisableAction {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::DisableAction::Id,
+    .commandId       = DisableAction::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace DisableAction
 namespace DisableActionWithDuration {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Actions::Commands::DisableActionWithDuration::Id,
+    .commandId       = DisableActionWithDuration::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Metadata.h
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Metadata.h
@@ -73,7 +73,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetCondition {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ActivatedCarbonFilterMonitoring::Commands::ResetCondition::Id,
+    .commandId       = ResetCondition::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/Metadata.h
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/Metadata.h
@@ -49,21 +49,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace OpenCommissioningWindow {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AdministratorCommissioning::Commands::OpenCommissioningWindow::Id,
+    .commandId       = OpenCommissioningWindow::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace OpenCommissioningWindow
 namespace OpenBasicCommissioningWindow {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AdministratorCommissioning::Commands::OpenBasicCommissioningWindow::Id,
+    .commandId       = OpenBasicCommissioningWindow::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace OpenBasicCommissioningWindow
 namespace RevokeCommissioning {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AdministratorCommissioning::Commands::RevokeCommissioning::Id,
+    .commandId       = RevokeCommissioning::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/Metadata.h
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/Metadata.h
@@ -41,21 +41,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace LaunchApp {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ApplicationLauncher::Commands::LaunchApp::Id,
+    .commandId       = LaunchApp::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace LaunchApp
 namespace StopApp {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ApplicationLauncher::Commands::StopApp::Id,
+    .commandId       = StopApp::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StopApp
 namespace HideApp {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ApplicationLauncher::Commands::HideApp::Id,
+    .commandId       = HideApp::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/AudioOutput/Metadata.h
+++ b/zzz_generated/app-common/clusters/AudioOutput/Metadata.h
@@ -41,14 +41,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SelectOutput {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AudioOutput::Commands::SelectOutput::Id,
+    .commandId       = SelectOutput::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SelectOutput
 namespace RenameOutput {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = AudioOutput::Commands::RenameOutput::Id,
+    .commandId       = RenameOutput::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/BasicInformation/Metadata.h
+++ b/zzz_generated/app-common/clusters/BasicInformation/Metadata.h
@@ -217,7 +217,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace MfgSpecificPing {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = BasicInformation::Commands::MfgSpecificPing::Id,
+    .commandId       = MfgSpecificPing::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/Metadata.h
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/Metadata.h
@@ -89,14 +89,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SuppressAlarm {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = BooleanStateConfiguration::Commands::SuppressAlarm::Id,
+    .commandId       = SuppressAlarm::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SuppressAlarm
 namespace EnableDisableAlarm {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = BooleanStateConfiguration::Commands::EnableDisableAlarm::Id,
+    .commandId       = EnableDisableAlarm::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Metadata.h
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Metadata.h
@@ -169,7 +169,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace KeepActive {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = BridgedDeviceBasicInformation::Commands::KeepActive::Id,
+    .commandId       = KeepActive::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Metadata.h
@@ -97,49 +97,49 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace MPTZSetPosition {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::MPTZSetPosition::Id,
+    .commandId       = MPTZSetPosition::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MPTZSetPosition
 namespace MPTZRelativeMove {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::MPTZRelativeMove::Id,
+    .commandId       = MPTZRelativeMove::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MPTZRelativeMove
 namespace MPTZMoveToPreset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::MPTZMoveToPreset::Id,
+    .commandId       = MPTZMoveToPreset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MPTZMoveToPreset
 namespace MPTZSavePreset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::MPTZSavePreset::Id,
+    .commandId       = MPTZSavePreset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MPTZSavePreset
 namespace MPTZRemovePreset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::MPTZRemovePreset::Id,
+    .commandId       = MPTZRemovePreset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MPTZRemovePreset
 namespace DPTZSetViewport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::DPTZSetViewport::Id,
+    .commandId       = DPTZSetViewport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace DPTZSetViewport
 namespace DPTZRelativeMove {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvSettingsUserLevelManagement::Commands::DPTZRelativeMove::Id,
+    .commandId       = DPTZRelativeMove::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/Metadata.h
@@ -353,70 +353,70 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AudioStreamAllocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::AudioStreamAllocate::Id,
+    .commandId       = AudioStreamAllocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AudioStreamAllocate
 namespace AudioStreamDeallocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::AudioStreamDeallocate::Id,
+    .commandId       = AudioStreamDeallocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AudioStreamDeallocate
 namespace VideoStreamAllocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::VideoStreamAllocate::Id,
+    .commandId       = VideoStreamAllocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace VideoStreamAllocate
 namespace VideoStreamModify {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::VideoStreamModify::Id,
+    .commandId       = VideoStreamModify::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace VideoStreamModify
 namespace VideoStreamDeallocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::VideoStreamDeallocate::Id,
+    .commandId       = VideoStreamDeallocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace VideoStreamDeallocate
 namespace SnapshotStreamAllocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::SnapshotStreamAllocate::Id,
+    .commandId       = SnapshotStreamAllocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SnapshotStreamAllocate
 namespace SnapshotStreamModify {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::SnapshotStreamModify::Id,
+    .commandId       = SnapshotStreamModify::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SnapshotStreamModify
 namespace SnapshotStreamDeallocate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::SnapshotStreamDeallocate::Id,
+    .commandId       = SnapshotStreamDeallocate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SnapshotStreamDeallocate
 namespace SetStreamPriorities {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::SetStreamPriorities::Id,
+    .commandId       = SetStreamPriorities::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetStreamPriorities
 namespace CaptureSnapshot {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CameraAvStreamManagement::Commands::CaptureSnapshot::Id,
+    .commandId       = CaptureSnapshot::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/Channel/Metadata.h
+++ b/zzz_generated/app-common/clusters/Channel/Metadata.h
@@ -49,42 +49,42 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeChannel {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::ChangeChannel::Id,
+    .commandId       = ChangeChannel::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ChangeChannel
 namespace ChangeChannelByNumber {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::ChangeChannelByNumber::Id,
+    .commandId       = ChangeChannelByNumber::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ChangeChannelByNumber
 namespace SkipChannel {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::SkipChannel::Id,
+    .commandId       = SkipChannel::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SkipChannel
 namespace GetProgramGuide {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::GetProgramGuide::Id,
+    .commandId       = GetProgramGuide::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetProgramGuide
 namespace RecordProgram {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::RecordProgram::Id,
+    .commandId       = RecordProgram::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace RecordProgram
 namespace CancelRecordProgram {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Channel::Commands::CancelRecordProgram::Id,
+    .commandId       = CancelRecordProgram::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/Chime/Metadata.h
+++ b/zzz_generated/app-common/clusters/Chime/Metadata.h
@@ -49,7 +49,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace PlayChimeSound {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Chime::Commands::PlayChimeSound::Id,
+    .commandId       = PlayChimeSound::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ClosureControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/ClosureControl/Metadata.h
@@ -65,21 +65,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Stop {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ClosureControl::Commands::Stop::Id,
+    .commandId       = Stop::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Stop
 namespace MoveTo {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ClosureControl::Commands::MoveTo::Id,
+    .commandId       = MoveTo::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveTo
 namespace Calibrate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ClosureControl::Commands::Calibrate::Id,
+    .commandId       = Calibrate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/ClosureDimension/Metadata.h
+++ b/zzz_generated/app-common/clusters/ClosureDimension/Metadata.h
@@ -113,14 +113,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetTarget {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ClosureDimension::Commands::SetTarget::Id,
+    .commandId       = SetTarget::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetTarget
 namespace Step {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ClosureDimension::Commands::Step::Id,
+    .commandId       = Step::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ColorControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/ColorControl/Metadata.h
@@ -441,133 +441,133 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace MoveToHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveToHue::Id,
+    .commandId       = MoveToHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToHue
 namespace MoveHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveHue::Id,
+    .commandId       = MoveHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveHue
 namespace StepHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::StepHue::Id,
+    .commandId       = StepHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StepHue
 namespace MoveToSaturation {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveToSaturation::Id,
+    .commandId       = MoveToSaturation::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToSaturation
 namespace MoveSaturation {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveSaturation::Id,
+    .commandId       = MoveSaturation::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveSaturation
 namespace StepSaturation {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::StepSaturation::Id,
+    .commandId       = StepSaturation::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StepSaturation
 namespace MoveToHueAndSaturation {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveToHueAndSaturation::Id,
+    .commandId       = MoveToHueAndSaturation::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToHueAndSaturation
 namespace MoveToColor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveToColor::Id,
+    .commandId       = MoveToColor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToColor
 namespace MoveColor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveColor::Id,
+    .commandId       = MoveColor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveColor
 namespace StepColor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::StepColor::Id,
+    .commandId       = StepColor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StepColor
 namespace MoveToColorTemperature {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveToColorTemperature::Id,
+    .commandId       = MoveToColorTemperature::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToColorTemperature
 namespace EnhancedMoveToHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::EnhancedMoveToHue::Id,
+    .commandId       = EnhancedMoveToHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnhancedMoveToHue
 namespace EnhancedMoveHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::EnhancedMoveHue::Id,
+    .commandId       = EnhancedMoveHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnhancedMoveHue
 namespace EnhancedStepHue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::EnhancedStepHue::Id,
+    .commandId       = EnhancedStepHue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnhancedStepHue
 namespace EnhancedMoveToHueAndSaturation {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::EnhancedMoveToHueAndSaturation::Id,
+    .commandId       = EnhancedMoveToHueAndSaturation::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnhancedMoveToHueAndSaturation
 namespace ColorLoopSet {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::ColorLoopSet::Id,
+    .commandId       = ColorLoopSet::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ColorLoopSet
 namespace StopMoveStep {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::StopMoveStep::Id,
+    .commandId       = StopMoveStep::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StopMoveStep
 namespace MoveColorTemperature {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::MoveColorTemperature::Id,
+    .commandId       = MoveColorTemperature::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveColorTemperature
 namespace StepColorTemperature {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ColorControl::Commands::StepColorTemperature::Id,
+    .commandId       = StepColorTemperature::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/CommissionerControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/CommissionerControl/Metadata.h
@@ -33,14 +33,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace RequestCommissioningApproval {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommissionerControl::Commands::RequestCommissioningApproval::Id,
+    .commandId       = RequestCommissioningApproval::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RequestCommissioningApproval
 namespace CommissionNode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommissionerControl::Commands::CommissionNode::Id,
+    .commandId       = CommissionNode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/CommodityPrice/Metadata.h
+++ b/zzz_generated/app-common/clusters/CommodityPrice/Metadata.h
@@ -57,14 +57,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace GetDetailedPriceRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommodityPrice::Commands::GetDetailedPriceRequest::Id,
+    .commandId       = GetDetailedPriceRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetDetailedPriceRequest
 namespace GetDetailedForecastRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommodityPrice::Commands::GetDetailedForecastRequest::Id,
+    .commandId       = GetDetailedForecastRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/CommodityTariff/Metadata.h
+++ b/zzz_generated/app-common/clusters/CommodityTariff/Metadata.h
@@ -177,14 +177,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace GetTariffComponent {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommodityTariff::Commands::GetTariffComponent::Id,
+    .commandId       = GetTariffComponent::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetTariffComponent
 namespace GetDayEntry {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = CommodityTariff::Commands::GetDayEntry::Id,
+    .commandId       = GetDayEntry::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ContentAppObserver/Metadata.h
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/Metadata.h
@@ -23,7 +23,7 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace ContentAppMessage {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentAppObserver::Commands::ContentAppMessage::Id,
+    .commandId       = ContentAppMessage::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ContentControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/ContentControl/Metadata.h
@@ -89,70 +89,70 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace UpdatePIN {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::UpdatePIN::Id,
+    .commandId       = UpdatePIN::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UpdatePIN
 namespace ResetPIN {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::ResetPIN::Id,
+    .commandId       = ResetPIN::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ResetPIN
 namespace Enable {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::Enable::Id,
+    .commandId       = Enable::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Enable
 namespace Disable {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::Disable::Id,
+    .commandId       = Disable::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Disable
 namespace AddBonusTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::AddBonusTime::Id,
+    .commandId       = AddBonusTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace AddBonusTime
 namespace SetScreenDailyTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::SetScreenDailyTime::Id,
+    .commandId       = SetScreenDailyTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetScreenDailyTime
 namespace BlockUnratedContent {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::BlockUnratedContent::Id,
+    .commandId       = BlockUnratedContent::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace BlockUnratedContent
 namespace UnblockUnratedContent {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::UnblockUnratedContent::Id,
+    .commandId       = UnblockUnratedContent::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UnblockUnratedContent
 namespace SetOnDemandRatingThreshold {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::SetOnDemandRatingThreshold::Id,
+    .commandId       = SetOnDemandRatingThreshold::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetOnDemandRatingThreshold
 namespace SetScheduledContentRatingThreshold {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentControl::Commands::SetScheduledContentRatingThreshold::Id,
+    .commandId       = SetScheduledContentRatingThreshold::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ContentLauncher/Metadata.h
+++ b/zzz_generated/app-common/clusters/ContentLauncher/Metadata.h
@@ -41,14 +41,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace LaunchContent {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentLauncher::Commands::LaunchContent::Id,
+    .commandId       = LaunchContent::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace LaunchContent
 namespace LaunchURL {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ContentLauncher::Commands::LaunchURL::Id,
+    .commandId       = LaunchURL::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DemandResponseLoadControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/DemandResponseLoadControl/Metadata.h
@@ -89,35 +89,35 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace RegisterLoadControlProgramRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DemandResponseLoadControl::Commands::RegisterLoadControlProgramRequest::Id,
+    .commandId       = RegisterLoadControlProgramRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace RegisterLoadControlProgramRequest
 namespace UnregisterLoadControlProgramRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DemandResponseLoadControl::Commands::UnregisterLoadControlProgramRequest::Id,
+    .commandId       = UnregisterLoadControlProgramRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UnregisterLoadControlProgramRequest
 namespace AddLoadControlEventRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DemandResponseLoadControl::Commands::AddLoadControlEventRequest::Id,
+    .commandId       = AddLoadControlEventRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace AddLoadControlEventRequest
 namespace RemoveLoadControlEventRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DemandResponseLoadControl::Commands::RemoveLoadControlEventRequest::Id,
+    .commandId       = RemoveLoadControlEventRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace RemoveLoadControlEventRequest
 namespace ClearLoadControlEventsRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DemandResponseLoadControl::Commands::ClearLoadControlEventsRequest::Id,
+    .commandId       = ClearLoadControlEventsRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Metadata.h
@@ -89,56 +89,56 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace PowerAdjustRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::PowerAdjustRequest::Id,
+    .commandId       = PowerAdjustRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace PowerAdjustRequest
 namespace CancelPowerAdjustRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::CancelPowerAdjustRequest::Id,
+    .commandId       = CancelPowerAdjustRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace CancelPowerAdjustRequest
 namespace StartTimeAdjustRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::StartTimeAdjustRequest::Id,
+    .commandId       = StartTimeAdjustRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StartTimeAdjustRequest
 namespace PauseRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::PauseRequest::Id,
+    .commandId       = PauseRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace PauseRequest
 namespace ResumeRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::ResumeRequest::Id,
+    .commandId       = ResumeRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ResumeRequest
 namespace ModifyForecastRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::ModifyForecastRequest::Id,
+    .commandId       = ModifyForecastRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ModifyForecastRequest
 namespace RequestConstraintBasedForecast {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::RequestConstraintBasedForecast::Id,
+    .commandId       = RequestConstraintBasedForecast::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace RequestConstraintBasedForecast
 namespace CancelRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagement::Commands::CancelRequest::Id,
+    .commandId       = CancelRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DeviceEnergyManagementMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/Metadata.h
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/Metadata.h
@@ -23,7 +23,7 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace RetrieveLogsRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DiagnosticLogs::Commands::RetrieveLogsRequest::Id,
+    .commandId       = RetrieveLogsRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/Metadata.h
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/Metadata.h
@@ -57,14 +57,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Reset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DishwasherAlarm::Commands::Reset::Id,
+    .commandId       = Reset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Reset
 namespace ModifyEnabledAlarms {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DishwasherAlarm::Commands::ModifyEnabledAlarms::Id,
+    .commandId       = ModifyEnabledAlarms::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DishwasherMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/DishwasherMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DishwasherMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/DoorLock/Metadata.h
+++ b/zzz_generated/app-common/clusters/DoorLock/Metadata.h
@@ -385,147 +385,147 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace LockDoor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::LockDoor::Id,
+    .commandId       = LockDoor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace LockDoor
 namespace UnlockDoor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::UnlockDoor::Id,
+    .commandId       = UnlockDoor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UnlockDoor
 namespace UnlockWithTimeout {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::UnlockWithTimeout::Id,
+    .commandId       = UnlockWithTimeout::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UnlockWithTimeout
 namespace SetWeekDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetWeekDaySchedule::Id,
+    .commandId       = SetWeekDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetWeekDaySchedule
 namespace GetWeekDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::GetWeekDaySchedule::Id,
+    .commandId       = GetWeekDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace GetWeekDaySchedule
 namespace ClearWeekDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearWeekDaySchedule::Id,
+    .commandId       = ClearWeekDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ClearWeekDaySchedule
 namespace SetYearDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetYearDaySchedule::Id,
+    .commandId       = SetYearDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetYearDaySchedule
 namespace GetYearDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::GetYearDaySchedule::Id,
+    .commandId       = GetYearDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace GetYearDaySchedule
 namespace ClearYearDaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearYearDaySchedule::Id,
+    .commandId       = ClearYearDaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ClearYearDaySchedule
 namespace SetHolidaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetHolidaySchedule::Id,
+    .commandId       = SetHolidaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetHolidaySchedule
 namespace GetHolidaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::GetHolidaySchedule::Id,
+    .commandId       = GetHolidaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace GetHolidaySchedule
 namespace ClearHolidaySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearHolidaySchedule::Id,
+    .commandId       = ClearHolidaySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ClearHolidaySchedule
 namespace SetUser {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetUser::Id,
+    .commandId       = SetUser::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetUser
 namespace GetUser {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::GetUser::Id,
+    .commandId       = GetUser::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace GetUser
 namespace ClearUser {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearUser::Id,
+    .commandId       = ClearUser::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ClearUser
 namespace SetCredential {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetCredential::Id,
+    .commandId       = SetCredential::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetCredential
 namespace GetCredentialStatus {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::GetCredentialStatus::Id,
+    .commandId       = GetCredentialStatus::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace GetCredentialStatus
 namespace ClearCredential {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearCredential::Id,
+    .commandId       = ClearCredential::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ClearCredential
 namespace UnboltDoor {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::UnboltDoor::Id,
+    .commandId       = UnboltDoor::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UnboltDoor
 namespace SetAliroReaderConfig {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::SetAliroReaderConfig::Id,
+    .commandId       = SetAliroReaderConfig::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetAliroReaderConfig
 namespace ClearAliroReaderConfig {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = DoorLock::Commands::ClearAliroReaderConfig::Id,
+    .commandId       = ClearAliroReaderConfig::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/EnergyEvse/Metadata.h
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Metadata.h
@@ -209,49 +209,49 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Disable {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::Disable::Id,
+    .commandId       = Disable::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Disable
 namespace EnableCharging {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::EnableCharging::Id,
+    .commandId       = EnableCharging::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnableCharging
 namespace EnableDischarging {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::EnableDischarging::Id,
+    .commandId       = EnableDischarging::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace EnableDischarging
 namespace StartDiagnostics {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::StartDiagnostics::Id,
+    .commandId       = StartDiagnostics::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StartDiagnostics
 namespace SetTargets {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::SetTargets::Id,
+    .commandId       = SetTargets::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetTargets
 namespace GetTargets {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::GetTargets::Id,
+    .commandId       = GetTargets::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetTargets
 namespace ClearTargets {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvse::Commands::ClearTargets::Id,
+    .commandId       = ClearTargets::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EnergyEvseMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Metadata.h
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Metadata.h
@@ -97,7 +97,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetCounts {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = EthernetNetworkDiagnostics::Commands::ResetCounts::Id,
+    .commandId       = ResetCounts::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/FanControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/FanControl/Metadata.h
@@ -121,7 +121,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Step {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = FanControl::Commands::Step::Id,
+    .commandId       = Step::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/FaultInjection/Metadata.h
+++ b/zzz_generated/app-common/clusters/FaultInjection/Metadata.h
@@ -23,14 +23,14 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace FailAtFault {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = FaultInjection::Commands::FailAtFault::Id,
+    .commandId       = FailAtFault::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace FailAtFault
 namespace FailRandomlyAtFault {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = FaultInjection::Commands::FailRandomlyAtFault::Id,
+    .commandId       = FailRandomlyAtFault::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/Metadata.h
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/Metadata.h
@@ -105,28 +105,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ArmFailSafe {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralCommissioning::Commands::ArmFailSafe::Id,
+    .commandId       = ArmFailSafe::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ArmFailSafe
 namespace SetRegulatoryConfig {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralCommissioning::Commands::SetRegulatoryConfig::Id,
+    .commandId       = SetRegulatoryConfig::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetRegulatoryConfig
 namespace CommissioningComplete {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralCommissioning::Commands::CommissioningComplete::Id,
+    .commandId       = CommissioningComplete::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace CommissioningComplete
 namespace SetTCAcknowledgements {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralCommissioning::Commands::SetTCAcknowledgements::Id,
+    .commandId       = SetTCAcknowledgements::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/Metadata.h
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/Metadata.h
@@ -97,21 +97,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace TestEventTrigger {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralDiagnostics::Commands::TestEventTrigger::Id,
+    .commandId       = TestEventTrigger::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace TestEventTrigger
 namespace TimeSnapshot {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralDiagnostics::Commands::TimeSnapshot::Id,
+    .commandId       = TimeSnapshot::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TimeSnapshot
 namespace PayloadTestRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GeneralDiagnostics::Commands::PayloadTestRequest::Id,
+    .commandId       = PayloadTestRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/Metadata.h
@@ -57,28 +57,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace KeySetWrite {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GroupKeyManagement::Commands::KeySetWrite::Id,
+    .commandId       = KeySetWrite::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace KeySetWrite
 namespace KeySetRead {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GroupKeyManagement::Commands::KeySetRead::Id,
+    .commandId       = KeySetRead::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace KeySetRead
 namespace KeySetRemove {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GroupKeyManagement::Commands::KeySetRemove::Id,
+    .commandId       = KeySetRemove::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace KeySetRemove
 namespace KeySetReadAllIndices {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = GroupKeyManagement::Commands::KeySetReadAllIndices::Id,
+    .commandId       = KeySetReadAllIndices::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/Groups/Metadata.h
+++ b/zzz_generated/app-common/clusters/Groups/Metadata.h
@@ -33,42 +33,42 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AddGroup {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::AddGroup::Id,
+    .commandId       = AddGroup::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AddGroup
 namespace ViewGroup {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::ViewGroup::Id,
+    .commandId       = ViewGroup::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ViewGroup
 namespace GetGroupMembership {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::GetGroupMembership::Id,
+    .commandId       = GetGroupMembership::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetGroupMembership
 namespace RemoveGroup {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::RemoveGroup::Id,
+    .commandId       = RemoveGroup::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RemoveGroup
 namespace RemoveAllGroups {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::RemoveAllGroups::Id,
+    .commandId       = RemoveAllGroups::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RemoveAllGroups
 namespace AddGroupIfIdentifying {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Groups::Commands::AddGroupIfIdentifying::Id,
+    .commandId       = AddGroupIfIdentifying::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/Metadata.h
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/Metadata.h
@@ -73,7 +73,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetCondition {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = HepaFilterMonitoring::Commands::ResetCondition::Id,
+    .commandId       = ResetCondition::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/IcdManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/IcdManagement/Metadata.h
@@ -105,21 +105,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace RegisterClient {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = IcdManagement::Commands::RegisterClient::Id,
+    .commandId       = RegisterClient::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RegisterClient
 namespace UnregisterClient {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = IcdManagement::Commands::UnregisterClient::Id,
+    .commandId       = UnregisterClient::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace UnregisterClient
 namespace StayActiveRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = IcdManagement::Commands::StayActiveRequest::Id,
+    .commandId       = StayActiveRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/Identify/Metadata.h
+++ b/zzz_generated/app-common/clusters/Identify/Metadata.h
@@ -41,14 +41,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Identify {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Identify::Commands::Identify::Id,
+    .commandId       = Identify::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace Identify
 namespace TriggerEffect {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Identify::Commands::TriggerEffect::Id,
+    .commandId       = TriggerEffect::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/KeypadInput/Metadata.h
+++ b/zzz_generated/app-common/clusters/KeypadInput/Metadata.h
@@ -23,7 +23,7 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace SendKey {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = KeypadInput::Commands::SendKey::Id,
+    .commandId       = SendKey::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LaundryWasherMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/LevelControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/LevelControl/Metadata.h
@@ -137,63 +137,63 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace MoveToLevel {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::MoveToLevel::Id,
+    .commandId       = MoveToLevel::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToLevel
 namespace Move {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::Move::Id,
+    .commandId       = Move::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Move
 namespace Step {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::Step::Id,
+    .commandId       = Step::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Step
 namespace Stop {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::Stop::Id,
+    .commandId       = Stop::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Stop
 namespace MoveToLevelWithOnOff {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::MoveToLevelWithOnOff::Id,
+    .commandId       = MoveToLevelWithOnOff::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveToLevelWithOnOff
 namespace MoveWithOnOff {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::MoveWithOnOff::Id,
+    .commandId       = MoveWithOnOff::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace MoveWithOnOff
 namespace StepWithOnOff {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::StepWithOnOff::Id,
+    .commandId       = StepWithOnOff::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StepWithOnOff
 namespace StopWithOnOff {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::StopWithOnOff::Id,
+    .commandId       = StopWithOnOff::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StopWithOnOff
 namespace MoveToClosestFrequency {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LevelControl::Commands::MoveToClosestFrequency::Id,
+    .commandId       = MoveToClosestFrequency::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/LowPower/Metadata.h
+++ b/zzz_generated/app-common/clusters/LowPower/Metadata.h
@@ -23,7 +23,7 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace Sleep {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = LowPower::Commands::Sleep::Id,
+    .commandId       = Sleep::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/MediaInput/Metadata.h
+++ b/zzz_generated/app-common/clusters/MediaInput/Metadata.h
@@ -41,28 +41,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SelectInput {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaInput::Commands::SelectInput::Id,
+    .commandId       = SelectInput::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SelectInput
 namespace ShowInputStatus {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaInput::Commands::ShowInputStatus::Id,
+    .commandId       = ShowInputStatus::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ShowInputStatus
 namespace HideInputStatus {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaInput::Commands::HideInputStatus::Id,
+    .commandId       = HideInputStatus::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace HideInputStatus
 namespace RenameInput {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaInput::Commands::RenameInput::Id,
+    .commandId       = RenameInput::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/MediaPlayback/Metadata.h
+++ b/zzz_generated/app-common/clusters/MediaPlayback/Metadata.h
@@ -113,98 +113,98 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Play {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Play::Id,
+    .commandId       = Play::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Play
 namespace Pause {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Pause::Id,
+    .commandId       = Pause::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Pause
 namespace Stop {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Stop::Id,
+    .commandId       = Stop::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Stop
 namespace StartOver {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::StartOver::Id,
+    .commandId       = StartOver::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StartOver
 namespace Previous {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Previous::Id,
+    .commandId       = Previous::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Previous
 namespace Next {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Next::Id,
+    .commandId       = Next::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Next
 namespace Rewind {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Rewind::Id,
+    .commandId       = Rewind::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Rewind
 namespace FastForward {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::FastForward::Id,
+    .commandId       = FastForward::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace FastForward
 namespace SkipForward {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::SkipForward::Id,
+    .commandId       = SkipForward::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SkipForward
 namespace SkipBackward {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::SkipBackward::Id,
+    .commandId       = SkipBackward::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SkipBackward
 namespace Seek {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::Seek::Id,
+    .commandId       = Seek::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Seek
 namespace ActivateAudioTrack {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::ActivateAudioTrack::Id,
+    .commandId       = ActivateAudioTrack::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ActivateAudioTrack
 namespace ActivateTextTrack {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::ActivateTextTrack::Id,
+    .commandId       = ActivateTextTrack::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ActivateTextTrack
 namespace DeactivateTextTrack {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MediaPlayback::Commands::DeactivateTextTrack::Id,
+    .commandId       = DeactivateTextTrack::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/Messages/Metadata.h
+++ b/zzz_generated/app-common/clusters/Messages/Metadata.h
@@ -41,14 +41,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace PresentMessagesRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Messages::Commands::PresentMessagesRequest::Id,
+    .commandId       = PresentMessagesRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace PresentMessagesRequest
 namespace CancelMessagesRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Messages::Commands::CancelMessagesRequest::Id,
+    .commandId       = CancelMessagesRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/Metadata.h
@@ -97,14 +97,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetCookingParameters {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MicrowaveOvenControl::Commands::SetCookingParameters::Id,
+    .commandId       = SetCookingParameters::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetCookingParameters
 namespace AddMoreTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = MicrowaveOvenControl::Commands::AddMoreTime::Id,
+    .commandId       = AddMoreTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ModeSelect/Metadata.h
+++ b/zzz_generated/app-common/clusters/ModeSelect/Metadata.h
@@ -73,7 +73,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ModeSelect::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/Metadata.h
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/Metadata.h
@@ -113,49 +113,49 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ScanNetworks {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::ScanNetworks::Id,
+    .commandId       = ScanNetworks::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ScanNetworks
 namespace AddOrUpdateWiFiNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::AddOrUpdateWiFiNetwork::Id,
+    .commandId       = AddOrUpdateWiFiNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace AddOrUpdateWiFiNetwork
 namespace AddOrUpdateThreadNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::AddOrUpdateThreadNetwork::Id,
+    .commandId       = AddOrUpdateThreadNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace AddOrUpdateThreadNetwork
 namespace RemoveNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::RemoveNetwork::Id,
+    .commandId       = RemoveNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace RemoveNetwork
 namespace ConnectNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::ConnectNetwork::Id,
+    .commandId       = ConnectNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ConnectNetwork
 namespace ReorderNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::ReorderNetwork::Id,
+    .commandId       = ReorderNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ReorderNetwork
 namespace QueryIdentity {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = NetworkCommissioning::Commands::QueryIdentity::Id,
+    .commandId       = QueryIdentity::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/OnOff/Metadata.h
+++ b/zzz_generated/app-common/clusters/OnOff/Metadata.h
@@ -65,42 +65,42 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Off {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::Off::Id,
+    .commandId       = Off::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Off
 namespace On {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::On::Id,
+    .commandId       = On::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace On
 namespace Toggle {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::Toggle::Id,
+    .commandId       = Toggle::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Toggle
 namespace OffWithEffect {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::OffWithEffect::Id,
+    .commandId       = OffWithEffect::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace OffWithEffect
 namespace OnWithRecallGlobalScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::OnWithRecallGlobalScene::Id,
+    .commandId       = OnWithRecallGlobalScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace OnWithRecallGlobalScene
 namespace OnWithTimedOff {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OnOff::Commands::OnWithTimedOff::Id,
+    .commandId       = OnWithTimedOff::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/OperationalCredentials/Metadata.h
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/Metadata.h
@@ -73,70 +73,70 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AttestationRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::AttestationRequest::Id,
+    .commandId       = AttestationRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace AttestationRequest
 namespace CertificateChainRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::CertificateChainRequest::Id,
+    .commandId       = CertificateChainRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace CertificateChainRequest
 namespace CSRRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::CSRRequest::Id,
+    .commandId       = CSRRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace CSRRequest
 namespace AddNOC {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::AddNOC::Id,
+    .commandId       = AddNOC::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace AddNOC
 namespace UpdateNOC {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::UpdateNOC::Id,
+    .commandId       = UpdateNOC::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace UpdateNOC
 namespace UpdateFabricLabel {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::UpdateFabricLabel::Id,
+    .commandId       = UpdateFabricLabel::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace UpdateFabricLabel
 namespace RemoveFabric {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::RemoveFabric::Id,
+    .commandId       = RemoveFabric::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace RemoveFabric
 namespace AddTrustedRootCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::AddTrustedRootCertificate::Id,
+    .commandId       = AddTrustedRootCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace AddTrustedRootCertificate
 namespace SetVIDVerificationStatement {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::SetVIDVerificationStatement::Id,
+    .commandId       = SetVIDVerificationStatement::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetVIDVerificationStatement
 namespace SignVIDVerificationRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalCredentials::Commands::SignVIDVerificationRequest::Id,
+    .commandId       = SignVIDVerificationRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/OperationalState/Metadata.h
+++ b/zzz_generated/app-common/clusters/OperationalState/Metadata.h
@@ -73,28 +73,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Pause {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalState::Commands::Pause::Id,
+    .commandId       = Pause::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Pause
 namespace Stop {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalState::Commands::Stop::Id,
+    .commandId       = Stop::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Stop
 namespace Start {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalState::Commands::Start::Id,
+    .commandId       = Start::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Start
 namespace Resume {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OperationalState::Commands::Resume::Id,
+    .commandId       = Resume::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Metadata.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Metadata.h
@@ -23,21 +23,21 @@ namespace Attributes {} // namespace Attributes
 namespace Commands {
 namespace QueryImage {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OtaSoftwareUpdateProvider::Commands::QueryImage::Id,
+    .commandId       = QueryImage::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace QueryImage
 namespace ApplyUpdateRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::Id,
+    .commandId       = ApplyUpdateRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ApplyUpdateRequest
 namespace NotifyUpdateApplied {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::Id,
+    .commandId       = NotifyUpdateApplied::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Metadata.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Metadata.h
@@ -57,7 +57,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AnnounceOTAProvider {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OtaSoftwareUpdateRequestor::Commands::AnnounceOTAProvider::Id,
+    .commandId       = AnnounceOTAProvider::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/Metadata.h
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/Metadata.h
@@ -73,14 +73,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Stop {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OvenCavityOperationalState::Commands::Stop::Id,
+    .commandId       = Stop::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Stop
 namespace Start {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OvenCavityOperationalState::Commands::Start::Id,
+    .commandId       = Start::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/OvenMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/OvenMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = OvenMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Metadata.h
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Metadata.h
@@ -49,42 +49,42 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AllocatePushTransport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::AllocatePushTransport::Id,
+    .commandId       = AllocatePushTransport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AllocatePushTransport
 namespace DeallocatePushTransport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::DeallocatePushTransport::Id,
+    .commandId       = DeallocatePushTransport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace DeallocatePushTransport
 namespace ModifyPushTransport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::ModifyPushTransport::Id,
+    .commandId       = ModifyPushTransport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace ModifyPushTransport
 namespace SetTransportStatus {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::SetTransportStatus::Id,
+    .commandId       = SetTransportStatus::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SetTransportStatus
 namespace ManuallyTriggerTransport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::ManuallyTriggerTransport::Id,
+    .commandId       = ManuallyTriggerTransport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ManuallyTriggerTransport
 namespace FindTransport {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = PushAvStreamTransport::Commands::FindTransport::Id,
+    .commandId       = FindTransport::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RefrigeratorAndTemperatureControlledCabinetMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/RvcCleanMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RvcCleanMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/RvcOperationalState/Metadata.h
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/Metadata.h
@@ -73,21 +73,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Pause {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RvcOperationalState::Commands::Pause::Id,
+    .commandId       = Pause::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Pause
 namespace Resume {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RvcOperationalState::Commands::Resume::Id,
+    .commandId       = Resume::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Resume
 namespace GoHome {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RvcOperationalState::Commands::GoHome::Id,
+    .commandId       = GoHome::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/RvcRunMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/RvcRunMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = RvcRunMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/SampleMei/Metadata.h
+++ b/zzz_generated/app-common/clusters/SampleMei/Metadata.h
@@ -33,14 +33,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Ping {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = SampleMei::Commands::Ping::Id,
+    .commandId       = Ping::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Ping
 namespace AddArguments {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = SampleMei::Commands::AddArguments::Id,
+    .commandId       = AddArguments::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ScenesManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/ScenesManagement/Metadata.h
@@ -41,56 +41,56 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AddScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::AddScene::Id,
+    .commandId       = AddScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AddScene
 namespace ViewScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::ViewScene::Id,
+    .commandId       = ViewScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ViewScene
 namespace RemoveScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::RemoveScene::Id,
+    .commandId       = RemoveScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RemoveScene
 namespace RemoveAllScenes {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::RemoveAllScenes::Id,
+    .commandId       = RemoveAllScenes::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RemoveAllScenes
 namespace StoreScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::StoreScene::Id,
+    .commandId       = StoreScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace StoreScene
 namespace RecallScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::RecallScene::Id,
+    .commandId       = RecallScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace RecallScene
 namespace GetSceneMembership {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::GetSceneMembership::Id,
+    .commandId       = GetSceneMembership::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetSceneMembership
 namespace CopyScene {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ScenesManagement::Commands::CopyScene::Id,
+    .commandId       = CopyScene::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/ServiceArea/Metadata.h
+++ b/zzz_generated/app-common/clusters/ServiceArea/Metadata.h
@@ -73,14 +73,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SelectAreas {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ServiceArea::Commands::SelectAreas::Id,
+    .commandId       = SelectAreas::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SelectAreas
 namespace SkipArea {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ServiceArea::Commands::SkipArea::Id,
+    .commandId       = SkipArea::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/Metadata.h
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/Metadata.h
@@ -129,7 +129,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SelfTestRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = SmokeCoAlarm::Commands::SelfTestRequest::Id,
+    .commandId       = SelfTestRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/Metadata.h
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/Metadata.h
@@ -57,7 +57,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetWatermarks {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = SoftwareDiagnostics::Commands::ResetWatermarks::Id,
+    .commandId       = ResetWatermarks::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/TargetNavigator/Metadata.h
+++ b/zzz_generated/app-common/clusters/TargetNavigator/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace NavigateTarget {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TargetNavigator::Commands::NavigateTarget::Id,
+    .commandId       = NavigateTarget::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/TemperatureControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/TemperatureControl/Metadata.h
@@ -73,7 +73,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetTemperature {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TemperatureControl::Commands::SetTemperature::Id,
+    .commandId       = SetTemperature::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/Thermostat/Metadata.h
+++ b/zzz_generated/app-common/clusters/Thermostat/Metadata.h
@@ -505,49 +505,49 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetpointRaiseLower {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::SetpointRaiseLower::Id,
+    .commandId       = SetpointRaiseLower::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetpointRaiseLower
 namespace SetWeeklySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::SetWeeklySchedule::Id,
+    .commandId       = SetWeeklySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SetWeeklySchedule
 namespace GetWeeklySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::GetWeeklySchedule::Id,
+    .commandId       = GetWeeklySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GetWeeklySchedule
 namespace ClearWeeklySchedule {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::ClearWeeklySchedule::Id,
+    .commandId       = ClearWeeklySchedule::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace ClearWeeklySchedule
 namespace SetActiveScheduleRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::SetActiveScheduleRequest::Id,
+    .commandId       = SetActiveScheduleRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetActiveScheduleRequest
 namespace SetActivePresetRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::SetActivePresetRequest::Id,
+    .commandId       = SetActivePresetRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetActivePresetRequest
 namespace AtomicRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Thermostat::Commands::AtomicRequest::Id,
+    .commandId       = AtomicRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Metadata.h
@@ -73,28 +73,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace GetActiveDatasetRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadBorderRouterManagement::Commands::GetActiveDatasetRequest::Id,
+    .commandId       = GetActiveDatasetRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace GetActiveDatasetRequest
 namespace GetPendingDatasetRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadBorderRouterManagement::Commands::GetPendingDatasetRequest::Id,
+    .commandId       = GetPendingDatasetRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace GetPendingDatasetRequest
 namespace SetActiveDatasetRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadBorderRouterManagement::Commands::SetActiveDatasetRequest::Id,
+    .commandId       = SetActiveDatasetRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SetActiveDatasetRequest
 namespace SetPendingDatasetRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadBorderRouterManagement::Commands::SetPendingDatasetRequest::Id,
+    .commandId       = SetPendingDatasetRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Metadata.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Metadata.h
@@ -545,7 +545,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetCounts {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadNetworkDiagnostics::Commands::ResetCounts::Id,
+    .commandId       = ResetCounts::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Metadata.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Metadata.h
@@ -49,21 +49,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace AddNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadNetworkDirectory::Commands::AddNetwork::Id,
+    .commandId       = AddNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace AddNetwork
 namespace RemoveNetwork {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadNetworkDirectory::Commands::RemoveNetwork::Id,
+    .commandId       = RemoveNetwork::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace RemoveNetwork
 namespace GetOperationalDataset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ThreadNetworkDirectory::Commands::GetOperationalDataset::Id,
+    .commandId       = GetOperationalDataset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Metadata.h
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Metadata.h
@@ -129,35 +129,35 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetUTCTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TimeSynchronization::Commands::SetUTCTime::Id,
+    .commandId       = SetUTCTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetUTCTime
 namespace SetTrustedTimeSource {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TimeSynchronization::Commands::SetTrustedTimeSource::Id,
+    .commandId       = SetTrustedTimeSource::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace SetTrustedTimeSource
 namespace SetTimeZone {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TimeSynchronization::Commands::SetTimeZone::Id,
+    .commandId       = SetTimeZone::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SetTimeZone
 namespace SetDSTOffset {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TimeSynchronization::Commands::SetDSTOffset::Id,
+    .commandId       = SetDSTOffset::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace SetDSTOffset
 namespace SetDefaultNTP {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TimeSynchronization::Commands::SetDefaultNTP::Id,
+    .commandId       = SetDefaultNTP::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/Timer/Metadata.h
+++ b/zzz_generated/app-common/clusters/Timer/Metadata.h
@@ -49,28 +49,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SetTimer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Timer::Commands::SetTimer::Id,
+    .commandId       = SetTimer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SetTimer
 namespace ResetTimer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Timer::Commands::ResetTimer::Id,
+    .commandId       = ResetTimer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ResetTimer
 namespace AddTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Timer::Commands::AddTime::Id,
+    .commandId       = AddTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace AddTime
 namespace ReduceTime {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = Timer::Commands::ReduceTime::Id,
+    .commandId       = ReduceTime::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Metadata.h
@@ -57,63 +57,63 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ProvisionRootCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::ProvisionRootCertificate::Id,
+    .commandId       = ProvisionRootCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ProvisionRootCertificate
 namespace FindRootCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::FindRootCertificate::Id,
+    .commandId       = FindRootCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace FindRootCertificate
 namespace LookupRootCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::LookupRootCertificate::Id,
+    .commandId       = LookupRootCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace LookupRootCertificate
 namespace RemoveRootCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::RemoveRootCertificate::Id,
+    .commandId       = RemoveRootCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace RemoveRootCertificate
 namespace TLSClientCSR {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::TLSClientCSR::Id,
+    .commandId       = TLSClientCSR::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace TLSClientCSR
 namespace ProvisionClientCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::ProvisionClientCertificate::Id,
+    .commandId       = ProvisionClientCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ProvisionClientCertificate
 namespace FindClientCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::FindClientCertificate::Id,
+    .commandId       = FindClientCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace FindClientCertificate
 namespace LookupClientCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::LookupClientCertificate::Id,
+    .commandId       = LookupClientCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace LookupClientCertificate
 namespace RemoveClientCertificate {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsCertificateManagement::Commands::RemoveClientCertificate::Id,
+    .commandId       = RemoveClientCertificate::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/TlsClientManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/Metadata.h
@@ -41,21 +41,21 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ProvisionEndpoint {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsClientManagement::Commands::ProvisionEndpoint::Id,
+    .commandId       = ProvisionEndpoint::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };
 } // namespace ProvisionEndpoint
 namespace FindEndpoint {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsClientManagement::Commands::FindEndpoint::Id,
+    .commandId       = FindEndpoint::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace FindEndpoint
 namespace RemoveEndpoint {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = TlsClientManagement::Commands::RemoveEndpoint::Id,
+    .commandId       = RemoveEndpoint::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kAdminister,
 };

--- a/zzz_generated/app-common/clusters/UnitTesting/Metadata.h
+++ b/zzz_generated/app-common/clusters/UnitTesting/Metadata.h
@@ -737,189 +737,189 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Test {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::Test::Id,
+    .commandId       = Test::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Test
 namespace TestNotHandled {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestNotHandled::Id,
+    .commandId       = TestNotHandled::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestNotHandled
 namespace TestSpecific {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestSpecific::Id,
+    .commandId       = TestSpecific::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestSpecific
 namespace TestUnknownCommand {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestUnknownCommand::Id,
+    .commandId       = TestUnknownCommand::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestUnknownCommand
 namespace TestAddArguments {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestAddArguments::Id,
+    .commandId       = TestAddArguments::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestAddArguments
 namespace TestSimpleArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestSimpleArgumentRequest::Id,
+    .commandId       = TestSimpleArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestSimpleArgumentRequest
 namespace TestStructArrayArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestStructArrayArgumentRequest::Id,
+    .commandId       = TestStructArrayArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestStructArrayArgumentRequest
 namespace TestStructArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestStructArgumentRequest::Id,
+    .commandId       = TestStructArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestStructArgumentRequest
 namespace TestNestedStructArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestNestedStructArgumentRequest::Id,
+    .commandId       = TestNestedStructArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestNestedStructArgumentRequest
 namespace TestListStructArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestListStructArgumentRequest::Id,
+    .commandId       = TestListStructArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestListStructArgumentRequest
 namespace TestListInt8UArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestListInt8UArgumentRequest::Id,
+    .commandId       = TestListInt8UArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestListInt8UArgumentRequest
 namespace TestNestedStructListArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestNestedStructListArgumentRequest::Id,
+    .commandId       = TestNestedStructListArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestNestedStructListArgumentRequest
 namespace TestListNestedStructListArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestListNestedStructListArgumentRequest::Id,
+    .commandId       = TestListNestedStructListArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestListNestedStructListArgumentRequest
 namespace TestListInt8UReverseRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestListInt8UReverseRequest::Id,
+    .commandId       = TestListInt8UReverseRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestListInt8UReverseRequest
 namespace TestEnumsRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestEnumsRequest::Id,
+    .commandId       = TestEnumsRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestEnumsRequest
 namespace TestNullableOptionalRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestNullableOptionalRequest::Id,
+    .commandId       = TestNullableOptionalRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestNullableOptionalRequest
 namespace TestComplexNullableOptionalRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestComplexNullableOptionalRequest::Id,
+    .commandId       = TestComplexNullableOptionalRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestComplexNullableOptionalRequest
 namespace SimpleStructEchoRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::SimpleStructEchoRequest::Id,
+    .commandId       = SimpleStructEchoRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SimpleStructEchoRequest
 namespace TimedInvokeRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TimedInvokeRequest::Id,
+    .commandId       = TimedInvokeRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kTimed },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TimedInvokeRequest
 namespace TestSimpleOptionalArgumentRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestSimpleOptionalArgumentRequest::Id,
+    .commandId       = TestSimpleOptionalArgumentRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestSimpleOptionalArgumentRequest
 namespace TestEmitTestEventRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestEmitTestEventRequest::Id,
+    .commandId       = TestEmitTestEventRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestEmitTestEventRequest
 namespace TestEmitTestFabricScopedEventRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestEmitTestFabricScopedEventRequest::Id,
+    .commandId       = TestEmitTestFabricScopedEventRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestEmitTestFabricScopedEventRequest
 namespace TestBatchHelperRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestBatchHelperRequest::Id,
+    .commandId       = TestBatchHelperRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestBatchHelperRequest
 namespace TestSecondBatchHelperRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestSecondBatchHelperRequest::Id,
+    .commandId       = TestSecondBatchHelperRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace TestSecondBatchHelperRequest
 namespace StringEchoRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::StringEchoRequest::Id,
+    .commandId       = StringEchoRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StringEchoRequest
 namespace GlobalEchoRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::GlobalEchoRequest::Id,
+    .commandId       = GlobalEchoRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GlobalEchoRequest
 namespace TestDifferentVendorMeiRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = UnitTesting::Commands::TestDifferentVendorMeiRequest::Id,
+    .commandId       = TestDifferentVendorMeiRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Metadata.h
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Metadata.h
@@ -113,14 +113,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Open {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ValveConfigurationAndControl::Commands::Open::Id,
+    .commandId       = Open::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Open
 namespace Close {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ValveConfigurationAndControl::Commands::Close::Id,
+    .commandId       = Close::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/Metadata.h
@@ -73,14 +73,14 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Boost {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WaterHeaterManagement::Commands::Boost::Id,
+    .commandId       = Boost::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace Boost
 namespace CancelBoost {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WaterHeaterManagement::Commands::CancelBoost::Id,
+    .commandId       = CancelBoost::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/Metadata.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ChangeToMode {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WaterHeaterMode::Commands::ChangeToMode::Id,
+    .commandId       = ChangeToMode::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/Metadata.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/Metadata.h
@@ -33,35 +33,35 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace SolicitOffer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportProvider::Commands::SolicitOffer::Id,
+    .commandId       = SolicitOffer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace SolicitOffer
 namespace ProvideOffer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportProvider::Commands::ProvideOffer::Id,
+    .commandId       = ProvideOffer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ProvideOffer
 namespace ProvideAnswer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportProvider::Commands::ProvideAnswer::Id,
+    .commandId       = ProvideAnswer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ProvideAnswer
 namespace ProvideICECandidates {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportProvider::Commands::ProvideICECandidates::Id,
+    .commandId       = ProvideICECandidates::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ProvideICECandidates
 namespace EndSession {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportProvider::Commands::EndSession::Id,
+    .commandId       = EndSession::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{ DataModel::CommandQualityFlags::kFabricScoped },
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Metadata.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Metadata.h
@@ -33,28 +33,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace Offer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportRequestor::Commands::Offer::Id,
+    .commandId       = Offer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Offer
 namespace Answer {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportRequestor::Commands::Answer::Id,
+    .commandId       = Answer::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace Answer
 namespace ICECandidates {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportRequestor::Commands::ICECandidates::Id,
+    .commandId       = ICECandidates::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace ICECandidates
 namespace End {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WebRTCTransportRequestor::Commands::End::Id,
+    .commandId       = End::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Metadata.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Metadata.h
@@ -129,7 +129,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace ResetCounts {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WiFiNetworkDiagnostics::Commands::ResetCounts::Id,
+    .commandId       = ResetCounts::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/Metadata.h
@@ -41,7 +41,7 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace NetworkPassphraseRequest {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WiFiNetworkManagement::Commands::NetworkPassphraseRequest::Id,
+    .commandId       = NetworkPassphraseRequest::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };

--- a/zzz_generated/app-common/clusters/WindowCovering/Metadata.h
+++ b/zzz_generated/app-common/clusters/WindowCovering/Metadata.h
@@ -201,49 +201,49 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace UpOrOpen {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::UpOrOpen::Id,
+    .commandId       = UpOrOpen::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace UpOrOpen
 namespace DownOrClose {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::DownOrClose::Id,
+    .commandId       = DownOrClose::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace DownOrClose
 namespace StopMotion {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::StopMotion::Id,
+    .commandId       = StopMotion::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace StopMotion
 namespace GoToLiftValue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::GoToLiftValue::Id,
+    .commandId       = GoToLiftValue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GoToLiftValue
 namespace GoToLiftPercentage {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::GoToLiftPercentage::Id,
+    .commandId       = GoToLiftPercentage::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GoToLiftPercentage
 namespace GoToTiltValue {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::GoToTiltValue::Id,
+    .commandId       = GoToTiltValue::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };
 } // namespace GoToTiltValue
 namespace GoToTiltPercentage {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = WindowCovering::Commands::GoToTiltPercentage::Id,
+    .commandId       = GoToTiltPercentage::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kOperate,
 };

--- a/zzz_generated/app-common/clusters/ZoneManagement/Metadata.h
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Metadata.h
@@ -57,28 +57,28 @@ inline constexpr DataModel::AttributeEntry kMetadataEntry = {
 namespace Commands {
 namespace CreateTwoDCartesianZone {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ZoneManagement::Commands::CreateTwoDCartesianZone::Id,
+    .commandId       = CreateTwoDCartesianZone::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace CreateTwoDCartesianZone
 namespace UpdateTwoDCartesianZone {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ZoneManagement::Commands::UpdateTwoDCartesianZone::Id,
+    .commandId       = UpdateTwoDCartesianZone::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace UpdateTwoDCartesianZone
 namespace GetTwoDCartesianZone {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ZoneManagement::Commands::GetTwoDCartesianZone::Id,
+    .commandId       = GetTwoDCartesianZone::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };
 } // namespace GetTwoDCartesianZone
 namespace RemoveZone {
 inline constexpr DataModel::AcceptedCommandEntry kMetadataEntry = {
-    .commandId       = ZoneManagement::Commands::RemoveZone::Id,
+    .commandId       = RemoveZone::Id,
     .flags           = BitFlags<DataModel::CommandQualityFlags>{},
     .invokePrivilege = Access::Privilege::kManage,
 };


### PR DESCRIPTION
This PR fixes an issue where the headers included unnecessary namespace prefix. For example:

In https://github.com/project-chip/connectedhomeip/blob/master/zzz_generated/app-common/clusters/Identify/Metadata.h#L51
```
Identify::Commands::Identify'; did you mean simply 'Commands'?
   44 |     .commandId       = Identify::Commands::Identify::Id,
      |                        ^~~~~~~~~~~~~~~~~~
      |                        Commands
```

In this case, for `Identify::Commands::Identify::Id`, the prefix `Identify::Commands::` is unnecessary because that code is already under the namespace.


To regenerate the headers I used:

```
echo "Matter-IDL generation of app-common files"
./scripts/codegen.py --output-dir zzz_generated/app-common/clusters --generator cpp-sdk src/controller/data_model/controller-clusters.matter

echo "Formatting generated files"
find zzz_generated/app-common/clusters/ -type f -name '*.h' -o -name '*.ipp' | xargs clang-format -i
```



#### Testing

Tested it builds successfully in an application that used the Identify cluster.

