### PR TITLE
Bump timeout on Java tests that were timing-out

### DIFF
--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -128,7 +128,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run IM Invoke Test
@@ -141,7 +141,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run IM Extendable Invoke Test
@@ -154,7 +154,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-extendable-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-im-extendable-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run IM Read Test
@@ -167,7 +167,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
+                     --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 8000" \
                      --factoryreset \
                   '
             - name: Run IM Write Test
@@ -180,7 +180,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run IM Subscribe Test
@@ -193,7 +193,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
+                     --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing AlreadyDiscovered Test
@@ -206,7 +206,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
+                     --tool-args "already-discovered --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing Address-PaseOnly Test
@@ -219,7 +219,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 1000" \
+                     --tool-args "address-paseonly --nodeid 1 --setup-pin-code 20202021 --address ::1 --port 5540 -t 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing SetupQRCode Test
@@ -232,7 +232,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "code --nodeid 1 --setup-payload MT:-24J0AFN00KA0648G00 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
+                     --tool-args "code --nodeid 1 --setup-payload MT:-24J0AFN00KA0648G00 --discover-once 1 --use-only-onnetwork-discovery 0 -t 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing ManualCode Test
@@ -245,7 +245,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "code --nodeid 1 --setup-payload 34970112332 --discover-once 1 --use-only-onnetwork-discovery 0 -t 1000" \
+                     --tool-args "code --nodeid 1 --setup-payload 34970112332 --discover-once 1 --use-only-onnetwork-discovery 0 -t 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing ICD Onnetwork Test
@@ -258,7 +258,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing ICD Onnetwork and OTA test
@@ -271,7 +271,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "ota" \
-                     --tool-args "onnetwork-long-ota-over-bdx  --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-ota-over-bdx  --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Pairing Onnetwork and get diagnostic log Test
@@ -282,7 +282,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1 --crash_log ./crashLog.log --end_user_support_log ./enduser.log --network_diagnostics_log ./network.log" \
                      --tool-path out/linux-x64-java-matter-controller \
                      --tool-cluster "bdx" \
-                     --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000 --logType CrashLogs --fileName ./crashLog.log" \
+                     --tool-args "onnetwork-long-downloadLog --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 3000 --logType CrashLogs --fileName ./crashLog.log" \
                      --factoryreset \
                   '
             - name: Run Pairing Onnetwork Test
@@ -295,7 +295,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "pairing" \
-                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Kotlin IM Invoke Test
@@ -308,7 +308,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-im-invoke --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Kotlin IM Read Test
@@ -321,7 +321,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
+                     --tool-args "onnetwork-long-im-read --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Kotlin IM Write Test
@@ -334,7 +334,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 1000" \
+                     --tool-args "onnetwork-long-im-write --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 5000" \
                      --factoryreset \
                   '
             - name: Run Kotlin IM Subscribe Test
@@ -347,7 +347,7 @@ jobs:
                      --app-args "--discriminator 3840 --interface-id -1" \
                      --tool-path out/linux-x64-kotlin-matter-controller \
                      --tool-cluster "im" \
-                     --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 -t 3000" \
+                     --tool-args "onnetwork-long-im-subscribe --nodeid 1 --setup-pin-code 20202021 --discriminator 3840 --timeout 8000" \
                      --factoryreset \
                   '
             - name: Uploading core files


### PR DESCRIPTION
- Add 5 seconds to the tests since the runners are now slower somehow.

#### Testing

- Works locally, and will be monitoring the CI
