### PR TITLE
Re-enable Darwin tests that have been fixed.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -2963,8 +2963,6 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
 - (void)testSubscriptionPool
 {
-    XCTSkip("Skipping due to flakyness/failing.  https://github.com/project-chip/connectedhomeip/issues/38825");
-
     // QRCodes generated for discriminators 1111~1115 and passcodes 1001~1005
     NSDictionary<NSNumber *, NSString *> * deviceOnboardingPayloads = @{
         @(101) : @"MT:00000UZ427U0D900000",
@@ -2989,8 +2987,6 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
 - (void)testSubscriptionPoolManyDevices
 {
-    XCTSkip("Skipping due to flakyness/failing.  https://github.com/project-chip/connectedhomeip/issues/38825");
-
     // QRCodes generated for discriminators 1111~1150 and passcodes 1001~1050
     NSDictionary<NSNumber *, NSString *> * deviceOnboardingPayloads = @{
         @(101) : @"MT:00000I9K17U0D900000",
@@ -3672,9 +3668,6 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
 
 - (void)testMTRDeviceDealloc
 {
-    // disabled:  see https://github.com/project-chip/connectedhomeip/issues/38715
-    XCTSkip("Skipping due to flakyness/failing.  (https://github.com/project-chip/connectedhomeip/issues/38715)");
-
     __auto_type * storageDelegate = [[MTRTestPerControllerStorageWithBulkReadWrite alloc] initWithControllerID:[NSUUID UUID]];
 
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];


### PR DESCRIPTION
This reverts commit 47b3a6aecc28e708ec67adc4d31cfc0412ac65f1.

The subscription pool tests were fixed in #38854.

testMTRDeviceDealloc was fixed in #38809.

Both happened before the PR to disable them got through review and landed.

Note that there are some failures in the subscription pool tests after #38854 which are very likely to be fixed by https://github.com/project-chip/connectedhomeip/pull/38971

#### Testing

CI should continue to be green.