### PR TITLE
Small bugfix and test improvements for VID Verification

### DIFF
--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1793,6 +1793,28 @@ CHIP_ERROR FabricTable::UpdatePendingFabricCommon(FabricIndex fabricIndex, const
     const auto * fabricInfo = FindFabricWithIndex(fabricIndex);
     VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
 
+    // Cannot have a VVSC already if NOC is provided.
+    if (!icac.empty())
+    {
+        uint8_t vvscBuffer[kMaxCHIPCertLength];
+        MutableByteSpan vvscSpan{vvscBuffer};
+
+        CHIP_ERROR err = mOpCertStore->GetVidVerificationElement(fabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, vvscSpan);
+        if (err == CHIP_NO_ERROR)
+        {
+            if (!vvscSpan.empty())
+            {
+                ChipLogError(FabricProvisioning,
+                            "Received an UpdateNOC storage request with ICAC when VVSC already present. VVSC must be removed first.");
+                return CHIP_ERROR_INCORRECT_STATE;
+            }
+        }
+        else if (err != CHIP_ERROR_NOT_IMPLEMENTED)
+        {
+            return err;
+        }
+    }
+
     // Check for an existing fabric matching RCAC and FabricID. We must find a correct
     // existing fabric that chains to same root. We assume the stored root is correct.
     if (!mStateFlags.Has(StateFlags::kAreCollidingFabricsIgnored))
@@ -2262,6 +2284,13 @@ CHIP_ERROR FabricTable::SetVIDVerificationStatementElements(FabricIndex fabricIn
     // Start with VVSC first as it's the most likely to fail.
     if (VVSC.HasValue())
     {
+        if (mOpCertStore->HasCertificateForFabric(fabricIndex, OperationalCertificateStore::CertChainElement::kIcac))
+        {
+            ChipLogError(FabricProvisioning,
+                "Received SetVIDVerificationStatement storage request with VVSC when ICAC already present. ICAC must be removed first.");
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+
         ReturnErrorOnFailure(mOpCertStore->UpdateVidVerificationSignerCertForFabric(fabricIndex, VVSC.Value()));
     }
 

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1793,7 +1793,7 @@ CHIP_ERROR FabricTable::UpdatePendingFabricCommon(FabricIndex fabricIndex, const
     const auto * fabricInfo = FindFabricWithIndex(fabricIndex);
     VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
 
-    // Cannot have a VVSC already if NOC is provided.
+    // Cannot have a VVSC already if ICAC is provided.
     if (!icac.empty())
     {
         uint8_t vvscBuffer[kMaxCHIPCertLength];

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1797,15 +1797,17 @@ CHIP_ERROR FabricTable::UpdatePendingFabricCommon(FabricIndex fabricIndex, const
     if (!icac.empty())
     {
         uint8_t vvscBuffer[kMaxCHIPCertLength];
-        MutableByteSpan vvscSpan{vvscBuffer};
+        MutableByteSpan vvscSpan{ vvscBuffer };
 
-        CHIP_ERROR err = mOpCertStore->GetVidVerificationElement(fabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, vvscSpan);
+        CHIP_ERROR err = mOpCertStore->GetVidVerificationElement(
+            fabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, vvscSpan);
         if (err == CHIP_NO_ERROR)
         {
             if (!vvscSpan.empty())
             {
-                ChipLogError(FabricProvisioning,
-                            "Received an UpdateNOC storage request with ICAC when VVSC already present. VVSC must be removed first.");
+                ChipLogError(
+                    FabricProvisioning,
+                    "Received an UpdateNOC storage request with ICAC when VVSC already present. VVSC must be removed first.");
                 return CHIP_ERROR_INCORRECT_STATE;
             }
         }
@@ -2287,7 +2289,8 @@ CHIP_ERROR FabricTable::SetVIDVerificationStatementElements(FabricIndex fabricIn
         if (mOpCertStore->HasCertificateForFabric(fabricIndex, OperationalCertificateStore::CertChainElement::kIcac))
         {
             ChipLogError(FabricProvisioning,
-                "Received SetVIDVerificationStatement storage request with VVSC when ICAC already present. ICAC must be removed first.");
+                         "Received SetVIDVerificationStatement storage request with VVSC when ICAC already present. ICAC must be "
+                         "removed first.");
             return CHIP_ERROR_INCORRECT_STATE;
         }
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -922,6 +922,7 @@ public:
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_INVALID_FABRIC_INDEX if the `fabricIndex` is not an existing fabric
      * @retval CHIP_ERROR_INCORRECT_STATE if this is called in an inconsistent order
+     *                                    or if VVSC cannot be set due to ICAC presence (maps to INVALID_COMMAND).
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient memory to store the pending updates
      * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds.
      * @retval other CHIP_ERROR_* on internal errors or certificate validation errors.
@@ -955,6 +956,7 @@ public:
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_INVALID_FABRIC_INDEX if the `fabricIndex` is not an existing fabric
      * @retval CHIP_ERROR_INCORRECT_STATE if this is called in an inconsistent order
+     *                                    or if VVSC cannot be set due to ICAC presence (maps to INVALID_COMMAND).
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient memory to store the pending updates
      * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds.
      * @retval other CHIP_ERROR_* on internal errors or certificate validation errors.

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -922,7 +922,7 @@ public:
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_INVALID_FABRIC_INDEX if the `fabricIndex` is not an existing fabric
      * @retval CHIP_ERROR_INCORRECT_STATE if this is called in an inconsistent order
-     *                                    or if VVSC cannot be set due to ICAC presence (maps to INVALID_COMMAND).
+     *                                    or if ICAC cannot be set due to VVSC presence (maps to INVALID_COMMAND).
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient memory to store the pending updates
      * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds.
      * @retval other CHIP_ERROR_* on internal errors or certificate validation errors.
@@ -956,7 +956,7 @@ public:
      * @retval CHIP_NO_ERROR on success
      * @retval CHIP_ERROR_INVALID_FABRIC_INDEX if the `fabricIndex` is not an existing fabric
      * @retval CHIP_ERROR_INCORRECT_STATE if this is called in an inconsistent order
-     *                                    or if VVSC cannot be set due to ICAC presence (maps to INVALID_COMMAND).
+     *                                    or if ICAC cannot be set due to VVSC presence (maps to INVALID_COMMAND).
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient memory to store the pending updates
      * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds.
      * @retval other CHIP_ERROR_* on internal errors or certificate validation errors.

--- a/src/credentials/OperationalCertificateStore.h
+++ b/src/credentials/OperationalCertificateStore.h
@@ -188,8 +188,7 @@ public:
      * @retval CHIP_ERROR_INCORRECT_STATE if the certificate store is not properly initialized, if this method
      *                                    is called after `AddNewOpCertsForFabric`, if there was
      *                                    already a pending cert chain for the given `fabricIndex`, if there are
-     *                                    no associated persisted root and NOC chain for the given `fabricIndex`,
-     *                                    or if a VVSC is present and `icac` is not empty.
+     *                                    no associated persisted root and NOC chain for the given `fabricIndex`.
      * @retval other CHIP_ERROR value on internal errors
      */
     virtual CHIP_ERROR UpdateOpCertsForFabric(FabricIndex fabricIndex, const ByteSpan & noc, const ByteSpan & icac) = 0;

--- a/src/credentials/PersistentStorageOpCertStore.h
+++ b/src/credentials/PersistentStorageOpCertStore.h
@@ -132,9 +132,6 @@ protected:
     // Returns true if any pending or persisted state exists for the fabricIndex, false if nothing at all is found.
     bool HasAnyCertificateForFabric(FabricIndex fabricIndex) const;
 
-    // Returns true if any pending or persisted state exists for the VVSC.
-    bool HasVvscForFabric(FabricIndex fabricIndex) const;
-
     // Returns true if there is stored or pending NOC chain .
     bool HasNocChainForFabric(FabricIndex fabricIndex) const;
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -807,7 +807,7 @@ TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
                                                                     fabricTableWasChanged),
                     CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, true);
-        
+
         EXPECT_EQ(storage.GetNumKeys(), numStorageAfterFirstAdd + 2); // VVSC and VVS added.
 
         // Make sure VVSC was stored.

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -1131,7 +1131,7 @@ TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
             EXPECT_EQ(nextFabricIndex, 3);
         }
 
-        // Validate contents of Fabric Index 2 is still OK
+        // Validate contents of Fabric Index 2 is still OK.
         const auto * fabricInfo = fabricTable.FindFabricWithIndex(2);
         ASSERT_NE(fabricInfo, nullptr);
         EXPECT_EQ(fabricInfo->GetFabricIndex(), 2);

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -3340,8 +3340,8 @@ TEST_F(TestFabricTable, SettingVvscFailsWithIcacAndSucceedWithout)
     {
         bool fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 1, /* vendorId = */ chip::NullOptional,
-                                                                  NullOptional,
-                                                                  chip::MakeOptional<>(vvscSpan), fabricTableWasChanged),
+                                                                  NullOptional, chip::MakeOptional<>(vvscSpan),
+                                                                  fabricTableWasChanged),
                   CHIP_ERROR_INCORRECT_STATE);
         EXPECT_EQ(fabricTableWasChanged, false);
     }
@@ -3350,8 +3350,8 @@ TEST_F(TestFabricTable, SettingVvscFailsWithIcacAndSucceedWithout)
     {
         bool fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  NullOptional,
-                                                                  chip::MakeOptional<>(vvscSpan), fabricTableWasChanged),
+                                                                  NullOptional, chip::MakeOptional<>(vvscSpan),
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, false);
 
@@ -3359,34 +3359,34 @@ TEST_F(TestFabricTable, SettingVvscFailsWithIcacAndSucceedWithout)
         vvsc[1]               = 0x00;
         fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  NullOptional,
-                                                                  chip::MakeOptional<>(vvscSpan), fabricTableWasChanged),
+                                                                  NullOptional, chip::MakeOptional<>(vvscSpan),
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, false);
 
         // The VVSC should match by the end.
         uint8_t actualVvsc[kMaxCHIPCertLength];
         MutableByteSpan actualVvscSpan{ actualVvsc };
-        EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
-                      /* fabricIndex = */ 2,
-                      Credentials::OperationalCertificateStore::VidVerificationElement::kVvsc, actualVvscSpan),
-                  CHIP_NO_ERROR);
+        EXPECT_EQ(
+            fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                /* fabricIndex = */ 2, Credentials::OperationalCertificateStore::VidVerificationElement::kVvsc, actualVvscSpan),
+            CHIP_NO_ERROR);
         EXPECT_TRUE(actualVvscSpan.data_equal(vvscSpan));
 
         // Erase VVSC with empty span.
         fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  NullOptional,
-                                                                  chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged),
+                                                                  NullOptional, chip::MakeOptional<>(emptyVvscSpan),
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, false);
 
         // The VVSC should be empty now.
         actualVvscSpan = MutableByteSpan{ actualVvsc };
-        EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
-                      /* fabricIndex = */ 2,
-                      Credentials::OperationalCertificateStore::VidVerificationElement::kVvsc, actualVvscSpan),
-                  CHIP_NO_ERROR);
+        EXPECT_EQ(
+            fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                /* fabricIndex = */ 2, Credentials::OperationalCertificateStore::VidVerificationElement::kVvsc, actualVvscSpan),
+            CHIP_NO_ERROR);
         EXPECT_TRUE(actualVvscSpan.empty());
     }
 
@@ -3394,16 +3394,16 @@ TEST_F(TestFabricTable, SettingVvscFailsWithIcacAndSucceedWithout)
     {
         bool fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  chip::MakeOptional<>(vvsSpan),
-                                                                  NullOptional, fabricTableWasChanged),
+                                                                  chip::MakeOptional<>(vvsSpan), NullOptional,
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, true);
 
         // Re-set VVS, should succeed again, but no fabric table changes seen.
         fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  chip::MakeOptional<>(vvsSpan),
-                                                                  NullOptional, fabricTableWasChanged),
+                                                                  chip::MakeOptional<>(vvsSpan), NullOptional,
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, false);
 
@@ -3411,8 +3411,8 @@ TEST_F(TestFabricTable, SettingVvscFailsWithIcacAndSucceedWithout)
         vvs[1]                = 0x02;
         fabricTableWasChanged = false;
         EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
-                                                                  chip::MakeOptional<>(vvsSpan),
-                                                                  NullOptional, fabricTableWasChanged),
+                                                                  chip::MakeOptional<>(vvsSpan), NullOptional,
+                                                                  fabricTableWasChanged),
                   CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, true);
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -3277,44 +3277,59 @@ TEST_F(TestFabricTable, SettingVvsFailsWithIcacAndSucceedWithout)
     uint8_t vvs[Crypto::kVendorIdVerificationStatementV1Size];
     memset(&vvs[0], 0x01, sizeof(vvs));
 
-    ByteSpan vvsSpan{vvs};
+    ByteSpan vvsSpan{ vvs };
     ByteSpan emptyVvscSpan{};
 
     // Try to set VVS when ICAC not set --> failure.
     {
         bool fabricTableWasChanged = false;
-        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 1 , /* vendorId = */ chip::NullOptional, chip::MakeOptional<>(vvsSpan), chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged), CHIP_ERROR_INCORRECT_STATE);
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 1, /* vendorId = */ chip::NullOptional,
+                                                                  chip::MakeOptional<>(vvsSpan),
+                                                                  chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged),
+                  CHIP_ERROR_INCORRECT_STATE);
         EXPECT_EQ(fabricTableWasChanged, false);
     }
 
     // Try top set VVS when ICAC not set --> success.
     {
-      bool fabricTableWasChanged = false;
-      EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2 , /* vendorId = */ chip::NullOptional, chip::MakeOptional<>(vvsSpan), chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-      EXPECT_EQ(fabricTableWasChanged, true);
+        bool fabricTableWasChanged = false;
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
+                                                                  chip::MakeOptional<>(vvsSpan),
+                                                                  chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableWasChanged, true);
 
-      // Set it again to same, should succeed again, no changes.
-      fabricTableWasChanged = false;
-      EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2 , /* vendorId = */ chip::NullOptional, chip::MakeOptional<>(vvsSpan), chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-      EXPECT_EQ(fabricTableWasChanged, false);
+        // Set it again to same, should succeed again, no changes.
+        fabricTableWasChanged = false;
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
+                                                                  chip::MakeOptional<>(vvsSpan),
+                                                                  chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableWasChanged, false);
 
-      // Change a byte, should succeed again, changes fouund
-      vvs[1] = 0x02;
-      fabricTableWasChanged = false;
-      EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2 , /* vendorId = */ chip::NullOptional, chip::MakeOptional<>(vvsSpan), chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-      EXPECT_EQ(fabricTableWasChanged, true);
+        // Change a byte, should succeed again, changes fouund
+        vvs[1]                = 0x02;
+        fabricTableWasChanged = false;
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(/* fabricIndex = */ 2, /* vendorId = */ chip::NullOptional,
+                                                                  chip::MakeOptional<>(vvsSpan),
+                                                                  chip::MakeOptional<>(emptyVvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableWasChanged, true);
 
-      // The VVS should match by the end.
-      uint8_t actualVvs[Crypto::kVendorIdVerificationStatementV1Size];
-      MutableByteSpan actualVvsSpan{actualVvs};
-      EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(/* fabricIndex = */ 2, Credentials::OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement, actualVvsSpan), CHIP_NO_ERROR);
-      EXPECT_TRUE(actualVvsSpan.data_equal(vvsSpan));
-  }
+        // The VVS should match by the end.
+        uint8_t actualVvs[Crypto::kVendorIdVerificationStatementV1Size];
+        MutableByteSpan actualVvsSpan{ actualVvs };
+        EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                      /* fabricIndex = */ 2,
+                      Credentials::OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement, actualVvsSpan),
+                  CHIP_NO_ERROR);
+        EXPECT_TRUE(actualVvsSpan.data_equal(vvsSpan));
+    }
 }
 
 TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
 {
-    //Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
+    // Credentials::TestOnlyLocalCertificateAuthority fabric11CertAuthority;
     Credentials::TestOnlyLocalCertificateAuthority fabric44CertAuthority;
     EXPECT_TRUE(fabric44CertAuthority.Init().IsSuccess());
 
@@ -3324,211 +3339,238 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
     EXPECT_EQ(fabricTableHolder.Init(&storage), CHIP_NO_ERROR);
     FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-    constexpr uint16_t kVendorId = 0xFFF1u;
+    constexpr uint16_t kVendorId    = 0xFFF1u;
     constexpr uint16_t kNewVendorId = 0xFFF2u;
-    FabricIndex newFabricIndex = kUndefinedFabricIndex;
+    FabricIndex newFabricIndex      = kUndefinedFabricIndex;
 
     // VVSC contents is not checked, so can be just zero bytes.
     uint8_t vvsc[kMaxCHIPCertLength];
     memset(&vvsc[0], 0x00, sizeof(vvsc));
-    ByteSpan vvscSpan{vvsc};
+    ByteSpan vvscSpan{ vvsc };
 
     // VVS contents is not checked, except first by that must be 0x01.
     uint8_t vvs[Crypto::kVendorIdVerificationStatementV1Size];
     memset(&vvs[0], 0x01, sizeof(vvs));
-    ByteSpan vvsSpan{vvs};
+    ByteSpan vvsSpan{ vvs };
 
     uint8_t csrBuf[chip::Crypto::kMIN_CSR_Buffer_Size];
 
     // Fabric Index 1: Add node ID 33 on fabric 44, using operational keystore and no ICAC. Set a default VVSC.
     {
-      FabricId fabricId = 44;
-      NodeId nodeId     = 333;
+        FabricId fabricId = 44;
+        NodeId nodeId     = 333;
 
-      MutableByteSpan csrSpan{ csrBuf };
-      EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
+        MutableByteSpan csrSpan{ csrBuf };
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(chip::NullOptional, csrSpan), CHIP_NO_ERROR);
 
-      EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                CHIP_NO_ERROR);
-      ByteSpan rcac = fabric44CertAuthority.GetRcac();
-      ByteSpan noc  = fabric44CertAuthority.GetNoc();
-      EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
-      EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, /*icac = */ ByteSpan{}, kVendorId, &newFabricIndex), CHIP_NO_ERROR);
-      EXPECT_EQ(newFabricIndex, 1u);
-      EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
-      EXPECT_EQ(fabricTable.FabricCount(), 1);
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
+        ByteSpan rcac = fabric44CertAuthority.GetRcac();
+        ByteSpan noc  = fabric44CertAuthority.GetNoc();
+        EXPECT_EQ(fabricTable.AddNewPendingTrustedRootCert(rcac), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.AddNewPendingFabricWithOperationalKeystore(noc, /*icac = */ ByteSpan{}, kVendorId, &newFabricIndex),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(newFabricIndex, 1u);
+        EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
 
-      bool fabricTableWasChanged = false;
-      EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional, MakeOptional(vvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-      // Changing VVSC doesn't change Fabrics table itself.
-      EXPECT_EQ(fabricTableWasChanged, false);
+        bool fabricTableWasChanged = false;
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional,
+                                                                  MakeOptional(vvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
+        // Changing VVSC doesn't change Fabrics table itself.
+        EXPECT_EQ(fabricTableWasChanged, false);
 
-      // Make sure VVSC was stored.
-      {
-          uint8_t readBackVvscBuf[kMaxCHIPCertLength];
-          memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
-          MutableByteSpan readBackVvscSpan{readBackVvscBuf};
+        // Make sure VVSC was stored.
+        {
+            uint8_t readBackVvscBuf[kMaxCHIPCertLength];
+            memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
+            MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
 
-          EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan), CHIP_NO_ERROR);
-          EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
-      }
+            EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                          newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                      CHIP_NO_ERROR);
+            EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
+        }
     }
 
-  // Try to update node ID to 33 on fabric 44 WITHOUT ICAC. Must succeed even if VVSC present.
-  // Then remove VVSC, and update NOC chain to include ICAC, and this should work.
-  // Then update NOC chain to WITHOUT ICAC, and add VVSC and VVS while pending. Then revert. Should go back to prior state.
-  {
-      MutableByteSpan csrSpan{ csrBuf };
-      FabricIndex existingFabricIndex = 1u;
+    // Try to update node ID to 33 on fabric 44 WITHOUT ICAC. Must succeed even if VVSC present.
+    // Then remove VVSC, and update NOC chain to include ICAC, and this should work.
+    // Then update NOC chain to WITHOUT ICAC, and add VVSC and VVS while pending. Then revert. Should go back to prior state.
+    {
+        MutableByteSpan csrSpan{ csrBuf };
+        FabricIndex existingFabricIndex = 1u;
 
-      // Update to NodeID 33 with ICAC
-      {
-          FabricId fabricId = 44;
-          NodeId nodeId     = 33;
+        // Update to NodeID 33 with ICAC
+        {
+            FabricId fabricId = 44;
+            NodeId nodeId     = 33;
 
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
-          EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                    CHIP_NO_ERROR);
-          ByteSpan noc  = fabric44CertAuthority.GetNoc();
+            ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
+            EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
+            ByteSpan noc = fabric44CertAuthority.GetNoc();
 
-          EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{}, FabricTable::AdvertiseIdentity::No),
-                    CHIP_NO_ERROR);
-          ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
-          EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
-          EXPECT_EQ(fabricTable.FabricCount(), 1);
-      }
+            EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{},
+                                                                             FabricTable::AdvertiseIdentity::No),
+                      CHIP_NO_ERROR);
+            ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+        }
 
-      // Remove VVSC and update to NodeID 66 WITH ICAC
-      {
-          {
-              bool fabricTableWasChanged = false;
-              EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional, MakeOptional(ByteSpan{}), fabricTableWasChanged), CHIP_NO_ERROR);
-              // Changing VVSC doesn't change Fabrics table itself.
-              EXPECT_EQ(fabricTableWasChanged, false);
+        // Remove VVSC and update to NodeID 66 WITH ICAC
+        {
+            {
+                bool fabricTableWasChanged = false;
+                EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional,
+                                                                          MakeOptional(ByteSpan{}), fabricTableWasChanged),
+                          CHIP_NO_ERROR);
+                // Changing VVSC doesn't change Fabrics table itself.
+                EXPECT_EQ(fabricTableWasChanged, false);
 
-              // Make sure VVSC appears removed.
-              {
+                // Make sure VVSC appears removed.
+                {
+                    uint8_t readBackVvscBuf[kMaxCHIPCertLength];
+                    memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
+                    MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
+
+                    EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                                  newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                              CHIP_NO_ERROR);
+                    EXPECT_TRUE(readBackVvscSpan.empty());
+                }
+            }
+
+            FabricId fabricId = 44;
+            NodeId nodeId     = 66;
+
+            csrSpan = MutableByteSpan{ csrBuf };
+            ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
+            EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
+            ByteSpan icac = fabric44CertAuthority.GetIcac();
+            ByteSpan noc  = fabric44CertAuthority.GetNoc();
+
+            EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, icac,
+                                                                             FabricTable::AdvertiseIdentity::No),
+                      CHIP_NO_ERROR);
+            ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
+            EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+        }
+
+        // Update to Node ID 88 without ICAC. Set VVS/VVSC/VendorID before reverting. Revert and make sure VVSC/VVS/VendorID are
+        // reverted.
+        {
+            FabricId fabricId = 44;
+            NodeId nodeId     = 88;
+
+            csrSpan = MutableByteSpan{ csrBuf };
+            ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
+            EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                      CHIP_NO_ERROR);
+            ByteSpan noc = fabric44CertAuthority.GetNoc();
+
+            EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{},
+                                                                             FabricTable::AdvertiseIdentity::No),
+                      CHIP_NO_ERROR);
+            ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kVendorId);
+
+            // Set new pending VVS, VVSC and VendorId.
+            bool fabricTableWasChanged = false;
+            EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, MakeOptional(kNewVendorId),
+                                                                      MakeOptional(vvsSpan), MakeOptional(vvscSpan),
+                                                                      fabricTableWasChanged),
+                      CHIP_NO_ERROR);
+            EXPECT_EQ(fabricTableWasChanged, true);
+
+            // Make sure VVSC was set pending.
+            {
                 uint8_t readBackVvscBuf[kMaxCHIPCertLength];
                 memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
-                MutableByteSpan readBackVvscSpan{readBackVvscBuf};
+                MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
 
-                EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan), CHIP_NO_ERROR);
+                EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                              newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                          CHIP_NO_ERROR);
+                EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
+            }
+
+            // Make sure VVS was also set pending
+            {
+                uint8_t readBackVvsBuf[Crypto::kVendorIdVerificationStatementV1Size];
+                memset(&readBackVvsBuf[0], 0x00, sizeof(readBackVvsBuf));
+                MutableByteSpan readBackVvsSpan{ readBackVvsBuf };
+
+                EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                              newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement,
+                              readBackVvsSpan),
+                          CHIP_NO_ERROR);
+                EXPECT_TRUE(readBackVvsSpan.data_equal(vvsSpan));
+            }
+
+            ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kNewVendorId);
+
+            // Revert state, expect previous fabric data, and empty VVSC/VVS again.
+            fabricTable.RevertPendingFabricData();
+
+            EXPECT_EQ(fabricTable.FabricCount(), 1);
+            ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), 44u);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), 66u);
+            EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kVendorId);
+
+            // Make sure VVSC got reverted.
+            {
+                uint8_t readBackVvscBuf[kMaxCHIPCertLength];
+                memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
+                MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
+
+                EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                              newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                          CHIP_NO_ERROR);
                 EXPECT_TRUE(readBackVvscSpan.empty());
-              }
-          }
+            }
 
-          FabricId fabricId = 44;
-          NodeId nodeId     = 66;
+            // Make sure VVS got reverted.
+            {
+                uint8_t readBackVvsBuf[Crypto::kVendorIdVerificationStatementV1Size];
+                memset(&readBackVvsBuf[0], 0x00, sizeof(readBackVvsBuf));
+                MutableByteSpan readBackVvsSpan{ readBackVvsBuf };
 
-          csrSpan = MutableByteSpan{ csrBuf };
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
-          EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                    CHIP_NO_ERROR);
-          ByteSpan icac = fabric44CertAuthority.GetIcac();
-          ByteSpan noc  = fabric44CertAuthority.GetNoc();
-
-          EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, icac, FabricTable::AdvertiseIdentity::No),
-                    CHIP_NO_ERROR);
-          ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
-          EXPECT_EQ(fabricTable.CommitPendingFabricData(), CHIP_NO_ERROR);
-          EXPECT_EQ(fabricTable.FabricCount(), 1);
-      }
-
-      // Update to Node ID 88 without ICAC. Set VVS/VVSC/VendorID before reverting. Revert and make sure VVSC/VVS/VendorID are reverted.
-      {
-          FabricId fabricId = 44;
-          NodeId nodeId     = 88;
-
-          csrSpan = MutableByteSpan{ csrBuf };
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
-          EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                    CHIP_NO_ERROR);
-          ByteSpan noc  = fabric44CertAuthority.GetNoc();
-
-          EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{}, FabricTable::AdvertiseIdentity::No),
-                    CHIP_NO_ERROR);
-          ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kVendorId);
-
-          // Set new pending VVS, VVSC and VendorId.
-          bool fabricTableWasChanged = false;
-          EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, MakeOptional(kNewVendorId), MakeOptional(vvsSpan), MakeOptional(vvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-          EXPECT_EQ(fabricTableWasChanged, true);
-
-          // Make sure VVSC was set pending.
-          {
-              uint8_t readBackVvscBuf[kMaxCHIPCertLength];
-              memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
-              MutableByteSpan readBackVvscSpan{readBackVvscBuf};
-
-              EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan), CHIP_NO_ERROR);
-              EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
-          }
-
-          // Make sure VVS was also set pending
-          {
-              uint8_t readBackVvsBuf[Crypto::kVendorIdVerificationStatementV1Size];
-              memset(&readBackVvsBuf[0], 0x00, sizeof(readBackVvsBuf));
-              MutableByteSpan readBackVvsSpan{readBackVvsBuf};
-
-              EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement, readBackVvsSpan), CHIP_NO_ERROR);
-              EXPECT_TRUE(readBackVvsSpan.data_equal(vvsSpan));
-          }
-
-          ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kNewVendorId);
-
-          // Revert state, expect previous fabric data, and empty VVSC/VVS again.
-          fabricTable.RevertPendingFabricData();
-
-          EXPECT_EQ(fabricTable.FabricCount(), 1);
-          ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), 44u);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), 66u);
-          EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetVendorId(), kVendorId);
-
-          // Make sure VVSC got reverted.
-          {
-              uint8_t readBackVvscBuf[kMaxCHIPCertLength];
-              memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
-              MutableByteSpan readBackVvscSpan{readBackVvscBuf};
-
-              EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan), CHIP_NO_ERROR);
-              EXPECT_TRUE(readBackVvscSpan.empty());
-          }
-
-          // Make sure VVS got reverted.
-          {
-              uint8_t readBackVvsBuf[Crypto::kVendorIdVerificationStatementV1Size];
-              memset(&readBackVvsBuf[0], 0x00, sizeof(readBackVvsBuf));
-              MutableByteSpan readBackVvsSpan{readBackVvsBuf};
-
-              EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement, readBackVvsSpan), CHIP_NO_ERROR);
-              EXPECT_TRUE(readBackVvsSpan.empty());
-          }
-      }
-  }
+                EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                              newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement,
+                              readBackVvsSpan),
+                          CHIP_NO_ERROR);
+                EXPECT_TRUE(readBackVvsSpan.empty());
+            }
+        }
+    }
 
     // Update to NodeID 33 without ICAC
     {
-        FabricId fabricId = 44;
-        NodeId nodeId     = 33;
+        FabricId fabricId               = 44;
+        NodeId nodeId                   = 33;
         FabricIndex existingFabricIndex = 1u;
 
         MutableByteSpan csrSpan{ csrBuf };
         ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
         EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                CHIP_NO_ERROR);
-        ByteSpan noc  = fabric44CertAuthority.GetNoc();
+                  CHIP_NO_ERROR);
+        ByteSpan noc = fabric44CertAuthority.GetNoc();
 
-        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{}, FabricTable::AdvertiseIdentity::No),
-                CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, ByteSpan{},
+                                                                         FabricTable::AdvertiseIdentity::No),
+                  CHIP_NO_ERROR);
         ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
         EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), fabricId);
         EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetNodeId(), nodeId);
@@ -3536,42 +3578,47 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
         EXPECT_EQ(fabricTable.FabricCount(), 1);
     }
 
-  {
-    // Set VVSC. Should succeed due to lack of ICAC.
-    bool fabricTableWasChanged = false;
-    EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional, MakeOptional(vvscSpan), fabricTableWasChanged), CHIP_NO_ERROR);
-    EXPECT_EQ(fabricTableWasChanged, false);
-
-    // Make sure VVSC was stored.
     {
-        uint8_t readBackVvscBuf[kMaxCHIPCertLength];
-        memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
-        MutableByteSpan readBackVvscSpan{readBackVvscBuf};
+        // Set VVSC. Should succeed due to lack of ICAC.
+        bool fabricTableWasChanged = false;
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(newFabricIndex, NullOptional, NullOptional,
+                                                                  MakeOptional(vvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTableWasChanged, false);
 
-        EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan), CHIP_NO_ERROR);
-        EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
+        // Make sure VVSC was stored.
+        {
+            uint8_t readBackVvscBuf[kMaxCHIPCertLength];
+            memset(&readBackVvscBuf[0], 0x11, sizeof(readBackVvscBuf));
+            MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
+
+            EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
+                          newFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                      CHIP_NO_ERROR);
+            EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
+        }
     }
-  }
 
-  // Fabric Index 1: Try to update node ID to 55 on fabric 44. Must fail due to VVSC present.
-  {
-      FabricId fabricId = 44;
-      NodeId nodeId     = 55;
+    // Fabric Index 1: Try to update node ID to 55 on fabric 44. Must fail due to VVSC present.
+    {
+        FabricId fabricId = 44;
+        NodeId nodeId     = 55;
 
-      MutableByteSpan csrSpan{ csrBuf };
-      FabricIndex existingFabricIndex = 1u;
-      EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
+        MutableByteSpan csrSpan{ csrBuf };
+        FabricIndex existingFabricIndex = 1u;
+        EXPECT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
 
-      EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
-                CHIP_NO_ERROR);
-      ByteSpan icac = fabric44CertAuthority.GetIcac();
-      ByteSpan noc  = fabric44CertAuthority.GetNoc();
+        EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
+                  CHIP_NO_ERROR);
+        ByteSpan icac = fabric44CertAuthority.GetIcac();
+        ByteSpan noc  = fabric44CertAuthority.GetNoc();
 
-      EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, icac, FabricTable::AdvertiseIdentity::No),
-                CHIP_ERROR_INCORRECT_STATE);
-      fabricTable.RevertPendingFabricData();
-      EXPECT_EQ(fabricTable.FabricCount(), 1);
-  }
+        EXPECT_EQ(fabricTable.UpdatePendingFabricWithOperationalKeystore(existingFabricIndex, noc, icac,
+                                                                         FabricTable::AdvertiseIdentity::No),
+                  CHIP_ERROR_INCORRECT_STATE);
+        fabricTable.RevertPendingFabricData();
+        EXPECT_EQ(fabricTable.FabricCount(), 1);
+    }
 }
 
 TEST_F(TestFabricTable, VidVerificationSigningFailsOnBadInput)

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -802,10 +802,9 @@ TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
 
         // Set new VVS, VVSC. Applies immediately due to no intermediate NOC update flow present.
         bool fabricTableWasChanged = false;
-        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(kFirstFabricIndex, NullOptional,
-                                                                    MakeOptional(vvsSpan), MakeOptional(vvscSpan),
-                                                                    fabricTableWasChanged),
-                    CHIP_NO_ERROR);
+        EXPECT_EQ(fabricTable.SetVIDVerificationStatementElements(kFirstFabricIndex, NullOptional, MakeOptional(vvsSpan),
+                                                                  MakeOptional(vvscSpan), fabricTableWasChanged),
+                  CHIP_NO_ERROR);
         EXPECT_EQ(fabricTableWasChanged, true);
 
         EXPECT_EQ(storage.GetNumKeys(), numStorageAfterFirstAdd + 2); // VVSC and VVS added.
@@ -817,8 +816,8 @@ TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
             MutableByteSpan readBackVvscSpan{ readBackVvscBuf };
 
             EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
-                            kFirstFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
-                        CHIP_NO_ERROR);
+                          kFirstFabricIndex, OperationalCertificateStore::VidVerificationElement::kVvsc, readBackVvscSpan),
+                      CHIP_NO_ERROR);
             EXPECT_TRUE(readBackVvscSpan.data_equal(vvscSpan));
         }
 
@@ -829,9 +828,9 @@ TEST_F(TestFabricTable, TestBasicAddNocUpdateNocFlow)
             MutableByteSpan readBackVvsSpan{ readBackVvsBuf };
 
             EXPECT_EQ(fabricTableHolder.GetOpCertStore().GetVidVerificationElement(
-                            kFirstFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement,
-                            readBackVvsSpan),
-                        CHIP_NO_ERROR);
+                          kFirstFabricIndex, OperationalCertificateStore::VidVerificationElement::kVidVerificationStatement,
+                          readBackVvsSpan),
+                      CHIP_NO_ERROR);
             EXPECT_TRUE(readBackVvsSpan.data_equal(vvsSpan));
         }
     }

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -3386,7 +3386,7 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
           FabricId fabricId = 44;
           NodeId nodeId     = 33;
 
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);  
+          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
           EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
                     CHIP_NO_ERROR);
           ByteSpan noc  = fabric44CertAuthority.GetNoc();
@@ -3423,7 +3423,7 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
           NodeId nodeId     = 66;
 
           csrSpan = MutableByteSpan{ csrBuf };
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);  
+          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
           EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(true).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
                     CHIP_NO_ERROR);
           ByteSpan icac = fabric44CertAuthority.GetIcac();
@@ -3444,7 +3444,7 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
           NodeId nodeId     = 88;
 
           csrSpan = MutableByteSpan{ csrBuf };
-          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);  
+          ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
           EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
                     CHIP_NO_ERROR);
           ByteSpan noc  = fabric44CertAuthority.GetNoc();
@@ -3486,7 +3486,7 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
 
           // Revert state, expect previous fabric data, and empty VVSC/VVS again.
           fabricTable.RevertPendingFabricData();
-          
+
           EXPECT_EQ(fabricTable.FabricCount(), 1);
           ASSERT_NE(fabricTable.FindFabricWithIndex(newFabricIndex), nullptr);
           EXPECT_EQ(fabricTable.FindFabricWithIndex(newFabricIndex)->GetFabricId(), 44u);
@@ -3522,7 +3522,7 @@ TEST_F(TestFabricTable, UpdateNocWithIcacFailsWithVvscSucceedsWithout)
         FabricIndex existingFabricIndex = 1u;
 
         MutableByteSpan csrSpan{ csrBuf };
-        ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);  
+        ASSERT_EQ(fabricTable.AllocatePendingOperationalKey(MakeOptional(existingFabricIndex), csrSpan), CHIP_NO_ERROR);
         EXPECT_EQ(fabric44CertAuthority.SetIncludeIcac(false).GenerateNocChain(fabricId, nodeId, csrSpan).GetStatus(),
                 CHIP_NO_ERROR);
         ByteSpan noc  = fabric44CertAuthority.GetNoc();

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -99,7 +99,7 @@ public:
     static StorageKeyName FabricNOC(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/n", fabric); }
     static StorageKeyName FabricICAC(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/i", fabric); }
     static StorageKeyName FabricRCAC(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/r", fabric); }
-    static StorageKeyName FabricVVSC(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/vvvc", fabric); }
+    static StorageKeyName FabricVVSC(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/vvsc", fabric); }
     static StorageKeyName FabricVidVerificationStatement(FabricIndex fabric)
     {
         return StorageKeyName::Formatted("f/%x/vvs", fabric);

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -525,9 +525,9 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
             asserts.assert_equal(exception_context.exception.status, Status.InvalidCommand,
                                  "Expected INVALID_COMMAND for SetVIDVerificationStatement with no arguments present")
 
-        with test_step(7, description="Invoke SetVIDVerificationStatement with VVSC field set to a size > 400 bytes, outside fail-safe. Expect CONSTRAINT_ERROR"):
+        with test_step(7, description="Invoke SetVIDVerificationStatement using TH2's fabric (no ICAC present) with VVSC field set to a size > 400 bytes, outside fail-safe. Expect CONSTRAINT_ERROR"):
             with asserts.assert_raises(InteractionModelError) as exception_context:
-                await self.send_single_cmd(cmd=opcreds.Commands.SetVIDVerificationStatement(vvsc=(b"\x01" * 401)))
+                await self.send_single_cmd(dev_ctrl=th2_dev_ctrl, node_id=th2_dut_node_id, cmd=opcreds.Commands.SetVIDVerificationStatement(vvsc=(b"\x01" * 401)))
             asserts.assert_equal(exception_context.exception.status, Status.ConstraintError,
                                  "Expected CONSTRAINT_ERROR for SetVIDVerificationStatement with VVSC too large")
 


### PR DESCRIPTION
#### Changes
- Apply follow-ups requested by @bzbarsky-apple in #38469:
  - Fix vvvc/vvsc persisten storage key typo
  - Move the burden of ICAC/VVSC interlock to Fabric table
  - Document why Fabrics attribute is always reported after VVS/VVSC are touched during fail-safe
  - Fix documentation of classes to match above.
- Minor fix of UpdateNOC handling when VVS/VVSC is involved

#### Testing

- Added exhaustive cases of fail-safe handling for VVS/VVSC to TestFabricTable.
- Minor update to TC_OPCREDS_3_8.py
