### PR TITLE
Fix various ZAP templates to handle name collisions between global and cluster-specific structs better.

### DIFF
--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -161,14 +161,14 @@ public:
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
         __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpointID:@(endpointId) queue:callbackQueue];
-        {{#if_is_fabric_scoped_struct type}}
+        {{#if_is_fabric_scoped_struct type cluster=../name}}
         __auto_type * params = [[MTRReadParams alloc] init];
         if (mFabricFiltered.HasValue()) {
           params.filterByFabric = mFabricFiltered.Value();
         }
         {{/if_is_fabric_scoped_struct}}
         [cluster read{{>attribute}}With
-        {{~#if_is_fabric_scoped_struct type~}}
+        {{~#if_is_fabric_scoped_struct type cluster=../name~}}
         Params:params completion:
         {{~else~}}
         Completion:

--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -9,7 +9,7 @@ namespace {{asUpperCamelCase name}} {
     struct Type {
     public:
         {{#zcl_struct_items}}
-        {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+        {{zapTypeToEncodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
         {{/zcl_struct_items}}
 
         {{#unless struct_contains_array}}
@@ -41,7 +41,7 @@ namespace {{asUpperCamelCase name}} {
     struct DecodableType {
     public:
         {{#zcl_struct_items}}
-        {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+        {{zapTypeToDecodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
         {{/zcl_struct_items}}
 
         CHIP_ERROR Decode(TLV::TLVReader &reader);

--- a/src/app/zap-templates/templates/app/cluster-commands-header.zapt
+++ b/src/app/zap-templates/templates/app/cluster-commands-header.zapt
@@ -59,7 +59,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
     {{/zcl_command_arguments}}
 
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
@@ -80,7 +80,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
     {{/zcl_command_arguments}}
     CHIP_ERROR Decode(TLV::TLVReader &reader);
 };

--- a/src/app/zap-templates/templates/app/cluster-events-header.zapt
+++ b/src/app/zap-templates/templates/app/cluster-events-header.zapt
@@ -43,7 +43,7 @@ public:
     static constexpr bool kIsFabricScoped = {{isFabricSensitive}};
 
     {{#zcl_event_fields}}
-    {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
+    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
     {{/zcl_event_fields}}
 
     {{#if isFabricSensitive}}
@@ -62,7 +62,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
-    {{zapTypeToDecodableClusterObjectType type}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
+    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
     {{/zcl_event_fields}}
 
     CHIP_ERROR Decode(TLV::TLVReader &reader);

--- a/src/app/zap-templates/templates/app/cluster-events-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-events-src.zapt
@@ -17,7 +17,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const{
     TLV::TLVType outer;
     ReturnErrorOnFailure(aWriter.StartContainer(aTag, TLV::kTLVType_Structure, outer));
     {{#zcl_event_fields}}
-    {{#if_is_fabric_scoped_struct type}}
+    {{#if_is_fabric_scoped_struct type cluster=../../name}}
     ReturnErrorOnFailure(DataModel::EncodeForRead(aWriter, TLV::ContextTag(Fields::k{{asUpperCamelCase name}}), GetFabricIndex(), {{asLowerCamelCase name}}));
     {{else}}
     ReturnErrorOnFailure(DataModel::Encode(aWriter, TLV::ContextTag(Fields::k{{asUpperCamelCase name}}), {{asLowerCamelCase name}}));

--- a/src/app/zap-templates/templates/app/cluster-structs-header.zapt
+++ b/src/app/zap-templates/templates/app/cluster-structs-header.zapt
@@ -22,7 +22,7 @@ namespace Structs {
 {{#if has_more_than_one_cluster}}
 namespace {{asUpperCamelCase name}} = Clusters::detail::Structs::{{asUpperCamelCase name}};
 {{else}}
-{{> cluster_objects_struct header=true}}
+{{> cluster_objects_struct cluster=../name header=true}}
 {{/if}}
 {{/zcl_structs}}
 } // namespace Structs

--- a/src/app/zap-templates/templates/app/cluster-structs-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-structs-src.zapt
@@ -11,7 +11,7 @@ namespace {{asUpperCamelCase name}} {
 namespace Structs {
 {{#zcl_structs}}
 {{#unless has_more_than_one_cluster}}
-{{> cluster_objects_struct header=false}}
+{{> cluster_objects_struct cluster=../name header=false}}
 {{/unless}}
 {{/zcl_structs}}
 } // namespace Structs

--- a/src/app/zap-templates/templates/app/shared-cluster-structs-src.zapt
+++ b/src/app/zap-templates/templates/app/shared-cluster-structs-src.zapt
@@ -13,7 +13,7 @@ namespace detail {
 namespace Structs {
 {{#zcl_structs}}
 {{#if has_more_than_one_cluster}}
-{{> cluster_objects_struct header=false}}
+{{> cluster_objects_struct cluster="" header=false}}
 {{/if}}
 {{/zcl_structs}}
 } // namespace Structs

--- a/src/app/zap-templates/templates/app/shared-cluster-structs.zapt
+++ b/src/app/zap-templates/templates/app/shared-cluster-structs.zapt
@@ -24,7 +24,7 @@ namespace Structs {
 
 {{#zcl_structs}}
 {{#if has_more_than_one_cluster}}
-{{> cluster_objects_struct header=true}}
+{{> cluster_objects_struct  cluster="" header=true}}
 {{/if}}
 {{/zcl_structs}}
 } // namespace Structs

--- a/src/controller/python/templates/partials/struct_def.zapt
+++ b/src/controller/python/templates/partials/struct_def.zapt
@@ -1,4 +1,4 @@
-{{! Takes cluster (possibly "Globals") as argument, already upper-camel-cased. }}
+{{! Takes cluster name (possibly "Globals") as argument, exactly as it looks in the XML. }}
         @dataclass
         class {{asUpperCamelCase name}}(ClusterObject):
             @ChipUtility.classproperty
@@ -6,10 +6,10 @@
                 return ClusterObjectDescriptor(
                     Fields=[
                     {{#zcl_struct_items}}
-                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ fieldIdentifier }}, Type={{zapTypeToPythonClusterObjectType type ns=../cluster}}),
+                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ fieldIdentifier }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase ../cluster) cluster=../cluster}}),
                     {{/zcl_struct_items}}
                     ])
 
             {{#zcl_struct_items}}
-            {{ asLowerCamelCase label }}: '{{zapTypeToPythonClusterObjectType type ns=../cluster}}' = {{getPythonFieldDefault type ns=../cluster}}
+            {{ asLowerCamelCase label }}: '{{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase ../cluster) cluster=../cluster}}' = {{getPythonFieldDefault type ns=(asUpperCamelCase ../cluster) cluster=../cluster}}
             {{/zcl_struct_items}}

--- a/src/controller/python/templates/python-cluster-Objects-py.zapt
+++ b/src/controller/python/templates/python-cluster-Objects-py.zapt
@@ -66,18 +66,18 @@ class {{asUpperCamelCase name}}(Cluster):
             Fields=[
 {{#zcl_attributes_server}}
             {{#if entryType}}
-                ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{asMEI manufacturerCode code}}, Type={{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name)}}),
+                ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{asMEI manufacturerCode code}}, Type={{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}}),
             {{else}}
-                ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{asMEI manufacturerCode code}}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name)}}),
+                ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{asMEI manufacturerCode code}}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name) cluster=parent.name}}),
             {{/if}}
 {{/zcl_attributes_server}}
             ])
 
 {{#zcl_attributes_server}}
 {{#if entryType}}
-    {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name)}} = {{getPythonFieldDefault entryType ns=(asUpperCamelCase parent.name)}}
+    {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}} = {{getPythonFieldDefault entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}}
 {{else}}
-    {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name)}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.name)}}
+    {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name) cluster=parent.name}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.name) cluster=parent.name}}
 {{/if}}
 {{/zcl_attributes_server}}
 
@@ -101,7 +101,7 @@ class {{asUpperCamelCase name}}(Cluster):
 {{#first}}
     class Structs:
 {{/first}}
-{{> struct_def cluster=(asUpperCamelCase parent.name) }}
+{{> struct_def cluster=parent.name }}
 
 {{/zcl_structs}}
 {{#zcl_commands}}
@@ -128,7 +128,7 @@ class {{asUpperCamelCase name}}(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                     {{#zcl_command_arguments}}
-                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ index }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}}),
+                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase label }}", Tag={{ index }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}}),
                     {{/zcl_command_arguments}}
                     ])
             {{#if mustUseTimedInvoke}}
@@ -141,7 +141,7 @@ class {{asUpperCamelCase name}}(Cluster):
             {{#first}}
 
             {{/first}}
-            {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.parent.name)}}
+            {{ asLowerCamelCase label }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}}
             {{/zcl_command_arguments}}
 
 {{/zcl_commands}}
@@ -168,15 +168,15 @@ class {{asUpperCamelCase name}}(Cluster):
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
             {{#if entryType}}
-                return ClusterObjectFieldDescriptor(Type={{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name)}})
+                return ClusterObjectFieldDescriptor(Type={{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}})
             {{else}}
-                return ClusterObjectFieldDescriptor(Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name)}})
+                return ClusterObjectFieldDescriptor(Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name) cluster=parent.name}})
             {{/if}}
 
             {{#if entryType}}
-            value: {{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name)}} = {{getPythonFieldDefault entryType ns=(asUpperCamelCase parent.name)}}
+            value: {{zapTypeToPythonClusterObjectType entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}} = {{getPythonFieldDefault entryType ns=(asUpperCamelCase parent.name) cluster=parent.name}}
             {{else}}
-            value: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name)}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.name)}}
+            value: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.name) cluster=parent.name}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.name) cluster=parent.name}}
             {{/if}}
 
 {{/zcl_attributes_server}}
@@ -199,14 +199,14 @@ class {{asUpperCamelCase name}}(Cluster):
                 return ClusterObjectDescriptor(
                     Fields=[
                     {{#zcl_event_fields}}
-                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase name }}", Tag={{ fieldIdentifier }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}}),
+                        ClusterObjectFieldDescriptor(Label="{{ asLowerCamelCase name }}", Tag={{ fieldIdentifier }}, Type={{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}}),
                     {{/zcl_event_fields}}
                     ])
             {{#zcl_event_fields}}
             {{#first}}
 
             {{/first}}
-            {{ asLowerCamelCase name }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name)}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.parent.name)}}
+            {{ asLowerCamelCase name }}: {{zapTypeToPythonClusterObjectType type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}} = {{getPythonFieldDefault type ns=(asUpperCamelCase parent.parent.name) cluster=parent.parent.name}}
             {{/zcl_event_fields}}
 
 {{/zcl_events}}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -120,7 +120,7 @@ MTR{{cluster}}Cluster{{command}}Params
                (wasIntroducedBeforeRelease "267F4B03-3256-4056-A62D-5237640FDCFE" (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name))))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
-{{~#if_is_fabric_scoped_struct type~}}
+{{~#if_is_fabric_scoped_struct type cluster=../name~}}
   Params:(MTRReadParams * _Nullable)params completion:
 {{~else~}}
   Completion:
@@ -131,7 +131,7 @@ MTR{{cluster}}Cluster{{command}}Params
     [self.device _readKnownAttributeWithEndpointID:self.endpointID
                                          clusterID:@(TypeInfo::GetClusterId())
                                        attributeID:@(TypeInfo::GetAttributeId())
-    {{#if_is_fabric_scoped_struct type}}
+    {{#if_is_fabric_scoped_struct type cluster=../name}}
                                             params:params
     {{else}}
                                             params:nil
@@ -273,14 +273,14 @@ reportHandler:(void (^)({{asObjectiveCClass type parent.name}} * _Nullable value
            (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name)))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
 - (void)read{{>attribute}}With
-{{~#if_is_fabric_scoped_struct type~}}
+{{~#if_is_fabric_scoped_struct type cluster=../name~}}
   Params:(MTRReadParams * _Nullable)params completionHandler:
 {{~else~}}
   CompletionHandler:
 {{~/if_is_fabric_scoped_struct~}}
 (void (^)({{asObjectiveCClass type parent.name compatRemapClusterName=true}} * _Nullable value, NSError * _Nullable error))completionHandler
 {
-  [self readAttribute{{asUpperCamelCase name preserveAcronyms=true}}With{{#if_is_fabric_scoped_struct type}}Params:params completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}
+  [self readAttribute{{asUpperCamelCase name preserveAcronyms=true}}With{{#if_is_fabric_scoped_struct type cluster=../name}}Params:params completion:{{else}}Completion:{{/if_is_fabric_scoped_struct}}
       ^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
         // Cast is safe because subclass does not add any selectors.
         completionHandler(static_cast<{{asObjectiveCClass type parent.name compatRemapClusterName=true}} *>(value), error);

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{#if (isSupported (asUpperCamelCase parent.name preserveAcronyms=true) attribute=(asUpperCamelCase name preserveAcronyms=true))}}
 {{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
-{{~#if_is_fabric_scoped_struct type~}}
+{{~#if_is_fabric_scoped_struct type cluster=../name~}}
   Params:(MTRReadParams * _Nullable)params completion:
 {{~else~}}
   Completion:
@@ -211,7 +211,7 @@ typedef NS_OPTIONS({{asUnderlyingZclType name}}, {{objCEnumName clusterName bitm
            (isSupported (compatClusterNameRemapping parent.name) attribute=(compatAttributeNameRemapping parent.name name)))}}
 {{#*inline "attribute"}}Attribute{{compatAttributeNameRemapping parent.name name}}{{/inline}}
 - (void)read{{>attribute}}With
-{{~#if_is_fabric_scoped_struct type~}}
+{{~#if_is_fabric_scoped_struct type cluster=../name~}}
   Params:(MTRReadParams * _Nullable)params completionHandler:
 {{~else~}}
   CompletionHandler:


### PR DESCRIPTION
Will also need https://github.com/project-chip/zap/pull/1584 to actually generate the right things.

#### Testing

Ensured that codegen without ZAP changes does not change and the ZAP changes do the right thing for codegen.