### PR TITLE
Add support for stream re-use for Audio/Video/Snapshot during allocation

### DIFF
--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -45,6 +45,9 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
     BitFlags<CameraAvStreamManagement::Feature> features;
     features.Set(CameraAvStreamManagement::Feature::kSnapshot);
     features.Set(CameraAvStreamManagement::Feature::kVideo);
+    features.Set(CameraAvStreamManagement::Feature::kWatermark);
+    features.Set(CameraAvStreamManagement::Feature::kOnScreenDisplay);
+
     if (mCameraDevice->GetCameraHALInterface().HasMicrophone())
     {
         features.Set(CameraAvStreamManagement::Feature::kAudio);

--- a/examples/camera-app/camera-common/src/camera-app.cpp
+++ b/examples/camera-app/camera-common/src/camera-app.cpp
@@ -45,8 +45,6 @@ CameraApp::CameraApp(chip::EndpointId aClustersEndpoint, CameraDeviceInterface *
     BitFlags<CameraAvStreamManagement::Feature> features;
     features.Set(CameraAvStreamManagement::Feature::kSnapshot);
     features.Set(CameraAvStreamManagement::Feature::kVideo);
-    features.Set(CameraAvStreamManagement::Feature::kWatermark);
-    features.Set(CameraAvStreamManagement::Feature::kOnScreenDisplay);
 
     if (mCameraDevice->GetCameraHALInterface().HasMicrophone())
     {

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -44,8 +44,7 @@ void CameraAVStreamManager::SetCameraDeviceHAL(CameraDeviceInterface * aCameraDe
 Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(const VideoStreamStruct & allocateArgs,
                                                                                uint16_t & outStreamID)
 {
-    outStreamID                  = kInvalidStreamID;
-    bool unallocatedStreamExists = false;
+    outStreamID = kInvalidStreamID;
 
     for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
     {
@@ -75,18 +74,9 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
 
             return Status::Success;
         }
-        if (!stream.isAllocated)
-        {
-            unallocatedStreamExists = true;
-        }
     }
 
-    if (!unallocatedStreamExists)
-    {
-        return Status::ResourceExhausted;
-    }
-
-    return Status::Failure;
+    return Status::DynamicConstraintError;
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamModify(const uint16_t streamID,
@@ -146,8 +136,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamDeallocate
 Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamAllocate(const AudioStreamStruct & allocateArgs,
                                                                                uint16_t & outStreamID)
 {
-    outStreamID                  = kInvalidStreamID;
-    bool unallocatedStreamExists = false;
+    outStreamID = kInvalidStreamID;
 
     for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
     {
@@ -169,18 +158,9 @@ Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamAllocate(c
             }
             return Status::Success;
         }
-        if (!stream.isAllocated)
-        {
-            unallocatedStreamExists = true;
-        }
     }
 
-    if (!unallocatedStreamExists)
-    {
-        return Status::ResourceExhausted;
-    }
-
-    return Status::Failure;
+    return Status::DynamicConstraintError;
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamDeallocate(const uint16_t streamID)
@@ -211,8 +191,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamDeallocate
 Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocate(const SnapshotStreamStruct & allocateArgs,
                                                                                   uint16_t & outStreamID)
 {
-    outStreamID                  = kInvalidStreamID;
-    bool unallocatedStreamExists = false;
+    outStreamID = kInvalidStreamID;
 
     for (SnapshotStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableSnapshotStreams())
     {
@@ -234,18 +213,9 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
             }
             return Status::Success;
         }
-        if (!stream.isAllocated)
-        {
-            unallocatedStreamExists = true;
-        }
     }
 
-    if (!unallocatedStreamExists)
-    {
-        return Status::ResourceExhausted;
-    }
-
-    return Status::Failure;
+    return Status::DynamicConstraintError;
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamModify(const uint16_t streamID,

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -49,14 +49,14 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
 
     for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
     {
-        if (!stream.isAllocated)
+        if (stream.IsCompatible(allocateArgs))
         {
             foundAvailableStream = true;
 
-            if (stream.IsCompatible(allocateArgs))
+            outStreamID = stream.videoStreamParams.videoStreamID;
+            if (!stream.isAllocated)
             {
                 stream.isAllocated = true;
-                outStreamID        = stream.videoStreamParams.videoStreamID;
 
                 // Start the video stream from HAL for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(outStreamID);
@@ -70,6 +70,11 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
 
                 return Status::Success;
             }
+            else
+            {
+                ChipLogProgress(Camera, "Matching pre-allocated stream with ID: %d exists", outStreamID);
+            }
+            return Status::Success;
         }
     }
 
@@ -134,20 +139,25 @@ Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamAllocate(c
 
     for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
     {
-        if (!stream.isAllocated)
+        if (stream.IsCompatible(allocateArgs))
         {
             foundAvailableStream = true;
 
-            if (stream.IsCompatible(allocateArgs))
+            outStreamID = stream.audioStreamParams.audioStreamID;
+            if (!stream.isAllocated)
             {
                 stream.isAllocated = true;
-                outStreamID        = stream.audioStreamParams.audioStreamID;
 
                 // Start the audio stream from HAL for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartAudioStream(outStreamID);
 
                 return Status::Success;
             }
+            else
+            {
+                ChipLogProgress(Camera, "Matching pre-allocated stream with ID: %d exists", outStreamID);
+            }
+            return Status::Success;
         }
     }
 
@@ -184,20 +194,25 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
 
     for (SnapshotStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableSnapshotStreams())
     {
-        if (!stream.isAllocated)
+        if (stream.IsCompatible(allocateArgs))
         {
             foundAvailableStream = true;
 
-            if (stream.IsCompatible(allocateArgs))
+            outStreamID = stream.snapshotStreamParams.snapshotStreamID;
+            if (!stream.isAllocated)
             {
                 stream.isAllocated = true;
-                outStreamID        = stream.snapshotStreamParams.snapshotStreamID;
 
                 // Start the snapshot stream for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartSnapshotStream(outStreamID);
 
                 return Status::Success;
             }
+            else
+            {
+                ChipLogProgress(Camera, "Matching pre-allocated stream with ID: %d exists", outStreamID);
+            }
+            return Status::Success;
         }
     }
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1621,13 +1621,6 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
     });
 
-    bool streamUsageSupported = std::find_if(mRankedVideoStreamPriorities.begin(), mRankedVideoStreamPriorities.end(),
-                                             [&commandData](const StreamUsageEnum & entry) {
-                                                 return entry == commandData.streamUsage;
-                                             }) != mRankedVideoStreamPriorities.end();
-
-    VerifyOrReturn(streamUsageSupported, ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidInState));
-
     VerifyOrReturn(commandData.minFrameRate >= 1 && commandData.minFrameRate <= commandData.maxFrameRate &&
                        commandData.maxFrameRate >= 1,
                    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
@@ -1644,6 +1637,13 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
     VerifyOrReturn(commandData.minFragmentLen <= commandData.maxFragmentLen &&
                        commandData.maxFragmentLen <= kMaxFragmentLenMaxValue,
                    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+
+    bool streamUsageSupported = std::find_if(mRankedVideoStreamPriorities.begin(), mRankedVideoStreamPriorities.end(),
+                                             [&commandData](const StreamUsageEnum & entry) {
+                                                 return entry == commandData.streamUsage;
+                                             }) != mRankedVideoStreamPriorities.end();
+
+    VerifyOrReturn(streamUsageSupported, ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidInState));
 
     VideoStreamStruct videoStreamArgs;
     videoStreamArgs.videoStreamID    = 0;
@@ -1748,13 +1748,6 @@ void CameraAVStreamMgmtServer::HandleAudioStreamAllocate(HandlerContext & ctx,
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
     });
 
-    bool streamUsageSupported = std::find_if(mRankedVideoStreamPriorities.begin(), mRankedVideoStreamPriorities.end(),
-                                             [&commandData](const StreamUsageEnum & entry) {
-                                                 return entry == commandData.streamUsage;
-                                             }) != mRankedVideoStreamPriorities.end();
-
-    VerifyOrReturn(streamUsageSupported, ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidInState));
-
     VerifyOrReturn(commandData.audioCodec != AudioCodecEnum::kUnknownEnumValue, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid audio codec", mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
@@ -1779,6 +1772,13 @@ void CameraAVStreamMgmtServer::HandleAudioStreamAllocate(HandlerContext & ctx,
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid channel count", mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
     });
+
+    bool streamUsageSupported = std::find_if(mRankedVideoStreamPriorities.begin(), mRankedVideoStreamPriorities.end(),
+                                             [&commandData](const StreamUsageEnum & entry) {
+                                                 return entry == commandData.streamUsage;
+                                             }) != mRankedVideoStreamPriorities.end();
+
+    VerifyOrReturn(streamUsageSupported, ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidInState));
 
     AudioStreamStruct audioStreamArgs;
     audioStreamArgs.audioStreamID  = 0;

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -614,6 +614,11 @@ private:
 
     CHIP_ERROR StoreRankedVideoStreamPriorities();
     CHIP_ERROR LoadRankedVideoStreamPriorities();
+
+    void ModifyVideoStream(const uint16_t streamID, const Optional<bool> waterMarkEnabled, const Optional<bool> osdEnabled);
+
+    void ModifySnapshotStream(const uint16_t streamID, const Optional<bool> waterMarkEnabled, const Optional<bool> osdEnabled);
+
     /**
      * @brief Inherited from CommandHandlerInterface
      */


### PR DESCRIPTION
--Modify Wmark and OSD for VideoStream Modify function. 
--Enable the optional Wmark and OSD features for verification of stream modify functions.
--Update error handling for stream modify and de-allocation.


#### Testing
* Commission chip-camera-app
* Allocate VideoStream/Snapshot streams
* Re-allocate stream with same params. Get back same StreamID.
* Issue StreamModify/StreamDeallocate commands and check AllocatedStreams attribute.