### PR TITLE
Fix CodeQL builds

### DIFF
--- a/.github/actions/perform-codeql-analysis/action.yaml
+++ b/.github/actions/perform-codeql-analysis/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{ inputs.language }}"
         upload: False
@@ -23,7 +23,7 @@ runs:
         output: "sarif-results/${{ inputs.language }}.sarif"
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: "sarif-results/${{ inputs.language }}.sarif"
     - name: Upload loc as a Build Artifact

--- a/.github/actions/perform-codeql-analysis/action.yaml
+++ b/.github/actions/perform-codeql-analysis/action.yaml
@@ -20,6 +20,12 @@ runs:
           -**/third_party/**
           -**/scripts/**
           -**/tests/**
+
+        # Disabling checks that are not too important, and that result in many hundreds of alerts due to generated code
+        # Disable checks: No trivial switch statements
+          -**/*.cpp:cpp/trivial-switch
+        # Disable check: Empty branch of conditional
+          -**/*.cpp:cpp/empty-block
         input: "sarif-results/${{ inputs.language }}.sarif"
         output: "sarif-results/${{ inputs.language }}.sarif"
 

--- a/.github/actions/perform-codeql-analysis/action.yaml
+++ b/.github/actions/perform-codeql-analysis/action.yaml
@@ -19,6 +19,7 @@ runs:
         patterns: |
           -**/third_party/**
           -**/scripts/**
+          -**/tests/**
         input: "sarif-results/${{ inputs.language }}.sarif"
         output: "sarif-results/${{ inputs.language }}.sarif"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,22 +81,32 @@ jobs:
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Run Tests
               run: scripts/tests/gn_tests.sh
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Set up Build Without Detail Logging
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
             - name: Run Build Without Detail Logging
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Cleanout build output
+              run: rm -rf ./out
             - name: Set up Build Without Progress Logging
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
             - name: Run Build Without Progress Logging
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Set up Build Without Error Logging
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false chip_error_logging=false"
             - name: Run Build Without Error Logging
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Set up Build Without Logging
               run: scripts/build/gn_gen.sh --args="chip_logging=false"
             - name: Run Build Without Logging
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Clean out build output
+              run: rm -rf ./out
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,6 +75,9 @@ jobs:
               uses: github/codeql-action/init@v3
               with:
                   languages: "cpp"
+                  # security-and-quality has more checks than security-extended, but ends up with too many false positives.
+                  # queries: security-and-quality
+                  queries: security-extended
             - name: Setup Build
               run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=false"
             - name: Run Build
@@ -83,30 +86,41 @@ jobs:
               run: scripts/tests/gn_tests.sh
             - name: Clean out build output
               run: rm -rf ./out
+
+            # Do not run below steps with CodeQL since we are getting "Out of runner space issues" with CodeQL and their added coverage is limited
             - name: Set up Build Without Detail Logging
+              if: inputs.run-codeql != true
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false"
             - name: Run Build Without Detail Logging
+              if: inputs.run-codeql != true
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Cleanout build output
+              if: inputs.run-codeql != true
               run: rm -rf ./out
             - name: Set up Build Without Progress Logging
+              if: inputs.run-codeql != true
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false"
             - name: Run Build Without Progress Logging
+              if: inputs.run-codeql != true
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Clean out build output
+              if: inputs.run-codeql != true
               run: rm -rf ./out
             - name: Set up Build Without Error Logging
+              if: inputs.run-codeql != true
               run: scripts/build/gn_gen.sh --args="chip_detail_logging=false chip_progress_logging=false chip_error_logging=false"
             - name: Run Build Without Error Logging
+              if: inputs.run-codeql != true
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Clean out build output
+              if: inputs.run-codeql != true
               run: rm -rf ./out
             - name: Set up Build Without Logging
+              if: inputs.run-codeql != true
               run: scripts/build/gn_gen.sh --args="chip_logging=false"
             - name: Run Build Without Logging
+              if: inputs.run-codeql != true
               run: scripts/run_in_build_env.sh "ninja -C ./out"
-            - name: Clean out build output
-              run: rm -rf ./out
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -302,7 +302,7 @@ jobs:
         name: Build on Linux (python_lib)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
             image: ghcr.io/project-chip/chip-build:125
@@ -367,7 +367,7 @@ jobs:
         name: Build on Linux (python lighting-app)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
             image: ghcr.io/project-chip/chip-build:125
@@ -400,7 +400,7 @@ jobs:
     build_darwin:
         name: Build on Darwin (clang, simulated)
         runs-on: macos-13
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]'  && inputs.run-codeql != true
 
         steps:
             - name: Checkout
@@ -415,11 +415,12 @@ jobs:
             - name: Try to ensure the directory for diagnostic log collection exists
               run: |
                   mkdir -p ~/Library/Logs/DiagnosticReports || true
-            - name: Initialize CodeQL
-              if: ${{ inputs.run-codeql  }}
-              uses: github/codeql-action/init@v3
-              with:
-                  languages: "cpp"
+            #  Build on Darwin + CodeQL often takes 6 hours (which is more than the maximum allowed by GitHub Runners), Deactivate it until we can investigate this
+            # - name: Initialize CodeQL
+            #   if: ${{ inputs.run-codeql  }}
+            #   uses: github/codeql-action/init@v3
+            #   with:
+            #       languages: "cpp"
 
             - name: Setup and Build Simulated Device
               run: |
@@ -473,11 +474,12 @@ jobs:
                   name: crash-log-darwin
                   path: ~/Library/Logs/DiagnosticReports/
 
-            - name: Perform CodeQL Analysis
-              if: ${{ inputs.run-codeql  }}
-              uses: ./.github/actions/perform-codeql-analysis
-              with:
-                language: cpp
+            #  Build on Darwin + CodeQL often takes 6 hours (which is more than the maximum allowed by GitHub Runners), Deactivate it until we can investigate this
+            # - name: Perform CodeQL Analysis
+            #   if: ${{ inputs.run-codeql  }}
+            #   uses: ./.github/actions/perform-codeql-analysis
+            #   with:
+            #     language: cpp
 
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
@@ -488,7 +490,7 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
         runs-on: ubuntu-latest
 
         container:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -161,11 +161,6 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: linux
-            - name: Initialize CodeQL
-              if: ${{ inputs.run-codeql  }}
-              uses: github/codeql-action/init@v3
-              with:
-                  languages: "cpp"
             - name: Setup and Build Simulated Device
               run: |
                   BUILD_TYPE=simulated
@@ -270,11 +265,6 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target linux-fake-tests build"
-            - name: Perform CodeQL Analysis
-              if: ${{ inputs.run-codeql  }}
-              uses: ./.github/actions/perform-codeql-analysis
-              with:
-                language: cpp
 
             - name: Uploading core files
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -138,7 +138,7 @@ jobs:
         name: Build on Linux (fake, gcc_release, clang, simulated)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
 
         container:
             image: ghcr.io/project-chip/chip-build:125
@@ -171,6 +171,13 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: linux
+            # CodeQL + this job is consistently failing (in the step "Run Tests with sanitizers")
+            # deactivate until a better workaround is found
+            # - name: Initialize CodeQL
+            #   if: ${{ inputs.run-codeql  }}
+            #   uses: github/codeql-action/init@v3
+            #   with:
+            #       languages: "cpp"
             - name: Setup and Build Simulated Device
               run: |
                   BUILD_TYPE=simulated
@@ -275,6 +282,13 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --target linux-fake-tests build"
+            # CodeQL + this job is consistently failing (in the step "Run Tests with sanitizers")
+            # deactivate until a better solution is found
+            # - name: Perform CodeQL Analysis
+            #   if: ${{ inputs.run-codeql  }}
+            #   uses: ./.github/actions/perform-codeql-analysis
+            #   with:
+            #     language: cpp
 
             - name: Uploading core files
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,9 +75,7 @@ jobs:
               uses: github/codeql-action/init@v3
               with:
                   languages: "cpp"
-                  # security-and-quality has more checks than security-extended, but ends up with too many false positives.
-                  # queries: security-and-quality
-                  queries: security-extended
+                  queries: security-extended, security-and-quality
             - name: Setup Build
               run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=false"
             - name: Run Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,13 +17,13 @@ on:
   workflow_dispatch:
 #   push:
 #     branches: [ "master", "sve*", "test_event_*", "v1.*" ]
-  pull_request:
+#   pull_request:
   schedule:
     - cron: '0 5 * * *'
 
 jobs:
   analyze:
-    uses: Alami-Amine/connectedhomeip/.github/workflows/build.yaml@master
+    uses: project-chip/connectedhomeip/.github/workflows/build.yaml@master
     with:
       run-codeql: true
   

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 #   push:
 #     branches: [ "master", "sve*", "test_event_*", "v1.*" ]
-#   pull_request:
+  pull_request:
   schedule:
     - cron: '0 5 * * *'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   analyze:
-    uses: project-chip/connectedhomeip/.github/workflows/build.yaml@master
+    uses: Alami-Amine/connectedhomeip/.github/workflows/build.yaml@master
     with:
       run-codeql: true
   


### PR DESCRIPTION
- CodeQL has been failing consistently:
1. in job `build_linux_gcc_debug`: failures were related to out of space issues
2. in job `build_linux`: failures were due to CodeQL conflict with ASAN sanitizer (we are getting false ASAN positives)
3. in job `build_darwin` : very frequent failure due to "exceeding maximum runner time of 6 hours". 


#### Fix
- Deactivate CodeQL for all jobs except the first build and test running steps in `build_linux_gcc_debug` .
- Updating CodeQL actions to V3 (V2 is deprecated)
- Adding more checks to CodeQL

#### Testing

Tested on personal Fork
