### PR TITLE
Postpone sending PAF packets while the wi-fi resource is unavailable

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -481,7 +481,7 @@ inline CHIP_ERROR ConnectivityManager::WiFiPAFShutdown(uint32_t id, WiFiPAF::WiF
     return static_cast<ImplClass *>(this)->_WiFiPAFShutdown(id, role);
 }
 
-inline bool ConnectivityManager::WiFiPAFResourceAvailable(void)
+inline bool ConnectivityManager::WiFiPAFResourceAvailable()
 {
     return static_cast<ImplClass *>(this)->_WiFiPAFResourceAvailable();
 }

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -190,6 +190,7 @@ public:
     WiFiPAF::WiFiPAFLayer * GetWiFiPAF();
     void WiFiPafSetApFreq(const uint16_t freq);
     CHIP_ERROR WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role);
+    bool WiFiPAFResourceAvailable(void);
 #endif
 
     // WiFi AP methods
@@ -478,6 +479,11 @@ inline CHIP_ERROR ConnectivityManager::WiFiPAFSend(const WiFiPAF::WiFiPAFSession
 inline CHIP_ERROR ConnectivityManager::WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role)
 {
     return static_cast<ImplClass *>(this)->_WiFiPAFShutdown(id, role);
+}
+
+inline bool ConnectivityManager::WiFiPAFResourceAvailable(void)
+{
+    return static_cast<ImplClass *>(this)->_WiFiPAFResourceAvailable();
 }
 #endif
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -190,7 +190,7 @@ public:
     WiFiPAF::WiFiPAFLayer * GetWiFiPAF();
     void WiFiPafSetApFreq(const uint16_t freq);
     CHIP_ERROR WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role);
-    bool WiFiPAFResourceAvailable(void);
+    bool WiFiPAFResourceAvailable();
 #endif
 
     // WiFi AP methods

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1129,6 +1129,9 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
 
         SuccessOrExit(ret);
     }
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    mPafChnlAvailable = false;
+#endif
 
     result = wpa_supplicant_1_interface_call_add_network_sync(
         mWpaSupplicant.iface.get(), args, &mWpaSupplicant.networkPath.GetReceiver(), nullptr, &err.GetReceiver());
@@ -1155,6 +1158,9 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
     {
         ChipLogError(DeviceLayer, "wpa_supplicant: failed to add network: %s", err ? err->message : "unknown error");
         mWpaSupplicant.networkPath.reset();
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        mPafChnlAvailable = true;
+#endif
         ret = CHIP_ERROR_INTERNAL;
     }
 
@@ -2386,6 +2392,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * 
     });
 
     g_strfreev(oldBsss);
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    mPafChnlAvailable = true;
+#endif
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_StartWiFiManagement()

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1130,7 +1130,7 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
         SuccessOrExit(ret);
     }
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mPafChnlAvailable = false;
+    mPafChannelAvailable = false;
 #endif
 
     result = wpa_supplicant_1_interface_call_add_network_sync(
@@ -1159,7 +1159,7 @@ ConnectivityManagerImpl::_ConnectWiFiNetworkAsync(GVariant * args,
         ChipLogError(DeviceLayer, "wpa_supplicant: failed to add network: %s", err ? err->message : "unknown error");
         mWpaSupplicant.networkPath.reset();
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        mPafChnlAvailable = true;
+        mPafChannelAvailable = true;
 #endif
         ret = CHIP_ERROR_INTERNAL;
     }
@@ -2393,7 +2393,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(WpaSupplicant1Interface * 
 
     g_strfreev(oldBsss);
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    mPafChnlAvailable = true;
+    mPafChannelAvailable = true;
 #endif
 }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -266,8 +266,9 @@ private:
     uint16_t mApFreq;
     CHIP_ERROR _WiFiPAFPublish(WiFiPAFAdvertiseParam & args);
     CHIP_ERROR _WiFiPAFCancelPublish(uint32_t PublishId);
-    bool _WiFiPAFResourceAvailable() { return mPafChnlAvailable; };
-    bool mPafChnlAvailable = true;
+    bool _WiFiPAFResourceAvailable() { return mPafChannelAvailable; };
+    // The resource checking is needed right before sending data packets that they are initialized and connected.
+    bool mPafChannelAvailable = true;
 #endif
 
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -266,6 +266,8 @@ private:
     uint16_t mApFreq;
     CHIP_ERROR _WiFiPAFPublish(WiFiPAFAdvertiseParam & args);
     CHIP_ERROR _WiFiPAFCancelPublish(uint32_t PublishId);
+    bool _WiFiPAFResourceAvailable() { return mPafChnlAvailable; };
+    bool mPafChnlAvailable = true;
 #endif
 
     bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -143,6 +143,11 @@ CHIP_ERROR WiFiPAFBase::WiFiPAFCloseSession(WiFiPAFSession & SessionInfo)
     return CHIP_NO_ERROR;
 }
 
+bool WiFiPAFBase::WiFiPAFResourceAvailable(void)
+{
+    return DeviceLayer::ConnectivityMgr().WiFiPAFResourceAvailable();
+}
+
 CHIP_ERROR WiFiPAFBase::SendAfterConnect(PacketBufferHandle && msg)
 {
     CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;

--- a/src/transport/raw/WiFiPAF.h
+++ b/src/transport/raw/WiFiPAF.h
@@ -66,6 +66,7 @@ public:
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAF::WiFiPAFSession & RxInfo, System::PacketBufferHandle && buffer) override;
     CHIP_ERROR WiFiPAFMessageSend(WiFiPAF::WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg) override;
     CHIP_ERROR WiFiPAFCloseSession(WiFiPAF::WiFiPAFSession & SessionInfo) override;
+    bool WiFiPAFResourceAvailable(void) override;
 
 private:
     /**

--- a/src/wifipaf/WiFiPAFEndPoint.cpp
+++ b/src/wifipaf/WiFiPAFEndPoint.cpp
@@ -72,7 +72,7 @@
 #define WIFIPAF_ACK_SEND_TIMEOUT_MS 2500
 #define WIFIPAF_WAIT_RES_TIMEOUT_MS 1000
 // Drop the connection if network resources remain unavailable for the period.
-// Known condition: If the remote site is awaiting an ACK packet, the wait time must not exceed PAFTP_ACK_TIMEOUT_MS.
+// Known condition: If the remote side is awaiting an ACK packet, the wait time must not exceed PAFTP_ACK_TIMEOUT_MS.
 #define WIFIPAF_MAX_RESOURCE_BLOCK_COUNT (PAFTP_ACK_TIMEOUT_MS / WIFIPAF_WAIT_RES_TIMEOUT_MS)
 
 /**

--- a/src/wifipaf/WiFiPAFEndPoint.h
+++ b/src/wifipaf/WiFiPAFEndPoint.h
@@ -117,6 +117,7 @@ private:
     enum class TimerStateFlag : uint8_t
     {
         kConnectTimerRunning     = 0x01, // PAFTP connect completion timer running.
+        kWaitResTimerRunning     = 0x02, // Wait for resource to be available
         kAckReceivedTimerRunning = 0x04, // Ack received timer running due to unacked sent fragment.
         kSendAckTimerRunning     = 0x08, // Send ack timer running; indicates pending ack to send.
     };
@@ -132,6 +133,7 @@ private:
 
     WiFiPAFTP mPafTP;
     WiFiPafRole mRole;
+    uint8_t mResWaitCount = 0;
 
     BitFlags<ConnectionStateFlag> mConnStateFlags;
     BitFlags<TimerStateFlag> mTimerStateFlags;
@@ -168,14 +170,17 @@ private:
     CHIP_ERROR StartAckReceivedTimer();   // Start ack-received timer if it's not already running.
     CHIP_ERROR RestartAckReceivedTimer(); // Restart ack-received timer.
     CHIP_ERROR StartSendAckTimer();       // Start send-ack timer if it's not already running.
+    CHIP_ERROR StartWaitResTimer();       // Start wait-res timer if it's not already running.
     void StopConnectTimer();              // Stop connect timer.
     void StopAckReceivedTimer();          // Stop ack-received timer.
     void StopSendAckTimer();              // Stop send-ack timer.
+    void StopWaitResTimer();              // Stop wait-res timer
 
     // Timer expired callbacks:
     static void HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState);
     static void HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState);
     static void HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleWaitResTimeout(chip::System::Layer * systemLayer, void * appState);
 
     // Close functions:
     void DoCloseCallback(uint8_t state, uint8_t flags, CHIP_ERROR err);

--- a/src/wifipaf/WiFiPAFEndPoint.h
+++ b/src/wifipaf/WiFiPAFEndPoint.h
@@ -133,7 +133,8 @@ private:
 
     WiFiPAFTP mPafTP;
     WiFiPafRole mRole;
-    uint8_t mResWaitCount = 0;
+    // How many continuing times the resource is unavailable. Will close the session if it's occupied too long
+    uint8_t mResourceWaitCount = 0;
 
     BitFlags<ConnectionStateFlag> mConnStateFlags;
     BitFlags<TimerStateFlag> mTimerStateFlags;
@@ -170,17 +171,17 @@ private:
     CHIP_ERROR StartAckReceivedTimer();   // Start ack-received timer if it's not already running.
     CHIP_ERROR RestartAckReceivedTimer(); // Restart ack-received timer.
     CHIP_ERROR StartSendAckTimer();       // Start send-ack timer if it's not already running.
-    CHIP_ERROR StartWaitResTimer();       // Start wait-res timer if it's not already running.
+    CHIP_ERROR StartWaitResourceTimer();  // Start wait-resource timer if it's not already running.
     void StopConnectTimer();              // Stop connect timer.
     void StopAckReceivedTimer();          // Stop ack-received timer.
     void StopSendAckTimer();              // Stop send-ack timer.
-    void StopWaitResTimer();              // Stop wait-res timer
+    void StopWaitResourceTimer();         // Stop wait-resource timer
 
     // Timer expired callbacks:
     static void HandleConnectTimeout(chip::System::Layer * systemLayer, void * appState);
     static void HandleAckReceivedTimeout(chip::System::Layer * systemLayer, void * appState);
     static void HandleSendAckTimeout(chip::System::Layer * systemLayer, void * appState);
-    static void HandleWaitResTimeout(chip::System::Layer * systemLayer, void * appState);
+    static void HandleWaitResourceTimeout(chip::System::Layer * systemLayer, void * appState);
 
     // Close functions:
     void DoCloseCallback(uint8_t state, uint8_t flags, CHIP_ERROR err);

--- a/src/wifipaf/WiFiPAFLayerDelegate.h
+++ b/src/wifipaf/WiFiPAFLayerDelegate.h
@@ -37,7 +37,7 @@ public:
     virtual CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) = 0;
     virtual CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg)     = 0;
     virtual CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession & SessionInfo)                                  = 0;
-    virtual bool WiFiPAFResourceAvailable(void)                                                           = 0;
+    virtual bool WiFiPAFResourceAvailable()                                                               = 0;
 };
 
 } // namespace WiFiPAF

--- a/src/wifipaf/WiFiPAFLayerDelegate.h
+++ b/src/wifipaf/WiFiPAFLayerDelegate.h
@@ -37,6 +37,7 @@ public:
     virtual CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) = 0;
     virtual CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg)     = 0;
     virtual CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession & SessionInfo)                                  = 0;
+    virtual bool WiFiPAFResourceAvailable(void)                                                           = 0;
 };
 
 } // namespace WiFiPAF

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -71,7 +71,7 @@ public:
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession & SessionInfo) override { return CHIP_NO_ERROR; }
-    bool WiFiPAFResourceAvailable(void) override { return true; }
+    bool WiFiPAFResourceAvailable() override { return true; }
     static constexpr size_t kTestPacketLength     = 100;
     static constexpr size_t kTestPacketLengthLong = 500;
 

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -71,6 +71,7 @@ public:
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession & SessionInfo) override { return CHIP_NO_ERROR; }
+    bool WiFiPAFResourceAvailable(void) override { return true; }
     static constexpr size_t kTestPacketLength     = 100;
     static constexpr size_t kTestPacketLengthLong = 500;
 

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -71,7 +71,7 @@ public:
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFMessageSend(WiFiPAFSession & TxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }
     CHIP_ERROR WiFiPAFCloseSession(WiFiPAFSession & SessionInfo) override { return CHIP_NO_ERROR; }
-    bool WiFiPAFResourceAvailable() override { return true; }
+    bool WiFiPAFResourceAvailable() override { return mResourceAvailable; }
     static constexpr size_t kTestPacketLength     = 100;
     static constexpr size_t kTestPacketLengthLong = 500;
 
@@ -81,6 +81,8 @@ public:
     CHIP_ERROR EpDoSendStandAloneAck() { return mEndPoint->DoSendStandAloneAck(); }
     void EpSetRxNextSeqNum(SequenceNumber_t seq) { mEndPoint->mPafTP.mRxNextSeqNum = seq; }
     WiFiPAFTP::State_t EpGetTxState() { return mEndPoint->mPafTP.mTxState; }
+    bool mResourceAvailable = true;
+    bool isSendQueueNull() { return mEndPoint->mSendQueue.IsNull(); }
 
 private:
     WiFiPAFEndPoint * mEndPoint;
@@ -350,6 +352,21 @@ TEST_F(TestWiFiPAFLayer, CheckRunAsCommissionee)
     packet_c1->AddToEnd(std::move(packet_c2));
     EXPECT_EQ(packet_c1->HasChainedBuffer(), true);
     EXPECT_EQ(newEndPoint->Send(std::move(packet_c1)), CHIP_NO_ERROR);
+    EXPECT_EQ(HandleWriteConfirmed(sessionInfo, true), CHIP_NO_ERROR);
+
+    // Test, Send the packet while resource is unavaialbe -> available
+    mResourceAvailable   = false;
+    auto packet_resource = System::PacketBufferHandle::NewWithData(buf_chain, sizeof(buf_chain));
+    EXPECT_EQ(newEndPoint->Send(std::move(packet_resource)), CHIP_NO_ERROR);
+    // break because resource is unavailable
+    EXPECT_EQ(isSendQueueNull(), false);
+    // Resource is available now
+    mResourceAvailable = true;
+    // PAF packets shoudl be sent within a second
+    sleep(2);
+    EXPECT_EQ(HandleWriteConfirmed(sessionInfo, true), CHIP_NO_ERROR);
+    // PAF packet has been sent
+    EXPECT_EQ(isSendQueueNull(), true);
 
     // Close the session
     EXPECT_EQ(RmPafSession(PafInfoAccess::kAccSessionId, sessionInfo), CHIP_NO_ERROR);


### PR DESCRIPTION
#### Testing

* Environment:
    AP: Asus RT-N66U, running at chnl#1
    ctrl: Rpi + NetGear, Inc. A6210
    dut#1: rpi + Linksys AE6000
    dut#2: imx93+iw612
* commands:
    commissionee:
        $ ./chip-all-clusters-app --wifi --wifipaf freq_list=2412
    commissioner:
        $ ./chip-tool pairing code-wifi 1 n_m_2g nxp12345 MT:-24J0M3810KA0648G00 --freq 2412
        or
        $ ./chip-tool pairing wifipaf-wifi 1 n_m_2g nxp12345 20202021 3840 --freq 2412


Problem to fix: if PAF packets are sent while the Wi-Fi is on another channel (For example, it's scanning the environment), the packets may be sent to the wrong channel (depends on the hardware implementation). 

