### PR TITLE
Add new test to check that _deviceMayBeReachable switches the device's state to notReachable

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -24,6 +24,7 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 @interface MTRDeviceTestDelegate : NSObject <MTRDeviceDelegate>
 @property (nonatomic, nullable) dispatch_block_t onReachable;
 @property (nonatomic, nullable) dispatch_block_t onNotReachable;
+@property (nonatomic, nullable) dispatch_block_t onInternalStateChanged;
 @property (nonatomic, nullable) MTRDeviceTestDelegateDataHandler onAttributeDataReceived;
 @property (nonatomic, nullable) MTRDeviceTestDelegateDataHandler onEventDataReceived;
 @property (nonatomic, nullable) dispatch_block_t onReportBegin;

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
@@ -26,6 +26,13 @@
     }
 }
 
+- (void)_deviceInternalStateChanged:(MTRDevice *)device
+{
+    if (self.onInternalStateChanged != nil) {
+        self.onInternalStateChanged();
+    }
+}
+
 - (void)device:(MTRDevice *)device receivedAttributeReport:(NSArray<NSDictionary<NSString *, id> *> *)attributeReport
 {
     if (self.onAttributeDataReceived != nil) {

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
@@ -45,11 +45,24 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)startAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments payload:(NSString *)payload;
 
 /**
- * Same thing as startAppWithName, but also starts a controller on a test fabric, commissions the
+ * Same thing as startAppWithName, but also commissions the application on
+ * controller with the provided node ID.
+ */
+- (void)startCommissionedAppWithName:(NSString *)name
+                           arguments:(NSArray<NSString *> *)arguments
+                          controller:(MTRDeviceController *)controller
+                             payload:(NSString *)payload
+                              nodeID:(NSNumber *)nodeID;
+
+/**
+ * Same thing, but also starts a controller on a test fabric, commissions the
  * application with the provided node ID and returns the controller.  The app
  * and controller will be killed at the end of the current suite.
  */
-+ (nullable MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments payload:(NSString *)payload nodeID:(NSNumber *)nodeID;
++ (nullable MTRDeviceController *)startCommissionedAppWithName:(NSString *)name
+                                                     arguments:(NSArray<NSString *> *)arguments
+                                                       payload:(NSString *)payload
+                                                        nodeID:(NSNumber *)nodeID;
 
 /**
  * Same thing, but will decide on a commissioning payload itself instead of

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.m
@@ -110,13 +110,9 @@ static const uint16_t kBasePort = 5542 - kMinDiscriminator;
 #endif // HAVE_NSTASK
 }
 
-+ (MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments payload:(NSString *)payload nodeID:(NSNumber *)nodeID
++ (void)commissionAppWithController:(MTRDeviceController *)controller payload:(NSString *)payload
+                             nodeID:(NSNumber *)nodeID
 {
-    BOOL started = [self startAppWithName:name arguments:arguments payload:payload];
-    XCTAssertTrue(started);
-
-    MTRDeviceController * controller = [self createControllerOnTestFabric];
-
     XCTestExpectation * expectation = [[XCTestExpectation alloc] initWithDescription:@"Wait for commissioning to complete"];
 
     MTRTestControllerDelegate * delegate = [[MTRTestControllerDelegate alloc] initWithExpectation:expectation newNodeID:nodeID];
@@ -132,6 +128,25 @@ static const uint16_t kBasePort = 5542 - kMinDiscriminator;
     XCTAssertNil(error);
 
     XCTAssertEqual([XCTWaiter waitForExpectations:@[ expectation ] timeout:kPairingTimeoutInSeconds], XCTWaiterResultCompleted);
+}
+
+- (void)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments controller:(MTRDeviceController *)controller payload:(NSString *)payload
+                              nodeID:(NSNumber *)nodeID
+{
+    BOOL started = [self startAppWithName:name arguments:arguments payload:payload];
+    XCTAssertTrue(started);
+
+    [self.class commissionAppWithController:controller payload:payload nodeID:nodeID];
+}
+
++ (MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments payload:(NSString *)payload nodeID:(NSNumber *)nodeID
+{
+    MTRDeviceController * controller = [self createControllerOnTestFabric];
+
+    BOOL started = [self startAppWithName:name arguments:arguments payload:payload];
+    XCTAssertTrue(started);
+
+    [self commissionAppWithController:controller payload:payload nodeID:nodeID];
 
     return controller;
 }

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
@@ -53,6 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 // shut down the returned controller earlier.
 + (MTRDeviceController *)createControllerOnTestFabric;
 
+// Hook for tests to notify that they have started a controller themselves that
+// has test suite scope (and therefore the factory needs to stay alive that
+// long).
++ (void)controllerWithSuiteScopeCreatedBySubclass;
+
 // Provides access to the mock CoreBlueooth instance managed automatically by
 // this class. Bluetooth mocking is enabled for all tests (even those that don't
 // actively interact with it) to avoid issues with accessing the real Bluetooth

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -199,6 +199,11 @@ static MTRMockCB * sMockCB;
     return controller;
 }
 
++ (void)controllerWithSuiteScopeCreatedBySubclass
+{
+    sControllerFactoryScope = MTRTestScopeSuite; // Make sure we don't shut down the controller too early.
+}
+
 #if HAVE_NSTASK
 - (NSTask *)createTaskForPath:(NSString *)path
 {


### PR DESCRIPTION
Test to make sure that calling `MTRDevice`'s `_deviceMayBeReachable` method while we're subscribing switches the internal state of the device to unreachable.

#### Testing

Ran `MTRDeviceTests` locally.