### PR TITLE
examples/tv-casting-app: move CommissionerDeclarationHandler cleanup to stop() flow

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/matter/casting/core/CastingApp.java
@@ -167,6 +167,7 @@ public final class CastingApp {
       Log.e(TAG, "CastingApp.stop failed to stop Matter server");
       return MatterError.CHIP_ERROR_INCORRECT_STATE;
     }
+    finishStopping();
     mState =
         CastingAppState.NOT_RUNNING; // CastingApp stopped successfully, set state to NOT_RUNNING
 
@@ -192,6 +193,9 @@ public final class CastingApp {
 
   /** Performs post Matter server startup registrations */
   private native MatterError finishStartup();
+
+  /** Performs cleanup after stopping Matter server */
+  private native void finishStopping();
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/core/CastingApp-JNI.cpp
@@ -127,15 +127,21 @@ JNI_METHOD(jobject, finishStartup)(JNIEnv *, jobject)
     return support::convertMatterErrorFromCppToJava(CHIP_NO_ERROR);
 }
 
-JNI_METHOD(jobject, shutdownAllSubscriptions)(JNIEnv * env, jobject)
+JNI_METHOD(void, finishStopping)(JNIEnv *, jobject)
 {
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "CastingApp-JNI::shutdownAllSubscriptions() called");
+    ChipLogProgress(AppServer, "CastingApp-JNI::finishStopping() called");
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
     // Remove the handler previously set for Commissioner's CommissionerDeclaration messages.
     chip::Server::GetInstance().GetUserDirectedCommissioningClient()->SetCommissionerDeclarationHandler(nullptr);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+}
+
+JNI_METHOD(jobject, shutdownAllSubscriptions)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "CastingApp-JNI::shutdownAllSubscriptions() called");
 
     CHIP_ERROR err = matter::casting::core::CastingApp::GetInstance()->ShutdownAllSubscriptions();
     return support::convertMatterErrorFromCppToJava(err);


### PR DESCRIPTION
#### Change summary
For the commissioner generated passcode flow, the android tv-casting-app code was setting the CommissionerDeclarationHandler in the `CastingApp.start()` method but cleaning it up in the `CastingApp.shutdownSubscriptions()` method. The cleanup was misplaced. This PR moves the cleanup to a call from the `CastingApp.stop()` method (counterpart to CastingApp.start())

#### Testing
Built and tested android tv-casting-app with linux tv-app
