### PR TITLE
[NXP] Upstream nxp zephyr 4.1.0 support

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -219,7 +219,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:129
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:132
 
         steps:
             - name: Checkout

--- a/config/nxp/chip-module/Kconfig.defaults
+++ b/config/nxp/chip-module/Kconfig.defaults
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2024 Project CHIP Authors
+#   Copyright (c) 2024-2025 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ config NET_TC_TX_THREAD_BASE_PRIO
 config NET_TC_RX_THREAD_BASE_PRIO
 	default 3
 
-config NET_TC_SKIP_FOR_HIGH_PRIO
+config NET_TC_TX_SKIP_FOR_HIGH_PRIO
 	default y
 
 config NET_CONTEXT_PRIORITY
@@ -214,7 +214,7 @@ config BT_RX_STACK_SIZE
 	default 1700
 
 config BT_LONG_WQ_STACK_SIZE
-	default 1024
+	default 2560
 
 config BT_DEVICE_NAME_GATT_WRITABLE
 	bool
@@ -244,6 +244,31 @@ if CHIP_WIFI
 choice NXP_WIFI_PART
 	default NXP_RW610 if SOC_SERIES_RW6XX
 endchoice
+
+# Disable unnecessary features to save code size
+# Saves 365kB of flash
+config NXP_WIFI_SOFTAP_SUPPORT
+	default n
+
+# Saves 61kB of flash
+config NXP_WIFI_CSI
+	default n
+
+# Saves 45kB of flash
+config WIFI_NM_WPA_SUPPLICANT_ADVANCED_FEATURES
+	default n
+
+config NXP_WIFI_MON_TASK_STACK_SIZE
+	default 1024
+
+config NXP_WIFI_WLCMGR_TASK_STACK_SIZE
+	default 2048
+
+config NXP_WIFI_TX_TASK_STACK_SIZE
+	default 1024
+
+config NXP_WIFI_SCAN_TASK_STACK_SIZE
+	default 1024
 
 config ZVFS_OPEN_MAX
 	default 30
@@ -321,7 +346,7 @@ config NET_MAX_CONN
 	default 10
 
 config SHELL_STACK_SIZE
-	default 2616
+	default 1536
 
 config HEAP_MEM_POOL_SIZE
 	default 122880
@@ -344,10 +369,6 @@ endif
 
 if CHIP_ETHERNET
 
-choice NXP_ENET_DRIVER
-	default ETH_NXP_ENET
-endchoice
-
 config NET_SOCKETS_POLL_MAX
 	default 7
 
@@ -359,6 +380,9 @@ config MBEDTLS
 
 config MBEDTLS_CFG_FILE
 	default "config-tls-generic.h"
+
+config MBEDTLS_PSA_KEY_SLOT_COUNT
+    default 64
 
 config MBEDTLS_USER_CONFIG_ENABLE
     default y
@@ -431,16 +455,22 @@ endif # MCUX_ELS_PKC
 
 if SHELL
 
-config KERNEL_SHELL
+config SHELL_MINIMAL
 	default y
 
-config DEVICE_SHELL
+config SHELL_HELP
+	default y
+
+config KERNEL_SHELL
 	default y
 
 config REBOOT
 	default y
 
 # Disable not used shell modules
+config DEVICE_SHELL
+	default n
+
 config SHELL_WILDCARD
 	default n
 

--- a/config/nxp/chip-module/Kconfig.features
+++ b/config/nxp/chip-module/Kconfig.features
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2024 Project CHIP Authors
+#   Copyright (c) 2024-2025 Project CHIP Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -25,10 +25,6 @@ config CHIP_WIFI
 	select WIFI
 	select WIFI_NXP
 	select WIFI_NM_WPA_SUPPLICANT
-	select WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-	select WIFI_NM_WPA_SUPPLICANT_DPP
-	select WIFI_NM_WPA_SUPPLICANT_EAPOL
-	select WIFI_NM_WPA_SUPPLICANT_WPS
 	select NET_L2_ETHERNET
 	select NET_IPV4
 	select NET_DHCPV4

--- a/docs/platforms/nxp/nxp_zephyr_guide.md
+++ b/docs/platforms/nxp/nxp_zephyr_guide.md
@@ -52,12 +52,12 @@ Prerequisites:
 -   Follow instruction from [BUILDING.md](../../guides/BUILDING.md) to setup the
     Matter environment
 -   Follow instruction from
-    [Getting Started Guide](https://docs.zephyrproject.org/4.0.0/develop/getting_started/index.html)
+    [Getting Started Guide](https://docs.zephyrproject.org/4.1.0/develop/getting_started/index.html)
     to setup a Zephyr workspace, however, the west init command to use is as
     follows:
 
 ```shell
-$ west init zephyrproject -m ssh://git@bitbucket.sw.nxp.com/mcucore/nxp-zsdk.git --mr nxp-v4.1.0-rc1
+$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.1.0
 ```
 
 > **Note**: While some of NXP platforms are supported in Zephyr upstream, we
@@ -65,7 +65,7 @@ $ west init zephyrproject -m ssh://git@bitbucket.sw.nxp.com/mcucore/nxp-zsdk.git
 > not upstream yet. While you can decide to use nxp-zsdk top of tree, we
 > recommend using a proper release tag delivered by NXP. This will ensure a
 > certain level of quality of the nxp-zsdk in use. Currently, we highly
-> recommend using the `nxp-v4.1.0-rc1` tag, based on Zephyr 4.1 release. Reach to
+> recommend using the `nxp-v4.1.0` tag, based on Zephyr 4.1 release. Reach to
 > your NXP contact for more details.
 
 Steps to build the example:

--- a/docs/platforms/nxp/nxp_zephyr_guide.md
+++ b/docs/platforms/nxp/nxp_zephyr_guide.md
@@ -57,7 +57,7 @@ Prerequisites:
     follows:
 
 ```shell
-$ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp-v4.0.0
+$ west init zephyrproject -m ssh://git@bitbucket.sw.nxp.com/mcucore/nxp-zsdk.git --mr nxp-v4.1.0-rc1
 ```
 
 > **Note**: While some of NXP platforms are supported in Zephyr upstream, we
@@ -65,7 +65,7 @@ $ west init zephyrproject -m https://github.com/nxp-zephyr/nxp-zsdk.git --mr nxp
 > not upstream yet. While you can decide to use nxp-zsdk top of tree, we
 > recommend using a proper release tag delivered by NXP. This will ensure a
 > certain level of quality of the nxp-zsdk in use. Currently, we highly
-> recommend using the `nxp-v4.0.0` tag, based on Zephyr 4.0 release. Reach to
+> recommend using the `nxp-v4.1.0-rc1` tag, based on Zephyr 4.1 release. Reach to
 > your NXP contact for more details.
 
 Steps to build the example:
@@ -211,6 +211,17 @@ See
 [Guide for writing manufacturing data on NXP devices](./nxp_manufacturing_flow.md)
 
 <a name="ota-software-update"></a>
+
+### Build in release mode
+
+To build the example in release mode, you can add
+`-DEXTRA_CONF_FILE=prj_release.conf` in the west build command line.
+
+Example:
+
+```bash
+west build -b <board> -p  <path to example folder> -- -DEXTRA_CONF_FILE=prj_release.conf
+```
 
 ## OTA Software Update
 

--- a/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/all-clusters-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2024-2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,3 @@ CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
 CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
 CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
 CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
-
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/all-clusters-app/nxp/zephyr/prj_release.conf
+++ b/examples/all-clusters-app/nxp/zephyr/prj_release.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,5 +14,27 @@
 #    limitations under the License.
 #
 
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0
+CONFIG_BOOT_BANNER=n
+
+CONFIG_THREAD_NAME=n
+CONFIG_MPU_STACK_GUARD=n
+
+CONFIG_ASSERT=n
+
+CONFIG_DEBUG=n
+CONFIG_DEBUG_INFO=n
+CONFIG_DEBUG_THREAD_INFO=n
+
+CONFIG_CHIP_STATISTICS=n
+CONFIG_SIZE_OPTIMIZATIONS_AGGRESSIVE=y
+# Additional debug features, user may want to disable some of them
+
+# Shell
+# CONFIG_CHIP_LIB_SHELL=n
+# CONFIG_SHELL=n
+
+# Console & Logs
+# CONFIG_SERIAL=n
+# CONFIG_LOG=n
+# CONFIG_CONSOLE=n
+# CONFIG_UART_CONSOLE=n

--- a/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2024-2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,3 @@ CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
 CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
 CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
 CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
-
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/laundry-washer-app/nxp/zephyr/prj_release.conf
+++ b/examples/laundry-washer-app/nxp/zephyr/prj_release.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,5 +14,27 @@
 #    limitations under the License.
 #
 
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0
+CONFIG_BOOT_BANNER=n
+
+CONFIG_THREAD_NAME=n
+CONFIG_MPU_STACK_GUARD=n
+
+CONFIG_ASSERT=n
+
+CONFIG_DEBUG=n
+CONFIG_DEBUG_INFO=n
+CONFIG_DEBUG_THREAD_INFO=n
+
+CONFIG_CHIP_STATISTICS=n
+CONFIG_SIZE_OPTIMIZATIONS_AGGRESSIVE=y
+# Additional debug features, user may want to disable some of them
+
+# Shell
+# CONFIG_CHIP_LIB_SHELL=n
+# CONFIG_SHELL=n
+
+# Console & Logs
+# CONFIG_SERIAL=n
+# CONFIG_LOG=n
+# CONFIG_CONSOLE=n
+# CONFIG_UART_CONSOLE=n

--- a/examples/thermostat/nxp/zephyr/boards/frdm_rw612_fdata.conf
+++ b/examples/thermostat/nxp/zephyr/boards/frdm_rw612_fdata.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2024-2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -21,6 +21,3 @@ CONFIG_CHIP_DEVICE_PRODUCT_ID=41510
 CONFIG_CHIP_DEVICE_PRODUCT_URL="https://www.nxp.com/design/design-center/development-boards-and-designs/general-purpose-mcus/frdm-development-board-for-rw612-wi-fi-6-plus-bluetooth-low-energy-plus-802-15-4-tri-radio-wireless-mcu:FRDM-RW612"
 CONFIG_CHIP_DEVICE_PRODUCT_LABEL="RW612"
 CONFIG_CHIP_DEVICE_PART_NUMBER="RW612"
-
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0

--- a/examples/thermostat/nxp/zephyr/prj_release.conf
+++ b/examples/thermostat/nxp/zephyr/prj_release.conf
@@ -1,5 +1,5 @@
 #
-#    Copyright (c) 2024 Project CHIP Authors
+#    Copyright (c) 2025 Project CHIP Authors
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -14,5 +14,27 @@
 #    limitations under the License.
 #
 
-# Workaround for nxp-zsdk v4.0.0 release
-CONFIG_FLASH_LOAD_SIZE=0
+CONFIG_BOOT_BANNER=n
+
+CONFIG_THREAD_NAME=n
+CONFIG_MPU_STACK_GUARD=n
+
+CONFIG_ASSERT=n
+
+CONFIG_DEBUG=n
+CONFIG_DEBUG_INFO=n
+CONFIG_DEBUG_THREAD_INFO=n
+
+CONFIG_CHIP_STATISTICS=n
+CONFIG_SIZE_OPTIMIZATIONS_AGGRESSIVE=y
+# Additional debug features, user may want to disable some of them
+
+# Shell
+# CONFIG_CHIP_LIB_SHELL=n
+# CONFIG_SHELL=n
+
+# Console & Logs
+# CONFIG_SERIAL=n
+# CONFIG_LOG=n
+# CONFIG_CONSOLE=n
+# CONFIG_UART_CONSOLE=n

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -32,6 +32,7 @@
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/net_stats.h>
+#include <zephyr/version.h>
 
 extern "C" {
 #include <common/defs.h>
@@ -301,7 +302,7 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
         info.mRssi         = static_cast<int8_t>(status.rssi);
         info.mChannel      = static_cast<uint16_t>(status.channel);
         info.mSsidLen      = status.ssid_len;
-#ifdef CONFIG_WIFI_NXP
+#if KERNEL_VERSION_MAJOR >= 4 && KERNEL_VERSION_MINOR >= 1
         info.mCurrentPhyRate = static_cast<uint64_t>(status.current_phy_tx_rate);
 #else
         info.mCurrentPhyRate = static_cast<uint64_t>(status.current_phy_rate);

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -296,11 +296,11 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 
     if (status.state >= WIFI_STATE_ASSOCIATED)
     {
-        info.mSecurityType   = MapToMatterSecurityType(status.security);
-        info.mWiFiVersion    = MapToMatterWiFiVersionCode(status.link_mode);
-        info.mRssi           = static_cast<int8_t>(status.rssi);
-        info.mChannel        = static_cast<uint16_t>(status.channel);
-        info.mSsidLen        = status.ssid_len;
+        info.mSecurityType = MapToMatterSecurityType(status.security);
+        info.mWiFiVersion  = MapToMatterWiFiVersionCode(status.link_mode);
+        info.mRssi         = static_cast<int8_t>(status.rssi);
+        info.mChannel      = static_cast<uint16_t>(status.channel);
+        info.mSsidLen      = status.ssid_len;
 #ifdef CONFIG_WIFI_NXP
         info.mCurrentPhyRate = static_cast<uint64_t>(status.current_phy_tx_rate);
 #else

--- a/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.cpp
+++ b/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2024-2025 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #ifdef CONFIG_WIFI_NXP
 #include <platform/Zephyr/wifi/WiFiManager.h>
+#include <platform/Zephyr/InetUtils.h>
 #endif
 
 namespace chip {
@@ -102,7 +103,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiBeaconLostCount(uint32_t & beac
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err  = WiFiManager::Instance().GetNetworkStatistics(stats);
-    beaconLostCount = stats.mBeaconsLostCount - mOldStats.beaconLostCount;
+    beaconLostCount = stats.mBeaconsLostCount;
     return err;
 }
 
@@ -110,7 +111,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiBeaconRxCount(uint32_t & beacon
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
-    beaconRxCount  = stats.mBeaconsSuccessCount - mOldStats.beaconRxCount;
+    beaconRxCount  = stats.mBeaconsSuccessCount;
     return err;
 }
 
@@ -118,7 +119,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiPacketMulticastRxCount(uint32_t
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err         = WiFiManager::Instance().GetNetworkStatistics(stats);
-    packetMulticastRxCount = stats.mPacketMulticastRxCount - mOldStats.packetMulticastRxCount;
+    packetMulticastRxCount = stats.mPacketMulticastRxCount;
     return err;
 }
 
@@ -126,7 +127,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiPacketMulticastTxCount(uint32_t
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err         = WiFiManager::Instance().GetNetworkStatistics(stats);
-    packetMulticastTxCount = stats.mPacketMulticastTxCount - mOldStats.packetMulticastTxCount;
+    packetMulticastTxCount = stats.mPacketMulticastTxCount;
     return err;
 }
 
@@ -134,7 +135,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiPacketUnicastRxCount(uint32_t &
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err       = WiFiManager::Instance().GetNetworkStatistics(stats);
-    packetUnicastRxCount = stats.mPacketUnicastRxCount - mOldStats.packetUnicastRxCount;
+    packetUnicastRxCount = stats.mPacketUnicastRxCount;
     return err;
 }
 
@@ -142,7 +143,7 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiPacketUnicastTxCount(uint32_t &
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err       = WiFiManager::Instance().GetNetworkStatistics(stats);
-    packetUnicastTxCount = stats.mPacketUnicastTxCount - mOldStats.packetUnicastTxCount;
+    packetUnicastTxCount = stats.mPacketUnicastTxCount;
     return err;
 }
 
@@ -150,29 +151,22 @@ CHIP_ERROR DiagnosticDataProviderImplNxp::GetWiFiOverrunCount(uint64_t & overrun
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
-    overrunCount   = static_cast<uint64_t>(stats.mOverRunCount) - mOldStats.overrunCount;
+    overrunCount   = static_cast<uint64_t>(stats.mOverRunCount);
     return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNxp::ResetWiFiNetworkDiagnosticsCounts()
 {
-    /* NET_REQUEST_STATS_RESET_WIFI can be used with net_mgmt API to achieve this.
-     * NXP WiFi Driver doesn't support this command yet.
-     * Workaround to reset the statistics manually in the Matter layer.
-     */
-    WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
-    if (err == CHIP_NO_ERROR)
+    net_if * iface = InetUtils::GetWiFiInterface();
+    VerifyOrReturnError(iface != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
+
+    if (net_mgmt(NET_REQUEST_STATS_RESET_WIFI, iface, NULL, 0))
     {
-        mOldStats.beaconLostCount        = stats.mBeaconsLostCount;
-        mOldStats.beaconRxCount          = stats.mBeaconsSuccessCount;
-        mOldStats.packetMulticastRxCount = stats.mPacketMulticastRxCount;
-        mOldStats.packetMulticastTxCount = stats.mPacketMulticastTxCount;
-        mOldStats.packetUnicastRxCount   = stats.mPacketUnicastRxCount;
-        mOldStats.packetUnicastTxCount   = stats.mPacketUnicastTxCount;
-        mOldStats.overrunCount           = static_cast<uint64_t>(stats.mOverRunCount);
+        ChipLogError(DeviceLayer, "WiFi statistics reset failed");
+        return CHIP_ERROR_INTERNAL;
     }
-    return err;
+
+    return CHIP_NO_ERROR;
 }
 #endif
 

--- a/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.cpp
+++ b/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.cpp
@@ -24,8 +24,8 @@
 #include "DiagnosticDataProviderImplNxp.h"
 
 #ifdef CONFIG_WIFI_NXP
-#include <platform/Zephyr/wifi/WiFiManager.h>
 #include <platform/Zephyr/InetUtils.h>
+#include <platform/Zephyr/wifi/WiFiManager.h>
 #endif
 
 namespace chip {

--- a/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.h
+++ b/src/platform/nxp/zephyr/DiagnosticDataProviderImplNxp.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 Project CHIP Authors
+ *    Copyright (c) 2024-2025 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,17 +28,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-struct WiFiStatistics
-{
-    uint32_t beaconLostCount        = 0;
-    uint32_t beaconRxCount          = 0;
-    uint32_t packetMulticastRxCount = 0;
-    uint32_t packetMulticastTxCount = 0;
-    uint32_t packetUnicastRxCount   = 0;
-    uint32_t packetUnicastTxCount   = 0;
-    uint64_t overrunCount           = 0;
-};
-
 class DiagnosticDataProviderImplNxp : public DiagnosticDataProviderImpl
 {
 public:
@@ -63,7 +52,6 @@ public:
 
 private:
     DiagnosticDataProviderImplNxp() = default;
-    WiFiStatistics mOldStats;
 };
 
 DiagnosticDataProvider & GetDiagnosticDataProviderImpl();

--- a/src/platform/nxp/zephyr/nxp-zephyr-mbedtls-config.h
+++ b/src/platform/nxp/zephyr/nxp-zephyr-mbedtls-config.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2024 NXP
+ *    Copyright (c) 2024-2025 NXP
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,6 @@
 
 #if CONFIG_CHIP_CRYPTO_PSA
 #define MBEDTLS_PSA_CRYPTO_DRIVERS
-#define MBEDTLS_PSA_KEY_SLOT_COUNT 64
 #endif /* CONFIG_CHIP_CRYPTO_PSA */
 
 #if CONFIG_MCUX_ELS_PKC


### PR DESCRIPTION
#### Description

the aim of this PR is to switch nxp zephyr application to zephyr 4.1.0 and add some optimization for release mode

#### Testing

Local test using rw61x board: build check, commissioning and OTA. 
CI build check