### PR TITLE
Fix how std::to_underlying is pulled into namespace chip.

### DIFF
--- a/src/lib/support/TypeTraits.h
+++ b/src/lib/support/TypeTraits.h
@@ -34,7 +34,7 @@ namespace chip {
 
 #if __cplusplus >= 202300L
 
-using to_underlying = std::to_underlying;
+using std::to_underlying;
 
 #else
 /**


### PR DESCRIPTION
Trying to type-alias function templates does not work; we just want to pull in the name.

Fixes https://github.com/project-chip/connectedhomeip/issues/38522

#### Testing

@AntoineSX said this fixes the issue.