### PR TITLE
Add pcsc dependencies to cert-bins Dockerfile

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -68,6 +68,7 @@ RUN set -x \
     libnspr4-dev \
     libpango1.0-dev \
     libpixman-1-dev \
+    libpcsclite1 \
     libreadline-dev \
     libssl-dev \
     libtool \
@@ -80,6 +81,7 @@ RUN set -x \
     ninja-build \
     openjdk-8-jdk \
     pkg-config \
+    pcscd \
     python3 \
     python3-dev \
     python3-pip \


### PR DESCRIPTION
The goal of this PR is to add the pcsc dependencies to cert-bins image  required for NFC tests 

### Related Issue
https://github.com/project-chip/certification-tool/issues/579

#### Testing
Dockerfile local build: success