### PR TITLE
[Darwin][Network.framework] Do not include TCPEndPointImpl.h if TCP e…

### DIFF
--- a/src/inet/tests/TestInetCommon.h
+++ b/src/inet/tests/TestInetCommon.h
@@ -35,7 +35,11 @@
 
 #include <sys/time.h>
 
+#include <lib/core/CHIPConfig.h>
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
 #include <inet/TCPEndPointImpl.h>
+#endif
 #include <inet/UDPEndPointImpl.h>
 #include <lib/support/CodeUtils.h>
 #include <system/SystemLayerImpl.h>
@@ -50,7 +54,9 @@
 
 extern chip::System::LayerImpl gSystemLayer;
 
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
 extern chip::Inet::TCPEndPointManagerImpl gTCP;
+#endif
 extern chip::Inet::UDPEndPointManagerImpl gUDP;
 
 extern bool gDone;


### PR DESCRIPTION
…ndpoint are not enabled

#### Description

This change updates `TestInetCommon.h` to avoid including `TCPEndPointImpl.h` when TCP endpoints are disabled via INET_CONFIG_ENABLE_TCP_ENDPOINT.

This ensures that tests can build in configurations where TCP is not supported or intentionally disabled.

#### Testing

- Verified build success with `INET_CONFIG_ENABLE_TCP_ENDPOINT=0`
- Verified tests still compile and pass when TCP endpoint is enabled (=1)
