### PR TITLE
Fix crash in HandleAnswer with illegal role actpass in remote answer description

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -41,8 +41,13 @@ void WebRTCProviderManager::Init()
 
     mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
 
-    mPeerConnection->onLocalDescription([this](rtc::Description description) {
-        mLocalSdp = std::string(description);
+    mPeerConnection->onLocalDescription([this](rtc::Description desc) {
+        if (mState == State::SendingAnswer && desc.type() != rtc::Description::Type::Answer)
+        {
+            return;
+        }
+
+        mLocalSdp = std::string(desc);
         ChipLogProgress(Camera, "Local Description:");
         ChipLogProgress(Camera, "%s", mLocalSdp.c_str());
 
@@ -201,6 +206,8 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
 
 CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession)
 {
+    ChipLogProgress(Camera, "HandleProvideOffer called");
+
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;
     outSession.peerNodeID  = args.peerNodeId;
@@ -260,7 +267,9 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     }
 
     MoveToState(State::SendingAnswer);
-    mPeerConnection->setRemoteDescription(args.sdp);
+    rtc::Description remoteOffer(args.sdp, rtc::Description::Type::Offer);
+    mPeerConnection->setRemoteDescription(remoteOffer);
+    mPeerConnection->createAnswer();
 
     return CHIP_NO_ERROR;
 }
@@ -385,6 +394,8 @@ const char * WebRTCProviderManager::GetStateStr() const
 
 void WebRTCProviderManager::ScheduleOfferSend()
 {
+    ChipLogProgress(Camera, "ScheduleOfferSend called.");
+
     DeviceLayer::SystemLayer().ScheduleLambda([this]() {
         ChipLogProgress(Camera, "Sending Offer command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 
@@ -402,6 +413,8 @@ void WebRTCProviderManager::ScheduleOfferSend()
 
 void WebRTCProviderManager::ScheduleAnswerSend()
 {
+    ChipLogProgress(Camera, "ScheduleAnswerSend called.");
+
     DeviceLayer::SystemLayer().ScheduleLambda([this]() {
         ChipLogProgress(Camera, "Sending Answer command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 
@@ -419,6 +432,8 @@ void WebRTCProviderManager::ScheduleAnswerSend()
 
 void WebRTCProviderManager::ScheduleICECandidatesSend()
 {
+    ChipLogProgress(Camera, "ScheduleICECandidatesSend called.");
+
     DeviceLayer::SystemLayer().ScheduleLambda([this]() {
         ChipLogProgress(Camera, "Sending ICECandidates command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -92,7 +92,8 @@ CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & s
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    mPeerConnection->setRemoteDescription(sdp);
+    rtc::Description answerDesc(sdp, rtc::Description::Type::Answer);
+    mPeerConnection->setRemoteDescription(answerDesc);
 
     // Schedule the ProvideICECandidates() call to run asynchronously.
     DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() { ProvideICECandidates(sessionId); });


### PR DESCRIPTION
```
WebRTCTransportRequestorServer: InvokeCommand called with CommandId=0x00000002[0m
[0;32m[1746380916.344] [49406:49413] [CAM] WebRTCRequestorDelegate::HandleAnswer[0m
[0;32m[1746380916.344] [49406:49413] [CAM] WebRTCManager::HandleAnswer[0m
[0;32m[1746380916.344] [49406:49413] [CAM] Answer command received for WebRTC session ID: 1[0m
[0;32m[1746380916.344] [49406:49413] [CAM] WebRTCProviderClient moving to [ Idle ][0m
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Illegal role actpass in remote answer description
```

std::invalid_argument: Illegal role actpass in remote answer description is thrown by libdatachannel’s SDP parser when it sees an answer that still says the DTLS role is actpass.

There is a bug in the provider’s answer generation.  The WebRTC protocol requires proper handling of DTLS setup attributes:

The offerer uses a=setup:actpass (correctly implemented in current code)
The answerer should respond with either a=setup:active or a=setup:passive ( no one ever created a real answer.)

#### Testing

1. Build example apps
source scripts/activate.sh
./scripts/build/build_examples.py --target linux-x64-camera-controller build 
./scripts/build/build_examples.py --target linux-x64-camera build 

2. Launch the Camera Application:
Open a terminal console.
Execute the command: ./chip-camera-app --camera-deferred-offer

3. Launch the Camera Controller:
Open a separate terminal console.
Execute the command: ./chip-camera-controller

4. Commission the Camera Device:
In the controller console, initiate the commissioning process using the pairing code.

pairing onnetwork 1 20202021

5. Init the WebRTC connection on Camera Controller
> webrtc connect 1 1

6. Trigger the normal flow
> webrtc provide-offer 3
