### PR TITLE
[camera-app] Enable Fault injection to introduce faults in runtime

### DIFF
--- a/examples/camera-app/camera-common/camera-app.matter
+++ b/examples/camera-app/camera-common/camera-app.matter
@@ -2792,6 +2792,45 @@ provisional cluster Chime = 1366 {
   command PlayChimeSound(): DefaultSuccess = 0;
 }
 
+/** The Fault Injection Cluster provide a means for a test harness to configure faults(for example triggering a fault in the system). */
+internal cluster FaultInjection = 4294048774 {
+  revision 1; // NOTE: Default/not specifically set
+
+  enum FaultType : enum8 {
+    kUnspecified = 0;
+    kSystemFault = 1;
+    kInetFault = 2;
+    kChipFault = 3;
+    kCertFault = 4;
+  }
+
+  readonly attribute command_id generatedCommandList[] = 65528;
+  readonly attribute command_id acceptedCommandList[] = 65529;
+  readonly attribute event_id eventList[] = 65530;
+  readonly attribute attrib_id attributeList[] = 65531;
+  readonly attribute bitmap32 featureMap = 65532;
+  readonly attribute int16u clusterRevision = 65533;
+
+  request struct FailAtFaultRequest {
+    FaultType type = 0;
+    int32u id = 1;
+    int32u numCallsToSkip = 2;
+    int32u numCallsToFail = 3;
+    boolean takeMutex = 4;
+  }
+
+  request struct FailRandomlyAtFaultRequest {
+    FaultType type = 0;
+    int32u id = 1;
+    int8u percentage = 2;
+  }
+
+  /** Configure a fault to be triggered deterministically */
+  command access(invoke: manage) FailAtFault(FailAtFaultRequest): DefaultSuccess = 0;
+  /** Configure a fault to be triggered randomly, with a given probability defined as a percentage */
+  command access(invoke: manage) FailRandomlyAtFault(FailRandomlyAtFaultRequest): DefaultSuccess = 1;
+}
+
 endpoint 0 {
   device type ma_rootdevice = 22, version 3;
   device type ma_otarequestor = 18, version 1;
@@ -3167,6 +3206,17 @@ endpoint 0 {
     callback attribute labelList;
     ram      attribute featureMap default = 0;
     ram      attribute clusterRevision default = 1;
+  }
+
+  server cluster FaultInjection {
+    callback attribute generatedCommandList;
+    callback attribute acceptedCommandList;
+    callback attribute attributeList;
+    ram      attribute featureMap default = 0;
+    ram      attribute clusterRevision default = 1;
+
+    handle command FailAtFault;
+    handle command FailRandomlyAtFault;
   }
 }
 endpoint 1 {

--- a/examples/camera-app/camera-common/camera-app.zap
+++ b/examples/camera-app/camera-common/camera-app.zap
@@ -4631,6 +4631,115 @@
               "reportableChange": 0
             }
           ]
+        },
+        {
+          "name": "Fault Injection",
+          "code": 4294048774,
+          "mfgCode": null,
+          "define": "FAULT_INJECTION_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "apiMaturity": "internal",
+          "commands": [
+            {
+              "name": "FailAtFault",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            },
+            {
+              "name": "FailRandomlyAtFault",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
         }
       ]
     },
@@ -5457,7 +5566,7 @@
           ],
           "attributes": [
             {
-              "name": "MaxConcurrentVideoEncoders",
+              "name": "MaxConcurrentEncoders",
               "code": 0,
               "mfgCode": null,
               "side": "server",
@@ -5585,7 +5694,7 @@
               "reportableChange": 0
             },
             {
-              "name": "SupportedSnapshotParams",
+              "name": "SnapshotCapabilities",
               "code": 10,
               "mfgCode": null,
               "side": "server",
@@ -5999,7 +6108,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6031,7 +6140,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6047,7 +6156,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6143,7 +6252,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6159,7 +6268,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6175,7 +6284,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/camera-app/linux/args.gni
+++ b/examples/camera-app/linux/args.gni
@@ -25,5 +25,7 @@ chip_project_config_include_dirs =
     [ "${chip_root}/examples/camera-app/linux/include" ]
 chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
+chip_with_nlfaultinjection = true
+
 matter_enable_tracing_support = true
 matter_enable_camera_server = true

--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -21,8 +21,8 @@
 #include <Options.h>
 #include <app/server/Server.h>
 #include <controller/InvokeInteraction.h>
-#include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/CHIPFaultInjection.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 #include <iostream>
 
@@ -328,8 +328,8 @@ CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager &
 
     auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "Answer command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
 
-    uint16_t sessionId = mCurrentSessionId; 
-    CHIP_FAULT_INJECT(FaultInjection::kFault_ModifyWebRTCAnswerSessionId, sessionId++);
+    uint16_t sessionId = mCurrentSessionId;
+    CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ModifyWebRTCAnswerSessionId, sessionId++);
 
     // Build the command
     WebRTCTransportRequestor::Commands::Answer::Type command;

--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -22,6 +22,7 @@
 #include <app/server/Server.h>
 #include <controller/InvokeInteraction.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <lib/support/CHIPFaultInjection.h>
 
 #include <iostream>
 
@@ -327,9 +328,12 @@ CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager &
 
     auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "Answer command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
 
+    uint16_t sessionId = mCurrentSessionId; 
+    CHIP_FAULT_INJECT(FaultInjection::kFault_ModifyWebRTCAnswerSessionId, sessionId++);
+
     // Build the command
     WebRTCTransportRequestor::Commands::Answer::Type command;
-    command.webRTCSessionID = mCurrentSessionId;
+    command.webRTCSessionID = sessionId;
     command.sdp             = CharSpan::fromCharString(mSdpAnswer.c_str());
 
     // Now invoke the command using the found session handle

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -73,6 +73,7 @@ typedef enum
     kFault_CHIPOBLESend, /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
 #endif
     kFault_CASEServerBusy, /**< Respond to CASE_Sigma1 with a BUSY status */
+    kFault_ModifyWebRTCAnswerSessionId, /**< Change the session ID in the outgoing WebRTC Answer command */
     kFault_NumItems,
 } Id;
 

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -72,7 +72,7 @@ typedef enum
 #if CONFIG_NETWORK_LAYER_BLE
     kFault_CHIPOBLESend, /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
 #endif
-    kFault_CASEServerBusy, /**< Respond to CASE_Sigma1 with a BUSY status */
+    kFault_CASEServerBusy,              /**< Respond to CASE_Sigma1 with a BUSY status */
     kFault_ModifyWebRTCAnswerSessionId, /**< Change the session ID in the outgoing WebRTC Answer command */
     kFault_NumItems,
 } Id;


### PR DESCRIPTION
Fault injection in the Matter SDK is a testing technique used to deliberately introduce errors or faults into the system to verify its robustness, error handling capabilities, and overall resilience. 

We need to use this feature to implement the negative test case of the certification test plan. 

#### Testing

Validated by CI
