### PR TITLE
Disable failings tests from REPL: TC_DefaultWarnings.py, TC_LTIME_3_1.py

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -131,6 +131,10 @@ not_automated:
           Fails after hard-coded values removed from defaults (seems to fail
           because fixed label is empty). See
           https://github.com/project-chip/connectedhomeip/issues/38857
+    - name: TC_LTIME_3_1.py
+      reason:
+          Flaky/failing (maybe after removing defaults)
+          https://github.com/project-chip/connectedhomeip/issues/38860
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -126,6 +126,12 @@ not_automated:
       reason:
           Shared code for Camera AV Settings (TC_AVSUM*), not a standalone test.
 
+    - name: TC_DefaultWarnings
+      reason:
+          Fails after hard-coded values removed from defaults (seems to fail
+          because fixed label is empty). See
+          https://github.com/project-chip/connectedhomeip/issues/38857
+
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially
 # to consider improving. May not be exhaustive

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -126,7 +126,7 @@ not_automated:
       reason:
           Shared code for Camera AV Settings (TC_AVSUM*), not a standalone test.
 
-    - name: TC_DefaultWarnings
+    - name: TC_DefaultWarnings.py
       reason:
           Fails after hard-coded values removed from defaults (seems to fail
           because fixed label is empty). See


### PR DESCRIPTION
Because of breakage described in:
  - #38857 - defaults warnings seems to complain tha "Fixed label list is empty"
  - #38860 - TC_LTIME_3_1 failing

#### Testing

Test apparently broke: as #38754 merged while REPL tests were disabled, it likely failed the defaults test.

