### PR TITLE
Test script updates for new RVC Operational States and Operational State Errors (TC-RVCOPSTATE-2.3, TC-RVCOPSTATE-2.4)

### DIFF
--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -375,21 +375,20 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                 self.write_to_app_pipe({"Name": "EmptyingDustBin"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             await self.read_operational_state_with_check(47, rvc_op_states.kEmptyingDustBin)
-            
+
             # EmptyingDustBin is not Pause compatible
             await self.send_pause_cmd_with_check(48, op_errors.kCommandInvalidInState)
-            
-            # !!! TODO: missing test step from test plan !!!
+
             test_step = "Manually put the device in the EmptyingDustBin(0x43) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
             self.print_step(49, test_step)
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             # EmptyingDustBin is not Resume compatible
             await self.send_resume_cmd_with_check(49, op_errors.kCommandInvalidInState)
-        
+
         if self.check_pics("RVCOPSTATE.S.M.ST_CLEANINGMOP"):
             test_step = "Manually put the device in the CleaningMop(0x44) operational state"
             self.print_step(50, test_step)
@@ -397,21 +396,20 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                 self.write_to_app_pipe({"Name": "CleaningMop"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             await self.read_operational_state_with_check(51, rvc_op_states.kCleaningMop)
-            
+
             # CleaningMop is not Pause compatible
             await self.send_pause_cmd_with_check(52, op_errors.kCommandInvalidInState)
-            
-            # !!! TODO: missing test step from test plan !!!
+
             test_step = "Manually put the device in the CleaningMop(0x44) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
             self.print_step(53, test_step)
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             # CleaningMop is not Resume compatible
             await self.send_resume_cmd_with_check(53, op_errors.kCommandInvalidInState)
-        
+
         if self.check_pics("RVCOPSTATE.S.M.ST_FILLINGWATERTNK"):
             test_step = "Manually put the device in the FillingWaterTank(0x45) operational state"
             self.print_step(54, test_step)
@@ -419,21 +417,20 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                 self.write_to_app_pipe({"Name": "FillingWaterTank"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             await self.read_operational_state_with_check(55, rvc_op_states.kFillingWaterTank)
-            
+
             # FillingWaterTank is not Pause compatible
             await self.send_pause_cmd_with_check(56, op_errors.kCommandInvalidInState)
-            
-            # !!! TODO: missing test step from test plan !!!
+
             test_step = "Manually put the device in the FillingWaterTank(0x45) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
             self.print_step(57, test_step)
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             # FillingWaterTank is not Resume compatible
             await self.send_resume_cmd_with_check(57, op_errors.kCommandInvalidInState)
-        
+
         if self.check_pics("RVCOPSTATE.S.M.ST_UPDATINGMAPS"):
             test_step = "Manually put the device in the UpdatingMaps(0x46) operational state"
             self.print_step(58, test_step)
@@ -441,18 +438,17 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
                 self.write_to_app_pipe({"Name": "UpdatingMaps"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             await self.read_operational_state_with_check(59, rvc_op_states.kUpdatingMaps)
-            
+
             # UpdatingMaps is not Pause compatible
             await self.send_pause_cmd_with_check(60, op_errors.kCommandInvalidInState)
-            
-            # !!! TODO: missing test step from test plan !!!
+
             test_step = "Manually put the device in the UpdatingMaps(0x46) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
             self.print_step(61, test_step)
             if not self.is_ci:
                 self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
-            
+
             # UpdatingMaps is not Resume compatible
             await self.send_resume_cmd_with_check(61, op_errors.kCommandInvalidInState)
 

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -368,6 +368,94 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
 
             await self.send_resume_cmd_with_check(45, op_errors.kCommandInvalidInState)
 
+        if self.check_pics("RVCOPSTATE.S.M.ST_EMPTYINGDUSTBIN"):
+            test_step = "Manually put the device in the EmptyingDustBin(0x43) operational state"
+            self.print_step(46, test_step)
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "EmptyingDustBin"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            await self.read_operational_state_with_check(47, rvc_op_states.kEmptyingDustBin)
+            
+            # EmptyingDustBin is not Pause compatible
+            await self.send_pause_cmd_with_check(48, op_errors.kCommandInvalidInState)
+            
+            # !!! TODO: missing test step from test plan !!!
+            test_step = "Manually put the device in the EmptyingDustBin(0x43) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(49, test_step)
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            # EmptyingDustBin is not Resume compatible
+            await self.send_resume_cmd_with_check(49, op_errors.kCommandInvalidInState)
+        
+        if self.check_pics("RVCOPSTATE.S.M.ST_CLEANINGMOP"):
+            test_step = "Manually put the device in the CleaningMop(0x44) operational state"
+            self.print_step(50, test_step)
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "CleaningMop"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            await self.read_operational_state_with_check(51, rvc_op_states.kCleaningMop)
+            
+            # CleaningMop is not Pause compatible
+            await self.send_pause_cmd_with_check(52, op_errors.kCommandInvalidInState)
+            
+            # !!! TODO: missing test step from test plan !!!
+            test_step = "Manually put the device in the CleaningMop(0x44) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(53, test_step)
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            # CleaningMop is not Resume compatible
+            await self.send_resume_cmd_with_check(53, op_errors.kCommandInvalidInState)
+        
+        if self.check_pics("RVCOPSTATE.S.M.ST_FILLINGWATERTNK"):
+            test_step = "Manually put the device in the FillingWaterTank(0x45) operational state"
+            self.print_step(54, test_step)
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "FillingWaterTank"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            await self.read_operational_state_with_check(55, rvc_op_states.kFillingWaterTank)
+            
+            # FillingWaterTank is not Pause compatible
+            await self.send_pause_cmd_with_check(56, op_errors.kCommandInvalidInState)
+            
+            # !!! TODO: missing test step from test plan !!!
+            test_step = "Manually put the device in the FillingWaterTank(0x45) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(57, test_step)
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            # FillingWaterTank is not Resume compatible
+            await self.send_resume_cmd_with_check(57, op_errors.kCommandInvalidInState)
+        
+        if self.check_pics("RVCOPSTATE.S.M.ST_UPDATINGMAPS"):
+            test_step = "Manually put the device in the UpdatingMaps(0x46) operational state"
+            self.print_step(58, test_step)
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "UpdatingMaps"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            await self.read_operational_state_with_check(59, rvc_op_states.kUpdatingMaps)
+            
+            # UpdatingMaps is not Pause compatible
+            await self.send_pause_cmd_with_check(60, op_errors.kCommandInvalidInState)
+            
+            # !!! TODO: missing test step from test plan !!!
+            test_step = "Manually put the device in the UpdatingMaps(0x46) operational state and RVC Run Mode cluster's CurrentMode attribute set to a mode with the Idle mode tag"
+            self.print_step(61, test_step)
+            if not self.is_ci:
+                self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
+            
+            # UpdatingMaps is not Resume compatible
+            await self.send_resume_cmd_with_check(61, op_errors.kCommandInvalidInState)
+
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -62,6 +62,14 @@ def state_enum_to_text(state_enum):
         return "Charging(0x41)"
     elif state_enum == Clusters.RvcOperationalState.Enums.OperationalStateEnum.kDocked:
         return "Docked(0x42)"
+    elif state_enum == Clusters.RvcOperationalState.Enums.OperationalStateEnum.kEmptyingDustBin:
+        return "EmptyingDustBin(0x43)"
+    elif state_enum == Clusters.RvcOperationalState.Enums.OperationalStateEnum.kCleaningMop:
+        return "CleaningMop(0x44)"
+    elif state_enum == Clusters.RvcOperationalState.Enums.OperationalStateEnum.kFillingWaterTank:
+        return "FillingWaterTank(0x45)"
+    elif state_enum == Clusters.RvcOperationalState.Enums.OperationalStateEnum.kUpdatingMaps:
+        return "UpdatingMaps(0x46)"
     else:
         return "UnknownEnumValue"
 
@@ -92,6 +100,22 @@ def error_enum_to_text(error_enum):
         return "WaterTankLidOpen(0x46)"
     elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kMopCleaningPadMissing:
         return "MopCleaningPadMissing(0x47)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kLowBattery:
+        return "LowBattery(0x48)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kCannotReachTargetArea:
+        return "CannotReachTargetArea(0x49)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kDirtyWaterTankFull:
+        return "DirtyWaterTankFull(0x4A)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kDirtyWaterTankMissing:
+        return "DirtyWaterTankMissing(0x4B)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kWheelsJammed:
+        return "WheelsJammed(0x4C)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kBrushJammed:
+        return "BrushJammed(0x4D)"
+    elif error_enum == Clusters.RvcOperationalState.Enums.ErrorStateEnum.kNavigationSensorObscured:
+        return "NavigationSensorObscured(0x4E)"
+    else:
+        return "UnknownEnumValue"
 
 
 class TC_RVCOPSTATE_2_3(MatterBaseTest):

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -175,69 +175,69 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
             await self.read_operational_state_with_check(12, rvc_op_states.kSeekingCharger)
 
             await self.send_go_home_cmd_with_check(13, op_errors.kNoError)
-        
+
         # State EmptyingDustBin is not GoHome-Compatible
         if self.check_pics("RVCOPSTATE.S.M.ST_EMPTYINGDUSTBIN"):
             step_name = "Manually put the device in the EMPTYING DUST BIN operational state"
             self.print_step(14, step_name)
-            
+
             if self.is_ci:
                 self.write_to_app_pipe({"Name": "Reset"})
                 self.write_to_app_pipe({"Name": "Docked"})
                 self.write_to_app_pipe({"Name": "EmptyingDustBin"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
-            
+
             await self.read_operational_state_with_check(15, rvc_op_states.kEmptyingDustBin)
-            
+
             await self.send_go_home_cmd_with_check(16, op_errors.kCommandInvalidInState)
-        
+
         # State CleaningMop is not GoHome-Compatible
         if self.check_pics("RVCOPSTATE.S.M.ST_CLEANINGMOP"):
             step_name = "Manually put the device in the CLEANING MOP operational state"
             self.print_step(17, step_name)
-            
+
             if self.is_ci:
                 self.write_to_app_pipe({"Name": "Reset"})
                 self.write_to_app_pipe({"Name": "Docked"})
                 self.write_to_app_pipe({"Name": "CleaningMop"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
-            
+
             await self.read_operational_state_with_check(18, rvc_op_states.kCleaningMop)
-            
+
             await self.send_go_home_cmd_with_check(19, op_errors.kCommandInvalidInState)
-        
+
         # State FillingWaterTank is not GoHome-Compatible
-        if self.check_pics("RVCOPSTATE.S.M.ST_FILLINGWATERNK"):
+        if self.check_pics("RVCOPSTATE.S.M.ST_FILLINGWATERTNK"):
             step_name = "Manually put the device in the FILLING WATER TANK operational state"
             self.print_step(20, step_name)
-            
+
             if self.is_ci:
                 self.write_to_app_pipe({"Name": "Reset"})
                 self.write_to_app_pipe({"Name": "Docked"})
                 self.write_to_app_pipe({"Name": "FillingWaterTank"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
-            
+
             await self.read_operational_state_with_check(21, rvc_op_states.kFillingWaterTank)
-            
+
             await self.send_go_home_cmd_with_check(22, op_errors.kCommandInvalidInState)
-        
+
         # State UpdatingMaps is not GoHome-Compatible
         if self.check_pics("RVCOPSTATE.S.M.ST_UPDATINGMAPS"):
             step_name = "Manually put the device in the UPDATING MAPS operational state"
             self.print_step(23, step_name)
-            
+
             if self.is_ci:
                 self.write_to_app_pipe({"Name": "Reset"})
                 self.write_to_app_pipe({"Name": "Docked"})
                 self.write_to_app_pipe({"Name": "UpdatingMaps"})
             else:
                 self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
-            
+
             await self.read_operational_state_with_check(24, rvc_op_states.kUpdatingMaps)
-            
+
             await self.send_go_home_cmd_with_check(25, op_errors.kCommandInvalidInState)
 
 

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -175,6 +175,70 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
             await self.read_operational_state_with_check(12, rvc_op_states.kSeekingCharger)
 
             await self.send_go_home_cmd_with_check(13, op_errors.kNoError)
+        
+        # State EmptyingDustBin is not GoHome-Compatible
+        if self.check_pics("RVCOPSTATE.S.M.ST_EMPTYINGDUSTBIN"):
+            step_name = "Manually put the device in the EMPTYING DUST BIN operational state"
+            self.print_step(14, step_name)
+            
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "Reset"})
+                self.write_to_app_pipe({"Name": "Docked"})
+                self.write_to_app_pipe({"Name": "EmptyingDustBin"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
+            
+            await self.read_operational_state_with_check(15, rvc_op_states.kEmptyingDustBin)
+            
+            await self.send_go_home_cmd_with_check(16, op_errors.kCommandInvalidInState)
+        
+        # State CleaningMop is not GoHome-Compatible
+        if self.check_pics("RVCOPSTATE.S.M.ST_CLEANINGMOP"):
+            step_name = "Manually put the device in the CLEANING MOP operational state"
+            self.print_step(17, step_name)
+            
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "Reset"})
+                self.write_to_app_pipe({"Name": "Docked"})
+                self.write_to_app_pipe({"Name": "CleaningMop"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
+            
+            await self.read_operational_state_with_check(18, rvc_op_states.kCleaningMop)
+            
+            await self.send_go_home_cmd_with_check(19, op_errors.kCommandInvalidInState)
+        
+        # State FillingWaterTank is not GoHome-Compatible
+        if self.check_pics("RVCOPSTATE.S.M.ST_FILLINGWATERNK"):
+            step_name = "Manually put the device in the FILLING WATER TANK operational state"
+            self.print_step(20, step_name)
+            
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "Reset"})
+                self.write_to_app_pipe({"Name": "Docked"})
+                self.write_to_app_pipe({"Name": "FillingWaterTank"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
+            
+            await self.read_operational_state_with_check(21, rvc_op_states.kFillingWaterTank)
+            
+            await self.send_go_home_cmd_with_check(22, op_errors.kCommandInvalidInState)
+        
+        # State UpdatingMaps is not GoHome-Compatible
+        if self.check_pics("RVCOPSTATE.S.M.ST_UPDATINGMAPS"):
+            step_name = "Manually put the device in the UPDATING MAPS operational state"
+            self.print_step(23, step_name)
+            
+            if self.is_ci:
+                self.write_to_app_pipe({"Name": "Reset"})
+                self.write_to_app_pipe({"Name": "Docked"})
+                self.write_to_app_pipe({"Name": "UpdatingMaps"})
+            else:
+                self.wait_for_user_input(prompt_msg=f"{step_name}, and press Enter when ready.")
+            
+            await self.read_operational_state_with_check(24, rvc_op_states.kUpdatingMaps)
+            
+            await self.send_go_home_cmd_with_check(25, op_errors.kCommandInvalidInState)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Testing

Test script updates for new and optional Operational State and Operational State Error enums for TC-RVCOPSTATE-2.3 and TC-RVCOPSTATE-2.4.  Updates to TC-RVCOPSTATE-2.1 were made [here](https://github.com/project-chip/connectedhomeip/pull/38569).

NOTE:  Test plan needs updating to accommodate test steps prior to checking `Resume` compatibility.  [Test Plans Issue filed](https://github.com/CHIP-Specifications/chip-test-plans/issues/5115) (EDIT: [fix PR is up](https://github.com/CHIP-Specifications/chip-test-plans/pull/5117)).  Also filed [SDK Trivial Issue](https://github.com/project-chip/connectedhomeip/issues/38605) to update the test step numbers once the test plan has been augmented.


