### PR TITLE
Complete subscription work item even if the MTRDevice went away.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -1418,7 +1418,11 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         MTRAsyncWorkItem * workItem = [[MTRAsyncWorkItem alloc] initWithQueue:self.queue];
         [workItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull completion) {
             mtr_strongify(self);
-            VerifyOrReturn(self, MTR_LOG_DEBUG("_scheduleSubscriptionPoolWork readyHandler called with nil MTRDevice"));
+            if (self == nil) {
+                MTR_LOG_DEBUG("_scheduleSubscriptionPoolWork readyHandler called with nil MTRDevice, nothing to do");
+                completion(MTRAsyncWorkComplete);
+                return;
+            }
 
             MTR_LOG("%@ - work item is ready to attempt pooled subscription", self);
             os_unfair_lock_lock(&self->_lock);

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2802,6 +2802,13 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
     NSArray<NSNumber *> * orderedDeviceIDs = [deviceOnboardingPayloads allKeys];
 
+    // We have one fake device, which we use an invalid node ID for, that we use
+    // to test what happens if a device is deallocated while its subscription
+    // work item is queued.
+    NSMutableArray<NSNumber *> * orderedDeviceIDsIncludingFake = [orderedDeviceIDs mutableCopy];
+    NSNumber * fakeDeviceID = @(0xFFFFFFFFFFFFFFFF);
+    [orderedDeviceIDsIncludingFake insertObject:fakeDeviceID atIndex:0];
+
     // Commission 5 devices
     for (NSNumber * deviceID in orderedDeviceIDs) {
         certificateIssuer.nextNodeID = deviceID;
@@ -2835,7 +2842,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     }
 
     NSMutableDictionary<NSNumber *, MTRDeviceTestDelegate *> * deviceDelegates = [NSMutableDictionary dictionary];
-    for (NSNumber * deviceID in orderedDeviceIDs) {
+    for (NSNumber * deviceID in orderedDeviceIDsIncludingFake) {
         deviceDelegates[deviceID] = [[MTRDeviceTestDelegate alloc] init];
     }
 
@@ -2845,7 +2852,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     __block NSUInteger subscriptionDequeueCount = 0;
     __block BOOL baseDeviceReadCompleted = NO;
 
-    for (NSNumber * deviceID in orderedDeviceIDs) {
+    for (NSNumber * deviceID in orderedDeviceIDsIncludingFake) {
         MTRDeviceTestDelegate * delegate = deviceDelegates[deviceID];
         delegate.pretendThreadEnabled = YES;
 
@@ -2874,11 +2881,39 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         };
         __weak __auto_type weakDelegate = delegate;
         delegate.onReportEnd = ^{
-            [subscriptionExpectations[deviceID] fulfill];
+            // We don't have a subscriptionExpectation for the fake device.
+            XCTestExpectation * subscriptionExpectation = subscriptionExpectations[deviceID];
+            if (subscriptionExpectation) {
+                [subscriptionExpectation fulfill];
+            }
             // reset callback so expectation not fulfilled twice, given the run time of this can be long due to subscription pool
             __strong __auto_type strongDelegate = weakDelegate;
             strongDelegate.onReportEnd = nil;
         };
+    }
+
+    // Schedule a job in the controller's pool that will not complete until the
+    // fake device is deallocated.
+    __auto_type * fakeDeviceDeletedExpectation = [self expectationWithDescription:@"Fake device deleted"];
+    MTRAsyncWorkItem * blockingWorkItem = [[MTRAsyncWorkItem alloc] initWithQueue:queue];
+    [blockingWorkItem setReadyHandler:^(id _Nonnull context, NSInteger retryCount, MTRAsyncWorkCompletionBlock _Nonnull completion) {
+        [self waitForExpectations:@[ fakeDeviceDeletedExpectation ] timeout:kTimeoutInSeconds];
+        completion(MTRAsyncWorkComplete);
+    }];
+    [controller.concurrentSubscriptionPool enqueueWorkItem:blockingWorkItem description:@"Waiting for fake device deletion"];
+
+    @autoreleasepool {
+        // Create our fake device and have it dealloc before the blockingWorkItem
+        // completes and hence before its subscription work item gets a chance
+        // to run (in the width-1 case).
+        MTRDeviceTestDelegate * delegate = deviceDelegates[fakeDeviceID];
+        // onSubscriptionPoolWorkComplete is called from dealloc
+        delegate.onSubscriptionCallbackDelete = ^{
+            [fakeDeviceDeletedExpectation fulfill];
+        };
+
+        __auto_type * device = [MTRDevice deviceWithNodeID:fakeDeviceID controller:controller];
+        [device setDelegate:delegate queue:queue];
     }
 
     for (NSNumber * deviceID in orderedDeviceIDs) {

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2903,7 +2903,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
     [controller.concurrentSubscriptionPool enqueueWorkItem:blockingWorkItem description:@"Waiting for fake device deletion"];
 
     @autoreleasepool {
-        // Create our fake device and have it dealloc before the blockingWorkItem
+        // Create our fake device and have it dealloc before the blocking WorkItem
         // completes and hence before its subscription work item gets a chance
         // to run (in the width-1 case).
         MTRDeviceTestDelegate * delegate = deviceDelegates[fakeDeviceID];

--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2907,7 +2907,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         // completes and hence before its subscription work item gets a chance
         // to run (in the width-1 case).
         MTRDeviceTestDelegate * delegate = deviceDelegates[fakeDeviceID];
-        // onSubscriptionPoolWorkComplete is called from dealloc
+        // onSubscriptionCallbackDelete is called from dealloc
         delegate.onSubscriptionCallbackDelete = ^{
             [fakeDeviceDeletedExpectation fulfill];
         };

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeDevice:(MTRDevice *)device;
 - (void)syncRunOnWorkQueue:(void (^)(void))block error:(NSError * __autoreleasing *)error;
 @property (nonatomic, readonly, nullable) id<MTRDeviceControllerDataStoreAttributeStoreMethods> controllerDataStore;
+@property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDeviceController *> * concurrentSubscriptionPool;
 @end
 
 @interface MTRDevice (Test)


### PR DESCRIPTION
If the MTRDevice went away between us queuing the pooled subscription work item and its readyHandler running, we could end up in a situation where that work item would never complete and hence the pool would get blocked.

#### Testing

Unit test added that fails without this fix.