### PR TITLE
Decouple software-fault-listener

### DIFF
--- a/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
+++ b/examples/air-quality-sensor-app/linux/AirQualitySensorAppAttrUpdateDelegate.cpp
@@ -20,7 +20,7 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/general-diagnostics-server/general-diagnostics-server.h>
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
 #include <platform/PlatformManager.h>

--- a/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
@@ -16,7 +16,7 @@
  */
 
 #include <app/clusters/software-diagnostics-server/SoftwareDiagnosticsTestEventTriggerHandler.h>
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
 
@@ -44,7 +44,7 @@ void SetTestEventTrigger_SoftwareFaultOccurred()
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
+    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 } // namespace

--- a/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
@@ -17,6 +17,7 @@
 
 #include <app/clusters/software-diagnostics-server/SoftwareDiagnosticsTestEventTriggerHandler.h>
 #include <app/clusters/software-diagnostics-server/software-fault-listener.h>
+#include <lib/support/CHIPMemString.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DiagnosticDataProvider.h>
 

--- a/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/software-diagnostics-stub.cpp
@@ -44,7 +44,7 @@ void SetTestEventTrigger_SoftwareFaultOccurred()
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
+    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 } // namespace

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -678,7 +678,7 @@ void AllClustersAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
+    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void AllClustersAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -24,7 +24,7 @@
 #include <app/clusters/occupancy-sensor-server/occupancy-sensor-server.h>
 #include <app/clusters/refrigerator-alarm-server/refrigerator-alarm-server.h>
 #include <app/clusters/smoke-co-alarm-server/smoke-co-alarm-server.h>
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -678,7 +678,7 @@ void AllClustersAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
+    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void AllClustersAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -100,8 +100,8 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/examples/all-clusters-app/all-clusters-common",
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app:attribute-persistence",
-    "${chip_root}/src/app/common:ids",
     "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
+    "${chip_root}/src/app/common:ids",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -101,6 +101,7 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app:attribute-persistence",
     "${chip_root}/src/app/common:ids",
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/examples/lighting-app-data-mode-no-unique-id/linux/BUILD.gn
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/BUILD.gn
@@ -45,6 +45,7 @@ executable("chip-lighting-app") {
     "${chip_root}/examples/lighting-app-data-mode-no-unique-id/lighting-common",
     "${chip_root}/examples/lighting-app-data-mode-no-unique-id/lighting-common:lighting-manager",
     "${chip_root}/examples/platform/linux:app-main",
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/examples/lighting-app-data-mode-no-unique-id/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/LightingAppCommandDelegate.cpp
@@ -20,7 +20,7 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/general-diagnostics-server/general-diagnostics-server.h>
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -254,7 +254,7 @@ void LightingAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
+    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void LightingAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)

--- a/examples/lighting-app-data-mode-no-unique-id/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app-data-mode-no-unique-id/linux/LightingAppCommandDelegate.cpp
@@ -254,7 +254,7 @@ void LightingAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
+    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void LightingAppCommandHandler::OnSwitchLatchedHandler(uint8_t newPosition)

--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -45,6 +45,7 @@ executable("chip-lighting-app") {
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/examples/lighting-app/lighting-common:lighting-manager",
     "${chip_root}/examples/platform/linux:app-main",
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
     "${chip_root}/src/app/common:ids",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",

--- a/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
@@ -20,7 +20,7 @@
 
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/general-diagnostics-server/general-diagnostics-server.h>
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #include <platform/PlatformManager.h>
@@ -216,7 +216,7 @@ void LightingAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
+    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void LightingAppCommandDelegate::OnEventCommandReceived(const char * json)

--- a/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
+++ b/examples/lighting-app/linux/LightingAppCommandDelegate.cpp
@@ -216,7 +216,7 @@ void LightingAppCommandHandler::OnSoftwareFaultEventHandler(uint32_t eventId)
         softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(timeChar), strlen(timeChar)));
     }
 
-    Clusters::Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
+    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 }
 
 void LightingAppCommandDelegate::OnEventCommandReceived(const char * json)

--- a/examples/platform/infineon/cyw30739/SoftwareDiagnostics.cpp
+++ b/examples/platform/infineon/cyw30739/SoftwareDiagnostics.cpp
@@ -52,7 +52,7 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 
     softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultRecordString), strlen(faultRecordString)));
 
-    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
+    SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 #endif // MATTER_DM_PLUGIN_SOFTWARE_DIAGNOSTICS_SERVER
 }
 

--- a/examples/platform/infineon/cyw30739/SoftwareDiagnostics.cpp
+++ b/examples/platform/infineon/cyw30739/SoftwareDiagnostics.cpp
@@ -18,7 +18,7 @@
 
 #include "SoftwareDiagnostics.h"
 
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/util/config.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -52,7 +52,7 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 
     softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultRecordString), strlen(faultRecordString)));
 
-    SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
+    Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault);
 #endif // MATTER_DM_PLUGIN_SOFTWARE_DIAGNOSTICS_SERVER
 }
 

--- a/examples/platform/infineon/cyw30739/cyw30739_example.gni
+++ b/examples/platform/infineon/cyw30739/cyw30739_example.gni
@@ -39,6 +39,7 @@ template("cyw30739_example") {
     deps = [
       "${chip_root}/examples/providers:device_info_provider_please_do_not_reuse_as_is",
       "${chip_root}/examples/shell/shell_common:shell_common",
+      "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
       "${chip_root}/src/setup_payload:onboarding-codes-utils",
       "${matter_wpan_sdk_build_root}:${board}",
       app_data_model,

--- a/examples/platform/silabs/SiWx917/BUILD.gn
+++ b/examples/platform/silabs/SiWx917/BUILD.gn
@@ -95,7 +95,10 @@ config("siwx917-common-config") {
 }
 
 source_set("siwx917-common") {
-  deps = [ "${silabs_common_plat_dir}/provision:storage" ]
+  deps = [
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
+    "${silabs_common_plat_dir}/provision:storage",
+  ]
   defines = []
   public_deps = []
 

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -19,7 +19,7 @@
 #include "SoftwareFaultReports.h"
 #include "FreeRTOSConfig.h"
 #include "silabs_utils.h"
-#include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 #include <app/util/attribute-storage.h>
 #include <cmsis_os2.h>
 #include <lib/support/CHIPMemString.h>
@@ -72,7 +72,8 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
     softwareFault.id = taskDetails.xTaskNumber;
     softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(faultRecordString), strlen(faultRecordString)));
 
-    SystemLayer().ScheduleLambda([&softwareFault] { SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault); });
+    SystemLayer().ScheduleLambda(
+        [&softwareFault] { Clusters::SoftwareDiagnostics::SoftwareFaultListener::GlobalNotifySoftwareFaultDetect(softwareFault); });
     // Allow some time for the Fault event to be sent as the next action after exiting this function
     // is typically an assert or reboot.
     // Depending on the task at fault, it is possible the event can't be transmitted.

--- a/examples/platform/silabs/efr32/BUILD.gn
+++ b/examples/platform/silabs/efr32/BUILD.gn
@@ -121,7 +121,10 @@ config("efr32-common-config") {
 }
 
 source_set("efr32-common") {
-  deps = [ "${silabs_common_plat_dir}/provision:storage" ]
+  deps = [
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
+    "${silabs_common_plat_dir}/provision:storage",
+  ]
   defines = []
   public_deps = []
   public_configs = [

--- a/src/app/clusters/ota-provider/tests/BUILD.gn
+++ b/src/app/clusters/ota-provider/tests/BUILD.gn
@@ -19,6 +19,8 @@ import("//build_overrides/pigweed.gni")
 import("${chip_root}/build/chip/chip_test_suite.gni")
 
 chip_test_suite("tests") {
+  output_name = "libTestOtaProviderCluster"
+
   test_sources = [ "TestOtaProviderCluster.cpp" ]
 
   sources = []

--- a/src/app/clusters/software-diagnostics-server/BUILD.gn
+++ b/src/app/clusters/software-diagnostics-server/BUILD.gn
@@ -27,5 +27,5 @@ source_set("software-fault-listener") {
 }
 
 group("software-diagnostics-server") {
-  deps = [ ":software-fault-listener" ]
+  public_deps = [ ":software-fault-listener" ]
 }

--- a/src/app/clusters/software-diagnostics-server/BUILD.gn
+++ b/src/app/clusters/software-diagnostics-server/BUILD.gn
@@ -11,5 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+source_set("software-fault-listener") {
+  sources = [
+    "software-fault-listener.cpp",
+    "software-fault-listener.h",
+  ]
+
+  public_deps =
+      [ "${chip_root}/zzz_generated/app-common/clusters/SoftwareDiagnostics" ]
+
+  public_configs = [ "${chip_root}/src:includes" ]
+}
+
 group("software-diagnostics-server") {
+  deps = [":software-fault-listener"]
 }

--- a/src/app/clusters/software-diagnostics-server/BUILD.gn
+++ b/src/app/clusters/software-diagnostics-server/BUILD.gn
@@ -27,5 +27,5 @@ source_set("software-fault-listener") {
 }
 
 group("software-diagnostics-server") {
-  deps = [":software-fault-listener"]
+  deps = [ ":software-fault-listener" ]
 }

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
@@ -19,3 +19,11 @@ TARGET_SOURCES(
     "${CLUSTER_DIR}/SoftwareDiagnosticsTestEventTriggerHandler.h"
     "${CLUSTER_DIR}/software-diagnostics-server.cpp"
 )
+
+# These are the things that BUILD.gn dependencies would pull
+TARGET_SOURCES(
+￼  ${APP_TARGET}
+￼  PRIVATE
+￼    "${CLUSTER_DIR}/software-fault-listener.cpp"
+￼    "${CLUSTER_DIR}/software-fault-listener.h"
+)

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
@@ -21,8 +21,8 @@ TARGET_SOURCES(
 
 # These are the things that BUILD.gn dependencies would pull
 TARGET_SOURCES(
-￼  ${APP_TARGET}
-￼  PRIVATE
-￼    "${CLUSTER_DIR}/software-fault-listener.cpp"
-￼    "${CLUSTER_DIR}/software-fault-listener.h"
+  ${APP_TARGET}
+  PRIVATE
+    "${CLUSTER_DIR}/software-fault-listener.cpp"
+    "${CLUSTER_DIR}/software-fault-listener.h"
 )

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
@@ -18,5 +18,4 @@ TARGET_SOURCES(
   PRIVATE
     "${CLUSTER_DIR}/SoftwareDiagnosticsTestEventTriggerHandler.h"
     "${CLUSTER_DIR}/software-diagnostics-server.cpp"
-    "${CLUSTER_DIR}/software-diagnostics-server.h"
 )

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.cmake
@@ -16,7 +16,6 @@
 TARGET_SOURCES(
   ${APP_TARGET}
   PRIVATE
-    "${CLUSTER_DIR}/SoftwareDiagnosticsTestEventTriggerHandler.h"
     "${CLUSTER_DIR}/software-diagnostics-server.cpp"
 )
 

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
@@ -14,5 +14,4 @@
 app_config_dependent_sources = [
   "SoftwareDiagnosticsTestEventTriggerHandler.h",
   "software-diagnostics-server.cpp",
-  "software-diagnostics-server.h",
 ]

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 app_config_dependent_sources = [
-  "SoftwareDiagnosticsTestEventTriggerHandler.h",
   "software-diagnostics-server.cpp",
 ]

--- a/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
+++ b/src/app/clusters/software-diagnostics-server/app_config_dependent_sources.gni
@@ -11,6 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-app_config_dependent_sources = [
-  "software-diagnostics-server.cpp",
-]
+app_config_dependent_sources = [ "software-diagnostics-server.cpp" ]

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -15,11 +15,8 @@
  *    limitations under the License.
  */
 
-#include "software-diagnostics-server.h"
-#include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-objects.h>
-#include <app-common/zap-generated/ids/Attributes.h>
-#include <app-common/zap-generated/ids/Clusters.h>
+#include "software-fault-listener.h"
+
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
 #include <app/CommandHandler.h>
@@ -28,7 +25,9 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
 #include <app/util/attribute-storage.h>
+#include <clusters/SoftwareDiagnostics/Events.h>
 #include <lib/core/Optional.h>
+#include <lib/support/CodeUtils.h>
 #include <platform/DiagnosticDataProvider.h>
 
 using namespace chip;
@@ -182,52 +181,50 @@ CHIP_ERROR SoftwareDiagnosticsCommandHandler::EnumerateAcceptedCommands(const Co
     return CHIP_NO_ERROR;
 }
 
-} // anonymous namespace
-
-namespace chip {
-namespace app {
-namespace Clusters {
-
-SoftwareDiagnosticsServer SoftwareDiagnosticsServer::instance;
-
-/**********************************************************
- * SoftwareDiagnosticsServer Implementation
- *********************************************************/
-
-SoftwareDiagnosticsServer & SoftwareDiagnosticsServer::Instance()
+class SoftwareFaultListenerImpl : public SoftwareDiagnostics::SoftwareFaultListener
 {
-    return instance;
-}
-
-// Gets called when a software fault that has taken place on the Node.
-void SoftwareDiagnosticsServer::OnSoftwareFaultDetect(const SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault)
-{
-    ChipLogDetail(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected");
-
-    for (auto endpoint : EnabledEndpointsWithServerCluster(SoftwareDiagnostics::Id))
+public:
+    void OnSoftwareFaultDetect(const Events::SoftwareFault::Type & softwareFault) override
     {
-        // If Software Diagnostics cluster is implemented on this endpoint
-        EventNumber eventNumber;
+        ChipLogDetail(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected");
 
-        if (CHIP_NO_ERROR != LogEvent(softwareFault, endpoint, eventNumber))
+        for (auto endpoint : EnabledEndpointsWithServerCluster(SoftwareDiagnostics::Id))
         {
-            ChipLogError(Zcl, "SoftwareDiagnosticsDelegate: Failed to record SoftwareFault event");
+            // If Software Diagnostics cluster is implemented on this endpoint
+            EventNumber eventNumber;
+
+            if (CHIP_NO_ERROR != LogEvent(softwareFault, endpoint, eventNumber))
+            {
+                ChipLogError(Zcl, "SoftwareDiagnosticsDelegate: Failed to record SoftwareFault event");
+            }
         }
     }
-}
 
-} // namespace Clusters
-} // namespace app
-} // namespace chip
+    static SoftwareFaultListener & Instance()
+    {
+        static SoftwareFaultListenerImpl instance;
+        return instance;
+    }
+};
+
+} // anonymous namespace
 
 void MatterSoftwareDiagnosticsPluginServerInitCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
     CommandHandlerInterfaceRegistry::Instance().RegisterCommandHandler(&gCommandHandler);
+    if (SoftwareFaultListener::GetGlobalListener() == nullptr)
+    {
+        SoftwareFaultListener::SetGlobalListener(&SoftwareFaultListenerImpl::Instance());
+    }
 }
 
 void MatterSoftwareDiagnosticsPluginServerShutdownCallback()
 {
     AttributeAccessInterfaceRegistry::Instance().Unregister(&gAttrAccess);
     CommandHandlerInterfaceRegistry::Instance().UnregisterCommandHandler(&gCommandHandler);
+    if (SoftwareFaultListener::GetGlobalListener() == &SoftwareFaultListenerImpl::Instance())
+    {
+        SoftwareFaultListener::SetGlobalListener(nullptr);
+    }
 }

--- a/src/app/clusters/software-diagnostics-server/software-fault-listener.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-fault-listener.cpp
@@ -1,6 +1,5 @@
 /*
- *
- *    Copyright (c) 2022 Project CHIP Authors
+ *    Copyright (c) 2025 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,35 +14,27 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
-#pragma once
-
-#include <app-common/zap-generated/cluster-objects.h>
-#include <app/CommandResponseHelper.h>
-#include <platform/GeneralFaults.h>
+#include <app/clusters/software-diagnostics-server/software-fault-listener.h>
 
 namespace chip {
 namespace app {
 namespace Clusters {
+namespace SoftwareDiagnostics {
+namespace {
+SoftwareFaultListener * gListener = nullptr;
+} // namespace
 
-/**
- * @brief software-diagnostics-server class
- */
-class SoftwareDiagnosticsServer
+SoftwareFaultListener * SoftwareFaultListener::GetGlobalListener()
 {
-public:
-    static SoftwareDiagnosticsServer & Instance();
+    return gListener;
+}
 
-    /**
-     * @brief
-     *   Called when a software fault that has taken place on the Node.
-     */
-    void OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault);
+void SoftwareFaultListener::SetGlobalListener(SoftwareFaultListener * newValue)
+{
+    gListener = newValue;
+}
 
-private:
-    static SoftwareDiagnosticsServer instance;
-};
-
+} // namespace SoftwareDiagnostics
 } // namespace Clusters
 } // namespace app
 } // namespace chip

--- a/src/app/clusters/software-diagnostics-server/software-fault-listener.h
+++ b/src/app/clusters/software-diagnostics-server/software-fault-listener.h
@@ -1,0 +1,60 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <clusters/SoftwareDiagnostics/Events.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace SoftwareDiagnostics {
+
+/// A global class that listens for software fault detection.
+///
+/// Platforms are expected to notify listeners of faults. This is generally
+/// used to trigger reports via the Software Diagnostics cluster.
+class SoftwareFaultListener
+{
+public:
+    SoftwareFaultListener()          = default;
+    virtual ~SoftwareFaultListener() = default;
+
+    /// Called by various layers to report software faults
+    virtual void
+    OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault) = 0;
+
+    /// Returs the set global listener (if any). May return nullptr if no such listener is set.
+    static SoftwareFaultListener * GetGlobalListener();
+
+    /// Set the global software fault listener, returns the old value
+    static void SetGlobalListener(SoftwareFaultListener * newValue);
+
+    /// Convenience method of "call softare fault detect if globa listener is not null"
+    static void
+    GlobalNotifySoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault)
+    {
+        if (SoftwareFaultListener * listener = GetGlobalListener(); listener != nullptr)
+        {
+            listener->OnSoftwareFaultDetect(softwareFault);
+        }
+    }
+};
+
+} // namespace SoftwareDiagnostics
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/app/clusters/software-diagnostics-server/software-fault-listener.h
+++ b/src/app/clusters/software-diagnostics-server/software-fault-listener.h
@@ -43,7 +43,7 @@ public:
     /// Set the global software fault listener, returns the old value
     static void SetGlobalListener(SoftwareFaultListener * newValue);
 
-    /// Convenience method of "call softare fault detect if globa listener is not null"
+    /// Convenience method of "call software fault detect if global listener is not null"
     static void
     GlobalNotifySoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault)
     {


### PR DESCRIPTION
This allows code to be written to send software fault data without needing to depend on the software fault cluster implementation directly.

#### Changes

- separated out the `global software fault listener` as a separate class/target/include under `src/app/clusters/software-diagnostics-server/software-fault-listener.h`
- updated software diagnostics server to register itself as the global listener at init (and unregister at shutdown)
- updated platform/app code that triggers events to call the software fault listener registered instance instead of relying that the software diagnostics server instance is compiled in.
- Removed the `SoftwareDiagnosticsTestEventTriggerHandler.h` from the source set ... the dependency there is odd as these get pulled as "source_set" inside platform and rely on global callbacks. We likely would want application logic instead and stop relying on c-function linkage. Fixing that would need to be a separate PR.


#### Testing

CI should still pass
