### PR TITLE
TC_SEPR and TC_EGC scripts were missing is_commissioning=True

### DIFF
--- a/src/python_testing/TC_EGC_2_1.py
+++ b/src/python_testing/TC_EGC_2_1.py
@@ -62,7 +62,8 @@ class EGC_2_1(ElectricalGridConditionsTestBaseHelper, MatterBaseTest):
 
     def steps_EGC_2_1(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the LocalGenerationAvailable attribute.",
                      "Verify that the DUT response contains either null or a bool value."),
             TestStep("3", "TH reads from the DUT the CurrentConditions attribute.",

--- a/src/python_testing/TC_EGC_2_2.py
+++ b/src/python_testing/TC_EGC_2_2.py
@@ -62,7 +62,8 @@ class EGC_2_2(ElectricalGridConditionsTestBaseHelper, MatterBaseTest):
 
     def steps_EGC_2_2(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "Set up a subscription to all ElectricalGridConditions cluster events"),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),

--- a/src/python_testing/TC_EGC_2_3.py
+++ b/src/python_testing/TC_EGC_2_3.py
@@ -62,7 +62,8 @@ class EGC_2_3(ElectricalGridConditionsTestBaseHelper, MatterBaseTest):
 
     def steps_EGC_2_3(self) -> list[TestStep]:
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends TestEventTrigger command to General Diagnostics Cluster on Endpoint 0 with EnableKey field set to PIXIT.EGC.TESTEVENT_TRIGGERKEY and EventTrigger field set to PIXIT.EGC.TESTEVENTTRIGGER for Forecast Conditions Update Test Event",

--- a/src/python_testing/TC_SEPR_2_1.py
+++ b/src/python_testing/TC_SEPR_2_1.py
@@ -71,7 +71,8 @@ class TC_SEPR_2_1(CommodityPriceTestBaseHelper, MatterBaseTest):
     def steps_TC_SEPR_2_1(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "TH reads from the DUT the TariffUnit attribute.",
                      "Verify that the DUT response contains a TariffUnitEnum value."),
             TestStep("3", "TH reads from the DUT the Currency attribute.",

--- a/src/python_testing/TC_SEPR_2_2.py
+++ b/src/python_testing/TC_SEPR_2_2.py
@@ -70,7 +70,8 @@ class TC_SEPR_2_2(CommodityPriceTestBaseHelper, MatterBaseTest):
     def steps_TC_SEPR_2_2(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "Set up a subscription to all CommodityPrice cluster events"),
             TestStep("3", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),

--- a/src/python_testing/TC_SEPR_2_3.py
+++ b/src/python_testing/TC_SEPR_2_3.py
@@ -70,7 +70,8 @@ class TC_SEPR_2_3(CommodityPriceTestBaseHelper, MatterBaseTest):
     def steps_TC_SEPR_2_3(self) -> list[TestStep]:
         """Execute the test steps."""
         steps = [
-            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test)."),
+            TestStep("1", "Commission DUT to TH (can be skipped if done in a preceding test).",
+                     is_commissioning=True),
             TestStep("2", "TH reads TestEventTriggersEnabled attribute from General Diagnostics Cluster",
                      "Value has to be 1 (True)"),
             TestStep("3", "TH sends command GetDetailedForecastRequest with Details=CommodityPriceDetailBitmap.Description set to True, and Components set to False.",


### PR DESCRIPTION
Fixes #38872 - Test harness is showing the scripts in the wrong place (Python No Commissioning)

#### Testing

Tested with CI