### PR TITLE
tv-casting-app/tv-app target app, commissioner passcode flow

### DIFF
--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -272,8 +272,8 @@ std::vector<SupportedCluster> make_default_supported_clusters()
 ContentAppFactoryImpl::ContentAppFactoryImpl() :
     mContentApps{ new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", make_default_supported_clusters(),
                                      nullptr, nullptr),
-                  new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021",
-                                     make_default_supported_clusters(), nullptr, nullptr),
+                  new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "0", make_default_supported_clusters(),
+                                     nullptr, nullptr),
                   new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", make_default_supported_clusters(),
                                      nullptr, nullptr),
                   new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021",

--- a/examples/tv-app/linux/README.md
+++ b/examples/tv-app/linux/README.md
@@ -70,6 +70,19 @@ Begin commissioning it by running
 
     $ controller ux ok
 
+The TV content app will check if has a hard coded passcode available, and if so,
+attempt commissioning with it. If no passcode is available, it will ask for the
+commissionable node's (commissionee) generated passcode.
+
+```
+CHIP:CTL: ------PROMPT USER: please enter passcode displayed in casting app
+CHIP:CTL: ------Via Shell Enter: controller ux ok [passcode]
+```
+
+Continue commissioning by providing the commissionee passcode
+
+    $ controller ux ok 20202021
+
 -   User Directed Commissioning (UDC)
 
 Print out the cached list of UDC sessions

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -107,6 +107,9 @@ class MyPasscodeService : public PasscodeService
     void LookupTargetContentApp(uint16_t vendorId, uint16_t productId, chip::CharSpan rotatingId,
                                 chip::Protocols::UserDirectedCommissioning::TargetAppInfo & info) override
     {
+        ChipLogProgress(DeviceLayer,
+                        "LookupTargetContentApp() client vendorID=%d productID=%d; TargetAppInfo vendorID=%d productID=%d",
+                        vendorId, productId, info.vendorId, info.productId);
         uint32_t passcode = 0;
         bool foundApp     = ContentAppPlatform::GetInstance().HasTargetContentApp(vendorId, productId, rotatingId, info, passcode);
         if (!foundApp)
@@ -653,7 +656,7 @@ void ContentAppFactoryImpl::InstallContentApp(uint16_t vendorId, uint16_t produc
     }
     else if (vendorId == 65521 && productId == 32769)
     {
-        auto ptr = std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "20202021",
+        auto ptr = std::make_unique<ContentAppImpl>("Vendor2", vendorId, "exampleString", productId, "Version2", "0",
                                                     make_default_supported_clusters());
         mContentApps.emplace_back(std::move(ptr));
     }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ApplicationBasicReadVendorIDExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ApplicationBasicReadVendorIDExampleFragment.java
@@ -37,7 +37,6 @@ import com.matter.casting.core.Endpoint;
 public class ApplicationBasicReadVendorIDExampleFragment extends Fragment {
   private static final String TAG =
       ApplicationBasicReadVendorIDExampleFragment.class.getSimpleName();
-  private static final int DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1;
 
   private final CastingPlayer selectedCastingPlayer;
   private final boolean useCommissionerGeneratedPasscode;
@@ -75,20 +74,8 @@ public class ApplicationBasicReadVendorIDExampleFragment extends Fragment {
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     this.readButtonClickListener =
         v -> {
-          Endpoint endpoint;
-          if (useCommissionerGeneratedPasscode) {
-            // For the example Commissioner-Generated passcode commissioning flow, run demo
-            // interactions with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this
-            // flow, we commissioned with the Target Content Application with Vendor ID 1111. Since
-            // this target content application does not report its Endpoint's Vendor IDs, we find
-            // the desired endpoint based on the Endpoint ID. See
-            // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
-            endpoint =
-                EndpointSelectorExample.selectEndpointById(
-                    selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);
-          } else {
-            endpoint = EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
-          }
+          Endpoint endpoint =
+              EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
           if (endpoint == null) {
             Log.e(TAG, "No Endpoint with sample vendorID found on CastingPlayer");
             return;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ConnectionExampleFragment.java
@@ -47,9 +47,6 @@ public class ConnectionExampleFragment extends Fragment {
   // Must be >= 3 minutes.
   private static final short MIN_CONNECTION_TIMEOUT_SEC = 3 * 60;
   private static final Integer DESIRED_TARGET_APP_VENDOR_ID = 65521;
-  // Use this Target Content Application Vendor ID, configured on the tv-app, to demonstrate the
-  // CastingPlayer/Commissioner-Generated passcode commissioning flow.
-  private static final Integer DESIRED_TARGET_APP_VENDOR_ID_FOR_CGP_FLOW = 1111;
   private static final long DEFAULT_COMMISSIONER_GENERATED_PASSCODE = 12345678;
   private static final int DEFAULT_DISCRIMINATOR_FOR_CGP_FLOW = 0;
   private final CastingPlayer targetCastingPlayer;
@@ -140,7 +137,6 @@ public class ConnectionExampleFragment extends Fragment {
                 // Set commissionerPasscode to true for CastingPlayer/Commissioner-Generated
                 // passcode commissioning.
                 idOptions = new IdentificationDeclarationOptions(false, false, true, false, false);
-                targetAppInfo = new TargetAppInfo(DESIRED_TARGET_APP_VENDOR_ID_FOR_CGP_FLOW);
                 Log.d(
                     TAG,
                     "onViewCreated() calling CastingPlayer.verifyOrEstablishConnection() Target Content Application Vendor ID: "

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ContentLauncherLaunchURLExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/ContentLauncherLaunchURLExampleFragment.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 public class ContentLauncherLaunchURLExampleFragment extends Fragment {
   private static final String TAG = ContentLauncherLaunchURLExampleFragment.class.getSimpleName();
   private static final Integer SAMPLE_ENDPOINT_VID = 65521;
-  private static final int DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1;
 
   private final CastingPlayer selectedCastingPlayer;
   private final boolean useCommissionerGeneratedPasscode;
@@ -75,20 +74,8 @@ public class ContentLauncherLaunchURLExampleFragment extends Fragment {
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
     this.launchUrlButtonClickListener =
         v -> {
-          Endpoint endpoint;
-          if (useCommissionerGeneratedPasscode) {
-            // For the example Commissioner-Generated passcode commissioning flow, run demo
-            // interactions with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this
-            // flow, we commissioned with the Target Content Application with Vendor ID 1111. Since
-            // this target content application does not report its Endpoint's Vendor IDs, we find
-            // the desired endpoint based on the Endpoint ID. See
-            // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
-            endpoint =
-                EndpointSelectorExample.selectEndpointById(
-                    selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);
-          } else {
-            endpoint = EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
-          }
+          Endpoint endpoint =
+              EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
           if (endpoint == null) {
             Log.e(TAG, "No Endpoint with sample vendorID found on CastingPlayer");
             return;

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/MediaPlaybackSubscribeToCurrentStateExampleFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/matter/casting/MediaPlaybackSubscribeToCurrentStateExampleFragment.java
@@ -40,7 +40,6 @@ import java.util.Date;
 public class MediaPlaybackSubscribeToCurrentStateExampleFragment extends Fragment {
   private static final String TAG =
       MediaPlaybackSubscribeToCurrentStateExampleFragment.class.getSimpleName();
-  private static final int DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1;
 
   private final CastingPlayer selectedCastingPlayer;
   private final boolean useCommissionerGeneratedPasscode;
@@ -77,19 +76,7 @@ public class MediaPlaybackSubscribeToCurrentStateExampleFragment extends Fragmen
   @Override
   public View onCreateView(
       LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-    Endpoint endpoint;
-    if (useCommissionerGeneratedPasscode) {
-      // For the example Commissioner-Generated passcode commissioning flow, run demo interactions
-      // with the Endpoint with ID DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW = 1. For this flow, we
-      // commissioned with the Target Content Application with Vendor ID 1111. Since this target
-      // content application does not report its Endpoint's Vendor IDs, we find the desired endpoint
-      // based on the Endpoint ID. See connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
-      endpoint =
-          EndpointSelectorExample.selectEndpointById(
-              selectedCastingPlayer, DEFAULT_ENDPOINT_ID_FOR_CGP_FLOW);
-    } else {
-      endpoint = EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
-    }
+    Endpoint endpoint = EndpointSelectorExample.selectFirstEndpointByVID(selectedCastingPlayer);
     if (endpoint == null) {
       Log.e(TAG, "No Endpoint with sample vendorID found on CastingPlayer");
       return inflater.inflate(

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/MCConnectionExampleViewModel.swift
@@ -27,14 +27,6 @@ class MCConnectionExampleViewModel: ObservableObject {
     
     // VendorId of the MCEndpoint on the MCCastingPlayer that the MCCastingApp desires to interact with after connection
     let kDesiredEndpointVendorId: UInt16 = 65521;
-
-    // VendorId of the MCEndpoint on the MCCastingPlayer that the MCCastingApp desires to interact with after connecting
-    // using the MCCastingPlayer/Commissioner-Generated passcode (CGP) commissioning flow.  Use this Target Content
-    // Application Vendor ID, which is configured on the tv-app. This Target Content Application Vendor ID (1111), does
-    // not implement the AccountLogin cluster, which would otherwise auto commission using the Commissionee-Generated
-    // passcode upon recieving the IdentificationDeclaration Message. See
-    // connectedhomeip/examples/tv-app/tv-common/include/AppTv.h.
-    let kDesiredEndpointVendorIdCGP: UInt16 = 1111;
     
     @Published var connectionSuccess: Bool?;
 
@@ -156,19 +148,17 @@ class MCConnectionExampleViewModel: ObservableObject {
         }
 
         let identificationDeclarationOptions: MCIdentificationDeclarationOptions
-        let targetAppInfo: MCTargetAppInfo
+        let targetAppInfo: MCTargetAppInfo = MCTargetAppInfo(vendorId: kDesiredEndpointVendorId)
         let connectionCallbacks: MCConnectionCallbacks
 
         if useCommissionerGeneratedPasscode {
             identificationDeclarationOptions = MCIdentificationDeclarationOptions(commissionerPasscodeOnly: true)
-            targetAppInfo = MCTargetAppInfo(vendorId: kDesiredEndpointVendorIdCGP)
             connectionCallbacks = MCConnectionCallbacks(
                 callbacks: connectionCompleteCallback,
                 commissionerDeclarationCallback: commissionerDeclarationCallback
             )
         } else {
             identificationDeclarationOptions = MCIdentificationDeclarationOptions()
-            targetAppInfo = MCTargetAppInfo(vendorId: kDesiredEndpointVendorId)
             connectionCallbacks = MCConnectionCallbacks(
                 callbacks: connectionCompleteCallback,
                 commissionerDeclarationCallback: commissionerDeclarationCallback

--- a/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/CastingPlayer.cpp
@@ -102,20 +102,23 @@ void CastingPlayer::VerifyOrEstablishConnection(ConnectionCallbacks connectionCa
     // as per IdentificationDeclarationOptions.mTargetAppInfos, simply Find or Re-establish the CASE session and return early.
     if (cachedCastingPlayers.size() != 0)
     {
-        ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() Re-establishing CASE with cached CastingPlayer");
+        ChipLogProgress(AppServer,
+                        "CastingPlayer::VerifyOrEstablishConnection() Checking cached CastingPlayer(s) for *this* CastingPlayer");
         it = std::find_if(cachedCastingPlayers.begin(), cachedCastingPlayers.end(),
                           [this](const core::CastingPlayer & castingPlayerParam) { return castingPlayerParam == *this; });
 
         // found the CastingPlayer in cache
         if (it != cachedCastingPlayers.end())
         {
-            ChipLogProgress(AppServer, "CastingPlayer::VerifyOrEstablishConnection() found this CastingPlayer in app cache");
+            ChipLogProgress(
+                AppServer,
+                "CastingPlayer::VerifyOrEstablishConnection() *this* CastingPlayer found in cache; checking for TargetApp(s)");
             unsigned index = (unsigned int) std::distance(cachedCastingPlayers.begin(), it);
             if (ContainsDesiredTargetApp(&cachedCastingPlayers[index], idOptions.getTargetAppInfoList()))
             {
                 ChipLogProgress(
                     AppServer,
-                    "CastingPlayer::VerifyOrEstablishConnection() calling FindOrEstablishSession on cached CastingPlayer");
+                    "CastingPlayer::VerifyOrEstablishConnection() Attempting to Re-establish CASE with cached CastingPlayer");
                 *this                          = cachedCastingPlayers[index];
                 mConnectionState               = CASTING_PLAYER_CONNECTING;
                 mOnCompleted                   = connectionCallbacks.mOnConnectionComplete;
@@ -314,6 +317,8 @@ void CastingPlayer::Disconnect()
 
 void CastingPlayer::RegisterEndpoint(const memory::Strong<Endpoint> endpoint)
 {
+    ChipLogProgress(AppServer, "CastingPlayer::RegisterEndpoint() EndpointID: %d, VendorID: %d, ProductID: %d", endpoint->GetId(),
+                    endpoint->GetVendorId(), endpoint->GetProductId());
     auto it = std::find_if(mEndpoints.begin(), mEndpoints.end(), [endpoint](const memory::Strong<Endpoint> & _endpoint) {
         return _endpoint->GetId() == endpoint->GetId();
     });
@@ -403,12 +408,13 @@ bool CastingPlayer::ContainsDesiredTargetApp(
                 match && (desiredTargetApps[i].productId == 0 || cachedEndpoint->GetProductId() == desiredTargetApps[i].productId);
             if (match)
             {
-                ChipLogProgress(AppServer, "CastingPlayer::ContainsDesiredTargetApp() matching cached CastingPlayer found");
+                ChipLogProgress(AppServer,
+                                "CastingPlayer::ContainsDesiredTargetApp() CastingPlayer's Endpoint(s) match Target App(s)");
                 return true;
             }
         }
     }
-    ChipLogProgress(AppServer, "CastingPlayer::ContainsDesiredTargetApp() matching cached CastingPlayer not found");
+    ChipLogError(AppServer, "CastingPlayer::ContainsDesiredTargetApp() CastingPlayer's Endpoints DO NOT match Target App(s)");
     return false;
 }
 

--- a/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
+++ b/examples/tv-casting-app/tv-casting-common/core/Endpoint.cpp
@@ -28,7 +28,8 @@ void Endpoint::RegisterClusters(std::vector<chip::ClusterId> clusters)
 {
     for (chip::ClusterId clusterId : clusters)
     {
-        ChipLogProgress(AppServer, "Endpoint::RegisterClusters() Registering clusterId %d for endpointId %d", clusterId, GetId());
+        ChipLogProgress(AppServer, "Endpoint::RegisterClusters() Registering clusterId %d for endpointId %d, vendorId: %d",
+                        clusterId, GetId(), GetVendorId());
         switch (clusterId)
         {
         case chip::app::Clusters::ApplicationBasic::Id:

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -47,6 +47,23 @@
 
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE 20202021
 
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
+ *
+ * 0xFFF1 (65521): Test Vendor #1 is reserved for test and development by device manufacturers or hobbyists. A Vendor Identifier
+ * (Vendor ID or VID) is a 16-bit number that uniquely identifies a particular product manufacturer, vendor, or group thereof.
+ * For production, replace with the Vendor ID allocated for you by the Connectivity Standards Alliance.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID
+ *
+ * 0x8001 (32769): A Product Identifier (Product ID or PID) is a 16-bit number that uniquely identifies a product of a vendor.
+ * The Product ID is assigned by the vendor and SHALL be unique for each product within a Vendor ID.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8001
+
 #define CHIP_DEVICE_CONFIG_USE_TEST_SETUP_DISCRIMINATOR 0xF00
 
 #define CHIP_DEVICE_CONFIG_DEVICE_NAME "Test TV casting app"

--- a/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/CastingStore.cpp
@@ -40,8 +40,8 @@ CastingStore * CastingStore::GetInstance()
 
 CHIP_ERROR CastingStore::AddOrUpdate(core::CastingPlayer castingPlayer)
 {
-    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() called with CastingPlayer deviceName: %s",
-                    castingPlayer.GetDeviceName());
+    ChipLogProgress(AppServer, "CastingStore::AddOrUpdate() called with CastingPlayer deviceName: %s, VendorID: %u, ProductID: %u",
+                    castingPlayer.GetDeviceName(), castingPlayer.GetVendorId(), castingPlayer.GetProductId());
 
     // Read cache of CastingPlayers
     std::vector<core::CastingPlayer> castingPlayers = ReadAll();
@@ -479,7 +479,9 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
 
     for (auto & castingPlayer : castingPlayers)
     {
-        ChipLogProgress(AppServer, "CastingStore::WriteAll() writing CastingPlayer:");
+        // ChipLogProgress(AppServer, "CastingStore::WriteAll() writing CastingPlayer:");
+        ChipLogProgress(AppServer, "CastingStore::WriteAll() writing CastingPlayer deviceName: %s, VendorID: %u, ProductID: %u",
+                        castingPlayer.GetDeviceName(), castingPlayer.GetVendorId(), castingPlayer.GetProductId());
         chip::TLV::TLVType castingPlayerContainerType;
         // CastingPlayer container starts
         ReturnErrorOnFailure(
@@ -512,8 +514,10 @@ CHIP_ERROR CastingStore::WriteAll(std::vector<core::CastingPlayer> castingPlayer
         std::vector<memory::Strong<core::Endpoint>> endpoints = core::CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
         for (auto & endpoint : endpoints)
         {
-            ChipLogProgress(AppServer, "CastingStore::WriteAll() writing CastingPlayer Endpoint with endpointId: %d",
-                            endpoint->GetId());
+            ChipLogProgress(
+                AppServer,
+                "CastingStore::WriteAll() writing CastingPlayer Endpoint with EndpointID: %d, VendorID: %d, ProductID: %d",
+                endpoint->GetId(), endpoint->GetVendorId(), endpoint->GetProductId());
             chip::TLV::TLVType endpointContainerType;
             // Endpoint container starts
             ReturnErrorOnFailure(

--- a/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/ChipDeviceEventHandler.cpp
@@ -35,7 +35,7 @@ bool ChipDeviceEventHandler::sUdcInProgress = false;
 
 void ChipDeviceEventHandler::Handle(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg)
 {
-    ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() called");
+    ChipLogProgress(AppServer, "ChipDeviceEventHandler::Handle() called with event type: %u", event->Type);
 
     // Make sure we have not disconnected from the TargetCastingPlayer when handling incoming messages.
     // Sometimes the tv-app will still send messages after we clean up the TargetCastingPlayer.

--- a/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
+++ b/examples/tv-casting-app/tv-casting-common/support/EndpointListLoader.cpp
@@ -109,7 +109,7 @@ CHIP_ERROR EndpointListLoader::Load()
         {
             // if we discovered a new Endpoint from the bindings, read its EndpointAttributes
             chip::EndpointId endpointId = binding.remote;
-            ChipLogProgress(AppServer, "EndpointListLoader::Load() Found new endpointId: %d", endpointId);
+            ChipLogProgress(AppServer, "EndpointListLoader::Load() Checking if endpointId: %d is new", endpointId);
             std::vector<memory::Strong<Endpoint>> endpoints = CastingPlayer::GetTargetCastingPlayer()->GetEndpoints();
             if (std::find_if(endpoints.begin(), endpoints.end(), [&endpointId](const memory::Strong<Endpoint> & endpoint) {
                     return endpoint->GetId() == endpointId;
@@ -149,7 +149,8 @@ void EndpointListLoader::Complete()
 
     if (mPendingAttributeReads == 0)
     {
-        ChipLogProgress(AppServer, "EndpointListLoader::Complete() Loading %lu endpoint(s)", mNewEndpointsToLoad);
+        ChipLogProgress(AppServer, "EndpointListLoader::Complete() Done reading attributes. Loading %lu endpoint(s)",
+                        mNewEndpointsToLoad);
         for (unsigned long i = 0; i < mNewEndpointsToLoad; i++)
         {
             EndpointAttributes endpointAttributes = mEndpointAttributesList[i];
@@ -212,6 +213,8 @@ CHIP_ERROR EndpointListLoader::ReadVendorId(EndpointAttributes * endpointAttribu
            chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo::DecodableArgType decodableVendorId) {
             EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
             _endpointAttributes->mVendorId           = decodableVendorId;
+            ChipLogProgress(AppServer, "EndpointListLoader::ReadVendorId() endpointId: %d, decodableVendorId: %d",
+                            _endpointAttributes->mId, decodableVendorId);
             EndpointListLoader::GetInstance()->Complete();
         },
         [](void * context, CHIP_ERROR err) {
@@ -233,6 +236,8 @@ CHIP_ERROR EndpointListLoader::ReadProductId(EndpointAttributes * endpointAttrib
            chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo::DecodableArgType decodableProductId) {
             EndpointAttributes * _endpointAttributes = static_cast<EndpointAttributes *>(context);
             _endpointAttributes->mProductId          = decodableProductId;
+            ChipLogProgress(AppServer, "EndpointListLoader::ReadProductId() endpointId: %d, decodableProductId: %d",
+                            _endpointAttributes->mId, decodableProductId);
             EndpointListLoader::GetInstance()->Complete();
         },
         [](void * context, CHIP_ERROR err) {

--- a/scripts/tests/linux/tv_casting_test_sequences.py
+++ b/scripts/tests/linux/tv_casting_test_sequences.py
@@ -71,8 +71,6 @@ VENDOR_ID = 0xFFF1  # 0xFFF1 = 65521; Spec 7.20.2.1 MEI code: test vendor IDs ar
 PRODUCT_ID = 0x8001  # 0x8001 = 32769 = Test product id
 DEVICE_TYPE_CASTING_VIDEO_PLAYER = 0x23  # 0x23 = 35 = Device type library 10.3: Casting Video Player
 
-# 0x457 = 1111 = Target Content Application Vendor ID for the commissioner generated passcode flow
-COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID = 0x457
 COMMISSIONER_GENERATED_PASSCODE = '0x00BC_614E'  # 0x00BC_614E = 12345678 = Default commissioner generated passcode
 
 # Value to verify the subscription state against in the Linux tv-casting-app output.
@@ -118,6 +116,12 @@ test_sequences = [
 
             # Send `controller ux ok\n` command to the tv-app subprocess.
             Step(app=App.TV_APP, input_cmd='controller ux ok\n'),
+
+            # Validate that we received the instructions on the tv-app output for sending the `controller ux ok [passcode]` command.
+            Step(app=App.TV_APP, output_msg=['Via Shell Enter: controller ux ok [passcode]']),
+
+            # Send `controller ux ok 20202021\n` command to the tv-app subprocess.
+            Step(app=App.TV_APP, input_cmd='controller ux ok 20202021\n'),
 
             # Validate that pairing succeeded between the tv-casting-app and the tv-app.
             Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),
@@ -179,10 +183,10 @@ test_sequences = [
             # mCommissionerPasscode:      true                        -> This flag instructs the commissioner to use the commissioner-generated-passcode flow for commissioning.
             # mCommissionerPasscodeReady: false                       -> This flag indicates that the commissionee has not obtained the commissioner passcode from the user and
             #                                                            thus is not ready for commissioning.
-            # Vendor ID: {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}  -> The initial VENDOR_ID of the casting player will be overridden to {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}.
-            #                                                            Otherwise we will enter the commissionee-generated-passcode flow.
+            # Vendor ID: {VENDOR_ID}                                  -> The target VENDOR_ID of the casting player is the same for both commissionee-generated-passcode and
+            #                                                            commissioner-generated-passcode flows.
             Step(app=App.TV_CASTING_APP, output_msg=['IdentificationDeclarationOptions::LogDetail()', 'IdentificationDeclarationOptions::mCommissionerPasscode:      true',
-                 'IdentificationDeclarationOptions::mCommissionerPasscodeReady: false', 'IdentificationDeclarationOptions::TargetAppInfos list:', f'TargetAppInfo 1, Vendor ID: {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}']),
+                 'IdentificationDeclarationOptions::mCommissionerPasscodeReady: false', 'IdentificationDeclarationOptions::TargetAppInfos list:', f'TargetAppInfo 1, Vendor ID: {VENDOR_ID}']),
 
             # Validate that we received the cast request from the tv-casting-app on the tv-app output.
             Step(app=App.TV_APP,
@@ -221,10 +225,10 @@ test_sequences = [
             # mCommissionerPasscode:      true                        -> This flag instructs the commissioner to use the commissioner-generated-passcode flow for commissioning.
             # mCommissionerPasscodeReady: true                        -> This flag indicates that the commissionee has obtained the commissioner passcode from the user and
             #                                                            thus is ready for commissioning.
-            # Vendor ID: {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}  -> The initial VENDOR_ID of the casting player will be overridden to {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}.
-            #                                                            Otherwise we will enter the commissionee-generated-passcode flow.
+            # Vendor ID: {VENDOR_ID}                                  -> The target VENDOR_ID of the casting player is the same for both commissionee-generated-passcode and
+            #                                                            commissioner-generated-passcode flows.
             Step(app=App.TV_CASTING_APP, output_msg=['IdentificationDeclarationOptions::LogDetail()', 'IdentificationDeclarationOptions::mCommissionerPasscode:      true',
-                                                     'IdentificationDeclarationOptions::mCommissionerPasscodeReady: true', 'IdentificationDeclarationOptions::TargetAppInfos list:', f'TargetAppInfo 1, Vendor ID: {COMMISSIONER_GENERATED_PASSCODE_VENDOR_ID}']),
+                                                     'IdentificationDeclarationOptions::mCommissionerPasscodeReady: true', 'IdentificationDeclarationOptions::TargetAppInfos list:', f'TargetAppInfo 1, Vendor ID: {VENDOR_ID}']),
 
             # Validate that pairing succeeded between the tv-casting-app and the tv-app.
             Step(app=App.TV_APP, output_msg=['Secure Pairing Success']),

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -324,13 +324,13 @@ ContentApp * ContentAppPlatform::LoadContentAppInternal(const CatalogVendorApp &
 
 ContentApp * ContentAppPlatform::LoadContentAppByClient(uint16_t vendorId, uint16_t productId)
 {
-    ChipLogProgress(DeviceLayer, "GetLoadContentAppByVendorId() - vendorId %d, productId %d", vendorId, productId);
+    ChipLogProgress(DeviceLayer, "LoadContentAppByVendorId() - vendorId %d, productId %d", vendorId, productId);
 
     CatalogVendorApp vendorApp;
     CHIP_ERROR err = mContentAppFactory->LookupCatalogVendorApp(vendorId, productId, &vendorApp);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetLoadContentAppByVendorId() - failed to find an app for vendorId %d, productId %d", vendorId,
+        ChipLogError(DeviceLayer, "LoadContentAppByVendorId() - failed to find an app for vendorId %d, productId %d", vendorId,
                      productId);
         return nullptr;
     }
@@ -514,7 +514,7 @@ bool ContentAppPlatform::HasTargetContentApp(uint16_t vendorId, uint16_t product
     ContentApp * app = LoadContentAppByClient(info.vendorId, info.productId);
     if (app == nullptr)
     {
-        ChipLogProgress(DeviceLayer, "no app found for vendor id=%d \r\n", info.vendorId);
+        ChipLogProgress(DeviceLayer, "no content app found for vendor id=%d \r\n", info.vendorId);
         return false;
     }
 
@@ -531,6 +531,8 @@ bool ContentAppPlatform::HasTargetContentApp(uint16_t vendorId, uint16_t product
         // if no match, then check allowed vendor list
         for (const auto & allowedVendor : app->GetApplicationBasicDelegate()->GetAllowedVendorList())
         {
+            ChipLogProgress(DeviceLayer, "HasTargetContentApp() allowedVendor id: %d, Client vendor id: %d", allowedVendor,
+                            vendorId);
             if (allowedVendor == vendorId)
             {
                 allow = true;
@@ -539,10 +541,10 @@ bool ContentAppPlatform::HasTargetContentApp(uint16_t vendorId, uint16_t product
         }
         if (!allow)
         {
-            ChipLogProgress(
-                DeviceLayer,
-                "no permission given by ApplicationBasic cluster on app with vendor id=%d to client with vendor id=%d\r\n",
-                info.vendorId, vendorId);
+            ChipLogProgress(DeviceLayer,
+                            "no permission given by ApplicationBasic cluster on Content App with vendor id=%d to Client "
+                            "(Commissionee) with vendor id=%d\r\n",
+                            info.vendorId, vendorId);
             return false;
         }
     }

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningServer.cpp
@@ -566,8 +566,9 @@ void UserDirectedCommissioningServer::PrintUDCClients()
             Encoding::BytesToUppercaseHexString(state->GetRotatingId(), chip::Dnssd::kMaxRotatingIdLen, rotatingIdString,
                                                 sizeof(rotatingIdString));
 
-            ChipLogProgress(AppServer, "UDC Client[%d] instance=%s deviceName=%s address=%s, vid/pid=%d/%d disc=%d rid=%s", i,
-                            state->GetInstanceName(), state->GetDeviceName(), addrBuffer, state->GetVendorId(),
+            ChipLogProgress(AppServer,
+                            "PrintUDCClients() UDC Client[%d] instance=%s deviceName=%s address=%s, vid/pid=%d/%d disc=%d rid=%s",
+                            i, state->GetInstanceName(), state->GetDeviceName(), addrBuffer, state->GetVendorId(),
                             state->GetProductId(), state->GetLongDiscriminator(), rotatingIdString);
         }
     }


### PR DESCRIPTION
Stop using Vendor ID 1111 for the target content app when running the commissioner generated passcode commissioning flow. This was causing confusion among developers. The TV content app with Vendor ID 1111 does not allow list the client’s Vendor ID 65521 which is why, upon successful commissioning the tv-casting-app did not receive and was not able to interact with Endpoints with Vendor ID 1111. This also caused re-connection issues since Endpoints with Vendor ID 1111 were not cached. 


### Change Summary

1.	Tv-app (Linux and Android) removed the hard coded passcode 20202021 from content app with Vendor ID 65521.
2.	Tv-app updated README.md with instructions on entering the commissionee generated passcode
3.	Tv-casting-app (Linux, Android, iOS) update TargetAppList sent in the UDC message when running the commissioner generated passcode commissioning flow
4.	Tv-casting-app (Linux, Android) update endpoint selection logic for demo interactions. iOS logic fallbacks to endpoint ID 1 if the sampleEndpointVid 65521 was not found – no update needed.
5.	Updated logging for better readability and context


### Testing

Verified and tested locally with the Linux tv-casting-app (mobile app) and the Linux tv-app (CastingPlayer). Able to build and commission with the example app using both the commissionee and commissioner generated passcode flows. Able to re-establish connection with a CastingPlayer which has already been commissioned. 
