### PR TITLE
[Python] Fix leak warnings reported by clang-tidy

### DIFF
--- a/scripts/run-clang-tidy-on-compile-commands.py
+++ b/scripts/run-clang-tidy-on-compile-commands.py
@@ -496,7 +496,7 @@ def cmd_check(context):
         sys.exit(1)
 
 
-@main.command("fix", help="Run check followd by fix")
+@main.command("fix", help="Run check followed by fix")
 @click.pass_context
 def cmd_fix(context):
     runner = context.obj

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -15,8 +15,8 @@
  *    limitations under the License.
  */
 
-#include "system/SystemClock.h"
 #include <cstdarg>
+#include <cstdio>
 #include <memory>
 #include <type_traits>
 
@@ -29,12 +29,10 @@
 #include <controller/CHIPDeviceController.h>
 #include <controller/python/chip/interaction_model/Delegate.h>
 #include <controller/python/chip/native/PyChipError.h>
-#include <lib/support/CodeUtils.h>
-
-#include <cstdio>
-#include <lib/support/logging/CHIPLogging.h>
-
 #include <lib/core/Optional.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/logging/CHIPLogging.h>
+#include <system/SystemClock.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -112,13 +110,16 @@ public:
         // callback. If we do, that's a bug.
         //
         VerifyOrDie(!aPath.IsListItemOperation());
-        size_t bufferLen                  = (apData == nullptr ? 0 : apData->GetRemainingLength() + apData->GetLengthRead());
-        std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(apData == nullptr ? nullptr : new uint8_t[bufferLen]);
-        size_t size                       = 0;
+
+        std::unique_ptr<uint8_t[]> buffer;
+        size_t size = 0;
+
         // When the apData is nullptr, means we did not receive a valid attribute data from server, status will be some error
         // status.
         if (apData != nullptr)
         {
+            size_t bufferLen = apData->GetRemainingLength() + apData->GetLengthRead();
+            buffer           = std::make_unique<uint8_t[]>(bufferLen);
             // The TLVReader's read head is not pointing to the first element in the container instead of the container itself, use
             // a TLVWriter to get a TLV with a normalized TLV buffer (Wrapped with a anonymous tag, no extra "end of container" tag
             // at the end.)
@@ -515,11 +516,10 @@ PyChipError pychip_ReadClient_Read(void * appContext, ReadClient ** pReadClient,
     // The readParamsBuf might be not aligned, using a memcpy to avoid some unexpected behaviors.
     memcpy(&pyParams, readParamsBuf, sizeof(pyParams));
 
-    std::unique_ptr<ReadClientCallback> callback = std::make_unique<ReadClientCallback>(appContext);
-
-    std::unique_ptr<AttributePathParams[]> attributePaths(new AttributePathParams[numAttributePaths]);
-    std::unique_ptr<chip::app::DataVersionFilter[]> dataVersionFilters(new chip::app::DataVersionFilter[numDataversionFilters]);
-    std::unique_ptr<EventPathParams[]> eventPaths(new EventPathParams[numEventPaths]);
+    auto callback           = std::make_unique<ReadClientCallback>(appContext);
+    auto attributePaths     = std::make_unique<AttributePathParams[]>(numAttributePaths);
+    auto dataVersionFilters = std::make_unique<chip::app::DataVersionFilter[]>(numDataversionFilters);
+    auto eventPaths         = std::make_unique<EventPathParams[]>(numEventPaths);
     std::unique_ptr<ReadClient> readClient;
 
     for (size_t i = 0; i < numAttributePaths; i++)


### PR DESCRIPTION
#### Problem

clang-tidy reports issue:
```
../../src/controller/python/chip/clusters/attribute.cpp:116:9: error: Potential leak of memory pointed to by 'buffer.__ptr_' [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]                                                                                    
  116 |         std::unique_ptr<uint8_t[]> buffer = std::unique_ptr<uint8_t[]>(apData == nullptr ? nullptr : new uint8_t[bufferLen]);
```

```
../../src/controller/python/chip/clusters/attribute.cpp:520:5: error: Potential leak of memory pointed to by 'attributePaths.__ptr_' [clang-analyzer-cplusplus.NewDeleteLeaks,-warnings-as-errors]
  520 |     std::unique_ptr<AttributePathParams[]> attributePaths(new AttributePathParams[numAttributePaths]);
```

#### Testing

CI will verify