### PR TITLE
Interim fix for chip-repl handling of large TCP messages

### DIFF
--- a/src/controller/python/chip/clusters/command.cpp
+++ b/src/controller/python/chip/clusters/command.cpp
@@ -80,7 +80,7 @@ public:
     void OnResponse(CommandSender * apCommandSender, const CommandSender::ResponseData & aResponseData) override
     {
         CHIP_ERROR err = CHIP_NO_ERROR;
-        uint8_t buffer[CHIP_CONFIG_DEFAULT_UDP_MTU_SIZE];
+        uint8_t buffer[CHIP_SYSTEM_CONFIG_MAX_LARGE_BUFFER_SIZE_BYTES];
         uint32_t size = 0;
         // When the apData is nullptr, means we did not receive a valid attribute data from server, status will be some error
         // status.


### PR DESCRIPTION
When testing TC_SEPR_2_3 it issues a command to fetch a payload larger than a UDP packet.
The payload is received ok, but then TLV Encoded using a small (UDP) buffer.

This is an short-term solution to make the buffer larger, but since this is a Linux (Python) then it is probably acceptable for now.

Fixes #38575

**NOTE: the test case TC_SEPR_2_3.py is still marked as disabled in test_metadata.yaml because a 2nd issue: #38580 is still currently unsolved.**


#### Testing

Tested by manually executing commands in chip-repl with energy-gateway-app (see issue for details).