### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-131 : [NXP] Update NXP Zephyr docker image to Zephyr 4.1.0
+132 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,7 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=2f112696a24c8921bcb196a3c4b90c4f8a37f710
+ARG ZEPHYR_REVISION=f7ae682dfb047c3ae7823c6b613f834b60364250
+ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -31,6 +31,7 @@ RUN set -x \
     && west init -l \
     && west update -o=--depth=1 -n -f smart \
     && west blobs fetch hal_telink \
+    && scripts/utils/telink_w91_post_build $PWD ${N22_BIN_REVISION} 1 \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.7.0; branch: develop
-ARG ZEPHYR_REVISION=6f10af9b4e7d453bc33089ccc74b62008822c47c
+ARG ZEPHYR_REVISION=b702c1597bd56f67d58167ef97342b234a9530f2
 ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.7.0; branch: develop
-ARG ZEPHYR_REVISION=ed037d7de7c23eb14c908453d2d481cdf782796a
+ARG ZEPHYR_REVISION=6f10af9b4e7d453bc33089ccc74b62008822c47c
+ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \
@@ -30,6 +31,7 @@ RUN set -x \
     && west init -l \
     && west update -o=--depth=1 -n -f smart \
     && west blobs fetch hal_telink \
+    && scripts/utils/telink_w91_post_build $PWD ${N22_BIN_REVISION} 1 \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.7.0; branch: develop
-ARG ZEPHYR_REVISION=b702c1597bd56f67d58167ef97342b234a9530f2
+ARG ZEPHYR_REVISION=5f49979be46451b30c92223d431f6dab5c131d80
 ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \


### PR DESCRIPTION
**Change overview**

- telink: Add support of Andes GCC compiler
- samples: boards: tlsr9x: sock_simple: Fix Application
- samples: boards: tlsr9x: net_cli: Network cli application
- telink: soc: fix to attach child devices when acting as leader for W91
- w91: post_build: skip fetch if files exist

**Changes of N22 binary:**

(latest hash 05f9bcecde9df997a7d735ea119bb9a8212b8a8f)
- Fix IPv4 with Zephyr

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully
