### PR TITLE
[ICD][Client] Continue to resubscribe when liveness timeout happens if peer is lit mode and client does't register its icd token

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1194,7 +1194,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
         ChipLogProgress(DataManagement, "ICD Check-In token has been registered in peer device " ChipLogFormatScopedNodeId,
-                        ChipLogValueScopedNodeId(GetPeerScopedId()));
+                        ChipLogValueScopedNodeId(mPeer);
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1193,8 +1193,8 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
 
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
-        ChipLogProgress(DataManagement,  "ICD Check-In token has been registered in peer device %" PRIu32,
-                        ChipLogValueX64(GetPeerNodeId()));
+        ChipLogProgress(DataManagement, "ICD Check-In token has been registered in peer device " ChipLogFormatScopedNodeId,
+                        ChipLogValueScopedNodeId(GetPeerScopedId));
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1193,7 +1193,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
 
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
-        ChipLogProgress(DataManagement, "Peer device has been registered with ICD CheckIn token");
+        ChipLogProgress(DataManagement, "Peer device has been registered with ICD Check-In token");
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1193,7 +1193,8 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
 
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
-        ChipLogProgress(DataManagement, "Peer device has been registered with ICD Check-In token");
+        ChipLogProgress(DataManagement,  "ICD Check-In token has been registered in peer device %" PRIu32,
+                        ChipLogValueX64(GetPeerNodeId()));
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1055,7 +1055,7 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
                  _this->mSubscriptionId, _this->GetFabricIndex(), ChipLogValueX64(_this->GetPeerNodeId()));
 
     // If subscription client is able to handle check-in messages and peer operation mode is LIT,
-    // use CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT is set as subscriptionTerminationCause.
+    // use CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT as subscriptionTerminationCause.
     // This will cause us to wait for a check-in message before trying to re-subscribe, instead of trying
     // (and probably failing, because we are dealing with a LIT ICD) off a timer.
     if (_this->mIsPeerLIT && _this->mReadPrepareParams.mRegisteredCheckInToken)

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1189,9 +1189,10 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
 
     mPeerIsOperatingAsLIT                      = aReadPrepareParams.mIsPeerLIT;
     mReadPrepareParams.mRegisteredCheckInToken = aReadPrepareParams.mRegisteredCheckInToken;
-    if (aReadPrepareParams.mIsPeerLIT)
+    if (aReadPrepareParams.mIsPeerLIT && !aReadPrepareParams.mRegisteredCheckInToken)
     {
-        mReadPrepareParams.mRegisteredCheckInToken = true;
+        ChipLogProgress(DataManagement, "Error: LIT ICD needs set mRegisteredCheckInToken as true");
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -519,13 +519,16 @@ void ReadClient::OnPeerTypeChange(PeerType aType)
 {
     VerifyOrDie(mpImEngine->InActiveReadClientList(this));
 
-    mIsPeerLIT = (aType == PeerType::kLITICD);
+    if (mReadPrepareParams.mIsPeerLIT)
+    {
+        mIsPeerLITOperationMode = (aType == PeerType::kLITCheckIn);
+    }
 
-    ChipLogProgress(DataManagement, "Peer is now %s LIT ICD.", mIsPeerLIT ? "a" : "not a");
+    ChipLogProgress(DataManagement, "Peer is now %s LIT ICD.", mIsPeerLITOperationMode ? "a" : "not a");
 
     // If the peer is no longer LIT and we were waiting for a check-in to try to resubscribe,
     // just try to resubscribe now, because a SIT is not going to send a check-in.
-    if (!mIsPeerLIT && IsInactiveICDSubscription())
+    if (!mIsPeerLITOperationMode && IsInactiveICDSubscription())
     {
         TriggerResubscriptionForLivenessTimeout(CHIP_ERROR_TIMEOUT);
     }
@@ -1054,7 +1057,7 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
                  "Subscription Liveness timeout with SubscriptionID = 0x%08" PRIx32 ", Peer = %02x:" ChipLogFormatX64,
                  _this->mSubscriptionId, _this->GetFabricIndex(), ChipLogValueX64(_this->GetPeerNodeId()));
 
-    if (_this->mIsPeerLIT)
+    if (_this->mIsPeerLITOperationMode)
     {
         subscriptionTerminationCause = CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT;
     }
@@ -1184,7 +1187,12 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
         mReadPrepareParams.mSessionHolder = aReadPrepareParams.mSessionHolder;
     }
 
-    mIsPeerLIT = aReadPrepareParams.mIsPeerLIT;
+    mReadPrepareParams.mIsPeerLIT = aReadPrepareParams.mIsPeerLIT;
+    mIsPeerLITOperationMode = aReadPrepareParams.mIsPeerLIT;
+    if (aReadPrepareParams.mIsPeerLIT)
+    {
+        ChipLogProgress(DataManagement, "Peer device has been registered with ICD CheckIn token");
+    }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1194,7 +1194,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
         ChipLogProgress(DataManagement, "ICD Check-In token has been registered in peer device " ChipLogFormatScopedNodeId,
-                        ChipLogValueScopedNodeId(GetPeerScopedId));
+                        ChipLogValueScopedNodeId(GetPeerScopedId()));
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1054,7 +1054,7 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
                  "Subscription Liveness timeout with SubscriptionID = 0x%08" PRIx32 ", Peer = %02x:" ChipLogFormatX64,
                  _this->mSubscriptionId, _this->GetFabricIndex(), ChipLogValueX64(_this->GetPeerNodeId()));
 
-    // If subscription client is capable to handle checkIn message and peer operation mode is LIT,
+    // If subscription client is able to handle check-in messages and peer operation mode is LIT,
     // CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT is set as subscriptionTerminationCause, subscription drops can usefully wait for a
     // check-in message before trying to resubscribe, otherwise, CHIP_ERROR_TIMEOUT is used as subscriptionTerminationCause, and the
     // subscription retry would not wait for check-in and still continue.

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1055,9 +1055,9 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
                  _this->mSubscriptionId, _this->GetFabricIndex(), ChipLogValueX64(_this->GetPeerNodeId()));
 
     // If subscription client is able to handle check-in messages and peer operation mode is LIT,
-    // CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT is set as subscriptionTerminationCause, subscription drops can usefully wait for a
-    // check-in message before trying to resubscribe, otherwise, CHIP_ERROR_TIMEOUT is used as subscriptionTerminationCause, and the
-    // subscription retry would not wait for check-in and still continue.
+    // use CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT is set as subscriptionTerminationCause.
+    // This will cause us to wait for a check-in message before trying to re-subscribe, instead of trying
+    // (and probably failing, because we are dealing with a LIT ICD) off a timer.
     if (_this->mIsPeerLIT && _this->mReadPrepareParams.mRegisteredCheckInToken)
     {
         subscriptionTerminationCause = CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1194,7 +1194,7 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     if (aReadPrepareParams.mRegisteredCheckInToken)
     {
         ChipLogProgress(DataManagement, "ICD Check-In token has been registered in peer device " ChipLogFormatScopedNodeId,
-                        ChipLogValueScopedNodeId(mPeer);
+                        ChipLogValueScopedNodeId(mPeer));
     }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -46,7 +46,8 @@ using Status = Protocols::InteractionModel::Status;
 
 ReadClient::ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,
                        InteractionType aInteractionType) :
-    mExchange(*this), mpCallback(apCallback), mOnConnectedCallback(HandleDeviceConnected, this),
+    mExchange(*this),
+    mpCallback(apCallback), mOnConnectedCallback(HandleDeviceConnected, this),
     mOnConnectionFailureCallback(HandleDeviceConnectionFailure, this)
 {
     assertChipStackLockedByCurrentThread();

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -382,6 +382,8 @@ public:
 
     FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
     NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
+    ScopedNodeId GetPeerScopedId() const { return mPeer; }
+
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -54,643 +54,637 @@
 namespace chip {
 namespace app {
 
-class InteractionModelEngine;
+    class InteractionModelEngine;
 
-/**
- *  @class ReadClient
- *
- *  @brief The read client represents the initiator side of a Read Or Subscribe Interaction (depending on the APIs invoked).
- *
- *         When used to manage subscriptions, the client provides functionality to automatically re-subscribe as needed,
- *         including re-establishing CASE under certain conditions (see Callback::OnResubscriptionNeeded for more info).
- *         This is the default behavior. A consumer can completely opt-out of this behavior by over-riding
- *         Callback::OnResubscriptionNeeded and providing an alternative implementation.
- *
- */
-class ReadClient : public Messaging::ExchangeDelegate
-{
-public:
-    class Callback
-    {
+    /**
+     *  @class ReadClient
+     *
+     *  @brief The read client represents the initiator side of a Read Or Subscribe Interaction (depending on the APIs invoked).
+     *
+     *         When used to manage subscriptions, the client provides functionality to automatically re-subscribe as needed,
+     *         including re-establishing CASE under certain conditions (see Callback::OnResubscriptionNeeded for more info).
+     *         This is the default behavior. A consumer can completely opt-out of this behavior by over-riding
+     *         Callback::OnResubscriptionNeeded and providing an alternative implementation.
+     *
+     */
+    class ReadClient : public Messaging::ExchangeDelegate {
     public:
-        Callback() = default;
+        class Callback {
+        public:
+            Callback() = default;
 
-        // Callbacks are not expected to be copyable or movable.
-        Callback(const Callback &)             = delete;
-        Callback(Callback &&)                  = delete;
-        Callback & operator=(const Callback &) = delete;
-        Callback & operator=(Callback &&)      = delete;
+            // Callbacks are not expected to be copyable or movable.
+            Callback(const Callback &) = delete;
+            Callback(Callback &&) = delete;
+            Callback & operator=(const Callback &) = delete;
+            Callback & operator=(Callback &&) = delete;
 
-        virtual ~Callback() = default;
+            virtual ~Callback() = default;
+
+            /**
+             * Used to notify a (maybe empty) report data is received from peer and the subscription and the peer is alive.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             */
+            virtual void NotifySubscriptionStillActive(const ReadClient & apReadClient) {}
+
+            /**
+             * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * Once OnReportBegin has been called, either OnReportEnd or OnError will be called before OnDone.
+             *
+             */
+            virtual void OnReportBegin() {}
+
+            /**
+             * Used to signal the completion of processing of the last attribute or event report in a given exchange.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             */
+            virtual void OnReportEnd() {}
+
+            /**
+             * Used to deliver event data received through the Read and Subscribe interactions
+             *
+             * Only one of the apData and apStatus can be non-null.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] aEventHeader The event header in report response.
+             * @param[in] apData A TLVReader positioned right on the payload of the event.
+             * @param[in] apStatus Event-specific status, containing an InteractionModel::Status code as well as an optional
+             *                     cluster-specific status code.
+             */
+            virtual void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) {}
+
+            /**
+             * Used to deliver attribute data received through the Read and Subscribe interactions.
+             *
+             * This callback will be called when:
+             *   - Receiving attribute data as response of Read interactions
+             *   - Receiving attribute data as reports of subscriptions
+             *   - Receiving attribute data as initial reports of subscriptions
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] aPath        The attribute path field in report response.
+             * @param[in] apData       The attribute data of the given path, will be a nullptr if status is not Success.
+             * @param[in] aStatus      Attribute-specific status, containing an InteractionModel::Status code as well as an
+             *                         optional cluster-specific status code.
+             */
+            virtual void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) {}
+
+            /**
+             * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
+             * If using auto resubscription, OnSubscriptionEstablished will be called whenever resubscription is established.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] aSubscriptionId The identifier of the subscription that was established.
+             */
+            virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) {}
+
+            /**
+             * OnResubscriptionNeeded will be called when a subscription that was started with SendAutoResubscribeRequest has terminated
+             * and re-subscription is needed. The termination cause is provided to help inform subsequent re-subscription logic.
+             *
+             * The base implementation automatically re-subscribes at appropriate intervals taking the termination cause into account
+             * (see ReadClient::DefaultResubscribePolicy for more details). If the default implementation doesn't suffice, the logic of
+             * ReadClient::DefaultResubscribePolicy is broken down into its constituent methods that are publicly available for
+             * applications to call and sequence.
+             *
+             * If the peer is LIT ICD, and the timeout is reached, `aTerminationCause` will be
+             * `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT`. In this case, returning `CHIP_NO_ERROR` will still trigger a resubscribe
+             * attempt, while returning `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT` will put the subscription in the
+             * `InactiveICDSubscription` state.  In the latter case, OnResubscriptionNeeded will be called again when
+             * `OnActiveModeNotification` is called.
+             *
+             * If the method is over-ridden, it's the application's responsibility to take the appropriate steps needed to eventually
+             * call-back into the ReadClient object to schedule a re-subscription (by invoking ReadClient::ScheduleResubscription).
+             *
+             * If the application DOES NOT want re-subscription to happen on a particular invocation of this method, returning anything
+             * other than CHIP_NO_ERROR will terminate the interaction and result in OnError, OnDeallocatePaths and OnDone being called
+             * in that sequence.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] aTerminationCause The cause of failure of the subscription that just terminated.
+             */
+            virtual CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
+            {
+                return apReadClient->DefaultResubscribePolicy(aTerminationCause);
+            }
+
+            /**
+             * OnError will be called when an error occurs *after* a successful call to SendRequest(). The following
+             * errors will be delivered through this call in the aError field:
+             *
+             * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
+             * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
+             * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
+             *   status response from the server.  In that case, constructing
+             *   a StatusIB from the error can be used to extract the status.
+             * - CHIP_ERROR*: All other cases.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] aError       A system error code that conveys the overall error code.
+             */
+            virtual void OnError(CHIP_ERROR aError) {}
+
+            /**
+             * OnDone will be called when ReadClient has finished all work and it is
+             * safe to destroy and free the allocated ReadClient object and any
+             * other objects associated with the Read or Subscribe interaction.
+             *
+             * The ReadClient is allowed to be destroyed during execution of this callback.
+             *
+             * This function will:
+             *      - Only be called after a successful call to SendRequest or
+             *        SendAutoResubscribeRequest has been made, when the read completes or
+             *        the subscription is shut down.
+             *      - Not be called if the ReadClient instance is destroyed before
+             *        the OnDone call happens.
+             *      - Always be called exactly *once* for a given ReadClient instance,
+             *        if it's called at all.
+             *      - Be called even in error circumstances.
+             *
+             * @param[in] apReadClient the ReadClient for the completed interaction.
+             */
+            virtual void OnDone(ReadClient * apReadClient) = 0;
+
+            /**
+             * This function is invoked when using SendAutoResubscribeRequest, where the ReadClient was configured to auto re-subscribe
+             * and the ReadPrepareParams was moved into this client for management. This will have to be free'ed appropriately by the
+             * application. If SendAutoResubscribeRequest fails, this function will be called before it returns the failure. If
+             * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone, or
+             * when the ReadClient is destroyed, if that happens before OnDone. If  SendAutoResubscribeRequest is not called,
+             * this function will not be called.
+             */
+            virtual void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) {}
+
+            /**
+             * This function is invoked when constructing a read/subscribeRequest that does not have data
+             * version filters specified, to give the callback a chance to provide some.
+             *
+             * This function is expected to encode as many complete data version filters as will fit into
+             * the buffer, rolling back any partially-encoded filters if it runs out of space, and set the
+             * aEncodedDataVersionList boolean to true if it has successfully encoded at least one data version filter.
+             *
+             * Otherwise aEncodedDataVersionList will be set to false.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             */
+            virtual CHIP_ERROR OnUpdateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+                const Span<AttributePathParams> & aAttributePaths,
+                bool & aEncodedDataVersionList)
+            {
+                aEncodedDataVersionList = false;
+                return CHIP_NO_ERROR;
+            }
+
+            /**
+             * Get highest received event number.
+             * If the application does not want to filter events by event number, it should call ClearValue() on aEventNumber
+             * and return CHIP_NO_ERROR.  An error return from this function will fail the entire read client interaction.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             */
+            virtual CHIP_ERROR GetHighestReceivedEventNumber(Optional<EventNumber> & aEventNumber)
+            {
+                aEventNumber.ClearValue();
+                return CHIP_NO_ERROR;
+            }
+
+            /**
+             * OnUnsolicitedMessageFromPublisher will be called for a subscription
+             * ReadClient when any incoming message is received from a matching
+             * node on the fabric.
+             *
+             * This callback will be called:
+             *   - When receiving any unsolicited communication from the node
+             *   - Even for disconnected subscriptions.
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             *
+             * @param[in] apReadClient the ReadClient for the subscription.
+             */
+            virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) {}
+
+            /**
+             * OnCASESessionEstablished will be called for a subscription ReadClient when
+             * it finishes setting up a CASE session, as part of either automatic
+             * re-subscription or doing an initial subscribe based on ScopedNodeId.
+             *
+             * The callee is allowed to modify the ReadPrepareParams (e.g. to change
+             * things like min/max intervals based on the session parameters).
+             *
+             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+             */
+            virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
+        };
+
+        enum class InteractionType : uint8_t {
+            Read,
+            Subscribe,
+        };
+
+        enum class PeerType : uint8_t {
+            kNormal,
+            kLITICD,
+        };
 
         /**
-         * Used to notify a (maybe empty) report data is received from peer and the subscription and the peer is alive.
          *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *  Constructor.
+         *
+         *  The callback passed in has to outlive this ReadClient object.
+         *
+         *  This object can outlive the InteractionModelEngine passed in. However, upon shutdown of the engine,
+         *  this object will cease to function correctly since it depends on the engine for a number of critical functions.
+         *
+         *  @param[in]    apImEngine       A valid pointer to the IM engine.
+         *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object. Allowed to be null
+         *                                 if the version of SendAutoResubscribeRequest that takes a
+         *                                 ScopedNodeId is used.
+         *  @param[in]    apCallback       Callback set by application.
+         *  @param[in]    aInteractionType Type of interaction (read or subscribe)
+         *
+         *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
+         *  @retval #CHIP_NO_ERROR On success.
          *
          */
-        virtual void NotifySubscriptionStillActive(const ReadClient & apReadClient) {}
+        ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,
+            InteractionType aInteractionType);
 
         /**
-         * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.
+         * Destructor.
          *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         * The ReadClient object may be destroyed at any time while not in the middle of executing a ReadClient::Callback
+         * callback, and may also be destroyed from inside the OnDone callback.
          *
-         * Once OnReportBegin has been called, either OnReportEnd or OnError will be called before OnDone.
+         * Destroying the ReadClient will abort the exchange context if a valid one still exists. It will also cancel any
+         * liveness timers that may be active.
          *
+         * OnDone() will not be called if the ReadClient is destroyed before that call would have happened.
          */
-        virtual void OnReportBegin() {}
+        ~ReadClient() override;
 
         /**
-         * Used to signal the completion of processing of the last attribute or event report in a given exchange.
+         *  Send a request.  There can be one request outstanding on a given ReadClient.
+         *  If SendRequest returns success, no more SendRequest calls can happen on this ReadClient
+         *  until the corresponding OnDone call has happened.
          *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *  This will send either a Read Request or a Subscribe Request depending on
+         *  the InteractionType this read client was initialized with.
          *
+         *  If the params contain more data version filters than can fit in the request packet
+         *  the list will be truncated as needed, i.e. filter inclusion is on a best effort basis.
+         *
+         *  @retval #others fail to send read request
+         *  @retval #CHIP_NO_ERROR On success.
          */
-        virtual void OnReportEnd() {}
+        CHIP_ERROR SendRequest(ReadPrepareParams & aReadPrepareParams);
 
         /**
-         * Used to deliver event data received through the Read and Subscribe interactions
+         *  Re-activate an inactive subscription.
          *
-         * Only one of the apData and apStatus can be non-null.
+         *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription
+         * that would cause that ICD to not need to check in anymore.
          *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] aEventHeader The event header in report response.
-         * @param[in] apData A TLVReader positioned right on the payload of the event.
-         * @param[in] apStatus Event-specific status, containing an InteractionModel::Status code as well as an optional
-         *                     cluster-specific status code.
+         *  This API only works when issuing subscription via SendAutoResubscribeRequest.
          */
-        virtual void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) {}
+        void OnActiveModeNotification();
 
-        /**
-         * Used to deliver attribute data received through the Read and Subscribe interactions.
-         *
-         * This callback will be called when:
-         *   - Receiving attribute data as response of Read interactions
-         *   - Receiving attribute data as reports of subscriptions
-         *   - Receiving attribute data as initial reports of subscriptions
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] aPath        The attribute path field in report response.
-         * @param[in] apData       The attribute data of the given path, will be a nullptr if status is not Success.
-         * @param[in] aStatus      Attribute-specific status, containing an InteractionModel::Status code as well as an
-         *                         optional cluster-specific status code.
-         */
-        virtual void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) {}
+        void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
 
-        /**
-         * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
-         * If using auto resubscription, OnSubscriptionEstablished will be called whenever resubscription is established.
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] aSubscriptionId The identifier of the subscription that was established.
-         */
-        virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) {}
-
-        /**
-         * OnResubscriptionNeeded will be called when a subscription that was started with SendAutoResubscribeRequest has terminated
-         * and re-subscription is needed. The termination cause is provided to help inform subsequent re-subscription logic.
-         *
-         * The base implementation automatically re-subscribes at appropriate intervals taking the termination cause into account
-         * (see ReadClient::DefaultResubscribePolicy for more details). If the default implementation doesn't suffice, the logic of
-         * ReadClient::DefaultResubscribePolicy is broken down into its constituent methods that are publicly available for
-         * applications to call and sequence.
-         *
-         * If the peer is LIT ICD, and the timeout is reached, `aTerminationCause` will be
-         * `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT`. In this case, returning `CHIP_NO_ERROR` will still trigger a resubscribe
-         * attempt, while returning `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT` will put the subscription in the
-         * `InactiveICDSubscription` state.  In the latter case, OnResubscriptionNeeded will be called again when
-         * `OnActiveModeNotification` is called.
-         *
-         * If the method is over-ridden, it's the application's responsibility to take the appropriate steps needed to eventually
-         * call-back into the ReadClient object to schedule a re-subscription (by invoking ReadClient::ScheduleResubscription).
-         *
-         * If the application DOES NOT want re-subscription to happen on a particular invocation of this method, returning anything
-         * other than CHIP_NO_ERROR will terminate the interaction and result in OnError, OnDeallocatePaths and OnDone being called
-         * in that sequence.
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] aTerminationCause The cause of failure of the subscription that just terminated.
-         */
-        virtual CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
+        void OnUnsolicitedMessageFromPublisher()
         {
-            return apReadClient->DefaultResubscribePolicy(aTerminationCause);
+            TriggerResubscribeIfScheduled("unsolicited message");
+
+            // Then notify callbacks
+            mpCallback.OnUnsolicitedMessageFromPublisher(this);
         }
 
-        /**
-         * OnError will be called when an error occurs *after* a successful call to SendRequest(). The following
-         * errors will be delivered through this call in the aError field:
-         *
-         * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
-         * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
-         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-         *   status response from the server.  In that case, constructing
-         *   a StatusIB from the error can be used to extract the status.
-         * - CHIP_ERROR*: All other cases.
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] aError       A system error code that conveys the overall error code.
-         */
-        virtual void OnError(CHIP_ERROR aError) {}
-
-        /**
-         * OnDone will be called when ReadClient has finished all work and it is
-         * safe to destroy and free the allocated ReadClient object and any
-         * other objects associated with the Read or Subscribe interaction.
-         *
-         * The ReadClient is allowed to be destroyed during execution of this callback.
-         *
-         * This function will:
-         *      - Only be called after a successful call to SendRequest or
-         *        SendAutoResubscribeRequest has been made, when the read completes or
-         *        the subscription is shut down.
-         *      - Not be called if the ReadClient instance is destroyed before
-         *        the OnDone call happens.
-         *      - Always be called exactly *once* for a given ReadClient instance,
-         *        if it's called at all.
-         *      - Be called even in error circumstances.
-         *
-         * @param[in] apReadClient the ReadClient for the completed interaction.
-         */
-        virtual void OnDone(ReadClient * apReadClient) = 0;
-
-        /**
-         * This function is invoked when using SendAutoResubscribeRequest, where the ReadClient was configured to auto re-subscribe
-         * and the ReadPrepareParams was moved into this client for management. This will have to be free'ed appropriately by the
-         * application. If SendAutoResubscribeRequest fails, this function will be called before it returns the failure. If
-         * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone, or
-         * when the ReadClient is destroyed, if that happens before OnDone. If  SendAutoResubscribeRequest is not called,
-         * this function will not be called.
-         */
-        virtual void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) {}
-
-        /**
-         * This function is invoked when constructing a read/subscribeRequest that does not have data
-         * version filters specified, to give the callback a chance to provide some.
-         *
-         * This function is expected to encode as many complete data version filters as will fit into
-         * the buffer, rolling back any partially-encoded filters if it runs out of space, and set the
-         * aEncodedDataVersionList boolean to true if it has successfully encoded at least one data version filter.
-         *
-         * Otherwise aEncodedDataVersionList will be set to false.
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         */
-        virtual CHIP_ERROR OnUpdateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                                         const Span<AttributePathParams> & aAttributePaths,
-                                                         bool & aEncodedDataVersionList)
+        auto GetSubscriptionId() const
         {
-            aEncodedDataVersionList = false;
+            using returnType = Optional<decltype(mSubscriptionId)>;
+            return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
+        }
+
+        FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
+        NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
+        bool IsReadType() { return mInteractionType == InteractionType::Read; }
+        bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
+
+        /*
+         * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
+         * interaction type and after a subscription has been established.
+         */
+        CHIP_ERROR GetReportingIntervals(uint16_t & aMinIntervalFloorSeconds, uint16_t & aMaxIntervalCeilingSeconds) const
+        {
+            VerifyOrReturnError(IsSubscriptionType(), CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(IsSubscriptionActive(), CHIP_ERROR_INCORRECT_STATE);
+
+            aMinIntervalFloorSeconds = mMinIntervalFloorSeconds;
+            aMaxIntervalCeilingSeconds = mMaxInterval;
+
             return CHIP_NO_ERROR;
         }
 
-        /**
-         * Get highest received event number.
-         * If the application does not want to filter events by event number, it should call ClearValue() on aEventNumber
-         * and return CHIP_NO_ERROR.  An error return from this function will fail the entire read client interaction.
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         */
-        virtual CHIP_ERROR GetHighestReceivedEventNumber(Optional<EventNumber> & aEventNumber)
-        {
-            aEventNumber.ClearValue();
-            return CHIP_NO_ERROR;
-        }
+        ReadClient * GetNextClient() { return mpNext; }
+        void SetNextClient(ReadClient * apClient) { mpNext = apClient; }
 
         /**
-         * OnUnsolicitedMessageFromPublisher will be called for a subscription
-         * ReadClient when any incoming message is received from a matching
-         * node on the fabric.
+         *  Like SendSubscribeRequest, but the ReadClient will automatically attempt to re-establish the subscription if
+         *  we decide that the subscription has dropped.  The exact behavior of the re-establishment can be controlled
+         *  by overriding Callback::OnResubscriptionNeeded().  If not overridden, a default behavior with exponential
+         *  backoff from will be used.
          *
-         * This callback will be called:
-         *   - When receiving any unsolicited communication from the node
-         *   - Even for disconnected subscriptions.
+         *  The application has to know to
+         *  a) allocate a ReadPrepareParams object that will have fields mpEventPathParamsList and mpAttributePathParamsList and
+         *  mpDataVersionFilterList with lifetimes as long as the ReadClient itself and b) free those up later in the call to
+         *  OnDeallocatePaths. Note: At a given time in the system, you can either have a single subscription with re-sub enabled that
+         *  has mKeepSubscriptions = false, OR, multiple subs with re-sub enabled with mKeepSubscriptions = true. You shall not
+         *  have a mix of both simultaneously. If SendAutoResubscribeRequest is called at all, it guarantees that it will call
+         *  OnDeallocatePaths (either before returning error, or when OnDone is called or the ReadClient is destroyed).
+         *  SendAutoResubscribeRequest is the only case that calls OnDeallocatePaths, since that's the only case when the consumer
+         *  moved a ReadParams into the client.
          *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-         *
-         * @param[in] apReadClient the ReadClient for the subscription.
          */
-        virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) {}
+        CHIP_ERROR SendAutoResubscribeRequest(ReadPrepareParams && aReadPrepareParams);
 
         /**
-         * OnCASESessionEstablished will be called for a subscription ReadClient when
-         * it finishes setting up a CASE session, as part of either automatic
-         * re-subscription or doing an initial subscribe based on ScopedNodeId.
+         * Like SendAutoResubscribeRequest above, but without a session being
+         * available in the ReadPrepareParams.  When this is used, the ReadClient is
+         * responsible for setting up the CASE session itself.
          *
-         * The callee is allowed to modify the ReadPrepareParams (e.g. to change
-         * things like min/max intervals based on the session parameters).
-         *
-         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         * When using this version of SendAutoResubscribeRequest, any session to
+         * which ReadPrepareParams has a reference will be ignored.
          */
-        virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
-    };
+        CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
 
-    enum class InteractionType : uint8_t
-    {
-        Read,
-        Subscribe,
-    };
+        /**
+         *   This provides a standard re-subscription policy implementation that given a termination cause, does the following:
+         *   - Calculates the time till next subscription with fibonacci back-off (implemented by ComputeTimeTillNextSubscription()).
+         *   - Schedules the next subscription attempt at the computed interval from the previous step. Operational discovery and
+         *     CASE establishment will be attempted if aTerminationCause was CHIP_ERROR_TIMEOUT. In all other cases, it will attempt
+         *     to re-use a previously established session.
+         */
+        CHIP_ERROR DefaultResubscribePolicy(CHIP_ERROR aTerminationCause);
 
-    enum class PeerType : uint8_t
-    {
-        kNormal,
-        kLITICD,
-    };
+        /**
+         * Computes the time, in milliseconds, until the next re-subscription over
+         * an ever increasing window following a fibonacci sequence with the current retry count
+         * used as input to the fibonacci algorithm.
+         *
+         * CHIP_RESUBSCRIBE_MAX_FIBONACCI_STEP_INDEX is the maximum value the retry count can tick up to.
+         *
+         */
+        uint32_t ComputeTimeTillNextSubscription();
 
-    /**
-     *
-     *  Constructor.
-     *
-     *  The callback passed in has to outlive this ReadClient object.
-     *
-     *  This object can outlive the InteractionModelEngine passed in. However, upon shutdown of the engine,
-     *  this object will cease to function correctly since it depends on the engine for a number of critical functions.
-     *
-     *  @param[in]    apImEngine       A valid pointer to the IM engine.
-     *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object. Allowed to be null
-     *                                 if the version of SendAutoResubscribeRequest that takes a
-     *                                 ScopedNodeId is used.
-     *  @param[in]    apCallback       Callback set by application.
-     *  @param[in]    aInteractionType Type of interaction (read or subscribe)
-     *
-     *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
-     *  @retval #CHIP_NO_ERROR On success.
-     *
-     */
-    ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,
-               InteractionType aInteractionType);
+        /**
+         * Schedules a re-subscription aTimeTillNextResubscriptionMs into the future.
+         *
+         * If an application wants to set up CASE on their own, they should call ComputeTimeTillNextSubscription() to compute the next
+         * interval at which they should attempt CASE and attempt CASE at that time. On successful CASE establishment, this method
+         * should be called with the new SessionHandle provided through 'aNewSessionHandle', 'aTimeTillNextResubscriptionMs' set to 0
+         * (i.e async, but as soon as possible) and 'aReestablishCASE' set to false.
+         *
+         * Otherwise, if aReestablishCASE is true, operational discovery and CASE will be attempted at that time before
+         * the actual IM interaction is initiated.
+         *
+         * aReestablishCASE SHALL NOT be set to true if a valid SessionHandle is provided through newSessionHandle.
+         */
+        CHIP_ERROR ScheduleResubscription(uint32_t aTimeTillNextResubscriptionMs, Optional<SessionHandle> aNewSessionHandle,
+            bool aReestablishCASE);
 
-    /**
-     * Destructor.
-     *
-     * The ReadClient object may be destroyed at any time while not in the middle of executing a ReadClient::Callback
-     * callback, and may also be destroyed from inside the OnDone callback.
-     *
-     * Destroying the ReadClient will abort the exchange context if a valid one still exists. It will also cancel any
-     * liveness timers that may be active.
-     *
-     * OnDone() will not be called if the ReadClient is destroyed before that call would have happened.
-     */
-    ~ReadClient() override;
-
-    /**
-     *  Send a request.  There can be one request outstanding on a given ReadClient.
-     *  If SendRequest returns success, no more SendRequest calls can happen on this ReadClient
-     *  until the corresponding OnDone call has happened.
-     *
-     *  This will send either a Read Request or a Subscribe Request depending on
-     *  the InteractionType this read client was initialized with.
-     *
-     *  If the params contain more data version filters than can fit in the request packet
-     *  the list will be truncated as needed, i.e. filter inclusion is on a best effort basis.
-     *
-     *  @retval #others fail to send read request
-     *  @retval #CHIP_NO_ERROR On success.
-     */
-    CHIP_ERROR SendRequest(ReadPrepareParams & aReadPrepareParams);
-
-    /**
-     *  Re-activate an inactive subscription.
-     *
-     *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription
-     * that would cause that ICD to not need to check in anymore.
-     *
-     *  This API only works when issuing subscription via SendAutoResubscribeRequest.
-     */
-    void OnActiveModeNotification();
-
-    void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
-
-    void OnUnsolicitedMessageFromPublisher()
-    {
-        TriggerResubscribeIfScheduled("unsolicited message");
-
-        // Then notify callbacks
-        mpCallback.OnUnsolicitedMessageFromPublisher(this);
-    }
-
-    auto GetSubscriptionId() const
-    {
-        using returnType = Optional<decltype(mSubscriptionId)>;
-        return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
-    }
-
-    FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
-    NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
-    bool IsReadType() { return mInteractionType == InteractionType::Read; }
-    bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
-
-    /*
-     * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
-     * interaction type and after a subscription has been established.
-     */
-    CHIP_ERROR GetReportingIntervals(uint16_t & aMinIntervalFloorSeconds, uint16_t & aMaxIntervalCeilingSeconds) const
-    {
-        VerifyOrReturnError(IsSubscriptionType(), CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(IsSubscriptionActive(), CHIP_ERROR_INCORRECT_STATE);
-
-        aMinIntervalFloorSeconds   = mMinIntervalFloorSeconds;
-        aMaxIntervalCeilingSeconds = mMaxInterval;
-
-        return CHIP_NO_ERROR;
-    }
-
-    ReadClient * GetNextClient() { return mpNext; }
-    void SetNextClient(ReadClient * apClient) { mpNext = apClient; }
-
-    /**
-     *  Like SendSubscribeRequest, but the ReadClient will automatically attempt to re-establish the subscription if
-     *  we decide that the subscription has dropped.  The exact behavior of the re-establishment can be controlled
-     *  by overriding Callback::OnResubscriptionNeeded().  If not overridden, a default behavior with exponential
-     *  backoff from will be used.
-     *
-     *  The application has to know to
-     *  a) allocate a ReadPrepareParams object that will have fields mpEventPathParamsList and mpAttributePathParamsList and
-     *  mpDataVersionFilterList with lifetimes as long as the ReadClient itself and b) free those up later in the call to
-     *  OnDeallocatePaths. Note: At a given time in the system, you can either have a single subscription with re-sub enabled that
-     *  has mKeepSubscriptions = false, OR, multiple subs with re-sub enabled with mKeepSubscriptions = true. You shall not
-     *  have a mix of both simultaneously. If SendAutoResubscribeRequest is called at all, it guarantees that it will call
-     *  OnDeallocatePaths (either before returning error, or when OnDone is called or the ReadClient is destroyed).
-     *  SendAutoResubscribeRequest is the only case that calls OnDeallocatePaths, since that's the only case when the consumer
-     *  moved a ReadParams into the client.
-     *
-     */
-    CHIP_ERROR SendAutoResubscribeRequest(ReadPrepareParams && aReadPrepareParams);
-
-    /**
-     * Like SendAutoResubscribeRequest above, but without a session being
-     * available in the ReadPrepareParams.  When this is used, the ReadClient is
-     * responsible for setting up the CASE session itself.
-     *
-     * When using this version of SendAutoResubscribeRequest, any session to
-     * which ReadPrepareParams has a reference will be ignored.
-     */
-    CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
-
-    /**
-     *   This provides a standard re-subscription policy implementation that given a termination cause, does the following:
-     *   - Calculates the time till next subscription with fibonacci back-off (implemented by ComputeTimeTillNextSubscription()).
-     *   - Schedules the next subscription attempt at the computed interval from the previous step. Operational discovery and
-     *     CASE establishment will be attempted if aTerminationCause was CHIP_ERROR_TIMEOUT. In all other cases, it will attempt
-     *     to re-use a previously established session.
-     */
-    CHIP_ERROR DefaultResubscribePolicy(CHIP_ERROR aTerminationCause);
-
-    /**
-     * Computes the time, in milliseconds, until the next re-subscription over
-     * an ever increasing window following a fibonacci sequence with the current retry count
-     * used as input to the fibonacci algorithm.
-     *
-     * CHIP_RESUBSCRIBE_MAX_FIBONACCI_STEP_INDEX is the maximum value the retry count can tick up to.
-     *
-     */
-    uint32_t ComputeTimeTillNextSubscription();
-
-    /**
-     * Schedules a re-subscription aTimeTillNextResubscriptionMs into the future.
-     *
-     * If an application wants to set up CASE on their own, they should call ComputeTimeTillNextSubscription() to compute the next
-     * interval at which they should attempt CASE and attempt CASE at that time. On successful CASE establishment, this method
-     * should be called with the new SessionHandle provided through 'aNewSessionHandle', 'aTimeTillNextResubscriptionMs' set to 0
-     * (i.e async, but as soon as possible) and 'aReestablishCASE' set to false.
-     *
-     * Otherwise, if aReestablishCASE is true, operational discovery and CASE will be attempted at that time before
-     * the actual IM interaction is initiated.
-     *
-     * aReestablishCASE SHALL NOT be set to true if a valid SessionHandle is provided through newSessionHandle.
-     */
-    CHIP_ERROR ScheduleResubscription(uint32_t aTimeTillNextResubscriptionMs, Optional<SessionHandle> aNewSessionHandle,
-                                      bool aReestablishCASE);
-
-    // Like SendSubscribeRequest, but allows sending certain forms of invalid
-    // subscribe requests that servers are expected to reject, for testing
-    // purposes.  Should only be called from tests.
+        // Like SendSubscribeRequest, but allows sending certain forms of invalid
+        // subscribe requests that servers are expected to reject, for testing
+        // purposes.  Should only be called from tests.
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    CHIP_ERROR SendSubscribeRequestWithoutValidation(const ReadPrepareParams & aReadPrepareParams)
-    {
-        return SendSubscribeRequestImpl(aReadPrepareParams);
-    }
+        CHIP_ERROR SendSubscribeRequestWithoutValidation(const ReadPrepareParams & aReadPrepareParams)
+        {
+            return SendSubscribeRequestImpl(aReadPrepareParams);
+        }
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
-    /**
-     * Override the interval at which liveness of the subscription is assessed.
-     * By default, this is set set to the max interval of the subscription + ACK timeout of the underlying session.
-     *
-     * This can be only be called once a subscription has been established and is active. Once called, this will cancel any existing
-     * liveness timers and schedule a new one.
-     *
-     * This can be called from the Callback::OnSubscriptionEstablished callback.
-     *
-     */
-    void OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout);
+        /**
+         * Override the interval at which liveness of the subscription is assessed.
+         * By default, this is set set to the max interval of the subscription + ACK timeout of the underlying session.
+         *
+         * This can be only be called once a subscription has been established and is active. Once called, this will cancel any existing
+         * liveness timers and schedule a new one.
+         *
+         * This can be called from the Callback::OnSubscriptionEstablished callback.
+         *
+         */
+        void OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout);
 
-    /**
-     * If the ReadClient currently has a resubscription attempt scheduled,
-     * trigger that attempt right now.  This is generally useful when a consumer
-     * has some sort of indication that the server side is currently up and
-     * communicating, so right now is a good time to try to resubscribe.
-     *
-     * The reason string is used for logging if a resubscribe is triggered.
-     *
-     * Returns whether a resubscribe is triggered.
-     */
-    bool TriggerResubscribeIfScheduled(const char * reason);
+        /**
+         * If the ReadClient currently has a resubscription attempt scheduled,
+         * trigger that attempt right now.  This is generally useful when a consumer
+         * has some sort of indication that the server side is currently up and
+         * communicating, so right now is a good time to try to resubscribe.
+         *
+         * The reason string is used for logging if a resubscribe is triggered.
+         *
+         * Returns whether a resubscribe is triggered.
+         */
+        bool TriggerResubscribeIfScheduled(const char * reason);
 
-    /**
-     * Returns the timeout after which we consider the subscription to have
-     * dropped, if we have received no messages within that amount of time.
-     *
-     * Returns NullOptional if a subscription has not yet been established (and
-     * hence the MaxInterval is not yet known), or if the subscription session
-     * is gone and hence the relevant MRP parameters can no longer be determined.
-     */
-    Optional<System::Clock::Timeout> GetSubscriptionTimeout();
+        /**
+         * Returns the timeout after which we consider the subscription to have
+         * dropped, if we have received no messages within that amount of time.
+         *
+         * Returns NullOptional if a subscription has not yet been established (and
+         * hence the MaxInterval is not yet known), or if the subscription session
+         * is gone and hence the relevant MRP parameters can no longer be determined.
+         */
+        Optional<System::Clock::Timeout> GetSubscriptionTimeout();
 
-private:
-    friend class TestReadInteraction;
-    friend class InteractionModelEngine;
+    private:
+        friend class TestReadInteraction;
+        friend class InteractionModelEngine;
 
-    enum class ClientState : uint8_t
-    {
-        Idle,                      ///< The client has been initialized and is ready for a SendRequest
-        AwaitingInitialReport,     ///< The client is waiting for initial report
-        AwaitingSubscribeResponse, ///< The client is waiting for subscribe response
-        SubscriptionActive,        ///< The client is maintaining subscription
-        InactiveICDSubscription,   ///< The client is waiting to resubscribe for LIT device
-    };
+        enum class ClientState : uint8_t {
+            Idle, ///< The client has been initialized and is ready for a SendRequest
+            AwaitingInitialReport, ///< The client is waiting for initial report
+            AwaitingSubscribeResponse, ///< The client is waiting for subscribe response
+            SubscriptionActive, ///< The client is maintaining subscription
+            InactiveICDSubscription, ///< The client is waiting to resubscribe for LIT device
+        };
 
-    enum class ReportType
-    {
-        // kUnsolicited reports are the first message in an exchange.
-        kUnsolicited,
-        // kContinuingTransaction reports are responses to a message we sent.
-        kContinuingTransaction
-    };
+        enum class ReportType {
+            // kUnsolicited reports are the first message in an exchange.
+            kUnsolicited,
+            // kContinuingTransaction reports are responses to a message we sent.
+            kContinuingTransaction
+        };
 
-    bool IsMatchingSubscriptionId(SubscriptionId aSubscriptionId)
-    {
-        return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
-    }
+        bool IsMatchingSubscriptionId(SubscriptionId aSubscriptionId)
+        {
+            return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
+        }
 
-    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
-                                 System::PacketBufferHandle && aPayload) override;
-    void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+        CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
+            System::PacketBufferHandle && aPayload) override;
+        void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
 
-    /**
-     *  Updates the type (LIT ICD or not) of the peer.
-     *
-     *  When the subscription is active, this function will just set the flag. When the subscription is an InactiveICDSubscription,
-     * setting the peer type to SIT or normal devices will also trigger a resubscription attempt.
-     *
-     */
-    void OnPeerTypeChange(PeerType aType);
+        /**
+         *  Updates the type (LIT ICD or not) of the peer.
+         *
+         *  When the subscription is active, this function will just set the flag. When the subscription is an InactiveICDSubscription,
+         * setting the peer type to SIT or normal devices will also trigger a resubscription attempt.
+         *
+         */
+        void OnPeerTypeChange(PeerType aType);
 
-    /**
-     *  Check if current read client is being used
-     *
-     */
-    bool IsIdle() const { return mState == ClientState::Idle; }
-    bool IsInactiveICDSubscription() const { return mState == ClientState::InactiveICDSubscription; }
-    bool IsSubscriptionActive() const { return mState == ClientState::SubscriptionActive; }
-    bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
-    bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
+        /**
+         *  Check if current read client is being used
+         *
+         */
+        bool IsIdle() const { return mState == ClientState::Idle; }
+        bool IsInactiveICDSubscription() const { return mState == ClientState::InactiveICDSubscription; }
+        bool IsSubscriptionActive() const { return mState == ClientState::SubscriptionActive; }
+        bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
+        bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
 
-    CHIP_ERROR GenerateEventPaths(EventPathIBs::Builder & aEventPathsBuilder, const Span<EventPathParams> & aEventPaths);
-    CHIP_ERROR GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
-                                      const Span<AttributePathParams> & aAttributePaths);
+        CHIP_ERROR GenerateEventPaths(EventPathIBs::Builder & aEventPathsBuilder, const Span<EventPathParams> & aEventPaths);
+        CHIP_ERROR GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
+            const Span<AttributePathParams> & aAttributePaths);
 
-    CHIP_ERROR GenerateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                             const Span<AttributePathParams> & aAttributePaths,
-                                             const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
-    CHIP_ERROR BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                                          const Span<AttributePathParams> & aAttributePaths,
-                                          const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
-    CHIP_ERROR ReadICDOperatingModeFromAttributeDataIB(TLV::TLVReader && aReader, PeerType & aType);
-    CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
-    CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
+        CHIP_ERROR GenerateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+            const Span<AttributePathParams> & aAttributePaths,
+            const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
+        CHIP_ERROR BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+            const Span<AttributePathParams> & aAttributePaths,
+            const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
+        CHIP_ERROR ReadICDOperatingModeFromAttributeDataIB(TLV::TLVReader && aReader, PeerType & aType);
+        CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
+        CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
 
-    static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
-    CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
-    CHIP_ERROR RefreshLivenessCheckTimer();
-    CHIP_ERROR ComputeLivenessCheckTimerTimeout(System::Clock::Timeout * aTimeout);
-    void CancelLivenessCheckTimer();
-    void CancelResubscribeTimer();
-    void TriggerResubscriptionForLivenessTimeout(CHIP_ERROR aReason);
-    void MoveToState(const ClientState aTargetState);
-    CHIP_ERROR ProcessAttributePath(AttributePathIB::Parser & aAttributePath, ConcreteDataAttributePath & aClusterInfo);
-    CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload, ReportType aReportType);
-    const char * GetStateStr() const;
+        static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
+        CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
+        CHIP_ERROR RefreshLivenessCheckTimer();
+        CHIP_ERROR ComputeLivenessCheckTimerTimeout(System::Clock::Timeout * aTimeout);
+        void CancelLivenessCheckTimer();
+        void CancelResubscribeTimer();
+        void TriggerResubscriptionForLivenessTimeout(CHIP_ERROR aReason);
+        void MoveToState(const ClientState aTargetState);
+        CHIP_ERROR ProcessAttributePath(AttributePathIB::Parser & aAttributePath, ConcreteDataAttributePath & aClusterInfo);
+        CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload, ReportType aReportType);
+        const char * GetStateStr() const;
 
-    /*
-     * Checks if we should re-subscribe based on the specified re-subscription policy. If we should, re-subscription is scheduled
-     * aNextResubscribeIntervalMsec is updated accordingly, and true is returned.
-     *
-     * If we should not resubscribe, false is returned.
-     *
-     *  @param[out]    aNextResubscribeIntervalMsec    How long we will wait before trying to auto-resubscribe.
-     */
-    bool ResubscribeIfNeeded(uint32_t & aNextResubscribeIntervalMsec);
+        /*
+         * Checks if we should re-subscribe based on the specified re-subscription policy. If we should, re-subscription is scheduled
+         * aNextResubscribeIntervalMsec is updated accordingly, and true is returned.
+         *
+         * If we should not resubscribe, false is returned.
+         *
+         *  @param[out]    aNextResubscribeIntervalMsec    How long we will wait before trying to auto-resubscribe.
+         */
+        bool ResubscribeIfNeeded(uint32_t & aNextResubscribeIntervalMsec);
 
-    // Specialized request-sending functions.
-    CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams);
-    // SendSubscribeRequest performs som validation on aSubscribePrepareParams
-    // and then calls SendSubscribeRequestImpl.
-    CHIP_ERROR SendSubscribeRequest(const ReadPrepareParams & aSubscribePrepareParams);
-    CHIP_ERROR SendSubscribeRequestImpl(const ReadPrepareParams & aSubscribePrepareParams);
-    void UpdateDataVersionFilters(const ConcreteDataAttributePath & aPath);
-    static void OnResubscribeTimerCallback(System::Layer * apSystemLayer, void * apAppState);
-    // Called to ensure OnReportBegin is called before calling OnEventData or OnAttributeData
-    void NoteReportingData();
+        // Specialized request-sending functions.
+        CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams);
+        // SendSubscribeRequest performs som validation on aSubscribePrepareParams
+        // and then calls SendSubscribeRequestImpl.
+        CHIP_ERROR SendSubscribeRequest(const ReadPrepareParams & aSubscribePrepareParams);
+        CHIP_ERROR SendSubscribeRequestImpl(const ReadPrepareParams & aSubscribePrepareParams);
+        void UpdateDataVersionFilters(const ConcreteDataAttributePath & aPath);
+        static void OnResubscribeTimerCallback(System::Layer * apSystemLayer, void * apAppState);
+        // Called to ensure OnReportBegin is called before calling OnEventData or OnAttributeData
+        void NoteReportingData();
 
-    /*
-     * Called internally to signal the completion of all work on this object, gracefully close the
-     * exchange and finally, signal to the application that it's
-     * safe to release this object.
-     *
-     * If aError != CHIP_NO_ERROR, this will trigger re-subscriptions if allowResubscription is true
-     * AND if this ReadClient instance is tracking a subscription AND the applications decides to do so
-     * in their implementation of Callback::OnResubscriptionNeeded().
-     */
-    void Close(CHIP_ERROR aError, bool allowResubscription = true);
+        /*
+         * Called internally to signal the completion of all work on this object, gracefully close the
+         * exchange and finally, signal to the application that it's
+         * safe to release this object.
+         *
+         * If aError != CHIP_NO_ERROR, this will trigger re-subscriptions if allowResubscription is true
+         * AND if this ReadClient instance is tracking a subscription AND the applications decides to do so
+         * in their implementation of Callback::OnResubscriptionNeeded().
+         */
+        void Close(CHIP_ERROR aError, bool allowResubscription = true);
 
-    void StopResubscription();
-    void ClearActiveSubscriptionState();
+        void StopResubscription();
+        void ClearActiveSubscriptionState();
 
-    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
-                                      const SessionHandle & sessionHandle);
-    static void HandleDeviceConnectionFailure(void * context, const OperationalSessionSetup::ConnectionFailureInfo & failureInfo);
+        static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
+            const SessionHandle & sessionHandle);
+        static void HandleDeviceConnectionFailure(void * context, const OperationalSessionSetup::ConnectionFailureInfo & failureInfo);
 
-    CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
+        CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
 
-    /**
-     * Start setting up a CASE session to our peer, if we can locate a
-     * CASESessionManager.  Returns error if we did not even manage to kick off
-     * a CASE attempt.
-     */
-    CHIP_ERROR EstablishSessionToPeer();
+        /**
+         * Start setting up a CASE session to our peer, if we can locate a
+         * CASESessionManager.  Returns error if we did not even manage to kick off
+         * a CASE attempt.
+         */
+        CHIP_ERROR EstablishSessionToPeer();
 
-    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    Messaging::ExchangeHolder mExchange;
-    Callback & mpCallback;
-    ClientState mState    = ClientState::Idle;
-    bool mIsReporting     = false;
-    bool mIsInitialReport = true;
-    // boolean to check if client is waiting for the first priming report
-    bool mWaitingForFirstPrimingReport = true;
-    bool mPendingMoreChunks            = false;
-    uint16_t mMinIntervalFloorSeconds  = 0;
-    uint16_t mMaxInterval              = 0;
-    SubscriptionId mSubscriptionId     = 0;
-    ScopedNodeId mPeer;
-    InteractionType mInteractionType = InteractionType::Read;
-    Timestamp mEventTimestamp;
+        Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+        Messaging::ExchangeHolder mExchange;
+        Callback & mpCallback;
+        ClientState mState = ClientState::Idle;
+        bool mIsReporting = false;
+        bool mIsInitialReport = true;
+        // boolean to check if client is waiting for the first priming report
+        bool mWaitingForFirstPrimingReport = true;
+        bool mPendingMoreChunks = false;
+        uint16_t mMinIntervalFloorSeconds = 0;
+        uint16_t mMaxInterval = 0;
+        SubscriptionId mSubscriptionId = 0;
+        ScopedNodeId mPeer;
+        InteractionType mInteractionType = InteractionType::Read;
+        Timestamp mEventTimestamp;
 
-    bool mForceCaseOnNextResub      = true;
-    bool mIsResubscriptionScheduled = false;
+        bool mForceCaseOnNextResub = true;
+        bool mIsResubscriptionScheduled = false;
 
-    // mMinimalResubscribeDelay is used to store the delay returned with a BUSY
-    // response to a Sigma1 message.
-    System::Clock::Milliseconds16 mMinimalResubscribeDelay = System::Clock::kZero;
+        // mMinimalResubscribeDelay is used to store the delay returned with a BUSY
+        // response to a Sigma1 message.
+        System::Clock::Milliseconds16 mMinimalResubscribeDelay = System::Clock::kZero;
 
-    chip::Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
-    chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> mOnConnectionFailureCallback;
+        chip::Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
+        chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> mOnConnectionFailureCallback;
 
-    ReadClient * mpNext                 = nullptr;
-    InteractionModelEngine * mpImEngine = nullptr;
+        ReadClient * mpNext = nullptr;
+        InteractionModelEngine * mpImEngine = nullptr;
 
-    //
-    // This stores the params associated with the interaction in a specific set of cases:
-    //      1. Stores all parameters when used with subscriptions initiated using SendAutoResubscribeRequest.
-    //      2. Stores just the SessionHolder when used with any subscriptions.
-    //
-    ReadPrepareParams mReadPrepareParams;
-    uint32_t mNumRetries = 0;
+        //
+        // This stores the params associated with the interaction in a specific set of cases:
+        //      1. Stores all parameters when used with subscriptions initiated using SendAutoResubscribeRequest.
+        //      2. Stores just the SessionHolder when used with any subscriptions.
+        //
+        ReadPrepareParams mReadPrepareParams;
+        uint32_t mNumRetries = 0;
 
-    System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
+        System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
 
-    bool mPeerIsOperatingAsLIT = false;
-    // End Of Container (0x18) uses one byte.
-    static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
-    // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the
-    // context tag, 1 byte for value
-    static constexpr uint16_t kReservedSizeForIMRevision = 1 + 1 + 1;
-    // Reserved buffer for TLV level overhead (the overhead for data version filter IBs EndOfContainer, IM reversion end
-    // of RequestMessage (another end of container)).
-    static constexpr uint16_t kReservedSizeForTLVEncodingOverhead =
-        kReservedSizeForEndOfContainer + kReservedSizeForIMRevision + kReservedSizeForEndOfContainer;
+        bool mIsPeerLIT = false;
+
+        // End Of Container (0x18) uses one byte.
+        static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
+        // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the
+        // context tag, 1 byte for value
+        static constexpr uint16_t kReservedSizeForIMRevision = 1 + 1 + 1;
+        // Reserved buffer for TLV level overhead (the overhead for data version filter IBs EndOfContainer, IM reversion end
+        // of RequestMessage (another end of container)).
+        static constexpr uint16_t kReservedSizeForTLVEncodingOverhead = kReservedSizeForEndOfContainer + kReservedSizeForIMRevision + kReservedSizeForEndOfContainer;
 
 #if CHIP_PROGRESS_LOGGING
-    // Tracks the time when a subscribe request is successfully sent.
-    // This timestamp allows for logging the duration taken to established the subscription.
-    System::Clock::Timestamp mSubscribeRequestTime = System::Clock::kZero;
+        // Tracks the time when a subscribe request is successfully sent.
+        // This timestamp allows for logging the duration taken to established the subscription.
+        System::Clock::Timestamp mSubscribeRequestTime = System::Clock::kZero;
 #endif
-};
+    };
 
-};     // namespace app
-};     // namespace chip
+}; // namespace app
+}; // namespace chip
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -673,7 +673,7 @@ private:
 
     System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
 
-    bool mIsPeerLITOperationMode = false;
+    bool mPeerIsOperatingAsLIT = false;
     // End Of Container (0x18) uses one byte.
     static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
     // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -673,8 +673,7 @@ private:
 
     System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
 
-    bool mIsPeerLIT = false;
-
+    bool mIsPeerLITOperationMode = false;
     // End Of Container (0x18) uses one byte.
     static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
     // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -54,637 +54,644 @@
 namespace chip {
 namespace app {
 
-    class InteractionModelEngine;
+class InteractionModelEngine;
 
-    /**
-     *  @class ReadClient
-     *
-     *  @brief The read client represents the initiator side of a Read Or Subscribe Interaction (depending on the APIs invoked).
-     *
-     *         When used to manage subscriptions, the client provides functionality to automatically re-subscribe as needed,
-     *         including re-establishing CASE under certain conditions (see Callback::OnResubscriptionNeeded for more info).
-     *         This is the default behavior. A consumer can completely opt-out of this behavior by over-riding
-     *         Callback::OnResubscriptionNeeded and providing an alternative implementation.
-     *
-     */
-    class ReadClient : public Messaging::ExchangeDelegate {
+/**
+ *  @class ReadClient
+ *
+ *  @brief The read client represents the initiator side of a Read Or Subscribe Interaction (depending on the APIs invoked).
+ *
+ *         When used to manage subscriptions, the client provides functionality to automatically re-subscribe as needed,
+ *         including re-establishing CASE under certain conditions (see Callback::OnResubscriptionNeeded for more info).
+ *         This is the default behavior. A consumer can completely opt-out of this behavior by over-riding
+ *         Callback::OnResubscriptionNeeded and providing an alternative implementation.
+ *
+ */
+class ReadClient : public Messaging::ExchangeDelegate
+{
+public:
+    class Callback
+    {
     public:
-        class Callback {
-        public:
-            Callback() = default;
+        Callback() = default;
 
-            // Callbacks are not expected to be copyable or movable.
-            Callback(const Callback &) = delete;
-            Callback(Callback &&) = delete;
-            Callback & operator=(const Callback &) = delete;
-            Callback & operator=(Callback &&) = delete;
+        // Callbacks are not expected to be copyable or movable.
+        Callback(const Callback &)             = delete;
+        Callback(Callback &&)                  = delete;
+        Callback & operator=(const Callback &) = delete;
+        Callback & operator=(Callback &&)      = delete;
 
-            virtual ~Callback() = default;
-
-            /**
-             * Used to notify a (maybe empty) report data is received from peer and the subscription and the peer is alive.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             */
-            virtual void NotifySubscriptionStillActive(const ReadClient & apReadClient) {}
-
-            /**
-             * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * Once OnReportBegin has been called, either OnReportEnd or OnError will be called before OnDone.
-             *
-             */
-            virtual void OnReportBegin() {}
-
-            /**
-             * Used to signal the completion of processing of the last attribute or event report in a given exchange.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             */
-            virtual void OnReportEnd() {}
-
-            /**
-             * Used to deliver event data received through the Read and Subscribe interactions
-             *
-             * Only one of the apData and apStatus can be non-null.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] aEventHeader The event header in report response.
-             * @param[in] apData A TLVReader positioned right on the payload of the event.
-             * @param[in] apStatus Event-specific status, containing an InteractionModel::Status code as well as an optional
-             *                     cluster-specific status code.
-             */
-            virtual void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) {}
-
-            /**
-             * Used to deliver attribute data received through the Read and Subscribe interactions.
-             *
-             * This callback will be called when:
-             *   - Receiving attribute data as response of Read interactions
-             *   - Receiving attribute data as reports of subscriptions
-             *   - Receiving attribute data as initial reports of subscriptions
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] aPath        The attribute path field in report response.
-             * @param[in] apData       The attribute data of the given path, will be a nullptr if status is not Success.
-             * @param[in] aStatus      Attribute-specific status, containing an InteractionModel::Status code as well as an
-             *                         optional cluster-specific status code.
-             */
-            virtual void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) {}
-
-            /**
-             * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
-             * If using auto resubscription, OnSubscriptionEstablished will be called whenever resubscription is established.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] aSubscriptionId The identifier of the subscription that was established.
-             */
-            virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) {}
-
-            /**
-             * OnResubscriptionNeeded will be called when a subscription that was started with SendAutoResubscribeRequest has terminated
-             * and re-subscription is needed. The termination cause is provided to help inform subsequent re-subscription logic.
-             *
-             * The base implementation automatically re-subscribes at appropriate intervals taking the termination cause into account
-             * (see ReadClient::DefaultResubscribePolicy for more details). If the default implementation doesn't suffice, the logic of
-             * ReadClient::DefaultResubscribePolicy is broken down into its constituent methods that are publicly available for
-             * applications to call and sequence.
-             *
-             * If the peer is LIT ICD, and the timeout is reached, `aTerminationCause` will be
-             * `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT`. In this case, returning `CHIP_NO_ERROR` will still trigger a resubscribe
-             * attempt, while returning `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT` will put the subscription in the
-             * `InactiveICDSubscription` state.  In the latter case, OnResubscriptionNeeded will be called again when
-             * `OnActiveModeNotification` is called.
-             *
-             * If the method is over-ridden, it's the application's responsibility to take the appropriate steps needed to eventually
-             * call-back into the ReadClient object to schedule a re-subscription (by invoking ReadClient::ScheduleResubscription).
-             *
-             * If the application DOES NOT want re-subscription to happen on a particular invocation of this method, returning anything
-             * other than CHIP_NO_ERROR will terminate the interaction and result in OnError, OnDeallocatePaths and OnDone being called
-             * in that sequence.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] aTerminationCause The cause of failure of the subscription that just terminated.
-             */
-            virtual CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
-            {
-                return apReadClient->DefaultResubscribePolicy(aTerminationCause);
-            }
-
-            /**
-             * OnError will be called when an error occurs *after* a successful call to SendRequest(). The following
-             * errors will be delivered through this call in the aError field:
-             *
-             * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
-             * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
-             * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
-             *   status response from the server.  In that case, constructing
-             *   a StatusIB from the error can be used to extract the status.
-             * - CHIP_ERROR*: All other cases.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] aError       A system error code that conveys the overall error code.
-             */
-            virtual void OnError(CHIP_ERROR aError) {}
-
-            /**
-             * OnDone will be called when ReadClient has finished all work and it is
-             * safe to destroy and free the allocated ReadClient object and any
-             * other objects associated with the Read or Subscribe interaction.
-             *
-             * The ReadClient is allowed to be destroyed during execution of this callback.
-             *
-             * This function will:
-             *      - Only be called after a successful call to SendRequest or
-             *        SendAutoResubscribeRequest has been made, when the read completes or
-             *        the subscription is shut down.
-             *      - Not be called if the ReadClient instance is destroyed before
-             *        the OnDone call happens.
-             *      - Always be called exactly *once* for a given ReadClient instance,
-             *        if it's called at all.
-             *      - Be called even in error circumstances.
-             *
-             * @param[in] apReadClient the ReadClient for the completed interaction.
-             */
-            virtual void OnDone(ReadClient * apReadClient) = 0;
-
-            /**
-             * This function is invoked when using SendAutoResubscribeRequest, where the ReadClient was configured to auto re-subscribe
-             * and the ReadPrepareParams was moved into this client for management. This will have to be free'ed appropriately by the
-             * application. If SendAutoResubscribeRequest fails, this function will be called before it returns the failure. If
-             * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone, or
-             * when the ReadClient is destroyed, if that happens before OnDone. If  SendAutoResubscribeRequest is not called,
-             * this function will not be called.
-             */
-            virtual void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) {}
-
-            /**
-             * This function is invoked when constructing a read/subscribeRequest that does not have data
-             * version filters specified, to give the callback a chance to provide some.
-             *
-             * This function is expected to encode as many complete data version filters as will fit into
-             * the buffer, rolling back any partially-encoded filters if it runs out of space, and set the
-             * aEncodedDataVersionList boolean to true if it has successfully encoded at least one data version filter.
-             *
-             * Otherwise aEncodedDataVersionList will be set to false.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             */
-            virtual CHIP_ERROR OnUpdateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-                const Span<AttributePathParams> & aAttributePaths,
-                bool & aEncodedDataVersionList)
-            {
-                aEncodedDataVersionList = false;
-                return CHIP_NO_ERROR;
-            }
-
-            /**
-             * Get highest received event number.
-             * If the application does not want to filter events by event number, it should call ClearValue() on aEventNumber
-             * and return CHIP_NO_ERROR.  An error return from this function will fail the entire read client interaction.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             */
-            virtual CHIP_ERROR GetHighestReceivedEventNumber(Optional<EventNumber> & aEventNumber)
-            {
-                aEventNumber.ClearValue();
-                return CHIP_NO_ERROR;
-            }
-
-            /**
-             * OnUnsolicitedMessageFromPublisher will be called for a subscription
-             * ReadClient when any incoming message is received from a matching
-             * node on the fabric.
-             *
-             * This callback will be called:
-             *   - When receiving any unsolicited communication from the node
-             *   - Even for disconnected subscriptions.
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             *
-             * @param[in] apReadClient the ReadClient for the subscription.
-             */
-            virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) {}
-
-            /**
-             * OnCASESessionEstablished will be called for a subscription ReadClient when
-             * it finishes setting up a CASE session, as part of either automatic
-             * re-subscription or doing an initial subscribe based on ScopedNodeId.
-             *
-             * The callee is allowed to modify the ReadPrepareParams (e.g. to change
-             * things like min/max intervals based on the session parameters).
-             *
-             * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
-             */
-            virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
-        };
-
-        enum class InteractionType : uint8_t {
-            Read,
-            Subscribe,
-        };
-
-        enum class PeerType : uint8_t {
-            kNormal,
-            kLITICD,
-        };
+        virtual ~Callback() = default;
 
         /**
+         * Used to notify a (maybe empty) report data is received from peer and the subscription and the peer is alive.
          *
-         *  Constructor.
-         *
-         *  The callback passed in has to outlive this ReadClient object.
-         *
-         *  This object can outlive the InteractionModelEngine passed in. However, upon shutdown of the engine,
-         *  this object will cease to function correctly since it depends on the engine for a number of critical functions.
-         *
-         *  @param[in]    apImEngine       A valid pointer to the IM engine.
-         *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object. Allowed to be null
-         *                                 if the version of SendAutoResubscribeRequest that takes a
-         *                                 ScopedNodeId is used.
-         *  @param[in]    apCallback       Callback set by application.
-         *  @param[in]    aInteractionType Type of interaction (read or subscribe)
-         *
-         *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
-         *  @retval #CHIP_NO_ERROR On success.
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
          *
          */
-        ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,
-            InteractionType aInteractionType);
+        virtual void NotifySubscriptionStillActive(const ReadClient & apReadClient) {}
 
         /**
-         * Destructor.
+         * Used to signal the commencement of processing of the first attribute or event report received in a given exchange.
          *
-         * The ReadClient object may be destroyed at any time while not in the middle of executing a ReadClient::Callback
-         * callback, and may also be destroyed from inside the OnDone callback.
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
          *
-         * Destroying the ReadClient will abort the exchange context if a valid one still exists. It will also cancel any
-         * liveness timers that may be active.
+         * Once OnReportBegin has been called, either OnReportEnd or OnError will be called before OnDone.
          *
-         * OnDone() will not be called if the ReadClient is destroyed before that call would have happened.
          */
-        ~ReadClient() override;
+        virtual void OnReportBegin() {}
 
         /**
-         *  Send a request.  There can be one request outstanding on a given ReadClient.
-         *  If SendRequest returns success, no more SendRequest calls can happen on this ReadClient
-         *  until the corresponding OnDone call has happened.
+         * Used to signal the completion of processing of the last attribute or event report in a given exchange.
          *
-         *  This will send either a Read Request or a Subscribe Request depending on
-         *  the InteractionType this read client was initialized with.
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
          *
-         *  If the params contain more data version filters than can fit in the request packet
-         *  the list will be truncated as needed, i.e. filter inclusion is on a best effort basis.
-         *
-         *  @retval #others fail to send read request
-         *  @retval #CHIP_NO_ERROR On success.
          */
-        CHIP_ERROR SendRequest(ReadPrepareParams & aReadPrepareParams);
+        virtual void OnReportEnd() {}
 
         /**
-         *  Re-activate an inactive subscription.
+         * Used to deliver event data received through the Read and Subscribe interactions
          *
-         *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription
-         * that would cause that ICD to not need to check in anymore.
+         * Only one of the apData and apStatus can be non-null.
          *
-         *  This API only works when issuing subscription via SendAutoResubscribeRequest.
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] aEventHeader The event header in report response.
+         * @param[in] apData A TLVReader positioned right on the payload of the event.
+         * @param[in] apStatus Event-specific status, containing an InteractionModel::Status code as well as an optional
+         *                     cluster-specific status code.
          */
-        void OnActiveModeNotification();
+        virtual void OnEventData(const EventHeader & aEventHeader, TLV::TLVReader * apData, const StatusIB * apStatus) {}
 
-        void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
+        /**
+         * Used to deliver attribute data received through the Read and Subscribe interactions.
+         *
+         * This callback will be called when:
+         *   - Receiving attribute data as response of Read interactions
+         *   - Receiving attribute data as reports of subscriptions
+         *   - Receiving attribute data as initial reports of subscriptions
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] aPath        The attribute path field in report response.
+         * @param[in] apData       The attribute data of the given path, will be a nullptr if status is not Success.
+         * @param[in] aStatus      Attribute-specific status, containing an InteractionModel::Status code as well as an
+         *                         optional cluster-specific status code.
+         */
+        virtual void OnAttributeData(const ConcreteDataAttributePath & aPath, TLV::TLVReader * apData, const StatusIB & aStatus) {}
 
-        void OnUnsolicitedMessageFromPublisher()
+        /**
+         * OnSubscriptionEstablished will be called when a subscription is established for the given subscription transaction.
+         * If using auto resubscription, OnSubscriptionEstablished will be called whenever resubscription is established.
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] aSubscriptionId The identifier of the subscription that was established.
+         */
+        virtual void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) {}
+
+        /**
+         * OnResubscriptionNeeded will be called when a subscription that was started with SendAutoResubscribeRequest has terminated
+         * and re-subscription is needed. The termination cause is provided to help inform subsequent re-subscription logic.
+         *
+         * The base implementation automatically re-subscribes at appropriate intervals taking the termination cause into account
+         * (see ReadClient::DefaultResubscribePolicy for more details). If the default implementation doesn't suffice, the logic of
+         * ReadClient::DefaultResubscribePolicy is broken down into its constituent methods that are publicly available for
+         * applications to call and sequence.
+         *
+         * If the peer is LIT ICD, and the timeout is reached, `aTerminationCause` will be
+         * `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT`. In this case, returning `CHIP_NO_ERROR` will still trigger a resubscribe
+         * attempt, while returning `CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT` will put the subscription in the
+         * `InactiveICDSubscription` state.  In the latter case, OnResubscriptionNeeded will be called again when
+         * `OnActiveModeNotification` is called.
+         *
+         * If the method is over-ridden, it's the application's responsibility to take the appropriate steps needed to eventually
+         * call-back into the ReadClient object to schedule a re-subscription (by invoking ReadClient::ScheduleResubscription).
+         *
+         * If the application DOES NOT want re-subscription to happen on a particular invocation of this method, returning anything
+         * other than CHIP_NO_ERROR will terminate the interaction and result in OnError, OnDeallocatePaths and OnDone being called
+         * in that sequence.
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] aTerminationCause The cause of failure of the subscription that just terminated.
+         */
+        virtual CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause)
         {
-            TriggerResubscribeIfScheduled("unsolicited message");
-
-            // Then notify callbacks
-            mpCallback.OnUnsolicitedMessageFromPublisher(this);
+            return apReadClient->DefaultResubscribePolicy(aTerminationCause);
         }
 
-        auto GetSubscriptionId() const
-        {
-            using returnType = Optional<decltype(mSubscriptionId)>;
-            return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
-        }
-
-        FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
-        NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
-        bool IsReadType() { return mInteractionType == InteractionType::Read; }
-        bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
-
-        /*
-         * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
-         * interaction type and after a subscription has been established.
+        /**
+         * OnError will be called when an error occurs *after* a successful call to SendRequest(). The following
+         * errors will be delivered through this call in the aError field:
+         *
+         * - CHIP_ERROR_TIMEOUT: A response was not received within the expected response timeout.
+         * - CHIP_ERROR_*TLV*: A malformed, non-compliant response was received from the server.
+         * - CHIP_ERROR encapsulating a StatusIB: If we got a non-path-specific
+         *   status response from the server.  In that case, constructing
+         *   a StatusIB from the error can be used to extract the status.
+         * - CHIP_ERROR*: All other cases.
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] aError       A system error code that conveys the overall error code.
          */
-        CHIP_ERROR GetReportingIntervals(uint16_t & aMinIntervalFloorSeconds, uint16_t & aMaxIntervalCeilingSeconds) const
+        virtual void OnError(CHIP_ERROR aError) {}
+
+        /**
+         * OnDone will be called when ReadClient has finished all work and it is
+         * safe to destroy and free the allocated ReadClient object and any
+         * other objects associated with the Read or Subscribe interaction.
+         *
+         * The ReadClient is allowed to be destroyed during execution of this callback.
+         *
+         * This function will:
+         *      - Only be called after a successful call to SendRequest or
+         *        SendAutoResubscribeRequest has been made, when the read completes or
+         *        the subscription is shut down.
+         *      - Not be called if the ReadClient instance is destroyed before
+         *        the OnDone call happens.
+         *      - Always be called exactly *once* for a given ReadClient instance,
+         *        if it's called at all.
+         *      - Be called even in error circumstances.
+         *
+         * @param[in] apReadClient the ReadClient for the completed interaction.
+         */
+        virtual void OnDone(ReadClient * apReadClient) = 0;
+
+        /**
+         * This function is invoked when using SendAutoResubscribeRequest, where the ReadClient was configured to auto re-subscribe
+         * and the ReadPrepareParams was moved into this client for management. This will have to be free'ed appropriately by the
+         * application. If SendAutoResubscribeRequest fails, this function will be called before it returns the failure. If
+         * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone, or
+         * when the ReadClient is destroyed, if that happens before OnDone. If  SendAutoResubscribeRequest is not called,
+         * this function will not be called.
+         */
+        virtual void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) {}
+
+        /**
+         * This function is invoked when constructing a read/subscribeRequest that does not have data
+         * version filters specified, to give the callback a chance to provide some.
+         *
+         * This function is expected to encode as many complete data version filters as will fit into
+         * the buffer, rolling back any partially-encoded filters if it runs out of space, and set the
+         * aEncodedDataVersionList boolean to true if it has successfully encoded at least one data version filter.
+         *
+         * Otherwise aEncodedDataVersionList will be set to false.
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         */
+        virtual CHIP_ERROR OnUpdateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+                                                         const Span<AttributePathParams> & aAttributePaths,
+                                                         bool & aEncodedDataVersionList)
         {
-            VerifyOrReturnError(IsSubscriptionType(), CHIP_ERROR_INCORRECT_STATE);
-            VerifyOrReturnError(IsSubscriptionActive(), CHIP_ERROR_INCORRECT_STATE);
-
-            aMinIntervalFloorSeconds = mMinIntervalFloorSeconds;
-            aMaxIntervalCeilingSeconds = mMaxInterval;
-
+            aEncodedDataVersionList = false;
             return CHIP_NO_ERROR;
         }
 
-        ReadClient * GetNextClient() { return mpNext; }
-        void SetNextClient(ReadClient * apClient) { mpNext = apClient; }
-
         /**
-         *  Like SendSubscribeRequest, but the ReadClient will automatically attempt to re-establish the subscription if
-         *  we decide that the subscription has dropped.  The exact behavior of the re-establishment can be controlled
-         *  by overriding Callback::OnResubscriptionNeeded().  If not overridden, a default behavior with exponential
-         *  backoff from will be used.
+         * Get highest received event number.
+         * If the application does not want to filter events by event number, it should call ClearValue() on aEventNumber
+         * and return CHIP_NO_ERROR.  An error return from this function will fail the entire read client interaction.
          *
-         *  The application has to know to
-         *  a) allocate a ReadPrepareParams object that will have fields mpEventPathParamsList and mpAttributePathParamsList and
-         *  mpDataVersionFilterList with lifetimes as long as the ReadClient itself and b) free those up later in the call to
-         *  OnDeallocatePaths. Note: At a given time in the system, you can either have a single subscription with re-sub enabled that
-         *  has mKeepSubscriptions = false, OR, multiple subs with re-sub enabled with mKeepSubscriptions = true. You shall not
-         *  have a mix of both simultaneously. If SendAutoResubscribeRequest is called at all, it guarantees that it will call
-         *  OnDeallocatePaths (either before returning error, or when OnDone is called or the ReadClient is destroyed).
-         *  SendAutoResubscribeRequest is the only case that calls OnDeallocatePaths, since that's the only case when the consumer
-         *  moved a ReadParams into the client.
-         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
          */
-        CHIP_ERROR SendAutoResubscribeRequest(ReadPrepareParams && aReadPrepareParams);
-
-        /**
-         * Like SendAutoResubscribeRequest above, but without a session being
-         * available in the ReadPrepareParams.  When this is used, the ReadClient is
-         * responsible for setting up the CASE session itself.
-         *
-         * When using this version of SendAutoResubscribeRequest, any session to
-         * which ReadPrepareParams has a reference will be ignored.
-         */
-        CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
-
-        /**
-         *   This provides a standard re-subscription policy implementation that given a termination cause, does the following:
-         *   - Calculates the time till next subscription with fibonacci back-off (implemented by ComputeTimeTillNextSubscription()).
-         *   - Schedules the next subscription attempt at the computed interval from the previous step. Operational discovery and
-         *     CASE establishment will be attempted if aTerminationCause was CHIP_ERROR_TIMEOUT. In all other cases, it will attempt
-         *     to re-use a previously established session.
-         */
-        CHIP_ERROR DefaultResubscribePolicy(CHIP_ERROR aTerminationCause);
-
-        /**
-         * Computes the time, in milliseconds, until the next re-subscription over
-         * an ever increasing window following a fibonacci sequence with the current retry count
-         * used as input to the fibonacci algorithm.
-         *
-         * CHIP_RESUBSCRIBE_MAX_FIBONACCI_STEP_INDEX is the maximum value the retry count can tick up to.
-         *
-         */
-        uint32_t ComputeTimeTillNextSubscription();
-
-        /**
-         * Schedules a re-subscription aTimeTillNextResubscriptionMs into the future.
-         *
-         * If an application wants to set up CASE on their own, they should call ComputeTimeTillNextSubscription() to compute the next
-         * interval at which they should attempt CASE and attempt CASE at that time. On successful CASE establishment, this method
-         * should be called with the new SessionHandle provided through 'aNewSessionHandle', 'aTimeTillNextResubscriptionMs' set to 0
-         * (i.e async, but as soon as possible) and 'aReestablishCASE' set to false.
-         *
-         * Otherwise, if aReestablishCASE is true, operational discovery and CASE will be attempted at that time before
-         * the actual IM interaction is initiated.
-         *
-         * aReestablishCASE SHALL NOT be set to true if a valid SessionHandle is provided through newSessionHandle.
-         */
-        CHIP_ERROR ScheduleResubscription(uint32_t aTimeTillNextResubscriptionMs, Optional<SessionHandle> aNewSessionHandle,
-            bool aReestablishCASE);
-
-        // Like SendSubscribeRequest, but allows sending certain forms of invalid
-        // subscribe requests that servers are expected to reject, for testing
-        // purposes.  Should only be called from tests.
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-        CHIP_ERROR SendSubscribeRequestWithoutValidation(const ReadPrepareParams & aReadPrepareParams)
+        virtual CHIP_ERROR GetHighestReceivedEventNumber(Optional<EventNumber> & aEventNumber)
         {
-            return SendSubscribeRequestImpl(aReadPrepareParams);
-        }
-#endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
-
-        /**
-         * Override the interval at which liveness of the subscription is assessed.
-         * By default, this is set set to the max interval of the subscription + ACK timeout of the underlying session.
-         *
-         * This can be only be called once a subscription has been established and is active. Once called, this will cancel any existing
-         * liveness timers and schedule a new one.
-         *
-         * This can be called from the Callback::OnSubscriptionEstablished callback.
-         *
-         */
-        void OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout);
-
-        /**
-         * If the ReadClient currently has a resubscription attempt scheduled,
-         * trigger that attempt right now.  This is generally useful when a consumer
-         * has some sort of indication that the server side is currently up and
-         * communicating, so right now is a good time to try to resubscribe.
-         *
-         * The reason string is used for logging if a resubscribe is triggered.
-         *
-         * Returns whether a resubscribe is triggered.
-         */
-        bool TriggerResubscribeIfScheduled(const char * reason);
-
-        /**
-         * Returns the timeout after which we consider the subscription to have
-         * dropped, if we have received no messages within that amount of time.
-         *
-         * Returns NullOptional if a subscription has not yet been established (and
-         * hence the MaxInterval is not yet known), or if the subscription session
-         * is gone and hence the relevant MRP parameters can no longer be determined.
-         */
-        Optional<System::Clock::Timeout> GetSubscriptionTimeout();
-
-    private:
-        friend class TestReadInteraction;
-        friend class InteractionModelEngine;
-
-        enum class ClientState : uint8_t {
-            Idle, ///< The client has been initialized and is ready for a SendRequest
-            AwaitingInitialReport, ///< The client is waiting for initial report
-            AwaitingSubscribeResponse, ///< The client is waiting for subscribe response
-            SubscriptionActive, ///< The client is maintaining subscription
-            InactiveICDSubscription, ///< The client is waiting to resubscribe for LIT device
-        };
-
-        enum class ReportType {
-            // kUnsolicited reports are the first message in an exchange.
-            kUnsolicited,
-            // kContinuingTransaction reports are responses to a message we sent.
-            kContinuingTransaction
-        };
-
-        bool IsMatchingSubscriptionId(SubscriptionId aSubscriptionId)
-        {
-            return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
+            aEventNumber.ClearValue();
+            return CHIP_NO_ERROR;
         }
 
-        CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
-            System::PacketBufferHandle && aPayload) override;
-        void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+        /**
+         * OnUnsolicitedMessageFromPublisher will be called for a subscription
+         * ReadClient when any incoming message is received from a matching
+         * node on the fabric.
+         *
+         * This callback will be called:
+         *   - When receiving any unsolicited communication from the node
+         *   - Even for disconnected subscriptions.
+         *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
+         *
+         * @param[in] apReadClient the ReadClient for the subscription.
+         */
+        virtual void OnUnsolicitedMessageFromPublisher(ReadClient * apReadClient) {}
 
         /**
-         *  Updates the type (LIT ICD or not) of the peer.
+         * OnCASESessionEstablished will be called for a subscription ReadClient when
+         * it finishes setting up a CASE session, as part of either automatic
+         * re-subscription or doing an initial subscribe based on ScopedNodeId.
          *
-         *  When the subscription is active, this function will just set the flag. When the subscription is an InactiveICDSubscription,
-         * setting the peer type to SIT or normal devices will also trigger a resubscription attempt.
+         * The callee is allowed to modify the ReadPrepareParams (e.g. to change
+         * things like min/max intervals based on the session parameters).
          *
+         * The ReadClient MUST NOT be destroyed during execution of this callback (i.e. before the callback returns).
          */
-        void OnPeerTypeChange(PeerType aType);
-
-        /**
-         *  Check if current read client is being used
-         *
-         */
-        bool IsIdle() const { return mState == ClientState::Idle; }
-        bool IsInactiveICDSubscription() const { return mState == ClientState::InactiveICDSubscription; }
-        bool IsSubscriptionActive() const { return mState == ClientState::SubscriptionActive; }
-        bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
-        bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
-
-        CHIP_ERROR GenerateEventPaths(EventPathIBs::Builder & aEventPathsBuilder, const Span<EventPathParams> & aEventPaths);
-        CHIP_ERROR GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
-            const Span<AttributePathParams> & aAttributePaths);
-
-        CHIP_ERROR GenerateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-            const Span<AttributePathParams> & aAttributePaths,
-            const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
-        CHIP_ERROR BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
-            const Span<AttributePathParams> & aAttributePaths,
-            const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
-        CHIP_ERROR ReadICDOperatingModeFromAttributeDataIB(TLV::TLVReader && aReader, PeerType & aType);
-        CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
-        CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
-
-        static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
-        CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
-        CHIP_ERROR RefreshLivenessCheckTimer();
-        CHIP_ERROR ComputeLivenessCheckTimerTimeout(System::Clock::Timeout * aTimeout);
-        void CancelLivenessCheckTimer();
-        void CancelResubscribeTimer();
-        void TriggerResubscriptionForLivenessTimeout(CHIP_ERROR aReason);
-        void MoveToState(const ClientState aTargetState);
-        CHIP_ERROR ProcessAttributePath(AttributePathIB::Parser & aAttributePath, ConcreteDataAttributePath & aClusterInfo);
-        CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload, ReportType aReportType);
-        const char * GetStateStr() const;
-
-        /*
-         * Checks if we should re-subscribe based on the specified re-subscription policy. If we should, re-subscription is scheduled
-         * aNextResubscribeIntervalMsec is updated accordingly, and true is returned.
-         *
-         * If we should not resubscribe, false is returned.
-         *
-         *  @param[out]    aNextResubscribeIntervalMsec    How long we will wait before trying to auto-resubscribe.
-         */
-        bool ResubscribeIfNeeded(uint32_t & aNextResubscribeIntervalMsec);
-
-        // Specialized request-sending functions.
-        CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams);
-        // SendSubscribeRequest performs som validation on aSubscribePrepareParams
-        // and then calls SendSubscribeRequestImpl.
-        CHIP_ERROR SendSubscribeRequest(const ReadPrepareParams & aSubscribePrepareParams);
-        CHIP_ERROR SendSubscribeRequestImpl(const ReadPrepareParams & aSubscribePrepareParams);
-        void UpdateDataVersionFilters(const ConcreteDataAttributePath & aPath);
-        static void OnResubscribeTimerCallback(System::Layer * apSystemLayer, void * apAppState);
-        // Called to ensure OnReportBegin is called before calling OnEventData or OnAttributeData
-        void NoteReportingData();
-
-        /*
-         * Called internally to signal the completion of all work on this object, gracefully close the
-         * exchange and finally, signal to the application that it's
-         * safe to release this object.
-         *
-         * If aError != CHIP_NO_ERROR, this will trigger re-subscriptions if allowResubscription is true
-         * AND if this ReadClient instance is tracking a subscription AND the applications decides to do so
-         * in their implementation of Callback::OnResubscriptionNeeded().
-         */
-        void Close(CHIP_ERROR aError, bool allowResubscription = true);
-
-        void StopResubscription();
-        void ClearActiveSubscriptionState();
-
-        static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
-            const SessionHandle & sessionHandle);
-        static void HandleDeviceConnectionFailure(void * context, const OperationalSessionSetup::ConnectionFailureInfo & failureInfo);
-
-        CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
-
-        /**
-         * Start setting up a CASE session to our peer, if we can locate a
-         * CASESessionManager.  Returns error if we did not even manage to kick off
-         * a CASE attempt.
-         */
-        CHIP_ERROR EstablishSessionToPeer();
-
-        Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-        Messaging::ExchangeHolder mExchange;
-        Callback & mpCallback;
-        ClientState mState = ClientState::Idle;
-        bool mIsReporting = false;
-        bool mIsInitialReport = true;
-        // boolean to check if client is waiting for the first priming report
-        bool mWaitingForFirstPrimingReport = true;
-        bool mPendingMoreChunks = false;
-        uint16_t mMinIntervalFloorSeconds = 0;
-        uint16_t mMaxInterval = 0;
-        SubscriptionId mSubscriptionId = 0;
-        ScopedNodeId mPeer;
-        InteractionType mInteractionType = InteractionType::Read;
-        Timestamp mEventTimestamp;
-
-        bool mForceCaseOnNextResub = true;
-        bool mIsResubscriptionScheduled = false;
-
-        // mMinimalResubscribeDelay is used to store the delay returned with a BUSY
-        // response to a Sigma1 message.
-        System::Clock::Milliseconds16 mMinimalResubscribeDelay = System::Clock::kZero;
-
-        chip::Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
-        chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> mOnConnectionFailureCallback;
-
-        ReadClient * mpNext = nullptr;
-        InteractionModelEngine * mpImEngine = nullptr;
-
-        //
-        // This stores the params associated with the interaction in a specific set of cases:
-        //      1. Stores all parameters when used with subscriptions initiated using SendAutoResubscribeRequest.
-        //      2. Stores just the SessionHolder when used with any subscriptions.
-        //
-        ReadPrepareParams mReadPrepareParams;
-        uint32_t mNumRetries = 0;
-
-        System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
-
-        bool mIsPeerLIT = false;
-
-        // End Of Container (0x18) uses one byte.
-        static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
-        // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the
-        // context tag, 1 byte for value
-        static constexpr uint16_t kReservedSizeForIMRevision = 1 + 1 + 1;
-        // Reserved buffer for TLV level overhead (the overhead for data version filter IBs EndOfContainer, IM reversion end
-        // of RequestMessage (another end of container)).
-        static constexpr uint16_t kReservedSizeForTLVEncodingOverhead = kReservedSizeForEndOfContainer + kReservedSizeForIMRevision + kReservedSizeForEndOfContainer;
-
-#if CHIP_PROGRESS_LOGGING
-        // Tracks the time when a subscribe request is successfully sent.
-        // This timestamp allows for logging the duration taken to established the subscription.
-        System::Clock::Timestamp mSubscribeRequestTime = System::Clock::kZero;
-#endif
+        virtual void OnCASESessionEstablished(const SessionHandle & aSession, ReadPrepareParams & aSubscriptionParams) {}
     };
 
-}; // namespace app
-}; // namespace chip
+    enum class InteractionType : uint8_t
+    {
+        Read,
+        Subscribe,
+    };
+
+    enum class PeerType : uint8_t
+    {
+        kNormal,
+        kLITICD,
+    };
+
+    /**
+     *
+     *  Constructor.
+     *
+     *  The callback passed in has to outlive this ReadClient object.
+     *
+     *  This object can outlive the InteractionModelEngine passed in. However, upon shutdown of the engine,
+     *  this object will cease to function correctly since it depends on the engine for a number of critical functions.
+     *
+     *  @param[in]    apImEngine       A valid pointer to the IM engine.
+     *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object. Allowed to be null
+     *                                 if the version of SendAutoResubscribeRequest that takes a
+     *                                 ScopedNodeId is used.
+     *  @param[in]    apCallback       Callback set by application.
+     *  @param[in]    aInteractionType Type of interaction (read or subscribe)
+     *
+     *  @retval #CHIP_ERROR_INCORRECT_STATE incorrect state if it is already initialized
+     *  @retval #CHIP_NO_ERROR On success.
+     *
+     */
+    ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeManager * apExchangeMgr, Callback & apCallback,
+               InteractionType aInteractionType);
+
+    /**
+     * Destructor.
+     *
+     * The ReadClient object may be destroyed at any time while not in the middle of executing a ReadClient::Callback
+     * callback, and may also be destroyed from inside the OnDone callback.
+     *
+     * Destroying the ReadClient will abort the exchange context if a valid one still exists. It will also cancel any
+     * liveness timers that may be active.
+     *
+     * OnDone() will not be called if the ReadClient is destroyed before that call would have happened.
+     */
+    ~ReadClient() override;
+
+    /**
+     *  Send a request.  There can be one request outstanding on a given ReadClient.
+     *  If SendRequest returns success, no more SendRequest calls can happen on this ReadClient
+     *  until the corresponding OnDone call has happened.
+     *
+     *  This will send either a Read Request or a Subscribe Request depending on
+     *  the InteractionType this read client was initialized with.
+     *
+     *  If the params contain more data version filters than can fit in the request packet
+     *  the list will be truncated as needed, i.e. filter inclusion is on a best effort basis.
+     *
+     *  @retval #others fail to send read request
+     *  @retval #CHIP_NO_ERROR On success.
+     */
+    CHIP_ERROR SendRequest(ReadPrepareParams & aReadPrepareParams);
+
+    /**
+     *  Re-activate an inactive subscription.
+     *
+     *  This function should be called when the peer is an ICD that is checking in and this ReadClient represents a subscription
+     * that would cause that ICD to not need to check in anymore.
+     *
+     *  This API only works when issuing subscription via SendAutoResubscribeRequest.
+     */
+    void OnActiveModeNotification();
+
+    void OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload);
+
+    void OnUnsolicitedMessageFromPublisher()
+    {
+        TriggerResubscribeIfScheduled("unsolicited message");
+
+        // Then notify callbacks
+        mpCallback.OnUnsolicitedMessageFromPublisher(this);
+    }
+
+    auto GetSubscriptionId() const
+    {
+        using returnType = Optional<decltype(mSubscriptionId)>;
+        return mInteractionType == InteractionType::Subscribe ? returnType(mSubscriptionId) : returnType::Missing();
+    }
+
+    FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
+    NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
+    bool IsReadType() { return mInteractionType == InteractionType::Read; }
+    bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
+
+    /*
+     * Retrieve the reporting intervals associated with an active subscription. This should only be called if we're of subscription
+     * interaction type and after a subscription has been established.
+     */
+    CHIP_ERROR GetReportingIntervals(uint16_t & aMinIntervalFloorSeconds, uint16_t & aMaxIntervalCeilingSeconds) const
+    {
+        VerifyOrReturnError(IsSubscriptionType(), CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(IsSubscriptionActive(), CHIP_ERROR_INCORRECT_STATE);
+
+        aMinIntervalFloorSeconds   = mMinIntervalFloorSeconds;
+        aMaxIntervalCeilingSeconds = mMaxInterval;
+
+        return CHIP_NO_ERROR;
+    }
+
+    ReadClient * GetNextClient() { return mpNext; }
+    void SetNextClient(ReadClient * apClient) { mpNext = apClient; }
+
+    /**
+     *  Like SendSubscribeRequest, but the ReadClient will automatically attempt to re-establish the subscription if
+     *  we decide that the subscription has dropped.  The exact behavior of the re-establishment can be controlled
+     *  by overriding Callback::OnResubscriptionNeeded().  If not overridden, a default behavior with exponential
+     *  backoff from will be used.
+     *
+     *  The application has to know to
+     *  a) allocate a ReadPrepareParams object that will have fields mpEventPathParamsList and mpAttributePathParamsList and
+     *  mpDataVersionFilterList with lifetimes as long as the ReadClient itself and b) free those up later in the call to
+     *  OnDeallocatePaths. Note: At a given time in the system, you can either have a single subscription with re-sub enabled that
+     *  has mKeepSubscriptions = false, OR, multiple subs with re-sub enabled with mKeepSubscriptions = true. You shall not
+     *  have a mix of both simultaneously. If SendAutoResubscribeRequest is called at all, it guarantees that it will call
+     *  OnDeallocatePaths (either before returning error, or when OnDone is called or the ReadClient is destroyed).
+     *  SendAutoResubscribeRequest is the only case that calls OnDeallocatePaths, since that's the only case when the consumer
+     *  moved a ReadParams into the client.
+     *
+     */
+    CHIP_ERROR SendAutoResubscribeRequest(ReadPrepareParams && aReadPrepareParams);
+
+    /**
+     * Like SendAutoResubscribeRequest above, but without a session being
+     * available in the ReadPrepareParams.  When this is used, the ReadClient is
+     * responsible for setting up the CASE session itself.
+     *
+     * When using this version of SendAutoResubscribeRequest, any session to
+     * which ReadPrepareParams has a reference will be ignored.
+     */
+    CHIP_ERROR SendAutoResubscribeRequest(const ScopedNodeId & aPublisherId, ReadPrepareParams && aReadPrepareParams);
+
+    /**
+     *   This provides a standard re-subscription policy implementation that given a termination cause, does the following:
+     *   - Calculates the time till next subscription with fibonacci back-off (implemented by ComputeTimeTillNextSubscription()).
+     *   - Schedules the next subscription attempt at the computed interval from the previous step. Operational discovery and
+     *     CASE establishment will be attempted if aTerminationCause was CHIP_ERROR_TIMEOUT. In all other cases, it will attempt
+     *     to re-use a previously established session.
+     */
+    CHIP_ERROR DefaultResubscribePolicy(CHIP_ERROR aTerminationCause);
+
+    /**
+     * Computes the time, in milliseconds, until the next re-subscription over
+     * an ever increasing window following a fibonacci sequence with the current retry count
+     * used as input to the fibonacci algorithm.
+     *
+     * CHIP_RESUBSCRIBE_MAX_FIBONACCI_STEP_INDEX is the maximum value the retry count can tick up to.
+     *
+     */
+    uint32_t ComputeTimeTillNextSubscription();
+
+    /**
+     * Schedules a re-subscription aTimeTillNextResubscriptionMs into the future.
+     *
+     * If an application wants to set up CASE on their own, they should call ComputeTimeTillNextSubscription() to compute the next
+     * interval at which they should attempt CASE and attempt CASE at that time. On successful CASE establishment, this method
+     * should be called with the new SessionHandle provided through 'aNewSessionHandle', 'aTimeTillNextResubscriptionMs' set to 0
+     * (i.e async, but as soon as possible) and 'aReestablishCASE' set to false.
+     *
+     * Otherwise, if aReestablishCASE is true, operational discovery and CASE will be attempted at that time before
+     * the actual IM interaction is initiated.
+     *
+     * aReestablishCASE SHALL NOT be set to true if a valid SessionHandle is provided through newSessionHandle.
+     */
+    CHIP_ERROR ScheduleResubscription(uint32_t aTimeTillNextResubscriptionMs, Optional<SessionHandle> aNewSessionHandle,
+                                      bool aReestablishCASE);
+
+    // Like SendSubscribeRequest, but allows sending certain forms of invalid
+    // subscribe requests that servers are expected to reject, for testing
+    // purposes.  Should only be called from tests.
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    CHIP_ERROR SendSubscribeRequestWithoutValidation(const ReadPrepareParams & aReadPrepareParams)
+    {
+        return SendSubscribeRequestImpl(aReadPrepareParams);
+    }
+#endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+    /**
+     * Override the interval at which liveness of the subscription is assessed.
+     * By default, this is set set to the max interval of the subscription + ACK timeout of the underlying session.
+     *
+     * This can be only be called once a subscription has been established and is active. Once called, this will cancel any existing
+     * liveness timers and schedule a new one.
+     *
+     * This can be called from the Callback::OnSubscriptionEstablished callback.
+     *
+     */
+    void OverrideLivenessTimeout(System::Clock::Timeout aLivenessTimeout);
+
+    /**
+     * If the ReadClient currently has a resubscription attempt scheduled,
+     * trigger that attempt right now.  This is generally useful when a consumer
+     * has some sort of indication that the server side is currently up and
+     * communicating, so right now is a good time to try to resubscribe.
+     *
+     * The reason string is used for logging if a resubscribe is triggered.
+     *
+     * Returns whether a resubscribe is triggered.
+     */
+    bool TriggerResubscribeIfScheduled(const char * reason);
+
+    /**
+     * Returns the timeout after which we consider the subscription to have
+     * dropped, if we have received no messages within that amount of time.
+     *
+     * Returns NullOptional if a subscription has not yet been established (and
+     * hence the MaxInterval is not yet known), or if the subscription session
+     * is gone and hence the relevant MRP parameters can no longer be determined.
+     */
+    Optional<System::Clock::Timeout> GetSubscriptionTimeout();
+
+private:
+    friend class TestReadInteraction;
+    friend class InteractionModelEngine;
+
+    enum class ClientState : uint8_t
+    {
+        Idle,                      ///< The client has been initialized and is ready for a SendRequest
+        AwaitingInitialReport,     ///< The client is waiting for initial report
+        AwaitingSubscribeResponse, ///< The client is waiting for subscribe response
+        SubscriptionActive,        ///< The client is maintaining subscription
+        InactiveICDSubscription,   ///< The client is waiting to resubscribe for LIT device
+    };
+
+    enum class ReportType
+    {
+        // kUnsolicited reports are the first message in an exchange.
+        kUnsolicited,
+        // kContinuingTransaction reports are responses to a message we sent.
+        kContinuingTransaction
+    };
+
+    bool IsMatchingSubscriptionId(SubscriptionId aSubscriptionId)
+    {
+        return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
+    }
+
+    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
+                                 System::PacketBufferHandle && aPayload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+
+    /**
+     *  Updates the type (LIT ICD or not) of the peer.
+     *
+     *  When the subscription is active, this function will just set the flag. When the subscription is an InactiveICDSubscription,
+     * setting the peer type to SIT or normal devices will also trigger a resubscription attempt.
+     *
+     */
+    void OnPeerTypeChange(PeerType aType);
+
+    /**
+     *  Check if current read client is being used
+     *
+     */
+    bool IsIdle() const { return mState == ClientState::Idle; }
+    bool IsInactiveICDSubscription() const { return mState == ClientState::InactiveICDSubscription; }
+    bool IsSubscriptionActive() const { return mState == ClientState::SubscriptionActive; }
+    bool IsAwaitingInitialReport() const { return mState == ClientState::AwaitingInitialReport; }
+    bool IsAwaitingSubscribeResponse() const { return mState == ClientState::AwaitingSubscribeResponse; }
+
+    CHIP_ERROR GenerateEventPaths(EventPathIBs::Builder & aEventPathsBuilder, const Span<EventPathParams> & aEventPaths);
+    CHIP_ERROR GenerateAttributePaths(AttributePathIBs::Builder & aAttributePathIBsBuilder,
+                                      const Span<AttributePathParams> & aAttributePaths);
+
+    CHIP_ERROR GenerateDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+                                             const Span<AttributePathParams> & aAttributePaths,
+                                             const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
+    CHIP_ERROR BuildDataVersionFilterList(DataVersionFilterIBs::Builder & aDataVersionFilterIBsBuilder,
+                                          const Span<AttributePathParams> & aAttributePaths,
+                                          const Span<DataVersionFilter> & aDataVersionFilters, bool & aEncodedDataVersionList);
+    CHIP_ERROR ReadICDOperatingModeFromAttributeDataIB(TLV::TLVReader && aReader, PeerType & aType);
+    CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
+    CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
+
+    static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
+    CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
+    CHIP_ERROR RefreshLivenessCheckTimer();
+    CHIP_ERROR ComputeLivenessCheckTimerTimeout(System::Clock::Timeout * aTimeout);
+    void CancelLivenessCheckTimer();
+    void CancelResubscribeTimer();
+    void TriggerResubscriptionForLivenessTimeout(CHIP_ERROR aReason);
+    void MoveToState(const ClientState aTargetState);
+    CHIP_ERROR ProcessAttributePath(AttributePathIB::Parser & aAttributePath, ConcreteDataAttributePath & aClusterInfo);
+    CHIP_ERROR ProcessReportData(System::PacketBufferHandle && aPayload, ReportType aReportType);
+    const char * GetStateStr() const;
+
+    /*
+     * Checks if we should re-subscribe based on the specified re-subscription policy. If we should, re-subscription is scheduled
+     * aNextResubscribeIntervalMsec is updated accordingly, and true is returned.
+     *
+     * If we should not resubscribe, false is returned.
+     *
+     *  @param[out]    aNextResubscribeIntervalMsec    How long we will wait before trying to auto-resubscribe.
+     */
+    bool ResubscribeIfNeeded(uint32_t & aNextResubscribeIntervalMsec);
+
+    // Specialized request-sending functions.
+    CHIP_ERROR SendReadRequest(ReadPrepareParams & aReadPrepareParams);
+    // SendSubscribeRequest performs som validation on aSubscribePrepareParams
+    // and then calls SendSubscribeRequestImpl.
+    CHIP_ERROR SendSubscribeRequest(const ReadPrepareParams & aSubscribePrepareParams);
+    CHIP_ERROR SendSubscribeRequestImpl(const ReadPrepareParams & aSubscribePrepareParams);
+    void UpdateDataVersionFilters(const ConcreteDataAttributePath & aPath);
+    static void OnResubscribeTimerCallback(System::Layer * apSystemLayer, void * apAppState);
+    // Called to ensure OnReportBegin is called before calling OnEventData or OnAttributeData
+    void NoteReportingData();
+
+    /*
+     * Called internally to signal the completion of all work on this object, gracefully close the
+     * exchange and finally, signal to the application that it's
+     * safe to release this object.
+     *
+     * If aError != CHIP_NO_ERROR, this will trigger re-subscriptions if allowResubscription is true
+     * AND if this ReadClient instance is tracking a subscription AND the applications decides to do so
+     * in their implementation of Callback::OnResubscriptionNeeded().
+     */
+    void Close(CHIP_ERROR aError, bool allowResubscription = true);
+
+    void StopResubscription();
+    void ClearActiveSubscriptionState();
+
+    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr,
+                                      const SessionHandle & sessionHandle);
+    static void HandleDeviceConnectionFailure(void * context, const OperationalSessionSetup::ConnectionFailureInfo & failureInfo);
+
+    CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
+
+    /**
+     * Start setting up a CASE session to our peer, if we can locate a
+     * CASESessionManager.  Returns error if we did not even manage to kick off
+     * a CASE attempt.
+     */
+    CHIP_ERROR EstablishSessionToPeer();
+
+    Messaging::ExchangeManager * mpExchangeMgr = nullptr;
+    Messaging::ExchangeHolder mExchange;
+    Callback & mpCallback;
+    ClientState mState    = ClientState::Idle;
+    bool mIsReporting     = false;
+    bool mIsInitialReport = true;
+    // boolean to check if client is waiting for the first priming report
+    bool mWaitingForFirstPrimingReport = true;
+    bool mPendingMoreChunks            = false;
+    uint16_t mMinIntervalFloorSeconds  = 0;
+    uint16_t mMaxInterval              = 0;
+    SubscriptionId mSubscriptionId     = 0;
+    ScopedNodeId mPeer;
+    InteractionType mInteractionType = InteractionType::Read;
+    Timestamp mEventTimestamp;
+
+    bool mForceCaseOnNextResub      = true;
+    bool mIsResubscriptionScheduled = false;
+
+    // mMinimalResubscribeDelay is used to store the delay returned with a BUSY
+    // response to a Sigma1 message.
+    System::Clock::Milliseconds16 mMinimalResubscribeDelay = System::Clock::kZero;
+
+    chip::Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
+    chip::Callback::Callback<OperationalSessionSetup::OnSetupFailure> mOnConnectionFailureCallback;
+
+    ReadClient * mpNext                 = nullptr;
+    InteractionModelEngine * mpImEngine = nullptr;
+
+    //
+    // This stores the params associated with the interaction in a specific set of cases:
+    //      1. Stores all parameters when used with subscriptions initiated using SendAutoResubscribeRequest.
+    //      2. Stores just the SessionHolder when used with any subscriptions.
+    //
+    ReadPrepareParams mReadPrepareParams;
+    uint32_t mNumRetries = 0;
+
+    System::Clock::Timeout mLivenessTimeoutOverride = System::Clock::kZero;
+
+    bool mIsPeerLIT = false;
+
+    // End Of Container (0x18) uses one byte.
+    static constexpr uint16_t kReservedSizeForEndOfContainer = 1;
+    // Reserved size for the uint8_t InteractionModelRevision flag, which takes up 1 byte for the control tag and 1 byte for the
+    // context tag, 1 byte for value
+    static constexpr uint16_t kReservedSizeForIMRevision = 1 + 1 + 1;
+    // Reserved buffer for TLV level overhead (the overhead for data version filter IBs EndOfContainer, IM reversion end
+    // of RequestMessage (another end of container)).
+    static constexpr uint16_t kReservedSizeForTLVEncodingOverhead =
+        kReservedSizeForEndOfContainer + kReservedSizeForIMRevision + kReservedSizeForEndOfContainer;
+
+#if CHIP_PROGRESS_LOGGING
+    // Tracks the time when a subscribe request is successfully sent.
+    // This timestamp allows for logging the duration taken to established the subscription.
+    System::Clock::Timestamp mSubscribeRequestTime = System::Clock::kZero;
+#endif
+};
+
+};     // namespace app
+};     // namespace chip
 #endif // CHIP_CONFIG_ENABLE_READ_CLIENT

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -47,12 +47,14 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds = 0;
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
-    // If Application knows the peer is LIT ICD, this can be set true. If application has subscribed
-    // ICDManagementCluster::OperatingMode, its operation mode can be set automatically, it is not required to set mIsPeerLIT.
+    // Indicates if the peer device is known to be a LIT ICD.
+    // This can be set by the application if it has prior knowledge of the peer's operating mode
+    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport are set, 
+    // and DynamicSitLitSupport is not set).
+    // Note: The peer's operating mode might also be pre-determined via the IcdManagementCluster::OperatingMode attribute.
     bool mIsPeerLIT                     = false;
 
-    // If Application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
-    // otherwise it should be false.
+    // If application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
     bool mRegisteredCheckInToken = false;
 
     ReadPrepareParams() {}

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -49,7 +49,7 @@ struct ReadPrepareParams
     bool mIsFabricFiltered              = true;
     // Indicates if the peer device is known to be a LIT ICD.
     // This can be set by the application if it has prior knowledge of the peer's operating mode
-    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport are set, 
+    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport are set,
     // and DynamicSitLitSupport is not set).
     // Note: The peer's operating mode might also be pre-determined via the IcdManagementCluster::OperatingMode attribute.
     bool mIsPeerLIT                     = false;

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -48,9 +48,11 @@ struct ReadPrepareParams
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
 
-    // Indicates if the peer device is known to be a LIT ICD. This can be set by the application if it has prior knowledge of the
+    // If set to true, indicates that the peer device is known to be a LIT ICD. This can be set by the application if it has prior knowledge of the
     // peer's operating mode (e.g. from previous reads of IcdManagementCluster::OperatingMode). This is useful for
-    // subscriptions that do not include the OperatingMode attribute. This field is ignored for read operations.
+    // subscriptions that do not include the OperatingMode attribute in the set of paths that are subscribed to.
+    //
+    // This field is ignored for read operations.
     bool mIsPeerLIT = false;
 
     // Set mRegisteredCheckInToken to true to indicate that the application has registered a check-in token

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -48,8 +48,8 @@ struct ReadPrepareParams
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
 
-    // If set to true, indicates that the peer device is known to be a LIT ICD. This can be set by the application if it has prior knowledge of the
-    // peer's operating mode (e.g. from previous reads of IcdManagementCluster::OperatingMode). This is useful for
+    // If set to true, indicates that the peer device is known to be a LIT ICD. This can be set by the application if it has prior
+    // knowledge of the peer's operating mode (e.g. from previous reads of IcdManagementCluster::OperatingMode). This is useful for
     // subscriptions that do not include the OperatingMode attribute in the set of paths that are subscribed to.
     //
     // This field is ignored for read operations.

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -48,6 +48,12 @@ struct ReadPrepareParams
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
     bool mIsPeerLIT                     = false;
+    // If Application knows the peer is LIT ICD, this can be set true. If application has subscribed
+    // ICDManagementCluster::OperatingMode, its operation mode can be set automatically, it is not required to set mIsPeerLIT.
+
+    bool mRegisteredCheckInToken = false;
+    // If Application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
+    // otherwise it should be false.
 
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
@@ -66,6 +72,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mRegisteredCheckInToken            = other.mRegisteredCheckInToken;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
@@ -91,6 +98,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mRegisteredCheckInToken            = other.mRegisteredCheckInToken;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -47,13 +47,13 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds = 0;
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
-    bool mIsPeerLIT                     = false;
     // If Application knows the peer is LIT ICD, this can be set true. If application has subscribed
     // ICDManagementCluster::OperatingMode, its operation mode can be set automatically, it is not required to set mIsPeerLIT.
+    bool mIsPeerLIT                     = false;
 
-    bool mRegisteredCheckInToken = false;
     // If Application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
     // otherwise it should be false.
+    bool mRegisteredCheckInToken = false;
 
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -47,14 +47,15 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds = 0;
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
-    // Indicates if the peer device is known to be a LIT ICD.
-    // This can be set by the application if it has prior knowledge of the peer's operating mode
-    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport
-    // are set, and DynamicSitLitSupport is not set). Note: The peer's operating mode might also be pre-determined via the
-    // IcdManagementCluster::OperatingMode attribute.
+
+    // Indicates if the peer device is known to be a LIT ICD. This can be set by the application if it has prior knowledge of the
+    // peer's operating mode (e.g. from previous reads of IcdManagementCluster::OperatingMode). This is useful for
+    // subscriptions that do not include the OperatingMode attribute. This field is ignored for read operations.
     bool mIsPeerLIT = false;
 
-    // If application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
+    // Set mRegisteredCheckInToken to true to indicate that the application has registered a check-in token
+    // with this peer, and therefore subscription drops can usefully wait for a check-in message before trying
+    // to resubscribe. This field is ignored for read operations.
     bool mRegisteredCheckInToken = false;
 
     ReadPrepareParams() {}

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -49,10 +49,10 @@ struct ReadPrepareParams
     bool mIsFabricFiltered              = true;
     // Indicates if the peer device is known to be a LIT ICD.
     // This can be set by the application if it has prior knowledge of the peer's operating mode
-    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport are set,
-    // and DynamicSitLitSupport is not set).
-    // Note: The peer's operating mode might also be pre-determined via the IcdManagementCluster::OperatingMode attribute.
-    bool mIsPeerLIT                     = false;
+    // (e.g., through previous reads of the IcdManagementCluster::FeatureMap and know CheckInProtocolSupport and LongIdleTimeSupport
+    // are set, and DynamicSitLitSupport is not set). Note: The peer's operating mode might also be pre-determined via the
+    // IcdManagementCluster::OperatingMode attribute.
+    bool mIsPeerLIT = false;
 
     // If application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
     bool mRegisteredCheckInToken = false;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1529,6 +1529,93 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
     EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
 }
 
+//
+// This validates the re-subscription logic within ReadClient that has register icd token with the LIT device. 
+// This achieves it by overriding the timeout for the liveness timer within ReadClient to be a smaller value than 
+// the nominal max interval of the subscription. This causes the subscription to fail on the client side, triggering 
+// re-subscription when device is operating as LIT and client has not registered its token in device.
+//
+TEST_F(TestRead, TestResubscribeAttributeTimeoutLITWithoutRegisteringToken)
+{
+    auto sessionHandle = GetSessionBobToAlice();
+
+    SetMRPMode(MessagingContext::MRPMode::kResponsive);
+
+    {
+        TestResubscriptionCallback callback;
+        ReadClient readClient(InteractionModelEngine::GetInstance(), &GetExchangeManager(), callback,
+                              ReadClient::InteractionType::Subscribe);
+
+        callback.SetReadClient(&readClient);
+
+        ReadPrepareParams readPrepareParams(GetSessionBobToAlice());
+
+        // Read full wildcard paths, repeat twice to ensure chunking.
+        AttributePathParams attributePathParams[1];
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = MATTER_ARRAY_SIZE(attributePathParams);
+        readPrepareParams.mIsPeerLIT = true;
+        readPrepareParams.mRegisteredCheckInToken = false;
+        attributePathParams[0].mEndpointId             = kTestEndpointId;
+        attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
+        attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;
+
+        constexpr uint16_t maxIntervalCeilingSeconds = 1;
+
+        readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
+
+        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        EXPECT_EQ(err, CHIP_NO_ERROR);
+
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount >= 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 0);
+
+        ReadHandler * readHandler = InteractionModelEngine::GetInstance()->ActiveHandlerAt(0);
+
+        uint16_t minInterval;
+        uint16_t maxInterval;
+        readHandler->GetReportingIntervals(minInterval, maxInterval);
+
+        //
+        // Disable packet transmission, and drive IO till we have reported a re-subscription attempt.
+        //
+        //
+        GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
+        GetIOContext().DriveIOUntil(ComputeSubscriptionTimeout(System::Clock::Seconds16(maxInterval)),
+                                    [&]() { return callback.mOnResubscriptionsAttempted > 0; });
+
+        EXPECT_EQ(callback.mOnResubscriptionsAttempted, 1);
+        EXPECT_EQ(callback.mLastError, CHIP_ERROR_TIMEOUT);
+
+        GetLoopback().mNumMessagesToDrop = 0;
+        callback.ClearCounters();
+
+        //
+        // Drive servicing IO till we have established a subscription.
+        //
+        GetIOContext().DriveIOUntil(System::Clock::Milliseconds32(2000),
+                                    [&]() { return callback.mOnSubscriptionEstablishedCount == 1; });
+        EXPECT_EQ(callback.mOnSubscriptionEstablishedCount, 1);
+
+        //
+        // With re-sub enabled, we shouldn't have encountered any errors
+        //
+        EXPECT_EQ(callback.mOnError, 0);
+        EXPECT_EQ(callback.mOnDone, 0);
+    }
+
+    SetMRPMode(MessagingContext::MRPMode::kDefault);
+
+    InteractionModelEngine::GetInstance()->ShutdownActiveReads();
+    EXPECT_EQ(GetExchangeManager().GetNumActiveExchanges(), 0u);
+}
+
 TEST_F(TestRead, TestShutdownAllSubscriptionHandlers)
 {
     auto sessionHandle = GetSessionBobToAlice();

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1554,8 +1554,8 @@ TEST_F(TestRead, TestResubscribeAttributeTimeoutLITWithoutRegisteringToken)
         AttributePathParams attributePathParams[1];
         readPrepareParams.mpAttributePathParamsList    = attributePathParams;
         readPrepareParams.mAttributePathParamsListSize = MATTER_ARRAY_SIZE(attributePathParams);
-        readPrepareParams.mIsPeerLIT = true;
-        readPrepareParams.mRegisteredCheckInToken = false;
+        readPrepareParams.mIsPeerLIT                   = true;
+        readPrepareParams.mRegisteredCheckInToken      = false;
         attributePathParams[0].mEndpointId             = kTestEndpointId;
         attributePathParams[0].mClusterId              = Clusters::UnitTesting::Id;
         attributePathParams[0].mAttributeId            = Clusters::UnitTesting::Attributes::Boolean::Id;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2374,7 +2374,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -2462,7 +2462,7 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -2533,7 +2533,7 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -2589,7 +2589,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -2659,7 +2659,7 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
@@ -2770,7 +2770,7 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
+        readPrepareParams.mRegisteredCheckInToken    = true;
         auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1530,7 +1530,7 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
 }
 
 //
-// This validates the re-subscription logic within ReadClient that has register icd token with the LIT device.
+// This validates the re-subscription logic within ReadClient that has registered an icd token with the LIT device.
 // This achieves it by overriding the timeout for the liveness timer within ReadClient to be a smaller value than
 // the nominal max interval of the subscription. This causes the subscription to fail on the client side, triggering
 // re-subscription when device is operating as LIT and client has not registered its token in device.

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2375,7 +2375,7 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2463,7 +2463,7 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2534,7 +2534,7 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2590,7 +2590,7 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
@@ -2660,7 +2660,7 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2771,7 +2771,7 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
         readPrepareParams.mRegisteredCheckInToken    = true;
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -1530,9 +1530,9 @@ TEST_F(TestRead, TestResubscribeAttributeTimeout)
 }
 
 //
-// This validates the re-subscription logic within ReadClient that has register icd token with the LIT device. 
-// This achieves it by overriding the timeout for the liveness timer within ReadClient to be a smaller value than 
-// the nominal max interval of the subscription. This causes the subscription to fail on the client side, triggering 
+// This validates the re-subscription logic within ReadClient that has register icd token with the LIT device.
+// This achieves it by overriding the timeout for the liveness timer within ReadClient to be a smaller value than
+// the nominal max interval of the subscription. This causes the subscription to fail on the client side, triggering
 // re-subscription when device is operating as LIT and client has not registered its token in device.
 //
 TEST_F(TestRead, TestResubscribeAttributeTimeoutLITWithoutRegisteringToken)


### PR DESCRIPTION
When ecosystem A has not yet been ready for LIT and device has been multi-admin by another controller ecosystem B with LIT,  re-subscription scheduler is put on hold in ecosystem A when liveness timeout happens, the expected behavior is to retry subscription.

Fix: Introduce a new parameter, mRegisteredCheckInToken in ReadPrepareParams, if Application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
otherwise it should be false. If peer operating mode is LIT and mRegisteredCheckInToken is false, subscription retry would continue once liveness timeout happens and not wait for check-in message since it cannot handle check-in.

#### Testing
update the tests.
