### PR TITLE
[WriteClient] Adding UnitTests for PutPreencodedAttribute and other  related methods

### DIFF
--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -247,7 +247,6 @@ CHIP_ERROR WriteClient::PutSinglePreencodedAttributeWritePayload(const chip::app
     return err;
 }
 
-// TODO #38287 Add Unit Tests for PutPreencodedAttribute and for TryPutPreencodedAttributeWritePayloadIntoList.
 CHIP_ERROR WriteClient::PutPreencodedAttribute(const ConcreteDataAttributePath & attributePath, const TLV::TLVReader & data)
 {
     ReturnErrorOnFailure(EnsureMessage());

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -155,6 +155,12 @@ public:
         AppContext::TearDown();
     }
 
+    enum class EncodingMethod
+    {
+        Standard,      // Encoding using WriteClient::EncodeAttribute()
+        PreencodedTLV, // Encoding using WriteClient::PutPreencodedAttribute()
+    };
+
     void TestWriteClient();
     void TestWriteClientGroup();
     void TestWriteHandlerReceiveInvalidMessage();
@@ -164,7 +170,7 @@ public:
     void TestWriteInvalidMessage3();
     void TestWriteInvalidMessage4();
 
-    static void AddAttributeDataIB(WriteClient & aWriteClient);
+    static void AddAttributeDataIB(WriteClient & aWriteClient, EncodingMethod encoding);
     static void AddAttributeStatus(WriteHandler & aWriteHandler);
     static void GenerateWriteRequest(bool aIsTimedWrite, System::PacketBufferHandle & aPayload);
     static void GenerateWriteResponse(System::PacketBufferHandle & aPayload);
@@ -230,7 +236,7 @@ public:
     CHIP_ERROR mError = CHIP_NO_ERROR;
 };
 
-void TestWriteInteraction::AddAttributeDataIB(WriteClient & aWriteClient)
+void TestWriteInteraction::AddAttributeDataIB(WriteClient & aWriteClient, EncodingMethod encoding = EncodingMethod::Standard)
 {
     AttributePathParams attributePathParams;
     bool attributeValue              = true;
@@ -238,7 +244,35 @@ void TestWriteInteraction::AddAttributeDataIB(WriteClient & aWriteClient)
     attributePathParams.mClusterId   = 3;
     attributePathParams.mAttributeId = 4;
 
-    EXPECT_EQ(aWriteClient.EncodeAttribute(attributePathParams, attributeValue), CHIP_NO_ERROR);
+    switch (encoding)
+    {
+    case EncodingMethod::Standard:
+
+        EXPECT_EQ(aWriteClient.EncodeAttribute(attributePathParams, attributeValue), CHIP_NO_ERROR);
+        break;
+
+    case EncodingMethod::PreencodedTLV:
+
+        // Encode AttributeData into TLV
+        uint8_t buffer[5];
+        TLV::TLVWriter writer;
+        writer.Init(buffer, sizeof(buffer));
+        TLV::TLVType outerContainer;
+
+        EXPECT_EQ(CHIP_NO_ERROR, writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainer));
+        EXPECT_EQ(CHIP_NO_ERROR, writer.PutBoolean(TLV::ContextTag(1), attributeValue));
+        EXPECT_EQ(CHIP_NO_ERROR, writer.EndContainer(outerContainer));
+
+        // Put Preencoded Data into AttributeDataIB
+        TLV::TLVReader reader;
+        reader.Init(buffer, writer.GetLengthWritten());
+        reader.Next();
+        EXPECT_EQ(aWriteClient.PutPreencodedAttribute(chip::app::ConcreteDataAttributePath(attributePathParams.mEndpointId,
+                                                                                           attributePathParams.mClusterId,
+                                                                                           attributePathParams.mAttributeId),
+                                                      reader),
+                  CHIP_NO_ERROR);
+    }
 }
 
 void TestWriteInteraction::AddAttributeStatus(WriteHandler & aWriteHandler)
@@ -341,44 +375,49 @@ void TestWriteInteraction::GenerateWriteResponse(System::PacketBufferHandle & aP
 TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteClient)
 {
 
-    TestWriteClientCallback callback;
-    app::WriteClient writeClient(&GetExchangeManager(), &callback, /* aTimedWriteTimeoutMs = */ NullOptional);
+    for (EncodingMethod encoding : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
+    {
+        TestWriteClientCallback callback;
+        app::WriteClient writeClient(&GetExchangeManager(), &callback, /* aTimedWriteTimeoutMs = */ NullOptional);
 
-    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    AddAttributeDataIB(writeClient);
+        System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+        AddAttributeDataIB(writeClient, encoding);
 
-    EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
+        EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
 
-    DrainAndServiceIO();
+        DrainAndServiceIO();
 
-    GenerateWriteResponse(buf);
+        GenerateWriteResponse(buf);
 
-    EXPECT_EQ(writeClient.ProcessWriteResponseMessage(std::move(buf)), CHIP_NO_ERROR);
+        EXPECT_EQ(writeClient.ProcessWriteResponseMessage(std::move(buf)), CHIP_NO_ERROR);
 
-    writeClient.Close();
+        writeClient.Close();
 
-    Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
-    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+        Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+        EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+    }
 }
 
 TEST_F_FROM_FIXTURE(TestWriteInteraction, TestWriteClientGroup)
 {
+    for (EncodingMethod encodingMethod : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
+    {
+        TestWriteClientCallback callback;
+        app::WriteClient writeClient(&GetExchangeManager(), &callback, /* aTimedWriteTimeoutMs = */ NullOptional);
 
-    TestWriteClientCallback callback;
-    app::WriteClient writeClient(&GetExchangeManager(), &callback, /* aTimedWriteTimeoutMs = */ NullOptional);
+        System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+        AddAttributeDataIB(writeClient, encodingMethod);
 
-    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    AddAttributeDataIB(writeClient);
+        SessionHandle groupSession = GetSessionBobToFriends();
+        EXPECT_TRUE(groupSession->IsGroupSession());
 
-    SessionHandle groupSession = GetSessionBobToFriends();
-    EXPECT_TRUE(groupSession->IsGroupSession());
+        EXPECT_EQ(writeClient.SendWriteRequest(groupSession), CHIP_NO_ERROR);
 
-    EXPECT_EQ(writeClient.SendWriteRequest(groupSession), CHIP_NO_ERROR);
+        DrainAndServiceIO();
 
-    DrainAndServiceIO();
-
-    // The WriteClient should be shutdown once we SendWriteRequest for group.
-    EXPECT_EQ(writeClient.mState, WriteClient::State::AwaitingDestruction);
+        // The WriteClient should be shutdown once we SendWriteRequest for group.
+        EXPECT_EQ(writeClient.mState, WriteClient::State::AwaitingDestruction);
+    }
 }
 
 TEST_F(TestWriteInteraction, TestWriteHandler)
@@ -424,65 +463,95 @@ TEST_F(TestWriteInteraction, TestWriteHandler)
 TEST_F(TestWriteInteraction, TestWriteRoundtripWithClusterObjects)
 {
 
-    Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
-    // Shouldn't have anything in the retransmit table when starting the test.
-    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
-
-    TestWriteClientCallback callback;
-    auto * engine = chip::app::InteractionModelEngine::GetInstance();
-    EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
-
-    app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
-
-    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-
-    AttributePathParams attributePathParams;
-    attributePathParams.mEndpointId  = 2;
-    attributePathParams.mClusterId   = 3;
-    attributePathParams.mAttributeId = 4;
-
-    const uint8_t byteSpanData[]     = { 0xde, 0xad, 0xbe, 0xef };
-    static const char charSpanData[] = "a simple test string";
-
-    app::Clusters::UnitTesting::Structs::SimpleStruct::Type dataTx;
-    dataTx.a = 12;
-    dataTx.b = true;
-    dataTx.d = chip::ByteSpan(byteSpanData);
-    // Spec A.11.2 strings SHALL NOT include a terminating null character to mark the end of a string.
-    dataTx.e = chip::Span<const char>(charSpanData, strlen(charSpanData));
-
-    EXPECT_EQ(writeClient.EncodeAttribute(attributePathParams, dataTx), CHIP_NO_ERROR);
-
-    EXPECT_EQ(callback.mOnSuccessCalled, 0);
-
-    EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
-
-    DrainAndServiceIO();
-
-    EXPECT_EQ(callback.mOnSuccessCalled, 1);
-
+    for (EncodingMethod encoding : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
     {
-        app::Clusters::UnitTesting::Structs::SimpleStruct::Type dataRx;
-        TLV::TLVReader reader;
-        reader.Init(chip::Test::attributeDataTLV, chip::Test::attributeDataTLVLen);
-        reader.Next();
-        EXPECT_EQ(CHIP_NO_ERROR, DataModel::Decode(reader, dataRx));
-        EXPECT_EQ(dataRx.a, dataTx.a);
-        EXPECT_EQ(dataRx.b, dataTx.b);
-        EXPECT_TRUE(dataRx.d.data_equal(dataTx.d));
-        // Equals to dataRx.e.size() == dataTx.e.size() && memncmp(dataRx.e.data(), dataTx.e.data(), dataTx.e.size()) == 0
-        EXPECT_TRUE(dataRx.e.data_equal(dataTx.e));
+        Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+        // Shouldn't have anything in the retransmit table when starting the test.
+        EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+        TestWriteClientCallback callback;
+        auto * engine = chip::app::InteractionModelEngine::GetInstance();
+        EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()),
+                  CHIP_NO_ERROR);
+
+        app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+
+        System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+
+        AttributePathParams attributePathParams;
+        attributePathParams.mEndpointId  = 2;
+        attributePathParams.mClusterId   = 3;
+        attributePathParams.mAttributeId = 4;
+
+        const uint8_t byteSpanData[]     = { 0xde, 0xad, 0xbe, 0xef };
+        static const char charSpanData[] = "a simple test string";
+
+        app::Clusters::UnitTesting::Structs::SimpleStruct::Type dataTx;
+        dataTx.a = 12;
+        dataTx.b = true;
+        dataTx.d = chip::ByteSpan(byteSpanData);
+        // Spec A.11.2 strings SHALL NOT include a terminating null character to mark the end of a string.
+        dataTx.e = chip::Span<const char>(charSpanData, strlen(charSpanData));
+
+        if (encoding == EncodingMethod::Standard)
+        {
+            EXPECT_EQ(writeClient.EncodeAttribute(attributePathParams, dataTx), CHIP_NO_ERROR);
+        }
+        else if (encoding == EncodingMethod::PreencodedTLV)
+        {
+            // Encode AttributeData into TLV
+            uint8_t buffer[50];
+            TLV::TLVWriter writer;
+            writer.Init(buffer, sizeof(buffer));
+            TLV::TLVType outerContainer;
+
+            EXPECT_EQ(CHIP_NO_ERROR, writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerContainer));
+            EXPECT_EQ(CHIP_NO_ERROR, writer.Put(TLV::ContextTag(0), dataTx.a));
+            EXPECT_EQ(CHIP_NO_ERROR, writer.PutBoolean(TLV::ContextTag(1), dataTx.b));
+            EXPECT_EQ(CHIP_NO_ERROR, writer.Put(TLV::ContextTag(3), dataTx.d));
+            EXPECT_EQ(CHIP_NO_ERROR, writer.PutString(TLV::ContextTag(4), dataTx.e));
+            EXPECT_EQ(CHIP_NO_ERROR, writer.EndContainer(outerContainer));
+
+            // Put Preencoded Data into AttributeDataIB
+            TLV::TLVReader dataTxTLV;
+            dataTxTLV.Init(buffer, writer.GetLengthWritten());
+            dataTxTLV.Next();
+            ConcreteDataAttributePath path = ConcreteDataAttributePath(
+                attributePathParams.mEndpointId, attributePathParams.mClusterId, attributePathParams.mAttributeId);
+            EXPECT_EQ(writeClient.PutPreencodedAttribute(path, dataTxTLV), CHIP_NO_ERROR);
+        }
+
+        EXPECT_EQ(callback.mOnSuccessCalled, 0);
+
+        EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
+
+        DrainAndServiceIO();
+
+        EXPECT_EQ(callback.mOnSuccessCalled, 1);
+
+        {
+            app::Clusters::UnitTesting::Structs::SimpleStruct::Type dataRx;
+            TLV::TLVReader reader;
+            reader.Init(chip::Test::attributeDataTLV, chip::Test::attributeDataTLVLen);
+            reader.Next();
+            EXPECT_EQ(CHIP_NO_ERROR, DataModel::Decode(reader, dataRx));
+            EXPECT_EQ(dataRx.a, dataTx.a);
+            EXPECT_EQ(dataRx.b, dataTx.b);
+            EXPECT_TRUE(dataRx.d.data_equal(dataTx.d));
+            // Equals to dataRx.e.size() == dataTx.e.size() && memncmp(dataRx.e.data(), dataTx.e.data(), dataTx.e.size()) == 0
+            EXPECT_TRUE(dataRx.e.data_equal(dataTx.e));
+        }
+
+        EXPECT_EQ(callback.mOnSuccessCalled, 1);
+        EXPECT_EQ(callback.mOnErrorCalled, 0);
+        EXPECT_EQ(callback.mOnDoneCalled, 1);
+
+        // By now we should have closed all exchanges and sent all pending acks, so
+        // there should be no queued-up things in the retransmit table.
+        EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+
+        engine->Shutdown();
     }
-
-    EXPECT_EQ(callback.mOnSuccessCalled, 1);
-    EXPECT_EQ(callback.mOnErrorCalled, 0);
-    EXPECT_EQ(callback.mOnDoneCalled, 1);
-
-    // By now we should have closed all exchanges and sent all pending acks, so
-    // there should be no queued-up things in the retransmit table.
-    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
-
-    engine->Shutdown();
 }
 
 TEST_F(TestWriteInteraction, TestWriteRoundtripWithClusterObjectsVersionMatch)
@@ -578,36 +647,39 @@ TEST_F(TestWriteInteraction, TestWriteRoundtripWithClusterObjectsVersionMismatch
 
 TEST_F(TestWriteInteraction, TestWriteRoundtrip)
 {
+    for (EncodingMethod encodingMethod : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
+    {
+        Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
+        // Shouldn't have anything in the retransmit table when starting the test.
+        EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 
-    Messaging::ReliableMessageMgr * rm = GetExchangeManager().GetReliableMessageMgr();
-    // Shouldn't have anything in the retransmit table when starting the test.
-    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
+        TestWriteClientCallback callback;
+        auto * engine = chip::app::InteractionModelEngine::GetInstance();
+        EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()),
+                  CHIP_NO_ERROR);
 
-    TestWriteClientCallback callback;
-    auto * engine = chip::app::InteractionModelEngine::GetInstance();
-    EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), app::reporting::GetDefaultReportScheduler()), CHIP_NO_ERROR);
+        app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
 
-    app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+        System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
+        AddAttributeDataIB(writeClient, encodingMethod);
 
-    System::PacketBufferHandle buf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
-    AddAttributeDataIB(writeClient);
+        EXPECT_EQ(callback.mOnSuccessCalled, 0);
+        EXPECT_EQ(callback.mOnErrorCalled, 0);
+        EXPECT_EQ(callback.mOnDoneCalled, 0);
 
-    EXPECT_EQ(callback.mOnSuccessCalled, 0);
-    EXPECT_EQ(callback.mOnErrorCalled, 0);
-    EXPECT_EQ(callback.mOnDoneCalled, 0);
+        EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
 
-    EXPECT_EQ(writeClient.SendWriteRequest(GetSessionBobToAlice()), CHIP_NO_ERROR);
+        DrainAndServiceIO();
 
-    DrainAndServiceIO();
+        EXPECT_EQ(callback.mOnSuccessCalled, 1);
+        EXPECT_EQ(callback.mOnErrorCalled, 0);
+        EXPECT_EQ(callback.mOnDoneCalled, 1);
+        // By now we should have closed all exchanges and sent all pending acks, so
+        // there should be no queued-up things in the retransmit table.
+        EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
 
-    EXPECT_EQ(callback.mOnSuccessCalled, 1);
-    EXPECT_EQ(callback.mOnErrorCalled, 0);
-    EXPECT_EQ(callback.mOnDoneCalled, 1);
-    // By now we should have closed all exchanges and sent all pending acks, so
-    // there should be no queued-up things in the retransmit table.
-    EXPECT_EQ(rm->TestGetCountRetransTable(), 0);
-
-    engine->Shutdown();
+        engine->Shutdown();
+    }
 }
 
 // This test creates a chunked write request, we drop the second write chunk message, then write handler receives unknown

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -267,9 +267,9 @@ void TestWriteInteraction::AddAttributeDataIB(WriteClient & aWriteClient, Encodi
         TLV::TLVReader reader;
         reader.Init(buffer, writer.GetLengthWritten());
         reader.Next();
-        EXPECT_EQ(aWriteClient.PutPreencodedAttribute(chip::app::ConcreteDataAttributePath(attributePathParams.mEndpointId,
-                                                                                           attributePathParams.mClusterId,
-                                                                                           attributePathParams.mAttributeId),
+        EXPECT_EQ(aWriteClient.PutPreencodedAttribute(ConcreteDataAttributePath(attributePathParams.mEndpointId,
+                                                                                attributePathParams.mClusterId,
+                                                                                attributePathParams.mAttributeId),
                                                       reader),
                   CHIP_NO_ERROR);
     }

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -38,7 +38,7 @@ chip_test_suite("tests") {
     ]
 
     # At some instances, this Test end ups allocating more than 32 Timers, and since the fake platform doesn`t use the heap, the maximum number of allowed timers is 32.
-    # So we get failures because we can't allocate anymore timers, in the log it looks like:
+    # So we get failures because we can't allocate any more timers, in the log it looks like:
     # SendMessage() to UDP:[::1]:5541 failed: b
     # deactivating since the Fake platform is mostly done to test Platform APIs
     if (chip_device_platform != "fake") {

--- a/src/controller/tests/BUILD.gn
+++ b/src/controller/tests/BUILD.gn
@@ -35,8 +35,15 @@ chip_test_suite("tests") {
       "TestEventNumberCaching.cpp",
       "TestReadChunking.cpp",
       "TestServerCommandDispatch.cpp",
-      "TestWriteChunking.cpp",
     ]
+
+    # At some instances, this Test end ups allocating more than 32 Timers, and since the fake platform doesn`t use the heap, the maximum number of allowed timers is 32.
+    # So we get failures because we can't allocate anymore timers, in the log it looks like:
+    # SendMessage() to UDP:[::1]:5541 failed: b
+    # deactivating since the Fake platform is mostly done to test Platform APIs
+    if (chip_device_platform != "fake") {
+      test_sources += [ "TestWriteChunking.cpp" ]
+    }
 
     # Not supported on efr32.
     if (chip_device_platform != "efr32") {

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -125,7 +125,7 @@ void TestWriteChunking::EncodeAttributeListIntoTLV(const DataModel::List<T> & aL
         }
         else if constexpr (std::is_same<T, chip::ByteSpan>::value)
         {
-            ASSERT_LE(aListAttribute[i].size(), UINT8_MAX);
+            ASSERT_LE(aListAttribute[i].size(), static_cast<size_t>(UINT8_MAX));
 
             // Control Octet (1) + Length Octet (1) + size of a single ByteSpan
             estimatedSize += 2 + aListAttribute[i].size();

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -1121,7 +1121,9 @@ TEST_F(TestWriteChunking, TestTransactionalList)
 
     for (EncodingMethod encodingMethod : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
     {
-        const char * encodingMethodName = (encodingMethod == EncodingMethod::Standard ? "StandardEncoding" : "PreencodedTLV");
+        // For builds without ChipLogProgress, encodingMethodName will be ununsed and trigger build failures
+        [[maybe_unused]] const char * encodingMethodName =
+            (encodingMethod == EncodingMethod::Standard ? "StandardEncoding" : "PreencodedTLV");
 
         // Test 1: we should receive transaction notifications
         ChipLogProgress(Zcl, "Test 1 [%s]: we should receive transaction notifications", encodingMethodName);
@@ -1375,7 +1377,9 @@ TEST_F(TestWriteChunking, TestTransactionalList_NonEmptyReplaceAllList)
 
     for (EncodingMethod encodingMethod : { EncodingMethod::Standard, EncodingMethod::PreencodedTLV })
     {
-        const char * encodingMethodName = (encodingMethod == EncodingMethod::Standard ? "StandardEncoding" : "PreencodedTLV");
+        // For builds without ChipLogProgress, encodingMethodName will be ununsed and trigger build failures
+        [[maybe_unused]] const char * encodingMethodName =
+            (encodingMethod == EncodingMethod::Standard ? "StandardEncoding" : "PreencodedTLV");
 
         // Test 1: we should receive transaction notifications
         ChipLogProgress(Zcl, "Test 1 [%s]: we should receive transaction notifications", encodingMethodName);


### PR DESCRIPTION
- Fixes #38287
- `WriteClient::PutPreencodedAttribute` and its child methods that are used by Python and Android Controllers are not covered by Unit Tests at all.
- Added TestCases to cover them all.
 
- currently WriteClient.cpp has 69.8 % coverage, these tests should put it above 90%


#### Testing

Unit Testing locally and CI
