### PR TITLE
[Chef] Set startUpColorTemperatureMireds to null

### DIFF
--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -2481,7 +2481,7 @@ endpoint 1 {
     ram      attribute colorTempPhysicalMinMireds default = 0x009A;
     ram      attribute colorTempPhysicalMaxMireds default = 0x01C6;
     ram      attribute coupleColorTempToLevelMinMireds default = 0x0000;
-    persist  attribute startUpColorTemperatureMireds default = 0x00FA;
+    persist  attribute startUpColorTemperatureMireds;
     callback attribute generatedCommandList;
     callback attribute acceptedCommandList;
     callback attribute attributeList;

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
@@ -3793,7 +3793,7 @@
               "storageOption": "NVM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x00FA",
+              "defaultValue": null,
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,


### PR DESCRIPTION
Set Chef color control cluster startUpColorTemperatureMireds to null

#### Testing
$ ./linux/out/rootnode_extendedcolorlight_8lcaaYJVAa

$ ./out/chip-tool/chip-tool colorcontrol read color-mode 0x11 1 | grep TOO
[1746182870.170] [730247:730255] [TOO] Sending command to node 0x11
[1746182870.375] [730247:730255] [TOO] Sending ReadAttribute to:
[1746182870.375] [730247:730255] [TOO] 	cluster 0x0000_0300, attribute: 0x0000_0008, endpoint 1
[1746182870.376] [730247:730255] [TOO] Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0008 DataVersion: 1987210543
[1746182870.376] [730247:730255] [TOO]   ColorMode: 1


$ ./out/chip-tool/chip-tool colorcontrol move-to-hue 100 1 100 0xf 0xf  0x11 1 | grep DMG


$ ./out/chip-tool/chip-tool colorcontrol read color-mode 0x11 1 | grep TOO
[1746182932.010] [730446:730454] [TOO] Sending command to node 0x11
[1746182932.217] [730446:730454] [TOO] Sending ReadAttribute to:
[1746182932.217] [730446:730454] [TOO] 	cluster 0x0000_0300, attribute: 0x0000_0008, endpoint 1
[1746182932.218] [730446:730454] [TOO] Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0008 DataVersion: 1987210550
[1746182932.218] [730446:730454] [TOO]   ColorMode: 0
