### PR TITLE
Assign a unique test PID to the network-manager example app

### DIFF
--- a/docs/examples/discussion/PID_allocation_for_example_apps.md
+++ b/docs/examples/discussion/PID_allocation_for_example_apps.md
@@ -19,22 +19,23 @@ same because they are all signed by the same PAI (vendor id `0xFFF1`).
 In order to allow some differentiation between the various example apps, each
 app is assigned a PID from the list below:
 
-| App                     | PID      |
-| ----------------------- | -------- |
-| All Clusters            | `0x8001` |
-| Bridge                  | `0x8002` |
-| Door Lock               | `0x8003` |
-| Light switch            | `0x8004` |
-| Lighting                | `0x8005` |
-| Lock                    | `0x8006` |
-| OTA provider            | `0x8007` |
-| OTA requestor           | `0x8008` |
-| Persistent Storage      | `0x8009` |
-| Pigweed                 | `0x800B` |
-| Pump                    | `0x800A` |
-| Pump Controller         | `0x8011` |
-| Shell                   | `0x8012` |
-| Temperature measurement | `0x800D` |
-| Thermostat              | `0x800E` |
-| TV                      | `0x800F` |
-| Window                  | `0x8010` |
+| App                            | PID      |
+| ------------------------------ | -------- |
+| All Clusters                   | `0x8001` |
+| Bridge                         | `0x8002` |
+| Door Lock                      | `0x8003` |
+| Light switch                   | `0x8004` |
+| Lighting                       | `0x8005` |
+| Lock                           | `0x8006` |
+| OTA provider                   | `0x8007` |
+| OTA requestor                  | `0x8008` |
+| Persistent Storage             | `0x8009` |
+| Pigweed                        | `0x800B` |
+| Pump                           | `0x800A` |
+| Pump Controller                | `0x8011` |
+| Shell                          | `0x8012` |
+| Temperature measurement        | `0x800D` |
+| Thermostat                     | `0x800E` |
+| TV                             | `0x800F` |
+| Window                         | `0x8010` |
+| Network Infrastructure Manager | `0x8013` |

--- a/examples/network-manager-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/network-manager-app/linux/include/CHIPProjectAppConfig.h
@@ -20,6 +20,7 @@
 
 #define CHIP_DEVICE_CONFIG_DEVICE_TYPE 144 // 0x0090 Network Infrastructure Manager
 #define CHIP_DEVICE_CONFIG_DEVICE_NAME "Network Infrastructure Manager"
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8013
 
 // Sufficient space for ArlReviewEvent of several fabrics.
 #define CHIP_DEVICE_CONFIG_EVENT_LOGGING_INFO_BUFFER_SIZE (32 * 1024)


### PR DESCRIPTION
Assign a unique test PID to the network-manager example app

#### Testing

Network manager example now builds with the assigned PID by default.