### PR TITLE
RVC Example app: new opstates/errors

### DIFF
--- a/examples/rvc-app/linux/RvcAppCommandDelegate.cpp
+++ b/examples/rvc-app/linux/RvcAppCommandDelegate.cpp
@@ -73,6 +73,22 @@ void RvcAppCommandHandler::HandleCommand(intptr_t context)
     {
         self->OnDockedHandler();
     }
+    else if (name == "EmptyingDustBin")
+    {
+        self->OnEmptyingDustBinHandler();
+    }
+    else if (name == "CleaningMop")
+    {
+        self->OnCleaningMopHandler();
+    }
+    else if (name == "FillingWaterTank")
+    {
+        self->OnFillingWaterTankHandler();
+    }
+    else if (name == "UpdatingMaps")
+    {
+        self->OnUpdatingMapsHandler();
+    }
     else if (name == "ChargerFound")
     {
         self->OnChargerFoundHandler();
@@ -148,6 +164,26 @@ void RvcAppCommandHandler::OnChargingHandler()
 void RvcAppCommandHandler::OnDockedHandler()
 {
     mRvcDevice->HandleDockedMessage();
+}
+
+void RvcAppCommandHandler::OnEmptyingDustBinHandler()
+{
+    mRvcDevice->HandleEmptyingDustBinMessage();
+}
+
+void RvcAppCommandHandler::OnCleaningMopHandler()
+{
+    mRvcDevice->HandleCleaningMopMessage();
+}
+
+void RvcAppCommandHandler::OnFillingWaterTankHandler()
+{
+    mRvcDevice->HandleFillingWaterTankMessage();
+}
+
+void RvcAppCommandHandler::OnUpdatingMapsHandler()
+{
+    mRvcDevice->HandleUpdatingMapsMessage();
 }
 
 void RvcAppCommandHandler::OnChargerFoundHandler()

--- a/examples/rvc-app/linux/RvcAppCommandDelegate.h
+++ b/examples/rvc-app/linux/RvcAppCommandDelegate.h
@@ -49,6 +49,14 @@ private:
 
     void OnDockedHandler();
 
+    void OnEmptyingDustBinHandler();
+
+    void OnCleaningMopHandler();
+
+    void OnFillingWaterTankHandler();
+
+    void OnUpdatingMapsHandler();
+
     void OnChargerFoundHandler();
 
     void OnLowChargeHandler();

--- a/examples/rvc-app/rvc-common/include/rvc-device.h
+++ b/examples/rvc-app/rvc-common/include/rvc-device.h
@@ -38,7 +38,7 @@ private:
 
 public:
     /**
-     * This class is responsible for initialising all the RVC clusters and manging the interactions between them as required by
+     * This class is responsible for initialising all the RVC clusters and managing the interactions between them as required by
      * the specific "business logic". See the state machine diagram.
      * @param aRvcClustersEndpoint The endpoint ID where all the RVC clusters exist.
      */
@@ -120,6 +120,14 @@ public:
     void HandleChargingMessage();
 
     void HandleDockedMessage();
+
+    void HandleEmptyingDustBinMessage();
+
+    void HandleCleaningMopMessage();
+
+    void HandleFillingWaterTankMessage();
+
+    void HandleUpdatingMapsMessage();
 
     void HandleChargerFoundMessage();
 

--- a/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
+++ b/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
@@ -37,7 +37,7 @@ namespace RvcOperationalState {
 class RvcOperationalStateDelegate : public RvcOperationalState::Delegate
 {
 private:
-    const Clusters::OperationalState::GenericOperationalState mOperationalStateList[7] = {
+    const Clusters::OperationalState::GenericOperationalState mOperationalStateList[11] = {
         OperationalState::GenericOperationalState(to_underlying(OperationalState::OperationalStateEnum::kStopped)),
         OperationalState::GenericOperationalState(to_underlying(OperationalState::OperationalStateEnum::kRunning)),
         OperationalState::GenericOperationalState(to_underlying(OperationalState::OperationalStateEnum::kPaused)),
@@ -46,6 +46,10 @@ private:
             to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kSeekingCharger)),
         OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kCharging)),
         OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kDocked)),
+        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kEmptyingDustBin)),
+        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kCleaningMop)),
+        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kFillingWaterTank)),
+        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kUpdatingMaps)),
     };
     const Span<const CharSpan> mOperationalPhaseList;
 

--- a/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
+++ b/examples/rvc-app/rvc-common/include/rvc-operational-state-delegate.h
@@ -46,10 +46,13 @@ private:
             to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kSeekingCharger)),
         OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kCharging)),
         OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kDocked)),
-        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kEmptyingDustBin)),
+        OperationalState::GenericOperationalState(
+            to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kEmptyingDustBin)),
         OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kCleaningMop)),
-        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kFillingWaterTank)),
-        OperationalState::GenericOperationalState(to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kUpdatingMaps)),
+        OperationalState::GenericOperationalState(
+            to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kFillingWaterTank)),
+        OperationalState::GenericOperationalState(
+            to_underlying(Clusters::RvcOperationalState::OperationalStateEnum::kUpdatingMaps)),
     };
     const Span<const CharSpan> mOperationalPhaseList;
 

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -267,6 +267,34 @@ void RvcDevice::HandleDockedMessage()
     mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kDocked));
 }
 
+void RvcDevice::HandleEmptyingDustBinMessage()
+{
+    // TODO:  should we only allow this transition while we are docked?
+
+    mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kEmptyingDustBin));
+}
+
+void RvcDevice::HandleCleaningMopMessage()
+{
+    // TODO:  should we only allow this transition while we are docked?
+
+    mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kCleaningMop));
+}
+
+void RvcDevice::HandleFillingWaterTankMessage()
+{
+    // TODO:  should we only allow this transition while we are docked?
+
+    mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kFillingWaterTank));
+}
+
+void RvcDevice::HandleUpdatingMapsMessage()
+{
+    // TODO:  should we only allow this transition while we are docked?
+
+    mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kUpdatingMaps));
+}
+
 void RvcDevice::HandleChargerFoundMessage()
 {
     if (mOperationalStateInstance.GetCurrentOperationalState() !=

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -395,6 +395,34 @@ void RvcDevice::HandleErrorEvent(const std::string & error)
     {
         err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kMopCleaningPadMissing);
     }
+    else if (error == "LowBattery")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kLowBattery);
+    }
+    else if (error == "CannotReachTargetArea")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kCannotReachTargetArea);
+    }
+    else if (error == "DirtyWaterTankFull")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kDirtyWaterTankFull);
+    }
+    else if (error == "DirtyWaterTankMissing")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kDirtyWaterTankMissing);
+    }
+    else if (error == "WheelsJammed")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kWheelsJammed);
+    }
+    else if (error == "BrushJammed")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kBrushJammed);
+    }
+    else if (error == "NavigationSensorObscured")
+    {
+        err.errorStateID = to_underlying(RvcOperationalState::ErrorStateEnum::kNavigationSensorObscured);
+    }
     else
     {
         ChipLogError(NotSpecified, "Unhandled command: The 'Error' key of the 'ErrorEvent' message is not valid.");

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -269,29 +269,21 @@ void RvcDevice::HandleDockedMessage()
 
 void RvcDevice::HandleEmptyingDustBinMessage()
 {
-    // TODO:  should we only allow this transition while we are docked?
-
     mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kEmptyingDustBin));
 }
 
 void RvcDevice::HandleCleaningMopMessage()
 {
-    // TODO:  should we only allow this transition while we are docked?
-
     mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kCleaningMop));
 }
 
 void RvcDevice::HandleFillingWaterTankMessage()
 {
-    // TODO:  should we only allow this transition while we are docked?
-
     mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kFillingWaterTank));
 }
 
 void RvcDevice::HandleUpdatingMapsMessage()
 {
-    // TODO:  should we only allow this transition while we are docked?
-
     mOperationalStateInstance.SetOperationalState(to_underlying(RvcOperationalState::OperationalStateEnum::kUpdatingMaps));
 }
 


### PR DESCRIPTION
Add the new Operational States / Operational State Errors to the example app.

### TODO

- [x] find out if new operational states should only be reachable from `Docked` state
- [x] check if other test scripts need to be run

#### Testing

Run the following test scripts:

- [x] `src/python_testing/TC_RVCOPSTATE_2_1.py` in TH
    - [x] passed against pre-change RVC sample app (in TH)
    - [x] passed against RVC sample app with change (in TH)
- [x] `src/python_testing/TC_RVCOPSTATE_2_1.py` directly
    - [x] passed against RVC sample app with change
    - [x] `scripts/run_in_python_env.sh pyenv-kmo "python3 src/python_testing/TC_RVCOPSTATE_2_1.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --storage-path admin_storage.json --app-pipe_prefix /tmp/chip_rvc_fifo_ --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --app-pid 55091"`
- [x] `src/python_testing/TC_RVCOPSTATE_2_3.py` directly
    - [x] passed against RVC sample app with change
    - [x] `scripts/run_in_python_env.sh pyenv-kmo "python3 src/python_testing/TC_RVCOPSTATE_2_3.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --storage-path admin_storage.json --app-pipe_prefix /tmp/chip_rvc_fifo_ --app-pid 54914 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values"`
- [x] `src/python_testing/TC_RVCOPSTATE_2_4.py` directly
    - [x] passed against RVC sample app with change
    - [x] `scripts/run_in_python_env.sh pyenv-kmo "python3 src/python_testing/TC_RVCOPSTATE_2_4.py --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1 --storage-path admin_storage.json --app-pipe_prefix /tmp/chip_rvc_fifo_ --app-pid 54990 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values"`