### PR TITLE
Adding TC-SC-3.4 + Python Bindings for Fault Injection into Controller

### DIFF
--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -237,6 +237,7 @@ public:
     CASESessionManager * CASESessionMgr() const { return mCASESessionManager; }
     Credentials::GroupDataProvider * GetGroupDataProvider() const { return mGroupDataProvider; }
     chip::app::reporting::ReportScheduler * GetReportScheduler() const { return mReportScheduler; }
+    SessionResumptionStorage * GetSessionResumptionStorage() const { return mSessionResumptionStorage; }
 
     Crypto::SessionKeystore * GetSessionKeystore() const { return mSessionKeystore; }
     void SetTempFabricTable(FabricTable * tempFabricTable, bool enableServerInteractions)

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -76,6 +76,7 @@ shared_library("ChipDeviceCtrl") {
       "chip/crypto/p256keypair.cpp",
       "chip/crypto/p256keypair.h",
       "chip/discovery/NodeResolution.cpp",
+      "chip/fault_injection/FaultInjection.cpp",
       "chip/icd/PyChipCheckInDelegate.cpp",
       "chip/icd/PyChipCheckInDelegate.h",
       "chip/interaction_model/Delegate.cpp",
@@ -198,6 +199,7 @@ chip_python_wheel_action("chip-core") {
         "chip/discovery/library_handle.py",
         "chip/discovery/types.py",
         "chip/exceptions/__init__.py",
+        "chip/fault_injection/__init__.py",
         "chip/interaction_model/__init__.py",
         "chip/interaction_model/delegate.py",
         "chip/internal/__init__.py",
@@ -265,6 +267,7 @@ chip_python_wheel_action("chip-core") {
     "chip.setup_payload",
     "chip.storage",
     "chip.tracing",
+    "chip.fault_injection",
   ]
 
   if (!chip_controller) {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -163,6 +163,7 @@ PyChipError pychip_DeviceController_SetIcdRegistrationParameters(bool enabled, c
 PyChipError pychip_DeviceController_ResetCommissioningParameters();
 PyChipError pychip_DeviceController_MarkSessionDefunct(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
 PyChipError pychip_DeviceController_MarkSessionForEviction(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid);
+PyChipError pychip_DeviceController_DeleteAllSessionResumption(chip::Controller::DeviceCommissioner * devCtrl);
 PyChipError pychip_DeviceController_EstablishPASESessionIP(chip::Controller::DeviceCommissioner * devCtrl, const char * peerAddrStr,
                                                            uint32_t setupPINCode, chip::NodeId nodeid, uint16_t port);
 PyChipError pychip_DeviceController_EstablishPASESessionBLE(chip::Controller::DeviceCommissioner * devCtrl, uint32_t setupPINCode,
@@ -708,6 +709,16 @@ PyChipError pychip_DeviceController_MarkSessionForEviction(chip::Controller::Dev
                                                                          session->MarkForEviction();
                                                                      }
                                                                  });
+
+    return ToPyChipError(CHIP_NO_ERROR);
+}
+
+PyChipError pychip_DeviceController_DeleteAllSessionResumption(chip::Controller::DeviceCommissioner * devCtrl)
+{
+    FabricIndex fabricIndex = devCtrl->GetFabricIndex();
+
+    PyReturnErrorOnFailure(ToPyChipError(
+        DeviceControllerFactory::GetInstance().GetSystemState()->GetSessionResumptionStorage()->DeleteAll(fabricIndex)));
 
     return ToPyChipError(CHIP_NO_ERROR);
 }

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -795,6 +795,20 @@ class ChipDeviceControllerBase():
                 self.devCtrl, nodeid)
         ).raise_on_error()
 
+    def DeleteAllSessionResumptionStorage(self):
+        '''
+        Remove all session resumption information associated with the fabric index of the controller.
+
+        Raises:
+            RuntimeError: If the controller is not active.
+            PyChipError: If the operation fails.
+        '''
+
+        self.CheckIsActive()
+        self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_DeleteAllSessionResumption(
+                self.devCtrl)).raise_on_error()
+
     async def _establishPASESession(self, callFunct):
         self.CheckIsActive()
 
@@ -2148,6 +2162,10 @@ class ChipDeviceControllerBase():
             self._dmLib.pychip_DeviceController_MarkSessionForEviction.argtypes = [
                 c_void_p, c_uint64]
             self._dmLib.pychip_DeviceController_MarkSessionForEviction.restype = PyChipError
+
+            self._dmLib.pychip_DeviceController_DeleteAllSessionResumption.argtypes = [
+                c_void_p]
+            self._dmLib.pychip_DeviceController_DeleteAllSessionResumption.restype = PyChipError
 
             self._dmLib.pychip_DeviceController_GetAddressAndPort.argtypes = [
                 c_void_p, c_uint64, c_char_p, c_uint64, POINTER(c_uint16)]

--- a/src/controller/python/chip/fault_injection/FaultInjection.cpp
+++ b/src/controller/python/chip/fault_injection/FaultInjection.cpp
@@ -18,8 +18,6 @@
 
 #include <lib/support/CHIPFaultInjection.h>
 
-// #if CHIP_WITH_NLFAULTINJECTION
-
 extern "C" int32_t pychip_faultinjection_fail_at_fault(uint32_t faultID, uint32_t numCallsToSkip, uint32_t numCallsToFail,
                                                        bool takeMutex)
 {
@@ -39,14 +37,7 @@ extern "C" void pychip_faultinjection_reset_fault_counters(void)
     return chip::FaultInjection::GetManager().ResetFaultCounters();
 }
 
-extern "C" const char * const * pychip_faultinjection_get_fault_names()
-{
-    return chip::FaultInjection::sFaultNames;
-}
-
 extern "C" int pychip_faultinjection_get_num_faults()
 {
     return chip::FaultInjection::kNumChipFaultsFromEnum;
 }
-
-// #endif // CHIP_WITH_NLFAULTINJECTION

--- a/src/controller/python/chip/fault_injection/FaultInjection.cpp
+++ b/src/controller/python/chip/fault_injection/FaultInjection.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2025 Project CHIP Authors
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,94 +16,37 @@
  *    limitations under the License.
  */
 
-#include <controller/python/chip/native/ChipMainLoopWork.h>
-
 #include <lib/support/CHIPFaultInjection.h>
-
-namespace {
-// chip::Tracing::Json::JsonBackend gJsonBackend;
-
-// chip::Tracing::Perfetto::FileTraceOutput gPerfettoFileOutput;
-// chip::Tracing::Perfetto::PerfettoBackend gPerfettoBackend;
-
-} // namespace
 
 // #if CHIP_WITH_NLFAULTINJECTION
 
-// Returns 0 if pass, -ve if failed
 extern "C" int32_t pychip_faultinjection_fail_at_fault(uint32_t faultID, uint32_t numCallsToSkip, uint32_t numCallsToFail,
                                                        bool takeMutex)
 {
+    // Only ChipFaults (defined in src/lib/support/CHIPFaultInjection.h) are implemented, Implement others by adding calls to thier
+    // fault injection managers (SystemFauls and InetFaults)
     return chip::FaultInjection::GetManager().FailAtFault(faultID, numCallsToSkip, numCallsToFail, takeMutex);
-    // return chip::FaultInjection::GetManager().FailAtFault(chip::FaultInjection::kFault_CASEInvalidDesintationID, 0, 1);
 }
 
-// extern "C" int32_t pychip_faultinjection_delete_Session_Resumption(uint32_t fabricIndex)
-// {
-//     chip::Server::GetInstance().GetSessionResumptionStorage()->DeleteAll(fabricIndex);
-// }
-
-/*
-extern "C" void pychip_tracing_start_json_log()
+extern "C" uint32_t pychip_faultinjection_get_fault_counter(uint32_t faultID)
 {
-    chip::MainLoopWork::ExecuteInMainLoop([] {
-        gJsonBackend.CloseFile(); // just in case, ensure no file output
-        chip::Tracing::Register(gJsonBackend);
-    });
+
+    return chip::FaultInjection::GetFaultCounter(faultID);
 }
 
-extern "C" PyChipError pychip_tracing_start_json_file(const char * file_name)
+extern "C" void pychip_faultinjection_reset_fault_counters(void)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    chip::MainLoopWork::ExecuteInMainLoop([&err, file_name] {
-        err = gJsonBackend.OpenFile(file_name);
-        if (err != CHIP_NO_ERROR)
-        {
-            return;
-        }
-        chip::Tracing::Register(gJsonBackend);
-    });
-
-    return ToPyChipError(err);
+    return chip::FaultInjection::GetManager().ResetFaultCounters();
 }
 
-extern "C" void pychip_tracing_start_perfetto_system()
+extern "C" const char * const * pychip_faultinjection_get_fault_names()
 {
-    chip::MainLoopWork::ExecuteInMainLoop([] {
-        chip::Tracing::Perfetto::Initialize(perfetto::kSystemBackend);
-        chip::Tracing::Perfetto::RegisterEventTrackingStorage();
-        chip::Tracing::Register(gPerfettoBackend);
-    });
+    return chip::FaultInjection::sFaultNames;
 }
 
-extern "C" PyChipError pychip_tracing_start_perfetto_file(const char * file_name)
+extern "C" int pychip_faultinjection_get_num_faults()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    chip::MainLoopWork::ExecuteInMainLoop([&err, file_name] {
-        chip::Tracing::Perfetto::Initialize(perfetto::kInProcessBackend);
-        chip::Tracing::Perfetto::RegisterEventTrackingStorage();
-
-        err = gPerfettoFileOutput.Open(file_name);
-        if (err != CHIP_NO_ERROR)
-        {
-            return;
-        }
-        chip::Tracing::Register(gPerfettoBackend);
-    });
-
-    return ToPyChipError(err);
+    return chip::FaultInjection::kNumChipFaultsFromEnum;
 }
-
-extern "C" void pychip_tracing_stop()
-{
-    chip::MainLoopWork::ExecuteInMainLoop([] {
-        chip::Tracing::Perfetto::FlushEventTrackingStorage();
-        gPerfettoFileOutput.Close();
-        chip::Tracing::Unregister(gPerfettoBackend);
-        chip::Tracing::Unregister(gJsonBackend);
-    });
-}
-*/
 
 // #endif // CHIP_WITH_NLFAULTINJECTION

--- a/src/controller/python/chip/fault_injection/FaultInjection.cpp
+++ b/src/controller/python/chip/fault_injection/FaultInjection.cpp
@@ -1,0 +1,109 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <controller/python/chip/native/ChipMainLoopWork.h>
+
+#include <lib/support/CHIPFaultInjection.h>
+
+namespace {
+// chip::Tracing::Json::JsonBackend gJsonBackend;
+
+// chip::Tracing::Perfetto::FileTraceOutput gPerfettoFileOutput;
+// chip::Tracing::Perfetto::PerfettoBackend gPerfettoBackend;
+
+} // namespace
+
+// #if CHIP_WITH_NLFAULTINJECTION
+
+// Returns 0 if pass, -ve if failed
+extern "C" int32_t pychip_faultinjection_fail_at_fault(uint32_t faultID, uint32_t numCallsToSkip, uint32_t numCallsToFail,
+                                                       bool takeMutex)
+{
+    return chip::FaultInjection::GetManager().FailAtFault(faultID, numCallsToSkip, numCallsToFail, takeMutex);
+    // return chip::FaultInjection::GetManager().FailAtFault(chip::FaultInjection::kFault_CASEInvalidDesintationID, 0, 1);
+}
+
+// extern "C" int32_t pychip_faultinjection_delete_Session_Resumption(uint32_t fabricIndex)
+// {
+//     chip::Server::GetInstance().GetSessionResumptionStorage()->DeleteAll(fabricIndex);
+// }
+
+/*
+extern "C" void pychip_tracing_start_json_log()
+{
+    chip::MainLoopWork::ExecuteInMainLoop([] {
+        gJsonBackend.CloseFile(); // just in case, ensure no file output
+        chip::Tracing::Register(gJsonBackend);
+    });
+}
+
+extern "C" PyChipError pychip_tracing_start_json_file(const char * file_name)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    chip::MainLoopWork::ExecuteInMainLoop([&err, file_name] {
+        err = gJsonBackend.OpenFile(file_name);
+        if (err != CHIP_NO_ERROR)
+        {
+            return;
+        }
+        chip::Tracing::Register(gJsonBackend);
+    });
+
+    return ToPyChipError(err);
+}
+
+extern "C" void pychip_tracing_start_perfetto_system()
+{
+    chip::MainLoopWork::ExecuteInMainLoop([] {
+        chip::Tracing::Perfetto::Initialize(perfetto::kSystemBackend);
+        chip::Tracing::Perfetto::RegisterEventTrackingStorage();
+        chip::Tracing::Register(gPerfettoBackend);
+    });
+}
+
+extern "C" PyChipError pychip_tracing_start_perfetto_file(const char * file_name)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::MainLoopWork::ExecuteInMainLoop([&err, file_name] {
+        chip::Tracing::Perfetto::Initialize(perfetto::kInProcessBackend);
+        chip::Tracing::Perfetto::RegisterEventTrackingStorage();
+
+        err = gPerfettoFileOutput.Open(file_name);
+        if (err != CHIP_NO_ERROR)
+        {
+            return;
+        }
+        chip::Tracing::Register(gPerfettoBackend);
+    });
+
+    return ToPyChipError(err);
+}
+
+extern "C" void pychip_tracing_stop()
+{
+    chip::MainLoopWork::ExecuteInMainLoop([] {
+        chip::Tracing::Perfetto::FlushEventTrackingStorage();
+        gPerfettoFileOutput.Close();
+        chip::Tracing::Unregister(gPerfettoBackend);
+        chip::Tracing::Unregister(gJsonBackend);
+    });
+}
+*/
+
+// #endif // CHIP_WITH_NLFAULTINJECTION

--- a/src/controller/python/chip/fault_injection/__init__.py
+++ b/src/controller/python/chip/fault_injection/__init__.py
@@ -1,0 +1,64 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import ctypes
+from enum import Enum, auto
+from typing import Optional
+
+from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArguments, PyChipError
+
+
+def _GetNlFaultInjectionLibraryHandle() -> ctypes.CDLL:
+    """ Get the native library handle with tracing methods initialized.
+
+      Retrieves the CHIP native library handle and attaches signatures to
+      native methods.
+      """
+
+    # Getting a handle without requiring init, as nlfaultinjection methods
+    # do not require chip stack startup
+    handle = GetLibraryHandle(HandleFlags(0))
+
+    # Uses one of the type decorators as an indicator for everything being
+    # initialized.
+    if not handle.pychip_tracing_start_json_file.argtypes:
+        setter = NativeLibraryHandleMethodArguments(handle)
+
+        setter.Set('pychip_faultinjection_fail_at_fault', ctypes.c_uint32, [
+                   ctypes.c_uint32, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_bool])
+
+    return handle
+
+
+class FaultIDs(Enum):
+    JSON = auto()
+    PERFETTO = auto()
+
+
+def FailAtFault(faultID, numCallsToSkip, numCallsToFail, takeMutex):
+    """
+    Initiate tracing to the specified destination.
+
+    Note that only one active trace can exist of a given type (i.e. cannot trace both
+    to files and logs/system).
+    """
+    handle = _GetNlFaultInjectionLibraryHandle()
+
+    nlfaultinjectionReturnCode = 0
+    nlfaultinjectionReturnCode = handle.pychip_faultinjection_fail_at_fault(faultID, numCallsToSkip, numCallsToFail, takeMutex)
+
+    if nlfaultinjectionReturnCode != 0:
+        raise Exception

--- a/src/controller/python/chip/fault_injection/__init__.py
+++ b/src/controller/python/chip/fault_injection/__init__.py
@@ -1,9 +1,8 @@
 import ctypes
 from enum import IntEnum
 from typing import Dict, List, Optional, Tuple
+
 from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArguments
-from enum import IntEnum
-import ctypes
 
 
 # Only ChipFaults (defined in src/lib/support/CHIPFaultInjection.h) are implemented, Implement others as needed

--- a/src/controller/python/chip/fault_injection/__init__.py
+++ b/src/controller/python/chip/fault_injection/__init__.py
@@ -1,11 +1,10 @@
 import ctypes
 from enum import IntEnum
-from typing import Dict, List, Optional, Tuple
 
 from ..native import GetLibraryHandle, HandleFlags, NativeLibraryHandleMethodArguments
 
 
-# Only ChipFaults (defined in src/lib/support/CHIPFaultInjection.h) are implemented, Implement others as needed
+# Only ChipFaults (defined in src/lib/support/CHIPFaultInjection.h) are supported in this module, Implement others as needed
 class FaultType(IntEnum):
     Unspecified = 0,
     SystemFault = 1,
@@ -13,14 +12,47 @@ class FaultType(IntEnum):
     ChipFault = 3,
 
 
+# IMPORTANT: CHIPFaultId enum must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h
+# If you change values in the C/C++ header, update them here as well.
+class CHIPFaultId(IntEnum):
+    """Fault IDs for CHIP fault injection, matching the `Id` enum in src/lib/support/CHIPFaultInjection.h"""
+    AllocExchangeContext = 0
+    DropIncomingUDPMsg = 1
+    DropOutgoingUDPMsg = 2
+    AllocBinding = 3
+    SendAlarm = 4
+    HandleAlarm = 5
+    FuzzExchangeHeaderTx = 6
+    RMPDoubleTx = 7
+    RMPSendError = 8
+    BDXBadBlockCounter = 9
+    BDXAllocTransfer = 10
+    SecMgrBusy = 11
+    IMInvoke_SeparateResponses = 12
+    IMInvoke_SeparateResponsesInvertResponseOrder = 13
+    IMInvoke_SkipSecondResponse = 14
+    ModifyWebRTCAnswerSessionId = 15
+    ModifyWebRTCOfferSessionId = 16
+    CASEServerBusy = 17
+    CASESkipInitiatorResumeMIC = 18
+    CASESkipResumptionID = 19
+    CASECorruptInitiatorResumeMIC = 20
+    CASECorruptDestinationID = 21
+    CASECorruptTBEData3Encrypted = 22
+    CASECorruptSigma3NOC = 23
+    CASECorruptSigma3ICAC = 24
+    CASECorruptSigma3Signature = 25
+    CASECorruptSigma3InitiatorEphPubKey = 26
+    CASECorruptSigma3ResponderEphPubKey = 27
+
+
 def _GetNlFaultInjectionLibraryHandle() -> ctypes.CDLL:
     """Get the native library handle with fault injection methods initialized."""
     handle = GetLibraryHandle(HandleFlags(0))
 
-    if not handle.pychip_faultinjection_get_num_faults.argtypes:
+    if not handle.pychip_faultinjection_fail_at_fault.argtypes:
         setter = NativeLibraryHandleMethodArguments(handle)
 
-        setter.Set('pychip_faultinjection_get_fault_names', ctypes.POINTER(ctypes.c_char_p), None)
         setter.Set('pychip_faultinjection_get_num_faults', ctypes.c_uint32, None)
 
         setter.Set('pychip_faultinjection_fail_at_fault', ctypes.c_uint32, [
@@ -31,36 +63,13 @@ def _GetNlFaultInjectionLibraryHandle() -> ctypes.CDLL:
 
         setter.Set('pychip_faultinjection_reset_fault_counters', None, None)
 
+        num_faults = handle.pychip_faultinjection_get_num_faults()
+        assert len(CHIPFaultId) == num_faults, "The Number of Faults in the CHIPFaultId Enum doesn't match that in the C++ CHIPFaultInjection Header"
+
     return handle
 
 
-def _generate_fault_enum_from_c(enum_name: str = "CHIPFaultId") -> IntEnum:
-    """Generate a Python IntEnum from the sFaultNames[] array defined in src/lib/support/CHIPFaultInjection.cpp """
-
-    handle = _GetNlFaultInjectionLibraryHandle()
-
-    count = handle.pychip_faultinjection_get_num_faults()
-    array_ptr = handle.pychip_faultinjection_get_fault_names()
-
-    names = []
-    for i in range(count):
-        c_str = array_ptr[i]
-        if c_str is None:
-            raise ValueError(
-                f"sFaultNames[{i}] is NULL —> check that all fault ids defined in enum 'Id' in src/lib/support/CHIPFaultInjection.h" +
-                "are present in sFaultNames[] array defined in src/lib/support/CHIPFaultInjection.cpp ")
-        names.append(c_str.decode())
-
-    enum_dict = {name: i for i, name in enumerate(names)}
-
-    return IntEnum(enum_name, enum_dict)
-
-
-# This Enum is dynamically generated, it will have the same names as the sFaultNames[] array defined in src/lib/support/CHIPFaultInjection.cpp
-CHIPFaultId = _generate_fault_enum_from_c()
-
-
-def FailAtFault(faultID, numCallsToSkip: int, numCallsToFail: int, takeMutex: bool = True):
+def FailAtFault(faultID: CHIPFaultId, numCallsToSkip: int, numCallsToFail: int, takeMutex: bool = True):
     """ Configure a fault to be triggered
     This should only be used to inject faults locally into the Client being run by the script. Otherwise to inject Faults over the data model, use the FailAtFault variant in clusters/Objects.py"""
     handle = _GetNlFaultInjectionLibraryHandle()
@@ -72,7 +81,7 @@ def FailAtFault(faultID, numCallsToSkip: int, numCallsToFail: int, takeMutex: bo
         raise Exception(f"Fault injection failed with return code: {nlfaultinjectionReturnCode}")
 
 
-def GetFaultCounter(faultID):
+def GetFaultCounter(faultID: CHIPFaultId):
     """ Returns the number of times a specific fault was checked during execution.
 
     This is useful for verifying that the code path containing the fault injection was actually executed,

--- a/src/controller/python/chip/fault_injection/__init__.py
+++ b/src/controller/python/chip/fault_injection/__init__.py
@@ -14,6 +14,7 @@ class FaultType(IntEnum):
 
 # IMPORTANT: CHIPFaultId enum must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h
 # If you change values in the C/C++ header, update them here as well.
+# BEGIN-IF-CHANGE-ALSO-CHANGE(/src/lib/support/CHIPFaultInjection.h)
 class CHIPFaultId(IntEnum):
     """Fault IDs for CHIP fault injection, matching the `Id` enum in src/lib/support/CHIPFaultInjection.h"""
     AllocExchangeContext = 0
@@ -44,6 +45,10 @@ class CHIPFaultId(IntEnum):
     CASECorruptSigma3Signature = 25
     CASECorruptSigma3InitiatorEphPubKey = 26
     CASECorruptSigma3ResponderEphPubKey = 27
+
+# END-IF-CHANGE-ALSO-CHANGE(/src/lib/support/CHIPFaultInjection.h)
+# IMPORTANT: CHIPFaultId enum above must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h
+# If you change values in the C/C++ header, update them here as well.
 
 
 def _GetNlFaultInjectionLibraryHandle() -> ctypes.CDLL:

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -621,11 +621,20 @@ public:
      **/
     const P256PublicKey & Pubkey() const override { return mPublicKey; }
 
+#if CHIP_WITH_NLFAULTINJECTION
+    P256PublicKey & TestOnlyMutablePubkey() { return mPublicKey; }
+#endif
+
     /** Release resources associated with this key pair */
     void Clear();
 
 protected:
+#if CHIP_WITH_NLFAULTINJECTION
+    mutable P256PublicKey mPublicKey;
+#else
     P256PublicKey mPublicKey;
+#endif
+    // P256PublicKey mPublicKey;
     mutable P256KeypairContext mKeypair;
     bool mInitialized = false;
 };

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -32,35 +32,13 @@ static int32_t sFault_CHIPNotificationSize_Arguments[1];
 static int32_t sFault_FuzzExchangeHeader_Arguments[1];
 static class nl::FaultInjection::Manager sChipFaultInMgr;
 static const nl::FaultInjection::Name sManagerName = "chip";
-const nl::FaultInjection::Name sFaultNames[]       = {
-    "AllocExchangeContext",
-    "DropIncomingUDPMsg",
-    "DropOutgoingUDPMsg",
-    "AllocBinding",
-    "SendAlarm",
-    "HandleAlarm",
-    "FuzzExchangeHeaderTx",
-    "RMPDoubleTx",
-    "RMPSendError",
-    "BDXBadBlockCounter",
-    "BDXAllocTransfer",
-    "SecMgrBusy",
-    "IMInvoke_SeparateResponses",
-    "IMInvoke_SeparateResponsesInvertResponseOrder",
-    "IMInvoke_SkipSecondResponse",
-    "ModifyWebRTCAnswerSessionId",
-    "ModifyWebRTCOfferSessionId",
-    "CASEServerBusy",
-    "CASESkipInitiatorResumeMIC",
-    "CASESkipResumptionID",
-    "CASECorruptInitiatorResumeMIC",
-    "CASECorruptDestinationID",
-    "CASECorruptTBEData3Encrypted",
-    "CASECorruptSigma3NOC",
-    "CASECorruptSigma3ICAC",
-    "CASECorruptSigma3Signature",
-    "CASECorruptSigma3InitiatorEphPubKey",
-    "CASECorruptSigma3ResponderEphPubKey",
+
+/*
+ * Array of strings containing the names for each Fault as defined in .h
+ */
+const nl::FaultInjection::Name sFaultNames[kFault_NumItems] = {
+#define _CHIP_FAULT_NAMES_STRING(FAULT, ...) #FAULT,
+    CHIP_FAULTS_ENUMERATE(_CHIP_FAULT_NAMES_STRING) //
 };
 
 static_assert(kFault_NumItems == sizeof(sFaultNames) / sizeof(sFaultNames[0]),

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -31,8 +31,8 @@ static nl::FaultInjection::Record sFaultRecordArray[kFault_NumItems];
 static int32_t sFault_CHIPNotificationSize_Arguments[1];
 static int32_t sFault_FuzzExchangeHeader_Arguments[1];
 static class nl::FaultInjection::Manager sChipFaultInMgr;
-static const nl::FaultInjection::Name sManagerName  = "chip";
-static const nl::FaultInjection::Name sFaultNames[] = {
+static const nl::FaultInjection::Name sManagerName = "chip";
+const nl::FaultInjection::Name sFaultNames[]       = {
     "AllocExchangeContext",
     "DropIncomingUDPMsg",
     "DropOutgoingUDPMsg",
@@ -48,14 +48,28 @@ static const nl::FaultInjection::Name sFaultNames[] = {
     "IMInvoke_SeparateResponses",
     "IMInvoke_SeparateResponsesInvertResponseOrder",
     "IMInvoke_SkipSecondResponse",
-#if CONFIG_NETWORK_LAYER_BLE
-    "CHIPOBLESend",
-#endif // CONFIG_NETWORK_LAYER_BLE
+    "ModifyWebRTCAnswerSessionId",
+    "ModifyWebRTCOfferSessionId",
     "CASEServerBusy",
+    "CASESkipInitiatorResumeMIC",
+    "CASESkipResumptionID",
+    "CASECorruptInitiatorResumeMIC",
+    "CASECorruptDestinationID",
+    "CASECorruptTBEData3Encrypted",
+    "CASECorruptSigma3NOC",
+    "CASECorruptSigma3ICAC",
+    "CASECorruptSigma3Signature",
+    "CASECorruptSigma3InitiatorEphPubKey",
+    "CASECorruptSigma3ResponderEphPubKey",
 };
 
+static_assert(kFault_NumItems == sizeof(sFaultNames) / sizeof(sFaultNames[0]),
+              "The last member of the Id enum (kFault_NumItems) should equal the length of sFaultNames[] ");
+
+const size_t kNumChipFaultsFromEnum = kFault_NumItems;
+
 /**
- * Get the singleton FaultInjection::Manager for Inet faults
+ * Get the singleton FaultInjection::Manager for CHIP faults
  */
 nl::FaultInjection::Manager & GetManager()
 {
@@ -69,6 +83,16 @@ nl::FaultInjection::Manager & GetManager()
             static_cast<uint8_t>(sizeof(sFault_FuzzExchangeHeader_Arguments) / sizeof(sFault_FuzzExchangeHeader_Arguments[0]));
     }
     return sChipFaultInMgr;
+}
+
+/**
+ * Get the number of times the fault injection point location got checked. This is useful for verifying that the code path
+ * containing the fault injection was actually executed.
+ * Note: The count includes all checks, even if the fault was not triggered.
+ */
+uint32_t GetFaultCounter(uint32_t faultID)
+{
+    return GetManager().GetFaultRecords()[faultID].mNumTimesChecked;
 }
 
 /**

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -34,17 +34,15 @@ static class nl::FaultInjection::Manager sChipFaultInMgr;
 static const nl::FaultInjection::Name sManagerName = "chip";
 
 /*
- * Array of strings containing the names for each Fault as defined in .h
+ * Array of strings containing the names for each Fault as defined in the CHIP_FAULTS_ENUMERATE(X) Macro in the Header file
  */
-const nl::FaultInjection::Name sFaultNames[kFault_NumItems] = {
+static const nl::FaultInjection::Name sFaultNames[kFault_NumItems] = {
 #define _CHIP_FAULT_NAMES_STRING(FAULT, ...) #FAULT,
     CHIP_FAULTS_ENUMERATE(_CHIP_FAULT_NAMES_STRING) //
 };
 
 static_assert(kFault_NumItems == sizeof(sFaultNames) / sizeof(sFaultNames[0]),
               "The last member of the Id enum (kFault_NumItems) should equal the length of sFaultNames[] ");
-
-const size_t kNumChipFaultsFromEnum = kFault_NumItems;
 
 /**
  * Get the singleton FaultInjection::Manager for CHIP faults

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -39,6 +39,42 @@
 namespace chip {
 namespace FaultInjection {
 
+// X-Macro style enumeration of Fault Names and their ID.
+// This list is used to generate the "Id" enum and the array of strings sFaultNames[]
+// WARNING: When adding/modifying Faults to the below macro, make sure the changes are duplicated to the CHIPFaultId enum in the
+// Python Module src/controller/python/chip/fault_injection/__init__.py
+
+#define CHIP_FAULTS_ENUMERATE(X)                                                                                                   \
+    X(AllocExchangeContext, 0) /**< Fail the allocation of an ExchangeContext */                                                   \
+    X(DropIncomingUDPMsg, 1)   /**< Drop an incoming UDP message without any processing */                                         \
+    X(DropOutgoingUDPMsg, 2)   /**< Drop an outgoing UDP message at the chip Message layer */                                      \
+    X(AllocBinding, 3)         /**< Fail the allocation of a Binding */                                                            \
+    X(SendAlarm, 4)            /**< Fail to send an alarm message */                                                               \
+    X(HandleAlarm, 5)          /**< Fail to handle an alarm message */                                                             \
+    X(FuzzExchangeHeaderTx, 6) /**< Fuzz an Exchange Header in the packet buffer; expects an int argument selecting a fuzzing      \
+                                  method. @see FuzzExchangeHeader */                                                               \
+    X(RMPDoubleTx, 7)          /**< Force RMP to transmit the outgoing message twice */                                            \
+    X(RMPSendError, 8)         /**< Simulate a send error in RMP as if retransmission count exceeded */                            \
+    X(BDXBadBlockCounter, 9)   /**< Corrupt the BDX Block Counter in a BlockSend or BlockEOF message */                            \
+    X(BDXAllocTransfer, 10)    /**< Fail the allocation of a BDXTransfer object */                                                 \
+    X(SecMgrBusy, 11)          /**< Simulate WEAVE_ERROR_SECURITY_MANAGER_BUSY on session start */                                 \
+    X(IMInvoke_SeparateResponses, 12) /**< Respond to 2 InvokeRequestMessage commands with 2 separate responses */                 \
+    X(IMInvoke_SeparateResponsesInvertResponseOrder, 13) /**< Respond with 2 InvokeResponses in reverse order of request */        \
+    X(IMInvoke_SkipSecondResponse, 14)                   /**< Respond to 2 commands but drop the second response */                \
+    X(ModifyWebRTCAnswerSessionId, 15)                   /**< Modify session ID in outgoing WebRTC Answer command */               \
+    X(ModifyWebRTCOfferSessionId, 16)                    /**< Modify session ID in outgoing WebRTC Offer command */                \
+    X(CASEServerBusy, 17)                                /**< Respond to CASE_Sigma1 with BUSY status */                           \
+    X(CASESkipInitiatorResumeMIC, 18)                    /**< Send Sigma1 with resumptionID but omit initiatorResumeMIC */         \
+    X(CASESkipResumptionID, 19)                          /**< Send Sigma1 with initiatorResumeMIC but omit resumptionID */         \
+    X(CASECorruptInitiatorResumeMIC, 20)                 /**< Send invalid initiatorResumeMIC in Sigma1 */                         \
+    X(CASECorruptDestinationID, 21)                      /**< Send Sigma1 with invalid DestinationID */                            \
+    X(CASECorruptTBEData3Encrypted, 22)                  /**< Send CASE_Sigma3 with improperly generated TBEData3Encrypted */      \
+    X(CASECorruptSigma3NOC, 23)                          /**< Send Sigma3 with invalid initiatorNOC */                             \
+    X(CASECorruptSigma3ICAC, 24)                         /**< Send Sigma3 with invalid initiatorICAC */                            \
+    X(CASECorruptSigma3Signature, 25)                    /**< Send Sigma3 with invalid signature */                                \
+    X(CASECorruptSigma3InitiatorEphPubKey, 26)           /**< Send Sigma3 with invalid initiator ephemeral public key */           \
+    X(CASECorruptSigma3ResponderEphPubKey, 27)           /**< Send Sigma3 with invalid responder ephemeral public key */
+
 /**
  * @brief   Fault injection points
  *
@@ -50,46 +86,13 @@ namespace FaultInjection {
  * src/controller/python/chip/fault_injection/__init__.py
  * If you change values here, update them there as well.
  */
-typedef enum
-{
-    kFault_AllocExchangeContext = 0, /**< Fail the allocation of an ExchangeContext */
-    kFault_DropIncomingUDPMsg   = 1, /**< Drop an incoming UDP message without any processing */
-    kFault_DropOutgoingUDPMsg   = 2, /**< Drop an outgoing UDP message at the chip Message layer */
-    kFault_AllocBinding         = 3, /**< Fail the allocation of a Binding */
-    kFault_SendAlarm            = 4, /**< Fail to send an alarm message */
-    kFault_HandleAlarm          = 5, /**< Fail to handle an alarm message */
-    kFault_FuzzExchangeHeaderTx = 6, /**< Fuzz a chip Exchange Header after it has been encoded into the packet buffer;
-                                       when the fault is enabled, it expects an integer argument, which is an index into
-                                       a table of modifications that can be applied to the header. @see FuzzExchangeHeader */
-    kFault_RMPDoubleTx        = 7,   /**< Force RMP to transmit the outgoing message twice */
-    kFault_RMPSendError       = 8,   /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
-    kFault_BDXBadBlockCounter = 9,   /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
-    kFault_BDXAllocTransfer   = 10,  /**< Fail the allocation of a BDXTransfer object */
-    kFault_SecMgrBusy         = 11,  /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */
-    kFault_IMInvoke_SeparateResponses = 12, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and
-                                         respond with 2 InvokeResponseMessages */
-    kFault_IMInvoke_SeparateResponsesInvertResponseOrder = 13, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid
-                                         commands and respond with 2 InvokeResponseMessages where the response order is inverted
-                                         compared to the request order */
-    kFault_IMInvoke_SkipSecondResponse = 14, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and
-                                         respond with 1 InvokeResponseMessage, dropping the response to the second request */
-    kFault_ModifyWebRTCAnswerSessionId         = 15, /**< Change the session ID in the outgoing WebRTC Answer command */
-    kFault_ModifyWebRTCOfferSessionId          = 16, /**< Change the session ID in the outgoing WebRTC Offer command */
-    kFault_CASEServerBusy                      = 17, /**< Respond to CASE_Sigma1 with a BUSY status */
-    kFault_CASESkipInitiatorResumeMIC          = 18, /**< Send CASE_Sigma1 with resumptionID but no initiatorResumeMIC  */
-    kFault_CASESkipResumptionID                = 19, /**< Send CASE_Sigma1 with initiatorResumeMIC but no resumptionID  */
-    kFault_CASECorruptInitiatorResumeMIC       = 20, /**< Send CASE_Sigma1 with an invalid initiatorResumeMIC  */
-    kFault_CASECorruptDestinationID            = 21, /**< Send CASE_Sigma1 with an invalid DestinationID */
-    kFault_CASECorruptTBEData3Encrypted        = 22, /**< Send CASE_Sigma3 with improperly generated TBEData3Encrypted */
-    kFault_CASECorruptSigma3NOC                = 23, /**< Send CASE_Sigma3 with invalid initiatorNOC   */
-    kFault_CASECorruptSigma3ICAC               = 24, /**< Send CASE_Sigma3 with invalid initiatorICAC   */
-    kFault_CASECorruptSigma3Signature          = 25, /**< Send CASE_Sigma3 with invalid Signature */
-    kFault_CASECorruptSigma3InitiatorEphPubKey = 26, /**< Send CASE_Sigma3 with invalid InitiatorEphPubKey */
-    kFault_CASECorruptSigma3ResponderEphPubKey = 27, /**< Send CASE_Sigma3 with invalid ResponderEphPubKey */
-    /** Please add new Fault IDs here  **/
-    kFault_NumItems
 
-} Id;
+enum Id
+{
+#define _CHIP_FAULTS_ENUMERATE_DECL(FAULT, ...) kFault_##FAULT,
+    CHIP_FAULTS_ENUMERATE(_CHIP_FAULTS_ENUMERATE_DECL) //
+    kFault_NumItems                                    // marker value
+};
 
 extern const char * const sFaultNames[];
 extern const size_t kNumChipFaultsFromEnum;

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -44,6 +44,7 @@ namespace FaultInjection {
 // WARNING: When adding/modifying Faults to the below macro, make sure the changes are duplicated to the CHIPFaultId enum in the
 // Python Module src/controller/python/chip/fault_injection/__init__.py
 
+// BEGIN-IF-CHANGE-ALSO-CHANGE(src/controller/python/chip/fault_injection/__init__.py)
 #define CHIP_FAULTS_ENUMERATE(X)                                                                                                   \
     X(AllocExchangeContext, 0) /**< Fail the allocation of an ExchangeContext */                                                   \
     X(DropIncomingUDPMsg, 1)   /**< Drop an incoming UDP message without any processing */                                         \
@@ -74,6 +75,10 @@ namespace FaultInjection {
     X(CASECorruptSigma3Signature, 25)                    /**< Send Sigma3 with invalid signature */                                \
     X(CASECorruptSigma3InitiatorEphPubKey, 26)           /**< Send Sigma3 with invalid initiator ephemeral public key */           \
     X(CASECorruptSigma3ResponderEphPubKey, 27)           /**< Send Sigma3 with invalid responder ephemeral public key */
+
+// END-IF-CHANGE-ALSO-CHANGE(src/controller/python/chip/fault_injection/__init__.py)
+// WARNING: When adding/modifying Faults to the below macro, make sure the changes are duplicated to the CHIPFaultId enum in the
+// Python Module src/controller/python/chip/fault_injection/__init__.py
 
 /**
  * @brief   Fault injection points

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -94,8 +94,8 @@ enum Id
     kFault_NumItems                                    // marker value
 };
 
-extern const char * const sFaultNames[];
-extern const size_t kNumChipFaultsFromEnum;
+// Exporting kNumChipFaultsFromEnum for usage in Python bindings
+const size_t kNumChipFaultsFromEnum = kFault_NumItems;
 
 static_assert(kFault_IMInvoke_SeparateResponses == 12, "Test plan specification and automation code relies on this value being 12");
 static_assert(kFault_IMInvoke_SeparateResponsesInvertResponseOrder == 13,

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -45,38 +45,54 @@ namespace FaultInjection {
  * @details
  * Each point in the code at which a fault can be injected
  * is identified by a member of this enum.
+ *
+ * @note IMPORTANT: This enum must be kept in sync with the CHIPFaultId enum in
+ * src/controller/python/chip/fault_injection/__init__.py
+ * If you change values here, update them there as well.
  */
 typedef enum
 {
-    kFault_AllocExchangeContext, /**< Fail the allocation of an ExchangeContext */
-    kFault_DropIncomingUDPMsg,   /**< Drop an incoming UDP message without any processing */
-    kFault_DropOutgoingUDPMsg,   /**< Drop an outgoing UDP message at the chip Message layer */
-    kFault_AllocBinding,         /**< Fail the allocation of a Binding */
-    kFault_SendAlarm,            /**< Fail to send an alarm message */
-    kFault_HandleAlarm,          /**< Fail to handle an alarm message */
-    kFault_FuzzExchangeHeaderTx, /**< Fuzz a chip Exchange Header after it has been encoded into the packet buffer;
-                                      when the fault is enabled, it expects an integer argument, which is an index into
-                                      a table of modifications that can be applied to the header. @see FuzzExchangeHeader */
-    kFault_RMPDoubleTx,          /**< Force RMP to transmit the outgoing message twice */
-    kFault_RMPSendError,         /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
-    kFault_BDXBadBlockCounter,   /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
-    kFault_BDXAllocTransfer,     /**< Fail the allocation of a BDXTransfer object */
-    kFault_SecMgrBusy,           /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */
-    kFault_IMInvoke_SeparateResponses, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and respond
-                                        with 2 InvokeResponseMessages */
-    kFault_IMInvoke_SeparateResponsesInvertResponseOrder, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid
-                                        commands and respond with 2 InvokeResponseMessages where the response order is inverted
-                                        compared to the request order */
-    kFault_IMInvoke_SkipSecondResponse, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and respond
-                                        with 1 InvokeResponseMessage, dropping the response to the second request */
-    kFault_ModifyWebRTCAnswerSessionId, /**< Change the session ID in the outgoing WebRTC Answer command */
-    kFault_ModifyWebRTCOfferSessionId,  /**< Change the session ID in the outgoing WebRTC Offer command */
-#if CONFIG_NETWORK_LAYER_BLE
-    kFault_CHIPOBLESend, /**< Inject a GATT error when sending the first fragment of a chip message over BLE */
-#endif
-    kFault_CASEServerBusy, /**< Respond to CASE_Sigma1 with a BUSY status */
-    kFault_NumItems,
+    kFault_AllocExchangeContext = 0, /**< Fail the allocation of an ExchangeContext */
+    kFault_DropIncomingUDPMsg   = 1, /**< Drop an incoming UDP message without any processing */
+    kFault_DropOutgoingUDPMsg   = 2, /**< Drop an outgoing UDP message at the chip Message layer */
+    kFault_AllocBinding         = 3, /**< Fail the allocation of a Binding */
+    kFault_SendAlarm            = 4, /**< Fail to send an alarm message */
+    kFault_HandleAlarm          = 5, /**< Fail to handle an alarm message */
+    kFault_FuzzExchangeHeaderTx = 6, /**< Fuzz a chip Exchange Header after it has been encoded into the packet buffer;
+                                       when the fault is enabled, it expects an integer argument, which is an index into
+                                       a table of modifications that can be applied to the header. @see FuzzExchangeHeader */
+    kFault_RMPDoubleTx        = 7,   /**< Force RMP to transmit the outgoing message twice */
+    kFault_RMPSendError       = 8,   /**< Fail a transmission in RMP as if the max number of retransmission has been exceeded */
+    kFault_BDXBadBlockCounter = 9,   /**< Corrupt the BDX Block Counter in the BDX BlockSend or BlockEOF message about to be sent */
+    kFault_BDXAllocTransfer   = 10,  /**< Fail the allocation of a BDXTransfer object */
+    kFault_SecMgrBusy         = 11,  /**< Trigger a WEAVE_ERROR_SECURITY_MANAGER_BUSY when starting an authentication session */
+    kFault_IMInvoke_SeparateResponses = 12, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and
+                                         respond with 2 InvokeResponseMessages */
+    kFault_IMInvoke_SeparateResponsesInvertResponseOrder = 13, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid
+                                         commands and respond with 2 InvokeResponseMessages where the response order is inverted
+                                         compared to the request order */
+    kFault_IMInvoke_SkipSecondResponse = 14, /**< Validate incoming InvokeRequestMessage contains exactly 2 valid commands and
+                                         respond with 1 InvokeResponseMessage, dropping the response to the second request */
+    kFault_ModifyWebRTCAnswerSessionId         = 15, /**< Change the session ID in the outgoing WebRTC Answer command */
+    kFault_ModifyWebRTCOfferSessionId          = 16, /**< Change the session ID in the outgoing WebRTC Offer command */
+    kFault_CASEServerBusy                      = 17, /**< Respond to CASE_Sigma1 with a BUSY status */
+    kFault_CASESkipInitiatorResumeMIC          = 18, /**< Send CASE_Sigma1 with resumptionID but no initiatorResumeMIC  */
+    kFault_CASESkipResumptionID                = 19, /**< Send CASE_Sigma1 with initiatorResumeMIC but no resumptionID  */
+    kFault_CASECorruptInitiatorResumeMIC       = 20, /**< Send CASE_Sigma1 with an invalid initiatorResumeMIC  */
+    kFault_CASECorruptDestinationID            = 21, /**< Send CASE_Sigma1 with an invalid DestinationID */
+    kFault_CASECorruptTBEData3Encrypted        = 22, /**< Send CASE_Sigma3 with improperly generated TBEData3Encrypted */
+    kFault_CASECorruptSigma3NOC                = 23, /**< Send CASE_Sigma3 with invalid initiatorNOC   */
+    kFault_CASECorruptSigma3ICAC               = 24, /**< Send CASE_Sigma3 with invalid initiatorICAC   */
+    kFault_CASECorruptSigma3Signature          = 25, /**< Send CASE_Sigma3 with invalid Signature */
+    kFault_CASECorruptSigma3InitiatorEphPubKey = 26, /**< Send CASE_Sigma3 with invalid InitiatorEphPubKey */
+    kFault_CASECorruptSigma3ResponderEphPubKey = 27, /**< Send CASE_Sigma3 with invalid ResponderEphPubKey */
+    /** Please add new Fault IDs here  **/
+    kFault_NumItems
+
 } Id;
+
+extern const char * const sFaultNames[];
+extern const size_t kNumChipFaultsFromEnum;
 
 static_assert(kFault_IMInvoke_SeparateResponses == 12, "Test plan specification and automation code relies on this value being 12");
 static_assert(kFault_IMInvoke_SeparateResponsesInvertResponseOrder == 13,
@@ -88,6 +104,8 @@ static_assert(kFault_ModifyWebRTCAnswerSessionId == 15,
 static_assert(kFault_ModifyWebRTCOfferSessionId == 16, "Test plan specification and automation code relies on this value being 16");
 
 DLL_EXPORT nl::FaultInjection::Manager & GetManager();
+
+DLL_EXPORT uint32_t GetFaultCounter(uint32_t faultID);
 
 /**
  * The number of ways in which chip Fault Injection fuzzers can

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -32,6 +32,7 @@
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/CHIPFaultInjection.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
@@ -794,6 +795,7 @@ CHIP_ERROR CASESession::SendSigma1()
         MutableByteSpan destinationIdSpan(destinationIdentifier);
         ReturnErrorOnFailure(GenerateCaseDestinationId(ByteSpan(mIPK), encodeSigma1Inputs.initiatorRandom, rootPubKeySpan, fabricId,
                                                        mPeerNodeId, destinationIdSpan));
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptDestinationID, destinationIdentifier[0] ^= 0xFF);
         encodeSigma1Inputs.destinationId = destinationIdSpan;
     }
 
@@ -889,8 +891,21 @@ CHIP_ERROR CASESession::EncodeSigma1(System::PacketBufferHandle & msg, EncodeSig
 
     if (input.sessionResumptionRequested)
     {
-        ReturnErrorOnFailure(tlvWriter.Put(AsTlvContextTag(Sigma1Tags::kResumptionID), input.resumptionId));
-        ReturnErrorOnFailure(tlvWriter.Put(AsTlvContextTag(Sigma1Tags::kResume1MIC), input.initiatorResumeMIC));
+        bool TestOnlySkipResumptionID       = false;
+        bool TestOnlySkipInitiatorResumeMIC = false;
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASESkipResumptionID, TestOnlySkipResumptionID = true);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASESkipInitiatorResumeMIC, TestOnlySkipInitiatorResumeMIC = true);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptInitiatorResumeMIC, input.initiatorResume1MICBuffer[0] ^= 0xFF);
+
+        if (!TestOnlySkipResumptionID)
+        {
+            ReturnErrorOnFailure(tlvWriter.Put(AsTlvContextTag(Sigma1Tags::kResumptionID), input.resumptionId));
+        }
+
+        if (!TestOnlySkipInitiatorResumeMIC)
+        {
+            ReturnErrorOnFailure(tlvWriter.Put(AsTlvContextTag(Sigma1Tags::kResume1MIC), input.initiatorResumeMIC));
+        }
     }
 
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
@@ -1733,6 +1748,12 @@ CHIP_ERROR CASESession::SendSigma3a()
         ReturnErrorOnFailure(mFabricsTable->FetchICACert(mFabricIndex, data.icaCert));
         ReturnErrorOnFailure(mFabricsTable->FetchNOCCert(mFabricIndex, data.nocCert));
 
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma3NOC, *data.nocCert.data() ^= 0xFF);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma3ICAC, *data.icaCert.data() ^= 0xFF);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma3InitiatorEphPubKey,
+                          *(const_cast<P256PublicKey *>(&mEphemeralKey->Pubkey()))->Bytes() ^= 0xFF);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma3ResponderEphPubKey, *mRemotePubKey ^= 0xFF);
+
         // Prepare Sigma3 TBS Data Blob
         size_t msgR3SignedLen = EstimateStructOverhead(data.nocCert.size(),    // initiatorNOC
                                                        data.icaCert.size(),    // initiatorICAC
@@ -1776,6 +1797,8 @@ CHIP_ERROR CASESession::SendSigma3b(SendSigma3Data & data, bool & cancel)
         // Legacy case: delegate to fabric table fabric info
         ReturnErrorOnFailure(data.fabricTable->SignWithOpKeypair(data.fabricIndex, data.msgR3SignedSpan, data.tbsData3Signature));
     }
+
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma3Signature, *data.tbsData3Signature.Bytes() ^= 0xFF);
 
     // Prepare Sigma3 TBE Data Blob
     data.msg_r3_encrypted_len =
@@ -1856,6 +1879,7 @@ CHIP_ERROR CASESession::SendSigma3c(SendSigma3Data & data, CHIP_ERROR status)
         tlvWriter.Init(std::move(msg_R3));
         err = tlvWriter.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType);
         SuccessOrExit(err);
+        CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptTBEData3Encrypted, *data.msg_R3_Encrypted.Get() ^= 0xFF);
         err = tlvWriter.PutBytes(AsTlvContextTag(Sigma3Tags::kEncrypted3), data.msg_R3_Encrypted.Get(),
                                  static_cast<uint32_t>(data.msg_r3_encrypted_len + CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES));
         SuccessOrExit(err);

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -560,14 +560,6 @@ private:
     void SetStopSigmaHandshakeAt(Optional<State> state) { mStopHandshakeAtState = state; }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
-#if CHIP_WITH_NLFAULTINJECTION
-    /*
-     * This method is only used by the Fault Injection API, to allow us to safely inject a fault into the Initiator Ephemeral
-     * Public.
-     */
-    void TestOnlyInjectFaultIntoInitiatorEphemeralKey();
-#endif // CHIP_WITH_NLFAULTINJECTION
-
     Crypto::Hash_SHA256_stream mCommissioningHash;
     Crypto::P256PublicKey mRemotePubKey;
     Crypto::P256Keypair * mEphemeralKey = nullptr;

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -560,6 +560,14 @@ private:
     void SetStopSigmaHandshakeAt(Optional<State> state) { mStopHandshakeAtState = state; }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
+#if CHIP_WITH_NLFAULTINJECTION
+    /*
+     * This method is only used by the Fault Injection API, to allow us to safely inject a fault into the Initiator Ephemeral
+     * Public.
+     */
+    void TestOnlyInjectFaultIntoInitiatorEphemeralKey();
+#endif // CHIP_WITH_NLFAULTINJECTION
+
     Crypto::Hash_SHA256_stream mCommissioningHash;
     Crypto::P256PublicKey mRemotePubKey;
     Crypto::P256Keypair * mEphemeralKey = nullptr;

--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -32,11 +32,10 @@
 # === END CI TEST ARGUMENTS ===
 
 
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
-from mobly import asserts
 from chip.exceptions import ChipStackError
 from chip.fault_injection import CHIPFaultId, FailAtFault, GetFaultCounter, ResetFaultCounters
-
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
 
 CHIP_ERROR_CODES = {
     "CHIP_ERROR_INVALID_CASE_PARAMETER": 0x54,

--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -97,7 +97,7 @@ class TC_SC_3_4(MatterBaseTest):
         try:
             await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
             asserts.fail(
-                f"Unexpected success return from CASE Establishment after injecting fault, CASE Establishment should have failed")
+                "Unexpected success return from CASE Establishment after injecting fault, CASE Establishment should have failed")
         except ChipStackError as e:
             asserts.assert_equal(e.err,  expectedErrorCode,
                                  f"Expected to return {expectedErrorName}")
@@ -140,7 +140,7 @@ class TC_SC_3_4(MatterBaseTest):
             await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
         except ChipStackError as e:
             asserts.fail(
-                f"Unexpected CASE Establishment Failure. Having an invalid InitiatorResumeMIC should have resulted in CASE falling back to the standard CASE without resumption")
+                f"Unexpected CASE Establishment Failure, CASE Should have succeeded. Having an invalid InitiatorResumeMIC should have resulted in CASE falling back to the standard CASE without resumption. \nError = {e}")
         self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptInitiatorResumeMIC)
 
         self.step(4)

--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -1,0 +1,229 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${ALL_CLUSTERS_APP}
+#     factory-reset: true
+#     quiet: true
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --endpoint 1
+# === END CI TEST ARGUMENTS ===
+
+
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+from chip.exceptions import ChipStackError
+from chip.fault_injection import CHIPFaultId, FailAtFault, GetFaultCounter, ResetFaultCounters
+
+
+CHIP_ERROR_CODES = {
+    "CHIP_ERROR_INVALID_CASE_PARAMETER": 0x54,
+    "CHIP_ERROR_NO_SHARED_TRUSTED_ROOT": 0xC9
+}
+
+
+class TC_SC_3_4(MatterBaseTest):
+
+    def desc_TC_SC_3_4(self) -> str:
+        return "[TC-SC-3.4] CASE Error Handling [DUT_Responder] "
+
+    def steps_TC_SC_3_4(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "TH constructs and sends a Sigma1 message with a resumptionID and NO initiatorResumeMIC to DUT",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(2, "TH constructs and sends a Sigma1 message with an initiatorResumeMIC and NO resumptionID to DUT",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(3, "TH constructs and sends a Sigma1 message with a resumptionID and an invalid initiatorResumeMIC",
+                     "DUT falls back to establishing CASE without resumption . DUT sends a status report to the TH with a Success general code, Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code as SESSION_ESTABLISHMENT_SUCCESS"),
+
+            TestStep(4, "TH constructs and sends a Sigma1 message with message with an invalid destinationId to DUT",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of NO_SHARED_TRUST_ROOTS (0X0001). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(5, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with improperly generated encrypted integrity data (TBEData3Encrypted)",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(6, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with invalid initiatorNOC data",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(7, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with invalid initiatorICAC data",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(8, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with invalid signature data",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(9, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with invalid initiatorEphPubKey data",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+            TestStep(10, "TH sends a valid Sigma1 message to DUT. In reply to the received Sigma2," +
+                     "TH Sends back a Sigma3 message with invalid responderEphPubKey data",
+                     "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
+
+        ]
+        return steps
+
+    async def reestablish_CASE_and_verify_DUT_Fails_with_Error(self, expectedErrorName):
+        ''' Session should be evicted or terminated before calling this method, such as using MarkSessionForEviction()'''
+
+        expectedErrorCode = CHIP_ERROR_CODES.get(expectedErrorName)
+
+        try:
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+            asserts.fail(
+                f"Unexpected success return from CASE Establishment after injecting fault, CASE Establishment should have failed")
+        except ChipStackError as e:
+            asserts.assert_equal(e.err,  expectedErrorCode,
+                                 f"Expected to return {expectedErrorName}")
+
+    def ensure_fault_injection_point_was_reached(self, faultID):
+        asserts.assert_equal(GetFaultCounter(faultID), 1)
+        ResetFaultCounters()
+
+    @async_test_body
+    async def test_TC_SC_3_4(self):
+
+        self.step(1)
+        self.th = self.default_controller
+        # using FaultInjection to skip InitiatorResumeMIC from Sigma1 with Resumption
+        FailAtFault(faultID=CHIPFaultId.CASESkipInitiatorResumeMIC,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        # Evicting Session to trigger a new CASE Handshake
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASESkipInitiatorResumeMIC)
+
+        self.step(2)
+        FailAtFault(faultID=CHIPFaultId.CASESkipResumptionID,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASESkipResumptionID)
+
+        self.step(3)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptInitiatorResumeMIC,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        try:
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+        except ChipStackError as e:
+            asserts.fail(
+                f"Unexpected CASE Establishment Failure. Having an invalid InitiatorResumeMIC should have resulted in CASE falling back to the standard CASE without resumption")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptInitiatorResumeMIC)
+
+        self.step(4)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptDestinationID,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        # We need to delete the session resumption info to trigger the TH to send a Sigma1 WITHOUT resumption and avoid the "CASE with resumption" path.
+        # This is necessary because the "CASE with resumption" path would result in the responder not processing/validating the "faulty" DestinationID in the received Sigma1.
+        # This will also be used for all subesquent steps to make sure that we take the standard CASE path (without resumption)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_NO_SHARED_TRUSTED_ROOT")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptDestinationID)
+
+        self.step(5)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptTBEData3Encrypted,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptTBEData3Encrypted)
+
+        self.step(6)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptSigma3NOC,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptSigma3NOC)
+
+        self.step(7)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptSigma3ICAC,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptSigma3ICAC)
+
+        self.step(8)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptSigma3Signature,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptSigma3Signature)
+
+        self.step(9)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptSigma3InitiatorEphPubKey,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptSigma3InitiatorEphPubKey)
+
+        self.step(10)
+        FailAtFault(faultID=CHIPFaultId.CASECorruptSigma3ResponderEphPubKey,
+                    numCallsToSkip=0,
+                    numCallsToFail=1
+                    )
+        self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
+        self.th.DeleteAllSessionResumptionStorage()
+
+        await self.reestablish_CASE_and_verify_DUT_Fails_with_Error("CHIP_ERROR_INVALID_CASE_PARAMETER")
+        self.ensure_fault_injection_point_was_reached(faultID=CHIPFaultId.CASECorruptSigma3ResponderEphPubKey)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()


### PR DESCRIPTION
#### Changes in this PR

- Adding automated Script for TC-SC-3.4
- Adding Python Bindings to inject faults locally into the Controller used in the Test Script
- Adding Fault Injection points in CASESession.cpp
- Adding Python Binding to delete SessionResumptionStorage
- Changes to CHIPFaultInjection.cpp and .h 
#### Testing
TC_SC_3_4 will run in CI
