### PR TITLE
Fix crash when re-sending a message over MRP fails fatally.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -222,7 +222,6 @@ void ReliableMessageMgr::ExecuteActions()
         MATTER_LOG_METRIC(Tracing::kMetricDeviceRMPRetryCount, entry->sendCount);
 
         SendFromRetransTable(entry);
-        CalculateNextRetransTime(*entry);
 
         return Loop::Continue;
     });
@@ -378,6 +377,8 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     if (err == CHIP_NO_ERROR)
     {
+        CalculateNextRetransTime(*entry);
+
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         app::ICDNotifier::GetInstance().NotifyNetworkActivityNotification();
 #endif // CHIP_CONFIG_ENABLE_ICD_SERVER


### PR DESCRIPTION
SendFromRetransTable clears out the table entry on fatal failures.  When we moved CalculateNextRetransTime to after SendFromRetransTable, that caused crashes in the cases when SendFromRetransTable clears the entry.

The simplest solution is to do the CalculateNextRetransTime right after the successful (or at least treated as successful) send inside SendFromRetransTable.

#### Testing

Manual testing with "no route to host" errors.