### PR TITLE
Update  per-cluster generated files: use public_deps instead of deps and fix up minor namespace ordering

### DIFF
--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Build.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/Build.jinja
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("{{cluster.name}}") {

--- a/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/CommandIds.jinja
+++ b/scripts/py_matter_idl/matter/idl/generators/cpp/sdk/CommandIds.jinja
@@ -25,6 +25,6 @@ inline constexpr CommandId Id = {{ "0x%08X" | format(struct.code)}};
 {% endfor -%}
 } // namespace Commands
 } // namespace {{cluster.name}}
-} // namespace app
 } // namespace Clusters
+} // namespace app
 } // namespace chip

--- a/zzz_generated/app-common/clusters/AccessControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AccessControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("AccessControl") {

--- a/zzz_generated/app-common/clusters/AccountLogin/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AccountLogin/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("AccountLogin") {

--- a/zzz_generated/app-common/clusters/Actions/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Actions/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Actions") {

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ActivatedCarbonFilterMonitoring") {

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("AdministratorCommissioning") {

--- a/zzz_generated/app-common/clusters/AirQuality/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AirQuality/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("AirQuality") {

--- a/zzz_generated/app-common/clusters/ApplicationBasic/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ApplicationBasic/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ApplicationBasic") {

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ApplicationLauncher") {

--- a/zzz_generated/app-common/clusters/AudioOutput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/AudioOutput/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("AudioOutput") {

--- a/zzz_generated/app-common/clusters/BallastConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BallastConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("BallastConfiguration") {

--- a/zzz_generated/app-common/clusters/BasicInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BasicInformation/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("BasicInformation") {

--- a/zzz_generated/app-common/clusters/Binding/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Binding/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Binding") {

--- a/zzz_generated/app-common/clusters/BooleanState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BooleanState/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("BooleanState") {

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("BooleanStateConfiguration") {

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("BridgedDeviceBasicInformation") {

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CameraAvSettingsUserLevelManagement") {

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CameraAvStreamManagement") {

--- a/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CarbonDioxideConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CarbonMonoxideConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/Channel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Channel/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Channel") {

--- a/zzz_generated/app-common/clusters/Chime/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Chime/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Chime") {

--- a/zzz_generated/app-common/clusters/ClosureControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ClosureControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ClosureControl") {

--- a/zzz_generated/app-common/clusters/ClosureDimension/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ClosureDimension/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ClosureDimension") {

--- a/zzz_generated/app-common/clusters/ColorControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ColorControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ColorControl") {

--- a/zzz_generated/app-common/clusters/CommissionerControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommissionerControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CommissionerControl") {

--- a/zzz_generated/app-common/clusters/CommodityMetering/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityMetering/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CommodityMetering") {

--- a/zzz_generated/app-common/clusters/CommodityPrice/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityPrice/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CommodityPrice") {

--- a/zzz_generated/app-common/clusters/CommodityTariff/BUILD.gn
+++ b/zzz_generated/app-common/clusters/CommodityTariff/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("CommodityTariff") {

--- a/zzz_generated/app-common/clusters/ContentAppObserver/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ContentAppObserver") {

--- a/zzz_generated/app-common/clusters/ContentControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ContentControl") {

--- a/zzz_generated/app-common/clusters/ContentLauncher/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ContentLauncher/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ContentLauncher") {

--- a/zzz_generated/app-common/clusters/Descriptor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Descriptor/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Descriptor") {

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DeviceEnergyManagement") {

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DeviceEnergyManagementMode") {

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DiagnosticLogs") {

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DishwasherAlarm") {

--- a/zzz_generated/app-common/clusters/DishwasherMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DishwasherMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DishwasherMode") {

--- a/zzz_generated/app-common/clusters/DoorLock/BUILD.gn
+++ b/zzz_generated/app-common/clusters/DoorLock/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("DoorLock") {

--- a/zzz_generated/app-common/clusters/EcosystemInformation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EcosystemInformation/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("EcosystemInformation") {

--- a/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ElectricalEnergyMeasurement") {

--- a/zzz_generated/app-common/clusters/ElectricalGridConditions/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalGridConditions/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ElectricalGridConditions") {

--- a/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ElectricalPowerMeasurement") {

--- a/zzz_generated/app-common/clusters/EnergyEvse/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyEvse/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("EnergyEvse") {

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("EnergyEvseMode") {

--- a/zzz_generated/app-common/clusters/EnergyPreference/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EnergyPreference/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("EnergyPreference") {

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("EthernetNetworkDiagnostics") {

--- a/zzz_generated/app-common/clusters/FanControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FanControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("FanControl") {

--- a/zzz_generated/app-common/clusters/FaultInjection/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FaultInjection/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("FaultInjection") {

--- a/zzz_generated/app-common/clusters/FixedLabel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FixedLabel/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("FixedLabel") {

--- a/zzz_generated/app-common/clusters/FlowMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FlowMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("FlowMeasurement") {

--- a/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("FormaldehydeConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("GeneralCommissioning") {

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("GeneralDiagnostics") {

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("GroupKeyManagement") {

--- a/zzz_generated/app-common/clusters/Groups/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Groups/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Groups") {

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/BUILD.gn
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("HepaFilterMonitoring") {

--- a/zzz_generated/app-common/clusters/IcdManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/IcdManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("IcdManagement") {

--- a/zzz_generated/app-common/clusters/Identify/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Identify/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Identify") {

--- a/zzz_generated/app-common/clusters/IlluminanceMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/IlluminanceMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("IlluminanceMeasurement") {

--- a/zzz_generated/app-common/clusters/KeypadInput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/KeypadInput/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("KeypadInput") {

--- a/zzz_generated/app-common/clusters/LaundryDryerControls/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryDryerControls/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LaundryDryerControls") {

--- a/zzz_generated/app-common/clusters/LaundryWasherControls/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryWasherControls/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LaundryWasherControls") {

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LaundryWasherMode") {

--- a/zzz_generated/app-common/clusters/LevelControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LevelControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LevelControl") {

--- a/zzz_generated/app-common/clusters/LocalizationConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LocalizationConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LocalizationConfiguration") {

--- a/zzz_generated/app-common/clusters/LowPower/BUILD.gn
+++ b/zzz_generated/app-common/clusters/LowPower/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("LowPower") {

--- a/zzz_generated/app-common/clusters/MediaInput/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MediaInput/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("MediaInput") {

--- a/zzz_generated/app-common/clusters/MediaPlayback/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MediaPlayback/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("MediaPlayback") {

--- a/zzz_generated/app-common/clusters/Messages/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Messages/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Messages") {

--- a/zzz_generated/app-common/clusters/MeterIdentification/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MeterIdentification/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("MeterIdentification") {

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("MicrowaveOvenControl") {

--- a/zzz_generated/app-common/clusters/MicrowaveOvenMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("MicrowaveOvenMode") {

--- a/zzz_generated/app-common/clusters/ModeSelect/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ModeSelect/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ModeSelect") {

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/BUILD.gn
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("NetworkCommissioning") {

--- a/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("NitrogenDioxideConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/OccupancySensing/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OccupancySensing/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OccupancySensing") {

--- a/zzz_generated/app-common/clusters/OnOff/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OnOff/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OnOff") {

--- a/zzz_generated/app-common/clusters/OperationalCredentials/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OperationalCredentials") {

--- a/zzz_generated/app-common/clusters/OperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OperationalState/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OperationalState") {

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OtaSoftwareUpdateProvider") {

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OtaSoftwareUpdateRequestor") {

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OvenCavityOperationalState") {

--- a/zzz_generated/app-common/clusters/OvenMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OvenMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OvenMode") {

--- a/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("OzoneConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Pm10ConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Pm1ConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Pm25ConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/PowerSource/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerSource/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PowerSource") {

--- a/zzz_generated/app-common/clusters/PowerSourceConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerSourceConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PowerSourceConfiguration") {

--- a/zzz_generated/app-common/clusters/PowerTopology/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PowerTopology/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PowerTopology") {

--- a/zzz_generated/app-common/clusters/PressureMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PressureMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PressureMeasurement") {

--- a/zzz_generated/app-common/clusters/ProxyConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ProxyConfiguration") {

--- a/zzz_generated/app-common/clusters/ProxyDiscovery/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyDiscovery/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ProxyDiscovery") {

--- a/zzz_generated/app-common/clusters/ProxyValid/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ProxyValid/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ProxyValid") {

--- a/zzz_generated/app-common/clusters/PulseWidthModulation/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PulseWidthModulation/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PulseWidthModulation") {

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PumpConfigurationAndControl") {

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/BUILD.gn
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("PushAvStreamTransport") {

--- a/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RadonConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/RefrigeratorAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RefrigeratorAlarm/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RefrigeratorAlarm") {

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RefrigeratorAndTemperatureControlledCabinetMode") {

--- a/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RelativeHumidityMeasurement") {

--- a/zzz_generated/app-common/clusters/RvcCleanMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RvcCleanMode") {

--- a/zzz_generated/app-common/clusters/RvcOperationalState/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RvcOperationalState") {

--- a/zzz_generated/app-common/clusters/RvcRunMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/RvcRunMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("RvcRunMode") {

--- a/zzz_generated/app-common/clusters/SampleMei/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SampleMei/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("SampleMei") {

--- a/zzz_generated/app-common/clusters/ScenesManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ScenesManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ScenesManagement") {

--- a/zzz_generated/app-common/clusters/ServiceArea/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ServiceArea/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ServiceArea") {

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("SmokeCoAlarm") {

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("SoftwareDiagnostics") {

--- a/zzz_generated/app-common/clusters/SoilMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/SoilMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("SoilMeasurement") {

--- a/zzz_generated/app-common/clusters/Switch/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Switch/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Switch") {

--- a/zzz_generated/app-common/clusters/TargetNavigator/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TargetNavigator/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TargetNavigator") {

--- a/zzz_generated/app-common/clusters/TemperatureControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TemperatureControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TemperatureControl") {

--- a/zzz_generated/app-common/clusters/TemperatureMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TemperatureMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TemperatureMeasurement") {

--- a/zzz_generated/app-common/clusters/Thermostat/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Thermostat/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Thermostat") {

--- a/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ThermostatUserInterfaceConfiguration") {

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ThreadBorderRouterManagement") {

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ThreadNetworkDiagnostics") {

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ThreadNetworkDirectory") {

--- a/zzz_generated/app-common/clusters/TimeFormatLocalization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TimeFormatLocalization/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TimeFormatLocalization") {

--- a/zzz_generated/app-common/clusters/TimeSynchronization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TimeSynchronization") {

--- a/zzz_generated/app-common/clusters/Timer/BUILD.gn
+++ b/zzz_generated/app-common/clusters/Timer/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("Timer") {

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TlsCertificateManagement") {

--- a/zzz_generated/app-common/clusters/TlsClientManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TlsClientManagement") {

--- a/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("TotalVolatileOrganicCompoundsConcentrationMeasurement") {

--- a/zzz_generated/app-common/clusters/UnitLocalization/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UnitLocalization/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("UnitLocalization") {

--- a/zzz_generated/app-common/clusters/UnitTesting/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UnitTesting/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("UnitTesting") {

--- a/zzz_generated/app-common/clusters/UserLabel/BUILD.gn
+++ b/zzz_generated/app-common/clusters/UserLabel/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("UserLabel") {

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ValveConfigurationAndControl") {

--- a/zzz_generated/app-common/clusters/WakeOnLan/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WakeOnLan/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WakeOnLan") {

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WaterHeaterManagement") {

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WaterHeaterMode") {

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WebRTCTransportProvider") {

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WebRTCTransportRequestor") {

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WiFiNetworkDiagnostics") {

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WiFiNetworkManagement") {

--- a/zzz_generated/app-common/clusters/WindowCovering/BUILD.gn
+++ b/zzz_generated/app-common/clusters/WindowCovering/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("WindowCovering") {

--- a/zzz_generated/app-common/clusters/ZoneManagement/BUILD.gn
+++ b/zzz_generated/app-common/clusters/ZoneManagement/BUILD.gn
@@ -11,7 +11,7 @@ source_set("ids") {
     "EventIds.h",
     "Ids.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/src/lib/core:types",
   ]
@@ -22,7 +22,7 @@ source_set("enums") {
     "Enums.h",
     "EnumsCheck.h",
   ]
-  deps = [
+  public_deps = [
     "${chip_root}/zzz_generated/app-common/clusters/shared:enums",
   ]
 }
@@ -34,12 +34,14 @@ source_set("headers") {
     "Events.h",
     "Structs.h",
   ]
-  deps = [
+  public_deps = [
     ":enums",
     ":ids",
+    "${chip_root}/src/app:events",
     "${chip_root}/src/app/common:global-ids",
     "${chip_root}/zzz_generated/app-common/clusters/shared:headers",
   ]
+
 
   public_configs = [ "${chip_root}/src/app/common:includes" ]
 
@@ -57,8 +59,7 @@ source_set("elements") {
   public_deps = [
     ":headers",
     ":ids",
-  ]
-  deps = [
+
     # NOTE: awkward dependency because cluster-objects contains ALL the cluster
     #       .cpp files as one compile unit to optimize for flash size during
     #       compilation.
@@ -74,11 +75,11 @@ source_set("elements") {
 
 source_set("metadata") {
   sources = [ "Metadata.h" ]
-  deps = [
+  public_deps = [
+    ":ids",
     "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:types",
   ]
-  public_deps = [ ":ids" ]
 }
 
 source_set("ZoneManagement") {


### PR DESCRIPTION
1) Use public_deps so that public_configs propagate: in particular we use includes that require include directories to be set: specifically event handling requires SubjectDescriptors which end up requiring application config headers.

Originally I thought that using `deps` would enforce better logic in our code, however since we have dynamic includes in our headers, we end up needing to propagate public_configs.

2) Add dependency to `src/app:events` since `Events.h` uses `app/EventLoggingTypes`

3) A minor change where the `// namespace` comment was switched in a header between app and Cluster. clang-format was auto-fixing this, so change is only visible in the jinja file.

#### Testing

This is mostly a noop, CI will validate that this still compiles.