### PR TITLE
[Darwin][CI] Fallback to SIGKILL after 10 seconds if terminate fails …

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.mm
@@ -32,7 +32,25 @@ static void ClearTaskSet(NSMutableSet<NSTask *> * __strong & tasks)
 {
     for (NSTask * task in tasks) {
         NSLog(@"Terminating task %@", task);
-        [task terminate];
+
+        [task terminate]; // Sends SIGTERM
+
+        // Wait up to 10 seconds for graceful shutdown
+        BOOL terminated = NO;
+        for (int i = 0; i < 100; i++) {
+            if (![task isRunning]) {
+                terminated = YES;
+                break;
+            }
+            [NSThread sleepForTimeInterval:0.1];
+        }
+
+        if (!terminated) {
+            NSLog(@"Force killing unresponsive task %@", task);
+            kill(task.processIdentifier, SIGKILL);
+        }
+
+        [task waitUntilExit];
     }
     tasks = nil;
 }


### PR DESCRIPTION
…for NSTask cleanup

#### Description

Ensure` NSTask` subprocesses are reliably cleaned up in CI by sending `SIGKIL`L if they don’t exit after terminate.

#### Testing

If this doesn’t work, we’ll know — because there will be zombies shambling around in CI. 🧟‍♂️