### PR TITLE
[1.4][Cherrypick] Add Mounted device types to v1.4-branch

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -851,6 +851,66 @@ limitations under the License.
         </clusters>
     </deviceType>
     <deviceType>
+        <name>MA-mounted-onoff-control</name>
+        <domain>CHIP</domain>
+        <typeName>Mounted On/Off Control</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x010F</deviceId>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireCommand>TriggerEffect</requireCommand>
+            </include>
+            <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                    <feature code="OO" name="OnOff"></feature>
+                </features>
+            </include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                </features>
+            </include>
+            <include cluster="Scenes Management" client="false" server="false" clientLocked="true" serverLocked="false">
+                <requireCommand>CopyScene</requireCommand>
+            </include>
+        </clusters>
+    </deviceType>
+    <deviceType>
+        <name>MA-mounted-dimmable-load-control</name>
+        <domain>CHIP</domain>
+        <typeName>Mounted Dimmable Load Control</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0110</deviceId>
+        <class>Simple</class>
+        <scope>Endpoint</scope>
+        <clusters>
+            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireCommand>TriggerEffect</requireCommand>
+            </include>
+            <include cluster="Level Control" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                    <feature code="OO" name="OnOff"></feature>
+                </features>
+            </include>
+            <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="true"></include>
+            <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true">
+                <features>
+                    <feature code="LT" name="Lighting"></feature>
+                </features>
+            </include>
+            <include cluster="Scenes Management" client="false" server="true" clientLocked="true" serverLocked="false">
+                <requireCommand>CopyScene</requireCommand>
+            </include>
+        </clusters>
+    </deviceType>
+    <deviceType>
         <name>MA-pump</name>
         <domain>CHIP</domain>
         <typeName>Matter Pump</typeName>

--- a/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRDeviceTypeMetadata.mm
@@ -85,6 +85,8 @@ constexpr DeviceTypeData knownDeviceTypes[] = {
     { 0x0000010B, DeviceTypeClass::Simple, "Matter Dimmable Plug-in Unit" },
     { 0x0000010C, DeviceTypeClass::Simple, "Matter Color Temperature Light" },
     { 0x0000010D, DeviceTypeClass::Simple, "Matter Extended Color Light" },
+    { 0x0000010F, DeviceTypeClass::Simple, "Mounted On/Off Control" },
+    { 0x00000110, DeviceTypeClass::Simple, "Mounted Dimmable Load Control" },
     { 0x00000202, DeviceTypeClass::Simple, "Matter Window Covering" },
     { 0x00000203, DeviceTypeClass::Simple, "Matter Window Covering Controller" },
     { 0x00000300, DeviceTypeClass::Simple, "Matter Heating/Cooling Unit" },

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6481,6 +6481,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Matter Color Temperature Light";
     case 0x0000010D:
         return "Matter Extended Color Light";
+    case 0x0000010F:
+        return "Mounted On/Off Control";
     case 0x00000202:
         return "Matter Window Covering";
     case 0x00000203:

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/EntryToText.cpp
@@ -6483,6 +6483,8 @@ char const * DeviceTypeIdToText(chip::DeviceTypeId id)
         return "Matter Extended Color Light";
     case 0x0000010F:
         return "Mounted On/Off Control";
+    case 0x00000110:
+        return "Mounted Dimmable Load Control";
     case 0x00000202:
         return "Matter Window Covering";
     case 0x00000203:


### PR DESCRIPTION
#### Description
The 1.4 Matter version brings mounted device types (from Matter 1.4):
- MountedOnOffControl: This was added in master branch https://github.com/project-chip/connectedhomeip/pull/37615, which was after the 1.4 branchpoint.
- MountedDimmableLoadControl: This was added in master branch https://github.com/project-chip/connectedhomeip/pull/37636, which was after the 1.4 branchpoint.

Fixes issue: #38718

#### Testing

The testing consisted of using the Zap tool to generate the example with a new device type.