### PR TITLE
Fix handling of global enums in ZAP templates.

### DIFF
--- a/src/app/zap-templates/partials/cluster-objects-field-init.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-field-init.zapt
@@ -8,7 +8,7 @@
           {{~#if_is_struct type}}
             {{! Structs have their own initializers }}
           {{~else~}}
-          = static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>(0)
+          = static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns cluster=cluster}}>(0)
           {{~/if_is_struct}}
         {{~/unless}}
       {{~/unless}}

--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -9,7 +9,7 @@ namespace {{asUpperCamelCase name}} {
     struct Type {
     public:
         {{#zcl_struct_items}}
-        {{zapTypeToEncodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+        {{zapTypeToEncodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init cluster=../cluster}};
         {{/zcl_struct_items}}
 
         {{#unless struct_contains_array}}
@@ -41,7 +41,7 @@ namespace {{asUpperCamelCase name}} {
     struct DecodableType {
     public:
         {{#zcl_struct_items}}
-        {{zapTypeToDecodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+        {{zapTypeToDecodableClusterObjectType type cluster=../cluster}} {{asLowerCamelCase label}}{{> cluster_objects_field_init cluster=../cluster}};
         {{/zcl_struct_items}}
 
         CHIP_ERROR Decode(TLV::TLVReader &reader);

--- a/src/app/zap-templates/templates/app/cluster-commands-header.zapt
+++ b/src/app/zap-templates/templates/app/cluster-commands-header.zapt
@@ -59,7 +59,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init cluster=../../name}};
     {{/zcl_command_arguments}}
 
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
@@ -80,7 +80,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_command_arguments}}
-    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init}};
+    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase label}}{{> cluster_objects_field_init cluster=../../name}};
     {{/zcl_command_arguments}}
     CHIP_ERROR Decode(TLV::TLVReader &reader);
 };

--- a/src/app/zap-templates/templates/app/cluster-events-header.zapt
+++ b/src/app/zap-templates/templates/app/cluster-events-header.zapt
@@ -43,7 +43,7 @@ public:
     static constexpr bool kIsFabricScoped = {{isFabricSensitive}};
 
     {{#zcl_event_fields}}
-    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
+    {{zapTypeToEncodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init cluster=../../name}};
     {{/zcl_event_fields}}
 
     {{#if isFabricSensitive}}
@@ -62,7 +62,7 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
 
     {{#zcl_event_fields}}
-    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
+    {{zapTypeToDecodableClusterObjectType type cluster=../../name}} {{asLowerCamelCase name}}{{> cluster_objects_field_init cluster=../../name}};
     {{/zcl_event_fields}}
 
     CHIP_ERROR Decode(TLV::TLVReader &reader);


### PR DESCRIPTION
We were passing in different information for the enum declaration and the cast to the enum type that initializes it.  Should be passing the same information.

#### Testing

Checked that with the ZAP updates in https://github.com/project-chip/zap/pull/1593 this does the right thing for enums/bitmaps.