### PR TITLE
[v1.3-branch] Update the mode-select-server with empty list handling.

### DIFF
--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -71,6 +71,13 @@ CHIP_ERROR ModeSelectAttrAccess::Read(const ConcreteReadAttributePath & aPath, A
 
     if (ModeSelect::Attributes::SupportedModes::Id == aPath.mAttributeId)
     {
+
+        if (gSupportedModeManager == nullptr)
+        {
+            ChipLogError(Zcl, "ModeSelect: SupportedModesManager is NULL");
+            return aEncoder.EncodeEmptyList();
+        }
+
         const ModeSelect::SupportedModesManager::ModeOptionsProvider modeOptionsProvider =
             gSupportedModeManager->getModeOptionsProvider(aPath.mEndpointId);
         if (modeOptionsProvider.begin() == nullptr)


### PR DESCRIPTION
**Problem**
- The supported-modes attribute read for empty list was crashing on esp32.

**Change Overview**
- Fixed the attribute read for supported-modes when list is empty.

#### Testing
-  Tested the changes with empty list (no entry in supported modes list).
