### PR TITLE
Fix post-certification tests

### DIFF
--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -190,8 +190,8 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
 
         do_test_over_pase = self.user_params.get("use_pase_only", False)
         if do_test_over_pase:
-            setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-            await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
+            setupCode = self.matter_test_config.qr_code_content or self.matter_test_config.manual_code
+            await self.default_controller.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
 
         # Commissioning - done
         self.step(0)

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -45,6 +45,7 @@ from chip.interaction_model import InteractionModelError, Status
 from chip.testing.basic_composition import BasicCompositionTests
 from chip.testing.conversions import hex_from_bytes
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from chip.testing.commissioning import connect_over_pase
 from chip.tlv import TLVReader
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -190,7 +191,8 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
 
         do_test_over_pase = self.user_params.get("use_pase_only", False)
         if do_test_over_pase:
-            self.connect_over_pase(self.default_controller)
+            setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
+            await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
 
         # Commissioning - done
         self.step(0)

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -43,7 +43,6 @@ import re
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.basic_composition import BasicCompositionTests
-from chip.testing.commissioning import connect_over_pase
 from chip.testing.conversions import hex_from_bytes
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
 from chip.tlv import TLVReader
@@ -192,7 +191,7 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
         do_test_over_pase = self.user_params.get("use_pase_only", False)
         if do_test_over_pase:
             setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-            await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
+            await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
 
         # Commissioning - done
         self.step(0)

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -43,9 +43,9 @@ import re
 import chip.clusters as Clusters
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.basic_composition import BasicCompositionTests
+from chip.testing.commissioning import connect_over_pase
 from chip.testing.conversions import hex_from_bytes
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
-from chip.testing.commissioning import connect_over_pase
 from chip.tlv import TLVReader
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
@@ -211,8 +211,3 @@ async def commission_devices(
         commissioned.append(await commission_device(dev_ctrl, node_id, setup_payload, commissioning_info))
 
     return all(commissioned)
-
-
-def connect_over_pase(dev_ctrl: ChipDeviceCtrl.ChipDeviceController, dut_node_id: int, setupCode: str):
-    """Establishes the PASE session to the DUT using the setup code."""
-    dev_ctrl.FindOrEstablishPASESession(setupCode, dut_node_id)

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
@@ -211,3 +211,8 @@ async def commission_devices(
         commissioned.append(await commission_device(dev_ctrl, node_id, setup_payload, commissioning_info))
 
     return all(commissioned)
+
+
+def connect_over_pase(dev_ctrl: ChipDeviceCtrl.ChipDeviceController, dut_node_id: int, setupCode: str):
+    """Establishes the PASE session to the DUT using the setup code."""
+    dev_ctrl.FindOrEstablishPASESession(setupCode, dut_node_id)

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -61,14 +61,12 @@ DEFAULT_CHIP_ROOT = os.path.abspath(
 
 try:
     from chip.testing.basic_composition import BasicCompositionTests
-    from chip.testing.commissioning import connect_over_pase
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
 except ImportError:
     sys.path.append(os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..')))
     from chip.testing.basic_composition import BasicCompositionTests
-    from chip.testing.commissioning import connect_over_pase
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
 
@@ -130,7 +128,7 @@ class TestEventTriggersCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def test_TestEventTriggersCheck(self):
         setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-        await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
+        await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
         gd = Clusters.GeneralDiagnostics
         ret = await self.read_single_attribute_check_success(cluster=gd, attribute=gd.Attributes.TestEventTriggersEnabled)
         asserts.assert_equal(ret, 0, "TestEventTriggers are still on")
@@ -140,7 +138,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def setup_class(self):
         setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-        await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
+        await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
         bi = Clusters.BasicInformation
         self.vid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.VendorID)
         self.pid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.ProductID)

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -63,12 +63,14 @@ try:
     from chip.testing.basic_composition import BasicCompositionTests
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
+    from chip.testing.commissioning import connect_over_pase
 except ImportError:
     sys.path.append(os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..')))
     from chip.testing.basic_composition import BasicCompositionTests
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
+    from chip.testing.commissioning import connect_over_pase
 
 try:
     import fetch_paa_certs_from_dcl
@@ -127,7 +129,8 @@ class Hooks():
 class TestEventTriggersCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def test_TestEventTriggersCheck(self):
-        self.connect_over_pase(self.default_controller)
+        setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
+        await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
         gd = Clusters.GeneralDiagnostics
         ret = await self.read_single_attribute_check_success(cluster=gd, attribute=gd.Attributes.TestEventTriggersEnabled)
         asserts.assert_equal(ret, 0, "TestEventTriggers are still on")
@@ -136,7 +139,8 @@ class TestEventTriggersCheck(MatterBaseTest, BasicCompositionTests):
 class DclCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def setup_class(self):
-        self.connect_over_pase(self.default_controller)
+        setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
+        await connect_over_pase(self.default_controller, self.dut_node_id, setupCode)
         bi = Clusters.BasicInformation
         self.vid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.VendorID)
         self.pid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.ProductID)

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -61,16 +61,16 @@ DEFAULT_CHIP_ROOT = os.path.abspath(
 
 try:
     from chip.testing.basic_composition import BasicCompositionTests
+    from chip.testing.commissioning import connect_over_pase
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
-    from chip.testing.commissioning import connect_over_pase
 except ImportError:
     sys.path.append(os.path.abspath(
         os.path.join(os.path.dirname(__file__), '..')))
     from chip.testing.basic_composition import BasicCompositionTests
+    from chip.testing.commissioning import connect_over_pase
     from chip.testing.matter_testing import (MatterBaseTest, MatterStackState, MatterTestConfig, TestStep, async_test_body,
                                              run_tests_no_exit)
-    from chip.testing.commissioning import connect_over_pase
 
 try:
     import fetch_paa_certs_from_dcl

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -127,8 +127,8 @@ class Hooks():
 class TestEventTriggersCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def test_TestEventTriggersCheck(self):
-        setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-        await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
+        setupCode = self.matter_test_config.qr_code_content or self.matter_test_config.manual_code
+        await self.default_controller.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
         gd = Clusters.GeneralDiagnostics
         ret = await self.read_single_attribute_check_success(cluster=gd, attribute=gd.Attributes.TestEventTriggersEnabled)
         asserts.assert_equal(ret, 0, "TestEventTriggers are still on")
@@ -137,8 +137,8 @@ class TestEventTriggersCheck(MatterBaseTest, BasicCompositionTests):
 class DclCheck(MatterBaseTest, BasicCompositionTests):
     @async_test_body
     async def setup_class(self):
-        setupCode = self.matter_test_config.qr_code_content if self.matter_test_config.qr_code_content is not None else self.matter_test_config.manual_code
-        await self.default_controller.FindOrEstablishPASESession(setupCode, self.dut_node_id)
+        setupCode = self.matter_test_config.qr_code_content or self.matter_test_config.manual_code
+        await self.default_controller.FindOrEstablishPASESession(setupCode[0], self.dut_node_id)
         bi = Clusters.BasicInformation
         self.vid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.VendorID)
         self.pid = await self.read_single_attribute_check_success(cluster=bi, attribute=bi.Attributes.ProductID)

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -149,17 +149,12 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         self.vid_pid_str = f'{self.vid_str} pid = 0x{self.pid:04X}'
         self.vid_pid_sv_str = f'{self.vid_pid_str} software version = {self.software_version}'
 
-    def get_DSL_data(self, url_path: str, force: bool = False):
-        """Retrieves DSL data and caches it. Returns JSON."""
-        full_url = f"{self.url.rstrip('/')}/{url_path.lstrip('/')}"
-        return requests.get(full_url).json()
-
     def steps_Vendor(self):
         return [TestStep(1, "Check if device VID is listed in the DCL vendor schema", "Listing found")]
 
     def test_Vendor(self):
         self.step(1)
-        entry = self.get_DSL_data(f"/dcl/vendorinfo/vendors/{self.vid}")
+        entry = requests.get(f"{self.url}/dcl/vendorinfo/vendors/{self.vid}").json()
         key = 'vendorInfo'
         asserts.assert_true(key in entry.keys(), f"Unable to find vendor entry for {self.vid_str}")
         logging.info(f'Found vendor key for {self.vid_str} in the DCL:')
@@ -171,7 +166,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_Model(self):
         self.step(1)
         key = 'model'
-        entry = self.get_DSL_data(f"/dcl/model/models/{self.vid}/{self.pid}")
+        entry = requests.get(f"{self.url}/dcl/model/models/{self.vid}/{self.pid}").json()
         asserts.assert_true(key in entry.keys(), f"Unable to find model entry for {self.vid_pid_str}")
         logging.info(f'Found model entry for {self.vid_pid_str} in the DCL:')
         logging.info(f'{entry[key]}')
@@ -182,7 +177,8 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_Compliance(self):
         self.step(1)
         key = 'complianceInfo'
-        entry = self.get_DSL_data(f"/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter")
+        entry = requests.get(
+            f"{self.url}/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter").json()
         asserts.assert_true(key in entry.keys(),
                             f"Unable to find compliance entry for {self.vid_pid_sv_str}")
         logging.info(
@@ -195,7 +191,8 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_CertifiedModel(self):
         self.step(1)
         key = 'certifiedModel'
-        entry = self.get_DSL_data(f"/dcl/compliance/certified-models/{self.vid}/{self.pid}/{self.software_version}/matter")
+        entry = requests.get(
+            f"{self.url}/dcl/compliance/certified-models/{self.vid}/{self.pid}/{self.software_version}/matter").json()
         asserts.assert_true(key in entry.keys(),
                             f"Unable to find certified model entry for {self.vid_pid_sv_str}")
         logging.info(
@@ -208,7 +205,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
 
     def test_AllSoftwareVersions(self):
         self.step(1)
-        versions_entry = self.get_DSL_data(f"/dcl/model/versions/{self.vid}/{self.pid}")
+        versions_entry = requests.get(f"{self.url}/dcl/model/versions/{self.vid}/{self.pid}").json()
         key_model_versions = 'modelVersions'
         asserts.assert_true(key_model_versions in versions_entry.keys(),
                             f"Unable to find {key_model_versions} in software versions schema for {self.vid_pid_str}")
@@ -221,7 +218,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         problems = []
         self.step(2)
         for software_version in versions_entry[key_model_versions][key_software_versions]:
-            entry_wrapper = self.get_DSL_data(f"/dcl/model/versions/{self.vid}/{self.pid}/{software_version}")
+            entry_wrapper = requests.get(f"{self.url}/dcl/model/versions/{self.vid}/{self.pid}/{software_version}").json()
             key_model_version = 'modelVersion'
             if key_model_version not in entry_wrapper:
                 problems.append(

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -77,6 +77,8 @@ except ImportError:
         os.path.join(DEFAULT_CHIP_ROOT, 'credentials')))
     import fetch_paa_certs_from_dcl
 
+sys.path.append(os.path.abspath(os.path.join(DEFAULT_CHIP_ROOT, 'src', 'python_testing')))
+
 
 @dataclass
 class Failure:

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -40,7 +40,6 @@ import asyncio
 import base64
 import hashlib
 import importlib
-import json
 import logging
 import os
 import shutil
@@ -51,7 +50,6 @@ import uuid
 from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
-from datetime import datetime, timedelta
 
 import chip.clusters as Clusters
 import cv2
@@ -151,79 +149,10 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         self.vid_pid_str = f'{self.vid_str} pid = 0x{self.pid:04X}'
         self.vid_pid_sv_str = f'{self.vid_pid_str} software version = {self.software_version}'
 
-    def get_DSL_data(self, url_path: str, local_filepath: typing.Optional[str] = None, force_download: bool = False, max_age_hours: int = 24) -> typing.Any:
-        """
-        Downloads a JSON file from a URL if it's missing locally, older than max_age_hours,
-        or if the force_download flag is set.
-
-        Args:
-            url (str): The URL of the JSON file.
-            local_filepath (str, optional): The local path to save the file.
-            force_download (bool, optional): Flag to force download. Defaults to False.
-            max_age_hours (int, optional): Maximum age of the file in hours. Defaults to 24.
-
-        Returns:
-            bool: True if the file was downloaded or was already up-to-date, False in case of an error.
-            dict or None: The downloaded JSON data if the download was successful or the file already existed, otherwise None.
-        """
-        target_url = f"{self.url.rstrip('/')}/{url_path.lstrip('/')}"
-        if local_filepath is None:
-            local_filepath = f"{url_path.lstrip('/')}"
-
-        file_exists = os.path.exists(local_filepath)
-        should_download = False
-
-        if force_download:
-            print(f"Forcing download of file: {local_filepath}")
-            should_download = True
-        elif not file_exists:
-            print(f"File not found locally: {local_filepath}. Downloading...")
-            should_download = True
-        else:
-            # Check file age
-            try:
-                file_mod_time = os.path.getmtime(local_filepath)
-                # Convert modification time to a datetime object
-                file_mod_datetime = datetime.fromtimestamp(file_mod_time)
-                # Determine the maximum allowed age
-                max_age_delta = timedelta(hours=max_age_hours)
-
-                if datetime.now() - file_mod_datetime > max_age_delta:
-                    print(f"Local file {local_filepath} is outdated (older than {max_age_hours} hours). Downloading...")
-                    should_download = True
-                else:
-                    print(f"Local file {local_filepath} is up-to-date.")
-            except Exception as e:
-                print(f"Could not check age of file {local_filepath}: {e}. Attempting download...")
-                should_download = True  # If we can't check the age, it's better to download
-
-        if should_download:
-            print(f"Downloading data from {target_url}...")
-            response = requests.get(target_url, timeout=30)  # 30-second timeout
-            response.raise_for_status()  # Check for HTTP errors (4xx or 5xx)
-
-            data = response.json()  # Decode JSON
-
-            # Create directory if it doesn't exist
-            # This ensures that if the path is "data/subdir/file.json", "data/subdir" will be created.
-            dir_name = os.path.dirname(local_filepath)
-            if dir_name:  # Ensure dirname is not empty (e.g. if filepath is just "file.json")
-                os.makedirs(dir_name, exist_ok=True)
-
-            with open(local_filepath, 'w', encoding='utf-8') as f:
-                json.dump(data, f, ensure_ascii=False, indent=4)
-            print(f"File successfully downloaded and saved as {local_filepath}")
-            return data
-        else:
-            # If not downloaded, try to read the existing file
-            if file_exists:
-                with open(local_filepath, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                print(f"Using existing file: {local_filepath}")
-                return data
-            # This case (file_exists is False and should_download is False) should ideally not be reached
-            # if logic is correct, but as a fallback:
-            return None  # File does not exist, and no download was triggered.
+    def get_DSL_data(self, url_path: str, force: bool = False):
+        """Retrieves DSL data and caches it. Returns JSON."""
+        full_url = f"{self.url.rstrip('/')}/{url_path.lstrip('/')}"
+        return requests.get(full_url).json()
 
     def steps_Vendor(self):
         return [TestStep(1, "Check if device VID is listed in the DCL vendor schema", "Listing found")]

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -149,12 +149,17 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         self.vid_pid_str = f'{self.vid_str} pid = 0x{self.pid:04X}'
         self.vid_pid_sv_str = f'{self.vid_pid_str} software version = {self.software_version}'
 
+    def get_DSL_data(self, url_path: str, force: bool = False):
+        """Retrieves DSL data and caches it. Returns JSON."""
+        full_url = f"{self.url.rstrip('/')}/{url_path.lstrip('/')}"
+        return requests.get(full_url).json()
+
     def steps_Vendor(self):
         return [TestStep(1, "Check if device VID is listed in the DCL vendor schema", "Listing found")]
 
     def test_Vendor(self):
         self.step(1)
-        entry = requests.get(f"{self.url}/dcl/vendorinfo/vendors/{self.vid}").json()
+        entry = self.get_DSL_data(f"/dcl/vendorinfo/vendors/{self.vid}")
         key = 'vendorInfo'
         asserts.assert_true(key in entry.keys(), f"Unable to find vendor entry for {self.vid_str}")
         logging.info(f'Found vendor key for {self.vid_str} in the DCL:')
@@ -166,7 +171,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_Model(self):
         self.step(1)
         key = 'model'
-        entry = requests.get(f"{self.url}/dcl/model/models/{self.vid}/{self.pid}").json()
+        entry = self.get_DSL_data(f"/dcl/model/models/{self.vid}/{self.pid}")
         asserts.assert_true(key in entry.keys(), f"Unable to find model entry for {self.vid_pid_str}")
         logging.info(f'Found model entry for {self.vid_pid_str} in the DCL:')
         logging.info(f'{entry[key]}')
@@ -177,8 +182,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_Compliance(self):
         self.step(1)
         key = 'complianceInfo'
-        entry = requests.get(
-            f"{self.url}/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter").json()
+        entry = self.get_DSL_data(f"/dcl/compliance/compliance-info/{self.vid}/{self.pid}/{self.software_version}/matter")
         asserts.assert_true(key in entry.keys(),
                             f"Unable to find compliance entry for {self.vid_pid_sv_str}")
         logging.info(
@@ -191,8 +195,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
     def test_CertifiedModel(self):
         self.step(1)
         key = 'certifiedModel'
-        entry = requests.get(
-            f"{self.url}/dcl/compliance/certified-models/{self.vid}/{self.pid}/{self.software_version}/matter").json()
+        entry = self.get_DSL_data(f"/dcl/compliance/certified-models/{self.vid}/{self.pid}/{self.software_version}/matter")
         asserts.assert_true(key in entry.keys(),
                             f"Unable to find certified model entry for {self.vid_pid_sv_str}")
         logging.info(
@@ -205,7 +208,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
 
     def test_AllSoftwareVersions(self):
         self.step(1)
-        versions_entry = requests.get(f"{self.url}/dcl/model/versions/{self.vid}/{self.pid}").json()
+        versions_entry = self.get_DSL_data(f"/dcl/model/versions/{self.vid}/{self.pid}")
         key_model_versions = 'modelVersions'
         asserts.assert_true(key_model_versions in versions_entry.keys(),
                             f"Unable to find {key_model_versions} in software versions schema for {self.vid_pid_str}")
@@ -218,7 +221,7 @@ class DclCheck(MatterBaseTest, BasicCompositionTests):
         problems = []
         self.step(2)
         for software_version in versions_entry[key_model_versions][key_software_versions]:
-            entry_wrapper = requests.get(f"{self.url}/dcl/model/versions/{self.vid}/{self.pid}/{software_version}").json()
+            entry_wrapper = self.get_DSL_data(f"/dcl/model/versions/{self.vid}/{self.pid}/{software_version}")
             key_model_version = 'modelVersion'
             if key_model_version not in entry_wrapper:
                 problems.append(

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -96,7 +96,7 @@ class Hooks():
     def stop(self, duration: int):
         pass
 
-    def test_start(self, filename: str, name: str, count: int):
+    def test_start(self, filename: str, name: str, count: int, steps: list[str] = []):
         self.current_test = name
         pass
 

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -49,9 +49,9 @@ import time
 import typing
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 from enum import Enum, auto
 from pathlib import Path
+from datetime import datetime, timedelta
 
 import chip.clusters as Clusters
 import cv2

--- a/src/python_testing/post_certification_tests/production_device_checks.py
+++ b/src/python_testing/post_certification_tests/production_device_checks.py
@@ -49,9 +49,9 @@ import time
 import typing
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 from enum import Enum, auto
 from pathlib import Path
-from datetime import datetime, timedelta
 
 import chip.clusters as Clusters
 import cv2


### PR DESCRIPTION
- Make `Hooks` class API to be matching `TestRunnerHooks`
- Fix existing tests by using the `FindOrEstablishPASESession` function.

Fixes: https://github.com/project-chip/matter-test-scripts/issues/558

#### Testing

Linux example app - lighting, tested for qr code and manual code