### PR TITLE
Clean up dependencies in codegen

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -184,19 +184,6 @@ template("chip_data_model") {
     }
 
     sources += [
-      "${_app_root}/clusters/basic-information/basic-information.h",
-      "${_app_root}/clusters/color-control-server/color-control-server.h",
-      "${_app_root}/clusters/door-lock-server/door-lock-server.h",
-      "${_app_root}/clusters/groups-server/groups-server.h",
-      "${_app_root}/clusters/identify-server/identify-server.h",
-      "${_app_root}/clusters/level-control/level-control.h",
-      "${_app_root}/clusters/on-off-server/on-off-server.h",
-      "${_app_root}/clusters/scenes-server/ExtensionFieldSets.h",
-      "${_app_root}/clusters/scenes-server/ExtensionFieldSetsImpl.h",
-      "${_app_root}/clusters/scenes-server/SceneHandlerImpl.h",
-      "${_app_root}/clusters/scenes-server/SceneTable.h",
-      "${_app_root}/clusters/scenes-server/SceneTableImpl.h",
-      "${_app_root}/clusters/scenes-server/scenes-server.h",
       "${_app_root}/util/binding-table.cpp",
       "${_app_root}/util/binding-table.h",
       "${_app_root}/util/generic-callback-stubs.cpp",

--- a/src/app/clusters/scenes-server/BUILD.gn
+++ b/src/app/clusters/scenes-server/BUILD.gn
@@ -13,30 +13,6 @@
 # limitations under the License.
 import("//build_overrides/chip.gni")
 
-static_library("scenes") {
-  output_name = "libCHIPScenes"
-
-  sources = [
-    "ExtensionFieldSets.h",
-    "ExtensionFieldSetsImpl.cpp",
-    "ExtensionFieldSetsImpl.h",
-    "SceneHandlerImpl.cpp",
-    "SceneHandlerImpl.h",
-    "SceneTable.h",
-    "SceneTableImpl.cpp",
-    "SceneTableImpl.h",
-  ]
-
-  deps = [ "${chip_root}/src/app" ]
-
-  public_deps = [ "${chip_root}/src/app/storage:fabric-table" ]
-
-  cflags = [
-    "-Wconversion",
-    "-Wshadow",
-  ]
-}
-
 # Empty default target, so that data_model.gni can properly depend on this
 group("scenes-server") {
 }


### PR DESCRIPTION
- Adding several cluster sources regardless of zap file selection in data model seems wrong (they are added when those clusters are in use only)
- scenes `static_library` was not in fact compilable as a stand-alone: in particular SceneHandlerImpl.cpp depends on attribute-table.h which needs generated endpoint_config.h. Deleted that target as it probably was never compiled.


#### Testing

Compile should still work. There are no functional changes except compilation with gn.
