### PR TITLE
Fix: remove inexistent files and dirs from zcl

### DIFF
--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -3,12 +3,7 @@
     "category": "matter",
     "version": 1,
     "requiredFeatureLevel": 102,
-    "xmlRoot": [
-        ".",
-        "./data-model/chip/",
-        "./data-model/silabs/",
-        "./data-model/test"
-    ],
+    "xmlRoot": [".", "./data-model/chip", "./data-model/test"],
     "_comment": "Ensure access-control-definitions.xml is first in xmlFile array",
     "xmlFile": [
         "access-control-definitions.xml",
@@ -114,8 +109,7 @@
         "refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml",
         "refrigerator-alarm.xml",
         "relative-humidity-measurement-cluster.xml",
-        "replacable-monitoring-cluster.xml",
-        "rvc-clean-mode-cluster.xml ",
+        "rvc-clean-mode-cluster.xml",
         "rvc-run-mode-cluster.xml",
         "resource-monitoring-cluster.xml",
         "scene.xml",
@@ -152,12 +146,9 @@
         "window-covering.xml",
         "matter-devices.xml",
         "sample-mei-cluster.xml",
-        "types/door-lock.xml",
-        "types/occupancy-sensing.xml",
-        "types/thermostat-user-interface-configuration.xml",
         "zone-management-cluster.xml"
     ],
-    "manufacturersXml": "../../../../src/app/zap-templates/zcl/data-model/manufacturers.xml",
+    "manufacturersXml": "./data-model/manufacturers.xml",
     "options": {
         "text": {
             "defaultResponsePolicy": ["Always", "Conditional", "Never"]

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -3,7 +3,7 @@
     "category": "matter",
     "version": 1,
     "requiredFeatureLevel": 102,
-    "xmlRoot": [".", "./data-model/chip/", "./data-model/silabs/"],
+    "xmlRoot": [".", "./data-model/chip"],
     "_comment": "Ensure access-control-definitions.xml is first in xmlFile array",
     "xmlFile": [
         "access-control-definitions.xml",
@@ -107,9 +107,8 @@
         "refrigerator-and-temperature-controlled-cabinet-mode-cluster.xml",
         "refrigerator-alarm.xml",
         "relative-humidity-measurement-cluster.xml",
-        "rvc-clean-mode-cluster.xml ",
+        "rvc-clean-mode-cluster.xml",
         "rvc-run-mode-cluster.xml",
-        "replacable-monitoring-cluster.xml",
         "resource-monitoring-cluster.xml",
         "scene.xml",
         "service-area-cluster.xml",
@@ -146,12 +145,9 @@
         "window-covering.xml",
         "matter-devices.xml",
         "sample-mei-cluster.xml",
-        "types/door-lock.xml",
-        "types/occupancy-sensing.xml",
-        "types/thermostat-user-interface-configuration.xml",
         "zone-management-cluster.xml"
     ],
-    "manufacturersXml": "../../../../src/app/zap-templates/zcl/data-model/manufacturers.xml",
+    "manufacturersXml": "./data-model/manufacturers.xml",
     "options": {
         "text": {
             "defaultResponsePolicy": ["Always", "Conditional", "Never"]


### PR DESCRIPTION
Cleanup zcl file to simplify its processiong:
- remove inexistent cluster files
- remove inexistent root directory
- remove trailing whitespace and slash
- shorten path to manufacturers file

#### Testing

Manual build