### PR TITLE
ESP32: Use all channel scan mode for NetworkCommissioning Wi-Fi Driver

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -614,6 +614,14 @@ menu "CHIP Device Layer"
             help
                 The maximum number of networks to return as a result of a CHIP NetworkProvisioning:ScanNetworks request.
 
+        config WIFI_SCAN_ALL_CHANNEL_MODE
+            bool "Enable All-channel Scan Mode"
+            default n
+            depends on ENABLE_WIFI_STATION
+            help
+                Select to enable all-channel scan mode for Wi-Fi station. Note that this option might increase the time of
+                the station connecting to the AP by about 1-2 seconds.
+
         config WIFI_SCAN_COMPLETION_TIMEOUT
             int "WiFi Scan Completion Timeout (ms)"
             range 0 65535

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -425,7 +425,7 @@ CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
             wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
             wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
 #endif // CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
-            esp_err_t err              = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
+            esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
             if (err != ESP_OK)
             {
                 ChipLogError(DeviceLayer, "esp_wifi_set_config() failed: %s", esp_err_to_name(err));

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -421,8 +421,10 @@ CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
                    std::min(sizeof(wifiConfig.sta.ssid), strlen(CONFIG_DEFAULT_WIFI_SSID)));
             memcpy(wifiConfig.sta.password, CONFIG_DEFAULT_WIFI_PASSWORD,
                    std::min(sizeof(wifiConfig.sta.password), strlen(CONFIG_DEFAULT_WIFI_PASSWORD)));
+#ifdef CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
             wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
             wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+#endif // CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
             esp_err_t err              = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);
             if (err != ESP_OK)
             {

--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -282,8 +282,10 @@ CHIP_ERROR ESP32Utils::SetWiFiStationProvision(const Internal::DeviceNetworkInfo
     memset(&wifiConfig, 0, sizeof(wifiConfig));
     memcpy(wifiConfig.sta.ssid, wifiSSID, std::min(strlen(wifiSSID) + 1, sizeof(wifiConfig.sta.ssid)));
     memcpy(wifiConfig.sta.password, netInfo.WiFiKey, std::min((size_t) netInfo.WiFiKeyLen, sizeof(wifiConfig.sta.password)));
+#ifdef CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
     wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+#endif // CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
 
     // Configure the ESP WiFi interface.
     esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -251,6 +251,10 @@ CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
     memset(&wifiConfig, 0, sizeof(wifiConfig));
     memcpy(wifiConfig.sta.ssid, ssid, std::min(ssidLen, static_cast<uint8_t>(sizeof(wifiConfig.sta.ssid))));
     memcpy(wifiConfig.sta.password, key, std::min(keyLen, static_cast<uint8_t>(sizeof(wifiConfig.sta.password))));
+#ifdef CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
+    wifiConfig.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    wifiConfig.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+#endif // CONFIG_WIFI_SCAN_ALL_CHANNEL_MODE
 
     // Configure the ESP WiFi interface.
     esp_err_t err = esp_wifi_set_config(WIFI_IF_STA, &wifiConfig);


### PR DESCRIPTION
Provide an menuconfig option which can be used to configure whether the station uses fast scan or all-channel scan.

#### Testing

Tested light example on ESP32-C3 with this configuration option enabled/disabled
