### PR TITLE
Update WebRTC DataChannel protocol name to align with spec

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc_provider/webrtc-provider-manager.cpp
@@ -34,6 +34,13 @@ using namespace chip::app::Clusters::WebRTCTransportProvider;
 
 using namespace Camera;
 
+namespace {
+
+// Constants
+constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
+
+} // namespace
+
 void WebRTCProviderManager::Init()
 {
     rtc::Configuration config;
@@ -181,7 +188,7 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     if (!mDataChannel)
     {
-        mDataChannel = mPeerConnection->createDataChannel("matter-av");
+        mDataChannel = mPeerConnection->createDataChannel(kWebRTCDataChannelName);
     }
 
     mPeerConnection->createOffer();

--- a/examples/camera-controller/commands/common/CHIPCommand.h
+++ b/examples/camera-controller/commands/common/CHIPCommand.h
@@ -99,6 +99,10 @@ public:
         AddArgument("commissioner-vendor-id", 0, UINT16_MAX, &mCommissionerVendorId,
                     "The vendor id to use for camera-controller. If not provided, chip::VendorId::TestVendor1 (65521, 0xFFF1) will "
                     "be used.");
+        AddArgument("start-websocket-server", 0, 1, &mStartWebSocketServer,
+                    "Start the built‑in WebSocket server that exposes the interactive‑command API. "
+                    "If not provided or 0 (\"false\"), the WebSocket server is disabled. "
+                    "If 1 (\"true\"), the WebSocket server is started and listens on the default port.");
     }
 
     /////////// Command Interface /////////
@@ -160,6 +164,7 @@ protected:
     PersistentStorage mCommissionerStorage;
 #endif // CONFIG_USE_LOCAL_STORAGE
     chip::Optional<char *> mLogFilePath;
+    chip::Optional<bool> mStartWebSocketServer;
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
     static chip::Crypto::RawKeySessionKeystore sSessionKeystore;

--- a/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc_manager/WebRTCManager.cpp
@@ -30,6 +30,13 @@ using namespace chip;
 using namespace chip::app;
 using namespace std::chrono_literals;
 
+namespace {
+
+// Constants
+constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
+
+} // namespace
+
 WebRTCManager::WebRTCManager() : mWebRTCRequestorServer(kWebRTCRequesterDynamicEndpointId, mWebRTCRequestorDelegate) {}
 
 WebRTCManager::~WebRTCManager()
@@ -169,7 +176,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     });
 
     // Create a data channel for this offerer
-    mDataChannel = mPeerConnection->createDataChannel("test");
+    mDataChannel = mPeerConnection->createDataChannel(kWebRTCDataChannelName);
 
     if (mDataChannel)
     {


### PR DESCRIPTION
1. Per spec, When WebRTC Transport Provider Cluster is supported and a session activates it, a WebRTC DataChannel using the protocol name "urn:csa:matter:av-metadata" SHALL be used for transmitting the metadata. 

2. Add option to start websocket server on startup

#### Testing

Validated via CI
