### PR TITLE
Revert "[Darwin] Install dispatch source handler for SIGINT/SIGTERM instead of posix signals to make it more reliable (#38910)"

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -809,31 +809,11 @@ void ChipLinuxAppMainLoop(AppMainLoopImplementation * impl)
     //       registered with sigaction() call and TSAN is enabled. The problem seems to be
     //       related with the dispatch_semaphore_wait() function in the RunEventLoop() method.
     //       If this call is commented out, the signal handler is called as expected...
-#if CHIP_DEVICE_LAYER_TARGET_DARWIN
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_queue_t workQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
-
-    dispatch_source_t sourceSigInt = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGINT, 0, workQueue);
-    dispatch_source_set_event_handler(sourceSigInt, ^{
-        StopSignalHandler(SIGINT);
-        dispatch_release(sourceSigInt);
-    });
-    dispatch_resume(sourceSigInt);
-    signal(SIGINT, SIG_IGN);
-
-    dispatch_source_t sourceSigTerm = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, SIGTERM, 0, workQueue);
-    dispatch_source_set_event_handler(sourceSigTerm, ^{
-        StopSignalHandler(SIGTERM);
-        dispatch_release(sourceSigTerm);
-    });
-    dispatch_resume(sourceSigTerm);
-    signal(SIGTERM, SIG_IGN);
-#else
+#if defined(__APPLE__)
     // NOLINTBEGIN(bugprone-signal-handler)
     signal(SIGINT, StopSignalHandler);
     signal(SIGTERM, StopSignalHandler);
     // NOLINTEND(bugprone-signal-handler)
-#endif
 #else
     struct sigaction sa                        = {};
     sa.sa_handler                              = StopSignalHandler;


### PR DESCRIPTION
This reverts commit 93d1ae26710c04a1533417efc06e8aea33e41f22.

After these changes, `[NSTask terminate]` (which sends SIGTERM) does not reliably terminate tasks, leading to random test failures.

Fixes https://github.com/project-chip/connectedhomeip/issues/38989

#### Testing

CI should verify that the random failures go away.