### PR TITLE
fix: android: do not initialize tracing if it is disabled

### DIFF
--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -37,13 +37,18 @@
 
 #include <android/log.h>
 
+#include <matter/tracing/build_config.h>
+
 #include "AndroidChipPlatform-JNI.h"
 #include "BLEManagerImpl.h"
 #include "BleConnectCallback-JNI.h"
 #include "CommissionableDataProviderImpl.h"
 #include "DiagnosticDataProviderImpl.h"
 #include "DnssdImpl.h"
+
+#if MATTER_TRACING_ENABLED
 #include "tracing.h"
+#endif // MATTER_TRACING_ENABLED
 
 using namespace chip;
 
@@ -97,7 +102,9 @@ CHIP_ERROR AndroidChipPlatformJNI_OnLoad(JavaVM * jvm, void * reserved)
     err = BleConnectCallbackJNI_OnLoad(jvm, reserved);
     SuccessOrExit(err);
 
+#if MATTER_TRACING_ENABLED
     chip::Android::InitializeTracing();
+#endif // MATTER_TRACING_ENABLED
 exit:
     if (err != CHIP_NO_ERROR)
     {
@@ -110,7 +117,9 @@ exit:
 
 void AndroidChipPlatformJNI_OnUnload(JavaVM * jvm, void * reserved)
 {
+#if MATTER_TRACING_ENABLED
     chip::Android::ShutdownTracing();
+#endif // MATTER_TRACING_ENABLED
 
     ChipLogProgress(DeviceLayer, "AndroidChipPlatform JNI_OnUnload() called");
     BleConnectCallbackJNI_OnUnload(jvm, reserved);

--- a/src/platform/android/BUILD.gn
+++ b/src/platform/android/BUILD.gn
@@ -19,6 +19,7 @@ import("${chip_root}/src/platform/device.gni")
 
 import("${build_root}/config/android_abi.gni")
 import("${chip_root}/build/chip/java/rules.gni")
+import("${chip_root}/src/tracing/tracing_args.gni")
 
 assert(chip_device_platform == "android")
 
@@ -83,14 +84,20 @@ static_library("android") {
   ]
 
   deps = [
-    ":tracing",
     "${chip_root}/src/app:app_config",
     "${chip_root}/src/app/common:ids",
     "${chip_root}/src/lib/dnssd:platform_header",
     "${chip_root}/src/setup_payload",
   ]
 
-  public_deps = [ "${chip_root}/src/platform:platform_base" ]
+  if (matter_enable_tracing_support) {
+    deps += [ ":tracing" ]
+  }
+
+  public_deps = [
+    "${chip_root}/src/platform:platform_base",
+    "${chip_root}/src/tracing:tracing_buildconfig",
+  ]
 
   public_configs = []
 }


### PR DESCRIPTION
For now android build always include perfetto tracing. We shouldn't build it if tracing is disabled via build argument `matter_enable_tracing_support `.

Tracing increases the target binary size and build time. Thats a "pay-for-use" thing: do not compile tracing code into target binary if tracing is disabled.

#### Testing

Manual build. Steps:
- build with `matter_enable_tracing_support = false`
- checkout binary for perfetto symbols
