### PR TITLE
[darwin] expose diagnostic log download state

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -77,6 +77,11 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (readonly) BOOL deviceCachePrimed MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
 
 /**
+ * Returns true if a diagnostic log transfer is ongoing.
+ */
+@property (readonly) BOOL diagnosticLogTransferInProgress MTR_PROVISIONALLY_AVAILABLE;
+
+/**
  * The estimated device system start time.
  *
  * A device can report its events with either calendar time or time since system start time. When events are reported with time

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -605,6 +605,12 @@ MTR_DIRECT_MEMBERS
     return NO;
 }
 
+- (BOOL)diagnosticLogTransferInProgress
+{
+    MTR_ABSTRACT_METHOD();
+    return NO;
+}
+
 #pragma mark - Suspend/resume management
 
 - (void)controllerSuspended

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -212,6 +212,7 @@ static NSString * const kMTRDeviceInternalPropertyMostRecentReportTime = @"MTRDe
 static NSString * const kMTRDeviceInternalPropertyLastSubscriptionFailureTime = @"MTRDeviceInternalPropertyLastSubscriptionFailureTime";
 static NSString * const kMTRDeviceInternalPropertyDeviceState = @"MTRDeviceInternalPropertyDeviceState";
 static NSString * const kMTRDeviceInternalPropertyDeviceCachePrimed = @"MTRDeviceInternalPropertyDeviceCachePrimed";
+static NSString * const kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress = @"kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress";
 static NSString * const kMTRDeviceInternalPropertyEstimatedStartTime = @"MTRDeviceInternalPropertyEstimatedStartTime";
 static NSString * const kMTRDeviceInternalPropertyEstimatedSubscriptionLatency = @"MTRDeviceInternalPropertyEstimatedSubscriptionLatency";
 

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -341,6 +341,7 @@
         kMTRDeviceInternalPropertyNetworkFeatures : NSNumber.class,
         kMTRDeviceInternalPropertyMostRecentReportTime : NSDate.class,
         kMTRDeviceInternalPropertyLastSubscriptionFailureTime : NSDate.class,
+        kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress : NSNumber.class
     };
 
     VerifyOrReturn([self _ensureValidValuesForKeys:requiredInternalStateKeys inInternalState:newState valueRequired:YES]);


### PR DESCRIPTION
Expose diagnostic log download state via `MTRDevice` (`MTRDevice_Concrete` and `MTRDevice_XPC`).

#### Testing

Tested on actual devices.

- Trigger diagnostic log collection from Home app.
- See breakpoint or logs for property updates, either on Home device or hub.