### PR TITLE
adding vector header for mac UT compilation.

### DIFF
--- a/src/app/tests/TestClosureDimensionCluster.cpp
+++ b/src/app/tests/TestClosureDimensionCluster.cpp
@@ -25,6 +25,7 @@
 #include <pw_unit_test/framework.h>
 #include <system/SystemClock.h>
 #include <system/SystemTimer.h>
+#include <vector>
 
 using namespace chip::app::Clusters::ClosureDimension;
 


### PR DESCRIPTION
on Mac I was getting this error when compiling unit tests:

![Screenshot 2025-05-06 at 12 21 11](https://github.com/user-attachments/assets/7d1bd224-5a0c-4f1b-b6fc-4992f1fbf418)



#### Testing

`./scripts/build/build_examples.py --target darwin-arm64-tests build`

