### PR TITLE
Fix random failure in test029_MTRDeviceWriteCoalescing.

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestDeclarations.h
@@ -63,7 +63,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setStorageBehaviorConfiguration:(MTRDeviceStorageBehaviorConfiguration *)storageBehaviorConfiguration;
 - (void)_deviceMayBeReachable;
 
-@property (nonatomic, readwrite, nullable) NSNumber * highestObservedEventNumber;
+@property (nonatomic, readonly, nullable) NSNumber * highestObservedEventNumber;
+@property (nonatomic, readonly) MTRAsyncWorkQueue<MTRDevice *> * asyncWorkQueue;
 @end
 
 #pragma mark - Declarations for items compiled only for DEBUG configuration


### PR DESCRIPTION
The idea is to avoid racing the thread enqueing work items and the thread handling them, so that we don't get "premature" work item dispatch.

Fixes https://github.com/project-chip/connectedhomeip/issues/38997

#### Testing

Test changes only.