### PR TITLE
[Darwin] Install dispatch source handler for SIGINT/SIGTERM instead o…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -809,11 +809,31 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     //       registered with sigaction() call and TSAN is enabled. The problem seems to be
     //       related with the dispatch_semaphore_wait() function in the RunEventLoop() method.
     //       If this call is commented out, the signal handler is called as expected...
-#if defined(__APPLE__)
+#if CHIP_DEVICE_LAYER_TARGET_DARWIN
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    dispatch_queue_t workQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
+
+    dispatch_source_t sourceSigInt = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGINT, 0, workQueue);
+    dispatch_source_set_event_handler(sourceSigInt, ^{
+        StopSignalHandler(SIGINT);
+        dispatch_release(sourceSigInt);
+    });
+    dispatch_resume(sourceSigInt);
+    signal(SIGINT, SIG_IGN);
+
+    dispatch_source_t sourceSigTerm = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, workQueue);
+    dispatch_source_set_event_handler(sourceSigTerm, ^{
+        StopSignalHandler(SIGTERM);
+        dispatch_release(sourceSigTerm);
+    });
+    dispatch_resume(sourceSigTerm);
+    signal(SIGTERM, SIG_IGN);
+#else
     // NOLINTBEGIN(bugprone-signal-handler)
     signal(SIGINT, StopSignalHandler);
     signal(SIGTERM, StopSignalHandler);
     // NOLINTEND(bugprone-signal-handler)
+#endif
 #else
     struct sigaction sa                        = {};
     sa.sa_handler                              = StopSignalHandler;


### PR DESCRIPTION
…f posix signals to make it more reliable

#### Description
This changes how we handle `SIGINT` and `SIGTERM` on Darwin when using the dispatch system layer.
Instead of using `signal()`, we now install `dispatch_source_t` handlers for these signals on the CHIP work queue.

This makes the signal handling more reliable and consistent with the rest of the dispatch-based code.

#### Testing
- Verified that `SIGINT` and `SIGTERM` cleanly shut down the app when using dispatch
