### PR TITLE
[Darwin][Network.framework] Update the interface monitor such that it…

### DIFF
--- a/src/platform/Darwin/DnssdHostNameRegistrar.h
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.h
@@ -39,11 +39,11 @@ public:
 
 private:
     template <typename T>
-    void RegisterInterfaces(std::vector<std::pair<uint32_t, T>> interfaces, uint16_t type)
+    void RegisterInterfaces(std::vector<std::pair<nw_interface_t, T>> interfaces, uint16_t type)
     {
         for (auto & interface : interfaces)
         {
-            auto interfaceId = interface.first;
+            auto interfaceId = nw_interface_get_index(interface.first);
 
             LogErrorOnFailure(RegisterInterface(interfaceId, interface.second, type));
         }

--- a/src/platform/Darwin/inet/InterfacesMonitor.h
+++ b/src/platform/Darwin/inet/InterfacesMonitor.h
@@ -28,11 +28,12 @@ namespace chip {
 namespace Inet {
     namespace Darwin {
 
-        typedef std::pair<uint32_t, in_addr> InetInterface;
-        typedef std::pair<uint32_t, in6_addr> Inet6Interface;
+        typedef std::pair<nw_interface_t, in_addr> InetInterface;
+        typedef std::pair<nw_interface_t, in6_addr> Inet6Interface;
         typedef std::vector<InetInterface> InetInterfacesVector;
-        typedef std::vector<std::pair<uint32_t, in6_addr>> Inet6InterfacesVector;
+        typedef std::vector<Inet6Interface> Inet6InterfacesVector;
         typedef void (^OnInterfaceChanges)(InetInterfacesVector inetInterfaces, Inet6InterfacesVector inet6Interfaces);
+        typedef void (^OnPathChange)(nw_path_t path);
 
         class InterfacesMonitor {
         public:
@@ -46,6 +47,9 @@ namespace Inet {
             void StopMonitorInterfaces();
 
         private:
+            nw_path_monitor_t CreatePathMonitor(nw_interface_type_t type, nw_path_monitor_update_handler_t handler, bool once);
+            void EnumeratePathInterfaces(nw_path_t path, InetInterfacesVector & out4, Inet6InterfacesVector & out6, bool searchLoopBackOnly);
+
             nw_path_monitor_t mInterfaceMonitor = nullptr;
 
             // Default to kDNSServiceInterfaceIndexLocalOnly so we don't mess around


### PR DESCRIPTION
… returns a nw_interface_t instead of the interface index

The `Network.framework` only uses `nw_interface_t` objects—you can’t round-trip back to a `nw_interface_t` from a numeric index. This change updates our `InterfacesMonitor` API so that it hands callers the actual `nw_interface_t` (and lets them extract name, index, type, etc.) rather than a bare index.

#### Testing

Our CI pipeline verifies that this change works as intended.