### PR TITLE
[Darwin] Add RegisterSignalHandler/UnregisterSignalHandler/Unregister…

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -34,6 +34,7 @@
 
 #include <atomic>
 #include <dispatch/dispatch.h>
+#include <map>
 
 namespace chip {
 namespace DeviceLayer {
@@ -62,6 +63,10 @@ public:
 
     CHIP_ERROR StartBleScan(BleScannerDelegate * delegate, BleScanMode mode = BleScanMode::kDefault);
     CHIP_ERROR StopBleScan();
+
+    bool RegisterSignalHandler(int sig, dispatch_block_t block);
+    bool UnregisterSignalHandler(int sig);
+    void UnregisterAllSignalHandlers();
 
     System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
@@ -110,6 +115,9 @@ private:
 
     // Semaphore used to implement blocking behavior in _RunEventLoop.
     dispatch_semaphore_t mRunLoopSem = nullptr;
+
+    dispatch_queue_t mSignalQueue = nullptr;
+    std::map<int, dispatch_source_t> mSignalSources;
 };
 
 /**

--- a/src/platform/Darwin/PlatformManagerImpl.mm
+++ b/src/platform/Darwin/PlatformManagerImpl.mm
@@ -46,6 +46,7 @@
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <lib/support/SafeInt.h>
 #include <tracing/metric_event.h>
 
 using namespace chip::Tracing::DarwinPlatform;
@@ -59,6 +60,7 @@ namespace DeviceLayer {
         : mWorkQueue(dispatch_queue_create("org.csa-iot.matter.workqueue",
             dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
                 QOS_CLASS_USER_INITIATED, QOS_MIN_RELATIVE_PRIORITY)))
+        , mSignalQueue(dispatch_queue_create("org.csa-iot.matter.signalqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL))
     {
         // Tag our queue for IsWorkQueueCurrentQueue()
         dispatch_queue_set_specific(mWorkQueue, this, this, nullptr);
@@ -176,6 +178,47 @@ namespace DeviceLayer {
 #else
         return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CONFIG_NETWORK_LAYER_BLE
+    }
+
+    bool PlatformManagerImpl::RegisterSignalHandler(int sig, dispatch_block_t block)
+    {
+        VerifyOrReturnValue(CanCastTo<uintptr_t>(sig), false);
+        VerifyOrReturnValue(mSignalSources.find(sig) == mSignalSources.end(), false); // Already registered
+
+        signal(sig, SIG_IGN); // Ignore signal so GCD can catch it.
+
+        __auto_type source = dispatch_source_create(DISPATCH_SOURCE_TYPE_SIGNAL, static_cast<uintptr_t>(sig), 0, mSignalQueue);
+        dispatch_source_set_event_handler(source, ^{
+            dispatch_async(mWorkQueue, block);
+        });
+
+        mSignalSources[sig] = source;
+        dispatch_resume(source);
+
+        return true;
+    }
+
+    bool PlatformManagerImpl::UnregisterSignalHandler(int sig)
+    {
+        VerifyOrReturnValue(CanCastTo<uintptr_t>(sig), false);
+
+        __auto_type it = mSignalSources.find(sig);
+        VerifyOrReturnValue(it != mSignalSources.end(), false); // Not registered
+
+        dispatch_source_cancel(it->second);
+        mSignalSources.erase(it);
+        signal(sig, SIG_DFL);
+
+        return true;
+    }
+
+    void PlatformManagerImpl::UnregisterAllSignalHandlers()
+    {
+        for (auto & [sig, source] : mSignalSources) {
+            dispatch_source_cancel(source);
+            signal(sig, SIG_DFL);
+        }
+        mSignalSources.clear();
     }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
…AllSignalHandlers to src/platform/Darwin/PlatformManagerImpl.h/.mm

#### Description

This PR adds signal handling support to the Darwin PlatformManagerImpl, including:
	- RegisterSignalHandler(int sig, dispatch_block_t block): Registers a dispatch-based handler for a given signal.
	- UnregisterSignalHandler(int sig): Removes a previously registered handler for a specific signal.
	- UnregisterAllSignalHandlers(): Removes all registered signal handlers.

#### Testing

Manually verified that signal handlers registered via RegisterSignalHandler execute as expected when triggered, and are properly cleaned up via UnregisterSignalHandler and UnregisterAllSignalHandlers.