### PR TITLE
Add more clearing of endpoint ID from test trigger event codes.

### DIFF
--- a/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
+++ b/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
@@ -58,6 +58,7 @@ public:
 
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         // WARNING: LEGACY SUPPORT ONLY, DO NOT EXTEND FOR STANDARD CLUSTERS
         return (AmebaHandleGlobalTestEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
     }

--- a/examples/platform/infineon/cyw30739/EventManagementTestEventTriggerHandler.cpp
+++ b/examples/platform/infineon/cyw30739/EventManagementTestEventTriggerHandler.cpp
@@ -27,6 +27,7 @@ namespace CYW30739 {
 
 CHIP_ERROR EventManagementTestEventTriggerHandler::HandleEventTrigger(uint64_t eventTrigger)
 {
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
     switch (eventTrigger)
     {
     case kFillUpEventLoggingBuffer:

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -374,6 +374,7 @@ class SampleTestEventTriggerHandler : public TestEventTriggerHandler
 public:
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         ChipLogProgress(Support, "Saw TestEventTrigger: " ChipLogFormatX64, ChipLogValueX64(eventTrigger));
 
         if (eventTrigger == kSampleTestEventTriggerAlwaysSuccess)

--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -119,7 +119,7 @@ void SmokeCoAlarmManager::EndSelfTestingEventHandler(AppEvent * aEvent)
 
 CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
 {
-    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+    eventTrigger           = clearEndpointInEventTrigger(eventTrigger);
     SmokeCOTrigger trigger = static_cast<SmokeCOTrigger>(eventTrigger);
 
     switch (trigger)

--- a/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
+++ b/examples/smoke-co-alarm-app/silabs/src/SmokeCoAlarmManager.cpp
@@ -119,6 +119,7 @@ void SmokeCoAlarmManager::EndSelfTestingEventHandler(AppEvent * aEvent)
 
 CHIP_ERROR SmokeCoAlarmManager::HandleEventTrigger(uint64_t eventTrigger)
 {
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
     SmokeCOTrigger trigger = static_cast<SmokeCOTrigger>(eventTrigger);
 
     switch (trigger)

--- a/src/app/TestEventTriggerDelegate.h
+++ b/src/app/TestEventTriggerDelegate.h
@@ -20,8 +20,9 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/IntrusiveList.h>
 #include <lib/support/Span.h>
-#include <stddef.h>
-#include <stdint.h>
+
+#include <cstddef>
+#include <cstdint>
 
 namespace chip {
 
@@ -38,7 +39,7 @@ public:
      */
     virtual CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) = 0;
 
-    uint64_t clearEndpointInEventTrigger(uint64_t eventTrigger)
+    static constexpr uint64_t clearEndpointInEventTrigger(uint64_t eventTrigger)
     {
         uint64_t endpointMask = 0x0000FFFF00000000;
         return eventTrigger & ~endpointMask;

--- a/src/app/TestEventTriggerDelegate.h
+++ b/src/app/TestEventTriggerDelegate.h
@@ -30,6 +30,7 @@ class TestEventTriggerHandler : public IntrusiveListNodeBase<IntrusiveMode::Auto
 {
 public:
     virtual ~TestEventTriggerHandler() = default;
+
     /**
      * Handles the test event trigger based on `eventTrigger` provided.
      *

--- a/src/app/TestEventTriggerDelegate.h
+++ b/src/app/TestEventTriggerDelegate.h
@@ -41,8 +41,8 @@ public:
 
     static constexpr uint64_t clearEndpointInEventTrigger(uint64_t eventTrigger)
     {
-        uint64_t endpointMask = 0x0000FFFF00000000;
-        return eventTrigger & ~endpointMask;
+        constexpr uint64_t kEndpointMask = 0x0000FFFF00000000;
+        return eventTrigger & ~kEndpointMask;
     }
 };
 

--- a/src/app/clusters/commodity-price-server/CommodityPriceTestEventTriggerHandler.h
+++ b/src/app/clusters/commodity-price-server/CommodityPriceTestEventTriggerHandler.h
@@ -60,6 +60,7 @@ public:
 
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         if (HandleCommodityPriceTestEventTrigger(eventTrigger))
         {
             return CHIP_NO_ERROR;

--- a/src/app/clusters/electrical-grid-conditions-server/ElectricalGridConditionsTestEventTriggerHandler.h
+++ b/src/app/clusters/electrical-grid-conditions-server/ElectricalGridConditionsTestEventTriggerHandler.h
@@ -62,6 +62,7 @@ public:
 
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         if (HandleElectricalGridConditionsTestEventTrigger(eventTrigger))
         {
             return CHIP_NO_ERROR;

--- a/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.cpp
+++ b/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.cpp
@@ -27,7 +27,7 @@ namespace chip {
 
 CHIP_ERROR GenericFaultTestEventTriggerHandler::HandleEventTrigger(uint64_t eventTrigger)
 {
-
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
     if (eventTrigger == kGenericFaultQueryTrigger)
     {
         // Fault injection

--- a/src/app/clusters/meter-identification-server/MeterIdentificationTestEventTriggerHandler.h
+++ b/src/app/clusters/meter-identification-server/MeterIdentificationTestEventTriggerHandler.h
@@ -61,6 +61,7 @@ public:
      */
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         if (HandleMeterIdentificationTestEventTrigger(eventTrigger))
         {
             return CHIP_NO_ERROR;

--- a/src/app/clusters/ota-requestor/OTATestEventTriggerHandler.cpp
+++ b/src/app/clusters/ota-requestor/OTATestEventTriggerHandler.cpp
@@ -26,6 +26,7 @@ namespace chip {
 
 CHIP_ERROR OTATestEventTriggerHandler::HandleEventTrigger(uint64_t eventTrigger)
 {
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
     if ((eventTrigger & ~kOtaQueryFabricIndexMask) == kOtaQueryTrigger)
     {
         OTARequestorInterface * requestor = GetRequestorInstance();

--- a/src/app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h
+++ b/src/app/clusters/smoke-co-alarm-server/SmokeCOTestEventTriggerHandler.h
@@ -71,6 +71,7 @@ public:
     SmokeCOTestEventTriggerHandler() = default;
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         return HandleSmokeCOTestEventTrigger(eventTrigger) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
     }
 };

--- a/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsTestEventTriggerHandler.h
+++ b/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsTestEventTriggerHandler.h
@@ -58,6 +58,7 @@ public:
      */
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         if (HandleSoftwareDiagnosticsTestEventTrigger(eventTrigger))
         {
             return CHIP_NO_ERROR;

--- a/src/app/clusters/wifi-network-diagnostics-server/WiFiDiagnosticsTestEventTriggerHandler.h
+++ b/src/app/clusters/wifi-network-diagnostics-server/WiFiDiagnosticsTestEventTriggerHandler.h
@@ -66,6 +66,7 @@ public:
      */
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
+        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         if (HandleWiFiDiagnosticsTestEventTrigger(eventTrigger))
         {
             return CHIP_NO_ERROR;

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -676,7 +676,7 @@ void ICDManager::ExtendActiveMode(Milliseconds16 extendDuration)
 
 CHIP_ERROR ICDManager::HandleEventTrigger(uint64_t eventTrigger)
 {
-    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+    eventTrigger                     = clearEndpointInEventTrigger(eventTrigger);
     ICDTestEventTriggerEvent trigger = static_cast<ICDTestEventTriggerEvent>(eventTrigger);
     CHIP_ERROR err                   = CHIP_NO_ERROR;
 

--- a/src/app/icd/server/ICDManager.cpp
+++ b/src/app/icd/server/ICDManager.cpp
@@ -676,6 +676,7 @@ void ICDManager::ExtendActiveMode(Milliseconds16 extendDuration)
 
 CHIP_ERROR ICDManager::HandleEventTrigger(uint64_t eventTrigger)
 {
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
     ICDTestEventTriggerEvent trigger = static_cast<ICDTestEventTriggerEvent>(eventTrigger);
     CHIP_ERROR err                   = CHIP_NO_ERROR;
 


### PR DESCRIPTION
#37921  introduced an encoding that changed test event trigger IDs to depend on endpoints. Most clusters are not aware of this and in particular SEPR_2_2 test breaks.

#### Testing

CI will test this. In particular I expect SEPR_2_2 test to start passing again.
Tested locally:

```
> : ./scripts/tests/local.py python-tests --test-filter SEPR
2025-05-06 09:07:55 INFO    Defaults read from 'out/local_py.ini'
Running tests |████████████████████████████████████████| 3/3 [100%] in 11.9s (0.21/s)
Script            Duration(sec)  Status
--------------  ---------------  --------
TC_SEPR_2_2.py          3.50535  PASS
TC_SEPR_2_3.py          3.80294  PASS
TC_SEPR_2_1.py          4.45061  PASS

```

