### PR TITLE
[E2E][JF] Add skeleton for steps 6-7 of JCM

### DIFF
--- a/docs/guides/joint_fabric_guide.md
+++ b/docs/guides/joint_fabric_guide.md
@@ -231,7 +231,7 @@ $ ./chip-lighting-app --capabilities 0x4 --passcode 110220066 --KVS light_b_kvs
 -   Commission lighting-app
 
 ```
->>> pairing onnetwork 22 110220044
+>>> pairing onnetwork 22 110220066
 ```
 
 Check that a Fabric having `AdminVendorID` set to 0xFFF2 has been installed:

--- a/examples/jf-admin-app/jfa-common/BUILD.gn
+++ b/examples/jf-admin-app/jfa-common/BUILD.gn
@@ -23,3 +23,9 @@ chip_data_model("jfa-common") {
   zap_file = "jfa-app.zap"
   is_server = true
 }
+
+source_set("jfa-manager") {
+  deps = [ "${chip_root}/src/lib" ]
+  public_configs = [ ":config" ]
+  sources = []
+}

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -18,6 +18,7 @@
 
 #include "JFAManager.h"
 
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
@@ -61,11 +62,13 @@ void JFAManager::HandleCommissioningCompleteEvent()
         FabricIndex fabricIndex = fb.GetFabricIndex();
         CATValues cats;
 
-        if ((jfFabricIndex == kUndefinedFabricId) && mServer->GetFabricTable().FetchCATs(fabricIndex, cats) == CHIP_NO_ERROR)
+        if ((jfFabricIndex == kUndefinedFabricIndex) && mServer->GetFabricTable().FetchCATs(fabricIndex, cats) == CHIP_NO_ERROR)
         {
-            /* When JFA is commissioned, it has to be issued with Anchor CAT and Administrator CAT */
+            /* When JFA is commissioned, it has to be issued a NOC with Anchor CAT and Administrator CAT */
             if (cats.ContainsIdentifier(kAdminCATIdentifier) && cats.ContainsIdentifier(kAnchorCATIdentifier))
             {
+                (void) app::Clusters::JointFabricAdministrator::Attributes::AdministratorFabricIndex::Set(1, fabricIndex);
+
                 jfFabricIndex = fabricIndex;
             }
         }

--- a/examples/jf-control-app/args.gni
+++ b/examples/jf-control-app/args.gni
@@ -34,3 +34,7 @@ matter_log_json_payload_decode_full = true
 # make jfc very strict by default
 chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true
+
+# enable Joint Fabric features in the code SDK code
+# (e.g.: commissioner related code from src/controller)
+chip_device_config_enable_joint_fabric = true

--- a/examples/jf-control-app/args.gni
+++ b/examples/jf-control-app/args.gni
@@ -35,6 +35,6 @@ matter_log_json_payload_decode_full = true
 chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true
 
-# enable Joint Fabric features in the code SDK code
+# enable Joint Fabric features in the core SDK code
 # (e.g.: commissioner related code from src/controller)
 chip_device_config_enable_joint_fabric = true

--- a/examples/jf-control-app/commands/pairing/PairingCommand.cpp
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.cpp
@@ -54,6 +54,12 @@ CHIP_ERROR PairingCommand::RunCommand()
         {
             chip::CASEAuthTag anchorCAT = GetAnchorCATWithVersion(CHIP_CONFIG_ANCHOR_CAT_INITIAL_VERSION);
 
+            if (mExecuteJCM.ValueOr(false))
+            {
+                ChipLogError(JointFabric, "--anchor and --execute-jcm options are not allowed simultaneously!");
+                return CHIP_ERROR_BAD_REQUEST;
+            }
+
             // JFA will be issued a NOC with Anchor CAT and Administrator CAT
             mCASEAuthTags = MakeOptional(std::vector<uint32_t>{ administratorCAT, anchorCAT });
         }
@@ -147,6 +153,7 @@ CommissioningParameters PairingCommand::GetCommissioningParameters()
 {
     auto params = CommissioningParameters();
     params.SetSkipCommissioningComplete(mSkipCommissioningComplete.ValueOr(false));
+    params.SetExecuteJCM(mExecuteJCM.ValueOr(false));
     if (mBypassAttestationVerifier.ValueOr(false))
     {
         params.SetDeviceAttestationDelegate(this);

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -82,6 +82,8 @@ public:
         AddArgument("icd-symmetric-key", &mICDSymmetricKey, "The 16 bytes ICD symmetric key, default: randomly generated.");
         AddArgument("icd-stay-active-duration", 0, UINT32_MAX, &mICDStayActiveDurationMsec,
                     "If set, a LIT ICD that is commissioned will be requested to stay active for this many milliseconds");
+        AddArgument("anchor", 0, 1, &mAnchor, "If set to true then a NOC with Anchor and Administrator CAT is issued");
+        AddArgument("execute-jcm", 0, 1, &mExecuteJCM, "Set it to true in order to commission a Joint Fabric Administrator");
         switch (networkType)
         {
         case PairingNetworkType::None:
@@ -105,8 +107,6 @@ public:
         case PairingMode::None:
             break;
         case PairingMode::Code:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("dcl-hostname", &mDCLHostName,
                         "Hostname of the DCL server to fetch information from. Defaults to 'on.dcl.csa-iot.org'.");
             AddArgument("dcl-port", 0, UINT16_MAX, &mDCLPort, "Port number for connecting to the DCL server. Defaults to '443'.");
@@ -118,20 +118,14 @@ public:
             AddArgument("use-only-onnetwork-discovery", 0, 1, &mUseOnlyOnNetworkDiscovery);
             break;
         case PairingMode::Ble:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             break;
         case PairingMode::OnNetwork:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::SoftAP:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             AddArgument("device-remote-ip", &mRemoteAddr);
@@ -140,30 +134,22 @@ public:
             break;
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         case PairingMode::WiFiPAF:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             break;
 #endif
         case PairingMode::AlreadyDiscovered:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::AlreadyDiscoveredByIndex:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("index", 0, UINT16_MAX, &mIndex);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::AlreadyDiscoveredByIndexWithCode:
-            AddArgument("anchor", 0, 1, &mAnchor);
-            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("index", 0, UINT16_MAX, &mIndex);
             AddArgument("pase-only", 0, 1, &mPaseOnly);

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -106,6 +106,7 @@ public:
             break;
         case PairingMode::Code:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("dcl-hostname", &mDCLHostName,
                         "Hostname of the DCL server to fetch information from. Defaults to 'on.dcl.csa-iot.org'.");
             AddArgument("dcl-port", 0, UINT16_MAX, &mDCLPort, "Port number for connecting to the DCL server. Defaults to '443'.");
@@ -118,16 +119,19 @@ public:
             break;
         case PairingMode::Ble:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             break;
         case PairingMode::OnNetwork:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::SoftAP:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             AddArgument("device-remote-ip", &mRemoteAddr);
@@ -137,12 +141,14 @@ public:
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
         case PairingMode::WiFiPAF:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("discriminator", 0, 4096, &mDiscriminator.emplace());
             break;
 #endif
         case PairingMode::AlreadyDiscovered:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("device-remote-ip", &mRemoteAddr);
             AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
@@ -150,12 +156,14 @@ public:
             break;
         case PairingMode::AlreadyDiscoveredByIndex:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode.emplace());
             AddArgument("index", 0, UINT16_MAX, &mIndex);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
             break;
         case PairingMode::AlreadyDiscoveredByIndexWithCode:
             AddArgument("anchor", 0, 1, &mAnchor);
+            AddArgument("execute-jcm", 0, 1, &mExecuteJCM);
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("index", 0, UINT16_MAX, &mIndex);
             AddArgument("pase-only", 0, 1, &mPaseOnly);
@@ -313,6 +321,8 @@ private:
 
     bool mDeviceIsICD = false;
     uint8_t mRandomGeneratedICDSymmetricKey[chip::Crypto::kAES_CCM128_Key_Length];
+
+    chip::Optional<bool> mExecuteJCM;
 
     // For unpair
     chip::Platform::UniquePtr<chip::Controller::CurrentFabricRemover> mCurrentFabricRemover;

--- a/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
+++ b/src/app/clusters/joint-fabric-administrator-server/joint-fabric-administrator-server.cpp
@@ -93,7 +93,7 @@ CHIP_ERROR JointFabricAdministratorAttrAccess::Read(const ConcreteReadAttributeP
 
 CHIP_ERROR JointFabricAdministratorAttrAccess::ReadAdministratorFabricIndex(AttributeValueEncoder & aEncoder)
 {
-    return aEncoder.Encode(Server::GetInstance().GetJointFabricDatastore().GetAdministratorFabricIndex());
+    return CHIP_NO_ERROR;
 }
 
 void MatterJointFabricAdministratorPluginServerInitCallback()

--- a/src/app/zap_cluster_list.json
+++ b/src/app/zap_cluster_list.json
@@ -65,8 +65,10 @@
         "ICD_MANAGEMENT_CLUSTER": [],
         "IDENTIFY_CLUSTER": [],
         "ILLUMINANCE_MEASUREMENT_CLUSTER": [],
-        "JOINT_FABRIC_DATASTORE_CLUSTER": [],
-        "JOINT_FABRIC_ADMINISTRATOR_CLUSTER": [],
+        "JOINT_FABRIC_DATASTORE_CLUSTER": ["joint-fabric-datastore-server"],
+        "JOINT_FABRIC_ADMINISTRATOR_CLUSTER": [
+            "joint-fabric-administrator-server"
+        ],
         "KEYPAD_INPUT_CLUSTER": [],
         "LAUNDRY_WASHER_MODE_CLUSTER": [],
         "LEVEL_CONTROL_CLUSTER": [],

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -387,14 +387,17 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
         return CommissioningStage::kAttestationRevocationCheck;
     case CommissioningStage::kAttestationRevocationCheck:
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-        if (mParams.GetExecuteJCM().ValueOr(false)) {
-            return CommissioningStage::kSendVIDVerificationRequest;
+        if (mParams.GetExecuteJCM().ValueOr(false))
+        {
+            return CommissioningStage::kJFValidateNOC;
         }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
         return CommissioningStage::kSendOpCertSigningRequest;
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-      case CommissioningStage::kSendVIDVerificationRequest:
-          return CommissioningStage::kSendOpCertSigningRequest;
+    case CommissioningStage::kJFValidateNOC:
+        return CommissioningStage::kSendVIDVerificationRequest;
+    case CommissioningStage::kSendVIDVerificationRequest:
+        return CommissioningStage::kSendOpCertSigningRequest;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     case CommissioningStage::kSendOpCertSigningRequest:
         return CommissioningStage::kValidateCSR;
@@ -789,7 +792,8 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
             if (mParams.GetExecuteJCM().ValueOr(false) &&
-                (mDeviceCommissioningInfo.JFAdministratorFabricIndex != kUndefinedFabricIndex)) {
+                (mDeviceCommissioningInfo.JFAdministratorFabricIndex != kUndefinedFabricIndex))
+            {
                 SaveCertificate(mDeviceCommissioningInfo.JFAdminNOC, &mJFAdminNOC, &mJFAdminNOCLen);
                 SaveCertificate(mDeviceCommissioningInfo.JFAdminICAC, &mJFAdminICAC, &mJFAdminICACLen);
                 SaveCertificate(mDeviceCommissioningInfo.JFAdminRCAC, &mJFAdminRCAC, &mJFAdminRCACLen);
@@ -971,7 +975,7 @@ CHIP_ERROR AutoCommissioner::PerformStep(CommissioningStage nextStage)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AutoCommissioner::SaveCertificate(ByteSpan inCertSpan, uint8_t **outCert, uint16_t *outCertSize)
+CHIP_ERROR AutoCommissioner::SaveCertificate(ByteSpan inCertSpan, uint8_t ** outCert, uint16_t * outCertSize)
 {
     if ((inCertSpan.size() > Credentials::kMaxDERCertLength) || !(CanCastTo<uint16_t>(inCertSpan.size())))
     {
@@ -996,7 +1000,7 @@ CHIP_ERROR AutoCommissioner::SaveCertificate(ByteSpan inCertSpan, uint8_t **outC
     return CHIP_NO_ERROR;
 }
 
-void AutoCommissioner::ReleaseCertificate(uint8_t **cert, uint16_t *certSize)
+void AutoCommissioner::ReleaseCertificate(uint8_t ** cert, uint16_t * certSize)
 {
     if (*cert != nullptr)
     {
@@ -1004,7 +1008,7 @@ void AutoCommissioner::ReleaseCertificate(uint8_t **cert, uint16_t *certSize)
     }
 
     *certSize = 0;
-    *cert = nullptr;
+    *cert     = nullptr;
 }
 
 } // namespace Controller

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -65,11 +65,9 @@ private:
 
     // Adjust the failsafe timer if CommissioningDelegate GetCASEFailsafeTimerSeconds is set
     void SetCASEFailsafeTimerIfNeeded();
-    void ReleaseDAC();
-    void ReleasePAI();
 
-    CHIP_ERROR SetDAC(const ByteSpan & dac);
-    CHIP_ERROR SetPAI(const ByteSpan & pai);
+    CHIP_ERROR SaveCertificate(ByteSpan inCertSpan, uint8_t **outCert, uint16_t *outCertSize);
+    void ReleaseCertificate(uint8_t **cert, uint16_t *certSize);
 
     ByteSpan GetDAC() const { return ByteSpan(mDAC, mDACLen); }
     ByteSpan GetPAI() const { return ByteSpan(mPAI, mPAILen); }

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -66,8 +66,8 @@ private:
     // Adjust the failsafe timer if CommissioningDelegate GetCASEFailsafeTimerSeconds is set
     void SetCASEFailsafeTimerIfNeeded();
 
-    ByteSpan GetDAC() const { return ByteSpan(mDAC.Get(), mDAC.AllocatedSize()); }
-    ByteSpan GetPAI() const { return ByteSpan(mPAI.Get(), mPAI.AllocatedSize()); }
+    const ByteSpan GetDAC() { return mDAC.Span(); }
+    const ByteSpan GetPAI() { return mPAI.Span(); }
 
     CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
                                  NodeId adminSubject);
@@ -80,6 +80,9 @@ private:
     // kThreadNetworkSetup or kCleanup, depending whether network information has
     // been provided that matches the thread/wifi endpoint of the target.
     CommissioningStage GetNextCommissioningStageNetworkSetup(CommissioningStage currentStage, CHIP_ERROR & lastErr);
+
+    // Helper function to allocate memory for a scopedMemoryBuffer and populate it with the data from the input span
+    CHIP_ERROR AllocateMemoryAndCopySpan(Platform::ScopedMemoryBufferWithSize<uint8_t> & scopedBuffer, ByteSpan span);
 
     // Helper function to determine if a scan attempt should be made given the
     // scan attempt commissioning params and the corresponding network endpoint of

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -163,6 +163,17 @@ private:
     uint8_t mAttestationElements[Credentials::kMaxRspLen];
     uint16_t mAttestationSignatureLen = 0;
     uint8_t mAttestationSignature[Crypto::kMax_ECDSA_Signature_Length];
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    uint8_t * mJFAdminRCAC   = nullptr;
+    uint16_t mJFAdminRCACLen = 0;
+
+    uint8_t * mJFAdminICAC   = nullptr;
+    uint16_t mJFAdminICACLen = 0;
+
+    uint8_t * mJFAdminNOC   = nullptr;
+    uint16_t mJFAdminNOCLen = 0;
+#endif
 };
 } // namespace Controller
 } // namespace chip

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -66,11 +66,8 @@ private:
     // Adjust the failsafe timer if CommissioningDelegate GetCASEFailsafeTimerSeconds is set
     void SetCASEFailsafeTimerIfNeeded();
 
-    CHIP_ERROR SaveCertificate(ByteSpan inCertSpan, uint8_t ** outCert, uint16_t * outCertSize);
-    void ReleaseCertificate(uint8_t ** cert, uint16_t * certSize);
-
-    ByteSpan GetDAC() const { return ByteSpan(mDAC, mDACLen); }
-    ByteSpan GetPAI() const { return ByteSpan(mPAI, mPAILen); }
+    ByteSpan GetDAC() const { return ByteSpan(mDAC.Get(), mDAC.AllocatedSize()); }
+    ByteSpan GetPAI() const { return ByteSpan(mPAI.Get(), mPAI.AllocatedSize()); }
 
     CHIP_ERROR NOCChainGenerated(ByteSpan noc, ByteSpan icac, ByteSpan rcac, Crypto::IdentityProtectionKeySpan ipk,
                                  NodeId adminSubject);
@@ -150,10 +147,9 @@ private:
 
     bool mNeedIcdRegistration = false;
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
-    uint8_t * mDAC   = nullptr;
-    uint16_t mDACLen = 0;
-    uint8_t * mPAI   = nullptr;
-    uint16_t mPAILen = 0;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mDAC;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mPAI;
+
     uint8_t mAttestationNonce[kAttestationNonceLength];
     uint8_t mCSRNonce[kCSRNonceLength];
     uint8_t mNOCertBuffer[Credentials::kMaxCHIPCertLength];
@@ -165,14 +161,9 @@ private:
     uint8_t mAttestationSignature[Crypto::kMax_ECDSA_Signature_Length];
 
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    uint8_t * mJFAdminRCAC   = nullptr;
-    uint16_t mJFAdminRCACLen = 0;
-
-    uint8_t * mJFAdminICAC   = nullptr;
-    uint16_t mJFAdminICACLen = 0;
-
-    uint8_t * mJFAdminNOC   = nullptr;
-    uint16_t mJFAdminNOCLen = 0;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mJFAdminRCAC;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mJFAdminICAC;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mJFAdminNOC;
 #endif
 };
 } // namespace Controller

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -66,8 +66,8 @@ private:
     // Adjust the failsafe timer if CommissioningDelegate GetCASEFailsafeTimerSeconds is set
     void SetCASEFailsafeTimerIfNeeded();
 
-    CHIP_ERROR SaveCertificate(ByteSpan inCertSpan, uint8_t **outCert, uint16_t *outCertSize);
-    void ReleaseCertificate(uint8_t **cert, uint16_t *certSize);
+    CHIP_ERROR SaveCertificate(ByteSpan inCertSpan, uint8_t ** outCert, uint16_t * outCertSize);
+    void ReleaseCertificate(uint8_t ** cert, uint16_t * certSize);
 
     ByteSpan GetDAC() const { return ByteSpan(mDAC, mDACLen); }
     ByteSpan GetPAI() const { return ByteSpan(mPAI, mPAILen); }

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3560,8 +3560,10 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         }
     }
     break;
+
+    case CommissioningStage::kJFValidateNOC:
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    case CommissioningStage::kJFValidateNOC: {
+    {
         if (!params.GetJFAdministratorFabricIndex().HasValue() || !params.GetJFAdminNOC().HasValue() ||
             params.GetJFAdministratorFabricIndex().Value() == kUndefinedFabricIndex)
         {
@@ -3581,8 +3583,11 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
 
         break;
     }
+#endif
 
-    case CommissioningStage::kSendVIDVerificationRequest: {
+    case CommissioningStage::kSendVIDVerificationRequest:
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    {
         /* TODO: send SignVidVerificationRequest */
         CommissioningStageComplete(CHIP_NO_ERROR);
         break;

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -1068,6 +1068,10 @@ private:
     CHIP_ERROR ParseTimeSyncInfo(ReadCommissioningInfo & info);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT
 
+#if (CHIP_CONFIG_ENABLE_READ_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC)
+    CHIP_ERROR ParseJFAdministratorInfo(ReadCommissioningInfo & info);
+#endif // CHIP_CONFIG_ENABLE_READ_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
     static CHIP_ERROR
     ConvertFromOperationalCertStatus(chip::app::Clusters::OperationalCredentials::NodeOperationalCertStatusEnum err);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -1070,6 +1070,7 @@ private:
 
 #if (CHIP_CONFIG_ENABLE_READ_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC)
     CHIP_ERROR ParseJFAdministratorInfo(ReadCommissioningInfo & info);
+    CHIP_ERROR ValidateJFAdminNOC(const ByteSpan & adminNOC);
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     static CHIP_ERROR

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -74,8 +74,11 @@ const char * StageToString(CommissioningStage stage)
         return "AttestationRevocationCheck";
 
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-        case kSendVIDVerificationRequest:
-            return "SendVIDVerificationRequest";
+    case kJFValidateNOC:
+        return "JFValidateNOC";
+
+    case kSendVIDVerificationRequest:
+        return "SendVIDVerificationRequest";
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     case kSendOpCertSigningRequest:

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -73,6 +73,11 @@ const char * StageToString(CommissioningStage stage)
     case kAttestationRevocationCheck:
         return "AttestationRevocationCheck";
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+        case kSendVIDVerificationRequest:
+            return "SendVIDVerificationRequest";
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
     case kSendOpCertSigningRequest:
         return "SendOpCertSigningRequest";
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -52,8 +52,9 @@ enum CommissioningStage : uint8_t
     kAttestationVerification,    ///< Verify AttestationResponse (0x3E:1) validity
     kAttestationRevocationCheck, ///< Verify Revocation Status of device's DAC chain
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    kJFValidateNOC,              ///< Verify Admin NOC contains an Administrator CAT
     kSendVIDVerificationRequest, ///< Send SignVIDVerificationRequest command to the device
-#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+#endif                           // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     kSendOpCertSigningRequest,   ///< Send CSRRequest (0x3E:4) command to the device
     kValidateCSR,                ///< Verify CSRResponse (0x3E:5) validity
     kGenerateNOCChain,           ///< TLV encode Node Operational Credentials (NOC) chain certs
@@ -774,7 +775,6 @@ private:
     Optional<ByteSpan> mJFAdminRCAC;
     Optional<uint16_t> mJFAdminRCACLen;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-
 };
 
 struct RequestedCertificate
@@ -876,7 +876,7 @@ struct ICDManagementClusterInfo
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 struct JFFabricTableInfo
 {
-    VendorId vendorId  = VendorId::Common;
+    VendorId vendorId = VendorId::Common;
     FabricId fabricId = kUndefinedFabricId;
 };
 
@@ -901,7 +901,7 @@ struct ReadCommissioningInfo
     ICDManagementClusterInfo icd;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    EndpointId JFAdminEndpointId = kInvalidEndpointId;
+    EndpointId JFAdminEndpointId           = kInvalidEndpointId;
     FabricIndex JFAdministratorFabricIndex = kUndefinedFabricIndex;
 
     JFFabricTableInfo JFAdminFabricTable;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -606,6 +606,17 @@ public:
         return *this;
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    // Execute Joint Commissioning Method
+    Optional<bool> GetExecuteJCM() const { return mExecuteJCM; }
+
+    CommissioningParameters & SetExecuteJCM(bool executeJCM)
+    {
+        mExecuteJCM = MakeOptional(executeJCM);
+        return *this;
+    }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
     // Clear all members that depend on some sort of external buffer.  Can be
     // used to make sure that we are not holding any dangling pointers.
     void ClearExternalBufferDependentValues()
@@ -679,6 +690,11 @@ private:
     ICDRegistrationStrategy mICDRegistrationStrategy = ICDRegistrationStrategy::kIgnore;
     bool mCheckForMatchingFabric                     = false;
     Span<const app::AttributePathParams> mExtraReadPaths;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    Optional<bool> mExecuteJCM;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
 };
 
 struct RequestedCertificate

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -767,13 +767,13 @@ private:
     Optional<VendorId> mJFAdminVendorId;
 
     Optional<ByteSpan> mJFAdminNOC;
-    Optional<uint16_t> mJFAdminNOCLen;
+    Optional<size_t> mJFAdminNOCLen;
 
     Optional<ByteSpan> mJFAdminICAC;
-    Optional<uint16_t> mJFAdminICACLen;
+    Optional<size_t> mJFAdminICACLen;
 
     Optional<ByteSpan> mJFAdminRCAC;
-    Optional<uint16_t> mJFAdminRCACLen;
+    Optional<size_t> mJFAdminRCACLen;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 };
 

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -51,6 +51,9 @@ enum CommissioningStage : uint8_t
     kSendAttestationRequest,     ///< Send AttestationRequest (0x3E:0) command to the device
     kAttestationVerification,    ///< Verify AttestationResponse (0x3E:1) validity
     kAttestationRevocationCheck, ///< Verify Revocation Status of device's DAC chain
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    kSendVIDVerificationRequest, ///< Send SignVIDVerificationRequest command to the device
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     kSendOpCertSigningRequest,   ///< Send CSRRequest (0x3E:4) command to the device
     kValidateCSR,                ///< Verify CSRResponse (0x3E:5) validity
     kGenerateNOCChain,           ///< TLV encode Node Operational Credentials (NOC) chain certs
@@ -615,6 +618,63 @@ public:
         mExecuteJCM = MakeOptional(executeJCM);
         return *this;
     }
+
+    const Optional<ByteSpan> GetJFAdminNOC() const { return mJFAdminNOC; }
+
+    CommissioningParameters & SetJFAdminNOC(const ByteSpan & JFAdminNOC)
+    {
+        mJFAdminNOC = MakeOptional(JFAdminNOC);
+        return *this;
+    }
+
+    const Optional<ByteSpan> GetJFAdminICAC() const { return mJFAdminICAC; }
+
+    CommissioningParameters & SetJFAdminICAC(const ByteSpan & JFAdminICAC)
+    {
+        mJFAdminICAC = MakeOptional(JFAdminICAC);
+        return *this;
+    }
+
+    const Optional<ByteSpan> GetJFAdminRCAC() const { return mJFAdminRCAC; }
+
+    CommissioningParameters & SetJFAdminRCAC(const ByteSpan & JFAdminRCAC)
+    {
+        mJFAdminRCAC = MakeOptional(JFAdminRCAC);
+        return *this;
+    }
+
+    const Optional<EndpointId> GetJFAdminEndpointId() const { return mJFAdminEndpointId; }
+
+    CommissioningParameters & SetJFAdminEndpointId(const EndpointId JFAdminEndpointId)
+    {
+        mJFAdminEndpointId = MakeOptional(JFAdminEndpointId);
+        return *this;
+    }
+
+    const Optional<FabricIndex> GetJFAdministratorFabricIndex() const { return mJFAdministratorFabricIndex; }
+
+    CommissioningParameters & SetJFAdministratorFabricIndex(const FabricIndex JFAdministratorFabricIndex)
+    {
+        mJFAdministratorFabricIndex = MakeOptional(JFAdministratorFabricIndex);
+        return *this;
+    }
+
+    const Optional<FabricId> GetJFAdminFabricId() const { return mJFAdminFabricId; }
+
+    CommissioningParameters & SetJFAdminFabricId(const FabricId JFAdminFabricId)
+    {
+        mJFAdminFabricId = MakeOptional(JFAdminFabricId);
+        return *this;
+    }
+
+    const Optional<VendorId> GetJFAdminVendorId() const { return mJFAdminVendorId; }
+
+    CommissioningParameters & SetJFAdminVendorId(const VendorId JFAdminVendorId)
+    {
+        mJFAdminVendorId = MakeOptional(JFAdminVendorId);
+        return *this;
+    }
+
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     // Clear all members that depend on some sort of external buffer.  Can be
@@ -640,6 +700,11 @@ public:
         mDefaultNTP.ClearValue();
         mICDSymmetricKey.ClearValue();
         mExtraReadPaths = decltype(mExtraReadPaths)();
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+        mJFAdminNOC.ClearValue();
+        mJFAdminICAC.ClearValue();
+        mJFAdminRCAC.ClearValue();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     }
 
 private:
@@ -693,6 +758,21 @@ private:
 
 #if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     Optional<bool> mExecuteJCM;
+
+    Optional<EndpointId> mJFAdminEndpointId;
+    Optional<FabricIndex> mJFAdministratorFabricIndex;
+
+    Optional<FabricId> mJFAdminFabricId;
+    Optional<VendorId> mJFAdminVendorId;
+
+    Optional<ByteSpan> mJFAdminNOC;
+    Optional<uint16_t> mJFAdminNOCLen;
+
+    Optional<ByteSpan> mJFAdminICAC;
+    Optional<uint16_t> mJFAdminICACLen;
+
+    Optional<ByteSpan> mJFAdminRCAC;
+    Optional<uint16_t> mJFAdminRCACLen;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
 };
@@ -793,6 +873,15 @@ struct ICDManagementClusterInfo
     CharSpan userActiveModeTriggerInstruction;
 };
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+struct JFFabricTableInfo
+{
+    VendorId vendorId  = VendorId::Common;
+    FabricId fabricId = kUndefinedFabricId;
+};
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
 struct ReadCommissioningInfo
 {
 #if CHIP_CONFIG_ENABLE_READ_CLIENT
@@ -810,6 +899,17 @@ struct ReadCommissioningInfo
     NodeId remoteNodeId               = kUndefinedNodeId;
     bool supportsConcurrentConnection = true;
     ICDManagementClusterInfo icd;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    EndpointId JFAdminEndpointId = kInvalidEndpointId;
+    FabricIndex JFAdministratorFabricIndex = kUndefinedFabricIndex;
+
+    JFFabricTableInfo JFAdminFabricTable;
+
+    ByteSpan JFAdminNOC;
+    ByteSpan JFAdminICAC;
+    ByteSpan JFAdminRCAC;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 };
 
 struct TimeZoneResponseInfo

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -51,10 +51,6 @@ enum CommissioningStage : uint8_t
     kSendAttestationRequest,     ///< Send AttestationRequest (0x3E:0) command to the device
     kAttestationVerification,    ///< Verify AttestationResponse (0x3E:1) validity
     kAttestationRevocationCheck, ///< Verify Revocation Status of device's DAC chain
-#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
-    kJFValidateNOC,              ///< Verify Admin NOC contains an Administrator CAT
-    kSendVIDVerificationRequest, ///< Send SignVIDVerificationRequest command to the device
-#endif                           // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     kSendOpCertSigningRequest,   ///< Send CSRRequest (0x3E:4) command to the device
     kValidateCSR,                ///< Verify CSRResponse (0x3E:5) validity
     kGenerateNOCChain,           ///< TLV encode Node Operational Credentials (NOC) chain certs
@@ -88,7 +84,9 @@ enum CommissioningStage : uint8_t
     kRemoveWiFiNetworkConfig,         ///< Remove Wi-Fi network config.
     kRemoveThreadNetworkConfig,       ///< Remove Thread network config.
     kConfigureTCAcknowledgments,      ///< Send SetTCAcknowledgements (0x30:6) command to the device
-    kCleanup,                         ///< Call delegates with status, free memory, clear timers and state
+    kCleanup,                         ///< Call delegates with status, free memory, clear timers and state/
+    kJFValidateNOC,                   ///< Verify Admin NOC contains an Administrator CAT
+    kSendVIDVerificationRequest,      ///< Send SignVIDVerificationRequest command to the device
 };
 
 enum class ICDRegistrationStrategy : uint8_t
@@ -767,13 +765,8 @@ private:
     Optional<VendorId> mJFAdminVendorId;
 
     Optional<ByteSpan> mJFAdminNOC;
-    Optional<size_t> mJFAdminNOCLen;
-
     Optional<ByteSpan> mJFAdminICAC;
-    Optional<size_t> mJFAdminICACLen;
-
     Optional<ByteSpan> mJFAdminRCAC;
-    Optional<size_t> mJFAdminRCACLen;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 };
 

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -457,6 +457,15 @@
 #endif
 
 /**
+ * CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+ *
+ * Enable support for Joint Fabric in core SDK.
+ */
+#ifndef CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+#define CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC 0
+#endif
+
+/**
  * CHIP_DEVICE_CONFIG_WIFIPAF_MIN_ADVERTISING_TIMEOUT_SECS
  *
  * The min amount of time (in seconds) after which the chip platform will stop PAF advertisement

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -141,6 +141,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
       "CHIP_USE_TRANSITIONAL_DEVICE_INSTANCE_INFO_PROVIDER=${chip_use_transitional_device_instance_info_provider}",
       "CHIP_DEVICE_CONFIG_ENABLE_DYNAMIC_MRP_CONFIG=${chip_device_config_enable_dynamic_mrp_config}",
       "CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF=${chip_device_config_enable_wifipaf}",
+      "CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC=${chip_device_config_enable_joint_fabric}",
     ]
 
     public_deps = [ "${chip_root}/src/app/icd/server:icd-server-config" ]

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -121,6 +121,11 @@ declare_args() {
 }
 
 declare_args() {
+  # Enable Joint Fabric features
+  chip_device_config_enable_joint_fabric = false
+}
+
+declare_args() {
   # Include wifi-paf to commission the device or not
   # This is a feature of Wi-Fi spec that it can be enabled if wifi is enabled
   # and the supplicant can support.


### PR DESCRIPTION
Role of this PR is to introduce the main building blocks for executing steps 6-7 of JCM (see spec, Figure 93 - Joint Commissioning Steps and the associated text).

High-level architecture is described in [Slide 4](https://docs.google.com/presentation/d/1eOGmYHz6L1jsVTAbpDpZjaD-avM_KJ9L/edit#slide=id.p4) and the associated use-case (which will be fully implemented in following PRs) is in [Slides 5-7](https://docs.google.com/presentation/d/1eOGmYHz6L1jsVTAbpDpZjaD-avM_KJ9L/edit#slide=id.p5).

Associated SDK execution plan can be found in [project-chip/123](https://github.com/orgs/project-chip/projects/123/views/1), SDK section.

Fix https://github.com/project-chip/connectedhomeip/issues/38178, https://github.com/project-chip/connectedhomeip/issues/38201:
- PR is split in multiple commits with clear description for easier review
- first commit is doing some general refactoring around PAI/DAC certification generation/release to avoid code duplication. (that API will be used also for handling the JF certificates). Rest of the commissioner code required for steps 6-7 of JCM is guarded by CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC - by doing this we make sure we don't break any existing functionality
- during the read commissioning phase, the AdministratorFabricIndex, Fabric Table and Trusted Root Certificates are read, associated information from the Fabric Table are also read. Then, only the entry from the Fabric Table corresponding to AdministratorFabricIndex is saved. This info will be used in a following PR for Fabric Table VID Verification.
- more details about the architecture can be found in the JF guide - [docs/guides/joint_fabric_guide.md](https://github.com/doru91/connectedhomeip/blob/feature/jf/docs/guides/joint_fabric_guide.md)

### Testing
- used jf-control-app for pairing jf-admin-app as anchor:  `pairing onnetwork 1 110220033 --anchor true `
- used jf-control-app to OCW on jf-admin-app: `pairing open-commissioning-window 1 1 400 1000 1261` -> extract pairing_code
- used jf-control-app to test that the JF information is saved correctly: `pairing onnetwork 10 pairing_code --execute-jcm true`  
