### PR TITLE
Remove obsolete comments from MetadataTree

### DIFF
--- a/src/app/data-model-provider/ProviderMetadataTree.h
+++ b/src/app/data-model-provider/ProviderMetadataTree.h
@@ -34,18 +34,6 @@ namespace DataModel {
 ///
 /// The data model can be viewed as a tree of endpoint/cluster/(attribute+commands+events)
 /// where each element can be iterated through independently.
-///
-/// Iteration rules:
-///   - Invalid paths will be returned when iteration ends (IDs will be kInvalid* and in particular
-///     mEndpointId will be kInvalidEndpointId). See `::kInvalid` constants for entries and
-///     can use ::IsValid() to determine if the entry is valid or not.
-///   - Global Attributes are NOT returned since they are implied
-///   - Any internal iteration errors are just logged (callers do not handle iteration CHIP_ERROR)
-///   - Iteration order is NOT guaranteed globally. Only the following is guaranteed:
-///     - Complete tree iteration (e.g. when iterating an endpoint, ALL clusters of that endpoint
-///       are returned, when iterating over a cluster, all attributes/commands are iterated over)
-///     - uniqueness and completeness (iterate over all possible distinct values as long as no
-///       internal structural changes occur)
 class ProviderMetadataTree
 {
 public:


### PR DESCRIPTION
Code switched from first/next ieration to CHIP_ERROR+ListBuilder. Almost all comments are obsolete (we have CHIP_ERROR, there are no invalid paths at the end, attribute iteration contains all global attributes, iteration order is not relevant anymore - you get a complete list....).

Just deleted the comments because of this.

#### Testing

Comment cleanup only
