### PR TITLE
[Bridge-App/Linux] Fix the bridge-app to use generic actions cluster interface using delegate.

### DIFF
--- a/examples/bridge-app/linux/bridged-actions-stub.cpp
+++ b/examples/bridge-app/linux/bridged-actions-stub.cpp
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/clusters/actions-server/actions-server.h>
 #include <app/util/attribute-storage.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -32,106 +33,231 @@
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::Actions;
 using namespace chip::app::Clusters::Actions::Attributes;
+using namespace chip::Protocols::InteractionModel;
+
+extern std::vector<Room *> gRooms;
+extern std::vector<Action *> gActions;
 
 namespace {
 
-class ActionsAttrAccess : public AttributeAccessInterface
+class LinuxActionsDelegateImpl : public Actions::Delegate
 {
 public:
-    // Register for the Actions cluster on all endpoints.
-    ActionsAttrAccess() : AttributeAccessInterface(Optional<EndpointId>::Missing(), Actions::Id) {}
+    LinuxActionsDelegateImpl() : mEndpointId(1) {}
 
-    CHIP_ERROR Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder) override;
+    void SetEndpointId(chip::EndpointId endpointId) { mEndpointId = endpointId; }
+    chip::EndpointId GetEndpointId() const { return mEndpointId; }
+
+    CHIP_ERROR ReadActionAtIndex(uint16_t index, ActionStructStorage & action) override;
+    CHIP_ERROR ReadEndpointListAtIndex(uint16_t index, EndpointListStorage & epList) override;
+    bool HaveActionWithId(uint16_t actionId, uint16_t & actionIndex) override;
+
+    Status HandleInstantAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandleInstantActionWithTransition(uint16_t actionId, uint16_t transitionTime, Optional<uint32_t> invokeId) override;
+    Status HandleStartAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandleStartActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId) override;
+    Status HandleStopAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandlePauseAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandlePauseActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId) override;
+    Status HandleResumeAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandleEnableAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandleEnableActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId) override;
+    Status HandleDisableAction(uint16_t actionId, Optional<uint32_t> invokeId) override;
+    Status HandleDisableActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId) override;
 
 private:
-    static constexpr uint16_t ClusterRevision = 1;
-
-    CHIP_ERROR ReadActionListAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder);
-    CHIP_ERROR ReadEndpointListAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder);
-    CHIP_ERROR ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder);
-    CHIP_ERROR ReadClusterRevision(EndpointId endpoint, AttributeValueEncoder & aEncoder);
+    chip::EndpointId mEndpointId;
 };
 
-constexpr uint16_t ActionsAttrAccess::ClusterRevision;
+LinuxActionsDelegateImpl gLinuxActionsDelegateImpl;
+std::unique_ptr<Actions::ActionsServer> sActionsServer;
 
-CHIP_ERROR ActionsAttrAccess::ReadActionListAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
+CHIP_ERROR LinuxActionsDelegateImpl::ReadActionAtIndex(uint16_t index, ActionStructStorage & action)
 {
-    CHIP_ERROR err = aEncoder.EncodeList([&endpoint](const auto & encoder) -> CHIP_ERROR {
-        std::vector<Action *> actionList = GetActionListInfo(endpoint);
+    std::vector<Action *> actionList = GetActionListInfo(mEndpointId);
 
-        for (auto action : actionList)
+    uint16_t visibleCount = 0;
+    for (auto actionPtr : actionList)
+    {
+        if (actionPtr->getIsVisible())
         {
-            if (action->getIsVisible())
+            if (visibleCount == index)
             {
-                Actions::Structs::ActionStruct::Type actionStruct = { action->getActionId(),
-                                                                      CharSpan::fromCharString(action->getName().c_str()),
-                                                                      action->getType(),
-                                                                      action->getEndpointListId(),
-                                                                      action->getSupportedCommands(),
-                                                                      action->getStatus() };
-                ReturnErrorOnFailure(encoder.Encode(actionStruct));
+                // Found the visible action at the requested index
+                action.Set(actionPtr->getActionId(), CharSpan::fromCharString(actionPtr->getName().c_str()), actionPtr->getType(),
+                           actionPtr->getEndpointListId(), actionPtr->getSupportedCommands(), actionPtr->getStatus());
+                return CHIP_NO_ERROR;
+            }
+            visibleCount++;
+        }
+    }
+
+    return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+}
+
+CHIP_ERROR LinuxActionsDelegateImpl::ReadEndpointListAtIndex(uint16_t index, EndpointListStorage & epList)
+{
+    std::vector<EndpointListInfo> infoList = GetEndpointListInfo(mEndpointId);
+
+    if (index >= infoList.size())
+    {
+        return CHIP_ERROR_PROVIDER_LIST_EXHAUSTED;
+    }
+
+    // Get the endpoint list at the specified index
+    EndpointListInfo info = infoList[index];
+    DataModel::List<const EndpointId> endpointList(info.GetEndpointListData(), info.GetEndpointListSize());
+
+    epList.Set(info.GetEndpointListId(), CharSpan::fromCharString(info.GetName().c_str()), info.GetType(), endpointList);
+
+    return CHIP_NO_ERROR;
+}
+
+bool LinuxActionsDelegateImpl::HaveActionWithId(uint16_t actionId, uint16_t & actionIndex)
+{
+    std::vector<Action *> actionList = GetActionListInfo(mEndpointId);
+
+    for (size_t i = 0; i < actionList.size(); i++)
+    {
+        if (actionList[i]->getActionId() == actionId)
+        {
+            actionIndex = static_cast<uint16_t>(i);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+Status LinuxActionsDelegateImpl::HandleInstantAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    EndpointId endpointID  = mEndpointId;
+    bool hasInvokeID       = invokeId.HasValue();
+    uint32_t invokeIDValue = invokeId.HasValue() ? invokeId.Value() : 0;
+
+    Action * targetAction = nullptr;
+    for (auto * action : gActions)
+    {
+        if (action->getActionId() == actionId && action->getIsVisible())
+        {
+            targetAction = action;
+            break;
+        }
+    }
+
+    if (targetAction)
+    {
+        // Determine the room and if it's an "on" action based on action ID
+        Room * targetRoom = nullptr;
+        bool turnOn       = true;
+
+        // Find room with matching endpoint list ID
+        for (auto * room : gRooms)
+        {
+            if (room->getEndpointListId() == targetAction->getEndpointListId())
+            {
+                targetRoom = room;
+                break;
             }
         }
 
-        return CHIP_NO_ERROR;
-    });
-    return err;
-}
-
-CHIP_ERROR ActionsAttrAccess::ReadEndpointListAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
-{
-    std::vector<EndpointListInfo> infoList = GetEndpointListInfo(endpoint);
-
-    CHIP_ERROR err = aEncoder.EncodeList([&infoList](const auto & encoder) -> CHIP_ERROR {
-        for (auto info : infoList)
+        // Determine if this is an "on" or "off" action based on name
+        if (targetAction->getName().find("Off") != std::string::npos)
         {
-            Actions::Structs::EndpointListStruct::Type endpointListStruct = {
-                info.GetEndpointListId(), CharSpan::fromCharString(info.GetName().c_str()), info.GetType(),
-                DataModel::List<chip::EndpointId>(info.GetEndpointListData(), info.GetEndpointListSize())
-            };
-            ReturnErrorOnFailure(encoder.Encode(endpointListStruct));
+            turnOn = false;
         }
-        return CHIP_NO_ERROR;
-    });
-    return err;
-}
 
-CHIP_ERROR ActionsAttrAccess::ReadSetupUrlAttribute(EndpointId endpoint, AttributeValueEncoder & aEncoder)
-{
-    static const char SetupUrl[] = "https://example.com";
-    return aEncoder.Encode(chip::CharSpan::fromCharString(SetupUrl));
-}
-
-CHIP_ERROR ActionsAttrAccess::ReadClusterRevision(EndpointId endpoint, AttributeValueEncoder & aEncoder)
-{
-    return aEncoder.Encode(ClusterRevision);
-}
-
-ActionsAttrAccess gAttrAccess;
-
-CHIP_ERROR ActionsAttrAccess::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
-{
-    VerifyOrDie(aPath.mClusterId == Actions::Id);
-
-    switch (aPath.mAttributeId)
-    {
-    case ActionList::Id:
-        return ReadActionListAttribute(aPath.mEndpointId, aEncoder);
-    case EndpointLists::Id:
-        return ReadEndpointListAttribute(aPath.mEndpointId, aEncoder);
-    case SetupURL::Id:
-        return ReadSetupUrlAttribute(aPath.mEndpointId, aEncoder);
-    case ClusterRevision::Id:
-        return ReadClusterRevision(aPath.mEndpointId, aEncoder);
-    default:
-        break;
+        if (targetRoom)
+        {
+            runOnOffRoomAction(targetRoom, turnOn, endpointID, actionId, invokeIDValue, hasInvokeID);
+            return Status::Success;
+        }
     }
-    return CHIP_NO_ERROR;
+
+    return Status::NotFound;
 }
+
+Status LinuxActionsDelegateImpl::HandleInstantActionWithTransition(uint16_t actionId, uint16_t transitionTime,
+                                                                   Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleStartAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleStartActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleStopAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandlePauseAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandlePauseActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleResumeAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleEnableAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleEnableActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleDisableAction(uint16_t actionId, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
+Status LinuxActionsDelegateImpl::HandleDisableActionWithDuration(uint16_t actionId, uint32_t duration, Optional<uint32_t> invokeId)
+{
+    // Not implemented
+    return Status::NotFound;
+}
+
 } // anonymous namespace
 
 void emberAfActionsClusterInitCallback(EndpointId endpoint)
 {
-    AttributeAccessInterfaceRegistry::Instance().Register(&gAttrAccess);
+    VerifyOrReturn(endpoint == 1,
+                   ChipLogError(Zcl, "Actions cluster delegate is not implemented for endpoint with id %d.", endpoint));
+    VerifyOrReturn(emberAfContainsServer(endpoint, Actions::Id) == true,
+                   ChipLogError(Zcl, "Endpoint %d does not support Actions cluster.", endpoint));
+
+    VerifyOrReturn(!sActionsServer);
+
+    gLinuxActionsDelegateImpl.SetEndpointId(endpoint);
+    sActionsServer = std::make_unique<Actions::ActionsServer>(endpoint, gLinuxActionsDelegateImpl);
+    sActionsServer->Init();
 }

--- a/examples/bridge-app/linux/include/main.h
+++ b/examples/bridge-app/linux/include/main.h
@@ -26,6 +26,8 @@ std::vector<EndpointListInfo> GetEndpointListInfo(chip::EndpointId parentId);
 
 std::vector<Action *> GetActionListInfo(chip::EndpointId parentId);
 
+std::vector<Room *> GetRoomListInfo(chip::EndpointId parentId);
+
 class BridgeAppCommandHandler
 {
 public:
@@ -48,6 +50,3 @@ public:
 // Declare runOnOffRoomAction as an external function that can be called from bridged-actions-stub.cpp
 void runOnOffRoomAction(Room * room, bool actionOn, chip::EndpointId endpointId, uint16_t actionID, uint32_t invokeID,
                         bool hasInvokeID);
-
-// Declare global variables as extern for use in bridged-actions-stub.cpp
-extern std::vector<Room *> gRooms;

--- a/examples/bridge-app/linux/include/main.h
+++ b/examples/bridge-app/linux/include/main.h
@@ -44,3 +44,10 @@ class BridgeCommandDelegate : public NamedPipeCommandDelegate
 public:
     void OnEventCommandReceived(const char * json) override;
 };
+
+// Declare runOnOffRoomAction as an external function that can be called from bridged-actions-stub.cpp
+void runOnOffRoomAction(Room * room, bool actionOn, chip::EndpointId endpointId, uint16_t actionID, uint32_t invokeID,
+                        bool hasInvokeID);
+
+// Declare global variables as extern for use in bridged-actions-stub.cpp
+extern std::vector<Room *> gRooms;

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -393,6 +393,11 @@ std::vector<Action *> GetActionListInfo(chip::EndpointId parentId)
     return gActions;
 }
 
+std::vector<Room *> GetRoomListInfo(chip::EndpointId parentId)
+{
+    return gRooms;
+}
+
 namespace {
 void CallReportingCallback(intptr_t closure)
 {

--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -62,6 +62,10 @@ using namespace chip::Transport;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters;
 
+// These variables need to be in global scope for bridged-actions-stub.cpp to access them
+std::vector<Room *> gRooms;
+std::vector<Action *> gActions;
+
 namespace {
 
 constexpr char kChipEventFifoPathPrefix[] = "/tmp/chip_bridge_fifo_";
@@ -77,8 +81,6 @@ EndpointId gCurrentEndpointId;
 EndpointId gFirstDynamicEndpointId;
 // Power source is on the same endpoint as the composed device
 Device * gDevices[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT + 1];
-std::vector<Room *> gRooms;
-std::vector<Action *> gActions;
 
 const int16_t minMeasuredValue     = -27315;
 const int16_t maxMeasuredValue     = 32766;
@@ -743,46 +745,6 @@ void runOnOffRoomAction(Room * room, bool actionOn, EndpointId endpointId, uint1
         EventNumber eventNumber;
         chip::app::LogEvent(event, endpointId, eventNumber);
     }
-}
-
-bool emberAfActionsClusterInstantActionCallback(app::CommandHandler * commandObj, const app::ConcreteCommandPath & commandPath,
-                                                const Actions::Commands::InstantAction::DecodableType & commandData)
-{
-    bool hasInvokeID      = false;
-    uint32_t invokeID     = 0;
-    EndpointId endpointID = commandPath.mEndpointId;
-    auto & actionID       = commandData.actionID;
-
-    if (commandData.invokeID.HasValue())
-    {
-        hasInvokeID = true;
-        invokeID    = commandData.invokeID.Value();
-    }
-
-    if (actionID == action1.getActionId() && action1.getIsVisible())
-    {
-        // Turn On Lights in Room 1
-        runOnOffRoomAction(&room1, true, endpointID, actionID, invokeID, hasInvokeID);
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-        return true;
-    }
-    if (actionID == action2.getActionId() && action2.getIsVisible())
-    {
-        // Turn On Lights in Room 2
-        runOnOffRoomAction(&room2, true, endpointID, actionID, invokeID, hasInvokeID);
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-        return true;
-    }
-    if (actionID == action3.getActionId() && action3.getIsVisible())
-    {
-        // Turn Off Lights in Room 1
-        runOnOffRoomAction(&room1, false, endpointID, actionID, invokeID, hasInvokeID);
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-        return true;
-    }
-
-    commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::NotFound);
-    return true;
 }
 
 const EmberAfDeviceType gBridgedOnOffDeviceTypes[] = { { DEVICE_TYPE_LO_ON_OFF_LIGHT, DEVICE_VERSION_DEFAULT },


### PR DESCRIPTION
#### Problem

Linux app did not use the generic actions server cluster interface and the cluster was marked as `CommandHandlerInterfaceOnlyClusters` but Linux add did not ever registered the CHI which causes `UNSUPPORTED_CLUSTER` in https://github.com/project-chip/connectedhomeip/issues/38935

#### Changes

Use the generic actions server cluster implementation and created a separate delegate class for the Linux bridge-app as it had a prototype to handler the actions commands.

#### Testing

Locally tested the actions cluster on Linux by reading all of its attributes using chip-tool.
Send InstantActions command on the server, `./chip-tool actions  instant-action  0x1001 1 1` to get the expected outcome.

> [1747421334.453] [10356:1892751:chip] [DMG] 				StatusIB =
> [1747421334.453] [10356:1892751:chip] [DMG] 				{
> [1747421334.453] [10356:1892751:chip] [DMG] 					status = 0x00 (SUCCESS),
> [1747421334.453] [10356:1892751:chip] [DMG] 				},