### PR TITLE
Move NXP zephyr build to docker image 129

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -219,7 +219,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:132
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:129
 
         steps:
             - name: Checkout


### PR DESCRIPTION
Otherwise builds seem to fail with:

```
: <choice NXP_ENET_DRIVER> (defined at /__w/connectedhomeip/connectedhomeip/examples/laundry-washer-app/nxp/zephyr/../../../../config/nxp/chip-module/Kconfig.defaults:347) defined with type unknown
```

#### Testing

Partial rollback of #39030 only. CI can validate, however generally seems like a reasonably safe change.