### PR TITLE
Bug fix: do not try to add global attributes in attribute path expand iterator

### DIFF
--- a/src/app/AttributePathExpandIterator.cpp
+++ b/src/app/AttributePathExpandIterator.cpp
@@ -181,33 +181,12 @@ std::optional<AttributeId> AttributePathExpandIterator::NextAttributeId()
     // Advance the existing attribute id if it can be advanced.
     VerifyOrReturnValue(mPosition.mAttributePath->mValue.HasWildcardAttributeId(), std::nullopt);
 
-    // Ensure (including ordering) that GlobalAttributesNotInMetadata is reported as needed
-    for (unsigned i = 0; i < MATTER_ARRAY_SIZE(GlobalAttributesNotInMetadata); i++)
-    {
-        if (GlobalAttributesNotInMetadata[i] != mPosition.mOutputPath.mAttributeId)
-        {
-            continue;
-        }
-
-        unsigned nextAttributeIndex = i + 1;
-        if (nextAttributeIndex < MATTER_ARRAY_SIZE(GlobalAttributesNotInMetadata))
-        {
-            return GlobalAttributesNotInMetadata[nextAttributeIndex];
-        }
-
-        // Reached the end of global attributes. Since global attributes are
-        // reported last, finishing global attributes means everything completed.
-        return std::nullopt;
-    }
-
     if (mAttributeIndex < mAttributes.size())
     {
         return mAttributes[mAttributeIndex].attributeId;
     }
 
-    // Finished the data model, start with global attributes
-    static_assert(MATTER_ARRAY_SIZE(GlobalAttributesNotInMetadata) > 0);
-    return GlobalAttributesNotInMetadata[0];
+    return std::nullopt;
 }
 
 std::optional<ClusterId> AttributePathExpandIterator::NextClusterId()

--- a/src/app/AttributePathExpandIterator.h
+++ b/src/app/AttributePathExpandIterator.h
@@ -140,8 +140,6 @@ private:
     /// Will start from the beginning if current mOutputPath.mAttributeId is kInvalidAttributeId
     ///
     /// Respects path expansion/values in mpAttributePath
-    ///
-    /// Handles Global attributes (which are returned at the end)
     std::optional<AttributeId> NextAttributeId();
 
     /// Get the next cluster ID in mOutputPath(endpoint) if one is available.


### PR DESCRIPTION
Global attributes are already part of the `Attributes` call in providers:

- https://github.com/project-chip/connectedhomeip/blob/master/src/data-model-providers/codegen/CodegenDataModelProvider.cpp#L369
- https://github.com/project-chip/connectedhomeip/blob/master/src/app/data-model-provider/ProviderMetadataTree.h#L74 explicitly says that global attributes MUST be contained here (all of them)

Currently this works only because order happens to match. However when I worked on ServerClusterInterface, because ordering was not identical things started failing.

This should save a tiny amount of flash as well.

#### Testing

CI will validate conformance.

I manually tested reading a cluster (BasicInfo) in wildcard mode and observed all attributes reported.

![image](https://github.com/user-attachments/assets/aae037c9-63b6-4234-86f5-119f08e030bb)

