### PR TITLE
[Camera] Add support for WebRTC Connect in Chip-Tool Adapter

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -209,6 +209,19 @@ _ALIASES = {
                 'has_endpoint': False,
             },
         }
+    },
+
+    'WebRTC': {
+        'alias': 'webrtc',
+        'commands': {
+            'Connect': {
+                'has_destination': False,
+                'alias': 'connect',
+                'arguments': {
+                    'nodeId': 'node-id',
+                }
+            },
+        }
     }
 }
 

--- a/src/python_testing/TC_WEBRTC_1_1.py
+++ b/src/python_testing/TC_WEBRTC_1_1.py
@@ -15,12 +15,12 @@
 #    limitations under the License.
 
 import logging
-from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
+
 from chip import webrtc
+from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
-                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from chip.webrtc import ErrorCallback_t, PeerConnectedCallback_t, PeerDisconnectedCallback_t, SdpAnswerCallback_t, StatsCallback_t
 from mobly import asserts
 from test_plan_support import commission_if_required
 

--- a/src/python_testing/TC_WEBRTC_1_1.py
+++ b/src/python_testing/TC_WEBRTC_1_1.py
@@ -1,0 +1,168 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
+from chip import webrtc
+from chip.clusters.Types import NullValue
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
+                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from mobly import asserts
+from test_plan_support import commission_if_required
+
+
+class TC_WEBRTC_1_1(MatterBaseTest):
+
+    def steps_TC_WEBRTC_1_1(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(1, "TH sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT."),
+            TestStep(2, "DUT sends Answer command to the TH/WEBRTCR."),
+            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(4, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
+            TestStep(5, "DUT sends ProvideICECandidates command to the TH/WEBRTCR."),
+            TestStep(6, "TH waits for 5 seconds. Verify the WebRTC session has been successfully established.")
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_1(self) -> str:
+        return '[TC-WEBRTC-1.1] Validate that setting an SDP Offer successfully initiates a new WebRTC session.'
+
+    def pics_TC_WEBRTC_1_1(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_1(self):
+
+        def on_answer(answer, peer):
+            logging.debug("on_answer called")
+
+        def on_error(error, peer):
+            logging.debug("on_error called")
+
+        def on_connected(peer):
+            logging.debug("on_connected called")
+
+        def on_disconnected(peer):
+            logging.debug("on_disconnected called")
+
+        def on_stats(stats, peer):
+            logging.debug(stats)
+
+        answer_callback = SdpAnswerCallback_t(on_answer)
+        error_callback = ErrorCallback_t(on_error)
+        peer_connected_callback = PeerConnectedCallback_t(on_connected)
+        peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+        stats_callback = StatsCallback_t(on_stats)
+
+        client = webrtc.CreateWebrtcClient(1)
+
+        webrtc.SetCallbacks(client, answer_callback, error_callback,
+                            peer_connected_callback, peer_disconnected_callback, stats_callback)
+
+        webrtc.webrtc_requestor_init()
+
+        self.step("precondition-1")
+
+        self.step("precondition-2")
+        endpoint = self.get_endpoint(default=1)
+        current_sessions = await self.read_single_attribute_check_success(cluster=WebRTCTransportProvider,
+                                                                          attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+                                                                          endpoint=endpoint)
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        # Allocate video stream in camera app to receive actual video stream
+        # This step is not from test plan
+        resolution = CameraAvStreamManagement.Structs.VideoResolutionStruct(
+            width=640, height=480
+        )
+
+        await self.send_single_cmd(cmd=CameraAvStreamManagement.Commands.VideoStreamAllocate(
+            streamUsage=0, videoCodec=0, minFrameRate=30, maxFrameRate=30, minBitRate=10000, maxBitRate=10000, minFragmentLen=1,
+            maxFragmentLen=10, minResolution=resolution, maxResolution=resolution), endpoint=endpoint)
+
+        # Test Invokation
+
+        #! TODO: upsert session from provide offer response.
+        #! But offer response simply reaches too slow here, by which time,
+        #! matter stack would have already received Answer command
+        #! and returned NOT_FOUND status
+        # TODO: Need to handle offer response with CommandSenderCallback directly
+        # Upserting expected session details for now
+
+        webrtc.webrtc_requestor_upsert_session(
+            sessionId=1,
+            audioStreamId=1,
+            videoStreamId=1,
+            nodeId=self.dut_node_id,
+            fabricIndex=self.default_controller.GetFabricIndexInternal(),
+            endpoint=endpoint
+        )
+        webrtc.InitialiseConnection(client)
+
+        self.step(1)
+
+        offer = webrtc.CreateOffer(client)
+
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=NullValue,
+                sdp=offer,
+                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=NullValue,
+                audioStreamID=NullValue,
+                originatingEndpointID=1
+            ), endpoint=endpoint
+        )
+
+        asserts.assert_true(provide_offer_response.webRTCSessionID >= 0, "Invalid response")
+
+        self.step(2)
+
+        answer_sessionId, answer = webrtc.get_remote_answer()
+
+        asserts.assert_equal(provide_offer_response.webRTCSessionID, answer_sessionId)
+
+        self.step(3)
+
+        webrtc.SetAnswer(client, answer)
+
+        self.step(4)
+        local_candidates = webrtc.GetCandidates()
+
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+            webRTCSessionID=answer_sessionId,
+            ICECandidates=local_candidates
+        ), endpoint=endpoint)
+
+        # TODO handle remote candidates
+        self.skip_step(5)
+        # remote_candidates = get_remote_ice_candidates()
+
+        # for candidate in remote_candidates:
+        #     webrtc.SetCandidate(client, candidate)
+
+        self.step(6)
+        self.wait_for_user_input("Press enter to complete TC execution")
+
+        webrtc.CloseConnection(client)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_2.py
+++ b/src/python_testing/TC_WEBRTC_1_2.py
@@ -16,14 +16,13 @@
 
 import logging
 from concurrent.futures import Future
-from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
+
 from chip import webrtc
+from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
-                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from chip.webrtc import ErrorCallback_t, PeerConnectedCallback_t, PeerDisconnectedCallback_t, SdpAnswerCallback_t, StatsCallback_t
 from mobly import asserts
-
 from test_plan_support import commission_if_required
 
 

--- a/src/python_testing/TC_WEBRTC_1_2.py
+++ b/src/python_testing/TC_WEBRTC_1_2.py
@@ -1,0 +1,241 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+from concurrent.futures import Future
+from chip.clusters import CameraAvStreamManagement, WebRTCTransportProvider
+from chip import webrtc
+from chip.clusters.Types import NullValue
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
+                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from mobly import asserts
+
+from test_plan_support import commission_if_required
+
+
+class TC_WEBRTC_1_2(MatterBaseTest):
+
+    def steps_TC_WEBRTC_1_2(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm there is an active WebRTC sessions exist in DUT"),
+            TestStep(0, "TH Reads CurrentSessions attribute from WEBRTCP (DUT)"),
+            TestStep(1, "TH sends the ProvideOffer command with an SDP Offer with the WebRTCSessionID saved in step 1 to the DUT."),
+            TestStep(2, "TH waits up to 30 seconds for Answer command from the DUT."),
+            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(4, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
+            TestStep(5, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
+            TestStep(6, "TH waits for 10 seconds."),
+            TestStep(7, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.")
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_2(self) -> str:
+        return '[TC-WEBRTC-1.2] Validate that providing an existing WebRTC session ID with an SDP Offer successfully triggers the re-offer flow.'
+
+    def pics_TC_WEBRTC_1_2(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_2(self):
+        def on_answer(answer, peer):
+            logging.debug("on_answer called")
+
+        def on_error(error, peer):
+            logging.debug("on_error called")
+
+        def on_connected(peer):
+            logging.debug("on_connected called")
+
+        def on_disconnected(peer):
+            logging.debug("on_disconnected called")
+
+        def on_stats(stats, peer):
+            logging.debug(stats)
+
+        answer_callback = SdpAnswerCallback_t(on_answer)
+        error_callback = ErrorCallback_t(on_error)
+        peer_connected_callback = PeerConnectedCallback_t(on_connected)
+        peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+        stats_callback = StatsCallback_t(on_stats)
+
+        self.step("precondition-1")
+
+        webrtc.webrtc_requestor_init()
+        # Test Invokation
+
+        client = webrtc.CreateWebrtcClient(1)
+        endpoint = self.get_endpoint(default=1)
+
+        #! TODO: upsert session from provide offer response.
+        #! But offer response simply reaches too slow here, by which time,
+        #! matter stack would have already received Answer command
+        #! and returned NOT_FOUND status
+        # TODO: Need to handle offer response with CommandSenderCallback directly
+        # Upserting expected session details for now
+
+        webrtc.webrtc_requestor_upsert_session(
+            sessionId=1,
+            audioStreamId=1,
+            videoStreamId=1,
+            nodeId=self.dut_node_id,
+            fabricIndex=self.default_controller.GetFabricIndexInternal(),
+            endpoint=endpoint
+        )
+
+        self.step("precondition-2")
+        await establish_webrtc_session(client, endpoint, self)
+
+        current_sessions = await self.read_single_attribute_check_success(cluster=WebRTCTransportProvider,
+                                                                          attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+                                                                          endpoint=endpoint)
+        asserts.assert_equal(len(current_sessions), 1, f"No Pre-Existing session found")
+
+        resolution = CameraAvStreamManagement.Structs.VideoResolutionStruct(
+            width=640, height=480
+        )
+        await self.send_single_cmd(cmd=CameraAvStreamManagement.Commands.VideoStreamAllocate(
+            streamUsage=0, videoCodec=0, minFrameRate=30, maxFrameRate=30, minBitRate=10000, maxBitRate=10000, minFragmentLen=1,
+            maxFragmentLen=10, minResolution=resolution, maxResolution=resolution), endpoint=endpoint)
+
+        self.step(0)
+        prev_sessionid = current_sessions[0].id
+
+        webrtc.SetCallbacks(client, answer_callback, error_callback,
+                            peer_connected_callback, peer_disconnected_callback, stats_callback)
+
+        self.step(1)
+        offer = webrtc.CreateOffer(client)
+
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+                webRTCSessionID=prev_sessionid,
+                sdp=offer,
+                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=NullValue,
+                audioStreamID=NullValue,
+                originatingEndpointID=1
+            ), endpoint=endpoint
+        )
+
+        asserts.assert_equal(provide_offer_response.webRTCSessionID, prev_sessionid, "Invalid response")
+
+        self.step(2)
+        answer_sessionId, answer = webrtc.get_remote_answer(timeout=30)
+
+        asserts.assert_equal(prev_sessionid, answer_sessionId)
+
+        self.step(3)
+        webrtc.SetAnswer(client, answer)
+
+        self.step(4)
+        local_candidates = webrtc.GetCandidates()
+
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+            webRTCSessionID=answer_sessionId,
+            ICECandidates=local_candidates
+        ), endpoint=endpoint)
+
+        # TODO: handle remote candidates
+        #  TH wait for 10s
+        # remote_candidates = get_remote_ice_candidates()
+
+        # for candidate in remote_candidates:
+        #     webrtc.SetCandidate(client, candidate)
+
+        self.skip_step(5)
+        self.step(6)
+        self.wait_for_user_input("Press enter to complete TC execution")
+
+        self.step(7)
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.EndSession(
+            webRTCSessionID=prev_sessionid,
+            reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+        ), endpoint=endpoint)
+
+        webrtc.CloseConnection(client)
+
+
+async def establish_webrtc_session(client, endpoint, ctrl):
+
+    session_established_future = Future()
+
+    def on_connected1(peer):
+        logging.debug("on_connected")
+        session_established_future.set_result(None)
+
+    def on_answer(answer, peer):
+        logging.debug("on_answer called")
+
+    def on_error(error, peer):
+        logging.debug("on_error called")
+
+    def on_disconnected(peer):
+        logging.debug("on_disconnected called")
+
+    def on_stats(stats, peer):
+        logging.debug(stats)
+
+    answer_callback = SdpAnswerCallback_t(on_answer)
+    error_callback = ErrorCallback_t(on_error)
+    peer_connected_callback = PeerConnectedCallback_t(on_connected1)
+    peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+    stats_callback = StatsCallback_t(on_stats)
+
+    webrtc.SetCallbacks(client, answer_callback, error_callback,
+                        peer_connected_callback, peer_disconnected_callback, stats_callback)
+    webrtc.InitialiseConnection(client)
+
+    offer = webrtc.CreateOffer(client)
+
+    provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await ctrl.send_single_cmd(
+        cmd=WebRTCTransportProvider.Commands.ProvideOffer(
+            webRTCSessionID=NullValue,
+            sdp=offer,
+            streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+            videoStreamID=NullValue,
+            audioStreamID=NullValue,
+            originatingEndpointID=1
+        ), endpoint=endpoint
+    )
+
+    asserts.assert_true(provide_offer_response.webRTCSessionID >= 0, "Invalid response")
+
+    answer_sessionId, answer = webrtc.get_remote_answer()
+
+    asserts.assert_equal(provide_offer_response.webRTCSessionID, answer_sessionId)
+
+    webrtc.SetAnswer(client, answer)
+
+    local_candidates = webrtc.GetCandidates()
+
+    await ctrl.send_single_cmd(cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+        webRTCSessionID=answer_sessionId,
+        ICECandidates=local_candidates
+    ), endpoint=endpoint)
+
+    # TODO handle remote candidates
+    # remote_candidates = get_remote_ice_candidates()
+
+    # for candidate in remote_candidates:
+    #     webrtc.SetCandidate(client, candidate)
+    return session_established_future.result()
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_3.py
+++ b/src/python_testing/TC_WEBRTC_1_3.py
@@ -1,0 +1,153 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+from chip.clusters import WebRTCTransportProvider
+from chip import webrtc
+from chip.clusters.Types import NullValue
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
+                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from mobly import asserts
+
+from test_plan_support import commission_if_required
+
+
+class TC_WEBRTC_1_3(MatterBaseTest):
+
+    def steps_TC_WEBRTC_1_3(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(1, "TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT."),
+            TestStep(2, "TH waits up to 30 seconds for Offer command from the DUT."),
+            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(4, "TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT."),
+            TestStep(5, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
+            TestStep(6, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
+            TestStep(7, "TH waits for 10 seconds."),
+            TestStep(8, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.")
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_3(self) -> str:
+        return '[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode.'
+
+    def pics_TC_WEBRTC_1_3(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_3(self):
+        def on_answer(answer, peer):
+            logging.debug("on_answer called")
+
+        def on_error(error, peer):
+            logging.debug("on_error called")
+
+        def on_connected(peer):
+            logging.debug("on_connected called")
+
+        def on_disconnected(peer):
+            logging.debug("on_disconnected called")
+
+        def on_stats(stats, peer):
+            logging.debug(stats)
+
+        answer_callback = SdpAnswerCallback_t(on_answer)
+        error_callback = ErrorCallback_t(on_error)
+        peer_connected_callback = PeerConnectedCallback_t(on_connected)
+        peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+        stats_callback = StatsCallback_t(on_stats)
+
+        client = webrtc.CreateWebrtcClient(1)
+
+        webrtc.SetCallbacks(client, answer_callback, error_callback,
+                            peer_connected_callback, peer_disconnected_callback, stats_callback)
+
+        webrtc.webrtc_requestor_init()
+
+        # TODO Initialise PeerConnection without setting local offer
+
+        endpoint = self.get_endpoint(default=1)
+
+        self.step("precondition-1")
+
+        self.step("precondition-2")
+        current_sessions = await self.read_single_attribute_check_success(cluster=WebRTCTransportProvider,
+                                                                          attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+                                                                          endpoint=endpoint)
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        self.step(1)
+        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.SolicitOffer(
+                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=NullValue,
+                audioStreamID=NullValue,
+            ), endpoint=endpoint
+        )
+        session_id = solicit_offer_response.webRTCSessionID
+        asserts.assert_true(session_id >= 0, "Invalid response")
+        asserts.assert_true(solicit_offer_response.deferredOffer, "Expected deferredOffer = True")
+
+        self.step(2)
+        offer_sessionId, remote_offer_sdp, remote_nodeid = webrtc.get_remote_offer(timeout=30)
+        asserts.assert_equal(offer_sessionId, session_id, "Invalid session id")
+        asserts.assert_true(len(remote_offer_sdp) > 0, "Invalid offer sdp received")
+
+        self.step(3)
+        webrtc.SetOffer(client, remote_offer_sdp)
+
+        self.step(4)
+        local_answer = webrtc.CreateAnswer(client)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideAnswer(
+                webRTCSessionID=session_id,
+                sdp=local_answer
+            ), endpoint=endpoint
+        )
+
+        self.step(5)
+        local_candidates = webrtc.GetCandidates()
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=session_id,
+                ICECandidates=local_candidates
+            ), endpoint=endpoint
+        )
+
+        self.step(6)
+        ice_session_id, remote_candidates = webrtc.get_remote_ice_candidates(timeout=30)
+        asserts.assert_equal(ice_session_id, session_id, "Invalid session id")
+        asserts.assert_true(len(remote_candidates) > 0, "Invalid ice candidates received")
+        for candidate in remote_candidates:
+            webrtc.SetCandidate(client, candidate)
+
+        self.step(7)
+        self.wait_for_user_input("Verify WebRTC session is established")
+
+        self.step(8)
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.EndSession(
+            webRTCSessionID=session_id,
+            reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+        ), endpoint=endpoint)
+
+        webrtc.CloseConnection(client)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_3.py
+++ b/src/python_testing/TC_WEBRTC_1_3.py
@@ -15,14 +15,13 @@
 #    limitations under the License.
 
 import logging
-from chip.clusters import WebRTCTransportProvider
+
 from chip import webrtc
+from chip.clusters import WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
-                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from chip.webrtc import ErrorCallback_t, PeerConnectedCallback_t, PeerDisconnectedCallback_t, SdpAnswerCallback_t, StatsCallback_t
 from mobly import asserts
-
 from test_plan_support import commission_if_required
 
 

--- a/src/python_testing/TC_WEBRTC_1_4.py
+++ b/src/python_testing/TC_WEBRTC_1_4.py
@@ -1,0 +1,154 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+from chip.clusters import WebRTCTransportProvider
+from chip import webrtc
+from chip.clusters.Types import NullValue
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
+                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from mobly import asserts
+
+from test_plan_support import commission_if_required
+
+
+class TC_WEBRTC_1_4(MatterBaseTest):
+
+    def steps_TC_WEBRTC_1_4(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(1, "TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT."),
+            TestStep(2, "DUT sends Offer command to TH/WEBRTCR."),
+            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(4, "TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT."),
+            TestStep(5, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
+            TestStep(6, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
+            TestStep(7, "TH waits for 10 seconds."),
+            TestStep(8, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.")
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_4(self) -> str:
+        return '[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode.'
+
+    def pics_TC_WEBRTC_1_4(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_4(self):
+        def on_answer(answer, peer):
+            logging.debug("on_answer called")
+
+        def on_error(error, peer):
+            logging.debug("on_error called")
+
+        def on_connected(peer):
+            logging.debug("on_connected called")
+
+        def on_disconnected(peer):
+            logging.debug("on_disconnected called")
+
+        def on_stats(stats, peer):
+            logging.debug(stats)
+
+        answer_callback = SdpAnswerCallback_t(on_answer)
+        error_callback = ErrorCallback_t(on_error)
+        peer_connected_callback = PeerConnectedCallback_t(on_connected)
+        peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+        stats_callback = StatsCallback_t(on_stats)
+
+        client = webrtc.CreateWebrtcClient(1)
+
+        webrtc.SetCallbacks(client, answer_callback, error_callback,
+                            peer_connected_callback, peer_disconnected_callback, stats_callback)
+
+        webrtc.webrtc_requestor_init()
+
+        # TODO Initialise PeerConnection without setting local offer
+
+        endpoint = self.get_endpoint(default=1)
+
+        self.step("precondition-1")
+
+        self.step("precondition-2")
+        current_sessions = await self.read_single_attribute_check_success(cluster=WebRTCTransportProvider,
+                                                                          attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+                                                                          endpoint=endpoint)
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        self.step(1)
+        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.SolicitOffer(
+                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=NullValue,
+                audioStreamID=NullValue,
+            ), endpoint=endpoint
+        )
+        session_id = solicit_offer_response.webRTCSessionID
+        asserts.assert_true(session_id >= 0, "Invalid response")
+        asserts.assert_false(solicit_offer_response.deferredOffer, "Expected deferredOffer = False")
+
+        self.step(2)
+        # TH should immediately get Answer from DUT
+        offer_sessionId, remote_offer_sdp, remote_nodeid = webrtc.get_remote_offer(timeout=5)
+        asserts.assert_equal(offer_sessionId, session_id, "Invalid session id")
+        asserts.assert_true(len(remote_offer_sdp) > 0, "Invalid offer sdp received")
+
+        self.step(3)
+        webrtc.SetOffer(client, remote_offer_sdp)
+
+        self.step(4)
+        local_answer = webrtc.CreateAnswer(client)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideAnswer(
+                webRTCSessionID=session_id,
+                sdp=local_answer
+            ), endpoint=endpoint
+        )
+
+        self.step(5)
+        local_candidates = webrtc.GetCandidates()
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=session_id,
+                ICECandidates=local_candidates
+            ), endpoint=endpoint
+        )
+
+        self.step(6)
+        ice_session_id, remote_candidates = webrtc.get_remote_ice_candidates(timeout=30)
+        asserts.assert_equal(ice_session_id, session_id, "Invalid session id")
+        asserts.assert_true(len(remote_candidates) > 0, "Invalid ice candidates received")
+        for candidate in remote_candidates:
+            webrtc.SetCandidate(client, candidate)
+
+        self.step(7)
+        self.wait_for_user_input("Verify WebRTC session is established")
+
+        self.step(8)
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.EndSession(
+            webRTCSessionID=session_id,
+            reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+        ), endpoint=endpoint)
+
+        webrtc.CloseConnection(client)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_4.py
+++ b/src/python_testing/TC_WEBRTC_1_4.py
@@ -15,14 +15,13 @@
 #    limitations under the License.
 
 import logging
-from chip.clusters import WebRTCTransportProvider
+
 from chip import webrtc
+from chip.clusters import WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
-                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from chip.webrtc import ErrorCallback_t, PeerConnectedCallback_t, PeerDisconnectedCallback_t, SdpAnswerCallback_t, StatsCallback_t
 from mobly import asserts
-
 from test_plan_support import commission_if_required
 
 

--- a/src/python_testing/TC_WEBRTC_1_5.py
+++ b/src/python_testing/TC_WEBRTC_1_5.py
@@ -1,0 +1,140 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+from chip.clusters import WebRTCTransportProvider
+from chip import webrtc
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
+                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
+from mobly import asserts
+
+from test_plan_support import commission_if_required
+
+
+class TC_WEBRTC_1_5(MatterBaseTest):
+
+    def steps_TC_WEBRTC_1_5(self) -> list[TestStep]:
+        steps = [
+            TestStep("precondition-1", commission_if_required(), is_commissioning=True),
+            TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
+            TestStep(1, "Follow manufacturer provided instructions to have DUT send the Offer command to the TH."),
+            TestStep(2, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(3, "TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT."),
+            TestStep(4, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
+            TestStep(5, "DUT sends ProvideICECandidates command to TH/WEBRTCR."),
+            TestStep(6, "TH waits for 5 seconds."),
+            TestStep(7, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.")
+        ]
+
+        return steps
+
+    def desc_TC_WEBRTC_1_5(self) -> str:
+        return '[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode.'
+
+    def pics_TC_WEBRTC_1_5(self) -> list[str]:
+        return ["WEBRTCR", "WEBRTCP"]
+
+    @async_test_body
+    async def test_TC_WEBRTC_1_5(self):
+        def on_answer(answer, peer):
+            logging.debug("on_answer called")
+
+        def on_error(error, peer):
+            logging.debug("on_error called")
+
+        def on_connected(peer):
+            logging.debug("on_connected called")
+
+        def on_disconnected(peer):
+            logging.debug("on_disconnected called")
+
+        def on_stats(stats, peer):
+            logging.debug(stats)
+
+        answer_callback = SdpAnswerCallback_t(on_answer)
+        error_callback = ErrorCallback_t(on_error)
+        peer_connected_callback = PeerConnectedCallback_t(on_connected)
+        peer_disconnected_callback = PeerDisconnectedCallback_t(on_disconnected)
+        stats_callback = StatsCallback_t(on_stats)
+
+        client = webrtc.CreateWebrtcClient(1)
+
+        webrtc.SetCallbacks(client, answer_callback, error_callback,
+                            peer_connected_callback, peer_disconnected_callback, stats_callback)
+
+        webrtc.webrtc_requestor_init()
+
+        # TODO Initialise PeerConnection without setting local offer
+
+        endpoint = self.get_endpoint(default=1)
+
+        self.step("precondition-1")
+
+        self.step("precondition-2")
+        current_sessions = await self.read_single_attribute_check_success(cluster=WebRTCTransportProvider,
+                                                                          attribute=WebRTCTransportProvider.Attributes.CurrentSessions,
+                                                                          endpoint=endpoint)
+        asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
+
+        self.step(1)
+        # TH should immediately get Answer from DUT
+        session_id, remote_offer_sdp, remote_nodeid = webrtc.get_remote_offer(timeout=5)
+        asserts.assert_true(session_id >= 0, "Invalid session id")
+        asserts.assert_true(len(remote_offer_sdp) > 0, "Invalid offer sdp received")
+
+        self.step(2)
+        webrtc.SetOffer(client, remote_offer_sdp)
+
+        self.step(3)
+        local_answer = webrtc.CreateAnswer(client)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideAnswer(
+                webRTCSessionID=session_id,
+                sdp=local_answer
+            ), endpoint=endpoint
+        )
+
+        self.step(4)
+        local_candidates = webrtc.GetCandidates()
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=session_id,
+                ICECandidates=local_candidates
+            ), endpoint=endpoint
+        )
+
+        self.step(5)
+        ice_session_id, remote_candidates = webrtc.get_remote_ice_candidates(timeout=30)
+        asserts.assert_equal(ice_session_id, session_id, "Invalid session id")
+        asserts.assert_true(len(remote_candidates) > 0, "Invalid ice candidates received")
+        for candidate in remote_candidates:
+            webrtc.SetCandidate(client, candidate)
+
+        self.step(6)
+        self.wait_for_user_input("Verify WebRTC session is established")
+
+        self.step(7)
+        await self.send_single_cmd(cmd=WebRTCTransportProvider.Commands.EndSession(
+            webRTCSessionID=session_id,
+            reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+        ), endpoint=endpoint)
+
+        webrtc.CloseConnection(client)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_WEBRTC_1_5.py
+++ b/src/python_testing/TC_WEBRTC_1_5.py
@@ -15,13 +15,12 @@
 #    limitations under the License.
 
 import logging
-from chip.clusters import WebRTCTransportProvider
-from chip import webrtc
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from chip.webrtc import (ErrorCallback_t,  PeerConnectedCallback_t,
-                         PeerDisconnectedCallback_t, SdpAnswerCallback_t,  StatsCallback_t)
-from mobly import asserts
 
+from chip import webrtc
+from chip.clusters import WebRTCTransportProvider
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from chip.webrtc import ErrorCallback_t, PeerConnectedCallback_t, PeerDisconnectedCallback_t, SdpAnswerCallback_t, StatsCallback_t
+from mobly import asserts
 from test_plan_support import commission_if_required
 
 


### PR DESCRIPTION
[Camera] Add support for WebRTC Connect in Chip-Tool Adapter
#### Problem
* For the Camera Controller
* The YAML test framework reuses chip-tool's adapter to convert commands in TCs and send to chip-camera-controller to execute camera TCs.
* This change is required to perform "webrtc connect" to retreive the SDP and ICECandidates during the test execution.
* This PR adds support to convert pseudo cluster command "WebRTC Connect" -> "webrtc connect" when running test cases.

#### Change overview
* Add support for WebRTC Connect pseudo cluster command

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission camera-app and It is possible to test full automation