### PR TITLE
Implement Standby Flow for Battery Camera

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc_provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc_provider/webrtc-provider-manager.h
@@ -116,6 +116,9 @@ private:
 
     uint16_t mCurrentSessionId = 0;
     std::string mLocalSdp;
+
+    // Each string in this vector represents a local ICE candidate used to facilitate the negotiation
+    // of peer-to-peer connections through NATs (Network Address Translators) and firewalls.
     std::vector<std::string> mLocalCandidates;
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;

--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -290,6 +290,7 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
 
     mPeerConnection->setRemoteDescription(sdpAnswer);
 
+    MoveToState(State::SendingICECandidates);
     ScheduleICECandidatesSend();
 
     return CHIP_NO_ERROR;
@@ -397,8 +398,6 @@ void WebRTCProviderManager::ScheduleOfferSend()
         caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
-
-    MoveToState(State::Idle);
 }
 
 void WebRTCProviderManager::ScheduleAnswerSend()
@@ -416,8 +415,6 @@ void WebRTCProviderManager::ScheduleAnswerSend()
         caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
-
-    MoveToState(State::Idle);
 }
 
 void WebRTCProviderManager::ScheduleICECandidatesSend()
@@ -435,8 +432,6 @@ void WebRTCProviderManager::ScheduleICECandidatesSend()
         caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
-
-    MoveToState(State::Idle);
 }
 
 void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
@@ -454,14 +449,17 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
     {
     case CommandType::kOffer:
         err = self->SendOfferCommand(exchangeMgr, sessionHandle);
+        self->MoveToState(State::Idle);
         break;
 
     case CommandType::kAnswer:
         err = self->SendAnswerCommand(exchangeMgr, sessionHandle);
+        self->MoveToState(State::Idle);
         break;
 
     case CommandType::kICECandidates:
         err = self->SendICECandidatesCommand(exchangeMgr, sessionHandle);
+        self->MoveToState(State::Idle);
         break;
 
     default:

--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -42,16 +42,28 @@ void WebRTCProviderManager::Init()
     mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
 
     mPeerConnection->onLocalDescription([this](rtc::Description description) {
-        mSdpAnswer = std::string(description);
+        mLocalSdp = std::string(description);
         ChipLogProgress(Camera, "Local Description:");
-        ChipLogProgress(Camera, "%s", mSdpAnswer.c_str());
+        ChipLogProgress(Camera, "%s", mLocalSdp.c_str());
 
-        ScheduleAnswerSend();
+        switch (mState)
+        {
+        case State::SendingOffer:
+            ScheduleOfferSend();
+            break;
+        case State::SendingAnswer:
+            ScheduleAnswerSend();
+            break;
+        default:
+            break;
+        }
     });
 
-    mPeerConnection->onLocalCandidate([](rtc::Candidate candidate) {
+    mPeerConnection->onLocalCandidate([this](rtc::Candidate candidate) {
+        std::string candidateStr = std::string(candidate);
+        mLocalCandidates.push_back(candidateStr);
         ChipLogProgress(Camera, "Local Candidate:");
-        ChipLogProgress(Camera, "%s", std::string(candidate).c_str());
+        ChipLogProgress(Camera, "%s", candidateStr.c_str());
     });
 
     mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
@@ -160,6 +172,15 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     outDeferredOffer = LinuxDeviceOptions::GetInstance().cameraDeferredOffer;
 
+    MoveToState(State::SendingOffer);
+
+    if (!mDataChannel)
+    {
+        mDataChannel = mPeerConnection->createDataChannel("matter-av");
+    }
+
+    mPeerConnection->createOffer();
+
     return CHIP_NO_ERROR;
 }
 
@@ -238,6 +259,7 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
             std::unique_ptr<WebrtcTransport>(new WebrtcTransport(args.sessionId, mPeerId.GetNodeId(), mPeerConnection));
     }
 
+    MoveToState(State::SendingAnswer);
     mPeerConnection->setRemoteDescription(args.sdp);
 
     return CHIP_NO_ERROR;
@@ -245,7 +267,32 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
 
 CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const std::string & sdpAnswer)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    ChipLogProgress(Camera, "HandleProvideAnswer called with sessionId: %u", sessionId);
+
+    // Check if the provided sessionId matches your current session
+    if (sessionId != mCurrentSessionId)
+    {
+        ChipLogError(Camera, "Session ID %u does not match the current session ID %u", sessionId, mCurrentSessionId);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (sdpAnswer.empty())
+    {
+        ChipLogError(Camera, "Provided SDP Answer is empty for session ID %u", sessionId);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (!mPeerConnection)
+    {
+        ChipLogError(Camera, "Cannot set remote description: mPeerConnection is null for session ID %u", sessionId);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    mPeerConnection->setRemoteDescription(sdpAnswer);
+
+    ScheduleICECandidatesSend();
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates)
@@ -295,7 +342,7 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         mCurrentSessionId      = 0;
         mOriginatingEndpointId = 0;
         mPeerId                = ScopedNodeId();
-        mSdpAnswer.clear();
+        mLocalSdp.clear();
     }
 
     return CHIP_NO_ERROR;
@@ -308,6 +355,50 @@ WebRTCProviderManager::ValidateStreamUsage(StreamUsageEnum streamUsage,
 {
     // TODO: Validates the requested stream usage against the camera's resource management and stream priority policies.
     return CHIP_NO_ERROR;
+}
+
+void WebRTCProviderManager::MoveToState(const State targetState)
+{
+    mState = targetState;
+    ChipLogProgress(Camera, "WebRTCProviderManager moving to [ %s ]", GetStateStr());
+}
+
+const char * WebRTCProviderManager::GetStateStr() const
+{
+    switch (mState)
+    {
+    case State::Idle:
+        return "Idle";
+
+    case State::SendingOffer:
+        return "SendingOffer";
+
+    case State::SendingAnswer:
+        return "SendingAnswer";
+
+    case State::SendingICECandidates:
+        return "SendingICECandidates";
+    }
+    return "N/A";
+}
+
+void WebRTCProviderManager::ScheduleOfferSend()
+{
+    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
+        ChipLogProgress(Camera, "Sending Offer command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+
+        mCommandType = CommandType::kOffer;
+
+        // Attempt to find or establish a CASE session to the target PeerId.
+        CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
+        VerifyOrDie(caseSessionMgr != nullptr);
+
+        // WebRTC Answer requires a large payload session establishment.
+        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+                                               TransportPayloadCapability::kLargePayload);
+    });
+
+    MoveToState(State::Idle);
 }
 
 void WebRTCProviderManager::ScheduleAnswerSend()
@@ -325,6 +416,27 @@ void WebRTCProviderManager::ScheduleAnswerSend()
         caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
+
+    MoveToState(State::Idle);
+}
+
+void WebRTCProviderManager::ScheduleICECandidatesSend()
+{
+    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
+        ChipLogProgress(Camera, "Sending ICECandidates command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+
+        mCommandType = CommandType::kICECandidates;
+
+        // Attempt to find or establish a CASE session to the target PeerId.
+        CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
+        VerifyOrDie(caseSessionMgr != nullptr);
+
+        // WebRTC Answer requires a large payload session establishment.
+        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+                                               TransportPayloadCapability::kLargePayload);
+    });
+
+    MoveToState(State::Idle);
 }
 
 void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
@@ -340,8 +452,16 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
 
     switch (self->mCommandType)
     {
+    case CommandType::kOffer:
+        err = self->SendOfferCommand(exchangeMgr, sessionHandle);
+        break;
+
     case CommandType::kAnswer:
         err = self->SendAnswerCommand(exchangeMgr, sessionHandle);
+        break;
+
+    case CommandType::kICECandidates:
+        err = self->SendICECandidatesCommand(exchangeMgr, sessionHandle);
         break;
 
     default:
@@ -362,6 +482,23 @@ void WebRTCProviderManager::OnDeviceConnectionFailure(void * context, const Scop
     VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDeviceConnectionFailure: context is null"));
 }
 
+CHIP_ERROR WebRTCProviderManager::SendOfferCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
+{
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(Camera, "Offer command succeeds");
+    };
+
+    auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "Offer command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
+
+    // Build the command
+    WebRTCTransportRequestor::Commands::Offer::Type command;
+    command.webRTCSessionID = mCurrentSessionId;
+    command.sdp             = CharSpan::fromCharString(mLocalSdp.c_str());
+
+    // Now invoke the command using the found session handle
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure);
+}
+
 CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -376,7 +513,44 @@ CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager &
     // Build the command
     WebRTCTransportRequestor::Commands::Answer::Type command;
     command.webRTCSessionID = sessionId;
-    command.sdp             = CharSpan::fromCharString(mSdpAnswer.c_str());
+    command.sdp             = CharSpan::fromCharString(mLocalSdp.c_str());
+
+    // Now invoke the command using the found session handle
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure);
+}
+
+CHIP_ERROR WebRTCProviderManager::SendICECandidatesCommand(Messaging::ExchangeManager & exchangeMgr,
+                                                           const SessionHandle & sessionHandle)
+{
+    auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
+        ChipLogProgress(Camera, "ICECandidates command succeeds");
+    };
+
+    auto onFailure = [](CHIP_ERROR error) {
+        ChipLogError(Camera, "ICECandidates command failed: %" CHIP_ERROR_FORMAT, error.Format());
+    };
+
+    // Build the command
+    WebRTCTransportRequestor::Commands::ICECandidates::Type command;
+
+    if (mLocalCandidates.empty())
+    {
+        ChipLogError(Camera, "No local ICE candidates to send");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Convert mLocalCandidates (std::vector<std::string>) into a list of CharSpans.
+    std::vector<chip::CharSpan> candidateSpans;
+    candidateSpans.reserve(mLocalCandidates.size());
+    for (const auto & candidate : mLocalCandidates)
+    {
+        candidateSpans.push_back(chip::CharSpan(candidate.c_str(), static_cast<uint16_t>(candidate.size())));
+    }
+
+    auto ICECandidates = chip::app::DataModel::List<const chip::CharSpan>(candidateSpans.data(), candidateSpans.size());
+
+    command.webRTCSessionID = mCurrentSessionId;
+    command.ICECandidates   = ICECandidates;
 
     // Now invoke the command using the found session handle
     return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure);

--- a/examples/camera-controller/commands/webrtc/Commands.h
+++ b/examples/camera-controller/commands/webrtc/Commands.h
@@ -28,6 +28,7 @@ void registerCommandsWebRTC(Commands & commands, CredentialIssuerCommands * cred
     commands_list clusterCommands = {
         make_unique<webrtc::ConnectCommand>(credsIssuerConfig),
         make_unique<webrtc::ProvideOfferCommand>(credsIssuerConfig),
+        make_unique<webrtc::SolicitOfferCommand>(credsIssuerConfig),
     };
 
     commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for WebRTC.");

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
@@ -29,15 +29,13 @@ namespace webrtc {
 
 CHIP_ERROR ConnectCommand::RunCommand()
 {
-    // print to console
-    std::cout << "Run ConnectCommand" << std::endl;
-
+    ChipLogProgress(Camera, "Run ConnectCommand");
     return WebRTCManager::Instance().Connnect(CurrentCommissioner(), mPeerNodeId, mPeerEndpointId);
 }
 
 CHIP_ERROR ProvideOfferCommand::RunCommand()
 {
-    std::cout << "Run ProvideOfferCommand" << std::endl;
+    ChipLogProgress(Camera, "Run ProvideOfferCommand");
 
     app::DataModel::Nullable<uint16_t> webrtcSessionId;
     if (mWebRTCSessionId.HasValue())
@@ -57,7 +55,7 @@ CHIP_ERROR ProvideOfferCommand::RunCommand()
 
 CHIP_ERROR SolicitOfferCommand::RunCommand()
 {
-    std::cout << "Run SolicitOfferCommand" << std::endl;
+    ChipLogProgress(Camera, "Run SolicitOfferCommand");
 
     // Convert the stream usage into its enum type:
     auto streamUsage = static_cast<app::Clusters::WebRTCTransportProvider::StreamUsageEnum>(mStreamUsage);

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
@@ -55,4 +55,14 @@ CHIP_ERROR ProvideOfferCommand::RunCommand()
     return WebRTCManager::Instance().ProvideOffer(webrtcSessionId, streamUsage);
 }
 
+CHIP_ERROR SolicitOfferCommand::RunCommand()
+{
+    std::cout << "Run SolicitOfferCommand" << std::endl;
+
+    // Convert the stream usage into its enum type:
+    auto streamUsage = static_cast<app::Clusters::WebRTCTransportProvider::StreamUsageEnum>(mStreamUsage);
+
+    return WebRTCManager::Instance().SolicitOffer(streamUsage);
+}
+
 } // namespace webrtc

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.h
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.h
@@ -60,4 +60,21 @@ private:
     chip::Optional<uint8_t> mWebRTCSessionId;
 };
 
+class SolicitOfferCommand : public CHIPCommand
+{
+public:
+    SolicitOfferCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("solicit-offer", credIssuerCommands)
+    {
+        AddArgument("stream-usage", 0, UINT8_MAX, &mStreamUsage);
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(1); }
+
+private:
+    uint8_t mStreamUsage = 0;
+};
+
 } // namespace webrtc

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.h
@@ -35,12 +35,20 @@ public:
 
     void Init();
 
+    CHIP_ERROR HandleOffer(uint16_t sessionId, const WebRTCRequestorDelegate::OfferArgs & args);
+
     CHIP_ERROR HandleAnswer(uint16_t sessionId, const std::string & sdp);
+
+    CHIP_ERROR HandleICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates);
 
     CHIP_ERROR Connnect(chip::Controller::DeviceCommissioner & commissioner, chip::NodeId nodeId, chip::EndpointId endpointId);
 
     CHIP_ERROR ProvideOffer(chip::app::DataModel::Nullable<uint16_t> sessionId,
                             chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage);
+
+    CHIP_ERROR SolicitOffer(chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage);
+
+    CHIP_ERROR ProvideAnswer(uint16_t sessionId, const std::string & sdp);
 
     CHIP_ERROR ProvideICECandidates(uint16_t sessionId);
 

--- a/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCRequestorDelegate.cpp
@@ -29,7 +29,7 @@ using namespace chip::app::Clusters::WebRTCTransportRequestor;
 CHIP_ERROR WebRTCRequestorDelegate::HandleOffer(uint16_t sessionId, const OfferArgs & args)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleOffer");
-    return CHIP_NO_ERROR;
+    return WebRTCManager::Instance().HandleOffer(sessionId, args);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(uint16_t sessionId, const std::string & sdpAnswer)
@@ -41,7 +41,7 @@ CHIP_ERROR WebRTCRequestorDelegate::HandleAnswer(uint16_t sessionId, const std::
 CHIP_ERROR WebRTCRequestorDelegate::HandleICECandidates(uint16_t sessionId, const std::vector<std::string> & candidates)
 {
     ChipLogProgress(Camera, "WebRTCRequestorDelegate::HandleICECandidates");
-    return CHIP_NO_ERROR;
+    return WebRTCManager::Instance().HandleICECandidates(sessionId, candidates);
 }
 
 CHIP_ERROR WebRTCRequestorDelegate::HandleEnd(uint16_t sessionId, WebRTCEndReasonEnum reasonCode)


### PR DESCRIPTION
Implement the missing pieces for Standby Flow for Battery Camera and this is needed to implement the test plans for WERTCR cluster.

#### Testing

1. Launch the Camera Application:
Open a terminal console.
Execute the command: ./chip-camera-app --camera-deferred-offer

2. Launch the Camera Controller:
Open a separate terminal console.
Execute the command: ./chip-camera-controller

3. Commission the Camera Device:
In the controller console, initiate the commissioning process using the pairing code.
> pairing onnetwork 1 20202021

4. Init the WebRTC connection on Camera Controller
> webrtc connect 1 1

5. Trigger the Standby flow
> webrtc solicit-offer 3

Confirm the data channel is successfully established from log

```
[1745965236.474] [2134812:2134845] [CAM] WebRTCRequestorDelegate::HandleICECandidates
[1745965236.474] [2134812:2134845] [CAM] WebRTCManager::HandleICECandidates
[1745965236.474] [2134812:2134845] [CAM] Applying candidate: a=candidate:2 1 UDP 2130706175 2a00:79e0:2e2e:6:1324:c304:30cb:26cd 46033 typ host
[1745965236.474] [2134812:2134845] [CAM] Applying candidate: a=candidate:1 1 UDP 2122317823 100.92.56.182 46033 typ host
[1745965236.474] [2134812:2134845] [DMG] Command handler moving to [NewRespons]
[1745965236.474] [2134812:2134845] [DMG] Command handler moving to [ Preparing]
[1745965236.474] [2134812:2134845] [DMG] Command handler moving to [AddingComm]
[1745965236.474] [2134812:2134845] [DMG] Command handler moving to [AddedComma]
[1745965236.474] [2134812:2134845] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 1
[1745965236.474] [2134812:2134845] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 0
[1745965236.474] [2134812:2134845] [DMG] Command handler moving to [AwaitingDe]
[1745965236.474] [2134812:2134845] [EM] <<< [E:25987r S:17015 M:46026165] (S) Msg TX from 000000000001B669 to 1:0000000000000001 [A202] [TCP:[fe80::20af:f6c1:586a:9b12%enp1s0]:5540] --- Type 0001:09 (IM:InvokeCommandResponse) (B:64)
[1745965236.474] [2134812:2134845] [DMG] Command response sender moving to [AllInvokeR]
[1745965236.476] [2134812:2134954] [CAM] [PeerConnection State: 2]
[1745965236.476] [2134812:2134958] [CAM] [DataChannel open: test]
```

