### PR TITLE
Persist the highest observed event number in MTRDevice_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -57,6 +57,7 @@
 #import <platform/PlatformManager.h>
 
 static NSString * const sLastInitialSubscribeLatencyKey = @"lastInitialSubscribeLatency";
+static NSString * const sHighestObservedEventNumberKey = @"highestObservedEventNumber";
 
 static NSString * const sDeviceMayBeReachableReason = @"SPI client indicated the device may now be reachable";
 
@@ -288,6 +289,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 // The highest event number we have observed, if there was one at all.
 @property (nonatomic, readwrite, nullable) NSNumber * highestObservedEventNumber;
 
+// Whether the highestObservedEventNumber value needs persisting to storage.
+@property (nonatomic, readwrite, assign) BOOL highestObservedEventNumberNeedsPersisting;
+
 // receivingReport is true if we are receving a subscription report.  In
 // particular, this will be false if we're just getting an attribute value from
 // a read-through.
@@ -373,6 +377,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 @implementation MTRDevice_Concrete {
 #ifdef DEBUG
     NSUInteger _unitTestAttributesReportedSinceLastCheck;
+    NSUInteger _unitTestEventsReportedSinceLastCheck;
 #endif
 
     // _deviceCachePrimed is true if we have the data that comes from an initial
@@ -483,6 +488,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         _clusterDataToPersist = nil;
         _persistedClusters = [NSMutableSet set];
         _highestObservedEventNumber = nil;
+        _highestObservedEventNumberNeedsPersisting = NO;
         _matterCPPObjectsHolder = [[MTRDeviceMatterCPPObjectsHolder alloc] init];
         _throttlingDeviceBecameActiveCallbacks = NO;
 
@@ -1784,6 +1790,13 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     return _persistedClusterData != nil;
 }
 
+- (BOOL)_haveClusterDataToPersist
+{
+    os_unfair_lock_assert_owner(&self->_lock);
+
+    return _clusterDataToPersist.count > 0 || self.highestObservedEventNumberNeedsPersisting;
+}
+
 // Need an inner method for dealloc to call, so unit test callbacks don't re-capture self.
 //
 // Returns whether persistence actually happened.
@@ -1795,6 +1808,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     if (![self _dataStoreExists]) {
         MTR_LOG_ERROR("%@ storage behavior: no data store in _persistClusterData!", self);
         return NO;
+    }
+
+    if (self.highestObservedEventNumberNeedsPersisting) {
+        [self _storePersistedDeviceData];
     }
 
     // Nothing to persist
@@ -1864,7 +1881,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     std::lock_guard lock(_lock);
 
     // Nothing to persist
-    if (!_clusterDataToPersist.count) {
+    if (![self _haveClusterDataToPersist]) {
         return;
     }
 
@@ -1923,7 +1940,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     }
 
     // Nothing to persist
-    if (!_clusterDataToPersist.count) {
+    if (![self _haveClusterDataToPersist]) {
         MTR_LOG_DEBUG("%@ storage behavior: nothing to persist", self);
         return;
     }
@@ -2420,6 +2437,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
             [self.highestObservedEventNumber compare:eventNumber] == NSOrderedAscending) {
             // This is an event we have not seen before.
             self.highestObservedEventNumber = eventNumber;
+            self.highestObservedEventNumberNeedsPersisting = YES;
         } else {
             // We have seen this event already; just filter it out.  But also, we must be getting
             // some sort of priming report if we are getting events we have seen before.
@@ -2869,6 +2887,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
                                        // OnAttributeData
                                        [self _handleAttributeReport:value fromSubscription:YES];
 #ifdef DEBUG
+                                       std::lock_guard lock(self->_lock);
                                        self->_unitTestAttributesReportedSinceLastCheck += value.count;
 #endif
                                    });
@@ -2888,6 +2907,10 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 
                                        // OnEventReport
                                        [self _handleEventReport:value];
+#ifdef DEBUG
+                                       std::lock_guard lock(self->_lock);
+                                       self->_unitTestEventsReportedSinceLastCheck += value.count;
+#endif
                                    });
                                },
                                ^(NSError * error) {
@@ -3081,9 +3104,20 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
 #ifdef DEBUG
 - (NSUInteger)unitTestAttributesReportedSinceLastCheck
 {
+    std::lock_guard lock(_lock);
+
     NSUInteger attributesReportedSinceLastCheck = _unitTestAttributesReportedSinceLastCheck;
     _unitTestAttributesReportedSinceLastCheck = 0;
     return attributesReportedSinceLastCheck;
+}
+
+- (NSUInteger)unitTestEventsReportedSinceLastCheck
+{
+    std::lock_guard lock(_lock);
+
+    NSUInteger eventsReportedSinceLastCheck = _unitTestEventsReportedSinceLastCheck;
+    _unitTestEventsReportedSinceLastCheck = 0;
+    return eventsReportedSinceLastCheck;
 }
 #endif
 
@@ -4412,10 +4446,14 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
 
     std::lock_guard lock(_lock);
 
-    // For now the only data we care about is our initial subscribe latency.
     id initialSubscribeLatency = data[sLastInitialSubscribeLatencyKey];
     if (initialSubscribeLatency != nil) {
         [self _setLastInitialSubscribeLatency:initialSubscribeLatency];
+    }
+
+    id highestObservedEventNumber = data[sHighestObservedEventNumberKey];
+    if (highestObservedEventNumber != nil && [highestObservedEventNumber isKindOfClass:NSNumber.class]) {
+        self.highestObservedEventNumber = highestObservedEventNumber;
     }
 }
 
@@ -4429,10 +4467,13 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         return;
     }
 
-    // For now the only data we have is our initial subscribe latency.
     NSMutableDictionary<NSString *, id> * data = [NSMutableDictionary dictionary];
     if (_estimatedSubscriptionLatency != nil) {
         data[sLastInitialSubscribeLatencyKey] = _estimatedSubscriptionLatency;
+    }
+    if (self.highestObservedEventNumber != nil) {
+        data[sHighestObservedEventNumberKey] = self.highestObservedEventNumber;
+        self.highestObservedEventNumberNeedsPersisting = NO;
     }
 
     [datastore storeDeviceData:[data copy] forNodeID:self.nodeID];

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -174,6 +174,9 @@ static BOOL slocalTestStorageEnabledBeforeUnitTest;
         [sController.controllerDataStore clearAllStoredClusterData];
         NSDictionary * storedClusterDataAfterClear = [sController.controllerDataStore getStoredClusterDataForNodeID:@(kDeviceId)];
         XCTAssertEqual(storedClusterDataAfterClear.count, 0);
+
+        [sController.controllerDataStore clearDeviceDataForNodeID:@(kDeviceId)];
+        XCTAssertNil([sController.controllerDataStore getStoredDeviceDataForNodeID:@(kDeviceId)]);
     }
 }
 
@@ -3874,6 +3877,10 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Remove the device, then try again, now with us having stored cluster
     // data.  All the events should still be reported as historical.
     [sController removeDevice:device];
+
+    // Clear out our device data, so we don't have a stored max event number
+    // that filters everything out.
+    [sController.controllerDataStore clearDeviceDataForNodeID:@(kDeviceId)];
 
     eventReportsReceived = 0;
 

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<NSNumber *> *)_fetchClusterIndexForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID;
 - (nullable MTRDeviceClusterData *)_fetchClusterDataForNodeID:(NSNumber *)nodeID endpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID;
 - (nullable NSDictionary<NSString *, id> *)getStoredDeviceDataForNodeID:(NSNumber *)nodeID;
+- (void)clearDeviceDataForNodeID:(NSNumber *)nodeID;
+
 @property (readonly, nonatomic) NSArray<NSNumber *> * nodesWithStoredData;
 @end
 
@@ -59,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSMutableArray<NSNumber *> *)arrayOfNumbersFromAttributeValue:(MTRDeviceDataValueDictionary)dataDictionary;
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration;
 - (void)_deviceMayBeReachable;
+
+@property (nonatomic, readwrite, nullable) NSNumber * highestObservedEventNumber;
 @end
 
 #pragma mark - Declarations for items compiled only for DEBUG configuration
@@ -78,6 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)unitTestInjectEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
 - (void)unitTestInjectAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport fromSubscription:(BOOL)isFromSubscription;
 - (NSUInteger)unitTestAttributesReportedSinceLastCheck;
+- (NSUInteger)unitTestEventsReportedSinceLastCheck;
 - (void)unitTestClearClusterData;
 - (MTRInternalDeviceState)_getInternalState;
 - (void)unitTestSetReportToPersistenceDelayTime:(NSTimeInterval)reportToPersistenceDelayTime


### PR DESCRIPTION
This way, we can avoid asking servers for events we have seen before when we create a new MTRDevice_Concrete instance for the same node ID.

Some of the test changes fix pre-existing bugs in the test, where the state of the wrong device instance was examined.

#### Testing

Unit tests added.