### PR TITLE
[docs] add `cmake` to necessary dependencies

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -92,7 +92,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following command:
 
 ```
-sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
+sudo apt-get install cmake git gcc g++ pkg-config libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
      python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev \
      default-jre

--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -92,7 +92,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following command:
 
 ```
-sudo apt-get install cmake git gcc g++ pkg-config libssl-dev libdbus-1-dev \
+sudo apt-get install git gcc g++ pkg-config cmake libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
      python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev \
      default-jre


### PR DESCRIPTION
needed to build `libdatachannel`

should fix cert blocker #38254

#### Testing

ran into the same issue building generally on Raspberry Pi in Linux; installing `cmake` fixed that issue.