### PR TITLE
clang-tidy: fallback to xcrun for sysroot detection on Darwin if xcod…

### DIFF
--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -207,16 +207,26 @@ class TidyState:
 
 
 def find_darwin_gcc_sysroot():
-    for line in subprocess.check_output(
-        "xcodebuild -sdk -version".split(), text=True
-    ).splitlines():
-        if not line.startswith("Path: "):
-            continue
-        path = line[line.find(": ") + 2:]
-        if "/MacOSX.platform/" not in path:
-            continue
-        logging.info("Found %s" % path)
-        return path
+    try:
+        for line in subprocess.check_output(
+            "xcodebuild -sdk -version".split(), text=True
+        ).splitlines():
+            if not line.startswith("Path: "):
+                continue
+            path = line[line.find(": ") + 2:]
+            if "/MacOSX.platform/" not in path:
+                continue
+            logging.info("Found %s" % path)
+            return path
+    except Exception:
+        # lets try with xcrun
+        try:
+            path = subprocess.check_output(
+                "xcrun --sdk macosx --show-sdk-path".split(), text=True
+            )
+            return path.strip()
+        except Exception:
+            pass
 
     # A hard-coded value that works on default installations
     logging.warning("Using default platform sdk path. This may be incorrect.")

--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -209,15 +209,13 @@ class TidyState:
 def find_darwin_gcc_sysroot():
     try:
         for line in subprocess.check_output(
-            "xcodebuild -sdk -version".split(), text=True
+            "xcodebuild -sdk macosx -version".split(), text=True
         ).splitlines():
             if not line.startswith("Path: "):
                 continue
             path = line[line.find(": ") + 2:]
-            if "/MacOSX.platform/" not in path:
-                continue
             logging.info("Found %s" % path)
-            return path
+            return path.strip()
     except Exception:
         # lets try with xcrun
         try:


### PR DESCRIPTION
…ebuild fails

Added exception handling to attempt fetching the macOS SDK path using `xcrun` when `xcodebuild` is unavailable or fails on Darwin systems.

Helpful especially when only Command Line Tools are installed.

#### Testing
Tried below commands and added the changed files from #38491 and can run successfully locally on my M3.
```
gn gen --export-compile-commands out/debug

./scripts/run-clang-tidy-on-compile-commands.py \
    --compile-database out/debug/compile_commands.json \
    --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write|QuieterReporting' \
    --file-list-file  /tmp/changed_files.txt check
```

Above would fail if with below error 
```
2025-04-25 19:21:15 INFO    Searching for a MacOS system root for gcc invocations...
xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance
```

<details><summary>Detailed exception</summary>
```
Traceback (most recent call last):
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/run-clang-tidy-on-compile-commands.py", line 514, in <module>
    main(auto_envvar_prefix="CHIP")
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1666, in invoke
    super().invoke(ctx)
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/pigweed-venv/lib/python3.11/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/run-clang-tidy-on-compile-commands.py", line 449, in main
    context.obj = runner = ClangTidyRunner()
                           ^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/run-clang-tidy-on-compile-commands.py", line 241, in __init__
    self.gcc_sysroot = find_darwin_gcc_sysroot()
                       ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/./scripts/run-clang-tidy-on-compile-commands.py", line 210, in find_darwin_gcc_sysroot
    for line in subprocess.check_output(
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/cipd/packages/pigweed/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shubhampatil/esp/connectedhomeip/.environment/cipd/packages/pigweed/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['xcodebuild', '-sdk', '-version']' returned non-zero exit status 1.
```
</details>