### PR TITLE
fix: aggregate types should not have user-declared constructors

### DIFF
--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -238,8 +238,6 @@ struct InterfaceInfo
 
 struct InterfaceKey
 {
-    InterfaceKey()  = default;
-    ~InterfaceKey() = default;
     inline bool operator<(const InterfaceKey & other) const
     {
         return (this->interfaceId < other.interfaceId) ||
@@ -260,9 +258,6 @@ struct InterfaceKey
 
 struct ResolveContextWithType
 {
-    ResolveContextWithType()  = delete;
-    ~ResolveContextWithType() = default;
-
     ResolveContext * const context;
     const bool isSRPResolve;
 };


### PR DESCRIPTION
Prior to C++11 and since C++20 aggregate types should not have user-declared constructors: https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers

With user-declared constructors aggregate initialization will not compile for such types. And we will get compile errors like:
```
In file included from src/platform/Darwin/MdnsError.cpp:18:
src/platform/Darwin/DnssdImpl.h:284:59: error: no matching constructor for initialization of 'ResolveContextWithType'
  284 |     ResolveContextWithType resolveContextWithSRPType    = { this, true };
      |                                                           ^~~~~~~~~~~~~~
src/platform/Darwin/DnssdImpl.h:261:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
  261 | struct ResolveContextWithType
      |        ^~~~~~~~~~~~~~~~~~~~~~
src/platform/Darwin/DnssdImpl.h:263:5: note: candidate constructor not viable: requires 0 arguments, but 2 were provided
  263 |     ResolveContextWithType()  = delete;
      |     ^
```

#### Testing
Build on OSX with `cpp_standard="c++20"`
