### PR TITLE
[Linux] Fix callback signature for InterfaceRemoved signal

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -741,7 +741,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const
         return;
     }
 
-    mWpaSupplicant.interfacePath = const_cast<gchar *>(path);
+    mWpaSupplicant.interfacePath = g_strdup(path);
     if (mWpaSupplicant.interfacePath)
     {
         mWpaSupplicant.state = GDBusWpaSupplicant::WpaState::GOT_INTERFACE_PATH;

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -765,7 +765,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const
     }
 }
 
-void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path, GVariant * properties)
+void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path)
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
@@ -824,12 +824,11 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * sourceObject, GAsyncRes
                 return self->_OnWpaInterfaceAdded(proxy, path, properties);
             }),
             this);
-        g_signal_connect(
-            mWpaSupplicant.proxy, "interface-removed",
-            G_CALLBACK(+[](WpaSupplicant1 * proxy, const char * path, GVariant * properties, ConnectivityManagerImpl * self) {
-                return self->_OnWpaInterfaceRemoved(proxy, path, properties);
-            }),
-            this);
+        g_signal_connect(mWpaSupplicant.proxy, "interface-removed",
+                         G_CALLBACK(+[](WpaSupplicant1 * proxy, const char * path, ConnectivityManagerImpl * self) {
+                             return self->_OnWpaInterfaceRemoved(proxy, path);
+                         }),
+                         this);
 
         wpa_supplicant_1_call_get_interface(mWpaSupplicant.proxy, sWiFiIfName, nullptr,
                                             reinterpret_cast<GAsyncReadyCallback>(

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -226,7 +226,7 @@ private:
     CHIP_ERROR StopAutoScan();
 
     void _OnWpaProxyReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path, GVariant * properties);
+    void _OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, const char * path);
     void _OnWpaInterfaceAdded(WpaSupplicant1 * proxy, const char * path, GVariant * properties);
     void _OnWpaPropertiesChanged(WpaSupplicant1Interface * proxy, GVariant * properties);
     void _OnWpaInterfaceScanDone(WpaSupplicant1Interface * proxy, gboolean success);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -64,6 +64,12 @@ namespace chip {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 
 template <>
+struct GAutoPtrDeleter<WpaSupplicant1>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<WpaSupplicant1BSS>
 {
     using deleter = GObjectDeleter;
@@ -107,7 +113,7 @@ struct GDBusWpaSupplicant
 
     WpaState state             = WpaState::INIT;
     WpaScanningState scanState = WpaScanningState::IDLE;
-    WpaSupplicant1 * proxy     = nullptr;
+    GAutoPtr<WpaSupplicant1> proxy;
     GAutoPtr<WpaSupplicant1Interface> iface;
     GAutoPtr<WpaSupplicant1BSS> bss;
     GAutoPtr<char> interfacePath;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -41,6 +41,7 @@
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
+#include <platform/GLibTypeDeleter.h>
 #include <platform/Linux/dbus/wpa/DBusWpa.h>
 #include <platform/Linux/dbus/wpa/DBusWpaBss.h>
 #include <platform/Linux/dbus/wpa/DBusWpaInterface.h>
@@ -92,8 +93,8 @@ struct GDBusWpaSupplicant
     WpaSupplicant1 * proxy          = nullptr;
     WpaSupplicant1Interface * iface = nullptr;
     WpaSupplicant1BSS * bss         = nullptr;
-    gchar * interfacePath           = nullptr;
-    gchar * networkPath             = nullptr;
+    GAutoPtr<char> interfacePath;
+    GAutoPtr<char> networkPath;
 };
 #endif
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -70,6 +70,12 @@ struct GAutoPtrDeleter<WpaSupplicant1BSS>
 };
 
 template <>
+struct GAutoPtrDeleter<WpaSupplicant1Interface>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
 struct GAutoPtrDeleter<WpaSupplicant1Network>
 {
     using deleter = GObjectDeleter;
@@ -99,10 +105,10 @@ struct GDBusWpaSupplicant
         SCANNING,
     };
 
-    WpaState state                  = WpaState::INIT;
-    WpaScanningState scanState      = WpaScanningState::IDLE;
-    WpaSupplicant1 * proxy          = nullptr;
-    WpaSupplicant1Interface * iface = nullptr;
+    WpaState state             = WpaState::INIT;
+    WpaScanningState scanState = WpaScanningState::IDLE;
+    WpaSupplicant1 * proxy     = nullptr;
+    GAutoPtr<WpaSupplicant1Interface> iface;
     GAutoPtr<WpaSupplicant1BSS> bss;
     GAutoPtr<char> interfacePath;
     GAutoPtr<char> networkPath;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -60,12 +60,23 @@
 #include <vector>
 
 namespace chip {
-namespace Inet {
-class IPAddress;
-} // namespace Inet
-} // namespace chip
 
-namespace chip {
+#if CHIP_DEVICE_CONFIG_ENABLE_WPA
+
+template <>
+struct GAutoPtrDeleter<WpaSupplicant1BSS>
+{
+    using deleter = GObjectDeleter;
+};
+
+template <>
+struct GAutoPtrDeleter<WpaSupplicant1Network>
+{
+    using deleter = GObjectDeleter;
+};
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
+
 namespace DeviceLayer {
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
@@ -92,7 +103,7 @@ struct GDBusWpaSupplicant
     WpaScanningState scanState      = WpaScanningState::IDLE;
     WpaSupplicant1 * proxy          = nullptr;
     WpaSupplicant1Interface * iface = nullptr;
-    WpaSupplicant1BSS * bss         = nullptr;
+    GAutoPtr<WpaSupplicant1BSS> bss;
     GAutoPtr<char> interfacePath;
     GAutoPtr<char> networkPath;
 };


### PR DESCRIPTION
#### Problem

Linux application crashes when WiFi interface is removed from the system because of wrong function signature for handling `InterfaceRemoved` signal. Also, there is a double-free error when interface is added/removed few times.

#### Changes

- First two commits resolve reported problems
- Other commits refactor the code to use `GAutoPtr<>` for managing memory allocated by glib (manual memory management is error-prone - found double-free bug)

#### Testing

Locally tested BLE-WiFi commissioning with PC and RPi4:
```sh
chip-lighting-app --wifi
```
```sh
out/linux-x64-chip-tool/chip-tool pairing ble-wifi 1 MATTER-AP password 20202021 3840
```

CI will check for build breaks.