### PR TITLE
Populate streamUsage field with the values sent in the original command

### DIFF
--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -54,9 +54,11 @@ void WebRTCManager::Init()
     mWebRTCRequestorServer.Init();
 }
 
-CHIP_ERROR WebRTCManager::SetRemoteDescription(uint16_t webRTCSessionID, const std::string & sdp)
+CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & sdp)
 {
-    mWebRTCProviderClient.NotifyRemoteDecryptorReceived(webRTCSessionID);
+    ChipLogProgress(Camera, "WebRTCManager::HandleAnswer");
+
+    mWebRTCProviderClient.HandleAnswerReceived(sessionId);
 
     if (!mPeerConnection)
     {
@@ -64,11 +66,10 @@ CHIP_ERROR WebRTCManager::SetRemoteDescription(uint16_t webRTCSessionID, const s
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    ChipLogProgress(Camera, "WebRTCManager::SetRemoteDescription");
     mPeerConnection->setRemoteDescription(sdp);
 
     // Schedule the ProvideICECandidates() call to run asynchronously.
-    DeviceLayer::SystemLayer().ScheduleLambda([this, webRTCSessionID]() { ProvideICECandidates(webRTCSessionID); });
+    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() { ProvideICECandidates(sessionId); });
 
     return CHIP_NO_ERROR;
 }
@@ -138,13 +139,13 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> webRTCSessionID,
+CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId,
                                        Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage)
 {
     ChipLogProgress(Camera, "Sending ProvideOffer command to the peer device");
 
     CHIP_ERROR err =
-        mWebRTCProviderClient.ProvideOffer(webRTCSessionID, mLocalDescription, streamUsage, kWebRTCRequesterDynamicEndpointId,
+        mWebRTCProviderClient.ProvideOffer(sessionId, mLocalDescription, streamUsage, kWebRTCRequesterDynamicEndpointId,
                                            MakeOptional(DataModel::NullNullable), // "Null" for video
                                            MakeOptional(DataModel::NullNullable), // "Null" for audio
                                            NullOptional,                          // Omit ICEServers (Optional not present)
@@ -159,7 +160,7 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> webRTCSessi
     return err;
 }
 
-CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t webRTCSessionID)
+CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t sessionId)
 {
     ChipLogProgress(Camera, "Sending ProvideICECandidates command to the peer device");
 
@@ -179,7 +180,7 @@ CHIP_ERROR WebRTCManager::ProvideICECandidates(uint16_t webRTCSessionID)
 
     auto ICECandidates = chip::app::DataModel::List<const chip::CharSpan>(candidateSpans.data(), candidateSpans.size());
 
-    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(webRTCSessionID, ICECandidates);
+    CHIP_ERROR err = mWebRTCProviderClient.ProvideICECandidates(sessionId, ICECandidates);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.h
@@ -35,14 +35,14 @@ public:
 
     void Init();
 
-    CHIP_ERROR SetRemoteDescription(uint16_t webRTCSessionID, const std::string & sdp);
+    CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdp);
 
     CHIP_ERROR Connnect(chip::Controller::DeviceCommissioner & commissioner, chip::NodeId nodeId, chip::EndpointId endpointId);
 
-    CHIP_ERROR ProvideOffer(chip::app::DataModel::Nullable<uint16_t> webRTCSessionID,
+    CHIP_ERROR ProvideOffer(chip::app::DataModel::Nullable<uint16_t> sessionId,
                             chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage);
 
-    CHIP_ERROR ProvideICECandidates(uint16_t webRTCSessionID);
+    CHIP_ERROR ProvideICECandidates(uint16_t sessionId);
 
 private:
     // Make the constructor private to enforce the singleton pattern

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -25,7 +25,8 @@ using namespace ::chip::app;
 namespace {
 
 // Constants
-constexpr uint32_t kSessionTimeoutSeconds = 30;
+constexpr uint32_t kSessionTimeoutSeconds       = 5;
+constexpr uint32_t kDeferredOfferTimeoutSeconds = 30;
 
 } // namespace
 
@@ -41,9 +42,9 @@ void WebRTCProviderClient::Init(const ScopedNodeId & peerId, EndpointId endpoint
 }
 
 CHIP_ERROR WebRTCProviderClient::ProvideOffer(
-    DataModel::Nullable<uint16_t> webRTCSessionID, std::string sdp, Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage,
-    EndpointId originatingEndpointID, Optional<DataModel::Nullable<uint16_t>> videoStreamID,
-    Optional<DataModel::Nullable<uint16_t>> audioStreamID,
+    DataModel::Nullable<uint16_t> webRTCSessionId, std::string sdp, Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage,
+    EndpointId originatingEndpointId, Optional<DataModel::Nullable<uint16_t>> videoStreamId,
+    Optional<DataModel::Nullable<uint16_t>> audioStreamId,
     Optional<DataModel::List<const Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>> ICEServers,
     Optional<chip::CharSpan> ICETransportPolicy)
 {
@@ -60,14 +61,17 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
 
     // Stash data in class members so the CommandSender can safely reference them async
     mSdpString                              = sdp;
-    mProvideOfferData.webRTCSessionID       = webRTCSessionID;
+    mProvideOfferData.webRTCSessionID       = webRTCSessionId;
     mProvideOfferData.sdp                   = CharSpan::fromCharString(mSdpString.c_str());
     mProvideOfferData.streamUsage           = streamUsage;
-    mProvideOfferData.originatingEndpointID = originatingEndpointID;
-    mProvideOfferData.videoStreamID         = videoStreamID;
-    mProvideOfferData.audioStreamID         = audioStreamID;
+    mProvideOfferData.originatingEndpointID = originatingEndpointId;
+    mProvideOfferData.videoStreamID         = videoStreamId;
+    mProvideOfferData.audioStreamID         = audioStreamId;
     mProvideOfferData.ICEServers            = ICEServers;
     mProvideOfferData.ICETransportPolicy    = ICETransportPolicy;
+
+    // Store the streamUsage from the original command so we can build the WebRTCSessionStruct when the response arrives.
+    mCurrentStreamUsage = streamUsage;
 
     // Attempt to find or establish a CASE session to the target PeerId.
     InteractionModelEngine * engine     = InteractionModelEngine::GetInstance();
@@ -83,7 +87,7 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, DataModel::List<const chip::CharSpan> ICECandidates)
+CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionId, DataModel::List<const chip::CharSpan> ICECandidates)
 {
     ChipLogProgress(Camera, "Sending ProvideICECandidates to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 
@@ -97,7 +101,7 @@ CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, 
     mCommandType = CommandType::kProvideICECandidates;
 
     // Stash data in class members so the CommandSender can safely reference them async
-    mProvideICECandidatesData.webRTCSessionID = webRTCSessionID;
+    mProvideICECandidatesData.webRTCSessionID = webRTCSessionId;
     mProvideICECandidatesData.ICECandidates   = ICECandidates;
 
     // Attempt to find or establish a CASE session to the target PeerId.
@@ -114,9 +118,9 @@ CHIP_ERROR WebRTCProviderClient::ProvideICECandidates(uint16_t webRTCSessionID, 
     return CHIP_NO_ERROR;
 }
 
-void WebRTCProviderClient::NotifyRemoteDecryptorReceived(uint16_t webRTCSessionID)
+void WebRTCProviderClient::HandleAnswerReceived(uint16_t webRTCSessionId)
 {
-    ChipLogProgress(Camera, "Remote decryptor received for WebRTC session ID: %u", webRTCSessionID);
+    ChipLogProgress(Camera, "Answer command received for WebRTC session ID: %u", webRTCSessionId);
 
     DeviceLayer::SystemLayer().CancelTimer(OnSessionEstablishTimeout, this);
     MoveToState(State::Idle);
@@ -125,7 +129,8 @@ void WebRTCProviderClient::NotifyRemoteDecryptorReceived(uint16_t webRTCSessionI
 void WebRTCProviderClient::OnResponse(CommandSender * client, const ConcreteCommandPath & path, const StatusIB & status,
                                       TLV::TLVReader * data)
 {
-    ChipLogProgress(Camera, "WebRTCProviderClient: OnResponse.");
+    ChipLogProgress(Camera, "WebRTCProviderClient: OnResponse received for cluster: 0x%" PRIx32 " command: 0x%" PRIx32,
+                    path.mClusterId, path.mCommandId);
 
     CHIP_ERROR error = status.ToChipError();
     if (CHIP_NO_ERROR != error)
@@ -134,16 +139,29 @@ void WebRTCProviderClient::OnResponse(CommandSender * client, const ConcreteComm
         return;
     }
 
-    if (path.mClusterId == Clusters::WebRTCTransportProvider::Id &&
-        path.mCommandId == Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::Id)
+    // Handle different command responses
+    if (path.mClusterId == Clusters::WebRTCTransportProvider::Id)
     {
-        if (data == nullptr)
+        switch (path.mCommandId)
         {
-            ChipLogError(Camera, "Response Failure: data is null");
-            return;
-        }
+        case Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::Id:
+            ChipLogDetail(Camera, "Processing ProvideOfferResponse");
+            if (data == nullptr)
+            {
+                ChipLogError(Camera, "Response failure: data pointer is null");
+                return;
+            }
+            HandleProvideOfferResponse(*data);
+            break;
 
-        HandleProvideOfferResponse(*data);
+        default:
+            ChipLogDetail(Camera, "Unexpected command ID: 0x%" PRIx32, path.mCommandId);
+            break;
+        }
+    }
+    else
+    {
+        ChipLogDetail(Camera, "Unexpected cluster ID: 0x%" PRIx32, path.mClusterId);
     }
 }
 
@@ -185,6 +203,9 @@ const char * WebRTCProviderClient::GetStateStr() const
 
     case State::AwaitingResponse:
         return "AwaitingResponse";
+
+    case State::AwaitingOffer:
+        return "AwaitingOffer";
 
     case State::AwaitingAnswer:
         return "AwaitingAnswer";
@@ -260,11 +281,8 @@ void WebRTCProviderClient::HandleProvideOfferResponse(TLV::TLVReader & data)
 
     Clusters::WebRTCTransportProvider::Commands::ProvideOfferResponse::DecodableType value;
     CHIP_ERROR error = app::DataModel::Decode(data, value);
-    if (error != CHIP_NO_ERROR)
-    {
-        ChipLogError(Camera, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format());
-        return;
-    }
+    VerifyOrReturn(error == CHIP_NO_ERROR,
+                   ChipLogError(Camera, "Failed to decode command response value. Error: %" CHIP_ERROR_FORMAT, error.Format()));
 
     // Create a new session record and populate fields from the decoded command response and current secure session info
     Clusters::WebRTCTransportProvider::Structs::WebRTCSessionStruct::Type session;
@@ -272,29 +290,13 @@ void WebRTCProviderClient::HandleProvideOfferResponse(TLV::TLVReader & data)
     session.peerNodeID     = mPeerId.GetNodeId();
     session.fabricIndex    = mPeerId.GetFabricIndex();
     session.peerEndpointID = mEndpointId;
+    session.streamUsage    = mCurrentStreamUsage;
 
     mCurrentSessionId = value.webRTCSessionID;
 
-    // TODO:: spec needs to clarify how to set streamUsage here
-
     // Populate optional fields for video/audio stream IDs if present; set them to Null otherwise
-    if (value.videoStreamID.HasValue())
-    {
-        session.videoStreamID = value.videoStreamID.Value();
-    }
-    else
-    {
-        session.videoStreamID.SetNull();
-    }
-
-    if (value.audioStreamID.HasValue())
-    {
-        session.audioStreamID = value.audioStreamID.Value();
-    }
-    else
-    {
-        session.audioStreamID.SetNull();
-    }
+    session.videoStreamID = value.videoStreamID.HasValue() ? value.videoStreamID.Value() : DataModel::MakeNullable<uint16_t>();
+    session.audioStreamID = value.audioStreamID.HasValue() ? value.audioStreamID.Value() : DataModel::MakeNullable<uint16_t>();
 
     if (mRequestorServer == nullptr)
     {

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
@@ -60,22 +60,22 @@ public:
      * the data remains valid for the asynchronous command flow, and then requests a device connection
      * to eventually send the command.
      *
-     * @param webRTCSessionID        Nullable ID for the WebRTC session.
+     * @param webRTCSessionId        Nullable ID for the WebRTC session.
      * @param sdp                    The raw SDP (Session Description Protocol) data as a standard string.
      * @param streamUsage            An enum value describing how the stream is intended to be used.
-     * @param originatingEndpointID  The endpoint ID that initiates the offer.
-     * @param videoStreamID          Optional Video stream ID if relevant.
-     * @param audioStreamID          Optional Audio stream ID if relevant.
+     * @param originatingEndpointId  The endpoint ID that initiates the offer.
+     * @param videoStreamId          Optional Video stream ID if relevant.
+     * @param audioStreamId          Optional Audio stream ID if relevant.
      * @param ICEServers             Optional list of ICE server structures, if using custom STUN/TURN servers.
      * @param ICETransportPolicy     Optional policy for ICE transport (e.g., 'all', 'relay', etc.).
      *
      * @return CHIP_NO_ERROR on success, or an appropriate CHIP_ERROR on failure.
      */
     CHIP_ERROR
-    ProvideOffer(chip::app::DataModel::Nullable<uint16_t> webRTCSessionID, std::string sdp,
-                 chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage, chip::EndpointId originatingEndpointID,
-                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamID,
-                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamID,
+    ProvideOffer(chip::app::DataModel::Nullable<uint16_t> webRTCSessionId, std::string sdp,
+                 chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage, chip::EndpointId originatingEndpointId,
+                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
+                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId,
                  chip::Optional<
                      chip::app::DataModel::List<const chip::app::Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>>
                      ICEServers,
@@ -89,24 +89,24 @@ public:
      * to inform the remote side about potential network endpoints it can use to establish or
      * enhance a WebRTC session.
      *
-     * @param webRTCSessionID   The unique identifier for the WebRTC session to which these
+     * @param webRTCSessionId   The unique identifier for the WebRTC session to which these
      *                          ICE candidates apply.
      * @param ICECandidates     A list of ICE candidate strings. Each string typically follows
      *                          the "candidate:" syntax defined in the ICE specification.
      *
      * @return CHIP_NO_ERROR on success, or an appropriate CHIP_ERROR on failure.
      */
-    CHIP_ERROR ProvideICECandidates(uint16_t webRTCSessionID, chip::app::DataModel::List<const chip::CharSpan> ICECandidates);
+    CHIP_ERROR ProvideICECandidates(uint16_t webRTCSessionId, chip::app::DataModel::List<const chip::CharSpan> ICECandidates);
 
     /**
-     * @brief Notify WebRTCProviderClient that the remote decryptor has been received.
+     * @brief Notify WebRTCProviderClient that the Answer command has been received.
      *
      * This allows the client to take appropriate transitions upon receiving
      * confirmation that the remote decryptor has been received.
      *
-     * @param webRTCSessionID   The unique identifier for the WebRTC session.
+     * @param webRTCSessionId   The unique identifier for the WebRTC session.
      */
-    void NotifyRemoteDecryptorReceived(uint16_t webRTCSessionID);
+    void HandleAnswerReceived(uint16_t webRTCSessionId);
 
     /////////// CommandSender Callback Interface /////////
     virtual void OnResponse(chip::app::CommandSender * client, const chip::app::ConcreteCommandPath & path,
@@ -134,6 +134,7 @@ private:
         Idle,             ///< Default state, no communication initiated yet
         Connecting,       ///< Waiting for OnDeviceConnected or OnDeviceConnectionFailure callbacks to be called
         AwaitingResponse, ///< Waiting for command response from camera
+        AwaitingOffer,    ///< Waiting for Offer command from camera
         AwaitingAnswer,   ///< Waiting for Answer command from camera
     };
 
@@ -185,6 +186,8 @@ private:
     // Data needed to send the WebRTCTransportProvider commands
     chip::app::Clusters::WebRTCTransportProvider::Commands::ProvideOffer::Type mProvideOfferData;
     chip::app::Clusters::WebRTCTransportProvider::Commands::ProvideICECandidates::Type mProvideICECandidatesData;
+    chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum mCurrentStreamUsage =
+        chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum::kUnknownEnumValue;
 
     // We store the SDP here so that mProvideOfferData.sdp points to a stable buffer.
     std::string mSdpString;

--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
@@ -35,7 +35,7 @@ CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferA
 CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleAnswer");
-    return WebRTCManager::Instance().SetRemoteDescription(sessionId, sdpAnswer);
+    return WebRTCManager::Instance().HandleAnswer(sessionId, sdpAnswer);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates)


### PR DESCRIPTION
Upon receiving SolicitOfferResponse/ProvideOfferResponse,, the client SHALL create a new WebRTCSessionStruct populated with the values from this command, along with the accessing Peer Node ID and Local Fabric Index entries stored in the Secure Session Context as the PeerNodeID and FabricIndex values, and store in the Requestor clusters CurrentSessions.
But SolicitOfferResponse/ProvideOfferResponse does not contain streamUsage field.

Per clarification, we need to populate the streamUsage field with the values sent in the original command.

```
Aron Rosenberg
The language isn't ideal, but we didn't need to reflect that value back since it sent it in the original Command
Any missing fields in the response needed to create the WebRTCSessionStruct should be populated with the values sent in the original command
```

#### Testing

Validated by CI
