### PR TITLE
Add debug logs for test inet limits

### DIFF
--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -33,7 +33,9 @@
 
 #include <CHIPVersion.h>
 #include <inet/IPPrefix.h>
+#include <inet/InetConfig.h>
 #include <inet/InetError.h>
+#include <inet/UDPEndPoint.h>
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
@@ -42,9 +44,6 @@
 
 #include "TestInetCommon.h"
 #include "TestSetupSignalling.h"
-#include "inet/InetConfig.h"
-#include "inet/UDPEndPoint.h"
-#include "lib/support/logging/TextOnlyLogging.h"
 
 using namespace chip;
 using namespace chip::Inet;

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -42,6 +42,7 @@
 
 #include "TestInetCommon.h"
 #include "TestSetupSignalling.h"
+#include "inet/InetConfig.h"
 
 using namespace chip;
 using namespace chip::Inet;
@@ -391,7 +392,17 @@ TEST_F(TestInetEndPoint, TestInetEndPointLimit)
     for (int i = INET_CONFIG_NUM_UDP_ENDPOINTS; i >= 0; --i)
     {
         err = gUDP.NewEndPoint(&testUDPEP[i]);
-        EXPECT_EQ(err, (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL));
+
+        CHIP_ERROR expected_error = (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL);
+        if (err != expected_error)
+        {
+            // have a log to debug things
+            ChipLogError(Test, "UDP: Failure on index %d: (out of %d)", i, INET_CONFIG_NUM_UDP_ENDPOINTS);
+
+            // this will fail after the above log
+            EXPECT_EQ(err, expected_error);
+        }
+
         if (err == CHIP_NO_ERROR)
         {
             ++udpCount;
@@ -407,7 +418,15 @@ TEST_F(TestInetEndPoint, TestInetEndPointLimit)
     for (int i = INET_CONFIG_NUM_TCP_ENDPOINTS; i >= 0; --i)
     {
         err = gTCP.NewEndPoint(&testTCPEP[i]);
-        EXPECT_EQ(err, (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL));
+        CHIP_ERROR expected_error = (i ? CHIP_NO_ERROR : CHIP_ERROR_ENDPOINT_POOL_FULL);
+        if (err != expected_error)
+        {
+            // have a log to debug things
+            ChipLogError(Test, "TCP: Failure on index %d: (out of %d)", i, INET_CONFIG_NUM_TCP_ENDPOINTS);
+
+            // this will fail after the above log
+            EXPECT_EQ(err, expected_error);
+        }
         if (err == CHIP_NO_ERROR)
         {
             ++tcpCount;

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -423,7 +423,7 @@ TEST_F(TestInetEndPoint, TestInetEndPointLimit)
 #if INET_CONFIG_ENABLE_TCP_ENDPOINT
     // we assume NO open endpoints
     gTCP.ForEachEndPoint([](TCPEndPoint * ep) {
-        ChipLogError(Test, "NOTE: Unexpected UDP endpoint in use. Will free it");
+        ChipLogError(Test, "NOTE: Unexpected TCP endpoint in use. Will free it");
         ep->Free();
         return Loop::Continue;
     });


### PR DESCRIPTION
TestInetEndPoint.TestInetEndPointLimit seems to be flaky, hard to figure out why.

Add some debug logs.

#### Testing

Manually introduced a failure (increased loop counts by one) and observed failure logs:

```
2025-05-07 09:27:40 INFO    [1746624460.543] [2344033:2344033] [IN] UDP endpoint pool FULL
2025-05-07 09:27:40 INFO    [1746624460.543] [2344033:2344033] [TST] UDP: Failure on index 1: (out of 64)
2025-05-07 09:27:40 INFO    src/inet/tests/TestInetEndPoint.cpp:403: Failure
2025-05-07 09:27:40 INFO          Expected: err == expected_error
2025-05-07 09:27:40 INFO            Actual: CHIP_ERROR:<c1> == CHIP_NO_ERROR
```
