### PR TITLE
Remove un-used parameters from SolicitOffer/ProvideOffer APIs

### DIFF
--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -198,9 +198,7 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId,
     CHIP_ERROR err =
         mWebRTCProviderClient.ProvideOffer(sessionId, mLocalDescription, streamUsage, kWebRTCRequesterDynamicEndpointId,
                                            MakeOptional(DataModel::NullNullable), // "Null" for video
-                                           MakeOptional(DataModel::NullNullable), // "Null" for audio
-                                           NullOptional,                          // Omit ICEServers (Optional not present)
-                                           NullOptional                           // Omit ICETransportPolicy (Optional not present)
+                                           MakeOptional(DataModel::NullNullable)  // "Null" for audio
         );
 
     if (err != CHIP_NO_ERROR)
@@ -217,9 +215,7 @@ CHIP_ERROR WebRTCManager::SolicitOffer(Clusters::WebRTCTransportProvider::Stream
 
     CHIP_ERROR err = mWebRTCProviderClient.SolicitOffer(streamUsage, kWebRTCRequesterDynamicEndpointId,
                                                         MakeOptional(DataModel::NullNullable), // "Null" for video
-                                                        MakeOptional(DataModel::NullNullable), // "Null" for audio
-                                                        NullOptional, // Omit ICEServers (Optional not present)
-                                                        NullOptional  // Omit ICETransportPolicy (Optional not present)
+                                                        MakeOptional(DataModel::NullNullable)  // "Null" for audio
     );
 
     if (err != CHIP_NO_ERROR)

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.cpp
@@ -41,11 +41,10 @@ void WebRTCProviderClient::Init(const ScopedNodeId & peerId, EndpointId endpoint
                     ChipLogValueX64(peerId.GetNodeId()), static_cast<unsigned>(endpointId));
 }
 
-CHIP_ERROR WebRTCProviderClient::SolicitOffer(
-    Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage, EndpointId originatingEndpointId,
-    Optional<DataModel::Nullable<uint16_t>> videoStreamId, Optional<DataModel::Nullable<uint16_t>> audioStreamId,
-    Optional<DataModel::List<const Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>> ICEServers,
-    Optional<chip::CharSpan> ICETransportPolicy)
+CHIP_ERROR WebRTCProviderClient::SolicitOffer(Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage,
+                                              EndpointId originatingEndpointId,
+                                              Optional<DataModel::Nullable<uint16_t>> videoStreamId,
+                                              Optional<DataModel::Nullable<uint16_t>> audioStreamId)
 {
     ChipLogProgress(Camera, "Sending SolicitOffer to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 
@@ -63,8 +62,10 @@ CHIP_ERROR WebRTCProviderClient::SolicitOffer(
     mSolicitOfferData.originatingEndpointID = originatingEndpointId;
     mSolicitOfferData.videoStreamID         = videoStreamId;
     mSolicitOfferData.audioStreamID         = audioStreamId;
-    mSolicitOfferData.ICEServers            = ICEServers;
-    mSolicitOfferData.ICETransportPolicy    = ICETransportPolicy;
+
+    // ICE info are sent during the ICE candidate exchange phase of this flow.
+    mSolicitOfferData.ICEServers         = NullOptional;
+    mSolicitOfferData.ICETransportPolicy = NullOptional;
 
     // Store the streamUsage from the original command so we can build the WebRTCSessionStruct when the response arrives.
     mCurrentStreamUsage = streamUsage;
@@ -83,12 +84,11 @@ CHIP_ERROR WebRTCProviderClient::SolicitOffer(
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WebRTCProviderClient::ProvideOffer(
-    DataModel::Nullable<uint16_t> webRTCSessionId, std::string sdp, Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage,
-    EndpointId originatingEndpointId, Optional<DataModel::Nullable<uint16_t>> videoStreamId,
-    Optional<DataModel::Nullable<uint16_t>> audioStreamId,
-    Optional<DataModel::List<const Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>> ICEServers,
-    Optional<chip::CharSpan> ICETransportPolicy)
+CHIP_ERROR WebRTCProviderClient::ProvideOffer(DataModel::Nullable<uint16_t> webRTCSessionId, std::string sdp,
+                                              Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage,
+                                              EndpointId originatingEndpointId,
+                                              Optional<DataModel::Nullable<uint16_t>> videoStreamId,
+                                              Optional<DataModel::Nullable<uint16_t>> audioStreamId)
 {
     ChipLogProgress(Camera, "Sending ProvideOffer to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
 
@@ -109,8 +109,10 @@ CHIP_ERROR WebRTCProviderClient::ProvideOffer(
     mProvideOfferData.originatingEndpointID = originatingEndpointId;
     mProvideOfferData.videoStreamID         = videoStreamId;
     mProvideOfferData.audioStreamID         = audioStreamId;
-    mProvideOfferData.ICEServers            = ICEServers;
-    mProvideOfferData.ICETransportPolicy    = ICETransportPolicy;
+
+    // ICE info are sent during the ICE candidate exchange phase of this flow.
+    mProvideOfferData.ICEServers         = NullOptional;
+    mProvideOfferData.ICETransportPolicy = NullOptional;
 
     // Store the streamUsage from the original command so we can build the WebRTCSessionStruct when the response arrives.
     mCurrentStreamUsage = streamUsage;

--- a/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
+++ b/examples/camera-controller/webrtc_manager/WebRTCProviderClient.h
@@ -63,19 +63,13 @@ public:
      * @param originatingEndpointId  The endpoint ID that initiates the offer.
      * @param videoStreamId          Optional Video stream ID if relevant.
      * @param audioStreamId          Optional Audio stream ID if relevant.
-     * @param ICEServers             Optional list of ICE server structures, if using custom STUN/TURN servers.
-     * @param ICETransportPolicy     Optional policy for ICE transport (e.g., 'all', 'relay', etc.).
      *
      * @return CHIP_NO_ERROR on success, or an appropriate CHIP_ERROR on failure.
      */
     CHIP_ERROR
     SolicitOffer(chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage, chip::EndpointId originatingEndpointId,
                  chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
-                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId,
-                 chip::Optional<
-                     chip::app::DataModel::List<const chip::app::Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>>
-                     ICEServers,
-                 chip::Optional<chip::CharSpan> ICETransportPolicy);
+                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId);
 
     /**
      * @brief Sends a ProvideOffer command to the remote device.
@@ -90,8 +84,6 @@ public:
      * @param originatingEndpointId  The endpoint ID that initiates the offer.
      * @param videoStreamId          Optional Video stream ID if relevant.
      * @param audioStreamId          Optional Audio stream ID if relevant.
-     * @param ICEServers             Optional list of ICE server structures, if using custom STUN/TURN servers.
-     * @param ICETransportPolicy     Optional policy for ICE transport (e.g., 'all', 'relay', etc.).
      *
      * @return CHIP_NO_ERROR on success, or an appropriate CHIP_ERROR on failure.
      */
@@ -99,11 +91,7 @@ public:
     ProvideOffer(chip::app::DataModel::Nullable<uint16_t> webRTCSessionId, std::string sdp,
                  chip::app::Clusters::WebRTCTransportProvider::StreamUsageEnum streamUsage, chip::EndpointId originatingEndpointId,
                  chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
-                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId,
-                 chip::Optional<
-                     chip::app::DataModel::List<const chip::app::Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>>
-                     ICEServers,
-                 chip::Optional<chip::CharSpan> ICETransportPolicy);
+                 chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId);
 
     /**
      * @brief Sends a ProvideAnswer command to the remote device.


### PR DESCRIPTION
Currently, the `SolicitOffer` and `ProvideOffer` method takes an `Optional<DataModel::List<const Clusters::WebRTCTransportProvider::Structs::ICEServerStruct::Type>>` as a parameter. This is stored in the `mSolicitOfferData.ICEServers` member for later use, presumably during the asynchronous operation. If the caller passes a non-`NullOptional` value, the memory backing the list must remain valid for the duration of the asynchronous operation. If the caller frees or modifies the memory before the operation completes, this could lead to undefined behavior.

Currently, we don't have command option to take ICEServers List, so we always pass `NullOptional` for `ICEServers`. This avoids the issue for now, but it is not good.

Since ICE candidates are always exchanged during the ICE candidate exchange phase of this flow, not passed from the command line, it is better to take this parameter off from from  `SolicitOffer` and `ProvideOffer` method. Same for ICETransportPolicy. 

#### Testing

Validated by CI
