### PR TITLE
[Darwin] Add NSManagedObjectModel to the leak suppression

### DIFF
--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -71,5 +71,6 @@ leak:_fetchInitializingClassList
 # TLS storage
 leak:CRYPTO_set_thread_local
 
-# Not our leak, clearly:
+# Not our leaks, clearly:
 leak:CFXNotificationRegistrarFind
+leak:NSManagedObjectModel


### PR DESCRIPTION
#### Description

When executing tests locally, memory leaks related to `NSManagedObjectModel are observed. It’s unclear whether these leaks are genuine, as they do not appear consistently for other developers or in the CI environment.

#### Testing

Running the following demonstrates the issue, failing without the suppression and succeeding when the suppression is applied:
```
$ export LSAN_OPTIONS="detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt"
$ ./out/darwin-arm64-all-clusters-no-ble-no-shell-asan-clang/chip-all-clusters-app
# Ctrl^C
```