### PR TITLE
Add support for concatenated QR codes to SetUpCodePairer.

### DIFF
--- a/examples/chip-tool/commands/common/DeviceScanner.cpp
+++ b/examples/chip-tool/commands/common/DeviceScanner.cpp
@@ -72,7 +72,7 @@ void DeviceScanner::OnNodeDiscovered(const DiscoveredNodeData & nodeData)
 
     for (size_t i = 0; i < resolutionData.numIPs; i++)
     {
-        auto params                = Controller::SetUpCodePairerParameters(resolutionData, i);
+        auto params                = Controller::SetUpCodePairerParameters(resolutionData, std::make_optional(discriminator), i);
         DeviceScannerResult result = { params, vendorId, productId, discriminator, chip::MakeOptional(resolutionData) };
         interfaceData.push_back(result);
     }

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -164,8 +164,10 @@ ALLOW: Dict[str, Set[str]] = {
     'src/lib/dnssd/minimal_mdns/ResponseSender.h': {'list'},
 
     # Not really for embedded consumers; uses std::deque to keep track
-    # of a list of discovered things.
-    'src/controller/SetUpCodePairer.h': {'deque'},
+    # of a list of discovered things and std::vector to keep track of
+    # lists of setup payloads and discriminators.
+    'src/controller/SetUpCodePairer.h': {'deque', 'vector'},
+    'src/controller/SetUpCodePairer.cpp': {'vector'},
 
     'src/controller/ExamplePersistentStorage.cpp': {'fstream', 'string', 'map'},
 

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -163,9 +163,7 @@ ALLOW: Dict[str, Set[str]] = {
     # Uses platform-define to switch between list and array
     'src/lib/dnssd/minimal_mdns/ResponseSender.h': {'list'},
 
-    # Not really for embedded consumers; uses std::deque to keep track
-    # of a list of discovered things and std::vector to keep track of
-    # lists of setup payloads and discriminators.
+    # Not really for embedded consumers, because commissioners tend to not be embedded.
     'src/controller/SetUpCodePairer.h': {'deque', 'vector'},
     'src/controller/SetUpCodePairer.cpp': {'vector'},
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -349,7 +349,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
             else
             {
                 ChipLogError(Controller,
-                             "SetUpCodePairer unable to handle discovered parameters with no discriminator, because it has %u "
+                             "SetUpCodePairer: Unable to handle discovered parameters with no discriminator, because it has %u "
                              "possible payloads",
                              static_cast<unsigned>(mSetupPayloads.size()));
                 continue;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -332,7 +332,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
             }
             if (!found)
             {
-                ChipLogError(Controller, "SetUpCodePairer discovered discriminator %u does not match any of our setup payloads",
+                ChipLogError(Controller, "SetUpCodePairer: Discovered discriminator %u does not match any of our setup payloads",
                              longDiscriminator);
                 // Move on to the the next discovered params; nothing we can do here.
                 continue;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -451,6 +451,8 @@ void SetUpCodePairer::OnDiscoveredDeviceOverWifiPAF()
     param.SetPeerAddress(Transport::PeerAddress(Transport::Type::kWiFiPAF, mRemoteId));
     // TODO: This needs to support concatenated QR codes and set the relevant
     // long discriminator on param.
+    //
+    // See https://github.com/project-chip/connectedhomeip/issues/39134
     mDiscoveredParameters.emplace_back(param);
     ConnectToDiscoveredDevice();
 }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>
+#include <vector>
 
 constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISCOVERY_TIMEOUT_SECS * chip::kMillisecondsPerSecond;
 
@@ -40,61 +41,44 @@ using namespace chip::Tracing;
 namespace chip {
 namespace Controller {
 
-namespace {
-
-CHIP_ERROR GetPayload(const char * setUpCode, SetupPayload & payload)
-{
-    bool isQRCode = strncmp(setUpCode, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
-    if (isQRCode)
-    {
-        ReturnErrorOnFailure(QRCodeSetupPayloadParser(setUpCode).populatePayload(payload));
-        VerifyOrReturnError(payload.isValidQRCodePayload(), CHIP_ERROR_INVALID_ARGUMENT);
-    }
-    else
-    {
-        ReturnErrorOnFailure(ManualSetupPayloadParser(setUpCode).populatePayload(payload));
-        VerifyOrReturnError(payload.isValidManualCode(), CHIP_ERROR_INVALID_ARGUMENT);
-    }
-
-    return CHIP_NO_ERROR;
-}
-} // namespace
-
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
                                        DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
 
-    SetupPayload payload;
-    ReturnErrorOnFailure(GetPayload(setUpCode, payload));
+    std::vector<SetupPayload> payloads;
+    ReturnErrorOnFailure(SetupPayload::FromStringRepresentation(setUpCode, payloads));
 
-    if (resolutionData.HasValue())
+    if (resolutionData.HasValue() && payloads.size() == 1 && mSetupPayloads.size() == 1)
     {
         VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, discoveryType != DiscoveryType::kAll,
                                       CHIP_ERROR_INVALID_ARGUMENT);
-        if (mRemoteId == remoteId && mSetUpPINCode == payload.setUpPINCode && mConnectionType == commission &&
+        if (mRemoteId == remoteId && mSetupPayloads[0].setUpPINCode == payloads[0].setUpPINCode && mConnectionType == commission &&
             mDiscoveryType == discoveryType)
         {
-            NotifyCommissionableDeviceDiscovered(resolutionData.Value());
+            // Not passing a discriminator is ok, since we have only one payload.
+            NotifyCommissionableDeviceDiscovered(resolutionData.Value(), std::nullopt);
             return CHIP_NO_ERROR;
         }
     }
 
+    ResetDiscoveryState();
+
     mConnectionType = commission;
     mDiscoveryType  = discoveryType;
     mRemoteId       = remoteId;
-    mSetUpPINCode   = payload.setUpPINCode;
+    mSetupPayloads  = std::move(payloads);
 
-    ResetDiscoveryState();
-
-    if (resolutionData.HasValue())
+    if (resolutionData.HasValue() && mSetupPayloads.size() == 1)
     {
-        NotifyCommissionableDeviceDiscovered(resolutionData.Value());
+        // No need to pass in a discriminator if we have only one payload, which
+        // is good because we don't have a full discriminator here anyway.
+        NotifyCommissionableDeviceDiscovered(resolutionData.Value(), std::nullopt);
         return CHIP_NO_ERROR;
     }
 
-    ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect(payload));
+    ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
     auto errorCode =
         mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback, this);
     if (CHIP_NO_ERROR == errorCode)
@@ -104,55 +88,50 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
     return errorCode;
 }
 
-CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
+CHIP_ERROR SetUpCodePairer::Connect()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    bool isRunning = false;
-
-    bool searchOverAll = !payload.rendezvousInformation.HasValue();
-
     if (mDiscoveryType == DiscoveryType::kAll)
     {
-        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
         {
-            if (CHIP_NO_ERROR == (err = StartDiscoveryOverBLE(payload)))
+            CHIP_ERROR err = StartDiscoveryOverBLE();
+            if (err != CHIP_NO_ERROR)
             {
-                isRunning = true;
+                ChipLogError(Controller, "Failed to start discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
 
-        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kSoftAP))
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kSoftAP))
         {
-            if (CHIP_NO_ERROR == (err = StartDiscoveryOverSoftAP(payload)))
+            CHIP_ERROR err = StartDiscoveryOverSoftAP();
+            if (err != CHIP_NO_ERROR)
             {
-                isRunning = true;
+                ChipLogError(Controller, "Failed to start discovery over SoftAP: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
-        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kWiFiPAF))
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
         {
-            ChipLogProgress(Controller, "WiFi-PAF: has RendezvousInformationFlag::kWiFiPAF");
-            if (CHIP_NO_ERROR == (err = StartDiscoveryOverWiFiPAF(payload)))
+            ChipLogProgress(Controller,
+                            "WiFi-PAF: has RendezvousInformationFlag::kWiFiPAF or has no discovery capabilities bitmask");
+            CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
+            if (err != CHIP_NO_ERROR)
             {
-                isRunning = true;
+                ChipLogError(Controller, "Failed to start discovery over WiFiPAF: %" CHIP_ERROR_FORMAT, err.Format());
             }
-            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
     }
 
     // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
     // QR code flag.
-    if (CHIP_NO_ERROR == (err = StartDiscoveryOverDNSSD(payload)))
+    CHIP_ERROR err = StartDiscoveryOverDNSSD();
+    if (err != CHIP_NO_ERROR)
     {
-        isRunning = true;
+        ChipLogError(Controller, "Failed to start discovery over DNS-SD: %" CHIP_ERROR_FORMAT, err.Format());
     }
-    VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
-
-    return isRunning ? CHIP_NO_ERROR : CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return err;
 }
 
-CHIP_ERROR SetUpCodePairer::StartDiscoveryOverBLE(SetupPayload & payload)
+CHIP_ERROR SetUpCodePairer::StartDiscoveryOverBLE()
 {
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
@@ -165,8 +144,24 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverBLE(SetupPayload & payload)
 
     // Handle possibly-sync callbacks.
     mWaitingForDiscovery[kBLETransport] = true;
-    CHIP_ERROR err = mBleLayer->NewBleConnectionByDiscriminator(payload.discriminator, this, OnDiscoveredDeviceOverBleSuccess,
-                                                                OnDiscoveredDeviceOverBleError);
+    CHIP_ERROR err;
+    if (mSetupPayloads.size() == 1)
+    {
+        err = mBleLayer->NewBleConnectionByDiscriminator(mSetupPayloads[0].discriminator, this, OnDiscoveredDeviceOverBleSuccess,
+                                                         OnDiscoveredDeviceOverBleError);
+    }
+    else
+    {
+        std::vector<SetupDiscriminator> discriminators;
+        discriminators.reserve(mSetupPayloads.size());
+        for (auto & payload : mSetupPayloads)
+        {
+            discriminators.emplace_back(payload.discriminator);
+        }
+        err = mBleLayer->NewBleConnectionByDiscriminators(Span(discriminators.data(), discriminators.size()), this,
+                                                          OnDiscoveredDeviceWithDiscriminatorOverBleSuccess,
+                                                          OnDiscoveredDeviceOverBleError);
+    }
     if (err != CHIP_NO_ERROR)
     {
         mWaitingForDiscovery[kBLETransport] = false;
@@ -201,27 +196,33 @@ CHIP_ERROR SetUpCodePairer::StopDiscoveryOverBLE()
 #endif // CONFIG_NETWORK_LAYER_BLE
 }
 
-CHIP_ERROR SetUpCodePairer::StartDiscoveryOverDNSSD(SetupPayload & payload)
+CHIP_ERROR SetUpCodePairer::StartDiscoveryOverDNSSD()
 {
     ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
 
-    auto & discriminator = payload.discriminator;
-    if (discriminator.IsShortDiscriminator())
+    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone);
+    if (mSetupPayloads.size() == 1)
     {
-        mCurrentFilter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
-        mCurrentFilter.code = discriminator.GetShortValue();
+        auto & discriminator = mSetupPayloads[0].discriminator;
+        if (discriminator.IsShortDiscriminator())
+        {
+            filter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
+            filter.code = discriminator.GetShortValue();
+        }
+        else
+        {
+            filter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
+            filter.code = discriminator.GetLongValue();
+        }
     }
-    else
-    {
-        mCurrentFilter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
-        mCurrentFilter.code = discriminator.GetLongValue();
-    }
-    mPayloadVendorID  = payload.vendorID;
-    mPayloadProductID = payload.productID;
+
+    // In theory we could try to filter on the vendor ID if it's the same across all the setup
+    // payloads, but DNS-SD advertisements are not required to include the Vendor ID subtype, so in
+    // practice that's not doable.
 
     // Handle possibly-sync callbacks.
     mWaitingForDiscovery[kIPTransport] = true;
-    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(mCurrentFilter);
+    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
     if (err != CHIP_NO_ERROR)
     {
         mWaitingForDiscovery[kIPTransport] = false;
@@ -234,15 +235,12 @@ CHIP_ERROR SetUpCodePairer::StopDiscoveryOverDNSSD()
     ChipLogDetail(Controller, "Stopping commissioning discovery over DNS-SD");
 
     mWaitingForDiscovery[kIPTransport] = false;
-    mCurrentFilter.type                = Dnssd::DiscoveryFilterType::kNone;
-    mPayloadVendorID                   = kNotAvailable;
-    mPayloadProductID                  = kNotAvailable;
 
     mCommissioner->StopCommissionableDiscovery();
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetUpCodePairer::StartDiscoveryOverSoftAP(SetupPayload & payload)
+CHIP_ERROR SetUpCodePairer::StartDiscoveryOverSoftAP()
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
@@ -253,9 +251,17 @@ CHIP_ERROR SetUpCodePairer::StopDiscoveryOverSoftAP()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF(SetupPayload & payload)
+CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if (mSetupPayloads.size() != 1)
+    {
+        ChipLogError(Controller, "WiFiPAF commissioning does not support concatenated QR codes yet.");
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
+    auto & payload = mSetupPayloads[0];
+
     ChipLogProgress(Controller, "Starting commissioning discovery over WiFiPAF");
     VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -310,7 +316,45 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         SetUpCodePairerParameters params(mDiscoveredParameters.front());
         mDiscoveredParameters.pop_front();
 
-        params.SetSetupPINCode(mSetUpPINCode);
+        if (params.mLongDiscriminator)
+        {
+            auto longDiscriminator = *params.mLongDiscriminator;
+            // Look for a matching setup passcode.
+            bool found = false;
+            for (auto & payload : mSetupPayloads)
+            {
+                if (payload.discriminator.MatchesLongDiscriminator(longDiscriminator))
+                {
+                    params.SetSetupPINCode(payload.setUpPINCode);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                ChipLogError(Controller, "SetUpCodePairer discovered discriminator %u does not match any of our setup payloads",
+                             longDiscriminator);
+                // Move on to the the next discovered params; nothing we can do here.
+                continue;
+            }
+        }
+        else
+        {
+            // No discriminator known for this discovered device.  This can work if we have only one
+            // setup payload, but otherwise we have no idea what setup passcode to use for it.
+            if (mSetupPayloads.size() == 1)
+            {
+                params.SetSetupPINCode(mSetupPayloads[0].setUpPINCode);
+            }
+            else
+            {
+                ChipLogError(Controller,
+                             "SetUpCodePairer unable to handle discovered parameters with no discriminator, because it has %u "
+                             "possible payloads",
+                             static_cast<unsigned>(mSetupPayloads.size()));
+                continue;
+            }
+        }
 
 #if CHIP_PROGRESS_LOGGING
         char buf[Transport::PeerAddress::kMaxToStringSize];
@@ -350,7 +394,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
 }
 
 #if CONFIG_NETWORK_LAYER_BLE
-void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
+void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, std::optional<uint16_t> matchedLongDiscriminator)
 {
     ChipLogProgress(Controller, "Discovered device to be commissioned over BLE");
 
@@ -362,13 +406,26 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
     //
     // It makes it the 'next' thing to try to connect to if there are already some
     // discovered parameters in the list.
-    mDiscoveredParameters.emplace_front(connObj);
+    //
+    // TODO: Consider implementing the SHOULD the spec has about commissioning things
+    // in QR code order by waiting for a second or something before actually starting
+    // the first PASE session when we have multiple setup payloads, and sorting the
+    // results in setup payload order.  If we do this, we might want to restrict it to
+    // cases when the different payloads have different vendor/product IDs, since if
+    // they are all the same product presumably ordering really does not matter.
+    mDiscoveredParameters.emplace_front(connObj, matchedLongDiscriminator);
     ConnectToDiscoveredDevice();
 }
 
 void SetUpCodePairer::OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj)
 {
-    (static_cast<SetUpCodePairer *>(appState))->OnDiscoveredDeviceOverBle(connObj);
+    (static_cast<SetUpCodePairer *>(appState))->OnDiscoveredDeviceOverBle(connObj, std::nullopt);
+}
+
+void SetUpCodePairer::OnDiscoveredDeviceWithDiscriminatorOverBleSuccess(void * appState, uint16_t matchedLongDiscriminator,
+                                                                        BLE_CONNECTION_OBJECT connObj)
+{
+    (static_cast<SetUpCodePairer *>(appState))->OnDiscoveredDeviceOverBle(connObj, std::make_optional(matchedLongDiscriminator));
 }
 
 void SetUpCodePairer::OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err)
@@ -392,6 +449,8 @@ void SetUpCodePairer::OnDiscoveredDeviceOverWifiPAF()
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
     auto param                              = SetUpCodePairerParameters();
     param.SetPeerAddress(Transport::PeerAddress(Transport::Type::kWiFiPAF, mRemoteId));
+    // TODO: This needs to support concatenated QR codes and set the relevant
+    // long discriminator on param.
     mDiscoveredParameters.emplace_back(param);
     ConnectToDiscoveredDevice();
 }
@@ -434,41 +493,38 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
         return false;
     }
 
-    // The advertisement may not include a vendor id.
-    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.vendorId) && mPayloadVendorID != nodeData.vendorId)
+    // Check whether this matches one of our setup payloads.
+    for (auto & payload : mSetupPayloads)
     {
-        ChipLogProgress(Controller, "Discovered device does not match our vendor id.");
-        return false;
+        // The advertisement may not include a vendor id, and the payload may not have one either.
+        if (IdIsPresent(payload.vendorID) && IdIsPresent(nodeData.vendorId) && payload.vendorID != nodeData.vendorId)
+        {
+            ChipLogProgress(Controller, "Discovered device vendor ID (%u) does not match our vendor ID (%u).", nodeData.vendorId,
+                            payload.vendorID);
+            continue;
+        }
+
+        // The advertisement may not include a product id, and the payload may not have one either.
+        if (IdIsPresent(payload.productID) && IdIsPresent(nodeData.productId) && payload.productID != nodeData.productId)
+        {
+            ChipLogProgress(Controller, "Discovered device product ID (%u) does not match our product ID (%u).", nodeData.productId,
+                            payload.productID);
+            continue;
+        }
+
+        if (!payload.discriminator.MatchesLongDiscriminator(nodeData.longDiscriminator))
+        {
+            ChipLogProgress(Controller, "Discovered device discriminator (%u) does not match our discriminator.",
+                            nodeData.longDiscriminator);
+            continue;
+        }
+
+        ChipLogProgress(Controller, "Discovered device with discriminator %u matches one of our setup payloads",
+                        nodeData.longDiscriminator);
+        return true;
     }
 
-    // The advertisement may not include a product id.
-    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.productId) && mPayloadProductID != nodeData.productId)
-    {
-        ChipLogProgress(Controller, "Discovered device does not match our product id.");
-        return false;
-    }
-
-    bool discriminatorMatches = false;
-    switch (mCurrentFilter.type)
-    {
-    case Dnssd::DiscoveryFilterType::kShortDiscriminator:
-        discriminatorMatches = (((nodeData.longDiscriminator >> 8) & 0x0F) == mCurrentFilter.code);
-        break;
-    case Dnssd::DiscoveryFilterType::kLongDiscriminator:
-        discriminatorMatches = (nodeData.longDiscriminator == mCurrentFilter.code);
-        break;
-    case Dnssd::DiscoveryFilterType::kNone:
-        ChipLogDetail(Controller, "Filter type none; all matches will fail");
-        return false;
-    default:
-        ChipLogError(Controller, "Unknown filter type; all matches will fail");
-        return false;
-    }
-    if (!discriminatorMatches)
-    {
-        ChipLogProgress(Controller, "Discovered device does not match our discriminator.");
-    }
-    return discriminatorMatches;
+    return false;
 }
 
 void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::DiscoveredNodeData & nodeData)
@@ -480,23 +536,26 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    NotifyCommissionableDeviceDiscovered(nodeData.Get<Dnssd::CommissionNodeData>());
+    auto & commissionableNodeData = nodeData.Get<Dnssd::CommissionNodeData>();
+
+    NotifyCommissionableDeviceDiscovered(commissionableNodeData, std::make_optional(commissionableNodeData.longDiscriminator));
 }
 
-void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData)
+void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::CommonResolutionData & resolutionData,
+                                                           std::optional<uint16_t> matchedLongDiscriminator)
 {
     if (mDiscoveryType == DiscoveryType::kDiscoveryNetworkOnlyWithoutPASEAutoRetry)
     {
         // If the discovery type does not want the PASE auto retry mechanism, we will just store
         // a single IP. So the discovery process is stopped as it won't be of any help anymore.
         StopDiscoveryOverDNSSD();
-        mDiscoveredParameters.emplace_back(resolutionData, 0);
+        mDiscoveredParameters.emplace_back(resolutionData, matchedLongDiscriminator, 0);
     }
     else
     {
         for (size_t i = 0; i < resolutionData.numIPs; i++)
         {
-            mDiscoveredParameters.emplace_back(resolutionData, i);
+            mDiscoveredParameters.emplace_back(resolutionData, matchedLongDiscriminator, i);
         }
     }
 
@@ -569,6 +628,8 @@ void SetUpCodePairer::ResetDiscoveryState()
     mDiscoveredParameters.clear();
     mCurrentPASEParameters.ClearValue();
     mLastPASEError = CHIP_NO_ERROR;
+
+    mSetupPayloads.clear();
 
     mSystemLayer->CancelTimer(OnDeviceDiscoveredTimeoutCallback, this);
 }
@@ -712,7 +773,31 @@ void SetUpCodePairer::OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, v
     }
 }
 
-SetUpCodePairerParameters::SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data, size_t index)
+bool SetUpCodePairer::ShouldDiscoverUsing(RendezvousInformationFlag commissioningChannel) const
+{
+    for (auto & payload : mSetupPayloads)
+    {
+        auto & rendezvousInformation = payload.rendezvousInformation;
+        if (!rendezvousInformation.HasValue())
+        {
+            // No idea which commissioning channels this device supports, so we
+            // should be trying using all of them.
+            return true;
+        }
+
+        if (rendezvousInformation.Value().Has(commissioningChannel))
+        {
+            return true;
+        }
+    }
+
+    // None of the payloads claimed support for this commissioning channel.
+    return false;
+}
+
+SetUpCodePairerParameters::SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data,
+                                                     std::optional<uint16_t> longDiscriminator, size_t index) :
+    mLongDiscriminator(longDiscriminator)
 {
     mInterfaceId = data.interfaceId;
     Platform::CopyString(mHostName, data.hostName);
@@ -732,7 +817,9 @@ SetUpCodePairerParameters::SetUpCodePairerParameters(const Dnssd::CommonResoluti
 }
 
 #if CONFIG_NETWORK_LAYER_BLE
-SetUpCodePairerParameters::SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj, bool connected)
+SetUpCodePairerParameters::SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj, std::optional<uint16_t> longDiscriminator,
+                                                     bool connected) :
+    mLongDiscriminator(longDiscriminator)
 {
     Transport::PeerAddress peerAddress = Transport::PeerAddress::BLE();
     SetPeerAddress(peerAddress);

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -42,6 +42,8 @@
 #include <controller/DeviceDiscoveryDelegate.h>
 
 #include <deque>
+#include <optional>
+#include <vector>
 
 namespace chip {
 namespace Controller {
@@ -52,12 +54,13 @@ class SetUpCodePairerParameters : public RendezvousParameters
 {
 public:
     SetUpCodePairerParameters() = default;
-    SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data, size_t index);
+    SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data, std::optional<uint16_t> longDiscriminator, size_t index);
 #if CONFIG_NETWORK_LAYER_BLE
-    SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj, bool connected = true);
+    SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj, std::optional<uint16_t> longDiscriminator, bool connected = true);
 #endif // CONFIG_NETWORK_LAYER_BLE
     char mHostName[Dnssd::kHostNameMaxLength + 1] = {};
     Inet::InterfaceId mInterfaceId;
+    std::optional<uint16_t> mLongDiscriminator = std::nullopt;
 };
 
 enum class SetupCodePairerBehaviour : uint8_t
@@ -104,14 +107,14 @@ private:
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
 
-    CHIP_ERROR Connect(SetupPayload & paload);
-    CHIP_ERROR StartDiscoveryOverBLE(SetupPayload & payload);
+    CHIP_ERROR Connect();
+    CHIP_ERROR StartDiscoveryOverBLE();
     CHIP_ERROR StopDiscoveryOverBLE();
-    CHIP_ERROR StartDiscoveryOverDNSSD(SetupPayload & payload);
+    CHIP_ERROR StartDiscoveryOverDNSSD();
     CHIP_ERROR StopDiscoveryOverDNSSD();
-    CHIP_ERROR StartDiscoveryOverSoftAP(SetupPayload & payload);
+    CHIP_ERROR StartDiscoveryOverSoftAP();
     CHIP_ERROR StopDiscoveryOverSoftAP();
-    CHIP_ERROR StartDiscoveryOverWiFiPAF(SetupPayload & payload);
+    CHIP_ERROR StartDiscoveryOverWiFiPAF();
     CHIP_ERROR StopDiscoveryOverWiFiPAF();
 
     // Returns whether we have kicked off a new connection attempt.
@@ -160,16 +163,19 @@ private:
         kTransportTypeCount,
     };
 
-    void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::CommonResolutionData & resolutionData);
+    void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::CommonResolutionData & resolutionData,
+                                              std::optional<uint16_t> matchedLongDiscriminator);
 
     static void OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, void * context);
 
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
-    void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj);
+    void OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj, std::optional<uint16_t> matchedLongDiscriminator);
     void OnBLEDiscoveryError(CHIP_ERROR err);
     /////////// BLEConnectionDelegate Callbacks /////////
     static void OnDiscoveredDeviceOverBleSuccess(void * appState, BLE_CONNECTION_OBJECT connObj);
+    static void OnDiscoveredDeviceWithDiscriminatorOverBleSuccess(void * appState, uint16_t matchedLongDiscriminator,
+                                                                  BLE_CONNECTION_OBJECT connObj);
     static void OnDiscoveredDeviceOverBleError(void * appState, CHIP_ERROR err);
 #endif // CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
@@ -182,20 +188,17 @@ private:
     bool NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const;
     static bool IdIsPresent(uint16_t vendorOrProductID);
 
-    Dnssd::DiscoveryFilter mCurrentFilter;
-    // The vendor id and product id from the SetupPayload.  They may be 0, which
-    // indicates "not available" (e.g. because the SetupPayload came from a
-    // short manual code).  In that case we should not filter on those values.
+    bool ShouldDiscoverUsing(RendezvousInformationFlag commissioningChannel) const;
+
+    // kNotAvailable represents unavailable vendor/product ID values in setup payloads.
     static constexpr uint16_t kNotAvailable = 0;
-    uint16_t mPayloadVendorID               = kNotAvailable;
-    uint16_t mPayloadProductID              = kNotAvailable;
 
     DeviceCommissioner * mCommissioner       = nullptr;
     System::Layer * mSystemLayer             = nullptr;
     chip::NodeId mRemoteId                   = kUndefinedNodeId;
-    uint32_t mSetUpPINCode                   = 0;
     SetupCodePairerBehaviour mConnectionType = SetupCodePairerBehaviour::kCommission;
     DiscoveryType mDiscoveryType             = DiscoveryType::kAll;
+    std::vector<SetupPayload> mSetupPayloads;
 
     // While we are trying to pair, we intercept the DevicePairingDelegate
     // notifications from mCommissioner.  We want to make sure we send them on

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -50,6 +50,12 @@ namespace Controller {
 
 class DeviceCommissioner;
 
+/**
+ * A class that represents a discovered device.  This includes both the inputs to discovery (via the
+ * RendezvousParameters super-class), and the outputs from discovery (the PeerAddress in
+ * RendezvousParameters but also some of our members like mHostName, mInterfaceId,
+ * mLongDiscriminator).
+ */
 class SetUpCodePairerParameters : public RendezvousParameters
 {
 public:
@@ -60,6 +66,12 @@ public:
 #endif // CONFIG_NETWORK_LAYER_BLE
     char mHostName[Dnssd::kHostNameMaxLength + 1] = {};
     Inet::InterfaceId mInterfaceId;
+
+    // The long discriminator of the device that was actually discovered, if this is known.  This
+    // differs from the mSetupDiscriminator member of RendezvousParameters in that the latter may be
+    // a short discriminator from a numeric setup code (which may match multiple devices), while
+    // this member, if set, is always a long discriminator that was actually advertised by the
+    // device represented by our PeerAddress.
     std::optional<uint16_t> mLongDiscriminator = std::nullopt;
 };
 


### PR DESCRIPTION
This requires backends to actually support discovery of multiple things with multiple discriminators. DNS-SD supports that, and BLE has APIs for it, which are not implemented on all platforms yet.  PAF and NFC will need to be fixed to handle it.

### Testing

Manually tested, for both BLE and DNS-SD discovery.