### PR TITLE
Fix wildcard subscriptions on all endpoints being rejected with "invalid action"

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -95,8 +95,8 @@ bool MayHaveAccessibleEventPathForEndpoint(DataModel::Provider * aProvider, Endp
 
     for (auto & cluster : aProvider->ServerClustersIgnoreError(aEndpoint))
     {
-        if (MayHaveAccessibleEventPathForEndpointAndCluster(ConcreteClusterPath(aEndpoint, cluster.clusterId),
-                                                            aEventPath, aSubjectDescriptor))
+        if (MayHaveAccessibleEventPathForEndpointAndCluster(ConcreteClusterPath(aEndpoint, cluster.clusterId), aEventPath,
+                                                            aSubjectDescriptor))
         {
             return true;
         }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -93,9 +93,9 @@ bool MayHaveAccessibleEventPathForEndpoint(DataModel::Provider * aProvider, Endp
                                                                aSubjectDescriptor);
     }
 
-    for (auto & cluster : aProvider->ServerClustersIgnoreError(aEventPath.mEndpointId))
+    for (auto & cluster : aProvider->ServerClustersIgnoreError(aEndpoint))
     {
-        if (MayHaveAccessibleEventPathForEndpointAndCluster(ConcreteClusterPath(aEventPath.mEndpointId, cluster.clusterId),
+        if (MayHaveAccessibleEventPathForEndpointAndCluster(ConcreteClusterPath(aEndpoint, cluster.clusterId),
                                                             aEventPath, aSubjectDescriptor))
         {
             return true;

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -185,7 +185,7 @@ from chip.testing.basic_composition import BasicCompositionTests
 from chip.testing.global_attribute_ids import (AttributeIdType, ClusterIdType, CommandIdType, GlobalAttributeIds, attribute_id_type,
                                                cluster_id_type, command_id_type)
 from chip.testing.matter_testing import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, MatterBaseTest, TestStep,
-                                         async_test_body, default_matter_test_main, UnknownProblemLocation)
+                                         UnknownProblemLocation, async_test_body, default_matter_test_main)
 from chip.testing.taglist_and_topology_test import (create_device_type_list_for_root, create_device_type_lists,
                                                     find_tag_list_problems, find_tree_roots, flat_list_ok,
                                                     get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
@@ -679,11 +679,12 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         subscription = None
         try:
             subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id,
-                                                                events=[('*')],
-                                                                fabricFiltered=True,
-                                                                reportInterval=(100, 1000))
+                                                                   events=[('*')],
+                                                                   fabricFiltered=True,
+                                                                   reportInterval=(100, 1000))
         except Exception as e:
-            self.record_error(self.get_test_name(), problem=f"Failed to wildcard subscribe events(*): {e}", location=UnknownProblemLocation())
+            self.record_error(self.get_test_name(),
+                              problem=f"Failed to wildcard subscribe events(*): {e}", location=UnknownProblemLocation())
 
         if subscription is None:
             self.fail_current_test()

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -950,8 +950,8 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                 logging.info(f'{start_tag}{line}')
             logging.info(f'{start_tag}END ====')
 
-        #log_structured_data('==== json: ', json_str)
-        #log_structured_data('==== txt: ', txt_str)
+        log_structured_data('==== json: ', json_str)
+        log_structured_data('==== txt: ', txt_str)
 
     @async_test_body
     async def test_TC_DESC_2_1(self):

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -180,6 +180,7 @@ from chip import ChipUtility
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ClusterAttributeDescriptor, ClusterObjectFieldDescriptor
 from chip.clusters.Types import Nullable
+from chip.exceptions import ChipStackError
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.basic_composition import BasicCompositionTests
 from chip.testing.global_attribute_ids import (AttributeIdType, ClusterIdType, CommandIdType, GlobalAttributeIds, attribute_id_type,
@@ -191,7 +192,6 @@ from chip.testing.taglist_and_topology_test import (create_device_type_list_for_
                                                     get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
 from chip.tlv import uint
 from TC_DeviceConformance import get_supersets
-from chip.exceptions import ChipStackError
 
 
 def get_vendor_id(mei: int) -> int:
@@ -696,7 +696,6 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         if test_failure:
             self.record_error(self.get_test_name(), problem=test_failure, location=UnknownProblemLocation())
             self.fail_current_test(test_failure)
-
 
     def test_TC_IDM_11_1(self):
         success = True

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -680,7 +680,7 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
         try:
             subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id,
                                                                    events=[('*')],
-                                                                   fabricFiltered=True,
+                                                                   fabricFiltered=False,
                                                                    reportInterval=(100, 1000))
         except Exception as e:
             self.record_error(self.get_test_name(),

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -674,6 +674,16 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
             self.fail_current_test(
                 "At least one cluster has failed the range and support checks for its listed attributes, commands or features")
 
+        # Wildcard reads of events: event list MUST NOT be empty since at least a boot event should be registered.
+        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id,
+                                                               events=[('*')],
+                                                               fabricFiltered=True,
+                                                               reportInterval=(100, 1000))
+
+        if len(subscription.GetEvents()) == 0:
+            self.fail_current_test('Wildcard event subscription returned no events')
+            success = False
+
     def test_TC_IDM_11_1(self):
         success = True
         for endpoint_id, endpoint in self.endpoints_tlv.items():
@@ -941,8 +951,8 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                 logging.info(f'{start_tag}{line}')
             logging.info(f'{start_tag}END ====')
 
-        log_structured_data('==== json: ', json_str)
-        log_structured_data('==== txt: ', txt_str)
+        #log_structured_data('==== json: ', json_str)
+        #log_structured_data('==== txt: ', txt_str)
 
     @async_test_body
     async def test_TC_DESC_2_1(self):

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -682,7 +682,6 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
 
         if len(subscription.GetEvents()) == 0:
             self.fail_current_test('Wildcard event subscription returned no events')
-            success = False
 
     def test_TC_IDM_11_1(self):
         success = True

--- a/src/python_testing/TC_DeviceBasicComposition.py
+++ b/src/python_testing/TC_DeviceBasicComposition.py
@@ -185,7 +185,7 @@ from chip.testing.basic_composition import BasicCompositionTests
 from chip.testing.global_attribute_ids import (AttributeIdType, ClusterIdType, CommandIdType, GlobalAttributeIds, attribute_id_type,
                                                cluster_id_type, command_id_type)
 from chip.testing.matter_testing import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, MatterBaseTest, TestStep,
-                                         async_test_body, default_matter_test_main)
+                                         async_test_body, default_matter_test_main, UnknownProblemLocation)
 from chip.testing.taglist_and_topology_test import (create_device_type_list_for_root, create_device_type_lists,
                                                     find_tag_list_problems, find_tree_roots, flat_list_ok,
                                                     get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
@@ -675,10 +675,19 @@ class TC_DeviceBasicComposition(MatterBaseTest, BasicCompositionTests):
                 "At least one cluster has failed the range and support checks for its listed attributes, commands or features")
 
         # Wildcard reads of events: event list MUST NOT be empty since at least a boot event should be registered.
-        subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id,
-                                                               events=[('*')],
-                                                               fabricFiltered=True,
-                                                               reportInterval=(100, 1000))
+        self.print_step(12, "Validate that event wildcard subscription works")
+        subscription = None
+        try:
+            subscription = await self.default_controller.ReadEvent(nodeid=self.dut_node_id,
+                                                                events=[('*')],
+                                                                fabricFiltered=True,
+                                                                reportInterval=(100, 1000))
+        except Exception as e:
+            self.record_error(self.get_test_name(), problem=f"Failed to wildcard subscribe events(*): {e}", location=UnknownProblemLocation())
+
+        if subscription is None:
+            self.fail_current_test()
+            return
 
         if len(subscription.GetEvents()) == 0:
             self.fail_current_test('Wildcard event subscription returned no events')


### PR DESCRIPTION
Instead of using the concrete `aEndpoint` value, code was using the wildcard endpoint from the path to call into the datamodel provider and datamodel provider will return empty list on invalid endpoint IDs.

This fixes #39013

#### Testing

Manual test as in the bug:

```
# app side:
rm -rf /tmp/chip_*; ./out/linux-x64-all-clusters-clang/chip-all-clusters-app

# chip-tool:
./out/linux-x64-chip-tool-clang//chip-tool pairing onnetwork 1 20202021
./out/linux-x64-chip-tool-clang//chip-tool interactive start 

    any subscribe-event-by-id 0xFFFFFFFF 0xFFFFFFFF 100 1000 1 0xFFFF
```

Before the change I got invalid action, after the change the operation succeeds.

Added integration test in TC_BasicDeviceComposition (we really need to catch this in cert as wildcard subscribe is VERY common). Tested locally with:

```sh
# app
rm -rf /tmp/chip_*; ./out/linux-x64-all-clusters-clang/chip-all-clusters-app --discriminator 1234

# test
python3 src/python_testing/TC_DeviceBasicComposition.py --commissioning-method on-network --manual-code 10054912339 --PICS src/app/tests/suites/certification/ci-pics-values
```

Before I get fail with:

![image](https://github.com/user-attachments/assets/3ac0f3f6-2ed7-4062-8169-7a1f3bebebc9)

And after it passes

```
...
INFO:chip.native.DL:System Layer shutdown
INFO:root:Final result: PASS !
```