### PR TITLE
Increase unit test coverage of minimal_mdns/core folder

### DIFF
--- a/src/lib/dnssd/minimal_mdns/core/tests/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/core/tests/BUILD.gn
@@ -33,6 +33,7 @@ chip_test_suite("tests") {
     "TestFlatAllocatedQName.cpp",
     "TestHeapQName.cpp",
     "TestQName.cpp",
+    "TestQNameString.cpp",
     "TestRecordWriter.cpp",
   ]
 

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
@@ -43,4 +43,4 @@ TEST_F(TestQNameString, Construction)
         EXPECT_NE(heapQName.c_str(), "");
     }
 }
-} // namespace 
+} // namespace

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
@@ -16,32 +16,31 @@
  *    limitations under the License.
  */
 
- #include <pw_unit_test/framework.h>
+#include <pw_unit_test/framework.h>
 
- #include <lib/core/StringBuilderAdapters.h>
- #include <lib/dnssd/minimal_mdns/core/HeapQName.h>
- #include <lib/dnssd/minimal_mdns/core/QNameString.h>
- #include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
- 
- namespace {
- 
- using namespace chip;
- using namespace mdns::Minimal;
- 
- class TestQNameString : public ::testing::Test
- {
- public:
-     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
-     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
- };
- 
- TEST_F(TestQNameString, Construction)
- {
-     {
-         const testing::TestQName<2> kShort({ "some", "test" });
-         QNameString heapQName(kShort.Serialized());
-         EXPECT_NE(heapQName.c_str(), "");
-     }
- }
- } // namespace
- 
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/dnssd/minimal_mdns/core/HeapQName.h>
+#include <lib/dnssd/minimal_mdns/core/QNameString.h>
+#include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
+
+namespace {
+
+using namespace chip;
+using namespace mdns::Minimal;
+
+class TestQNameString : public ::testing::Test
+{
+public:
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestQNameString, Construction)
+{
+    {
+        const testing::TestQName<2> kShort({ "some", "test" });
+        QNameString heapQName(kShort.Serialized());
+        EXPECT_NE(heapQName.c_str(), "");
+    }
+}
+} // namespace 

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
@@ -1,0 +1,47 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+ #include <pw_unit_test/framework.h>
+
+ #include <lib/core/StringBuilderAdapters.h>
+ #include <lib/dnssd/minimal_mdns/core/HeapQName.h>
+ #include <lib/dnssd/minimal_mdns/core/QNameString.h>
+ #include <lib/dnssd/minimal_mdns/core/tests/QNameStrings.h>
+ 
+ namespace {
+ 
+ using namespace chip;
+ using namespace mdns::Minimal;
+ 
+ class TestQNameString : public ::testing::Test
+ {
+ public:
+     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+ };
+ 
+ TEST_F(TestQNameString, Construction)
+ {
+     {
+         const testing::TestQName<2> kShort({ "some", "test" });
+         QNameString heapQName(kShort.Serialized());
+         EXPECT_NE(heapQName.c_str(), "");
+     }
+ }
+ } // namespace
+ 

--- a/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/tests/TestQNameString.cpp
@@ -40,7 +40,11 @@ TEST_F(TestQNameString, Construction)
     {
         const testing::TestQName<2> kShort({ "some", "test" });
         QNameString heapQName(kShort.Serialized());
-        EXPECT_NE(heapQName.c_str(), "");
+        EXPECT_STREQ(heapQName.c_str(), "some.test");
+
+        mdns::Minimal::SerializedQNameIterator SInvalid;
+        QNameString heapQNameI(SInvalid);
+        EXPECT_STREQ(heapQNameI.c_str(), "(!INVALID!)");
     }
 }
 } // namespace


### PR DESCRIPTION
To complete the expected percentage of coverage of that folder is increasing the coverage of QNameString file. The only Method not actually coverage on the file is the constructor by serialize argument.
increasing the coverage result from 50% to 100%.

That pr is related to the ticket #37242 

#### Testing

To check that is necessary run build_covrage.sh script on master branch and compare with the result that on 37242 branch
