### PR TITLE
PushAV Initial Implementation of Clip recorder and uploader

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -573,6 +573,7 @@ FFF
 FFFFFFFFFFFF0102
 fffe
 fffff
+FFmpeg
 Fi
 filepath
 fini

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:140
+            image: ghcr.io/project-chip/chip-build-crosscompile:148
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build:140
+            image: ghcr.io/project-chip/chip-build:148
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build-java:140
+            image: ghcr.io/project-chip/chip-build-java:148
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=0 net.ipv6.conf.all.forwarding=0"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -496,7 +496,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:140
+            image: ghcr.io/project-chip/chip-build:148
             options: >-
                 --privileged
                 --sysctl net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
         runs-on: ubuntu-latest
 
         container:
-            image: ghcr.io/project-chip/chip-build:140
+            image: ghcr.io/project-chip/chip-build:148
             options: >-
                 --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"

--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -43,11 +43,20 @@ config("config") {
     "include/clusters/camera-avsettingsuserlevel-mgmt",
     "include/media-controller",
     "include/transport",
+    "include/uploader",
     "${chip_root}/examples/camera-app/camera-common/include",
     "${chip_root}/examples/camera-app/camera-common/include/media-controller",
     "${chip_root}/examples/camera-app/camera-common/include/camera-avstream-controller",
     "${chip_root}/examples/camera-app/camera-common/include/transport",
     "${chip_root}/third_party/libdatachannel/repo/include",
+  ]
+}
+
+pkg_config("ffmpeg") {
+  packages = [
+    "libavformat",
+    "libavcodec",
+    "libavutil",
   ]
 }
 
@@ -64,6 +73,9 @@ executable("chip-camera-app") {
 
   configs += [ ":gstreamer" ]
 
+  configs += [ ":ffmpeg" ]
+  libs = [ "curl" ]
+
   sources = [
     "${chip_root}/examples/camera-app/linux/include/media-controller/default-media-controller.h",
     "${chip_root}/examples/camera-app/linux/src/camera-device.cpp",
@@ -72,6 +84,8 @@ executable("chip-camera-app") {
     "${chip_root}/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp",
     "${chip_root}/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp",
     "${chip_root}/examples/camera-app/linux/src/media-controller/default-media-controller.cpp",
+    "${chip_root}/examples/camera-app/linux/src/pushav-clip-recorder.cpp",
+    "${chip_root}/examples/camera-app/linux/src/uploader/pushav-uploader.cpp",
     "${chip_root}/examples/camera-app/linux/src/webrtc-libdatachannel.cpp",
     "${chip_root}/examples/camera-app/linux/src/webrtc-transport.cpp",
     "include/CHIPProjectAppConfig.h",

--- a/examples/camera-app/linux/README.md
+++ b/examples/camera-app/linux/README.md
@@ -14,8 +14,9 @@ Linux.
 
 ### 1. Prerequisites
 
-Before building, you must install the necessary GStreamer libraries and
-development packages, which are used for video processing and streaming.
+Before building, you must install the necessary GStreamer, FFmpeg, curl
+libraries and development packages, which are used for video processing,
+streaming, recording and uploading.
 
 ```
 sudo apt update
@@ -25,7 +26,11 @@ sudo apt install \
   gstreamer1.0-plugins-bad \
   gstreamer1.0-libav \
   libgstreamer1.0-dev \
-  libgstreamer-plugins-base1.0-dev
+  libgstreamer-plugins-base1.0-dev \
+  libavcodec-dev \
+  libavformat-dev \
+  libavutil-dev \
+  libcurl4-openssl-dev
 ```
 
 ### 2. Building
@@ -72,7 +77,7 @@ environment to ensure all dependencies are correct.
 1. Pull the Cross-Compilation Docker Image
 
 ```
-docker pull ghcr.io/project-chip/chip-build-crosscompile:140
+docker pull ghcr.io/project-chip/chip-build-crosscompile:148
 ```
 
 2. Run the Docker Container This command starts an interactive shell inside the
@@ -80,7 +85,7 @@ docker pull ghcr.io/project-chip/chip-build-crosscompile:140
    container's /var/connectedhomeip directory.
 
 ```
-docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:140 /bin/bash
+docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:148 /bin/bash
 ```
 
 3. Build Inside the Container From within the Docker container's shell, execute

--- a/examples/camera-app/linux/include/pushav-clip-recorder.h
+++ b/examples/camera-app/linux/include/pushav-clip-recorder.h
@@ -1,0 +1,226 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include "pushav-uploader.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+#include <vector>
+
+// FFmpeg headers
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libavutil/error.h>
+#include <libavutil/opt.h>
+#include <libavutil/timestamp.h>
+}
+
+/**
+ * @struct BufferData
+ * @brief Contains buffer information for custom IO operations
+ */
+struct BufferData
+{
+    uint8_t * mPtr; ///< Pointer to buffer data
+    size_t mSize;   ///< Size left in the buffer
+};
+
+/**
+ * @class PushAVClipRecorder
+ * @brief Manages multimedia clip recording with DASH/CMAF segmentation
+ *
+ * Handles video/audio stream processing, packet queueing, and segmented file output
+ */
+class PushAVClipRecorder
+{
+public:
+    /**
+     * @struct ClipInfoStruct
+     * @brief Contains clip configuration and runtime state
+     */
+    struct ClipInfoStruct
+    {
+        bool mHasVideo;                                       ///< Video recording enabled flag
+        bool mHasAudio;                                       ///< Audio recording enabled flag
+        int mClipId;                                          ///< Current clip identifier
+        uint32_t mMaxClipDuration;                            ///< Maximum clip duration in seconds
+        uint16_t mInitialDuration;                            ///< Initial clip duration in seconds
+        uint16_t mAugmentationDuration;                       ///< Duration increment on motion detect
+        uint16_t mChunkDuration;                              ///< Segment duration in seconds
+        uint16_t mBlindDuration;                              ///< Duration without recording after motion stop
+        std::string mRecorderId;                              ///< Unique recorder identifier
+        std::string mOutputPath;                              ///< Base output directory path
+        AVRational mInputTimeBase;                            ///< Input time base
+        std::string mUrl;                                     ///< URL for uploading clips;
+        int mTriggerType;                                     ///< Recording trigger type
+        std::chrono::steady_clock::time_point activationTime; ///< Time when the recording started
+        int mPreRollLength;                                   ///< Pre-roll length in seconds
+    };
+
+    /**
+     * @struct AudioInfoStruct
+     * @brief Audio stream configuration parameters
+     */
+    struct AudioInfoStruct
+    {
+        uint64_t mChannelLayout;   ///< Audio channel layout
+        int mChannels;             ///< Number of audio channels
+        AVCodecID mAudioCodecId;   ///< Audio codec identifier
+        int mSampleRate;           ///< Sampling rate in Hz
+        int mBitRate;              ///< Audio bitrate in bps
+        int64_t mAudioPts;         ///< Audio presentation timestamp
+        int64_t mAudioDts;         ///< Audio decoding timestamp
+        int mAudioStreamIndex;     ///< Audio stream index
+        int mAudioFrameDuration;   ///< Audio frame duration in samples
+        AVRational mAudioTimeBase; ///< Audio time base
+    };
+
+    /**
+     * @struct VideoInfoStruct
+     * @brief Video stream configuration parameters
+     */
+    struct VideoInfoStruct
+    {
+        AVCodecID mVideoCodecId;   ///< Video codec identifier
+        int64_t mVideoPts;         ///< Video presentation timestamp
+        int64_t mVideoDts;         ///< Video decoding timestamp
+        int mWidth;                ///< Video frame width
+        int mHeight;               ///< Video frame height
+        int mFrameRate;            ///< Video frame rate (fps)
+        int mVideoFrameDuration;   ///< Video frame duration (μs)
+        AVRational mVideoTimeBase; ///< Video time base
+        int mVideoStreamIndex;     ///< Video stream index
+        uint32_t mBitRate;         ///< Video bitrate in bps
+    };
+
+    /// @name Construction/Destruction
+    /// @{
+    PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
+                       PushAVUploader * aUploader);
+    ~PushAVClipRecorder();
+    /// @}
+
+    /// @name Recording Control
+    /// @{
+    void Start();
+    void Stop();
+    /// @}
+
+    /**
+     * @brief Enqueues media data for processing
+     * @param data Raw media data pointer
+     * @param size Data size in bytes
+     * @param isVideo True for video data, false for audio
+     */
+    void PushPacket(const char * data, size_t size, bool isVideo);
+
+    std::atomic<bool> mDeinitializeRecorder{ false }; ///< Deinitialization flag
+    ClipInfoStruct mClipInfo;                         ///< Clip configuration parameters
+    void SetRecorderStatus(bool status);              ///< Sets the recorder status
+    bool GetRecorderStatus();                         ///< Gets the recorder status
+
+private:
+    long unsigned int kMaxQueueSize = 500; ///< Maximum queue size for media packets
+    std::atomic<bool> mRunning{ false };   ///< Recording activity flag
+
+    /// @name Stream Configuration
+    /// @{
+    AudioInfoStruct mAudioInfo; ///< Audio stream parameters
+    VideoInfoStruct mVideoInfo; ///< Video stream parameters
+    /// @}
+
+    AVFormatContext * mFormatContext;
+    AVFormatContext * mInputFormatContext;
+    AVStream * mVideoStream;
+    AVStream * mAudioStream;
+    AVCodecContext * mAudioEncoderContext;
+    std::thread mWorkerThread;
+    std::mutex mQueueMutex;
+    std::condition_variable mCondition;
+
+    std::queue<AVPacket *> mAudioQueue;
+    std::queue<AVPacket *> mVideoQueue;
+
+    int mAudioFragment           = 1;
+    int mVideoFragment           = 1;
+    int64_t mCurrentClipStartPts = AV_NOPTS_VALUE;
+    int64_t mFoundFirstIFramePts = -1;
+    int64_t currentPts           = AV_NOPTS_VALUE;
+    bool mMetadataSet            = false;
+    bool mUploadedInitSegment    = false;
+    bool mUploadMPD              = false;
+
+    PushAVUploader * mUploader;
+
+    /// @name Internal Methods
+    /// @{
+    bool FileExists(const std::string & path);
+    bool CheckAndUploadFile(std::string path);
+    bool IsH264IFrame(const uint8_t * data, unsigned int length);
+    AVPacket * CreatePacket(const uint8_t * data, int size, bool isVideo);
+
+    /**
+     * @brief Processes queued packets and writes them to the output file.
+     * @return Zero if processing was successful, negative otherwise, positive for warnings.
+     */
+    int ProcessBuffersAndWrite();
+
+    /**
+     * @brief Configures the output format context for DASH/CMAF VoD.
+     *
+     * @param output_prefix Base path for output files.
+     * @param init_seg_pattern Pattern for initialization segments.
+     * @param media_seg_pattern Pattern for media segments.
+     */
+    int SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern, const std::string & mediaSegPattern);
+
+    /**
+     * @brief Starts the clip recording process.
+     * @return 0 on success, error code otherwise.
+     */
+    int StartClipRecording();
+
+    /**
+     * @brief Adds a video or audio stream to the output context.
+     *
+     * @param type The type of stream to add (AVMEDIA_TYPE_VIDEO or AVMEDIA_TYPE_AUDIO).
+     */
+    int AddStreamToOutput(AVMediaType type);
+
+    /**
+     * @brief Cleans up the output context and associated resources.
+     */
+    void CleanupOutput();
+
+    /**
+     * @brief Finalizes the current clip and prepares for a new one.
+     *
+     * @param reason Zero for normal clip finalization or Positive number for abrupt finalization
+     */
+    void FinalizeCurrentClip(int reason);
+    /// @}
+};

--- a/examples/camera-app/linux/include/uploader/pushav-uploader.h
+++ b/examples/camera-app/linux/include/uploader/pushav-uploader.h
@@ -1,0 +1,65 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <curl/curl.h>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <thread>
+
+typedef struct UploadDataInfo
+{
+    char * mData;
+    long mSize;
+    long mBytesRead;
+} PushAvUploadInfo;
+
+class PushAVUploader
+{
+public:
+    typedef struct CertificatesInfo
+    {
+        std::string mRootCert;
+        std::string mDevCert;
+        std::string mDevKey;
+    } PushAVCertPath;
+
+    PushAVUploader(PushAVCertPath certPath);
+    ~PushAVUploader();
+
+    void Start();
+    void Stop();
+    void AddUploadData(std::string & filename, std::string & url);
+    size_t GetUploadQueueSize()
+    {
+        std::lock_guard<std::mutex> lock(mQueueMutex);
+        return mAvData.size();
+    }
+
+private:
+    void ProcessQueue();
+    void UploadData(std::pair<std::string, std::string> data);
+    PushAVCertPath mCertPath;
+    std::queue<std::pair<std::string, std::string>> mAvData;
+    std::mutex mQueueMutex;
+    std::atomic<bool> mIsRunning;
+    std::thread mUploaderThread;
+};

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -1,0 +1,708 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "pushav-clip-recorder.h"
+#include <cstring>
+#include <lib/support/logging/CHIPLogging.h>
+#include <sys/stat.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/avutil.h>
+#include <libavutil/error.h>
+#include <libavutil/opt.h>
+#include <libavutil/timestamp.h>
+}
+
+#define IS_H264_FRAME_NALU_HEAD(frame)                                                                                             \
+    (((frame)[0] == 0x00) && ((frame)[1] == 0x00) && (((frame)[2] == 0x01) || (((frame)[2] == 0x00) && ((frame)[3] == 0x01))))
+
+AVDictionary * options = NULL;
+
+PushAVClipRecorder::PushAVClipRecorder(ClipInfoStruct & aClipInfo, AudioInfoStruct & aAudioInfo, VideoInfoStruct & aVideoInfo,
+                                       PushAVUploader * aUploader) :
+    mClipInfo(aClipInfo),
+    mAudioInfo(aAudioInfo), mVideoInfo(aVideoInfo), mUploader(aUploader)
+{
+
+    mVideoInfo.mVideoPts  = 0;
+    mVideoInfo.mVideoDts  = 0;
+    mAudioInfo.mAudioPts  = 0;
+    mAudioInfo.mAudioDts  = 0;
+    int streamIndex       = 0;
+    mMetadataSet          = false;
+    mDeinitializeRecorder = false;
+    if (mClipInfo.mHasVideo)
+    {
+        mVideoInfo.mVideoStreamIndex = streamIndex++;
+    }
+    else
+    {
+        ChipLogError(Camera, "ERROR: No video stream provided");
+    }
+    if (mClipInfo.mHasAudio)
+    {
+        mAudioInfo.mAudioStreamIndex = streamIndex;
+    }
+    SetRecorderStatus(false); // Start off as not running
+
+    mClipInfo.mRecorderId = std::to_string(mVideoInfo.mVideoStreamIndex) + "-" + std::to_string(mAudioInfo.mAudioStreamIndex);
+    ChipLogProgress(Camera, "PushAVClipRecorder initialized with ID: %s, output path: %s", mClipInfo.mRecorderId.c_str(),
+                    mClipInfo.mOutputPath.c_str());
+}
+
+PushAVClipRecorder::~PushAVClipRecorder()
+{
+    if (mWorkerThread.joinable())
+    {
+        Stop();
+        mWorkerThread.join();
+    }
+}
+
+namespace {
+int ReadPacket(void * opaque, uint8_t * buf, int bufSize)
+{
+    struct BufferData * bd = (struct BufferData *) opaque;
+    bufSize                = (int) (FFMIN(bufSize, bd->mSize));
+
+    if (!bufSize)
+        return AVERROR_EOF;
+
+    /* copy internal buffer data to buf */
+    memcpy(buf, bd->mPtr, bufSize);
+    bd->mPtr += bufSize;
+    bd->mSize -= bufSize;
+
+    return bufSize;
+}
+} // namespace
+
+bool PushAVClipRecorder::IsH264IFrame(const uint8_t * data, unsigned int length)
+{
+    unsigned int idx = 0;
+    int frameType    = 0;
+    int foundSps     = 0;
+    int foundPps     = 0;
+    int foundIdr     = 0;
+    bool ret         = false;
+
+    if (data == nullptr || (length < 5))
+    {
+        return ret;
+    }
+
+    do
+    {
+        if (IS_H264_FRAME_NALU_HEAD(data + idx))
+        {
+            if (data[idx + 2] == 0x01)
+                frameType = data[idx + 3] & 0x1f;
+            else if ((data[idx + 2] == 0x00) && (data[idx + 3] == 0x01))
+                frameType = data[idx + 4] & 0x1f;
+
+            if (frameType == 7)
+            {
+                foundSps = 1;
+            }
+            else if (frameType == 8)
+            {
+                foundPps = 1;
+            }
+            else if (frameType == 5)
+            {
+                foundIdr = 1;
+                break;
+            }
+            if ((data[idx + 2] == 0x00) && (data[idx + 3] == 0x01))
+                idx++;
+
+            idx += 4;
+        }
+        else
+        {
+            idx++;
+        }
+    } while (idx < (length - 4));
+
+    if (foundSps == 1 && foundPps == 1 && foundIdr == 1)
+    {
+        ret = true;
+    }
+
+    return ret;
+}
+
+AVPacket * PushAVClipRecorder::CreatePacket(const uint8_t * data, int size, bool isVideo)
+{
+    AVPacket * packet = av_packet_alloc();
+    if (!packet)
+    {
+        ChipLogError(Camera, "ERROR: AVPacket allocation failed!");
+        return nullptr;
+    }
+    packet->data = (uint8_t *) av_malloc(size);
+    if (!packet->data)
+    {
+        ChipLogError(Camera, "ERROR: AVPacket data allocation failed!");
+        av_packet_free(&packet);
+        return nullptr;
+    }
+    memcpy(packet->data, data, size);
+    packet->size = size;
+    if (isVideo)
+    {
+        if (IsH264IFrame(data, size))
+        {
+
+            mFoundFirstIFramePts = mVideoInfo.mVideoPts;
+            packet->flags        = AV_PKT_FLAG_KEY;
+            ChipLogProgress(Camera, "Found I-frame at PTS: %ld", mVideoInfo.mVideoPts);
+        }
+        if (mFoundFirstIFramePts < 0)
+        {
+            ChipLogError(Camera, "ERROR: First frame is not an I-frame. Dropping packet.");
+            av_packet_free(&packet);
+            return nullptr;
+        }
+        packet->pts          = mVideoInfo.mVideoPts;
+        packet->dts          = mVideoInfo.mVideoDts;
+        packet->stream_index = mVideoInfo.mVideoStreamIndex;
+        packet->duration     = mVideoInfo.mVideoFrameDuration;
+        mVideoInfo.mVideoDts += mVideoInfo.mVideoFrameDuration;
+        mVideoInfo.mVideoPts += mVideoInfo.mVideoFrameDuration;
+    }
+    else
+    {
+        if (mFoundFirstIFramePts < 0 && mFoundFirstIFramePts <= mAudioInfo.mAudioPts)
+        {
+            ChipLogError(Camera, "ERROR: frames will be dropped till an Iframe is recived");
+            av_packet_free(&packet);
+            return nullptr;
+        }
+        packet->pts          = mAudioInfo.mAudioPts;
+        packet->dts          = mAudioInfo.mAudioDts;
+        packet->stream_index = mAudioInfo.mAudioStreamIndex;
+        packet->duration     = mAudioInfo.mAudioFrameDuration;
+        mAudioInfo.mAudioDts += mAudioInfo.mAudioFrameDuration;
+        mAudioInfo.mAudioPts += mAudioInfo.mAudioFrameDuration;
+    }
+    return (mFoundFirstIFramePts < 0) ? nullptr : packet;
+}
+
+void PushAVClipRecorder::Start()
+{
+    if (GetRecorderStatus())
+    {
+        ChipLogError(Camera, "ERROR: Recording is already running. Stop before starting again");
+        return;
+    }
+    SetRecorderStatus(true);
+    mWorkerThread = std::thread(&PushAVClipRecorder::StartClipRecording, this);
+    ChipLogProgress(Camera, "Recording started for ID: %s", mClipInfo.mRecorderId.c_str());
+}
+
+void PushAVClipRecorder::Stop()
+{
+    if (GetRecorderStatus())
+    {
+        SetRecorderStatus(false);
+        while (!mVideoQueue.empty())
+        {
+            av_packet_free(&mVideoQueue.front());
+            mVideoQueue.pop();
+        }
+        while (!mAudioQueue.empty())
+        {
+            av_packet_free(&mAudioQueue.front());
+            mAudioQueue.pop();
+        }
+    }
+    else
+    {
+        ChipLogError(Camera, "Error recording is not running");
+    }
+    mDeinitializeRecorder = true;
+    CleanupOutput();
+    ChipLogProgress(Camera, "Recording stopped for ID: %s", mClipInfo.mRecorderId.c_str());
+}
+
+void PushAVClipRecorder::PushPacket(const char * data, size_t size, bool isVideo)
+{
+    if (!GetRecorderStatus())
+    {
+        ChipLogError(Camera, "ERROR: Push packet dropped as recorder is not active");
+        return;
+    }
+
+    AVPacket * packet = CreatePacket((const uint8_t *) data, (int) size, isVideo);
+    if (!packet)
+    {
+        ChipLogError(Camera, "ERROR: PACKET DROPPED!");
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mQueueMutex);
+    std::queue<AVPacket *> & queue = isVideo ? mVideoQueue : mAudioQueue;
+    if (queue.size() >= kMaxQueueSize)
+    {
+        AVPacket * oldPacket = queue.front();
+        queue.pop();
+        av_packet_free(&oldPacket);
+        ChipLogProgress(Camera, "Queue full. Dropped old packet");
+    }
+    queue.push(packet);
+    mCondition.notify_one();
+    if (mClipInfo.activationTime == std::chrono::steady_clock::time_point())
+    {
+        mClipInfo.activationTime = std::chrono::steady_clock::now();
+    }
+}
+
+int PushAVClipRecorder::SetupOutput(const std::string & outputPrefix, const std::string & initSegPattern,
+                                    const std::string & mediaSegPattern)
+{
+    const std::string mpdFilename = outputPrefix + ".mpd";
+    if (avformat_alloc_output_context2(&mFormatContext, nullptr, nullptr, mpdFilename.c_str()) < 0)
+    {
+        ChipLogError(Camera, "ERROR: Failed to allocate output context");
+        Stop();
+        return -1;
+    }
+    if (!mFormatContext)
+    {
+        ChipLogError(Camera, "ERROR: Output context is null");
+    }
+    // Set DASH/CMAF options
+    av_opt_set(mFormatContext->priv_data, "increment_tc", "1", 0);
+    av_opt_set(mFormatContext->priv_data, "use_timeline", "1", 0);
+    av_opt_set(mFormatContext->priv_data, "movflags", "+cmaf+dash+delay_moov+skip_sidx+skip_trailer+frag_custom", 0);
+    av_opt_set(mFormatContext->priv_data, "seg_duration", std::to_string(mClipInfo.mChunkDuration).c_str(), 0);
+    av_opt_set(mFormatContext->priv_data, "init_seg_name", initSegPattern.c_str(), 0);
+    av_opt_set(mFormatContext->priv_data, "media_seg_name", mediaSegPattern.c_str(), 0);
+    av_opt_set_int(mFormatContext->priv_data, "use_template", 1, 0);
+    av_dict_set_int(&options, "dash_segment_type", 1, 0);
+    av_dict_set_int(&options, "use_timeline", 1, 0);
+    av_dict_set(&options, "strict", "experimental", 0);
+
+    if (mClipInfo.mHasVideo && (AddStreamToOutput(AVMEDIA_TYPE_VIDEO) < 0))
+    {
+        ChipLogError(Camera, "ERROR: adding video stream to output");
+        return -1;
+    }
+    if (mClipInfo.mHasAudio && (AddStreamToOutput(AVMEDIA_TYPE_AUDIO) < 0))
+    {
+        ChipLogError(Camera, "ERROR: adding video stream to output");
+        return -1;
+    }
+
+    if (!(mFormatContext->oformat->flags & AVFMT_NOFILE))
+    {
+        if (avio_open(&mFormatContext->pb, mpdFilename.c_str(), AVIO_FLAG_WRITE) < 0)
+        {
+            ChipLogError(Camera, "ERROR: Failed to open output file: %s", mpdFilename.c_str());
+            Stop();
+            return -1;
+        }
+    }
+
+    if (avformat_write_header(mFormatContext, &options) < 0)
+    {
+        ChipLogError(Camera, "Error: writing output header");
+        Stop();
+        return -1;
+    }
+    return 0;
+}
+
+int PushAVClipRecorder::StartClipRecording()
+{
+    if (!mClipInfo.mHasVideo)
+    {
+        ChipLogError(Camera, "ERROR: No video stream available. Stopping recording");
+        return -1;
+    }
+
+    while (GetRecorderStatus())
+    {
+        std::unique_lock<std::mutex> lock(mQueueMutex);
+        mCondition.wait(lock, [this] { return !mVideoQueue.empty() || !mAudioQueue.empty(); });
+        ProcessBuffersAndWrite();
+    }
+
+    ChipLogProgress(Camera, "Recorder thread closing");
+    return 0;
+}
+
+int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
+{
+    if (type == AVMEDIA_TYPE_VIDEO)
+    {
+        mVideoStream = avformat_new_stream(mFormatContext, nullptr);
+        if (avcodec_parameters_copy(mVideoStream->codecpar, mInputFormatContext->streams[0]->codecpar) < 0)
+        {
+            ChipLogError(Camera, "ERROR: Failed to copy codec parameters for media type: %d", type);
+            Stop();
+            return -1;
+        }
+        mVideoStream->codecpar->codec_tag = 0;
+        mVideoStream->codecpar->width     = mVideoInfo.mWidth;
+        mVideoStream->codecpar->height    = mVideoInfo.mHeight;
+        mVideoStream->avg_frame_rate      = (AVRational){ mVideoInfo.mFrameRate, 1 };
+    }
+    else if (type == AVMEDIA_TYPE_AUDIO)
+    {
+        mAudioStream = avformat_new_stream(mFormatContext, nullptr);
+        if (!mAudioStream)
+        {
+            ChipLogError(Camera, "ERROR: Failed to add audio stream");
+            Stop();
+            return -1;
+        }
+        const AVCodec * audioCodec = avcodec_find_encoder(mAudioInfo.mAudioCodecId);
+        if (!audioCodec)
+        {
+            ChipLogError(Camera, "ERROR: Audio encoder not found");
+            Stop();
+            return -1;
+        }
+        mAudioEncoderContext = avcodec_alloc_context3(audioCodec);
+        if (!mAudioEncoderContext)
+        {
+            ChipLogError(Camera, "Error: failed to allocate the encoder context");
+            Stop();
+            return -1;
+        }
+        mAudioEncoderContext->sample_rate           = mAudioInfo.mSampleRate;
+        mAudioEncoderContext->channels              = mAudioInfo.mChannels;
+        mAudioEncoderContext->channel_layout        = av_get_default_channel_layout(mAudioEncoderContext->channels);
+        mAudioEncoderContext->bit_rate              = mAudioInfo.mBitRate;
+        mAudioEncoderContext->sample_fmt            = audioCodec->sample_fmts[0];
+        mAudioEncoderContext->time_base             = (AVRational){ 1, mAudioInfo.mSampleRate };
+        mAudioEncoderContext->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
+        AVDictionary * opts                         = NULL;
+        av_dict_set(&opts, "strict", "experimental", 0);
+        if (avcodec_open2(mAudioEncoderContext, audioCodec, &opts) < 0)
+        {
+            ChipLogError(Camera, "Error: Cannot open audio encoder for audio stream");
+            Stop();
+            return -1;
+        }
+        if (avcodec_parameters_from_context(mAudioStream->codecpar, mAudioEncoderContext) < 0)
+        {
+            ChipLogError(Camera, "Error: Failed to copy encoder parameters to audio output stream");
+            Stop();
+            return -1;
+        }
+        if (mFormatContext->oformat->flags & AVFMT_GLOBALHEADER)
+        {
+            mAudioEncoderContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        }
+    }
+    return 0;
+}
+
+int PushAVClipRecorder::ProcessBuffersAndWrite()
+{
+    if (mVideoQueue.empty() && mAudioQueue.empty())
+    {
+        return -1;
+    }
+
+    bool useVideo  = false;
+    AVPacket * pkt = nullptr;
+
+    if (!mVideoQueue.empty() && !mAudioQueue.empty())
+    {
+        AVPacket * videoPkt = mVideoQueue.front();
+        AVPacket * audioPkt = mAudioQueue.front();
+
+        if (videoPkt->pts != AV_NOPTS_VALUE && audioPkt->pts != AV_NOPTS_VALUE)
+        {
+            useVideo = (videoPkt->pts <= audioPkt->pts);
+        }
+        else if (videoPkt->pts != AV_NOPTS_VALUE)
+        {
+            useVideo = true;
+        }
+        else if (audioPkt->pts != AV_NOPTS_VALUE)
+        {
+            useVideo = false;
+        }
+        pkt = useVideo ? videoPkt : audioPkt;
+    }
+    else if (!mVideoQueue.empty())
+    {
+        pkt      = mVideoQueue.front();
+        useVideo = true;
+    }
+    else if (!mAudioQueue.empty())
+    {
+        pkt      = mAudioQueue.front();
+        useVideo = false;
+    }
+    else
+    {
+        return false;
+    }
+    if (!pkt)
+    {
+        ChipLogError(Camera, "Error: No valid packet to process");
+        return -1;
+    }
+
+    if (mMetadataSet == false)
+    {
+        if (mClipInfo.mHasVideo && !useVideo)
+        {
+            return false;
+        }
+        std::string prefix           = mClipInfo.mRecorderId + "_clip_" + std::to_string(mClipInfo.mClipId);
+        std::string initSegName      = prefix + "_init-stream$RepresentationID$.fmp4";
+        std::string mediaSegName     = prefix + "_chunk-stream$RepresentationID$-$Number%05d$.cmfv";
+        mInputFormatContext          = avformat_alloc_context();
+        int avioCtxBufferSize        = 1048576; // 1MB
+        uint8_t * mAvioContextBuffer = (uint8_t *) av_malloc(avioCtxBufferSize);
+        struct BufferData data       = { 0 };
+        data.mPtr                    = (uint8_t *) pkt->data;
+        data.mSize                   = pkt->size;
+        mInputFormatContext->pb =
+            avio_alloc_context(mAvioContextBuffer, avioCtxBufferSize, 0, &data, &ReadPacket, nullptr, nullptr);
+        mInputFormatContext->flags = AVFMT_FLAG_CUSTOM_IO;
+
+        if (avformat_open_input(&mInputFormatContext, "", nullptr, nullptr) < 0)
+        {
+            ChipLogError(Camera, "Error: Failed to open input format for video");
+            Stop();
+            return -1;
+        }
+
+        if (avformat_find_stream_info(mInputFormatContext, nullptr) < 0)
+        {
+            ChipLogError(Camera, "Error: Failed to find stream info for video");
+            Stop();
+            return -1;
+        }
+        if (SetupOutput(mClipInfo.mOutputPath + prefix, initSegName, mediaSegName) < 0)
+        {
+            ChipLogError(Camera, "Error: setting up output");
+            return -1;
+        }
+        if (!mFormatContext)
+        {
+            ChipLogError(Camera, "Error: Output context not initialized. Skipping packet");
+            Stop();
+            return -1;
+        }
+        mMetadataSet = true;
+    }
+
+    AVRational outputTimeBase = useVideo ? mVideoInfo.mVideoTimeBase : mAudioInfo.mAudioTimeBase;
+
+    if (pkt->pts == AV_NOPTS_VALUE && pkt->dts == AV_NOPTS_VALUE)
+    {
+        ChipLogError(Camera, "Warning packet has no valid timestamps\n");
+        av_packet_unref(pkt);
+        return 0;
+    }
+
+    currentPts = (pkt->pts != AV_NOPTS_VALUE) ? pkt->pts : pkt->dts;
+    if (mCurrentClipStartPts == AV_NOPTS_VALUE)
+    {
+        mCurrentClipStartPts = currentPts;
+    }
+
+    pkt->pts      = av_rescale_q(pkt->pts, mClipInfo.mInputTimeBase, outputTimeBase);
+    pkt->dts      = av_rescale_q(pkt->dts, mClipInfo.mInputTimeBase, outputTimeBase);
+    pkt->duration = av_rescale_q(pkt->duration, mClipInfo.mInputTimeBase, outputTimeBase);
+    pkt->pos      = -1;
+
+    if (pkt->pts < 0)
+    {
+        ChipLogError(Camera, "Warning Negative PTS detected: %ld", pkt->pts);
+        pkt->pts = (pkt->dts != AV_NOPTS_VALUE) ? pkt->dts : 0;
+    }
+    if (av_interleaved_write_frame(mFormatContext, pkt) < 0)
+    {
+        ChipLogError(Camera, "Error writing frame to output file");
+        FinalizeCurrentClip(1);
+        return -1;
+    }
+
+    av_packet_free(&pkt);
+    if (useVideo)
+    {
+        mVideoQueue.pop();
+    }
+    else
+    {
+        mAudioQueue.pop();
+    }
+    FinalizeCurrentClip(0);
+
+    return 0;
+}
+
+void PushAVClipRecorder::CleanupOutput()
+{
+    if (mFormatContext)
+    {
+        av_interleaved_write_frame(mFormatContext, nullptr);
+        if (av_write_trailer(mFormatContext) < 0)
+        {
+            ChipLogError(Camera, "Error writing trailer to output file");
+        }
+        if (!(mFormatContext->oformat->flags & AVFMT_NOFILE) && mFormatContext->pb)
+        {
+            avio_closep(&mFormatContext->pb);
+        }
+        avformat_free_context(mFormatContext);
+        mFormatContext = nullptr;
+    }
+    if (mInputFormatContext)
+    {
+        avformat_close_input(&mInputFormatContext);
+        mInputFormatContext = nullptr;
+    }
+    if (mAudioEncoderContext)
+    {
+        avcodec_free_context(&mAudioEncoderContext);
+    }
+    mVideoStream = nullptr;
+    mAudioStream = nullptr;
+    mMetadataSet = false;
+    ChipLogProgress(Camera, "Cleanup completed");
+}
+
+/**
+ * @brief Finalizes the current clip and starts a new one.
+ *
+ * Writes the trailer of the current clip and initializes a new output file.
+ */
+
+void PushAVClipRecorder::FinalizeCurrentClip(int reason)
+{
+    int64_t clipLengthInPTS    = currentPts - mCurrentClipStartPts;
+    const int64_t clipDuration = mClipInfo.mInitialDuration * AV_TIME_BASE_Q.den;
+    // Pre-calculate common path components
+    const std::string prefix   = mClipInfo.mRecorderId + "_clip_" + std::to_string(mClipInfo.mClipId);
+    const std::string basePath = mClipInfo.mOutputPath + prefix;
+
+    if (reason || ((clipLengthInPTS >= clipDuration) && (mClipInfo.mTriggerType != 2)))
+    {
+        mClipInfo.mClipId++;
+        Stop();
+        mClipInfo.mClipId++;
+        mCurrentClipStartPts = currentPts;
+    }
+
+    // Helper function for safe path formatting
+    char path_buffer[512];
+    auto make_path = [&](const char * format, int number = -1) -> std::string {
+        if (number >= 0)
+        {
+            snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str(), number);
+        }
+        else
+        {
+            snprintf(path_buffer, sizeof(path_buffer), format, basePath.c_str());
+        }
+        return std::string(path_buffer);
+    };
+
+    // 1. Handle initialization files
+    std::string fmp4_path = make_path("%s_init-stream0.fmp4");
+    if (mUploadedInitSegment && FileExists(fmp4_path) && !FileExists(fmp4_path + ".tmp"))
+    {
+        mUploadedInitSegment = false;
+        CheckAndUploadFile(fmp4_path);
+
+        if (mClipInfo.mHasAudio)
+        {
+            std::string audio_fmp4 = make_path("%s_init-stream1.fmp4");
+            if (FileExists(audio_fmp4) && !FileExists(audio_fmp4 + ".tmp"))
+            {
+                CheckAndUploadFile(audio_fmp4);
+            }
+        }
+    }
+
+    // 2. Handle video fragments
+    std::string video_cmfv = make_path("%s_chunk-stream0-%05d.cmfv", mVideoFragment);
+    while (FileExists(video_cmfv) && !FileExists(video_cmfv + ".tmp"))
+    {
+
+        if (mVideoFragment == 1)
+        {
+            mUploadedInitSegment = true;
+        }
+        mUploadMPD = true;
+        CheckAndUploadFile(video_cmfv);
+        mVideoFragment++;
+        video_cmfv = make_path("%s_chunk-stream0-%05d.cmfv", mVideoFragment);
+    }
+
+    // 3. Handle audio fragments
+    if (mClipInfo.mHasAudio)
+    {
+        std::string audio_cmfv = make_path("%s_chunk-stream1-%05d.cmfv", mAudioFragment);
+        while (FileExists(audio_cmfv) && !FileExists(audio_cmfv + ".tmp"))
+        {
+            mUploadMPD = true;
+            CheckAndUploadFile(audio_cmfv);
+            mAudioFragment++;
+            audio_cmfv = make_path("%s_chunk-stream1-%05d.cmfv", mAudioFragment);
+        }
+    }
+
+    // 4. Handle MPD file
+    if (mUploadMPD)
+    {
+        std::string mpd_path = make_path("%s.mpd");
+        if (FileExists(mpd_path) && !FileExists(mpd_path + ".tmp"))
+        {
+            CheckAndUploadFile(mpd_path);
+            mUploadMPD = false; // Reset flag after successful upload
+        }
+    }
+}
+
+bool PushAVClipRecorder::CheckAndUploadFile(std::string filename)
+{
+    ChipLogProgress(Camera, "Recorder:File upload ready [%s] to [%s]", filename.c_str(), mClipInfo.mUrl.c_str());
+    mUploader->AddUploadData(filename, mClipInfo.mUrl);
+    return true;
+}
+
+bool PushAVClipRecorder::FileExists(const std::string & path)
+{
+    struct stat buffer;
+    return (stat(path.c_str(), &buffer) == 0);
+}
+
+void PushAVClipRecorder::SetRecorderStatus(bool status)
+{
+    ChipLogProgress(Camera, "Setting Clip Recorder to Status %d", status);
+    mRunning = status;
+}
+
+bool PushAVClipRecorder::GetRecorderStatus()
+{
+    return mRunning;
+}

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -391,12 +391,12 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
             Stop();
             return -1;
         }
-        mAudioEncoderContext->sample_rate           = mAudioInfo.mSampleRate;
-        mAudioEncoderContext->channels              = mAudioInfo.mChannels;
-        mAudioEncoderContext->channel_layout        = static_cast<uint64_t>(av_get_default_channel_layout(mAudioEncoderContext->channels));
-        mAudioEncoderContext->bit_rate              = mAudioInfo.mBitRate;
-        mAudioEncoderContext->sample_fmt            = audioCodec->sample_fmts[0];
-        mAudioEncoderContext->time_base             = (AVRational){ 1, mAudioInfo.mSampleRate };
+        mAudioEncoderContext->sample_rate    = mAudioInfo.mSampleRate;
+        mAudioEncoderContext->channels       = mAudioInfo.mChannels;
+        mAudioEncoderContext->channel_layout = static_cast<uint64_t>(av_get_default_channel_layout(mAudioEncoderContext->channels));
+        mAudioEncoderContext->bit_rate       = mAudioInfo.mBitRate;
+        mAudioEncoderContext->sample_fmt     = audioCodec->sample_fmts[0];
+        mAudioEncoderContext->time_base      = (AVRational){ 1, mAudioInfo.mSampleRate };
         mAudioEncoderContext->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
         AVDictionary * opts                         = NULL;
         av_dict_set(&opts, "strict", "experimental", 0);

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -1,0 +1,173 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "pushav-uploader.h"
+#include <fstream>
+#include <iostream>
+#include <lib/support/logging/CHIPLogging.h>
+
+PushAVUploader::PushAVUploader(PushAVCertPath certPath) : mCertPath(certPath), mIsRunning(false) {}
+
+PushAVUploader::~PushAVUploader()
+{
+    Stop();
+}
+
+void PushAVUploader::ProcessQueue()
+{
+    while (mIsRunning)
+    {
+        std::pair<std::string, std::string> uploadJob;
+        {
+            std::lock_guard<std::mutex> lock(mQueueMutex);
+            if (!mAvData.empty())
+            {
+                uploadJob = std::move(mAvData.front());
+                mAvData.pop();
+            }
+        }
+        if (!uploadJob.first.empty() && !uploadJob.second.empty())
+        {
+            UploadData(uploadJob);
+        }
+        else
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+}
+
+void PushAVUploader::Start()
+{
+    if (!mIsRunning)
+    {
+        mIsRunning      = true;
+        mUploaderThread = std::thread(&PushAVUploader::ProcessQueue, this);
+    }
+}
+
+void PushAVUploader::Stop()
+{
+    if (mIsRunning)
+    {
+        mIsRunning = false;
+        if (mUploaderThread.joinable())
+        {
+            mUploaderThread.join();
+        }
+    }
+}
+
+void PushAVUploader::AddUploadData(std::string & filename, std::string & url)
+{
+    ChipLogError(Camera, "Added file name %s to queue", filename.c_str());
+    std::lock_guard<std::mutex> lock(mQueueMutex);
+    auto data = make_pair(filename, url);
+    mAvData.push(data);
+}
+
+size_t PushAvUploadCb(void * ptr, size_t size, size_t nmemb, void * stream)
+{
+    int bufferSize            = (int) (size * nmemb);
+    PushAvUploadInfo * upload = (PushAvUploadInfo *) stream;
+    if (ptr == NULL)
+    {
+        ChipLogError(Camera, "Invalid destination pointer");
+        return 0;
+    }
+    if ((size == 0) || (nmemb == 0) || ((size * nmemb) < 1))
+    {
+        ChipLogError(Camera, "Zero buffer size = %ld nmemb = %ld %ld\n", size, nmemb, size * nmemb);
+        return 0;
+    }
+    long remaining          = upload->mSize - upload->mBytesRead;
+    unsigned long copyChunk = (unsigned long) ((remaining < bufferSize) ? remaining : bufferSize);
+
+    if (copyChunk)
+    {
+        memcpy(ptr, upload->mData + upload->mBytesRead, copyChunk);
+        upload->mBytesRead += copyChunk;
+    }
+    return (size_t) copyChunk;
+}
+
+void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
+{
+    CURL * curl = curl_easy_init();
+    if (!curl)
+    {
+        ChipLogError(Camera, "Failed to initialize CURL");
+        return;
+    }
+
+    std::ifstream file(data.first.c_str(), std::ios::binary);
+    if (!file)
+    {
+        ChipLogError(Camera, "Failed to open file %s", data.first.c_str());
+        return;
+    }
+    file.seekg(0, std::ios::end);
+    unsigned long size = (unsigned long) file.tellg();
+    file.seekg(0, std::ios::beg);
+    std::vector<char> buffer(size);
+    if (!file.read(buffer.data(), size))
+    {
+        ChipLogError(Camera, "Failed to read file into buffer");
+        return;
+    }
+    file.close();
+    PushAvUploadInfo upload;
+    upload.mData = (char *) std::malloc(size);
+    memcpy(upload.mData, buffer.data(), size);
+    upload.mSize                = size;
+    upload.mBytesRead           = 0;
+    struct curl_slist * headers = nullptr;
+    headers                     = curl_slist_append(headers, "Content-Type: application/*");
+    std::string fullUrl         = data.second + data.first;
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_URL, fullUrl.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_0);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, true);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, static_cast<curl_off_t>(size));
+    curl_easy_setopt(curl, CURLOPT_CAINFO, mCertPath.mRootCert.c_str());
+    curl_easy_setopt(curl, CURLOPT_SSLCERT, mCertPath.mDevCert.c_str());
+    curl_easy_setopt(curl, CURLOPT_SSLKEY, mCertPath.mDevKey.c_str());
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, PushAvUploadCb);
+    curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
+
+    CURLcode res = curl_easy_perform(curl);
+
+    if (res != CURLE_OK)
+    {
+        ChipLogError(Camera, "CURL upload  failed [%s] %s", data.first.c_str(), curl_easy_strerror(res));
+    }
+    else
+    {
+        ChipLogError(Camera, "CURL uploaded file  %s size: %ld", data.first.c_str(), size);
+    }
+    if (upload.mData)
+    {
+        std::free(upload.mData);
+        upload.mData = nullptr;
+    }
+    curl_easy_cleanup(curl);
+    curl_slist_free_all(headers);
+}

--- a/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
+++ b/examples/camera-app/linux/src/uploader/pushav-uploader.cpp
@@ -125,7 +125,7 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     unsigned long size = (unsigned long) file.tellg();
     file.seekg(0, std::ios::beg);
     std::vector<char> buffer(size);
-    if (!file.read(buffer.data(), size))
+    if (!file.read(buffer.data(), static_cast<std::streamsize>(size)))
     {
         ChipLogError(Camera, "Failed to read file into buffer");
         return;
@@ -134,7 +134,7 @@ void PushAVUploader::UploadData(std::pair<std::string, std::string> data)
     PushAvUploadInfo upload;
     upload.mData = (char *) std::malloc(size);
     memcpy(upload.mData, buffer.data(), size);
-    upload.mSize                = size;
+    upload.mSize                = static_cast<long>(size);
     upload.mBytesRead           = 0;
     struct curl_slist * headers = nullptr;
     headers                     = curl_slist_append(headers, "Content-Type: application/*");


### PR DESCRIPTION
####  Summary
- Implementation of Clip recorder for PushAV using FFMPEG
- Implementation of Clip uploader for PushAV using CURL
- TLS cluster dependency not added while uploading the clip

This PR requires https://github.com/project-chip/connectedhomeip/pull/39830 to be merged first.

#### Testing

#### Manual Verification
- Build & run camera application
```
./scripts/examples/gn_build_example.sh examples/camera-app/linux out/debug
/out/debug/chip-camera-app
```
- Setup local push av server : 
`https://github.com/project-chip/connectedhomeip/blob/master/src/tools/push_av_server/README.md`
- Build & run camera-controller steps for clip recording & uploading
```
./scripts/build/build_examples.py --target linux-x64-camera-controller build
./out/linux-x64-camera-controller/chip-camera-controller
```
- pair camera
`pairing code 1 34970112332`

- video stream allocation
```
cameraavstreammanagement video-stream-allocate 3 0 30 30 '{ "width":640, "height":480}' '{ "width":640, "height":480}' 10000 10000 1 10 1 1 --WatermarkEnabled 1 --OSDEnabled 1
```
- audio stream allocation
`cameraavstreammanagement audio-stream-allocate 0 0 2 48000 96000 16 1 1`

- push av transport allocation
```
pushavstreamtransport allocate-push-transport '{"streamUsage":0, "videoStreamID":1, "audioStreamID":1, "endpointID":1, "url":"https://localhost:1234/streams/1", "triggerOptions":{"triggerType":0, "maxPreRollLen":1, "motionTimeControl":{"initialDuration":20, "augmentationDuration":5,"maxDuration":40, "blindDuration":5}}, "ingestMethod":0, "containerOptions":{"containerType":0, "CMAFContainerOptions": {"chunkDuration": 4}}}'  1 1
```
- update transport status to 0 (active) 
`pushavstreamtransport set-transport-status 1 0 1 1`

-  trigger manual transport 
`pushavstreamtransport manually-trigger-transport 1 0 1 1`

#### Test Scripts
- https://github.com/project-chip/connectedhomeip/pull/39727
