### PR TITLE
Improve detection of fabric-sensitive missing on OPCREDS-3.8

### DIFF
--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -173,6 +173,7 @@ async def AddNOCForNewFabricFromExisting(commissionerDevCtrl, newFabricDevCtrl, 
     if (chainForAddNOC.rcacBytes is None or
             chainForAddNOC.nocBytes is None or chainForAddNOC.ipkBytes is None):
         # Expiring the failsafe timer in an attempt to clean up.
+        logging.error(f"INTERNAL ERROR: Got invalid cert chain from issuer! Chain: {chainForAddNOC}. Disarming fail-safe!")
         await commissionerDevCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False, nocResp, None
 
@@ -187,11 +188,13 @@ async def AddNOCForNewFabricFromExisting(commissionerDevCtrl, newFabricDevCtrl, 
 
     if nocResp.statusCode is not opCreds.Enums.NodeOperationalCertStatusEnum.kOk:
         # Expiring the failsafe timer in an attempt to clean up.
+        logging.error(f"AddNOC failed on DUT. Status code was: {resp.statusCode}. Disarming fail-safe!")
         await commissionerDevCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False, nocResp
 
     # Immediately return if skipping CommissioningComplete is requested.
     if omitCommissioningComplete:
+        logging.info("Not sending CommissioningComplete to allow further testing in commissioning session.")
         return True, nocResp, chainForAddNOC
 
     # Send CommissioningComplete to finalize commissioning.
@@ -199,10 +202,12 @@ async def AddNOCForNewFabricFromExisting(commissionerDevCtrl, newFabricDevCtrl, 
 
     if resp.errorCode is not generalCommissioning.Enums.CommissioningErrorEnum.kOk:
         # Expiring the failsafe timer in an attempt to clean up.
+        logging.error(f"CommissioningComplete failed on DUT. Status code was: {resp.errorCode}. Disarming fail-safe!")
         await commissionerDevCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False, nocResp, chainForAddNOC
 
     if not await _IsNodeInFabricList(newFabricDevCtrl, newNodeId):
+        logging.error(f"Failed to find new NodeID 0x{newNodeId:016X} in Fabrics list after CommissioningComplete!")
         return False, nocResp, chainForAddNOC
 
     return True, nocResp, chainForAddNOC
@@ -233,6 +238,7 @@ async def UpdateNOC(devCtrl, existingNodeId, newNodeId, omitCommissioningComplet
     chainForUpdateNOC = await devCtrl.IssueNOCChain(csrForUpdateNOC, newNodeId)
     if (chainForUpdateNOC.rcacBytes is None or
             chainForUpdateNOC.nocBytes is None or chainForUpdateNOC.ipkBytes is None):
+        logging.error(f"INTERNAL ERROR: Got invalid cert chain from issuer! Chain: {chainForUpdateNOC}. Disarming fail-safe!")
         await devCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False
 
@@ -240,6 +246,7 @@ async def UpdateNOC(devCtrl, existingNodeId, newNodeId, omitCommissioningComplet
                                                                                    chainForUpdateNOC.icacBytes))
     if resp.statusCode is not opCreds.Enums.NodeOperationalCertStatusEnum.kOk:
         # Expiring the failsafe timer in an attempt to clean up.
+        logging.error(f"UpdateNOC failed on DUT. Status code was: {resp.statusCode}. Disarming fail-safe!")
         await devCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False
 
@@ -248,16 +255,19 @@ async def UpdateNOC(devCtrl, existingNodeId, newNodeId, omitCommissioningComplet
 
     # Immediately return if skipping CommissioningComplete is requested.
     if omitCommissioningComplete:
+        logging.info("Not sending CommissioningComplete to allow further testing in commissioning session.")
         return True
 
     # Send CommissioningComplete to finalize commissioning.
     resp = await devCtrl.SendCommand(newNodeId, 0, generalCommissioning.Commands.CommissioningComplete())
     if resp.errorCode is not generalCommissioning.Enums.CommissioningErrorEnum.kOk:
         # Expiring the failsafe timer in an attempt to clean up.
+        logging.error(f"CommissioningComplete failed on DUT. Status code was: {resp.errorCode}. Disarming fail-safe!")
         await devCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0))
         return False
 
     if not await _IsNodeInFabricList(devCtrl, newNodeId):
+        logging.error(f"Failed to find new NodeID 0x{newNodeId:016X} in Fabrics list after CommissioningComplete!")
         return False
 
     return True

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -459,7 +459,8 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
                         continue
 
                     found_fabric_indices.add(noc_struct.fabricIndex)
-                    asserts.assert_true(noc_struct.noc is not None and len(noc_struct.noc) > 0, "`noc` field in NOCs attribute entry not found for fabric index {fabric_index}! Ensure you are running a Matter stack for >= 1.4.2 where NOCStruct fields are not fabric-sensitive.")
+                    asserts.assert_true(noc_struct.noc is not None and len(
+                        noc_struct.noc) > 0, "`noc` field in NOCs attribute entry not found for fabric index {fabric_index}! Ensure you are running a Matter stack for >= 1.4.2 where NOCStruct fields are not fabric-sensitive.")
 
                     try:
                         logging.info(f"Trying to parse NOC for fabric index {fabric_index}")
@@ -476,8 +477,10 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
 
             logging.info(f"Fabric IDs found: {fabric_ids_from_certs}")
 
-            asserts.assert_true(th1_fabric_index in found_fabric_indices, f"Expected to have seen entry for TH1's fabric (fabric Index {th1_fabric_index}) in NOCs attribute, but did not find it!")
-            asserts.assert_true(th2_fabric_index in found_fabric_indices, f"Expected to have seen entry for TH2's fabric (fabric Index {th2_fabric_index}) in NOCs attribute, but did not find it!")
+            asserts.assert_true(th1_fabric_index in found_fabric_indices,
+                                f"Expected to have seen entry for TH1's fabric (fabric Index {th1_fabric_index}) in NOCs attribute, but did not find it!")
+            asserts.assert_true(th2_fabric_index in found_fabric_indices,
+                                f"Expected to have seen entry for TH2's fabric (fabric Index {th2_fabric_index}) in NOCs attribute, but did not find it!")
 
             for controller_name, fabric_id in fabric_ids.items():
                 asserts.assert_in(controller_name, fabric_ids_from_certs.keys(),

--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -429,7 +429,7 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
 
         # Read NOCs and validate that both the entry for TH1 and TH2 are readable
         # and have the right expected fabricId
-        with test_step(2, description="Read DUT's NOCs attribute and validate both fabrics have expected values extractable from their NOC."):
+        with test_step(2, description="Read DUT's NOCs attribute and validate both fabrics have expected values extractable from their NOC. The NOCs attribute must show the NOC for every fabric."):
             nocs_list = await self.read_single_attribute_check_success(
                 dev_ctrl=th1_dev_ctrl,
                 node_id=th1_dut_node_id,
@@ -451,10 +451,15 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
                 "TH2": th2_fabricId
             }
 
+            found_fabric_indices = set()
+
             for controller_name, fabric_index in fabric_indices.items():
                 for noc_struct in nocs_list:
                     if noc_struct.fabricIndex != fabric_index:
                         continue
+
+                    found_fabric_indices.add(noc_struct.fabricIndex)
+                    asserts.assert_true(noc_struct.noc is not None and len(noc_struct.noc) > 0, "`noc` field in NOCs attribute entry not found for fabric index {fabric_index}! Ensure you are running a Matter stack for >= 1.4.2 where NOCStruct fields are not fabric-sensitive.")
 
                     try:
                         logging.info(f"Trying to parse NOC for fabric index {fabric_index}")
@@ -470,6 +475,9 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
                     logging.info(f"  -> NOC public key bytes: {to_octet_string(noc_public_keys_from_certs[controller_name])}")
 
             logging.info(f"Fabric IDs found: {fabric_ids_from_certs}")
+
+            asserts.assert_true(th1_fabric_index in found_fabric_indices, f"Expected to have seen entry for TH1's fabric (fabric Index {th1_fabric_index}) in NOCs attribute, but did not find it!")
+            asserts.assert_true(th2_fabric_index in found_fabric_indices, f"Expected to have seen entry for TH2's fabric (fabric Index {th2_fabric_index}) in NOCs attribute, but did not find it!")
 
             for controller_name, fabric_id in fabric_ids.items():
                 asserts.assert_in(controller_name, fabric_ids_from_certs.keys(),


### PR DESCRIPTION
#### Changes
- Ensure we detect if NOC is fabric-sensitive still (happened to DUTs in TE2 that were running old code)
- Improve logging more in commissioning building blocks.

#### Testing

- Tests still pass, better logs present