### PR TITLE
[NXP] Fix wifi commissioning issue when using wrong credentials

### DIFF
--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -204,7 +204,7 @@ CHIP_ERROR NXPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
 void NXPWiFiDriver::OnConnectWiFiNetwork(Status commissioningError, CharSpan debugText, int32_t connectStatus)
 {
     /* Commit wifi network credentials in flash only if the connexion succeeded */
-    if(commissioningError == NetworkCommissioning::Status::kSuccess)
+    if (commissioningError == NetworkCommissioning::Status::kSuccess)
         CommitConfiguration();
 
     if (mpConnectCallback != nullptr)

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -203,9 +203,11 @@ CHIP_ERROR NXPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
 
 void NXPWiFiDriver::OnConnectWiFiNetwork(Status commissioningError, CharSpan debugText, int32_t connectStatus)
 {
-    /* Commit wifi network credentials in flash only if the connexion succeeded */
+    /* Commit wifi network credentials in flash only if the connection succeeded */
     if (commissioningError == NetworkCommissioning::Status::kSuccess)
+    {
         CommitConfiguration();
+    }
 
     if (mpConnectCallback != nullptr)
     {

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -112,6 +112,17 @@ CHIP_ERROR NXPWiFiDriver::CommitConfiguration()
 
 CHIP_ERROR NXPWiFiDriver::RevertConfiguration()
 {
+    struct wlan_network searchedNetwork = { 0 };
+
+    /* If network was added we have to remove it (as the connection failed) from wifi driver to be able
+    to connect to another network next commissioning */
+    if (wlan_get_network_byname(mStagingNetwork.ssid, &searchedNetwork) == WM_SUCCESS)
+    {
+        if (wlan_remove_network(mStagingNetwork.ssid) != WM_SUCCESS)
+        {
+            return CHIP_ERROR_INTERNAL;
+        }
+    }
     mStagingNetwork = mSavedNetwork;
 
     return CHIP_NO_ERROR;
@@ -192,7 +203,9 @@ CHIP_ERROR NXPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
 
 void NXPWiFiDriver::OnConnectWiFiNetwork(Status commissioningError, CharSpan debugText, int32_t connectStatus)
 {
-    CommitConfiguration();
+    /* Commit wifi network credentials in flash only if the connexion succeeded */
+    if(commissioningError == NetworkCommissioning::Status::kSuccess)
+        CommitConfiguration();
 
     if (mpConnectCallback != nullptr)
     {


### PR DESCRIPTION
Fix wifi commissioning issue when using wrong credentials, example of failing scenario:
- Use chip-tool to commission RW612 but using a wrong wifi credential (wrong wifi-ssid or password)
- Due to the wrong wifi credential, RW612 cannot join wifi network until the fail-safe timer expire, RW612 go back to waiting for pairing mode, start ble adv again
- Use chip-tool to commission RW612 again, this time using the correct wifi credential
- Still RW612 cannot connect to wifi network

#### Testing

repeat the failing scenario and be able to connect network during the second try using correct wifi credential


