### PR TITLE
[TI] Dynamic Short/Long Idle Time Support for CC13x4_26x4

### DIFF
--- a/docs/platforms/ti/matter-users-guide/enabling_icd_on_ti_devices.md
+++ b/docs/platforms/ti/matter-users-guide/enabling_icd_on_ti_devices.md
@@ -35,7 +35,8 @@ chip_persist_subscriptions = true
 Subscription timeout resumption allows devices to attempt re-establishing
 subscriptions that may have expired. This feature is disabled out of box.
 
-To enable Dynamic SIT/LIT Support (DSLS), set the following parameter to true (LIT must be enabled first):
+To enable Dynamic SIT/LIT Support (DSLS), set the following parameter to true
+(LIT must be enabled first):
 
 ```
 chip_enable_icd_dsls = true

--- a/docs/platforms/ti/matter-users-guide/enabling_icd_on_ti_devices.md
+++ b/docs/platforms/ti/matter-users-guide/enabling_icd_on_ti_devices.md
@@ -35,6 +35,12 @@ chip_persist_subscriptions = true
 Subscription timeout resumption allows devices to attempt re-establishing
 subscriptions that may have expired. This feature is disabled out of box.
 
+To enable Dynamic SIT/LIT Support (DSLS), set the following parameter to true (LIT must be enabled first):
+
+```
+chip_enable_icd_dsls = true
+```
+
 In addition, various ICD parameters such as idle/active mode duration, active
 mode threshold, and polling intervals can be configured in
 `src/platform/cc13xx_26xx/cc13x4_26x4/CHIPPlatformConfig.h`
@@ -60,6 +66,8 @@ To enable LIT ICD behavior, set the FeatureMap to 0x0007 to enable Check-In
 Protocol Support, User Active Mode Trigger Support, and Long Idle Time Support.
 In addition, enable the UserActiveModeTriggerHint,
 UserActiveModeTriggerInstruction, and MaximumCheckInBackOff attributes.
+
+To enable DSLS support, change the FeatureMap to 0x000F.
 
 After making the desired changes in the zap file, generate the .matter file by
 running the following commands:

--- a/examples/light-switch-app/cc13x4_26x4/README.md
+++ b/examples/light-switch-app/cc13x4_26x4/README.md
@@ -46,11 +46,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                                  | Functionality                        |
-| ------------------------------------------------------- | ------------------------------------ |
-| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
-| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
-| Right Button (`BTN-2`) Press (less than 1000 ms)        | Connected bulb is toggled            |
+| Action                                                 | Functionality                        |
+| ------------------------------------------------------ | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)        | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)       | Connected bulb is toggled            |
 
 ## Building
 

--- a/examples/light-switch-app/cc13x4_26x4/README.md
+++ b/examples/light-switch-app/cc13x4_26x4/README.md
@@ -46,10 +46,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                           | Functionality             |
-| ------------------------------------------------ | ------------------------- |
-| Left Button (`BTN-1`) Press (less than 1000 ms)  | User Active Mode Trigger  |
-| Right Button (`BTN-2`) Press (less than 1000 ms) | Connected Bulb is toggled |
+| Action                                                  | Functionality                        |
+| ------------------------------------------------------- | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)        | Connected bulb is toggled            |
 
 ## Building
 

--- a/examples/light-switch-app/cc13x4_26x4/args.gni
+++ b/examples/light-switch-app/cc13x4_26x4/args.gni
@@ -66,6 +66,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
+chip_enable_icd_dsls = false
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/light-switch-app/cc13x4_26x4/src/AppEvent.h
+++ b/examples/light-switch-app/cc13x4_26x4/src/AppEvent.h
@@ -42,6 +42,7 @@ struct AppEvent
         kAppEventButtonType_None = 0,
         kAppEventButtonType_Clicked,
         kAppEventButtonType_LongClicked,
+        kAppEventButtonType_DoubleClicked,
     };
 
     enum AppEventIdentifyType

--- a/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
@@ -151,6 +151,10 @@ TimerHandle_t sOTAInitTimer = 0;
 // be set to false.
 bool isAppStarting = true;
 
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+static bool sitModeRequested;
+#endif // CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS
+
 #if CHIP_CONFIG_ENABLE_ICD_UAT
 bool switchIsTurnedOn = false;
 #endif
@@ -490,6 +494,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)
         {
 #if CHIP_CONFIG_ENABLE_ICD_UAT
+            PLAT_LOG("Enabled UAT");
             PlatformMgr().ScheduleWork([](intptr_t) { app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
 #else
             actor = AppEvent::kEventType_ButtonLeft;
@@ -500,6 +505,25 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         {
             chip::Server::GetInstance().ScheduleFactoryReset();
         }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+        else if (AppEvent::kAppEventButtonType_DoubleClicked == aEvent->ButtonEvent.Type)
+        {
+            if (!sitModeRequested)
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); }, 0);
+                sitModeRequested = true;
+                PLAT_LOG("Enabled SIT in DSLS");
+            }
+            else
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
+                sitModeRequested = false;
+                PLAT_LOG("Enabled LIT in DSLS");
+            }
+        }
+#endif
         break;
 
     case AppEvent::kEventType_ButtonRight:
@@ -656,6 +680,12 @@ void AppTask::ButtonLeftEventHandler(Button_Handle handle, Button_EventMask even
     {
         event.ButtonEvent.Type = AppEvent::kAppEventButtonType_LongClicked;
     }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+    else if (events & Button_EV_DOUBLECLICKED)
+    {
+        event.ButtonEvent.Type = AppEvent::kAppEventButtonType_DoubleClicked;
+    }
+#endif
     // button callbacks are in ISR context
     if (xQueueSendFromISR(sAppEventQueue, &event, NULL) != pdPASS)
     {
@@ -735,7 +765,7 @@ void AppTask::uiInit(void)
     Button_init();
 
     Button_Params_init(&buttonParams);
-    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED;
+    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED | Button_EV_DOUBLECLICKED;
     buttonParams.longPressDuration = 1000U; // ms
     sAppLeftHandle                 = Button_open(CONFIG_BTN_LEFT, &buttonParams);
     Button_setCallback(sAppLeftHandle, ButtonLeftEventHandler);

--- a/examples/lighting-app/cc13x4_26x4/README.md
+++ b/examples/lighting-app/cc13x4_26x4/README.md
@@ -49,10 +49,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                           | Functionality            |
-| ------------------------------------------------ | ------------------------ |
-| Left Button (`BTN-1`) Press (less than 1000 ms)  | User Active Mode Trigger |
-| Right Button (`BTN-2`) Press (less than 1000 ms) | Light is toggled         |
+| Action                                                  | Functionality                        |
+| ------------------------------------------------------- | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)        | Light is toggled                     |
 
 ## Building
 

--- a/examples/lighting-app/cc13x4_26x4/README.md
+++ b/examples/lighting-app/cc13x4_26x4/README.md
@@ -49,11 +49,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                                  | Functionality                        |
-| ------------------------------------------------------- | ------------------------------------ |
-| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
-| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
-| Right Button (`BTN-2`) Press (less than 1000 ms)        | Light is toggled                     |
+| Action                                                 | Functionality                        |
+| ------------------------------------------------------ | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)        | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)       | Light is toggled                     |
 
 ## Building
 

--- a/examples/lighting-app/cc13x4_26x4/args.gni
+++ b/examples/lighting-app/cc13x4_26x4/args.gni
@@ -66,7 +66,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
-chip_enable_icd_dsls = false 
+chip_enable_icd_dsls = false
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/lighting-app/cc13x4_26x4/args.gni
+++ b/examples/lighting-app/cc13x4_26x4/args.gni
@@ -66,6 +66,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
+chip_enable_icd_dsls = false 
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/lighting-app/cc13x4_26x4/src/AppEvent.h
+++ b/examples/lighting-app/cc13x4_26x4/src/AppEvent.h
@@ -42,6 +42,7 @@ struct AppEvent
         kAppEventButtonType_None = 0,
         kAppEventButtonType_Clicked,
         kAppEventButtonType_LongClicked,
+        kAppEventButtonType_DoubleClicked,
     };
 
     enum AppEventIdentifyType

--- a/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
@@ -145,6 +145,10 @@ bool isAppStarting = true;
 ::Identify stIdentify = { LIGHTING_APPLICATION_IDENTIFY_ENDPOINT, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
                           Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator, AppTask::TriggerIdentifyEffectHandler };
 
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+static bool sitModeRequested;
+#endif // CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS
+
 int AppTask::StartAppTask()
 {
     int ret = 0;
@@ -482,6 +486,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)
         {
 #if CHIP_CONFIG_ENABLE_ICD_UAT
+            PLAT_LOG("Enabled UAT");
             PlatformMgr().ScheduleWork([](intptr_t) { app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
 #else
             actor = AppEvent::kEventType_ButtonLeft;
@@ -492,6 +497,25 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         {
             chip::Server::GetInstance().ScheduleFactoryReset();
         }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+        else if (AppEvent::kAppEventButtonType_DoubleClicked == aEvent->ButtonEvent.Type)
+        {
+            if (!sitModeRequested)
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); }, 0);
+                sitModeRequested = true;
+                PLAT_LOG("Enabled SIT in DSLS");
+            }
+            else
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
+                sitModeRequested = false;
+                PLAT_LOG("Enabled LIT in DSLS");
+            }
+        }
+#endif
         break;
 
     case AppEvent::kEventType_ButtonRight:
@@ -677,6 +701,12 @@ void AppTask::ButtonLeftEventHandler(Button_Handle handle, Button_EventMask even
     {
         event.ButtonEvent.Type = AppEvent::kAppEventButtonType_LongClicked;
     }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+    else if (events & Button_EV_DOUBLECLICKED)
+    {
+        event.ButtonEvent.Type = AppEvent::kAppEventButtonType_DoubleClicked;
+    }
+#endif
     // button callbacks are in ISR context
     if (xQueueSendFromISR(sAppEventQueue, &event, NULL) != pdPASS)
     {
@@ -732,7 +762,7 @@ void AppTask::uiInit(void)
     Button_init();
 
     Button_Params_init(&buttonParams);
-    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED;
+    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED | Button_EV_DOUBLECLICKED;
     buttonParams.longPressDuration = 1000U; // ms
     sAppLeftHandle                 = Button_open(CONFIG_BTN_LEFT, &buttonParams);
     Button_setCallback(sAppLeftHandle, ButtonLeftEventHandler);

--- a/examples/lock-app/cc13x4_26x4/README.md
+++ b/examples/lock-app/cc13x4_26x4/README.md
@@ -50,10 +50,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                           | Functionality            |
-| ------------------------------------------------ | ------------------------ |
-| Left Button (`BTN-1`) Press (less than 1000 ms)  | User Active Mode Trigger |
-| Right Button (`BTN-2`) Press (less than 1000 ms) | Lock state is toggled    |
+| Action                                                  | Functionality                        |
+| ------------------------------------------------------- | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)        | Lock state is toggled                |
 
 ## Building
 

--- a/examples/lock-app/cc13x4_26x4/README.md
+++ b/examples/lock-app/cc13x4_26x4/README.md
@@ -50,11 +50,11 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the short button presses changes as
 described below:
 
-| Action                                                  | Functionality                        |
-| ------------------------------------------------------- | ------------------------------------ |
-| Left Button (`BTN-1`) Press (less than 1000 ms)         | User Active Mode Trigger             |
-| Left Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
-| Right Button (`BTN-2`) Press (less than 1000 ms)        | Lock state is toggled                |
+| Action                                                 | Functionality                        |
+| ------------------------------------------------------ | ------------------------------------ |
+| Left Button (`BTN-1`) Press (less than 1000 ms)        | User Active Mode Trigger             |
+| Left Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
+| Right Button (`BTN-2`) Press (less than 1000 ms)       | Lock state is toggled                |
 
 ## Building
 

--- a/examples/lock-app/cc13x4_26x4/args.gni
+++ b/examples/lock-app/cc13x4_26x4/args.gni
@@ -66,6 +66,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
+chip_enable_icd_dsls = false
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/lock-app/cc13x4_26x4/src/AppEvent.h
+++ b/examples/lock-app/cc13x4_26x4/src/AppEvent.h
@@ -39,6 +39,7 @@ struct AppEvent
         kAppEventButtonType_None = 0,
         kAppEventButtonType_Clicked,
         kAppEventButtonType_LongClicked,
+        kAppEventButtonType_DoubleClicked,
     };
 
     enum AppEventType Type;

--- a/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
@@ -140,6 +140,10 @@ bool isAppStarting = true;
 ::Identify stIdentify = { 0, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
                           Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator, AppTask::TriggerIdentifyEffectHandler };
 
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+static bool sitModeRequested;
+#endif // CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS
+
 int AppTask::StartAppTask()
 {
     int ret = 0;
@@ -534,6 +538,25 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         {
             chip::Server::GetInstance().ScheduleFactoryReset();
         }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+        else if (AppEvent::kAppEventButtonType_DoubleClicked == aEvent->ButtonEvent.Type)
+        {
+            if (!sitModeRequested)
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); }, 0);
+                sitModeRequested = true;
+                PLAT_LOG("Enabled SIT in DSLS");
+            }
+            else
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
+                sitModeRequested = false;
+                PLAT_LOG("Enabled LIT in DSLS");
+            }
+        }
+#endif
         break;
 
     case AppEvent::kEventType_ButtonRight:
@@ -701,6 +724,12 @@ void AppTask::ButtonLeftEventHandler(Button_Handle handle, Button_EventMask even
     {
         event.ButtonEvent.Type = AppEvent::kAppEventButtonType_LongClicked;
     }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+    else if (events & Button_EV_DOUBLECLICKED)
+    {
+        event.ButtonEvent.Type = AppEvent::kAppEventButtonType_DoubleClicked;
+    }
+#endif
     // button callbacks are in ISR context
     if (xQueueSendFromISR(sAppEventQueue, &event, NULL) != pdPASS)
     {
@@ -756,7 +785,7 @@ void AppTask::uiInit(void)
     Button_init();
 
     Button_Params_init(&buttonParams);
-    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED;
+    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED  | Button_EV_DOUBLECLICKED ;
     buttonParams.longPressDuration = 1000U; // ms
     sAppLeftHandle                 = Button_open(CONFIG_BTN_LEFT, &buttonParams);
     Button_setCallback(sAppLeftHandle, ButtonLeftEventHandler);

--- a/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
@@ -785,7 +785,7 @@ void AppTask::uiInit(void)
     Button_init();
 
     Button_Params_init(&buttonParams);
-    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED  | Button_EV_DOUBLECLICKED ;
+    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED | Button_EV_DOUBLECLICKED;
     buttonParams.longPressDuration = 1000U; // ms
     sAppLeftHandle                 = Button_open(CONFIG_BTN_LEFT, &buttonParams);
     Button_setCallback(sAppLeftHandle, ButtonLeftEventHandler);

--- a/examples/pump-app/cc13x4_26x4/README.md
+++ b/examples/pump-app/cc13x4_26x4/README.md
@@ -49,10 +49,10 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the right long button press changes as
 described below:
 
-| Action                                                   | Functionality                        |
-| -------------------------------------------------------- | ------------------------------------ |
-| Right Button (`BTN-1`) Press (more than 1000 ms)         | User Active Mode Trigger             |
-| Right Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
+| Action                                                  | Functionality                        |
+| ------------------------------------------------------- | ------------------------------------ |
+| Right Button (`BTN-1`) Press (more than 1000 ms)        | User Active Mode Trigger             |
+| Right Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
 
 ## Building
 

--- a/examples/pump-app/cc13x4_26x4/README.md
+++ b/examples/pump-app/cc13x4_26x4/README.md
@@ -49,9 +49,10 @@ When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
 true in args.gni), the functionality of the right long button press changes as
 described below:
 
-| Action                                           | Functionality            |
-| ------------------------------------------------ | ------------------------ |
-| Right Button (`BTN-2`) Press (more than 1000 ms) | User Active Mode Trigger |
+| Action                                                   | Functionality                        |
+| -------------------------------------------------------- | ------------------------------------ |
+| Right Button (`BTN-1`) Press (more than 1000 ms)         | User Active Mode Trigger             |
+| Right Button (`BTN-1`) Double Press (less than 1000 ms)  | Dynamic Short/Long Idle Time Support |
 
 ## Building
 

--- a/examples/pump-app/cc13x4_26x4/args.gni
+++ b/examples/pump-app/cc13x4_26x4/args.gni
@@ -65,6 +65,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
+chip_enable_icd_dsls = false
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/pump-app/cc13x4_26x4/main/include/AppEvent.h
+++ b/examples/pump-app/cc13x4_26x4/main/include/AppEvent.h
@@ -39,6 +39,7 @@ struct AppEvent
         kAppEventButtonType_None = 0,
         kAppEventButtonType_Clicked,
         kAppEventButtonType_LongClicked,
+        kAppEventButtonType_DoubleClicked,
     };
 
     enum AppEventType Type;

--- a/examples/pump-controller-app/cc13x4_26x4/README.md
+++ b/examples/pump-controller-app/cc13x4_26x4/README.md
@@ -47,14 +47,13 @@ Instruments devices.
 | Red & Green LED Off State                        | Pump stopped                           |
 
 When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
-true in args.gni), the functionality of the button presses changes as
-described below:
+true in args.gni), the functionality of the button presses changes as described
+below:
 
 | Action                                                  | Functionality                        |
 | ------------------------------------------------------- | ------------------------------------ |
 | Right Button (`BTN-1`) Press (more than 1000 ms)        | User Active Mode Trigger             |
 | Right Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
-
 
 ## Building
 

--- a/examples/pump-controller-app/cc13x4_26x4/README.md
+++ b/examples/pump-controller-app/cc13x4_26x4/README.md
@@ -47,12 +47,14 @@ Instruments devices.
 | Red & Green LED Off State                        | Pump stopped                           |
 
 When the device has LIT ICD functionality enabled (`chip_enable_icd_lit` set to
-true in args.gni), the functionality of the short button presses changes as
+true in args.gni), the functionality of the button presses changes as
 described below:
 
-| Action                                           | Functionality            |
-| ------------------------------------------------ | ------------------------ |
-| Right Button (`BTN-2`) Press (more than 1000 ms) | User Active Mode Trigger |
+| Action                                                  | Functionality                        |
+| ------------------------------------------------------- | ------------------------------------ |
+| Right Button (`BTN-1`) Press (more than 1000 ms)        | User Active Mode Trigger             |
+| Right Button (`BTN-1`) Double Press (less than 1000 ms) | Dynamic Short/Long Idle Time Support |
+
 
 ## Building
 

--- a/examples/pump-controller-app/cc13x4_26x4/args.gni
+++ b/examples/pump-controller-app/cc13x4_26x4/args.gni
@@ -65,6 +65,7 @@ chip_enable_icd_server = false
 chip_persist_subscriptions = false
 chip_subscription_timeout_resumption = false
 chip_enable_icd_lit = false
+chip_enable_icd_dsls = false
 
 freertos_root = "//third_party/connectedhomeip/third_party/ti_simplelink_sdk/repo_cc13xx_cc26xx/source/third_party/freertos"
 

--- a/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
@@ -132,6 +132,10 @@ static const uint32_t sIdentifyBlinkRateMs        = 500;
 ::Identify stIdentify = { sIdentifyEndpointId, AppTask::IdentifyStartHandler, AppTask::IdentifyStopHandler,
                           Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator, AppTask::TriggerIdentifyEffectHandler };
 
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+static bool sitModeRequested;
+#endif // CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS
+
 int AppTask::StartAppTask()
 {
     int ret = 0;
@@ -466,9 +470,29 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
         else if (AppEvent::kAppEventButtonType_LongClicked == aEvent->ButtonEvent.Type)
         {
 #if CHIP_CONFIG_ENABLE_ICD_UAT
+            PLAT_LOG("Enabled UAT");
             PlatformMgr().ScheduleWork([](intptr_t) { app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification(); });
 #endif
         }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+        else if (AppEvent::kAppEventButtonType_DoubleClicked == aEvent->ButtonEvent.Type)
+        {
+            if (!sitModeRequested)
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestNotification(); }, 0);
+                sitModeRequested = true;
+                PLAT_LOG("Enabled SIT in DSLS");
+            }
+            else
+            {
+                chip::DeviceLayer::PlatformMgr().ScheduleWork(
+                    [](intptr_t arg) { chip::app::ICDNotifier::GetInstance().NotifySITModeRequestWithdrawal(); }, 0);
+                sitModeRequested = false;
+                PLAT_LOG("Enabled LIT in DSLS");
+            }
+        }
+#endif        
         break;
     case AppEvent::kEventType_ButtonLeft:
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)
@@ -611,6 +635,12 @@ void AppTask::ButtonRightEventHandler(Button_Handle handle, Button_EventMask eve
     {
         event.ButtonEvent.Type = AppEvent::kAppEventButtonType_LongClicked;
     }
+#if (CHIP_CONFIG_ENABLE_ICD_LIT && CHIP_CONFIG_ENABLE_ICD_DSLS)
+    else if (events & Button_EV_DOUBLECLICKED)
+    {
+        event.ButtonEvent.Type = AppEvent::kAppEventButtonType_DoubleClicked;
+    }
+#endif
     // button callbacks are in ISR context
     if (xQueueSendFromISR(sAppEventQueue, &event, NULL) != pdPASS)
     {
@@ -652,7 +682,7 @@ void AppTask::uiInit(void)
     Button_setCallback(sAppLeftHandle, ButtonLeftEventHandler);
 
     Button_Params_init(&buttonParams);
-    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED;
+    buttonParams.buttonEventMask   = Button_EV_CLICKED | Button_EV_LONGCLICKED | Button_EV_DOUBLECLICKED;
     buttonParams.longPressDuration = 1000U; // ms
     sAppRightHandle                = Button_open(CONFIG_BTN_RIGHT, &buttonParams);
     Button_setCallback(sAppRightHandle, ButtonRightEventHandler);

--- a/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
@@ -492,7 +492,7 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
                 PLAT_LOG("Enabled LIT in DSLS");
             }
         }
-#endif        
+#endif
         break;
     case AppEvent::kEventType_ButtonLeft:
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)

--- a/examples/pump-controller-app/cc13x4_26x4/main/include/AppEvent.h
+++ b/examples/pump-controller-app/cc13x4_26x4/main/include/AppEvent.h
@@ -39,6 +39,7 @@ struct AppEvent
         kAppEventButtonType_None = 0,
         kAppEventButtonType_Clicked,
         kAppEventButtonType_LongClicked,
+        kAppEventButtonType_DoubleClicked,
     };
 
     enum AppEventType Type;


### PR DESCRIPTION
ICD DSLS Support and Documentation for TI CC13x4_26x4. 

#### Testing

Functional testing performed on the applications supported. 

Testing on lighting-app (examples/lighting-app/cc13x4_26x4):
- Build with ICD, LIT, and DSLS set to true and idle mode polling period/active mode threshold set to 20 seconds/5 seconds
- Commission lighting app onto Matter network via CHIP tool
- Check polling period (packet sniffer) and operating mode ( ./chip-tool icdmanagement read operating-mode) before pressing DSLS trigger to see that it is an LIT/has a polling period of 20 seconds
- Press DSLS button and check to see the change in polling period and operating mode to confirm it behaves as an SIT.

