### PR TITLE
[NXP] Update NXP Zephyr Docker image for nxp-zsdk v4.1.0 migration

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-130 : [Tizen] QEMU coredump extraction
+131 : [NXP] Update NXP Zephyr docker image to Zephyr 4.1.0

--- a/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp-zephyr/Dockerfile
@@ -15,7 +15,7 @@ RUN set -x \
     && rm -rf zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
     && zephyr-sdk-0.17.0/setup.sh -t arm-zephyr-eabi \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.0.0 \
+    && west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.1.0 \
     && cd zephyrproject \
     && west update -o=--depth=1 -n \
     && west zephyr-export \


### PR DESCRIPTION
#### Description
Update NXP Zephyr Docker image for nxp-zsdk v4.1.0 migration

#### Testing

local test with new zephyr tag
