### PR TITLE
Do not create new webrtc session when handling offer command

### DIFF
--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
@@ -26,7 +26,7 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WebRTCTransportRequestor;
 
-CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferArgs & args, WebRTCSessionTypeStruct & outSession)
+CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferArgs & args)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleOffer");
     return CHIP_NO_ERROR;

--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.h
@@ -27,8 +27,7 @@ public:
     WebRTCRequestorDelegate()  = default;
     ~WebRTCRequestorDelegate() = default;
 
-    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args,
-                           chip::app::Clusters::WebRTCTransportRequestor::WebRTCSessionTypeStruct & outSession) override;
+    CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) override;
 
     CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
 

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp
@@ -238,15 +238,12 @@ void WebRTCTransportRequestorServer::HandleOffer(HandlerContext & ctx, const Com
     WebRTCSessionTypeStruct outSession;
     // Delegate processing: handle the SDP offer, gather ICE candidates, SDP answer, etc.
     Protocols::InteractionModel::ClusterStatusCode delegateStatus =
-        Protocols::InteractionModel::ClusterStatusCode(mDelegate.HandleOffer(sessionId, args, outSession));
+        Protocols::InteractionModel::ClusterStatusCode(mDelegate.HandleOffer(sessionId, args));
     if (!delegateStatus.IsSuccess())
     {
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, delegateStatus);
         return;
     }
-
-    // Store the new WebRTCSessionTypeStruct in CurrentSessions.
-    UpsertSession(outSession);
 
     ctx.mCommandHandler.AddStatus(ctx.mRequestPath, delegateStatus);
 }

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h
@@ -49,7 +49,6 @@ public:
 
     struct OfferArgs
     {
-        uint16_t sessionId;
         std::string sdp;
         Optional<std::vector<ICEServerDecodableTypeStruct>> iceServers;
         Optional<std::string> iceTransportPolicy;
@@ -63,12 +62,10 @@ public:
      * @param[in] args
      *   Structure containing all input arguments for the command.
      *
-     * @param[out] outSession New session struct is created with the new session details received.
-     *
      * @return CHIP_ERROR
      *   - Returns error if the session is invalid or the candidates cannot be processed
      */
-    virtual CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args, WebRTCSessionTypeStruct & outSession) = 0;
+    virtual CHIP_ERROR HandleOffer(uint16_t sessionId, const OfferArgs & args) = 0;
     /**
      * @brief
      *   Handles the Answer command received by the server.


### PR DESCRIPTION
Per spec,  the Offer command is sent following the receipt of a SolicitOffer command or a re-Offer initiated by the Provider.

When hande the Offer command, the client must not create a new session, it SHALL respond with a response status of NOT_FOUND, if the WebRTCSessionID is not valid, or if the WebRTCSessionID is valid, but the accessing Peer Node ID and Local Fabric Index entry stored in the Secure Session Context of the command does not match the PeerNodeID and FabricIndex for the WebRTCSessionID entry in CurrentSessions.

#### Testing

Validated by CI
