### PR TITLE
[v1.4] ESP32: disable debug mode when compiler optimization assertions are d…

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -41,9 +41,9 @@ endif()
 
 if (NOT CMAKE_BUILD_EARLY_EXPANSION)
     if (CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)
-        set(is_debug TRUE)
-    else()
         set(is_debug FALSE)
+    else()
+        set(is_debug TRUE)
     endif()
 endif()
 


### PR DESCRIPTION
…isabled (#38384)

Earlier we were setting is_debug to TRUE when assertions were disabled and it is incorrect.

Earlier we were setting is_debug to TRUE when assertions were disabled and it is incorrect.

All components would be built using cmake build system would honour the CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS.... configuration. But sources compiled using gn will have -NDEBUG flag by default. This would create a mismatch.

---
cherry-picking #38384 on v1.4-branch

#### Testing

- Verified manually by idf.py build with assertion enabled and disabled. More details in #38384's testing section