### PR TITLE
Update time when it's wildly incorrect

### DIFF
--- a/examples/all-clusters-app/linux/AppOptions.cpp
+++ b/examples/all-clusters-app/linux/AppOptions.cpp
@@ -18,25 +18,89 @@
 
 #include "AppOptions.h"
 
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <system/SystemClock.h>
 
 #include <string>
 
 using namespace chip::ArgParser;
+using namespace chip::System;
+using namespace chip::app::Clusters::TimeSynchronization::Attributes;
 
 using chip::ArgParser::OptionDef;
 using chip::ArgParser::OptionSet;
 using chip::ArgParser::PrintArgError;
+using chip::System::Clock::ClockBase;
+using chip::System::Clock::Microseconds64;
+using chip::System::Clock::Milliseconds64;
 
 constexpr uint16_t kOptionMinCommissioningTimeout    = 0xFF02;
 constexpr uint16_t kOptionEndUserSupportFilePath     = 0xFF03;
 constexpr uint16_t kOptionNetworkDiagnosticsFilePath = 0xFF04;
 constexpr uint16_t kOptionCrashFilePath              = 0xFF05;
+constexpr uint16_t kOptionUseMockClock               = 0xFF06;
+
+namespace {
+struct MockClock : public ClockBase
+{
+private:
+    using Offset = std::chrono::duration<int64_t, std::micro>;
+
+    static CHIP_ERROR GetOffsetFrom(ClockBase & aRealClock, const Microseconds64 & aOverride, Offset & aOffset)
+    {
+        Microseconds64 curTime;
+        auto err = aRealClock.GetClock_RealTime(curTime);
+        if (err == CHIP_NO_ERROR)
+        {
+            aOffset = curTime - aOverride;
+        }
+        else
+        {
+            aOffset = Clock::kZero;
+        }
+        return err;
+    }
+
+public:
+    MockClock() : mRealClock(SystemClock()) { Clock::Internal::SetSystemClockForTesting(this); }
+    ~MockClock() { Clock::Internal::SetSystemClockForTesting(&mRealClock); }
+
+    void SetUTCTime(Microseconds64 aOverride) { GetOffsetFrom(mRealClock, aOverride, mOffset); }
+
+    Microseconds64 GetMonotonicMicroseconds64() override { return mRealClock.GetMonotonicMicroseconds64(); }
+    Milliseconds64 GetMonotonicMilliseconds64() override { return mRealClock.GetMonotonicMilliseconds64(); }
+
+    CHIP_ERROR GetClock_RealTime(Microseconds64 & aCurTime) override
+    {
+        auto err = mRealClock.GetClock_RealTime(aCurTime);
+        if (err == CHIP_NO_ERROR)
+        {
+            aCurTime -= mOffset;
+        }
+        return err;
+    }
+    CHIP_ERROR GetClock_RealTimeMS(Milliseconds64 & aCurTime) override
+    {
+        Microseconds64 curTimeUs;
+        auto err = GetClock_RealTime(curTimeUs);
+        aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+        return err;
+    }
+    CHIP_ERROR SetClock_RealTime(Microseconds64 aNewCurTime) override { return GetOffsetFrom(mRealClock, aNewCurTime, mOffset); }
+
+private:
+    ClockBase & mRealClock;
+    Offset mOffset;
+};
+
+} // namespace
 
 static chip::Optional<std::string> sEndUserSupportLogFilePath;
 static chip::Optional<std::string> sNetworkDiagnosticsLogFilePath;
 static chip::Optional<std::string> sCrashLogFilePath;
+static chip::Optional<MockClock> sMockClock;
 
 bool AppOptions::IsEmptyString(const char * value)
 {
@@ -74,6 +138,22 @@ bool AppOptions::HandleOptions(const char * program, OptionSet * options, int id
         }
         break;
     }
+    case kOptionUseMockClock: {
+        if (!sMockClock.HasValue())
+        {
+            sMockClock.Emplace();
+            // This ensures that the UTCTime attribute will be reported to have a value.
+            TimeSource::Set(chip::kRootEndpointId, chip::app::Clusters::TimeSynchronization::TimeSourceEnum::kUnknown);
+        }
+        long longValue = atoi(value);
+        if (longValue >= 0)
+        {
+            uint64_t override = uint64_t(longValue) * chip::kMicrosecondsPerSecond;
+            retval            = chip::ChipEpochToUnixEpochMicros(override, override);
+            sMockClock.Value().SetUTCTime(Microseconds64(override));
+        }
+        break;
+    }
     default:
         PrintArgError("%s: INTERNAL ERROR: Unhandled option: %s\n", program, name);
         retval = false;
@@ -90,6 +170,7 @@ OptionSet * AppOptions::GetOptions()
         { "end_user_support_log", kArgumentRequired, kOptionEndUserSupportFilePath },
         { "network_diagnostics_log", kArgumentRequired, kOptionNetworkDiagnosticsFilePath },
         { "crash_log", kArgumentRequired, kOptionCrashFilePath },
+        { "use_mock_clock", kArgumentRequired, kOptionUseMockClock },
         {},
     };
 
@@ -103,6 +184,9 @@ OptionSet * AppOptions::GetOptions()
         "       The network diagnostics log file to be used for diagnostic logs transfer.\n"
         "  --crash_log <value>\n"
         "       The crash log file to be used for diagnostic logs transfer.\n"
+        "  --use_mock_clock <value>\n"
+        "       Forces the use of a mock clock, to enable setting an incorrect initial UTC time (value is treated as a Matter "
+        "       epoch time in seconds, like the UTCTime attribute of the Time Synchronization cluster).\n"
     };
 
     return &options;

--- a/src/darwin/Framework/CHIP/MTRConversion.h
+++ b/src/darwin/Framework/CHIP/MTRConversion.h
@@ -18,6 +18,7 @@
 #import "NSStringSpanConversion.h"
 
 #import <Foundation/Foundation.h>
+#import <dispatch/time.h>
 
 #include <chrono>
 #include <lib/core/CASEAuthTag.h>
@@ -40,6 +41,13 @@ inline NSDate * MatterEpochSecondsAsDate(uint32_t matterEpochSeconds)
 {
     const auto interval = static_cast<uint64_t>(chip::kChipEpochSecondsSinceUnixEpoch) + static_cast<uint64_t>(matterEpochSeconds);
     return [NSDate dateWithTimeIntervalSince1970:(NSTimeInterval) interval];
+}
+
+inline NSDate * MatterEpochMicrosecondsAsDate(uint64_t matterEpochMicroseconds)
+{
+    const auto microseconds = static_cast<uint64_t>(chip::kChipEpochSecondsSinceUnixEpoch) * USEC_PER_SEC + matterEpochMicroseconds;
+    const auto interval = static_cast<NSTimeInterval>(microseconds) / USEC_PER_SEC;
+    return [NSDate dateWithTimeIntervalSince1970:interval];
 }
 
 template <typename Rep, typename Period>

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -61,6 +61,18 @@ static MTRDeviceController * sController = nil;
 // Keys we can use to restart the controller.
 static MTRTestKeys * sTestKeys = nil;
 
+static NSDate * MatterEpoch(void)
+{
+    __auto_type * utcTz = [NSTimeZone timeZoneForSecondsFromGMT:0];
+    __auto_type * dateComponents = [[NSDateComponents alloc] init];
+    dateComponents.timeZone = utcTz;
+    dateComponents.year = 2000;
+    dateComponents.month = 1;
+    dateComponents.day = 1;
+    NSCalendar * gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    return [gregorianCalendar dateFromComponents:dateComponents];
+}
+
 static void WaitForCommissionee(XCTestExpectation * expectation)
 {
     MTRDeviceController * controller = sController;
@@ -2870,21 +2882,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTAssertTrue(dstOffset.count > 0);
     MTRTimeSynchronizationClusterDSTOffsetStruct * currentDSTOffset = dstOffset[0];
 
-    __auto_type * utcTz = [NSTimeZone timeZoneForSecondsFromGMT:0];
-    __auto_type * dateComponents = [[NSDateComponents alloc] init];
-    dateComponents.timeZone = utcTz;
-    dateComponents.year = 2000;
-    dateComponents.month = 1;
-    dateComponents.day = 1;
-    NSCalendar * gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSDate * matterEpoch = [gregorianCalendar dateFromComponents:dateComponents];
-
     NSDate * nextReportedDSTTransition;
     if (currentDSTOffset.validUntil == nil) {
         nextReportedDSTTransition = nil;
     } else {
         double validUntilMicroSeconds = currentDSTOffset.validUntil.doubleValue;
-        nextReportedDSTTransition = [NSDate dateWithTimeInterval:validUntilMicroSeconds / 1e6 sinceDate:matterEpoch];
+        nextReportedDSTTransition = [NSDate dateWithTimeInterval:validUntilMicroSeconds / 1e6 sinceDate:MatterEpoch()];
     }
 
     __auto_type * tz = [NSTimeZone localTimeZone];
@@ -6222,6 +6225,103 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     [device _handleResubscriptionNeededWithDelayOnDeviceQueue:@(0)];
 
     [self waitForExpectations:@[ subscriptionPoolWorkCompleteForTriggerTestExpectation ] timeout:kTimeoutInSeconds];
+}
+
+- (void)test049_CorrectTimeOnDevice
+{
+    MTRDeviceController * controller = [self createControllerOnTestFabric];
+    XCTAssertNotNil(controller);
+
+    __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId2) controller:controller];
+    dispatch_queue_t queue = dispatch_get_main_queue();
+
+    __auto_type * delegate = [[MTRDeviceTestDelegate alloc] init];
+    delegate.forceTimeUpdateShortDelayToZero = YES;
+
+    XCTestExpectation * reachableExpectation = [self expectationWithDescription:@"Device is reachable"];
+    delegate.onReachable = ^{
+        [reachableExpectation fulfill];
+    };
+
+    [device setDelegate:delegate queue:queue];
+
+    MTRTestCaseServerApp * app = [self startCommissionedAppWithName:@"all-clusters"
+                                                          arguments:@[]
+                                                         controller:controller
+                                                            payload:kOnboardingPayload2
+                                                             nodeID:@(kDeviceId2)];
+
+    [self waitForExpectations:@[ reachableExpectation ] timeout:60];
+
+    // We relaunch the app multiple times, to try to trigger time
+    // synchronization loss detection. These are the different cases:
+    //
+    //   1) Relaunch with a bad clock, this should just trigger an update,
+    //      because it's the first time that we detect a bad time.
+    //   2) Relaunch with a bad clock again, this should not trigger an update,
+    //      because we avoid doing it too soon after a previous update (see
+    //      MTR_DEVICE_TIME_SYNCHRONIZATION_LOSS_CHECK_CADENCE).
+    //   3) Set the cadence to zero and relaunch with a bad clock again. This
+    //      should trigger an update, because with cadence being zero we won't
+    //      block an update.
+    //   4) Relaunch with a slightly bad clock (and cadence still set to zero).
+    //      This should not trigger an update, because the time is not out of
+    //      sync enough.
+    for (int i = 0; i < 4; ++i) {
+        if (i == 2) {
+            delegate.forceTimeSynchronizationLossDetectionCadenceToZero = YES;
+        }
+
+        __weak __auto_type weakDelegate = delegate;
+
+        XCTestExpectation * subscriptionDroppedExpectation = [self expectationWithDescription:@"Subscription has dropped"];
+        delegate.onNotReachable = ^() {
+            [subscriptionDroppedExpectation fulfill];
+        };
+
+        XCTestExpectation * resubscriptionReachableExpectation =
+            [self expectationWithDescription:@"Resubscription has become reachable"];
+        XCTestExpectation * gotReportsExpectation = [self expectationWithDescription:@"Resubscription got reports"];
+        XCTestExpectation * correctedTime = [self expectationWithDescription:@"onUTCTimeSet called"];
+        delegate.onReachable = ^() {
+            __strong __auto_type strongDelegate = weakDelegate;
+
+            strongDelegate.onReportEnd = ^() {
+                __strong __auto_type strongDelegate = weakDelegate;
+                strongDelegate.onReportEnd = nil;
+                [gotReportsExpectation fulfill];
+            };
+
+            strongDelegate.onUTCTimeSet = ^(NSError * _Nullable error) {
+                XCTAssertNil(error);
+                [correctedTime fulfill];
+            };
+            if (i == 1 || i == 3) {
+                correctedTime.inverted = YES;
+            }
+            [resubscriptionReachableExpectation fulfill];
+        };
+
+        double utcTime;
+        if (i < 3) {
+            utcTime = 0;
+        } else {
+            // Set an incorrect time that's within the range that we ignore (we
+            // offset it by 4 minutes, which is smaller than the 5 minutes that
+            // MTR_DEVICE_TIME_DIFFERENCE_TRIGGERING_TIME_SYNC is currently set
+            // to.
+            utcTime = [[NSDate dateWithTimeIntervalSinceNow:-240] timeIntervalSinceDate:MatterEpoch()];
+        }
+        // This will add duplicate arguments, but that shouldn't hurt anything. Last one will take precedence.
+        BOOL started = [self restartApp:app additionalArguments:@[ @"--use_mock_clock", @(utcTime).stringValue ]];
+        XCTAssertTrue(started);
+
+        [self waitForExpectations:@[ subscriptionDroppedExpectation, resubscriptionReachableExpectation, gotReportsExpectation ] timeout:60];
+
+        // correctedTime is sometimes inverted, so wait on it separately with a lower timeout to avoid
+        // always waiting for at least a minute every time we don't expect onUTCTimeset to be called.
+        [self waitForExpectations:@[ correctedTime ] timeout:10];
+    }
 }
 
 @end

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -20,6 +20,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *, id> *> *);
+typedef void (^MTRDeviceTestDelegateHandler)(NSError * error);
 
 @interface MTRDeviceTestDelegate : NSObject <MTRDeviceDelegate>
 @property (nonatomic, nullable) dispatch_block_t onReachable;
@@ -40,6 +41,9 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 @property (nonatomic, nullable) dispatch_block_t onSubscriptionCallbackDelete;
 @property (nonatomic, nullable) dispatch_block_t onSubscriptionReset;
 @property (nonatomic, nullable) NSNumber * subscriptionMaxIntervalOverride;
+@property (nonatomic, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
+@property (nonatomic) BOOL forceTimeUpdateShortDelayToZero;
+@property (nonatomic) BOOL forceTimeSynchronizationLossDetectionCadenceToZero;
 @end
 
 @interface MTRDeviceTestDelegateWithSubscriptionSetupOverride : MTRDeviceTestDelegate

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.m
@@ -144,6 +144,23 @@
     }
 }
 
+- (void)unitTestSetUTCTimeInvokedForDevice:(MTRDevice *)device error:(NSError * _Nullable)error
+{
+    if (self.onUTCTimeSet != nil) {
+        self.onUTCTimeSet(error);
+    }
+}
+
+- (BOOL)unitTestTimeUpdateShortDelayIsZero:(MTRDevice *)device
+{
+    return self.forceTimeUpdateShortDelayToZero;
+}
+
+- (BOOL)unitTestTimeSynchronizationLossDetectionCadenceIsZero:(MTRDevice *)device
+{
+    return self.forceTimeSynchronizationLossDetectionCadenceToZero;
+}
+
 @end
 
 @implementation MTRDeviceTestDelegateWithSubscriptionSetupOverride

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase+ServerAppRunner.h
@@ -20,6 +20,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface MTRTestCaseServerApp : NSObject
+@end
+
 @interface MTRTestCase (ServerAppRunner)
 
 /**
@@ -48,11 +51,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Same thing as startAppWithName, but also commissions the application on
  * controller with the provided node ID.
  */
-- (void)startCommissionedAppWithName:(NSString *)name
-                           arguments:(NSArray<NSString *> *)arguments
-                          controller:(MTRDeviceController *)controller
-                             payload:(NSString *)payload
-                              nodeID:(NSNumber *)nodeID;
+- (nullable MTRTestCaseServerApp *)startCommissionedAppWithName:(NSString *)name
+                                                      arguments:(NSArray<NSString *> *)arguments
+                                                     controller:(MTRDeviceController *)controller
+                                                        payload:(NSString *)payload
+                                                         nodeID:(NSNumber *)nodeID;
 
 /**
  * Same thing, but also starts a controller on a test fabric, commissions the
@@ -70,6 +73,12 @@ NS_ASSUME_NONNULL_BEGIN
  * end of the current suite.
  */
 + (nullable MTRDeviceController *)startCommissionedAppWithName:(NSString *)name arguments:(NSArray<NSString *> *)arguments nodeID:(NSNumber *)nodeID;
+
+/**
+ * Restarts a server app, using the original arguments of the app, concatenated
+ * with additionalArguments.
+ */
+- (BOOL)restartApp:(MTRTestCaseServerApp *)app additionalArguments:(NSArray<NSString *> *)additionalArguments;
 
 /**
  * Get the unique index that will be used for the next initialization.  This

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestCase.h
@@ -92,6 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
  * tearDown happens.
  */
 + (void)launchTask:(NSTask *)task;
+
+/**
+ * Terminates a task, and launches a new task with the same executable URL, standard output
+ * and error output handlers as the task to be terminated. The new task will also get the
+ * arguments of the task to be terminated, concatenated with the arguments passed in.
+ */
+- (NSTask *)relaunchTask:(NSTask *)task additionalArguments:(NSArray<NSString *> *)additionalArguments;
 #endif // HAVE_NSTASK
 
 /**


### PR DESCRIPTION
Detect that the difference with the device's time is outside of a certain range, which means there's a loss of synchronization. If a synchronization loss is detected, then try to update the device's time. Avoid detecting synchronization loss too frequently, currently do it once every hour after the first detection.

#### Testing

I added a new test which checks the time synchronization detection. Ran the MTRDeviceTests locally to verify that they still pass.