### PR TITLE
[Tizen] QEMU coredump extraction

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-129 : [Telink] Update Docker image (Zephyr update)
+130 : [Tizen] QEMU coredump extraction

--- a/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-tizen-qemu/Dockerfile
@@ -165,6 +165,10 @@ RUN set -x \
     | guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload - $SYSTEMD_UNIT_9P_MOUNT : \
     ln-sf $SYSTEMD_UNIT_9P_MOUNT $SYSTEMD_REQUIRES_LOCAL_FS : \
     mkdir /mnt/chip \
+    # Setup crash manager
+    && guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda download /etc/crash-manager.conf crash-manager.conf \
+    && sed -i 's|# CrashRootPath=/usr/opt/share/crash/|CrashRootPath=/mnt/chip/|g' crash-manager.conf \
+    && guestfish --rw -a $TIZEN_IOT_IMAGE_ROOT -m /dev/sda upload crash-manager.conf /etc/crash-manager.conf \
     # Setup auto-login for root user
     && SYSTEMD_UNIT_SERIAL_GETTY=$SYSTEMD_SYSTEM/serial-getty@.service \
     && virt-edit $TIZEN_IOT_IMAGE_ROOT -e \

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -81,7 +81,7 @@ provided.
 -   Create sysroot directory
 -   Mount `/opt/tizen-sdk/iot-rootfs.img`
 -   Copy `/usr` from the mounted image to your sysroot directory
--   Fix potentially broken symlinks in the libs as needed
+-   Fix potentially broken symlinks in the libraries as needed
 
 Core dumps are generated in the `dump` directory as a zip archive file. After
 extracting it the core dump should be extracted from tar archive file.

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -72,3 +72,24 @@ Then, use the run command and add the `rootshell` keyword to kernel arguments
 passed to QEMU (the string after the `-append` option). This will run QEMU, but
 instead of running the test, it will drop you to the shell. From there, you can
 run the test manually by typing `/mnt/chip/runner.sh`.
+
+## Analyzing coredumps
+
+In order for GDB to work correctly, same sysroot as is present on QEMU must be
+provided.
+- Create sysroot directory
+- Mount `/opt/tizen-sdk/iot-rootfs.img`
+- Copy `/usr` from the mounted image to your sysroot directory
+- Fix potentially broken symlinks in the libs as needed
+
+Coredumps are generated in the `dump` directory as a zip archive file.
+After extracting it the coredump should be extracted from tar archive file.
+
+Set GDB config
+```
+set auto-load safe-path /
+set sysroot /path/to/sysroot/
+```
+
+And then run `gdb-multiarch` specifying `.coredump` file extracted before,
+your GDB config file if present and lastly the executable.

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -73,7 +73,7 @@ passed to QEMU (the string after the `-append` option). This will run QEMU, but
 instead of running the test, it will drop you to the shell. From there, you can
 run the test manually by typing `/mnt/chip/runner.sh`.
 
-## Analyzing coredumps
+## Analyzing core dumps
 
 In order for GDB to work correctly, same sysroot as is present on QEMU must be
 provided.
@@ -83,8 +83,8 @@ provided.
 -   Copy `/usr` from the mounted image to your sysroot directory
 -   Fix potentially broken symlinks in the libs as needed
 
-Coredumps are generated in the `dump` directory as a zip archive file. After
-extracting it the coredump should be extracted from tar archive file.
+Core dumps are generated in the `dump` directory as a zip archive file. After
+extracting it the core dump should be extracted from tar archive file.
 
 Set GDB config
 

--- a/src/test_driver/tizen/README.md
+++ b/src/test_driver/tizen/README.md
@@ -77,19 +77,21 @@ run the test manually by typing `/mnt/chip/runner.sh`.
 
 In order for GDB to work correctly, same sysroot as is present on QEMU must be
 provided.
-- Create sysroot directory
-- Mount `/opt/tizen-sdk/iot-rootfs.img`
-- Copy `/usr` from the mounted image to your sysroot directory
-- Fix potentially broken symlinks in the libs as needed
 
-Coredumps are generated in the `dump` directory as a zip archive file.
-After extracting it the coredump should be extracted from tar archive file.
+-   Create sysroot directory
+-   Mount `/opt/tizen-sdk/iot-rootfs.img`
+-   Copy `/usr` from the mounted image to your sysroot directory
+-   Fix potentially broken symlinks in the libs as needed
+
+Coredumps are generated in the `dump` directory as a zip archive file. After
+extracting it the coredump should be extracted from tar archive file.
 
 Set GDB config
+
 ```
 set auto-load safe-path /
 set sysroot /path/to/sysroot/
 ```
 
-And then run `gdb-multiarch` specifying `.coredump` file extracted before,
-your GDB config file if present and lastly the executable.
+And then run `gdb-multiarch` specifying `.coredump` file extracted before, your
+GDB config file if present and lastly the executable.

--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -113,7 +113,7 @@ if args.share:
     # Add directory sharing.
     qemu_args += [
         '-virtfs',
-        'local,path=%s,mount_tag=host0,security_model=none' % args.share
+        'local,path=%s,mount_tag=host0,security_model=mapped-xattr' % args.share
     ]
 
 if args.virtio_net:


### PR DESCRIPTION
### Feature
- Set QEMU crash manager to generate coredumps in `/mnt/chip` which is host-mounted.
- Describe in `README` how to handle crash manager's output to see a backtrace.

### Testing
Procedure for analyzing coredumps mentioned in `README` correctly produces backtrace.