### PR TITLE
Add more HAL API support for some CameraAVStream attributes.

### DIFF
--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -23,17 +23,17 @@
 #include <app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h>
 #include <media-controller.h>
 
+using chip::app::Clusters::CameraAvStreamManagement::AudioCapabilitiesStruct;
 using chip::app::Clusters::CameraAvStreamManagement::AudioStreamStruct;
 using chip::app::Clusters::CameraAvStreamManagement::ImageSnapshot;
+using chip::app::Clusters::CameraAvStreamManagement::RateDistortionTradeOffStruct;
+using chip::app::Clusters::CameraAvStreamManagement::SnapshotCapabilitiesStruct;
 using chip::app::Clusters::CameraAvStreamManagement::SnapshotStreamStruct;
+using chip::app::Clusters::CameraAvStreamManagement::StreamUsageEnum;
 using chip::app::Clusters::CameraAvStreamManagement::VideoResolutionStruct;
 using chip::app::Clusters::CameraAvStreamManagement::VideoSensorParamsStruct;
 using chip::app::Clusters::CameraAvStreamManagement::VideoStreamStruct;
 using chip::app::Clusters::CameraAvStreamManagement::ViewportStruct;
-using chip::app::Clusters::CameraAvStreamManagement::AudioCapabilitiesStruct;
-using chip::app::Clusters::CameraAvStreamManagement::SnapshotCapabilitiesStruct;
-using chip::app::Clusters::CameraAvStreamManagement::RateDistortionTradeOffStruct;
-using chip::app::Clusters::CameraAvStreamManagement::StreamUsageEnum;
 
 struct VideoStream
 {

--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -30,6 +30,10 @@ using chip::app::Clusters::CameraAvStreamManagement::VideoResolutionStruct;
 using chip::app::Clusters::CameraAvStreamManagement::VideoSensorParamsStruct;
 using chip::app::Clusters::CameraAvStreamManagement::VideoStreamStruct;
 using chip::app::Clusters::CameraAvStreamManagement::ViewportStruct;
+using chip::app::Clusters::CameraAvStreamManagement::AudioCapabilitiesStruct;
+using chip::app::Clusters::CameraAvStreamManagement::SnapshotCapabilitiesStruct;
+using chip::app::Clusters::CameraAvStreamManagement::RateDistortionTradeOffStruct;
+using chip::app::Clusters::CameraAvStreamManagement::StreamUsageEnum;
 
 struct VideoStream
 {
@@ -165,7 +169,7 @@ public:
         virtual CameraError StopSnapshotStream(uint16_t streamID) = 0;
 
         // Get the maximum number of concurrent encoders supported by camera.
-        virtual uint8_t GetMaxConcurrentVideoEncoders() = 0;
+        virtual uint8_t GetMaxConcurrentEncoders() = 0;
 
         // Get the maximum data rate in encoded pixels per second that the
         // camera can produce given the hardware encoders it has.
@@ -182,9 +186,21 @@ public:
         // its viewport.
         virtual VideoResolutionStruct & GetMinViewport() = 0;
 
+        // Get the rate distortion tradeoff points(min bitrate for resolutions) for video codecs.
+        virtual std::vector<RateDistortionTradeOffStruct> & GetRateDistortionTradeOffPoints() = 0;
+
         // Get the maximum size of content buffer in bytes. This buffer holds
         // compressed and/or raw audio/video content.
         virtual uint32_t GetMaxContentBufferSize() = 0;
+
+        // Get microphone capabilities.
+        virtual AudioCapabilitiesStruct & GetMicrophoneCapabilities() = 0;
+
+        // Get speaker capabilities.
+        virtual AudioCapabilitiesStruct & GetSpeakerCapabilities() = 0;
+
+        // Get snapshot capabilities
+        virtual std::vector<SnapshotCapabilitiesStruct> & GetSnapshotCapabilities() = 0;
 
         // Get the maximum network bandwidth(mbps) that the camera would consume
         // for transmission of its media streams.
@@ -198,6 +214,14 @@ public:
 
         // Get the current camera HDR mode.
         virtual bool GetHDRMode() = 0;
+
+        // Get Supported Stream usages; Typically set by manudacturer.
+        // This also sets the default priority of the stream usages.
+        virtual std::vector<StreamUsageEnum> & GetSupportedStreamUsages() = 0;
+
+        // Get Ranked stream priorities as an ordered list. This is expected to
+        // be a subset of the SupportedStreamUsages.
+        virtual std::vector<StreamUsageEnum> & GetRankedStreamPriorities() = 0;
 
         // Does camera have a speaker
         virtual bool HasSpeaker() = 0;

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -56,20 +56,21 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
     optionalAttrs.Set(OptionalAttribute::kNightVision);
     optionalAttrs.Set(OptionalAttribute::kNightVisionIllum);
 
-    uint32_t maxConcurrentVideoEncoders  = mCameraDevice->GetCameraHALInterface().GetMaxConcurrentVideoEncoders();
+    uint32_t maxConcurrentVideoEncoders  = mCameraDevice->GetCameraHALInterface().GetMaxConcurrentEncoders();
     uint32_t maxEncodedPixelRate         = mCameraDevice->GetCameraHALInterface().GetMaxEncodedPixelRate();
     VideoSensorParamsStruct sensorParams = mCameraDevice->GetCameraHALInterface().GetVideoSensorParams();
     bool nightVisionCapable              = mCameraDevice->GetCameraHALInterface().GetNightVisionCapable();
     VideoResolutionStruct minViewport    = mCameraDevice->GetCameraHALInterface().GetMinViewport();
-    std::vector<RateDistortionTradeOffStruct> rateDistortionTradeOffPoints = {};
+    std::vector<RateDistortionTradeOffStruct> rateDistortionTradeOffPoints =
+        mCameraDevice->GetCameraHALInterface().GetRateDistortionTradeOffPoints();
 
-    uint32_t maxContentBufferSize = mCameraDevice->GetCameraHALInterface().GetMaxContentBufferSize();
-    AudioCapabilitiesStruct micCapabilities{};
-    AudioCapabilitiesStruct spkrCapabilities{};
-    TwoWayTalkSupportTypeEnum twowayTalkSupport                  = TwoWayTalkSupportTypeEnum::kNotSupported;
-    std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities = {};
+    uint32_t maxContentBufferSize               = mCameraDevice->GetCameraHALInterface().GetMaxContentBufferSize();
+    AudioCapabilitiesStruct micCapabilities     = mCameraDevice->GetCameraHALInterface().GetMicrophoneCapabilities();
+    AudioCapabilitiesStruct spkrCapabilities    = mCameraDevice->GetCameraHALInterface().GetSpeakerCapabilities();
+    TwoWayTalkSupportTypeEnum twowayTalkSupport = TwoWayTalkSupportTypeEnum::kNotSupported;
+    std::vector<SnapshotCapabilitiesStruct> snapshotCapabilities = mCameraDevice->GetCameraHALInterface().GetSnapshotCapabilities();
     uint32_t maxNetworkBandwidth                                 = mCameraDevice->GetCameraHALInterface().GetMaxNetworkBandwidth();
-    std::vector<StreamUsageEnum> supportedStreamUsages           = { StreamUsageEnum::kLiveView, StreamUsageEnum::kRecording };
+    std::vector<StreamUsageEnum> supportedStreamUsages = mCameraDevice->GetCameraHALInterface().GetSupportedStreamUsages();
 
     // Instantiate the CameraAVStreamMgmt Server
     mAVStreamMgmtServerPtr = std::make_unique<CameraAVStreamMgmtServer>(

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -53,8 +53,8 @@ static constexpr uint32_t kMinBitRateBps             = 10000;   // 10 kbps
 static constexpr uint32_t kMaxBitRateBps             = 2000000; // 2 mbps
 static constexpr uint32_t kMinFragLenMsec            = 1000;    // 1 sec
 static constexpr uint32_t kMaxFragLenMsec            = 10000;   // 10 sec
-static constexpr uint16_t kVideoSensorWidthPixels    = 854;     // 640X480 resolution
-static constexpr uint16_t kVideoSensorHeightPixels   = 480;     // 640X480 resolution
+static constexpr uint16_t kVideoSensorWidthPixels    = 1920;    // 1080p resolution
+static constexpr uint16_t kVideoSensorHeightPixels   = 1080;    // 1080p resolution
 
 #define INVALID_SPKR_LEVEL (0)
 

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -42,8 +42,8 @@ static constexpr uint32_t kMaxEncodedPixelRate       = 27648000; // 720p at 30fp
 static constexpr uint8_t kMicrophoneMinLevel         = 1;
 static constexpr uint8_t kMicrophoneMaxLevel         = 254;  // Spec constraint
 static constexpr uint8_t kMicrophoneMaxChannelCount  = 8;    // Spec Constraint in AudioStreamAllocate
-static constexpr uint16_t kMinResolutionWidth        = 320;  // Low SD resolution
-static constexpr uint16_t kMinResolutionHeight       = 240;  // Low SD resolution
+static constexpr uint16_t kMinResolutionWidth        = 256;  // Low SD resolution
+static constexpr uint16_t kMinResolutionHeight       = 144;  // Low SD resolution
 static constexpr uint16_t kMaxResolutionWidth        = 1920; // 1080p resolution
 static constexpr uint16_t kMaxResolutionHeight       = 1080; // 1080p resolution
 static constexpr uint16_t kSnapshotStreamFrameRate   = 30;
@@ -53,7 +53,7 @@ static constexpr uint32_t kMinBitRateBps             = 10000;   // 10 kbps
 static constexpr uint32_t kMaxBitRateBps             = 2000000; // 2 mbps
 static constexpr uint32_t kMinFragLenMsec            = 1000;    // 1 sec
 static constexpr uint32_t kMaxFragLenMsec            = 10000;   // 10 sec
-static constexpr uint16_t kVideoSensorWidthPixels    = 640;     // 640X480 resolution
+static constexpr uint16_t kVideoSensorWidthPixels    = 854;     // 640X480 resolution
 static constexpr uint16_t kVideoSensorHeightPixels   = 480;     // 640X480 resolution
 
 #define INVALID_SPKR_LEVEL (0)


### PR DESCRIPTION
--Define various constraint parameters based on typical values.

Required for various operations invoked by upcoming test scripts

#### Testing
* Start chip-camera-app
* Use chip-tool or camera-controller for invoking video-stream-allocate and snapshot-stream-allocate commands.
* Use chip-tool or camera-controller for invoking Read operations for various attributes.