### PR TITLE
[Camera] Add support for WebRTC Connect in Chip-Tool Adapter

### DIFF
--- a/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
+++ b/examples/chip-tool/py_matter_chip_tool_adapter/matter_chip_tool_adapter/encoder.py
@@ -209,6 +209,19 @@ _ALIASES = {
                 'has_endpoint': False,
             },
         }
+    },
+
+    'WebRTC': {
+        'alias': 'webrtc',
+        'commands': {
+            'Connect': {
+                'has_destination': False,
+                'alias': 'connect',
+                'arguments': {
+                    'nodeId': 'node-id',
+                }
+            },
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
* For the Camera Controller
* The YAML test framework reuses chip-tool's adapter to convert commands in TCs and send to chip-camera-controller to execute camera TCs.
* This change is required to perform "webrtc connect" to retreive the SDP and ICECandidates during the test execution.
* This PR adds support to convert pseudo cluster command "WebRTC Connect" -> "webrtc connect" when running test cases.

#### Change overview
* Add support for WebRTC Connect pseudo cluster command

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations