### PR TITLE
Move discovery timeout from 3 seconds to 10 seconds

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -211,7 +211,7 @@ class BaseTestHelper:
         return ctypes.string_at(addrStrStorage).decode("utf-8")
 
     async def TestDiscovery(self, discriminator: int):
-        DISCOVERY_TIMEOUT_SECONDS=10
+        DISCOVERY_TIMEOUT_SECONDS = 10
         self.logger.info(
             f"Discovering commissionable nodes with discriminator {discriminator} a with {DISCOVERY_TIMEOUT_SECONDS} timeout.")
         res = await self.devCtrl.DiscoverCommissionableNodes(

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -211,10 +211,11 @@ class BaseTestHelper:
         return ctypes.string_at(addrStrStorage).decode("utf-8")
 
     async def TestDiscovery(self, discriminator: int):
+        DISCOVERY_TIMEOUT_SECONDS=10
         self.logger.info(
-            f"Discovering commissionable nodes with discriminator {discriminator}")
+            f"Discovering commissionable nodes with discriminator {discriminator} a with {DISCOVERY_TIMEOUT_SECONDS} timeout.")
         res = await self.devCtrl.DiscoverCommissionableNodes(
-            chip.discovery.FilterType.LONG_DISCRIMINATOR, discriminator, stopOnFirst=True, timeoutSecond=3)
+            chip.discovery.FilterType.LONG_DISCRIMINATOR, discriminator, stopOnFirst=True, timeoutSecond=DISCOVERY_TIMEOUT_SECONDS)
         if not res:
             self.logger.info(
                 "Device not found")


### PR DESCRIPTION
Switching the discovery timeout to 10 seconds instead of 3.
This is to test if github CI all of the sudden uses slower runners (we already had java timing out on 1 second commissioning)

#### Testing

Testing if CI for REPL passes (and after how much time).