### PR TITLE
Fix ServerInit triggering ember workflow, false positive

### DIFF
--- a/src/controller/python/chip/server/ServerInit.cpp
+++ b/src/controller/python/chip/server/ServerInit.cpp
@@ -182,7 +182,6 @@ PyChipError pychip_server_native_init()
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
 {
-    // ChipLogProgress(NotSpecified, "emberAfPostAttributeChangeCallback()");
     if (gPythonServerDelegate.mPostAttributeChangeCallback != nullptr)
     {
         // ChipLogProgress(NotSpecified, "callback %p", gPythonServerDelegate.mPostAttributeChangeCallback);


### PR DESCRIPTION
Fixes #39088 

#### Testing

When running the lint workflow, it doesn't trigger the lint workflow from this place anymore.
