### PR TITLE
Add command line arguments to control max BDX block size to Linux versions of example OTA apps.

### DIFF
--- a/examples/ota-provider-app/linux/main.cpp
+++ b/examples/ota-provider-app/linux/main.cpp
@@ -29,6 +29,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <unistd.h>
 
 using chip::BitFlags;
@@ -47,6 +48,7 @@ constexpr uint16_t kOptionUpdateAction              = 'a';
 constexpr uint16_t kOptionUserConsentNeeded         = 'c';
 constexpr uint16_t kOptionFilepath                  = 'f';
 constexpr uint16_t kOptionImageUri                  = 'i';
+constexpr uint16_t kOptionMaxBDXBlockSize           = 'm';
 constexpr uint16_t kOptionOtaImageList              = 'o';
 constexpr uint16_t kOptionDelayedApplyActionTimeSec = 'p';
 constexpr uint16_t kOptionQueryImageStatus          = 'q';
@@ -72,6 +74,7 @@ static bool gUserConsentNeeded                       = false;
 static uint32_t gIgnoreQueryImageCount               = 0;
 static uint32_t gIgnoreApplyUpdateCount              = 0;
 static uint32_t gPollInterval                        = 0;
+static std::optional<uint16_t> gMaxBDXBlockSize      = std::nullopt;
 
 // Parses the JSON filepath and extracts DeviceSoftwareVersionModel parameters
 static bool ParseJsonFileAndPopulateCandidates(const char * filepath,
@@ -245,6 +248,19 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
     case kOptionPollInterval:
         gPollInterval = static_cast<uint32_t>(strtoul(aValue, NULL, 0));
         break;
+    case kOptionMaxBDXBlockSize: {
+        auto blockSize = static_cast<uint16_t>(strtoul(aValue, NULL, 0));
+        if (blockSize == 0)
+        {
+            PrintArgError("%s: ERROR: Invalid maxBDXBlockSize parameter: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        else
+        {
+            gMaxBDXBlockSize = blockSize;
+        }
+        break;
+    }
 
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
@@ -268,6 +284,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "ignoreQueryImage", chip::ArgParser::kArgumentRequired, kOptionIgnoreQueryImage },
     { "ignoreApplyUpdate", chip::ArgParser::kArgumentRequired, kOptionIgnoreApplyUpdate },
     { "pollInterval", chip::ArgParser::kArgumentRequired, kOptionPollInterval },
+    { "maxBDXBlockSize", chip::ArgParser::kArgumentRequired, kOptionMaxBDXBlockSize },
     {},
 };
 
@@ -285,6 +302,9 @@ OptionSet cmdLineOptions = { HandleOptions, cmdLineOptionsDef, "PROGRAM OPTIONS"
                              "  -i, --imageUri <uri>\n"
                              "        Value for the ImageURI field in the QueryImageResponse.\n"
                              "        If none is supplied, a valid URI is generated.\n"
+                             "  -m, --maxBDXBlockSize <size>\n"
+                             "        Value for the maximum BDX block size to use for the transfer.\n"
+                             "        If none is supplied, a default value will be used.\n"
                              "  -o, --otaImageList <file path>\n"
                              "        Path to a file containing a list of OTA images\n"
                              "  -p, --delayedApplyActionTimeSec <time in seconds>\n"
@@ -359,6 +379,11 @@ void ApplicationInit()
     if (gPollInterval != 0)
     {
         gOtaProvider.SetPollInterval(gPollInterval);
+    }
+
+    if (gMaxBDXBlockSize)
+    {
+        gOtaProvider.SetMaxBDXBlockSize(*gMaxBDXBlockSize);
     }
 
     ChipLogDetail(SoftwareUpdate, "Using ImageList file: %s", gOtaImageListFilepath ? gOtaImageListFilepath : "(none)");

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -54,7 +54,7 @@ constexpr uint8_t kUpdateTokenStrLen = kUpdateTokenLen * 2 + 1; // Hex string ne
 constexpr size_t kOtaHeaderMaxSize   = 1024;
 
 // Arbitrary BDX Transfer Params
-constexpr uint32_t kMaxBdxBlockSize                = 1024;
+constexpr uint16_t kMaxBdxBlockSize                = 1024;
 constexpr chip::System::Clock::Timeout kBdxTimeout = chip::System::Clock::Seconds16(5 * 60); // OTA Spec mandates >= 5 minutes
 constexpr uint32_t kBdxServerPollIntervalMillis    = 50;                                     // poll every 50ms by default
 
@@ -89,6 +89,7 @@ OTAProviderExample::OTAProviderExample()
     mUserConsentDelegate       = nullptr;
     mUserConsentNeeded         = false;
     mPollInterval              = kBdxServerPollIntervalMillis;
+    mMaxBDXBlockSize           = kMaxBdxBlockSize;
     mCandidates.clear();
 }
 
@@ -275,7 +276,7 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
         {
             CHIP_ERROR error =
                 mBdxOtaSender.PrepareForTransfer(&chip::DeviceLayer::SystemLayer(), chip::bdx::TransferRole::kSender, bdxFlags,
-                                                 kMaxBdxBlockSize, kBdxTimeout, chip::System::Clock::Milliseconds32(mPollInterval));
+                                                 mMaxBDXBlockSize, kBdxTimeout, chip::System::Clock::Milliseconds32(mPollInterval));
             if (error != CHIP_NO_ERROR)
             {
                 ChipLogError(SoftwareUpdate, "Cannot prepare for transfer: %" CHIP_ERROR_FORMAT, error.Format());

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.h
@@ -89,6 +89,8 @@ public:
             mPollInterval = interval;
     }
 
+    void SetMaxBDXBlockSize(uint16_t blockSize) { mMaxBDXBlockSize = blockSize; }
+
 private:
     bool SelectOTACandidate(const uint16_t requestorVendorID, const uint16_t requestorProductID,
                             const uint32_t requestorSoftwareVersion,
@@ -123,4 +125,5 @@ private:
     uint32_t mSoftwareVersion;
     char mSoftwareVersionString[SW_VER_STR_MAX_LEN];
     uint32_t mPollInterval;
+    uint16_t mMaxBDXBlockSize;
 };

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -24,6 +24,8 @@
 #include <app/clusters/ota-requestor/ExtendedOTARequestorDriver.h>
 #include <platform/Linux/OTAImageProcessorImpl.h>
 
+#include <optional>
+
 using chip::BDXDownloader;
 using chip::ByteSpan;
 using chip::CharSpan;
@@ -74,6 +76,7 @@ constexpr uint16_t kOptionAutoApplyImage       = 'a';
 constexpr uint16_t kOptionRequestorCanConsent  = 'c';
 constexpr uint16_t kOptionDisableNotify        = 'd';
 constexpr uint16_t kOptionOtaDownloadPath      = 'f';
+constexpr uint16_t kOptionMaxBDXBlockSize      = 'm';
 constexpr uint16_t kOptionPeriodicQueryTimeout = 'p';
 constexpr uint16_t kOptionUserConsentState     = 'u';
 constexpr uint16_t kOptionWatchdogTimeout      = 'w';
@@ -83,10 +86,11 @@ constexpr size_t kMaxFilePathSize              = 256;
 uint32_t gPeriodicQueryTimeoutSec = 0;
 uint32_t gWatchdogTimeoutSec      = 0;
 chip::Optional<bool> gRequestorCanConsent;
-static char gOtaDownloadPath[kMaxFilePathSize] = "/tmp/test.bin";
-bool gAutoApplyImage                           = false;
-bool gSendNotifyUpdateApplied                  = true;
-bool gSkipExecImageFile                        = false;
+static char gOtaDownloadPath[kMaxFilePathSize]  = "/tmp/test.bin";
+bool gAutoApplyImage                            = false;
+bool gSendNotifyUpdateApplied                   = true;
+bool gSkipExecImageFile                         = false;
+static std::optional<uint16_t> gMaxBDXBlockSize = std::nullopt;
 
 OptionDef cmdLineOptionsDef[] = {
     { "autoApplyImage", chip::ArgParser::kNoArgument, kOptionAutoApplyImage },
@@ -97,6 +101,7 @@ OptionDef cmdLineOptionsDef[] = {
     { "userConsentState", chip::ArgParser::kArgumentRequired, kOptionUserConsentState },
     { "watchdogTimeout", chip::ArgParser::kArgumentRequired, kOptionWatchdogTimeout },
     { "skipExecImageFile", chip::ArgParser::kNoArgument, kSkipExecImageFile },
+    { "maxBDXBlockSize", chip::ArgParser::kArgumentRequired, kOptionMaxBDXBlockSize },
     {},
 };
 
@@ -115,6 +120,9 @@ OptionSet cmdLineOptions = {
     "  -f, --otaDownloadPath <file path>\n"
     "       If supplied, the OTA image is downloaded to the given fully-qualified file-path.\n"
     "       Otherwise, the default location for the downloaded image is at /tmp/test.bin\n"
+    "  -m, --maxBDXBlockSize <size>\n"
+    "        Value for the maximum BDX block size to use for the transfer.\n"
+    "        If none is supplied, a default value will be used.\n"
     "  -p, --periodicQueryTimeout <time in seconds>\n"
     "       The periodic time interval to wait before attempting to query a provider from the default OTA provider list.\n"
     "       If none or zero is supplied, the timeout is determined by the driver.\n"
@@ -223,6 +231,11 @@ static void InitOTARequestor(void)
         gUserConsentProvider.SetUserConsentState(gUserConsentState);
         gRequestorUser.SetUserConsentDelegate(&gUserConsentProvider);
     }
+
+    if (gMaxBDXBlockSize)
+    {
+        gRequestorUser.SetMaxDownloadBlockSize(*gMaxBDXBlockSize);
+    }
 }
 
 bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue)
@@ -284,6 +297,19 @@ bool HandleOptions(const char * aProgram, OptionSet * aOptions, int aIdentifier,
     case kSkipExecImageFile:
         gSkipExecImageFile = true;
         break;
+    case kOptionMaxBDXBlockSize: {
+        auto blockSize = static_cast<uint16_t>(strtoul(aValue, NULL, 0));
+        if (blockSize == 0)
+        {
+            PrintArgError("%s: ERROR: Invalid maxBDXBlockSize parameter: %s\n", aProgram, aValue);
+            retval = false;
+        }
+        else
+        {
+            gMaxBDXBlockSize = blockSize;
+        }
+        break;
+    }
     default:
         ChipLogError(SoftwareUpdate, "%s: INTERNAL ERROR: Unhandled option: %s\n", aProgram, aName);
         retval = false;


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/18779

#### Testing

Modified `scripts/tests/ota_test.sh` to pass these arguments and checked that the right things happened with the BDX transfers.