### PR TITLE
Go back to using 1024 bytes for the BDX block size for Thread devices by default.

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.mm
@@ -70,6 +70,10 @@ static constexpr uint16_t ComputeBDXBlockSizeForThread(uint8_t framesPerBlock)
     return 74 + (framesPerBlock - 1) * 95 - 38;
 }
 
+// For now, don't use kMaxThreadFramesPerBdxBlock unless explicitly opted in.
+// The user default will still be respected if it's set.
+constexpr bool kUseSmartBlockSizingForThread = false;
+
 // Timeout for the BDX transfer session. The OTA Spec mandates this should be >= 5 minutes.
 constexpr System::Clock::Timeout kBdxTimeout = System::Clock::Seconds16(5 * 60);
 
@@ -149,7 +153,14 @@ CHIP_ERROR MTROTAImageTransferHandler::Init(Messaging::ExchangeContext * exchang
 
     uint16_t blockSize;
     if (mIsPeerNodeAKnownThreadDevice) {
-        blockSize = ComputeBDXBlockSizeForThread(Platform::GetUserDefaultBDXThreadFramesPerBlock().value_or(kMaxThreadFramesPerBdxBlock));
+        auto framesPerBlock = Platform::GetUserDefaultBDXThreadFramesPerBlock();
+        if (framesPerBlock.has_value()) {
+            blockSize = ComputeBDXBlockSizeForThread(Platform::GetUserDefaultBDXThreadFramesPerBlock().value());
+        } else if (kUseSmartBlockSizingForThread) {
+            blockSize = ComputeBDXBlockSizeForThread(kMaxThreadFramesPerBdxBlock);
+        } else {
+            blockSize = kMaxBdxBlockSize;
+        }
     } else {
         blockSize = kMaxBdxBlockSize;
     }


### PR DESCRIPTION
Apparently some products fail OTA if you use a different block size.

#### Testing

Manual testing, CI will verify normal OTA.