### PR TITLE
restyle-diff: Fix dropping files from changed paths

### DIFF
--- a/scripts/helpers/restyle-diff.sh
+++ b/scripts/helpers/restyle-diff.sh
@@ -93,4 +93,4 @@ fi
 
 paths=$(git diff --ignore-submodules --name-only --merge-base "$ref")
 
-echo "$paths" | xargs -n "$MAX_ARGS" bash -c 'restyle-paths "$@"'
+echo "$paths" | xargs -n "$MAX_ARGS" "$BASH" -c 'restyle-paths "$@"' -


### PR DESCRIPTION
The first argument after a `-c` shell command is assigned to $0.

#### Testing

Tested manually. Before this change the first file in the list of changed files won’t be restyled because it becomes $0 instead of $1. But unless that first file actually requires style changes it won’t be noticed. After this change all modified files get restyled as expected.