### PR TITLE
fix: explicit attribute path comparison

### DIFF
--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -157,6 +157,10 @@ struct ConcreteDataAttributePath : public ConcreteAttributePath
 
     bool operator<(const ConcreteDataAttributePath & aOther) const = delete;
 
+    // Explicit comparison with ConcreteAttributePath objects
+    using ConcreteAttributePath::operator==;
+    using ConcreteAttributePath::operator!=;
+
     //
     // This index is only valid if `mListOp` is set to a list item operation, i.e
     // ReplaceItem, DeleteItem or AppendItem. Otherwise, it is to be ignored.


### PR DESCRIPTION
Avoid comparison operators ambiguity with c++20 (reverse order comparison)

```
src/app/ChunkedWriteCallback.cpp:84:57: error: use of overloaded operator '==' is ambiguous (with operand types 'const chip::app::ConcreteDataAttributePath' and 'chip::app::ConcreteAttributePath')
    if (!mProcessingAttributePath.HasValue() || !(mProcessingAttributePath.Value() == aPath))
                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~
src/app/ConcreteAttributePath.h:53:10: note: candidate function (with reversed parameter order)
    bool operator==(const ConcreteAttributePath & aOther) const
         ^
src/app/ConcreteAttributePath.h:150:10: note: candidate function
    bool operator==(const ConcreteDataAttributePath & aOther) const
         ^
1 error generated.
```

#### Testing

Compile with C++20 and run autotests
