### PR TITLE
Disable flaky Telink CI for zephyr 3.3

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -356,7 +356,10 @@ jobs:
             BUILD_TYPE: telink
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        # TODO: disabled due to flakes. Enable back when flakes are root caused and fixed
+        #       https://github.com/project-chip/connectedhomeip/issues/38882
+        # if: github.actor != 'restyled-io[bot]'
+        if: false
 
         container:
             image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:129


### PR DESCRIPTION
Disabled until we fix the root cause of the flake described in #38882

#### Testing

Small change, CI will validate (telink CI will not run)
Verified after CI started:

![image](https://github.com/user-attachments/assets/8b483d40-6303-4cdc-ad00-75327a2403c5)

