### PR TITLE
[ESP32] Fix the compilation error when LWIP_IPV6_NUM_ADDRESSES > 8.

### DIFF
--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -193,7 +193,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     esp_netif_t * netif     = esp_netif_next(NULL);
     NetworkInterface * head = NULL;
     uint8_t ipv6_addr_count = 0;
-    esp_ip6_addr_t ip6_addr[kMaxIPv6AddrCount];
+    esp_ip6_addr_t ip6_addr[LWIP_IPV6_NUM_ADDRESSES];
     if (netif == NULL)
     {
         ChipLogError(DeviceLayer, "Failed to get network interfaces");
@@ -245,7 +245,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 #endif
 
             static_assert(kMaxIPv6AddrCount <= UINT8_MAX, "Count might not fit in ipv6_addr_count");
-            static_assert(ArraySize(ip6_addr) >= LWIP_IPV6_NUM_ADDRESSES, "Not enough space for our addresses.");
             auto addr_count = esp_netif_get_all_ip6(ifa, ip6_addr);
             if (addr_count < 0)
             {


### PR DESCRIPTION
#### Problem 
- Compilation fails when LWIP_IPV6_NUM_ADDRESSES >8.

#### Change Overview
- Fix the compilation failure on v1.3-branch when LWIP_IPV6_NUM_ADDRESSES > 8 .
- This change is cherry-picked from this [PR commit](https://github.com/project-chip/connectedhomeip/pull/35114/commits/75117202b59a3fa95ca93bf4e01ceef26d5e9c8e).

#### Testing
- Tested the lighting-app esp32 with LWIP_IPV6_NUM_ADDRESSES = 12 before and after the change.
Steps:
```
- cd /path/to/lighting-app/esp32
- idf.py set-target esp32h2
- idf.py build

```