### PR TITLE
[bouffalo lab] Add/update platform configuration to track psram/wifi …

### DIFF
--- a/scripts/tools/memory/platform/bl702.cfg
+++ b/scripts/tools/memory/platform/bl702.cfg
@@ -18,8 +18,9 @@
     'section': {
         # By default, only these sections will be included
         # when operating by sections.
-        'default': ['.text', '.rodata', '.data', '.bss', '.wifibss']
+        'default': ['.text', '.rodata', '.data', '.bss', '.bss_psram', '.psram']
     },
+
     'region': {
         # Regions are sets of sections that can be used for aggregate reports.
         'sections': {
@@ -29,8 +30,9 @@
             ],
             'RAM': [
                 '.bss',
+                '.bss_psram',
                 '.data',
-                '.wifibss'
+                '.psram'
             ],
         }
     },

--- a/scripts/tools/memory/platform/bl702l.cfg
+++ b/scripts/tools/memory/platform/bl702l.cfg
@@ -18,8 +18,9 @@
     'section': {
         # By default, only these sections will be included
         # when operating by sections.
-        'default': ['.text', '.rodata', '.data', '.bss', '.wifibss']
+        'default': ['.text', '.rodata', '.data', '.bss', '.bss_psram', '.psram']
     },
+
     'region': {
         # Regions are sets of sections that can be used for aggregate reports.
         'sections': {
@@ -29,8 +30,9 @@
             ],
             'RAM': [
                 '.bss',
+                '.bss_psram',
                 '.data',
-                '.wifibss'
+                '.psram'
             ],
         }
     },


### PR DESCRIPTION
#### Change Summary
- Add BL702 and BL702L memory platform configuration to track all SRAM/PSRAM as RAM.
- Update BL602 memory platform configuration to track all SRAM as RAM.

#### Testing

targets and memory track test commands as below

-  bouffalolab-bl602dk-light-wifi-littlefs
  scripts/tools/memory/gh_sizes.py bl602 bl602+littlefs lighting-app out/bouffalolab-bl602dk-light-wifi-littlefs/chip-bl602-lighting-example.out
- bouffalolab-bl706dk-light-wifi-littlefs
  scripts/tools/memory/gh_sizes.py bl702 bl702+wifi lighting-app out/bouffalolab-bl706dk-light-wifi-littlefs/chip-bl702-lighting-example.out
- bouffalolab-bl704ldk-light-thread-littlefs
  scripts/tools/memory/gh_sizes.py bl702l bl702l+littlefs lighting-app out/bouffalolab-bl704ldk-light-thread-littlefs/chip-bl702l-lighting-example.out
