### PR TITLE
[bouffalo lab] fix bl616 wifi scan operation with/without specified ssid

### DIFF
--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -206,6 +206,9 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
     if (callback != nullptr)
     {
         mpScanCallback = nullptr;
+
+        memcpy(mScanSSID, ssid.data(), ssid.size());
+        mScanSSIDlength = ssid.size();
         if (0 == wifi_start_scan(ssid.data(), ssid.size()))
         {
             mpScanCallback = callback;
@@ -231,9 +234,26 @@ void BLWiFiDriver::OnScanWiFiNetworkDone()
         }
         else
         {
+            wifi_mgmr_scan_item_t * pScanResult = NULL;
+            uint32_t                scanResultNum = 0;
 
-            if (CHIP_NO_ERROR == DeviceLayer::SystemLayer().ScheduleLambda([nums, pScanList]() {
-                    BLScanResponseIterator iter(nums, pScanList);
+            if (mScanSSIDlength) {
+                for (uint32_t i = 0; i < nums; i ++) {
+                    if (mScanSSIDlength == pScanList[i].ssid_len && memcmp(pScanList[i].ssid, mScanSSID, mScanSSIDlength) == 0) {
+                        pScanResult = pScanList;
+                        scanResultNum = 1;
+                        break;
+                    }
+                }
+            }
+            else {
+                pScanResult = pScanList;
+                scanResultNum = nums;
+            }
+
+            if (CHIP_NO_ERROR != DeviceLayer::SystemLayer().ScheduleLambda([scanResultNum, pScanResult, pScanList]() {
+                    BLScanResponseIterator iter(scanResultNum, pScanResult);
+
                     if (GetInstance().mpScanCallback)
                     {
                         GetInstance().mpScanCallback->OnFinished(Status::kSuccess, CharSpan(), &iter);
@@ -243,6 +263,8 @@ void BLWiFiDriver::OnScanWiFiNetworkDone()
                     {
                         ChipLogError(DeviceLayer, "can't find the ScanCallback function");
                     }
+
+                    MemoryFree(pScanList);
                 }))
             {
                 MemoryFree(pScanList);

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -213,7 +213,7 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
         {
             memcpy(mScanSSID, ssid.data(), ssid.size());
             mScanSSIDlength = ssid.size();
-            mpScanCallback = callback;
+            mpScanCallback  = callback;
         }
         else
         {

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -206,10 +206,9 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
     if (callback != nullptr)
     {
         mpScanCallback = nullptr;
-        memset(mScanSSID, 0, sizeof(mScanSSID));
         mScanSSIDlength = 0;
 
-        if (ssid.size() < sizeof(mScanSSID) && 0 == wifi_start_scan(ssid.data(), ssid.size()))
+        if (ssid.size() <= sizeof(mScanSSID) && 0 == wifi_start_scan(ssid.data(), ssid.size()))
         {
             memcpy(mScanSSID, ssid.data(), ssid.size());
             mScanSSIDlength = ssid.size();

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -207,14 +207,18 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
     {
         mpScanCallback = nullptr;
 
-        memcpy(mScanSSID, ssid.data(), ssid.size());
-        mScanSSIDlength = ssid.size();
-        if (0 == wifi_start_scan(ssid.data(), ssid.size()))
+        if (ssid.size() <= DeviceLayer::Internal::kMaxWiFiSSIDLength 
+            && 0 == wifi_start_scan(ssid.data(), ssid.size()))
         {
+            memcpy(mScanSSID, ssid.data(), ssid.size());
+            mScanSSIDlength = ssid.size();
             mpScanCallback = callback;
+
+            ChipLogError(NetworkProvisioning, "mScanSSID=%s, %d", ssid.data(), ssid.size());
         }
         else
         {
+            mScanSSIDlength = 0;
             callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
         }
     }

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -205,7 +205,7 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
 {
     if (callback != nullptr)
     {
-        mpScanCallback = nullptr;
+        mpScanCallback  = nullptr;
         mScanSSIDlength = 0;
 
         if (ssid.size() <= sizeof(mScanSSID) && 0 == wifi_start_scan(ssid.data(), ssid.size()))

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -235,19 +235,23 @@ void BLWiFiDriver::OnScanWiFiNetworkDone()
         else
         {
             wifi_mgmr_scan_item_t * pScanResult = NULL;
-            uint32_t                scanResultNum = 0;
+            uint32_t scanResultNum              = 0;
 
-            if (mScanSSIDlength) {
-                for (uint32_t i = 0; i < nums; i ++) {
-                    if (mScanSSIDlength == pScanList[i].ssid_len && memcmp(pScanList[i].ssid, mScanSSID, mScanSSIDlength) == 0) {
-                        pScanResult = pScanList;
+            if (mScanSSIDlength)
+            {
+                for (uint32_t i = 0; i < nums; i++)
+                {
+                    if (mScanSSIDlength == pScanList[i].ssid_len && memcmp(pScanList[i].ssid, mScanSSID, mScanSSIDlength) == 0)
+                    {
+                        pScanResult   = pScanList;
                         scanResultNum = 1;
                         break;
                     }
                 }
             }
-            else {
-                pScanResult = pScanList;
+            else
+            {
+                pScanResult   = pScanList;
                 scanResultNum = nums;
             }
 

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -206,19 +206,17 @@ void BLWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callba
     if (callback != nullptr)
     {
         mpScanCallback = nullptr;
+        memset(mScanSSID, 0, sizeof(mScanSSID));
+        mScanSSIDlength = 0;
 
-        if (ssid.size() <= DeviceLayer::Internal::kMaxWiFiSSIDLength 
-            && 0 == wifi_start_scan(ssid.data(), ssid.size()))
+        if (ssid.size() < sizeof(mScanSSID) && 0 == wifi_start_scan(ssid.data(), ssid.size()))
         {
             memcpy(mScanSSID, ssid.data(), ssid.size());
             mScanSSIDlength = ssid.size();
             mpScanCallback = callback;
-
-            ChipLogError(NetworkProvisioning, "mScanSSID=%s, %d", ssid.data(), ssid.size());
         }
         else
         {
-            mScanSSIDlength = 0;
             callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
         }
     }
@@ -247,7 +245,7 @@ void BLWiFiDriver::OnScanWiFiNetworkDone()
                 {
                     if (mScanSSIDlength == pScanList[i].ssid_len && memcmp(pScanList[i].ssid, mScanSSID, mScanSSIDlength) == 0)
                     {
-                        pScanResult   = pScanList;
+                        pScanResult   = &pScanList[i];
                         scanResultNum = 1;
                         break;
                     }

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
@@ -142,7 +142,7 @@ private:
     NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
     int32_t mLastDisconnectedReason;
 
-    char mScanSSID[DeviceLayer::Internal::kMaxWiFiSSIDLength + 1];
+    char mScanSSID[DeviceLayer::Internal::kMaxWiFiSSIDLength];
     int mScanSSIDlength;
 };
 

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.h
@@ -141,6 +141,9 @@ private:
     ConnectCallback * mpConnectCallback;
     NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
     int32_t mLastDisconnectedReason;
+
+    char mScanSSID[DeviceLayer::Internal::kMaxWiFiSSIDLength + 1];
+    int mScanSSIDlength;
 };
 
 } // namespace NetworkCommissioning


### PR DESCRIPTION
fix wifi scan issue on bl616 platform
#### Testing

target: bouffalolab-bl616dk-light-wifi-littlefs
commands: 
`./out/linux-x64-chip-tool/chip-tool networkcommissioning scan-networks 1 0`
`./out/linux-x64-chip-tool/chip-tool networkcommissioning scan-networks 1 0 --Ssid <wifi ssid>`