### PR TITLE
[Darwin] MTRDevice needs to clear subscription pool work in edge cases

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1433,16 +1433,18 @@ CHIP_ERROR ReadClient::GetMinEventNumber(const ReadPrepareParams & aReadPrepareP
     return CHIP_NO_ERROR;
 }
 
-void ReadClient::TriggerResubscribeIfScheduled(const char * reason)
+bool ReadClient::TriggerResubscribeIfScheduled(const char * reason)
 {
     if (!mIsResubscriptionScheduled)
     {
-        return;
+        return false;
     }
 
     ChipLogDetail(DataManagement, "ReadClient[%p] triggering resubscribe, reason: %s", this, reason);
     CancelResubscribeTimer();
     OnResubscribeTimerCallback(nullptr, this);
+
+    return true;
 }
 
 Optional<System::Clock::Timeout> ReadClient::GetSubscriptionTimeout()

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -496,8 +496,10 @@ public:
      * communicating, so right now is a good time to try to resubscribe.
      *
      * The reason string is used for logging if a resubscribe is triggered.
+     *
+     * Returns whether a resubscribe is triggered.
      */
-    void TriggerResubscribeIfScheduled(const char * reason);
+    bool TriggerResubscribeIfScheduled(const char * reason);
 
     /**
      * Returns the timeout after which we consider the subscription to have


### PR DESCRIPTION
There are two places in MTRDevice's `- (void)_triggerResubscribeWithReason:(NSString *)reason nodeLikelyReachable:(BOOL)nodeLikelyReachable` where it exists without actually having a re-subscription happen. In those cases we need to clear subscription work from the pool, to allow other operations to continue.

#### Testing

Existing CI to test for regression. Created https://github.com/project-chip/connectedhomeip/issues/39004 as follow up to add unit testing for this specifically.