### PR TITLE
Define new JF server variables for JF Admins only

### DIFF
--- a/examples/jf-admin-app/linux/args.gni
+++ b/examples/jf-admin-app/linux/args.gni
@@ -34,3 +34,5 @@ chip_enable_additional_data_advertising = true
 chip_enable_rotating_device_id = true
 
 chip_enable_read_client = false
+
+chip_device_config_enable_joint_fabric = true

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -168,6 +168,10 @@ if (chip_build_tests) {
       output_name = "libCHIP_tests"
       output_dir = "${root_out_dir}/lib"
     }
+
+    if (chip_device_config_enable_joint_fabric) {
+      tests += [ "${chip_root}/src/app/server/tests" ]
+    }
   }
 
   chip_test_group("example_tests") {

--- a/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
+++ b/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
@@ -27,6 +27,9 @@
 #include <app/reporting/reporting.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <platform/CHIPDeviceConfig.h>
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
 using namespace chip;
 using namespace chip::app;
@@ -459,3 +462,5 @@ void MatterJointFabricDatastorePluginServerInitCallback()
 
     Server::GetInstance().GetJointFabricDatastore().AddListener(gJointFabricDatastoreAttrAccess);
 }
+
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/src/access/access.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/app/icd/icd.gni")
+import("${chip_root}/src/platform/device.gni")
 
 config("server_config") {
   defines = []
@@ -41,6 +42,18 @@ source_set("terms_and_conditions") {
   ]
 }
 
+source_set("joint_fabric_datastore") {
+  sources = [
+    "JointFabricDatastore.cpp",
+    "JointFabricDatastore.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/lib/core",
+    "${chip_root}/zzz_generated/app-common/clusters/JointFabricDatastore",
+  ]
+}
+
 static_library("server") {
   output_name = "libCHIPAppServer"
 
@@ -57,8 +70,6 @@ static_library("server") {
     "Dnssd.h",
     "EchoHandler.cpp",
     "EchoHandler.h",
-    "JointFabricDatastore.cpp",
-    "JointFabricDatastore.h",
     "Server.cpp",
     "Server.h",
   ]
@@ -86,6 +97,10 @@ static_library("server") {
 
   if (chip_terms_and_conditions_required) {
     public_deps += [ ":terms_and_conditions" ]
+  }
+
+  if (chip_device_config_enable_joint_fabric) {
+    public_deps += [ ":joint_fabric_datastore" ]
   }
 
   # TODO: Server.cpp uses TestGroupData.h. Unsure why test code would be in such a central place

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -33,7 +33,6 @@
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/DefaultAclStorage.h>
-#include <app/server/JointFabricDatastore.h>
 #include <credentials/CertificateValidityPolicy.h>
 #include <credentials/FabricTable.h>
 #include <credentials/GroupDataProvider.h>
@@ -81,6 +80,10 @@
 #include <app/icd/server/ICDCheckInBackOffStrategy.h>        // nogncheck
 #endif                                                       // CHIP_CONFIG_ENABLE_ICD_CIP
 #endif                                                       // CHIP_CONFIG_ENABLE_ICD_SERVER
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+#include <app/server/JointFabricDatastore.h> //nogncheck
+#endif                                       // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
 namespace chip {
 
@@ -419,7 +422,9 @@ public:
 
     app::reporting::ReportScheduler * GetReportScheduler() { return mReportScheduler; }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     app::JointFabricDatastore & GetJointFabricDatastore() { return mJointFabricDatastore; }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     app::ICDManager & GetICDManager() { return mICDManager; }
@@ -700,7 +705,9 @@ private:
     Access::AccessControl mAccessControl;
     app::AclStorage * mAclStorage;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
     app::JointFabricDatastore mJointFabricDatastore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     TestEventTriggerDelegate * mTestEventTriggerDelegate;
     Crypto::OperationalKeystore * mOperationalKeystore;

--- a/src/app/server/tests/BUILD.gn
+++ b/src/app/server/tests/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "jointFabricDatastoreTests"
+
+  test_sources = [ "TestJointFabricDatastore.cpp" ]
+
+  public_deps = [
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/app/server:joint_fabric_datastore",
+    "${chip_root}/src/lib/core",
+    "${chip_root}/src/lib/support:testing",
+  ]
+}

--- a/src/app/server/tests/TestJointFabricDatastore.cpp
+++ b/src/app/server/tests/TestJointFabricDatastore.cpp
@@ -1,0 +1,45 @@
+#include "app/server/JointFabricDatastore.h"
+#include <pw_unit_test/framework.h>
+
+using namespace chip;
+using namespace chip::app;
+
+namespace {
+
+class DummyListener : public JointFabricDatastore::Listener
+{
+public:
+    void MarkNodeListChanged() override { mNotified = true; }
+    void Reset() { mNotified = false; }
+
+    bool mNotified = false;
+};
+
+TEST(JointFabricDatastoreTest, AddPendingNodeNotifiesListener)
+{
+    JointFabricDatastore store;
+    DummyListener listener;
+
+    store.AddListener(listener);
+
+    // Add a pending node — should notify the listener via MarkNodeListChange
+    store.AddPendingNode(123, CharSpan::fromCharString("controller-a"));
+
+    EXPECT_TRUE(listener.mNotified);
+}
+
+TEST(JointFabricDatastoreTest, RemoveListenerPreventsNotification)
+{
+    JointFabricDatastore store;
+    DummyListener listener;
+
+    store.AddListener(listener);
+    store.RemoveListener(listener);
+    listener.Reset();
+
+    store.AddPendingNode(456, CharSpan::fromCharString("controller-b"));
+
+    EXPECT_FALSE(listener.mNotified);
+}
+
+} // namespace


### PR DESCRIPTION
The new server variables introduced in PR https://github.com/project-chip/connectedhomeip/pull/38842 are only needed for JF admins and should not be exposed to all devices.

Addresses https://github.com/project-chip/connectedhomeip/issues/39093

#### Testing
Verify if the server variables are available only if for JF Admins

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/app/server/tests:tests_run
```
