### PR TITLE
Fix CI broken on TC_AVSUM_2_7.py

### DIFF
--- a/src/python_testing/TC_AVSUMTestBase.py
+++ b/src/python_testing/TC_AVSUMTestBase.py
@@ -193,7 +193,7 @@ class AVSUMTestBase:
                 videoCodec=0,
                 minFrameRate=30,
                 maxFrameRate=120,
-                minResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=400, height=300),
+                minResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=640, height=360),
                 maxResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=1920, height=1080),  # 16/9
                 minBitRate=20000,
                 maxBitRate=150000,


### PR DESCRIPTION
CI was broken on TC_AVSUM_2_7.py due to minimum resolution adjust

#### Testing

Validated by CI