### PR TITLE
fix: do not build boringssl if openssl selected

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -117,7 +117,7 @@ static_library("chip-tool-utils") {
     sources += [ "commands/common/DeviceScanner.cpp" ]
   }
 
-  if (chip_device_platform == "darwin" || chip_crypto == "boringssl") {
+  if (chip_crypto == "boringssl") {
     deps += [ "${boringssl_root}:boringssl_with_ssl_sources" ]
   }
 


### PR DESCRIPTION
On darwin `chip_crypto == "boringssl"` by default. But if I force to build with `openssl` than `boringssl` shouldn't be built

#### Testing

Manual build on OSX:
- set `chip_crypto: openssl`
- build
- check that boringssl is not compiled
