### PR TITLE
Simplify/fix handling of fabric-scoped command payloads.

### DIFF
--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/IMClusterCommandHandler.cpp
@@ -49,7 +49,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::SuppressAlarm::Id: {
             Commands::SuppressAlarm::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfBooleanStateConfigurationClusterSuppressAlarmCallback(apCommandObj, aCommandPath, commandData);
@@ -58,7 +58,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnableDisableAlarm::Id: {
             Commands::EnableDisableAlarm::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -100,7 +100,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::MoveToHue::Id: {
             Commands::MoveToHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToHueCallback(apCommandObj, aCommandPath, commandData);
@@ -109,7 +109,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveHue::Id: {
             Commands::MoveHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveHueCallback(apCommandObj, aCommandPath, commandData);
@@ -118,7 +118,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepHue::Id: {
             Commands::StepHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepHueCallback(apCommandObj, aCommandPath, commandData);
@@ -127,7 +127,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToSaturation::Id: {
             Commands::MoveToSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -136,7 +136,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveSaturation::Id: {
             Commands::MoveSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -145,7 +145,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepSaturation::Id: {
             Commands::StepSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -154,7 +154,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToHueAndSaturation::Id: {
             Commands::MoveToHueAndSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToHueAndSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -163,7 +163,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToColor::Id: {
             Commands::MoveToColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToColorCallback(apCommandObj, aCommandPath, commandData);
@@ -172,7 +172,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveColor::Id: {
             Commands::MoveColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveColorCallback(apCommandObj, aCommandPath, commandData);
@@ -181,7 +181,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepColor::Id: {
             Commands::StepColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepColorCallback(apCommandObj, aCommandPath, commandData);
@@ -190,7 +190,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToColorTemperature::Id: {
             Commands::MoveToColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -199,7 +199,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveToHue::Id: {
             Commands::EnhancedMoveToHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedMoveToHueCallback(apCommandObj, aCommandPath, commandData);
@@ -208,7 +208,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveHue::Id: {
             Commands::EnhancedMoveHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedMoveHueCallback(apCommandObj, aCommandPath, commandData);
@@ -217,7 +217,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedStepHue::Id: {
             Commands::EnhancedStepHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedStepHueCallback(apCommandObj, aCommandPath, commandData);
@@ -226,7 +226,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveToHueAndSaturation::Id: {
             Commands::EnhancedMoveToHueAndSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -236,7 +236,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::ColorLoopSet::Id: {
             Commands::ColorLoopSet::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterColorLoopSetCallback(apCommandObj, aCommandPath, commandData);
@@ -245,7 +245,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StopMoveStep::Id: {
             Commands::StopMoveStep::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStopMoveStepCallback(apCommandObj, aCommandPath, commandData);
@@ -254,7 +254,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveColorTemperature::Id: {
             Commands::MoveColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -263,7 +263,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepColorTemperature::Id: {
             Commands::StepColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -304,7 +304,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::RetrieveLogsRequest::Id: {
             Commands::RetrieveLogsRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -345,7 +345,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Reset::Id: {
             Commands::Reset::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfDishwasherAlarmClusterResetCallback(apCommandObj, aCommandPath, commandData);
@@ -354,7 +354,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::ModifyEnabledAlarms::Id: {
             Commands::ModifyEnabledAlarms::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfDishwasherAlarmClusterModifyEnabledAlarmsCallback(apCommandObj, aCommandPath, commandData);
@@ -395,7 +395,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::ResetCounts::Id: {
             Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);
@@ -436,7 +436,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Step::Id: {
             Commands::Step::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfFanControlClusterStepCallback(apCommandObj, aCommandPath, commandData);
@@ -477,7 +477,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::FailAtFault::Id: {
             Commands::FailAtFault::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfFaultInjectionClusterFailAtFaultCallback(apCommandObj, aCommandPath, commandData);
@@ -486,7 +486,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::FailRandomlyAtFault::Id: {
             Commands::FailRandomlyAtFault::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfFaultInjectionClusterFailRandomlyAtFaultCallback(apCommandObj, aCommandPath, commandData);
@@ -527,7 +527,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::KeySetWrite::Id: {
             Commands::KeySetWrite::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetWriteCallback(apCommandObj, aCommandPath, commandData);
@@ -536,7 +536,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetRead::Id: {
             Commands::KeySetRead::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetReadCallback(apCommandObj, aCommandPath, commandData);
@@ -545,7 +545,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetRemove::Id: {
             Commands::KeySetRemove::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetRemoveCallback(apCommandObj, aCommandPath, commandData);
@@ -554,7 +554,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetReadAllIndices::Id: {
             Commands::KeySetReadAllIndices::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetReadAllIndicesCallback(apCommandObj, aCommandPath, commandData);
@@ -595,7 +595,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AddGroup::Id: {
             Commands::AddGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterAddGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -604,7 +604,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::ViewGroup::Id: {
             Commands::ViewGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterViewGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -613,7 +613,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GetGroupMembership::Id: {
             Commands::GetGroupMembership::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterGetGroupMembershipCallback(apCommandObj, aCommandPath, commandData);
@@ -622,7 +622,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveGroup::Id: {
             Commands::RemoveGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterRemoveGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -631,7 +631,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveAllGroups::Id: {
             Commands::RemoveAllGroups::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterRemoveAllGroupsCallback(apCommandObj, aCommandPath, commandData);
@@ -640,7 +640,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddGroupIfIdentifying::Id: {
             Commands::AddGroupIfIdentifying::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(apCommandObj, aCommandPath, commandData);
@@ -681,7 +681,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Identify::Id: {
             Commands::Identify::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfIdentifyClusterIdentifyCallback(apCommandObj, aCommandPath, commandData);
@@ -690,7 +690,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TriggerEffect::Id: {
             Commands::TriggerEffect::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfIdentifyClusterTriggerEffectCallback(apCommandObj, aCommandPath, commandData);
@@ -731,7 +731,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::MoveToLevel::Id: {
             Commands::MoveToLevel::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveToLevelCallback(apCommandObj, aCommandPath, commandData);
@@ -740,7 +740,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Move::Id: {
             Commands::Move::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveCallback(apCommandObj, aCommandPath, commandData);
@@ -749,7 +749,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Step::Id: {
             Commands::Step::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStepCallback(apCommandObj, aCommandPath, commandData);
@@ -758,7 +758,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Stop::Id: {
             Commands::Stop::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStopCallback(apCommandObj, aCommandPath, commandData);
@@ -767,7 +767,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToLevelWithOnOff::Id: {
             Commands::MoveToLevelWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveToLevelWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -776,7 +776,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveWithOnOff::Id: {
             Commands::MoveWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -785,7 +785,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepWithOnOff::Id: {
             Commands::StepWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStepWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -794,7 +794,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StopWithOnOff::Id: {
             Commands::StopWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -835,7 +835,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Sleep::Id: {
             Commands::Sleep::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLowPowerClusterSleepCallback(apCommandObj, aCommandPath, commandData);
@@ -876,7 +876,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::ChangeToMode::Id: {
             Commands::ChangeToMode::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfModeSelectClusterChangeToModeCallback(apCommandObj, aCommandPath, commandData);
@@ -917,7 +917,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AnnounceOTAProvider::Id: {
             Commands::AnnounceOTAProvider::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -959,7 +959,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Off::Id: {
             Commands::Off::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOffCallback(apCommandObj, aCommandPath, commandData);
@@ -968,7 +968,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::On::Id: {
             Commands::On::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnCallback(apCommandObj, aCommandPath, commandData);
@@ -977,7 +977,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Toggle::Id: {
             Commands::Toggle::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterToggleCallback(apCommandObj, aCommandPath, commandData);
@@ -986,7 +986,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OffWithEffect::Id: {
             Commands::OffWithEffect::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOffWithEffectCallback(apCommandObj, aCommandPath, commandData);
@@ -995,7 +995,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OnWithRecallGlobalScene::Id: {
             Commands::OnWithRecallGlobalScene::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnWithRecallGlobalSceneCallback(apCommandObj, aCommandPath, commandData);
@@ -1004,7 +1004,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OnWithTimedOff::Id: {
             Commands::OnWithTimedOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnWithTimedOffCallback(apCommandObj, aCommandPath, commandData);
@@ -1045,7 +1045,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AttestationRequest::Id: {
             Commands::AttestationRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1055,7 +1055,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::CertificateChainRequest::Id: {
             Commands::CertificateChainRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1065,7 +1065,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::CSRRequest::Id: {
             Commands::CSRRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterCSRRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1074,7 +1074,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddNOC::Id: {
             Commands::AddNOC::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterAddNOCCallback(apCommandObj, aCommandPath, commandData);
@@ -1083,7 +1083,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::UpdateNOC::Id: {
             Commands::UpdateNOC::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterUpdateNOCCallback(apCommandObj, aCommandPath, commandData);
@@ -1092,7 +1092,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::UpdateFabricLabel::Id: {
             Commands::UpdateFabricLabel::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(apCommandObj, aCommandPath, commandData);
@@ -1101,7 +1101,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveFabric::Id: {
             Commands::RemoveFabric::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterRemoveFabricCallback(apCommandObj, aCommandPath, commandData);
@@ -1110,7 +1110,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddTrustedRootCertificate::Id: {
             Commands::AddTrustedRootCertificate::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1152,7 +1152,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::SelfTestRequest::Id: {
             Commands::SelfTestRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfSmokeCoAlarmClusterSelfTestRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1193,7 +1193,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::SetTemperature::Id: {
             Commands::SetTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTemperatureControlClusterSetTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -1234,7 +1234,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::SetpointRaiseLower::Id: {
             Commands::SetpointRaiseLower::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThermostatClusterSetpointRaiseLowerCallback(apCommandObj, aCommandPath, commandData);
@@ -1243,7 +1243,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetActiveScheduleRequest::Id: {
             Commands::SetActiveScheduleRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThermostatClusterSetActiveScheduleRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1252,7 +1252,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetActivePresetRequest::Id: {
             Commands::SetActivePresetRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThermostatClusterSetActivePresetRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1261,7 +1261,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AtomicRequest::Id: {
             Commands::AtomicRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThermostatClusterAtomicRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1302,7 +1302,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::ResetCounts::Id: {
             Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);
@@ -1343,7 +1343,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::SetUTCTime::Id: {
             Commands::SetUTCTime::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTimeSynchronizationClusterSetUTCTimeCallback(apCommandObj, aCommandPath, commandData);
@@ -1352,7 +1352,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetTrustedTimeSource::Id: {
             Commands::SetTrustedTimeSource::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTimeSynchronizationClusterSetTrustedTimeSourceCallback(apCommandObj, aCommandPath, commandData);
@@ -1361,7 +1361,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetTimeZone::Id: {
             Commands::SetTimeZone::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTimeSynchronizationClusterSetTimeZoneCallback(apCommandObj, aCommandPath, commandData);
@@ -1370,7 +1370,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetDSTOffset::Id: {
             Commands::SetDSTOffset::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTimeSynchronizationClusterSetDSTOffsetCallback(apCommandObj, aCommandPath, commandData);
@@ -1379,7 +1379,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SetDefaultNTP::Id: {
             Commands::SetDefaultNTP::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfTimeSynchronizationClusterSetDefaultNTPCallback(apCommandObj, aCommandPath, commandData);
@@ -1420,7 +1420,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Test::Id: {
             Commands::Test::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestCallback(apCommandObj, aCommandPath, commandData);
@@ -1429,7 +1429,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestNotHandled::Id: {
             Commands::TestNotHandled::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestNotHandledCallback(apCommandObj, aCommandPath, commandData);
@@ -1438,7 +1438,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestSpecific::Id: {
             Commands::TestSpecific::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestSpecificCallback(apCommandObj, aCommandPath, commandData);
@@ -1447,7 +1447,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestAddArguments::Id: {
             Commands::TestAddArguments::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestAddArgumentsCallback(apCommandObj, aCommandPath, commandData);
@@ -1456,7 +1456,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestStructArgumentRequest::Id: {
             Commands::TestStructArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestStructArgumentRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1465,7 +1465,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestNestedStructArgumentRequest::Id: {
             Commands::TestNestedStructArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1475,7 +1475,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestListStructArgumentRequest::Id: {
             Commands::TestListStructArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1485,7 +1485,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestListInt8UArgumentRequest::Id: {
             Commands::TestListInt8UArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestListInt8UArgumentRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1494,7 +1494,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestNestedStructListArgumentRequest::Id: {
             Commands::TestNestedStructListArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1504,7 +1504,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestListNestedStructListArgumentRequest::Id: {
             Commands::TestListNestedStructListArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestListNestedStructListArgumentRequestCallback(apCommandObj, aCommandPath,
@@ -1514,7 +1514,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestListInt8UReverseRequest::Id: {
             Commands::TestListInt8UReverseRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestListInt8UReverseRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1523,7 +1523,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestEnumsRequest::Id: {
             Commands::TestEnumsRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestEnumsRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1532,7 +1532,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestNullableOptionalRequest::Id: {
             Commands::TestNullableOptionalRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestNullableOptionalRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1541,7 +1541,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::SimpleStructEchoRequest::Id: {
             Commands::SimpleStructEchoRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterSimpleStructEchoRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1550,7 +1550,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TimedInvokeRequest::Id: {
             Commands::TimedInvokeRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTimedInvokeRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1559,7 +1559,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestSimpleOptionalArgumentRequest::Id: {
             Commands::TestSimpleOptionalArgumentRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1569,7 +1569,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestEmitTestEventRequest::Id: {
             Commands::TestEmitTestEventRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestEmitTestEventRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1578,7 +1578,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestEmitTestFabricScopedEventRequest::Id: {
             Commands::TestEmitTestFabricScopedEventRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1588,7 +1588,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestBatchHelperRequest::Id: {
             Commands::TestBatchHelperRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestBatchHelperRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1597,7 +1597,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestSecondBatchHelperRequest::Id: {
             Commands::TestSecondBatchHelperRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfUnitTestingClusterTestSecondBatchHelperRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -1606,7 +1606,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TestDifferentVendorMeiRequest::Id: {
             Commands::TestDifferentVendorMeiRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -1648,7 +1648,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Open::Id: {
             Commands::Open::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfValveConfigurationAndControlClusterOpenCallback(apCommandObj, aCommandPath, commandData);
@@ -1657,7 +1657,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Close::Id: {
             Commands::Close::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfValveConfigurationAndControlClusterCloseCallback(apCommandObj, aCommandPath, commandData);
@@ -1698,7 +1698,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::UpOrOpen::Id: {
             Commands::UpOrOpen::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterUpOrOpenCallback(apCommandObj, aCommandPath, commandData);
@@ -1707,7 +1707,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::DownOrClose::Id: {
             Commands::DownOrClose::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterDownOrCloseCallback(apCommandObj, aCommandPath, commandData);
@@ -1716,7 +1716,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StopMotion::Id: {
             Commands::StopMotion::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterStopMotionCallback(apCommandObj, aCommandPath, commandData);
@@ -1725,7 +1725,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GoToLiftValue::Id: {
             Commands::GoToLiftValue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterGoToLiftValueCallback(apCommandObj, aCommandPath, commandData);
@@ -1734,7 +1734,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GoToLiftPercentage::Id: {
             Commands::GoToLiftPercentage::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterGoToLiftPercentageCallback(apCommandObj, aCommandPath, commandData);
@@ -1743,7 +1743,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GoToTiltValue::Id: {
             Commands::GoToTiltValue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterGoToTiltValueCallback(apCommandObj, aCommandPath, commandData);
@@ -1752,7 +1752,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GoToTiltPercentage::Id: {
             Commands::GoToTiltPercentage::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfWindowCoveringClusterGoToTiltPercentageCallback(apCommandObj, aCommandPath, commandData);

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/IMClusterCommandHandler.cpp
@@ -49,7 +49,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::MoveToHue::Id: {
             Commands::MoveToHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToHueCallback(apCommandObj, aCommandPath, commandData);
@@ -58,7 +58,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveHue::Id: {
             Commands::MoveHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveHueCallback(apCommandObj, aCommandPath, commandData);
@@ -67,7 +67,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepHue::Id: {
             Commands::StepHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepHueCallback(apCommandObj, aCommandPath, commandData);
@@ -76,7 +76,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToSaturation::Id: {
             Commands::MoveToSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -85,7 +85,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveSaturation::Id: {
             Commands::MoveSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -94,7 +94,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepSaturation::Id: {
             Commands::StepSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -103,7 +103,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToHueAndSaturation::Id: {
             Commands::MoveToHueAndSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToHueAndSaturationCallback(apCommandObj, aCommandPath, commandData);
@@ -112,7 +112,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToColor::Id: {
             Commands::MoveToColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToColorCallback(apCommandObj, aCommandPath, commandData);
@@ -121,7 +121,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveColor::Id: {
             Commands::MoveColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveColorCallback(apCommandObj, aCommandPath, commandData);
@@ -130,7 +130,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepColor::Id: {
             Commands::StepColor::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepColorCallback(apCommandObj, aCommandPath, commandData);
@@ -139,7 +139,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToColorTemperature::Id: {
             Commands::MoveToColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveToColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -148,7 +148,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveToHue::Id: {
             Commands::EnhancedMoveToHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedMoveToHueCallback(apCommandObj, aCommandPath, commandData);
@@ -157,7 +157,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveHue::Id: {
             Commands::EnhancedMoveHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedMoveHueCallback(apCommandObj, aCommandPath, commandData);
@@ -166,7 +166,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedStepHue::Id: {
             Commands::EnhancedStepHue::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterEnhancedStepHueCallback(apCommandObj, aCommandPath, commandData);
@@ -175,7 +175,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::EnhancedMoveToHueAndSaturation::Id: {
             Commands::EnhancedMoveToHueAndSaturation::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -185,7 +185,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::ColorLoopSet::Id: {
             Commands::ColorLoopSet::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterColorLoopSetCallback(apCommandObj, aCommandPath, commandData);
@@ -194,7 +194,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StopMoveStep::Id: {
             Commands::StopMoveStep::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStopMoveStepCallback(apCommandObj, aCommandPath, commandData);
@@ -203,7 +203,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveColorTemperature::Id: {
             Commands::MoveColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterMoveColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -212,7 +212,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepColorTemperature::Id: {
             Commands::StepColorTemperature::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfColorControlClusterStepColorTemperatureCallback(apCommandObj, aCommandPath, commandData);
@@ -253,7 +253,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::RetrieveLogsRequest::Id: {
             Commands::RetrieveLogsRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -294,7 +294,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::ResetCounts::Id: {
             Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);
@@ -335,7 +335,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::KeySetWrite::Id: {
             Commands::KeySetWrite::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetWriteCallback(apCommandObj, aCommandPath, commandData);
@@ -344,7 +344,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetRead::Id: {
             Commands::KeySetRead::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetReadCallback(apCommandObj, aCommandPath, commandData);
@@ -353,7 +353,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetRemove::Id: {
             Commands::KeySetRemove::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetRemoveCallback(apCommandObj, aCommandPath, commandData);
@@ -362,7 +362,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::KeySetReadAllIndices::Id: {
             Commands::KeySetReadAllIndices::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupKeyManagementClusterKeySetReadAllIndicesCallback(apCommandObj, aCommandPath, commandData);
@@ -403,7 +403,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AddGroup::Id: {
             Commands::AddGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterAddGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -412,7 +412,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::ViewGroup::Id: {
             Commands::ViewGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterViewGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -421,7 +421,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::GetGroupMembership::Id: {
             Commands::GetGroupMembership::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterGetGroupMembershipCallback(apCommandObj, aCommandPath, commandData);
@@ -430,7 +430,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveGroup::Id: {
             Commands::RemoveGroup::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterRemoveGroupCallback(apCommandObj, aCommandPath, commandData);
@@ -439,7 +439,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveAllGroups::Id: {
             Commands::RemoveAllGroups::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterRemoveAllGroupsCallback(apCommandObj, aCommandPath, commandData);
@@ -448,7 +448,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddGroupIfIdentifying::Id: {
             Commands::AddGroupIfIdentifying::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfGroupsClusterAddGroupIfIdentifyingCallback(apCommandObj, aCommandPath, commandData);
@@ -489,7 +489,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Identify::Id: {
             Commands::Identify::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfIdentifyClusterIdentifyCallback(apCommandObj, aCommandPath, commandData);
@@ -498,7 +498,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::TriggerEffect::Id: {
             Commands::TriggerEffect::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfIdentifyClusterTriggerEffectCallback(apCommandObj, aCommandPath, commandData);
@@ -539,7 +539,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::MoveToLevel::Id: {
             Commands::MoveToLevel::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveToLevelCallback(apCommandObj, aCommandPath, commandData);
@@ -548,7 +548,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Move::Id: {
             Commands::Move::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveCallback(apCommandObj, aCommandPath, commandData);
@@ -557,7 +557,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Step::Id: {
             Commands::Step::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStepCallback(apCommandObj, aCommandPath, commandData);
@@ -566,7 +566,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Stop::Id: {
             Commands::Stop::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStopCallback(apCommandObj, aCommandPath, commandData);
@@ -575,7 +575,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveToLevelWithOnOff::Id: {
             Commands::MoveToLevelWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveToLevelWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -584,7 +584,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::MoveWithOnOff::Id: {
             Commands::MoveWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterMoveWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -593,7 +593,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StepWithOnOff::Id: {
             Commands::StepWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStepWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -602,7 +602,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::StopWithOnOff::Id: {
             Commands::StopWithOnOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfLevelControlClusterStopWithOnOffCallback(apCommandObj, aCommandPath, commandData);
@@ -643,7 +643,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AnnounceOTAProvider::Id: {
             Commands::AnnounceOTAProvider::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -685,7 +685,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::Off::Id: {
             Commands::Off::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOffCallback(apCommandObj, aCommandPath, commandData);
@@ -694,7 +694,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::On::Id: {
             Commands::On::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnCallback(apCommandObj, aCommandPath, commandData);
@@ -703,7 +703,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::Toggle::Id: {
             Commands::Toggle::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterToggleCallback(apCommandObj, aCommandPath, commandData);
@@ -712,7 +712,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OffWithEffect::Id: {
             Commands::OffWithEffect::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOffWithEffectCallback(apCommandObj, aCommandPath, commandData);
@@ -721,7 +721,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OnWithRecallGlobalScene::Id: {
             Commands::OnWithRecallGlobalScene::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnWithRecallGlobalSceneCallback(apCommandObj, aCommandPath, commandData);
@@ -730,7 +730,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::OnWithTimedOff::Id: {
             Commands::OnWithTimedOff::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOnOffClusterOnWithTimedOffCallback(apCommandObj, aCommandPath, commandData);
@@ -771,7 +771,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::AttestationRequest::Id: {
             Commands::AttestationRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -781,7 +781,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::CertificateChainRequest::Id: {
             Commands::CertificateChainRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -791,7 +791,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::CSRRequest::Id: {
             Commands::CSRRequest::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterCSRRequestCallback(apCommandObj, aCommandPath, commandData);
@@ -800,7 +800,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddNOC::Id: {
             Commands::AddNOC::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterAddNOCCallback(apCommandObj, aCommandPath, commandData);
@@ -809,7 +809,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::UpdateNOC::Id: {
             Commands::UpdateNOC::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterUpdateNOCCallback(apCommandObj, aCommandPath, commandData);
@@ -818,7 +818,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::UpdateFabricLabel::Id: {
             Commands::UpdateFabricLabel::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(apCommandObj, aCommandPath, commandData);
@@ -827,7 +827,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::RemoveFabric::Id: {
             Commands::RemoveFabric::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfOperationalCredentialsClusterRemoveFabricCallback(apCommandObj, aCommandPath, commandData);
@@ -836,7 +836,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         }
         case Commands::AddTrustedRootCertificate::Id: {
             Commands::AddTrustedRootCertificate::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled =
@@ -878,7 +878,7 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
         {
         case Commands::ResetCounts::Id: {
             Commands::ResetCounts::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            TLVError = DataModel::Decode(aDataTlv, commandData);
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAfThreadNetworkDiagnosticsClusterResetCountsCallback(apCommandObj, aCommandPath, commandData);

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -21,6 +21,7 @@
 #include <app/ConcreteCommandPath.h>
 #include <app/data-model/EncodableToTLV.h>
 #include <app/data-model/Encode.h>
+#include <app/data-model/FabricScoped.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/IntrusiveList.h>
@@ -262,7 +263,7 @@ public:
     template <typename CommandData>
     CHIP_ERROR AddResponseData(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        DataModel::EncodableType<CommandData> encoder(aData);
+        EncodableResponseCommandPayload<CommandData> encoder(aData);
         return AddResponseData(aRequestCommandPath, CommandData::GetCommandId(), encoder);
     }
 
@@ -286,11 +287,42 @@ public:
     template <typename CommandData>
     void AddResponse(const ConcreteCommandPath & aRequestCommandPath, const CommandData & aData)
     {
-        DataModel::EncodableType<CommandData> encodable(aData);
+        EncodableResponseCommandPayload<CommandData> encodable(aData);
         AddResponse(aRequestCommandPath, CommandData::GetCommandId(), encodable);
     }
 
 protected:
+    // Encoding a response command payload requires a fabric index, in general,
+    // because any fabric-scoped fields in the payload need it to deal with
+    // their fabric-sensitive fields.
+    template <typename CommandData>
+    class EncodableResponseCommandPayload : public DataModel::EncodableToTLV
+    {
+    public:
+        EncodableResponseCommandPayload(const CommandData & value) : mValue(value) {}
+
+        CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag, [[maybe_unused]] FabricIndex aAccessingFabricIndex) const final
+        {
+            if constexpr (DataModel::IsFabricScoped<CommandData>::value)
+            {
+                return mValue.Encode(writer, tag, aAccessingFabricIndex);
+            }
+            else
+            {
+                return mValue.Encode(writer, tag);
+            }
+        }
+
+        CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const final
+        {
+            // Not used, keep it as small as we can.
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+
+    private:
+        const CommandData & mValue;
+    };
+
     /**
      * IncrementHoldOff will increase the inner refcount of the CommandHandler.
      *

--- a/src/app/CommandHandlerImpl.cpp
+++ b/src/app/CommandHandlerImpl.cpp
@@ -135,16 +135,28 @@ CHIP_ERROR CommandHandlerImpl::TryAddResponseData(const ConcreteCommandPath & aR
 
     TLV::TLVWriter * writer = GetCommandDataIBTLVWriter();
     VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     auto context = GetExchangeContext();
+    // If we have no exchange or it has no session, we won't be able to send a
+    // response anyway, so it doesn't matter how we encode it, but we have unit
+    // tests that have a kinda-broken CommandHandler with no session... just use
+    // kUndefinedFabricIndex in those cases.
+    //
+    // Note that just calling GetAccessingFabricIndex() here is not OK, because
+    // we may have gone async already and our exchange/session may be gone, so
+    // that would crash.  Which is one of the reasons GetAccessingFabricIndex()
+    // is not allowed to be called once we have gone async.
+    FabricIndex accessingFabricIndex;
     if (context && context->HasSessionHandle())
     {
-        ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields),
-                                                 context->GetSessionHandle()->GetFabricIndex()));
+        accessingFabricIndex = context->GetSessionHandle()->GetFabricIndex();
     }
     else
     {
-        ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields)));
+        accessingFabricIndex = kUndefinedFabricIndex;
     }
+
+    ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields), accessingFabricIndex));
     return FinishCommand(/* aEndDataStruct = */ false);
 }
 

--- a/src/app/CommandHandlerInterface.h
+++ b/src/app/CommandHandlerInterface.h
@@ -254,8 +254,8 @@ protected:
             //
             handlerContext.SetCommandHandled();
 
-            if (DataModel::Decode(handlerContext.mPayload, requestPayload,
-                                  handlerContext.mCommandHandler.GetAccessingFabricIndex()) != CHIP_NO_ERROR)
+            if (requestPayload.Decode(handlerContext.mPayload, handlerContext.mCommandHandler.GetAccessingFabricIndex()) !=
+                CHIP_NO_ERROR)
             {
                 handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath,
                                                          Protocols::InteractionModel::Status::InvalidCommand);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -563,15 +563,7 @@ CHIP_ERROR CommandSender::AddRequestData(const CommandPathParams & aCommandPath,
     ReturnErrorOnFailure(PrepareCommand(aCommandPath, prepareCommandParams));
     TLV::TLVWriter * writer = GetCommandDataIBTLVWriter();
     VerifyOrReturnError(writer != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    if (mExchangeCtx.Get() && mExchangeCtx.Get()->HasSessionHandle())
-    {
-        ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields),
-                                                 mExchangeCtx.Get()->GetSessionHandle()->GetFabricIndex()));
-    }
-    else
-    {
-        ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields)));
-    }
+    ReturnErrorOnFailure(aEncodable.EncodeTo(*writer, TLV::ContextTag(CommandDataIB::Tag::kFields)));
     FinishCommandParameters finishCommandParams(aAddRequestDataParams);
     ReturnErrorOnFailure(FinishCommand(finishCommandParams));
     rollback.DisableAutomaticRollback();

--- a/src/app/data-model/Decode.h
+++ b/src/app/data-model/Decode.h
@@ -117,46 +117,6 @@ CHIP_ERROR Decode(TLV::TLVReader & reader, X & x)
 /*
  * @brief
  *
- * Overload for Decode(TLV::TLVReader & reader, X & x) matching structs which
- * are fabric-scoped, to allow for consistent usage at call-site
- *
- * CHIP_ERROR <Object>::Decode(TLVReader &reader);
- *
- */
-template <typename X,
-          typename std::enable_if_t<
-              std::is_class<X>::value &&
-                  std::is_same<decltype(std::declval<X>().Decode(std::declval<TLV::TLVReader &>())), CHIP_ERROR>::value,
-              X> * = nullptr>
-CHIP_ERROR Decode(TLV::TLVReader & reader, X & x, FabricIndex aAccessingFabricIndex)
-{
-    return x.Decode(reader);
-}
-
-/*
- * @brief
- *
- * This specific variant that decodes cluster objects which are fabric-scoped
- * (like structs, commands, events) from TLV depends on the presence of a Decode
- * method on X. The signature of that method is as follows:
- *
- * CHIP_ERROR <Object>::Decode(TLVReader &reader, FabricIndex aAccessingFabricIndex);
- *
- */
-template <typename X,
-          typename std::enable_if_t<
-              std::is_class<X>::value &&
-                  std::is_same<decltype(std::declval<X>().Decode(std::declval<TLV::TLVReader &>(), std::declval<FabricIndex>())),
-                               CHIP_ERROR>::value,
-              X> * = nullptr>
-CHIP_ERROR Decode(TLV::TLVReader & reader, X & x, FabricIndex aAccessingFabricIndex)
-{
-    return x.Decode(reader, aAccessingFabricIndex);
-}
-
-/*
- * @brief
- *
  * This specific variant decodes from TLV a cluster object that contains all attributes encapsulated within a single, monolithic
  * cluster object.
  *

--- a/src/app/data-model/EncodableToTLV.h
+++ b/src/app/data-model/EncodableToTLV.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <app/data-model/Encode.h>
+#include <app/data-model/FabricScoped.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/TLV.h>
 
@@ -32,8 +33,13 @@ class EncodableToTLV
 public:
     virtual ~EncodableToTLV() = default;
 
-    virtual CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex aAccessingFabricIndex) const = 0;
-    virtual CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const                                    = 0;
+    virtual CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex aAccessingFabricIndex) const
+    {
+        // By default, just ignore the fabric index.  Implementations that care
+        // about it should override as needed.
+        return EncodeTo(writer, tag);
+    }
+    virtual CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const = 0;
 };
 
 /// An `EncodableToTLV` that uses `DataModel::Encode` to encode things in one call.
@@ -51,11 +57,6 @@ public:
     /// LIFETIME NOTE: uses a reference to value, so value must live longer than
     ///                this object.
     EncodableType(const T & value) : mValue(value) {}
-
-    CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex aAccessingFabricIndex) const override
-    {
-        return DataModel::EncodeForRead(writer, tag, aAccessingFabricIndex, mValue);
-    }
 
     CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const override { return DataModel::Encode(writer, tag, mValue); }
 

--- a/src/app/data-model/Encode.h
+++ b/src/app/data-model/Encode.h
@@ -137,22 +137,6 @@ CHIP_ERROR EncodeForWrite(TLV::TLVWriter & writer, TLV::Tag tag, const X & x)
 /*
  * @brief
  *
- * A way to encode fabric-scoped structs for a write that omits encoding the containing fabric index field.
- */
-template <typename X,
-          typename std::enable_if_t<std::is_class<X>::value &&
-                                        std::is_same<decltype(std::declval<X>().EncodeForWrite(std::declval<TLV::TLVWriter &>(),
-                                                                                               std::declval<TLV::Tag>())),
-                                                     CHIP_ERROR>::value,
-                                    X> * = nullptr>
-CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const X & x)
-{
-    return x.EncodeForWrite(writer, tag);
-}
-
-/*
- * @brief
- *
  * A way to encode fabric-scoped structs for a read that always encodes the containing fabric index field.
  *
  * An accessing fabric index must be passed in to permit including/omitting sensitive fields based on a match with the fabric index
@@ -169,28 +153,6 @@ template <typename X,
 CHIP_ERROR EncodeForRead(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex accessingFabricIndex, const X & x)
 {
     return x.EncodeForRead(writer, tag, accessingFabricIndex);
-}
-
-/*
- * @brief
- *
- * This specific variant that encodes cluster objects (like non fabric-scoped structs, commands, events) to TLV
- * depends on the presence of an Encode method on the object. The signature of that method
- * is as follows:
- *
- * CHIP_ERROR <Object>::Encode(TLVWriter &writer, TLV::Tag tag) const;
- *
- *
- */
-template <typename X,
-          typename std::enable_if_t<
-              std::is_class<X>::value &&
-                  std::is_same<decltype(std::declval<X>().Encode(std::declval<TLV::TLVWriter &>(), std::declval<TLV::Tag>())),
-                               CHIP_ERROR>::value,
-              X> * = nullptr>
-CHIP_ERROR EncodeForRead(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex accessingFabricIndex, const X & x)
-{
-    return x.Encode(writer, tag);
 }
 
 /*

--- a/src/app/data-model/WrappedStructEncoder.h
+++ b/src/app/data-model/WrappedStructEncoder.h
@@ -42,19 +42,18 @@ public:
         mLastError = DataModel::Encode(mWriter, TLV::ContextTag(contextTag), std::forward<Args>(args)...);
     }
 
-    template <typename... Args>
-    void EncodeForWrite(uint8_t contextTag, Args &&... args)
+    template <typename T>
+    void EncodeRequestCommandFabricScopedStructField(uint8_t contextTag, const T & field)
     {
         VerifyOrReturn(mLastError == CHIP_NO_ERROR);
-        mLastError = DataModel::EncodeForWrite(mWriter, TLV::ContextTag(contextTag), std::forward<Args>(args)...);
+        mLastError = DataModel::EncodeForWrite(mWriter, TLV::ContextTag(contextTag), field);
     }
 
-    template <typename... Args>
-    void EncodeForRead(uint8_t contextTag, FabricIndex accessingFabricIndex, Args &&... args)
+    template <typename T>
+    void EncodeResponseCommandFabricScopedStructField(uint8_t contextTag, const uint8_t accessingFabricIndex, const T & field)
     {
         VerifyOrReturn(mLastError == CHIP_NO_ERROR);
-        mLastError =
-            DataModel::EncodeForRead(mWriter, TLV::ContextTag(contextTag), accessingFabricIndex, std::forward<Args>(args)...);
+        mLastError = DataModel::EncodeForRead(mWriter, TLV::ContextTag(contextTag), accessingFabricIndex, field);
     }
 
     CHIP_ERROR Finalize();

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -88,11 +88,6 @@ const app::CommandSender::TestOnlyMarker kCommandSenderTestOnlyMarker;
 class SimpleTLVPayload : public app::DataModel::EncodableToTLV
 {
 public:
-    CHIP_ERROR EncodeTo(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const override
-    {
-        return EncodeTo(aWriter, aTag);
-    }
-
     CHIP_ERROR EncodeTo(TLV::TLVWriter & aWriter, TLV::Tag aTag) const override
     {
         TLV::TLVType outerType;
@@ -155,11 +150,6 @@ public:
 
     // No significance with using 0x12 as the CommandId, just using a value.
     static constexpr chip::CommandId GetCommandId() { return 0x12; }
-
-    CHIP_ERROR EncodeTo(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const override
-    {
-        return EncodeTo(aWriter, aTag);
-    }
 
     CHIP_ERROR EncodeTo(TLV::TLVWriter & aWriter, TLV::Tag aTag) const override
     {

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -56,11 +56,6 @@ namespace {
 class TestTLVDataEncoder : public DataModel::EncodableToTLV
 {
 public:
-    CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag, FabricIndex aAccessingFabricIndex) const override
-    {
-        return EncodeTo(writer, tag);
-    }
-
     CHIP_ERROR EncodeTo(TLV::TLVWriter & writer, TLV::Tag tag) const override
     {
         TLV::TLVType outerType;

--- a/src/app/zap-templates/templates/app/clusters-Commands.h.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Commands.h.zapt
@@ -68,8 +68,7 @@ public:
 
     {{#if isFabricScoped~}}
     {{#if (isServer source)}}
-    CHIP_ERROR EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
-    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
     {{else}}
     CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
     {{/if}}

--- a/src/app/zap-templates/templates/app/clusters-Commands.ipp.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Commands.ipp.zapt
@@ -17,36 +17,22 @@ namespace {{asUpperCamelCase name}} {
 
 {{#if isFabricScoped~}}
 {{#if (isServer source)}}
-CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const {
+{{else}}
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const {
+{{/if}}
+{{else}}
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const {
+{{/if}}
     DataModel::WrappedStructEncoder encoder{aWriter, aTag};
     {{#zcl_command_arguments~}}
 
-    {{~#if_is_fabric_scoped_struct type~}}
-    encoder.EncodeForRead(to_underlying(Fields::k{{asUpperCamelCase label}}), aAccessingFabricIndex, {{asLowerCamelCase label}});
+    {{~#if_is_fabric_scoped_struct type cluster=../../name~}}
+    {{#if (isClient parent.source)}}
+    encoder.EncodeRequestCommandFabricScopedStructField(to_underlying(Fields::k{{asUpperCamelCase label}}), {{asLowerCamelCase label}});
     {{else}}
-    encoder.Encode(to_underlying(Fields::k{{asUpperCamelCase label}}), {{asLowerCamelCase label}});
-    {{/if_is_fabric_scoped_struct}}
-
-    {{~/zcl_command_arguments}}
-    return encoder.Finalize();
-}
-{{/if}}
-{{/if}}
-
-{{#if isFabricScoped~}}
-{{#if (isServer source)}}
-CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const {
-{{else}}
-CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const {
-{{/if}}
-{{else}}
-CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const {
-{{/if}}
-    DataModel::WrappedStructEncoder encoder{aWriter, aTag};
-    {{#zcl_command_arguments~}}
-
-    {{~#if_is_fabric_scoped_struct type~}}
-    encoder.EncodeForWrite(to_underlying(Fields::k{{asUpperCamelCase label}}), {{asLowerCamelCase label}});
+    encoder.EncodeResponseCommandFabricScopedStructField(to_underlying(Fields::k{{asUpperCamelCase label}}), aAccessingFabricIndex, {{asLowerCamelCase label}});
+    {{/if}}
     {{else}}
     encoder.Encode(to_underlying(Fields::k{{asUpperCamelCase label}}), {{asLowerCamelCase label}});
     {{/if_is_fabric_scoped_struct}}
@@ -80,7 +66,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader &reader) {
         {
             err = DataModel::Decode(reader, {{asLowerCamelCase label}});
 
-            {{~#if_is_fabric_scoped_struct type~}}
+            {{~#if_is_fabric_scoped_struct type cluster=../../name~}}
             {{#if (isClient parent.source)}}
             if (err == CHIP_NO_ERROR)
             {

--- a/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
+++ b/src/app/zap-templates/templates/app/im-cluster-command-handler.zapt
@@ -37,7 +37,11 @@ Protocols::InteractionModel::Status DispatchServerCommand(CommandHandler * apCom
     {{/first}}
         case Commands::{{asUpperCamelCase commandName}}::Id: {
             Commands::{{asUpperCamelCase commandName}}::DecodableType commandData;
-            TLVError = DataModel::Decode(aDataTlv, commandData, apCommandObj->GetAccessingFabricIndex());
+            {{#if isFabricScoped}}
+            TLVError = commandData.Decode(aDataTlv, apCommandObj->GetAccessingFabricIndex());
+            {{else}}
+            TLVError = DataModel::Decode(aDataTlv, commandData);
+            {{/if}}
             if (TLVError == CHIP_NO_ERROR)
             {
                 wasHandled = emberAf{{asUpperCamelCase parent.clusterName}}Cluster{{asUpperCamelCase commandName}}Callback(apCommandObj, aCommandPath, commandData);

--- a/zzz_generated/app-common/clusters/AccountLogin/Commands.h
+++ b/zzz_generated/app-common/clusters/AccountLogin/Commands.h
@@ -120,8 +120,7 @@ public:
 
     chip::CharSpan setupPIN;
 
-    CHIP_ERROR EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
-    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
 
     using ResponseType = DataModel::NullObjectType;
 

--- a/zzz_generated/app-common/clusters/AccountLogin/Commands.ipp
+++ b/zzz_generated/app-common/clusters/AccountLogin/Commands.ipp
@@ -59,14 +59,7 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
 } // namespace GetSetupPIN.
 namespace GetSetupPINResponse {
 
-CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
-{
-    DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
-    encoder.Encode(to_underlying(Fields::kSetupPIN), setupPIN);
-    return encoder.Finalize();
-}
-
-CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
 {
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
     encoder.Encode(to_underlying(Fields::kSetupPIN), setupPIN);

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.h
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.h
@@ -248,8 +248,7 @@ public:
 
     DataModel::List<const Structs::TLSCertStruct::Type> certificateDetails;
 
-    CHIP_ERROR EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
-    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
 
     using ResponseType = DataModel::NullObjectType;
 
@@ -538,8 +537,7 @@ public:
 
     DataModel::List<const Structs::TLSClientCertificateDetailStruct::Type> certificateDetails;
 
-    CHIP_ERROR EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
-    CHIP_ERROR EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const;
+    CHIP_ERROR Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const;
 
     using ResponseType = DataModel::NullObjectType;
 

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.ipp
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Commands.ipp
@@ -120,17 +120,11 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
 } // namespace FindRootCertificate.
 namespace FindRootCertificateResponse {
 
-CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
 {
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
-    encoder.EncodeForRead(to_underlying(Fields::kCertificateDetails), aAccessingFabricIndex, certificateDetails);
-    return encoder.Finalize();
-}
-
-CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
-{
-    DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
-    encoder.EncodeForWrite(to_underlying(Fields::kCertificateDetails), certificateDetails);
+    encoder.EncodeResponseCommandFabricScopedStructField(to_underlying(Fields::kCertificateDetails), aAccessingFabricIndex,
+                                                         certificateDetails);
     return encoder.Finalize();
 }
 
@@ -309,7 +303,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
 {
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
     encoder.Encode(to_underlying(Fields::kCcdid), ccdid);
-    encoder.EncodeForWrite(to_underlying(Fields::kClientCertificateDetails), clientCertificateDetails);
+    encoder.EncodeRequestCommandFabricScopedStructField(to_underlying(Fields::kClientCertificateDetails), clientCertificateDetails);
     return encoder.Finalize();
 }
 
@@ -370,17 +364,11 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader, FabricIndex aAccessing
 } // namespace FindClientCertificate.
 namespace FindClientCertificateResponse {
 
-CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
+CHIP_ERROR Type::Encode(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIndex aAccessingFabricIndex) const
 {
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
-    encoder.EncodeForRead(to_underlying(Fields::kCertificateDetails), aAccessingFabricIndex, certificateDetails);
-    return encoder.Finalize();
-}
-
-CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter & aWriter, TLV::Tag aTag) const
-{
-    DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
-    encoder.EncodeForWrite(to_underlying(Fields::kCertificateDetails), certificateDetails);
+    encoder.EncodeResponseCommandFabricScopedStructField(to_underlying(Fields::kCertificateDetails), aAccessingFabricIndex,
+                                                         certificateDetails);
     return encoder.Finalize();
 }
 


### PR DESCRIPTION
* Remove DataModel::Encode/Decode overloads that were slight footguns.
* Fix CommandSender::AddRequestData to not look like it has a usable fabric index.  It doesn't.
* Fix WrappedStructEncoder be explicit about what it's encoding when dealing with fabric-scoped struct fields of commands.
* Fix command payload codegen to just have Encode() methods, including for response commands, but take a FabricIndex argument for response commands that is then used for encoding the fabric-scoped structs appropriately (i.e. skipping fabric-sensitive fields as needed).
* Fix a few new uses of if_is_fabric_scoped_struct to pass in the cluster name.
* Make TestCommandInteraction.cpp not executable again, since it doesn't need to be.

#### Testing

Existing unit tests continue to work.