### PR TITLE
[E2E][JF] Implemented JCM mDNS advertisement

### DIFF
--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -92,13 +92,6 @@ public:
         return sInstance;
     }
 
-    CHIP_ERROR SetAdministratorFabricIndex(FabricIndex fabricIndex)
-    {
-        mAdministratorFabricIndex = fabricIndex;
-        return CHIP_NO_ERROR;
-    }
-    FabricIndex GetAdministratorFabricIndex() { return mAdministratorFabricIndex; }
-
     CHIP_ERROR SetAnchorNodeId(NodeId anchorNodeId)
     {
         mAnchorNodeId = anchorNodeId;
@@ -179,8 +172,6 @@ private:
     static constexpr size_t kMaxAdminNodes  = 32;
     static constexpr size_t kMaxGroups      = kMaxNodes / 16;
     static constexpr size_t kMaxGroupKeySet = kMaxGroups * 16;
-
-    FabricIndex mAdministratorFabricIndex = kUndefinedFabricIndex;
 
     NodeId mAnchorNodeId     = kUndefinedNodeId;
     VendorId mAnchorVendorId = VendorId::NotSpecified;

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -27,6 +27,7 @@
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/SafeString.h>
 #include <lib/support/Span.h>
+#include <platform/CHIPDeviceConfig.h>
 
 namespace chip {
 namespace Dnssd {
@@ -204,6 +205,15 @@ public:
     }
     CommissioningMode GetCommissioningMode() const { return mCommissioningMode; }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    CommissionAdvertisingParameters & SetJointFabricMode(BitFlags<JointFabricMode> mode)
+    {
+        mJointFabricMode = mode;
+        return *this;
+    }
+    BitFlags<JointFabricMode> GetJointFabricMode() const { return mJointFabricMode; }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
     CommissionAdvertisingParameters & SetDeviceType(std::optional<uint32_t> deviceType)
     {
         mDeviceType = deviceType;
@@ -291,6 +301,9 @@ private:
     uint16_t mLongDiscriminator          = 0; // 12-bit according to spec
     CommssionAdvertiseMode mMode         = CommssionAdvertiseMode::kCommissionableNode;
     CommissioningMode mCommissioningMode = CommissioningMode::kEnabledBasic;
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    BitFlags<JointFabricMode> mJointFabricMode;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     std::optional<uint16_t> mVendorId;
     std::optional<uint16_t> mProductId;
     std::optional<uint32_t> mDeviceType;

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -848,6 +848,9 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
     char txtRotatingDeviceId[chip::Dnssd::kKeyRotatingDeviceIdMaxLength + 4];
     char txtPairingHint[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
     char txtPairingInstr[chip::Dnssd::kKeyPairingInstructionMaxLength + 4];
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    char txtJointFabricMode[chip::Dnssd::kKeyJointFabricModeMaxLength + 4];
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     // the following sub types only apply to commissioner discovery advertisements
     char txtCommissionerPasscode[chip::Dnssd::kKeyCommissionerPasscodeMaxLength + 4];
@@ -878,6 +881,14 @@ FullQName AdvertiserMinMdns::GetCommissioningTxtEntries(const CommissionAdvertis
             snprintf(txtPairingInstr, sizeof(txtPairingInstr), "PI=%s", *pairingInstruction);
             txtFields[numTxtFields++] = txtPairingInstr;
         }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+        if (const auto & jointFabricMode = params.GetJointFabricMode(); jointFabricMode.HasAny())
+        {
+            snprintf(txtJointFabricMode, sizeof(txtJointFabricMode), "JF=%d", static_cast<int>(jointFabricMode.Raw()));
+            txtFields[numTxtFields++] = txtJointFabricMode;
+        }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     }
     else
     {

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -198,6 +198,13 @@ CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, CommissioningMod
     return CopyTextRecordValue(buffer, bufferLen, static_cast<uint16_t>(value));
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, BitFlags<JointFabricMode> value)
+{
+    return CopyTextRecordValue(buffer, bufferLen, static_cast<uint16_t>(value.Raw()));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
 template <class T>
 CHIP_ERROR CopyTextRecordValue(char * buffer, size_t bufferLen, std::optional<T> value)
 {
@@ -294,6 +301,10 @@ CHIP_ERROR CopyTxtRecord(TxtFieldKey key, char * buffer, size_t bufferLen, const
     case TxtFieldKey::kCommissionerPasscode:
         return CopyTextRecordValue(buffer, bufferLen,
                                    static_cast<uint16_t>(params.GetCommissionerPasscodeSupported().value_or(false) ? 1 : 0));
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    case TxtFieldKey::kJointFabricMode:
+        return CopyTextRecordValue(buffer, bufferLen, params.GetJointFabricMode());
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     default:
         return CopyTxtRecord(key, buffer, bufferLen, static_cast<BaseAdvertisingParams<CommissionAdvertisingParameters>>(params));
     }

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -161,6 +161,13 @@ uint8_t GetCommissioningMode(const ByteSpan & value)
     return MakeU8FromAsciiDecimal(value);
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+BitFlags<JointFabricMode> GetJointFabricMode(const ByteSpan & value)
+{
+    return BitFlags<JointFabricMode>(MakeU8FromAsciiDecimal(value));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
 uint32_t GetDeviceType(const ByteSpan & value)
 {
     return MakeU32FromAsciiDecimal(value);
@@ -261,6 +268,11 @@ void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionN
     case TxtFieldKey::kCommissionerPasscode:
         nodeData.supportsCommissionerGeneratedPasscode = Internal::GetCommissionerPasscode(val);
         break;
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    case TxtFieldKey::kJointFabricMode:
+        nodeData.jointFabricMode = Internal::GetJointFabricMode(val);
+        break;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     default:
         FillNodeDataFromTxt(key, val, static_cast<CommonResolutionData &>(nodeData));
         break;

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -20,6 +20,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/Span.h>
+#include <platform/CHIPDeviceConfig.h>
 #include <system/SystemClock.h>
 
 #include <cstddef>
@@ -49,6 +50,10 @@ static constexpr size_t kKeyPairingInstructionMaxLength   = 128;
 static constexpr size_t kKeyPairingHintMaxLength          = 10;
 static constexpr size_t kKeyCommissionerPasscodeMaxLength = 1;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+static constexpr size_t kKeyJointFabricModeMaxLength = 3;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
 enum class TxtKeyUse : uint8_t
 {
     kNone,
@@ -73,6 +78,9 @@ enum class TxtFieldKey : uint8_t
     kSessionActiveThreshold,
     kTcpSupported,
     kLongIdleTimeICD,
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    kJointFabricMode,
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     kCount,
 };
 
@@ -101,6 +109,9 @@ constexpr const TxtFieldInfo txtFieldInfo[static_cast<size_t>(TxtFieldKey::kCoun
     { kKeySessionActiveThresholdMaxLength, TxtFieldKey::kSessionActiveThreshold, TxtKeyUse::kCommon, "SAT" },
     { kKeyTcpSupportedMaxLength, TxtFieldKey::kTcpSupported, TxtKeyUse::kCommon, "T" },
     { kKeyLongIdleTimeICDMaxLength, TxtFieldKey::kLongIdleTimeICD, TxtKeyUse::kCommon, "ICD" },
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    { kKeyJointFabricModeMaxLength, TxtFieldKey::kJointFabricMode, TxtKeyUse::kCommission, "JF" },
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 };
 #ifdef CHIP_CONFIG_TEST
 
@@ -110,6 +121,9 @@ uint16_t GetProduct(const ByteSpan & value);
 uint16_t GetVendor(const ByteSpan & value);
 uint16_t GetLongDiscriminator(const ByteSpan & value);
 uint8_t GetCommissioningMode(const ByteSpan & value);
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+BitFlags<JointFabricMode> GetJointFabricMode(const ByteSpan & value);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 uint32_t GetDeviceType(const ByteSpan & value);
 void GetDeviceName(const ByteSpan & value, char * name);
 void GetRotatingDeviceId(const ByteSpan & value, uint8_t * rotatingId, size_t * len);

--- a/src/lib/dnssd/Types.h
+++ b/src/lib/dnssd/Types.h
@@ -29,9 +29,18 @@
 #include <lib/support/Variant.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
+#include <platform/CHIPDeviceConfig.h>
 
 namespace chip {
 namespace Dnssd {
+
+enum class JointFabricMode : uint8_t
+{
+    kAvailable     = 1 << 0, // This device is capable of acting as a Joint Fabric Administrator.
+    kAdministrator = 1 << 1, // This device is acting as a Joint Fabric Administrator.
+    kAnchor        = 1 << 2, // This device is acting as a Joint Fabric Anchor Administrator.
+    kDatastore     = 1 << 3  // This device is acting as a Joint Fabric Datastore.
+};
 
 enum class DiscoveryFilterType : uint8_t
 {
@@ -234,6 +243,9 @@ struct CommissionNodeData : public CommonResolutionData
     char instanceName[Commission::kInstanceNameMaxLength + 1] = {};
     char deviceName[kMaxDeviceNameLen + 1]                    = {};
     char pairingInstruction[kMaxPairingInstructionLen + 1]    = {};
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    BitFlags<JointFabricMode> jointFabricMode;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     CommissionNodeData() {}
 
@@ -292,6 +304,9 @@ struct CommissionNodeData : public CommonResolutionData
         ChipLogDetail(Discovery, "\tCommissioning Mode: %u", commissioningMode);
         ChipLogDetail(Discovery, "\tSupports Commissioner Generated Passcode: %s",
                       supportsCommissionerGeneratedPasscode ? "true" : "false");
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+        ChipLogDetail(Discovery, "\tJoint Fabric Mode: 0x%02X", jointFabricMode.Raw());
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     }
 };
 


### PR DESCRIPTION
Implemented JCM mDNS advertisement
Addresses https://github.com/project-chip/connectedhomeip/issues/38544 & https://github.com/project-chip/connectedhomeip/issues/39101

#### Testing
Verified using the below instructions

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```

Tested and validated parsing of JF TXT keys with both case-sensitive and case-insensitive scenarios.
Also tested retrieval of a valid Joint Fabric mode from the mDNS advertisement string, as well as handling of overflow conditions.