### PR TITLE
Fix typo in ReadAndEncodeAllocatedSnapshotStreams in CameraAVStreamMgmtServer.

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -788,7 +788,7 @@ void CameraDevice::InitializeSnapshotStreams()
                                         ImageCodecEnum::kJpeg,
                                         kSnapshotStreamFrameRate /* FrameRate */,
                                         { kMinResolutionWidth, kMinResolutionHeight } /* MinResolution*/,
-                                        { kMinResolutionWidth, kMinResolutionHeight } /* MaxResolution */,
+                                        { kMaxResolutionWidth, kMaxResolutionHeight } /* MaxResolution */,
                                         90 /* Quality */,
                                         0 /* RefCount */ },
                                       false,

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -78,11 +78,18 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamModify(con
                                                                              const chip::Optional<bool> waterMarkEnabled,
                                                                              const chip::Optional<bool> osdEnabled)
 {
-    // TODO : Needs Change
     for (VideoStream & stream : mCameraDeviceHAL->GetAvailableVideoStreams())
     {
         if (stream.videoStreamParams.videoStreamID == streamID && stream.isAllocated)
         {
+            if (waterMarkEnabled.HasValue())
+            {
+                stream.videoStreamParams.watermarkEnabled = waterMarkEnabled;
+            }
+            if (osdEnabled.HasValue())
+            {
+                stream.videoStreamParams.OSDEnabled = osdEnabled;
+            }
             ChipLogError(Camera, "Modified video stream with ID: %d", streamID);
             return Status::Success;
         }
@@ -197,7 +204,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamModify(
                                                                                 const chip::Optional<bool> waterMarkEnabled,
                                                                                 const chip::Optional<bool> osdEnabled)
 {
-    // TODO : change
+    // TODO: Change this after SnapshotStreamStruct gets WMark and OSD
     for (SnapshotStream & stream : mCameraDeviceHAL->GetAvailableSnapshotStreams())
     {
         if (stream.snapshotStreamParams.snapshotStreamID == streamID && stream.isAllocated)

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -229,9 +229,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedAudioStreams(const At
 
 CHIP_ERROR CameraAVStreamMgmtServer::ReadAndEncodeAllocatedSnapshotStreams(const AttributeValueEncoder::ListEncodeHelper & encoder)
 {
-    for (const auto & audioStream : mAllocatedAudioStreams)
+    for (const auto & snapshotStream : mAllocatedSnapshotStreams)
     {
-        ReturnErrorOnFailure(encoder.Encode(audioStream));
+        ReturnErrorOnFailure(encoder.Encode(snapshotStream));
     }
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
-Assign WMark and OSD for VideStreamModify


#### Testing
* Commission camera-app
* Allocate SnapshotStream using chip-tool