### PR TITLE
[Feature]: Support runtime configuration of commissioning window timeout

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -355,7 +355,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     else
     {
 #if CHIP_DEVICE_CONFIG_ENABLE_PAIRING_AUTOSTART
-        SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow());
+        SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow(initParams.discoveryTimeout));
 #endif
     }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -133,6 +133,8 @@ struct ServerInitParams
 
     // Application delegate to handle some commissioning lifecycle events
     AppDelegate * appDelegate = nullptr;
+    // device discovery timeout
+    System::Clock::Seconds32 discoveryTimeout = System::Clock::Seconds32(CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS);
     // Port to use for Matter commissioning/operational traffic
     uint16_t operationalServicePort = CHIP_PORT;
     // Port to use for UDC if supported


### PR DESCRIPTION
Fixes #38939 

#### Changes

- Adding a discovery_timeout parameter to `ServerInitParams`
- Passing this parameter to `chip::Server::Init()`
- Using the value in the call to `OpenBasicCommissioningWindow()` to determine how long the commissioning window remains open

#### Testing

- Passed discovery timeout to server init in ESP32 lighting example
- Verified that the commissioning window opens and successfully closes after the specified timeout duration