### PR TITLE
[HVAC] fix TRV attr MinSetpointDeadBand shall allow 0-127 but ignore any attempted change

### DIFF
--- a/src/app/clusters/thermostat-server/thermostat-server.cpp
+++ b/src/app/clusters/thermostat-server/thermostat-server.cpp
@@ -720,6 +720,18 @@ CHIP_ERROR ThermostatAttrAccess::Write(const ConcreteDataAttributePath & aPath, 
 
     switch (aPath.mAttributeId)
     {
+    case MinSetpointDeadBand::Id: {
+        int8_t minSetpointDeadBand;
+        ReturnErrorOnFailure(aDecoder.Decode(minSetpointDeadBand));
+        if (minSetpointDeadBand < 0) // || (minSetpointDeadBand > 127): type is int8_t, check is skipped
+        {
+            return CHIP_IM_GLOBAL_STATUS(ConstraintError);
+        }
+        // Spec requirement: For backwards compatiblity, this attribute is optionally writable. However any
+        // writes to this attribute SHALL be silently ignored.
+        return CHIP_NO_ERROR;
+    }
+    break;
     case RemoteSensing::Id:
         if (localTemperatureNotExposedSupported)
         {

--- a/src/python_testing/TC_TSTAT_2_2.py
+++ b/src/python_testing/TC_TSTAT_2_2.py
@@ -592,15 +592,19 @@ class TC_TSTAT_2_2(MatterBaseTest):
         # Test Harness Reads MinSetpointDeadBand attribute from Server DUT and verifies that the value is within range
         if self.pics_guard(hasAutoModeFeature):
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
-            asserts.assert_less_equal(val, 25)
+            asserts.assert_less_equal(val, 127)
+            asserts.assert_greater_equal(val, 0)
 
             if self.pics_guard(self.check_pics("TSTAT.S.M.MinSetpointDeadBandWritable")):
-                # Test Harness Writes a value back that is different but valid for MinSetpointDeadBand attribute
-                await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(5), endpoint_id=endpoint)
+                validval = val - 1 if val > 0 else 5    # only non-negative integer smaller than val is guaranteed valid
+                # otherwise if val = 0 then randomly pick 5 for testing as the write will always be discarded
 
-                # Test Harness Reads it back again to confirm the successful write of MinSetpointDeadBand attribute
-                val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
-                asserts.assert_equal(val, 5)
+                # Test Harness Writes a value back that is different but valid for MinSetpointDeadBand attribute
+                await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(validval), endpoint_id=endpoint)
+
+                # Test Harness Reads it back again to confirm the write of MinSetpointDeadBand attribute is discarded
+                newval = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
+                asserts.assert_equal(val, newval)
 
         self.step("11b")
 
@@ -610,17 +614,27 @@ class TC_TSTAT_2_2(MatterBaseTest):
             asserts.assert_equal(status, Status.ConstraintError)
 
             # Test Harness Writes the value above MinSetpointDeadBand
-            status = await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(30), endpoint_id=endpoint, expect_success=False)
+            status = await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(128), endpoint_id=endpoint, expect_success=False)
             asserts.assert_equal(status, Status.ConstraintError)
 
         self.step("11c")
 
         if self.pics_guard(hasAutoModeFeature and self.check_pics("TSTAT.S.M.MinSetpointDeadBandWritable")):
+            val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
+
             # Test Harness Writes the min limit of MinSetpointDeadBand
             await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(0), endpoint_id=endpoint)
 
+            # Test Harness Reads it back again to confirm the write of MinSetpointDeadBand attribute is discarded
+            newval = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
+            asserts.assert_equal(val, newval)
+
             # Test Harness Writes the max limit of MinSetpointDeadBand
-            await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(25), endpoint_id=endpoint)
+            await self.write_single_attribute(attribute_value=cluster.Attributes.MinSetpointDeadBand(127), endpoint_id=endpoint)
+
+            # Test Harness Reads it back again to confirm the write of MinSetpointDeadBand attribute is discarded
+            newval = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.MinSetpointDeadBand)
+            asserts.assert_equal(val, newval)
 
         self.step("12")
 


### PR DESCRIPTION
* Updated MinSetpointDeadBand range from 0-25 to 0-127
* Discard any attemped changes
* Refer to cluster specification v1.4 section 4.3.9.21

### Testing
* Automated testing
* Unit tests updated for 11a, 11b, 11c in TC_TSTAT_2_2
* MTH tests on the above cases pass