### PR TITLE
Fix the memory leak of PAF.

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1442,7 +1442,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     char * paddr;
     value = g_variant_lookup_value(discov_info, "peer_addr", G_VARIANT_TYPE_STRING);
     dataValue.reset(value);
-    g_variant_get(dataValue.get(), "s", &paddr);
+    g_variant_get(dataValue.get(), "&s", &paddr);
     strncpy(addr_str, paddr, sizeof(addr_str));
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
            &peer_addr[4], &peer_addr[5]);
@@ -1535,7 +1535,7 @@ void ConnectivityManagerImpl::OnReplied(GVariant * reply_info)
     char * paddr;
     value = g_variant_lookup_value(reply_info, "peer_addr", G_VARIANT_TYPE_STRING);
     dataValue.reset(value);
-    g_variant_get(dataValue.get(), "s", &paddr);
+    g_variant_get(dataValue.get(), "&s", &paddr);
     strncpy(addr_str, paddr, sizeof(addr_str));
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &peer_addr[0], &peer_addr[1], &peer_addr[2], &peer_addr[3],
            &peer_addr[4], &peer_addr[5]);
@@ -1614,7 +1614,7 @@ void ConnectivityManagerImpl::OnNanReceive(GVariant * obj)
     char * paddr;
     value = g_variant_lookup_value(obj, "peer_addr", G_VARIANT_TYPE_STRING);
     dataValue.reset(value);
-    g_variant_get(dataValue.get(), "s", &paddr);
+    g_variant_get(dataValue.get(), "&s", &paddr);
     strncpy(addr_str, paddr, sizeof(addr_str));
     sscanf(addr_str, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &RxInfo.peer_addr[0], &RxInfo.peer_addr[1], &RxInfo.peer_addr[2],
            &RxInfo.peer_addr[3], &RxInfo.peer_addr[4], &RxInfo.peer_addr[5]);


### PR DESCRIPTION
Fix the memory leak issue in using PAF 

#### Testing
* Build the chip-all-clusters-app and chip-tool from build_examples.py with -asan-clang:
    $ ./scripts/build/build_examples.py --target linux-arm64-all-clusters-asan-clang build
    $ ./scripts/build/build_examples.py --target linux-arm64-chip-tool-asan-clang  build
* No error reported in running the apps
[commissionee]
    ./chip-all-clusters-app --wifi --wifipaf freq_list=2412
[commissioner]
    ./chip-tool pairing wifipaf-wifi 1 n_m_2g nxp12345 20202021 3840 --freq 2412

Fixes #38694 

