### PR TITLE
Stop building ota-provider-app as part of the Darwin job.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -99,9 +99,6 @@ jobs:
             - name: Build example All Clusters Server
               run: |
                   scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/all-clusters-app chip_config_network_layer_ble=false
-            - name: Build example OTA Provider
-              run: |
-                  scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug/ota-provider-app chip_config_network_layer_ble=false
             - name: Build example OTA Requestor
               run: |
                   scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug/ota-requestor-app chip_config_network_layer_ble=false non_spec_compliant_ota_action_delay_floor=0


### PR DESCRIPTION
This job does not use this app, and just checking that it compiles is handled by us compiling it in other jobs (like the "tests" jobs) that do use it.

#### Testing

Changes to tests only; CI will check.