### PR TITLE
Fix typo in parameter used in XPC path

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_XPC.mm
@@ -270,7 +270,7 @@
 
 - (BOOL)diagnosticLogTransferInProgress
 {
-    NSNumber * diagnosticLogTransferInProgressNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDeviceCachePrimed], NSNumber);
+    NSNumber * diagnosticLogTransferInProgressNumber = MTR_SAFE_CAST(self._internalState[kMTRDeviceInternalPropertyDiagnosticLogTransferInProgress], NSNumber);
     return diagnosticLogTransferInProgressNumber.boolValue;
 }
 


### PR DESCRIPTION
Wrong parameter was passed in

#### Testing
CI testing 
Manual testing to verify this