### PR TITLE
[Darwin] MTRDevice diagnostic log transfer state improvements

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -3926,6 +3926,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
         // we should use a counter internally.
         std::lock_guard lock(self->_lock);
         self.diagnosticLogTransferInProgress = YES;
+        [self _notifyDelegateOfPrivateInternalPropertiesChanges];
     }
 
     mtr_weakify(self);
@@ -3938,6 +3939,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                            {
                                std::lock_guard lock(self->_lock);
                                self.diagnosticLogTransferInProgress = NO;
+                               [self _notifyDelegateOfPrivateInternalPropertiesChanges];
                            }
                            MTR_LOG("%@ downloadLogOfType %lu completed: %@", self, static_cast<unsigned long>(type), error);
                            completion(url, error);

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -627,6 +627,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
         MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDeviceCachePrimed, @(_deviceCachePrimed), properties);
         MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyEstimatedStartTime, _estimatedStartTime, properties);
         MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyEstimatedSubscriptionLatency, _estimatedSubscriptionLatency, properties);
+        MTR_OPTIONAL_ATTRIBUTE(kMTRDeviceInternalPropertyDiagnosticLogTransferInProgress, @(_diagnosticLogTransferInProgress), properties);
     }
 
     return properties;

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -212,7 +212,7 @@ static NSString * const kMTRDeviceInternalPropertyMostRecentReportTime = @"MTRDe
 static NSString * const kMTRDeviceInternalPropertyLastSubscriptionFailureTime = @"MTRDeviceInternalPropertyLastSubscriptionFailureTime";
 static NSString * const kMTRDeviceInternalPropertyDeviceState = @"MTRDeviceInternalPropertyDeviceState";
 static NSString * const kMTRDeviceInternalPropertyDeviceCachePrimed = @"MTRDeviceInternalPropertyDeviceCachePrimed";
-static NSString * const kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress = @"kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress";
+static NSString * const kMTRDeviceInternalPropertyDiagnosticLogTransferInProgress = @"MTRDeviceInternalPropertyDiagnosticLogTransferInProgress";
 static NSString * const kMTRDeviceInternalPropertyEstimatedStartTime = @"MTRDeviceInternalPropertyEstimatedStartTime";
 static NSString * const kMTRDeviceInternalPropertyEstimatedSubscriptionLatency = @"MTRDeviceInternalPropertyEstimatedSubscriptionLatency";
 

--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -268,6 +268,12 @@
     // Not needed since this is a state update now
 }
 
+- (BOOL)diagnosticLogTransferInProgress
+{
+    NSNumber * diagnosticLogTransferInProgressNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceCachePrimed], NSNumber);
+    return diagnosticLogTransferInProgressNumber.boolValue;
+}
+
 - (oneway void)deviceConfigurationChanged:(NSNumber *)nodeID
 {
     MTR_LOG("%@ %s", self, __PRETTY_FUNCTION__);
@@ -341,7 +347,7 @@
         kMTRDeviceInternalPropertyNetworkFeatures : NSNumber.class,
         kMTRDeviceInternalPropertyMostRecentReportTime : NSDate.class,
         kMTRDeviceInternalPropertyLastSubscriptionFailureTime : NSDate.class,
-        kMTRDeviceInternalPropertyNumDiagLogTransfersInProgress : NSNumber.class
+        kMTRDeviceInternalPropertyDiagnosticLogTransferInProgress : NSNumber.class
     };
 
     VerifyOrReturn([self _ensureValidValuesForKeys:requiredInternalStateKeys inInternalState:newState valueRequired:YES]);


### PR DESCRIPTION
- Replace `os_unfair_lock` use with `std::lock_guard`
- implement state accessor for `MTRDevice_XPC`

#### Testing

- updates to `MTRDevice_Concrete` tested on real device as tested in #39002 
- updates to `MTRDevice_XPC` tested on real device
  - add print of before `[self _setInternalState:newState];` of `newState` to validate
  - do log transfers in Home app
  - see that `MTRDeviceInternalPropertyDiagnosticLogTransferInProgress` alternates 0/1 as transfers are begun and end, settling on 0.
