### PR TITLE
Fix TC_EventTrigger

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -374,7 +374,6 @@ class SampleTestEventTriggerHandler : public TestEventTriggerHandler
 public:
     CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
     {
-        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
         ChipLogProgress(Support, "Saw TestEventTrigger: " ChipLogFormatX64, ChipLogValueX64(eventTrigger));
 
         if (eventTrigger == kSampleTestEventTriggerAlwaysSuccess)


### PR DESCRIPTION
#38512 was too agressive for adding clearing of endpoint id, this test uses a fixed number that has the "endpoint id" as not zero.

#### Testing

Local test:

```
> : ./scripts/tests/local.py python-tests --test-filter Event
2025-05-06 16:51:32 INFO    Defaults read from 'out/local_py.ini'
Running tests |████████████████████████████████████████| 1/1 [100%] in 4.0s (0.25/s)
Script                    Duration(sec)  Status
----------------------  ---------------  --------
TC_TestEventTrigger.py          3.93459  PASS
```