### PR TITLE
Increase timeout in TestTimedHandler to limit flakiness on CI

### DIFF
--- a/src/app/tests/TestTimedHandler.cpp
+++ b/src/app/tests/TestTimedHandler.cpp
@@ -100,7 +100,9 @@ void TestTimedHandler::TestFollowingMessageFastEnough(MsgType aMsgType)
 {
 
     System::PacketBufferHandle payload;
-    GenerateTimedRequest(500, payload);
+    // Make sure we have a timeout that is long enough to not cause
+    // a timeout on slow systems (CI or QEMU emulation).
+    GenerateTimedRequest(1500, payload);
 
     TestExchangeDelegate delegate;
     ExchangeContext * exchange = NewExchangeToAlice(&delegate);


### PR DESCRIPTION
#### Problem

Fixes https://github.com/project-chip/connectedhomeip/issues/38927

#### Testing

CI will verify