### PR TITLE
[YAML Tests] Add a `isSetOValues` constraint on in YAML tests.

### DIFF
--- a/docs/testing/yaml_schema.md
+++ b/docs/testing/yaml_schema.md
@@ -7,6 +7,7 @@ Script: generate_yaml_doc_tables.py
 # YAML Schema
 
 YAML schema
+
 |key | type| supports variables
 |:---|:---|:---|
 |name |str||
@@ -54,6 +55,7 @@ YAML schema
 |&emsp; &emsp; &emsp; endsWith |str||
 |&emsp; &emsp; &emsp; isUpperCase |bool||
 |&emsp; &emsp; &emsp; isLowerCase |bool||
+|&emsp; &emsp; &emsp; isSetOfValues |bool||
 |&emsp; &emsp; &emsp; minValue |int,float|Y|
 |&emsp; &emsp; &emsp; maxValue |int,float|Y|
 |&emsp; &emsp; &emsp; contains |list||

--- a/docs/testing/yaml_schema.md
+++ b/docs/testing/yaml_schema.md
@@ -55,7 +55,7 @@ YAML schema
 |&emsp; &emsp; &emsp; endsWith |str||
 |&emsp; &emsp; &emsp; isUpperCase |bool||
 |&emsp; &emsp; &emsp; isLowerCase |bool||
-|&emsp; &emsp; &emsp; isSetOfValues |bool||
+|&emsp; &emsp; &emsp; isSetOfValues |list||
 |&emsp; &emsp; &emsp; minValue |int,float|Y|
 |&emsp; &emsp; &emsp; maxValue |int,float|Y|
 |&emsp; &emsp; &emsp; contains |list||

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -769,6 +769,7 @@ class _ConstraintIsSetOfValues(BaseConstraint):
         self._expected = expected
 
     def _get_missing_extra(self, value):
+        # Start with sets containing every element index. We will remove elements as they match.
         expected_but_missing_idx = set(range(len(self._expected)))
         values_not_expected_idx = set(range(len(value)))
         for expected_idx, expected_element in enumerate(self._expected):

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -895,8 +895,7 @@ class _ConstraintPython(BaseConstraint):
 
     def validate(self, value, value_type_name, runtime_variables):
         # Build a global scope that includes all runtime variables
-        scope = {name: fix_typed_yaml_value(
-            value) for name, value in runtime_variables.items()}
+        scope = {name: fix_typed_yaml_value(value) for name, value in runtime_variables.items()}
         scope['__builtins__'] = self.BUILTINS
         # Execute the module AST and extract the defined function
         exec(compile(self._ast, '<string>', 'exec'), scope)
@@ -907,8 +906,7 @@ class _ConstraintPython(BaseConstraint):
         except Exception as ex:
             self._raise_error(f'Python constraint {type(ex).__name__}: {ex}')
         if type(valid) is not bool:
-            self._raise_error(
-                "Python constraint TypeError: must return a bool")
+            self._raise_error("Python constraint TypeError: must return a bool")
         if not valid:
             self._raise_error(f'The response value "{value}" is not valid')
 

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -110,6 +110,11 @@ class ConstraintIsLowerCaseError(ConstraintCheckError):
         super().__init__(context, 'isLowerCase', reason)
 
 
+class ConstraintIsSetOfValuesError(ConstraintCheckError):
+    def __init__(self, context, reason):
+        super().__init__(context, 'isSetOfValues', reason)
+
+
 class ConstraintMinValueError(ConstraintCheckError):
     def __init__(self, context, reason):
         super().__init__(context, 'minValue', reason)
@@ -200,6 +205,8 @@ class BaseConstraint(ABC):
             raise ConstraintIsUpperCaseError(self._context, reason)
         elif isinstance(self, _ConstraintIsLowerCase):
             raise ConstraintIsLowerCaseError(self._context, reason)
+        elif isinstance(self, _ConstraintIsSetOfValues):
+            raise ConstraintIsSetOfValuesError(self._context, reason)
         elif isinstance(self, _ConstraintMinValue):
             raise ConstraintMinValueError(self._context, reason)
         elif isinstance(self, _ConstraintMaxValue):
@@ -756,6 +763,40 @@ class _ConstraintContains(BaseConstraint):
         return f'The response ({value}) is missing {expected_values}.'
 
 
+class _ConstraintIsSetOfValues(BaseConstraint):
+    def __init__(self, context, expected):
+        super().__init__(context, types=[list])
+        self._expected = expected
+
+    def _get_missing_extra(self, value):
+        expected_but_missing_idx = set(range(len(self._expected)))
+        values_not_expected_idx = set(range(len(value)))
+        for expected_idx, expected_element in enumerate(self._expected):
+            for value_idx, value_element in enumerate(value):
+                if _values_match(expected_element, value_element):
+                    expected_but_missing_idx.remove(expected_idx)
+                    values_not_expected_idx.remove(value_idx)
+
+        return [self._expected[i] for i in expected_but_missing_idx], [value[i] for i in values_not_expected_idx]
+
+    def check_response(self, value, value_type_name) -> bool:
+        missing, extra = self._get_missing_extra(value)
+
+        return (not missing) and (not extra)
+
+    def get_reason(self, value, value_type_name) -> str:
+        missing, extra = self._get_missing_extra(value)
+
+        errors = []
+        if missing:
+            errors.append(f'it is missing [{missing}]')
+
+        if extra:
+            errors.append(f'has extra values [{extra}]')
+
+        return f'The response ({value}) is an invalid set: ' + ' and '.join(errors)
+
+
 class _ConstraintExcludes(BaseConstraint):
     def __init__(self, context, excludes):
         super().__init__(context, types=[list])
@@ -854,7 +895,8 @@ class _ConstraintPython(BaseConstraint):
 
     def validate(self, value, value_type_name, runtime_variables):
         # Build a global scope that includes all runtime variables
-        scope = {name: fix_typed_yaml_value(value) for name, value in runtime_variables.items()}
+        scope = {name: fix_typed_yaml_value(
+            value) for name, value in runtime_variables.items()}
         scope['__builtins__'] = self.BUILTINS
         # Execute the module AST and extract the defined function
         exec(compile(self._ast, '<string>', 'exec'), scope)
@@ -865,7 +907,8 @@ class _ConstraintPython(BaseConstraint):
         except Exception as ex:
             self._raise_error(f'Python constraint {type(ex).__name__}: {ex}')
         if type(valid) is not bool:
-            self._raise_error("Python constraint TypeError: must return a bool")
+            self._raise_error(
+                "Python constraint TypeError: must return a bool")
         if not valid:
             self._raise_error(f'The response value "{value}" is not valid')
 
@@ -911,6 +954,9 @@ def get_constraints(constraints: dict) -> List[BaseConstraint]:
         elif 'isLowerCase' == constraint:
             _constraints.append(_ConstraintIsLowerCase(
                 context, constraint_value))
+        elif 'isSetOfValues' == constraint:
+            _constraints.append(_ConstraintIsSetOfValues(
+                context, constraint_value))
         elif 'minValue' == constraint:
             _constraints.append(_ConstraintMinValue(
                 context, constraint_value))
@@ -955,6 +1001,7 @@ def is_typed_constraint(constraint: str):
         'endsWith': True,
         'isUpperCase': False,
         'isLowerCase': False,
+        'isSetOfValues': True,
         'minValue': True,
         'maxValue': True,
         'contains': True,

--- a/scripts/py_matter_yamltests/matter_yamltests/constraints.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/constraints.py
@@ -895,7 +895,8 @@ class _ConstraintPython(BaseConstraint):
 
     def validate(self, value, value_type_name, runtime_variables):
         # Build a global scope that includes all runtime variables
-        scope = {name: fix_typed_yaml_value(value) for name, value in runtime_variables.items()}
+        scope = {name: fix_typed_yaml_value(
+            value) for name, value in runtime_variables.items()}
         scope['__builtins__'] = self.BUILTINS
         # Execute the module AST and extract the defined function
         exec(compile(self._ast, '<string>', 'exec'), scope)
@@ -906,7 +907,8 @@ class _ConstraintPython(BaseConstraint):
         except Exception as ex:
             self._raise_error(f'Python constraint {type(ex).__name__}: {ex}')
         if type(valid) is not bool:
-            self._raise_error("Python constraint TypeError: must return a bool")
+            self._raise_error(
+                "Python constraint TypeError: must return a bool")
         if not valid:
             self._raise_error(f'The response value "{value}" is not valid')
 

--- a/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
+++ b/scripts/py_matter_yamltests/matter_yamltests/yaml_loader.py
@@ -99,6 +99,7 @@ _TEST_STEP_RESPONSE_CONSTRAINTS_SCHEMA = {
     'endsWith': str,
     'isUpperCase': bool,
     'isLowerCase': bool,
+    'isSetOfValues': list,  # order independent set of values
     'minValue': (int, float, str),  # Can be a variable
     'maxValue': (int, float, str),  # Can be a variable
     'contains': list,

--- a/src/app/tests/suites/README.md
+++ b/src/app/tests/suites/README.md
@@ -170,19 +170,20 @@ properties:
 
 ##### Property: [_constraints_](../../../../src/app/tests/suites/TestConstraints.yaml)
 
-| Name        | Description                                                 | Required               |
-| ----------- | ----------------------------------------------------------- | ---------------------- |
-| hasValue    | If true, must have value. If false, must not have value.    | No (If other provided) |
-| minValue    | Minimum value to expect from the command response.          | No (If other provided) |
-| maxValue    | Maximum value to expect from the command response.          | No (If other provided) |
-| notValue    | Validate the the value is not what is provided.             | No (If other provided) |
-| minLength   | Minimum length of the response parameter.                   | No (If other provided) |
-| maxLength   | Maximum length of the string parameter.                     | No (If other provided) |
-| startsWith  | Condition is which will validate what a string starts with. | No (If other provided) |
-| endsWith    | Condition is which will validate what a string ends with.   | No (If other provided) |
-| isLowerCase | Validates if the char_string is lower case.                 | No (If other provided) |
-| isUpperCase | Validates if the char_string is upper case.                 | No (If other provided) |
-| isHexString | Checks whether the char_string is a hex string.             | No (If other provided) |
+| Name          | Description                                                 | Required               |
+| ------------- | ----------------------------------------------------------- | ---------------------- |
+| hasValue      | If true, must have value. If false, must not have value.    | No (If other provided) |
+| minValue      | Minimum value to expect from the command response.          | No (If other provided) |
+| maxValue      | Maximum value to expect from the command response.          | No (If other provided) |
+| notValue      | Validate the the value is not what is provided.             | No (If other provided) |
+| minLength     | Minimum length of the response parameter.                   | No (If other provided) |
+| maxLength     | Maximum length of the string parameter.                     | No (If other provided) |
+| startsWith    | Condition is which will validate what a string starts with. | No (If other provided) |
+| endsWith      | Condition is which will validate what a string ends with.   | No (If other provided) |
+| isLowerCase   | Validates if the char_string is lower case.                 | No (If other provided) |
+| isUpperCase   | Validates if the char_string is upper case.                 | No (If other provided) |
+| isHexString   | Checks whether the char_string is a hex string.             | No (If other provided) |
+| isSetOfValues | Uses a order-independent on the list contents.              | No (If other provided) |
 
 Note: The hasValue constraint is only applied to optional fields. The other
 constraints are ignored for optional fields that do not have a value.

--- a/src/app/tests/suites/README.md
+++ b/src/app/tests/suites/README.md
@@ -183,7 +183,7 @@ properties:
 | isLowerCase   | Validates if the char_string is lower case.                 | No (If other provided) |
 | isUpperCase   | Validates if the char_string is upper case.                 | No (If other provided) |
 | isHexString   | Checks whether the char_string is a hex string.             | No (If other provided) |
-| isSetOfValues | Uses a order-independent on the list contents.              | No (If other provided) |
+| isSetOfValues | Uses a order-independent compare on the list contents.      | No (If other provided) |
 
 Note: The hasValue constraint is only applied to optional fields. The other
 constraints are ignored for optional fields that do not have a value.

--- a/src/app/tests/suites/TestDescriptorCluster.yaml
+++ b/src/app/tests/suites/TestDescriptorCluster.yaml
@@ -39,35 +39,36 @@ tests:
       command: "readAttribute"
       attribute: "ServerList"
       response:
-          value: [
-                  0x0004, # Groups
-                  0x001D, # Descriptor
-                  0x001E, # Binding
-                  0x001F, # Access Control
-                  0x0028, # Basic Information
-                  0x002A, # OTA Software Update Requestor
-                  0x002B, # Localization Configuration
-                  0x002C, # Time Format Localization
-                  0x002D, # Unit Localization
-                  0x002E, # Power Source Configuration
-                  0x002F, # Power Source
-                  0x0030, # General Commissioning
-                  0x0031, # Network Commissioning
-                  0x0032, # Diagnostic Logs
-                  0x0033, # General Diagnostics
-                  0x0034, # Software Diagnostics
-                  0x0035, # Thread Network Diagnostiscs
-                  0x0036, # Wi-Fi Network Diagnostics
-                  0x0037, # Ethernet Network Diagnostics
-                  0x0038, # Time Synchronization
-                  0x003C, # Administrator Commissioning
-                  0x003E, # Operational Credentials
-                  0x003F, # Group Key Management
-                  0x0040, # Fixed Label
-                  0x0041, # User Label
-                  0x0405, # Relative Humidity Measurement (why on EP0?)
-                  0xFFF1FC06, # Fault Injection
-              ]
+          constraints:
+              isSetOfValues: [
+                      0x0004, # Groups
+                      0x001D, # Descriptor
+                      0x001E, # Binding
+                      0x001F, # Access Control
+                      0x0028, # Basic Information
+                      0x002A, # OTA Software Update Requestor
+                      0x002B, # Localization Configuration
+                      0x002C, # Time Format Localization
+                      0x002D, # Unit Localization
+                      0x002E, # Power Source Configuration
+                      0x002F, # Power Source
+                      0x0030, # General Commissioning
+                      0x0031, # Network Commissioning
+                      0x0032, # Diagnostic Logs
+                      0x0033, # General Diagnostics
+                      0x0034, # Software Diagnostics
+                      0x0035, # Thread Network Diagnostiscs
+                      0x0036, # Wi-Fi Network Diagnostics
+                      0x0037, # Ethernet Network Diagnostics
+                      0x0038, # Time Synchronization
+                      0x003C, # Administrator Commissioning
+                      0x003E, # Operational Credentials
+                      0x003F, # Group Key Management
+                      0x0040, # Fixed Label
+                      0x0041, # User Label
+                      0x0405, # Relative Humidity Measurement (why on EP0?)
+                      0xFFF1FC06, # Fault Injection
+                  ]
 
     - label: "Read attribute Client list"
       command: "readAttribute"


### PR DESCRIPTION
This allows to check for "these values are returned, regardless of order".

I used this in the descriptor cluster test, where we seem to validate that AllClusters app has a particular list of clusters. Specification does not say that the list is ordered and order may change depending on execution order when using code-driven clusters (i.e. when we inject code driven clusters to the server cluster interface registry).


#### Testing

- CI should still pass when using the new constraint.
- I manually removed and added items in the list and obeserved failures with a clear error message
