### PR TITLE
[NXP][cmake][common] Provide a way to customize the toolchain in the NXP freertos cmake abstraction

### DIFF
--- a/config/nxp/chip-cmake-freertos/CMakeLists.txt
+++ b/config/nxp/chip-cmake-freertos/CMakeLists.txt
@@ -99,6 +99,10 @@ endif()
 # Enable map file generation by default
 matter_add_gn_arg_bool("chip_generate_link_map_file" true)
 
+matter_add_gn_arg_string("nxp_ar" ${CMAKE_AR})
+matter_add_gn_arg_string("nxp_cc" ${CMAKE_C_COMPILER})
+matter_add_gn_arg_string("nxp_cxx" ${CMAKE_CXX_COMPILER})
+
 matter_common_gn_args(
     DEBUG CONFIG_DEBUG
     LIB_SHELL CONFIG_CHIP_LIB_SHELL

--- a/config/nxp/chip-gn-freertos/args.gni
+++ b/config/nxp/chip-gn-freertos/args.gni
@@ -28,3 +28,5 @@ chip_ble_project_config_include = ""
 
 # mbedtls is built as part of the NXP SDK build process
 mbedtls_target = "${nxp_sdk_build_root}:nxp_mbedtls"
+
+custom_toolchain = "${chip_root}/config/nxp/chip-gn-freertos/toolchain:nxpFreeRTOS"

--- a/config/nxp/chip-gn-freertos/args.gni
+++ b/config/nxp/chip-gn-freertos/args.gni
@@ -29,4 +29,5 @@ chip_ble_project_config_include = ""
 # mbedtls is built as part of the NXP SDK build process
 mbedtls_target = "${nxp_sdk_build_root}:nxp_mbedtls"
 
-custom_toolchain = "${chip_root}/config/nxp/chip-gn-freertos/toolchain:nxpFreeRTOS"
+custom_toolchain =
+    "${chip_root}/config/nxp/chip-gn-freertos/toolchain:nxpFreeRTOS"

--- a/config/nxp/chip-gn-freertos/toolchain/BUILD.gn
+++ b/config/nxp/chip-gn-freertos/toolchain/BUILD.gn
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+import("${build_root}/toolchain/arm_gcc/arm_toolchain.gni")
+
+declare_args() {
+  nxp_ar = ""
+  nxp_cc = ""
+  nxp_cxx = ""
+}
+
+gcc_toolchain("nxpFreeRTOS") {
+  ar = nxp_ar
+  cc = nxp_cc
+  cxx = nxp_cxx
+
+  toolchain_args = {
+    current_os = "freertos"
+    is_clang = false
+  }
+}


### PR DESCRIPTION
The aim of this PR is to provide a way to allow the customization of the toolchain in the NXP freertos cmake abstraction.

This PR is :
- Adding "config/nxp/chip-gn-freertos/toolchain/BUILD.gn" to create the "nxpFreeRTOS" custom toolchain.
- Updating the "config/nxp/chip-cmake-freertos/CMakeLists.txt" accordingly.

#### Testing

Testing done with manual build.
