### PR TITLE
[camera] Improve the stability of WebRTC session establishment

### DIFF
--- a/examples/camera-controller/args.gni
+++ b/examples/camera-controller/args.gni
@@ -34,3 +34,4 @@ chip_tlv_validate_char_string_on_read = true
 chip_tlv_validate_char_string_on_write = true
 
 chip_build_controller_dynamic_server = true
+chip_device_config_enable_wifipaf = false

--- a/examples/camera-controller/commands/common/CHIPCommand.h
+++ b/examples/camera-controller/commands/common/CHIPCommand.h
@@ -99,10 +99,6 @@ public:
         AddArgument("commissioner-vendor-id", 0, UINT16_MAX, &mCommissionerVendorId,
                     "The vendor id to use for camera-controller. If not provided, chip::VendorId::TestVendor1 (65521, 0xFFF1) will "
                     "be used.");
-        AddArgument("start-websocket-server", 0, 1, &mStartWebSocketServer,
-                    "Start the built‑in WebSocket server that exposes the interactive‑command API. "
-                    "If not provided or 0 (\"false\"), the WebSocket server is disabled. "
-                    "If 1 (\"true\"), the WebSocket server is started and listens on the default port.");
     }
 
     /////////// Command Interface /////////
@@ -164,7 +160,6 @@ protected:
     PersistentStorage mCommissionerStorage;
 #endif // CONFIG_USE_LOCAL_STORAGE
     chip::Optional<char *> mLogFilePath;
-    chip::Optional<bool> mStartWebSocketServer;
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
     static chip::Crypto::RawKeySessionKeystore sSessionKeystore;

--- a/examples/camera-controller/commands/interactive/InteractiveCommands.h
+++ b/examples/camera-controller/commands/interactive/InteractiveCommands.h
@@ -87,6 +87,8 @@ public:
     /////////// RemoteDataModelLoggerDelegate interface /////////
     CHIP_ERROR LogJSON(const char * json) override;
 
+    void StopCommand();
+
 private:
     WebSocketServer mWebSocketServer;
     chip::Optional<uint16_t> mPort;

--- a/examples/camera-controller/main.cpp
+++ b/examples/camera-controller/main.cpp
@@ -39,8 +39,8 @@ int main(int argc, char * argv[])
     // Convert command line arguments to a vector of strings for easier manipulation
     std::vector<std::string> args(argv, argv + argc);
 
-    // Check if "interactive" and "start" are not in the arguments
-    if (args.size() < 3 || args[1] != "interactive" || args[2] != "start")
+    // Check if "interactive" is not in the arguments
+    if (args.size() < 3 || args[1] != "interactive")
     {
         // Insert "interactive" and "start" after the executable name
         args.insert(args.begin() + 1, "interactive");

--- a/examples/common/websocket-server/WebSocketServer.h
+++ b/examples/common/websocket-server/WebSocketServer.h
@@ -30,10 +30,12 @@ class WebSocketServer : public WebSocketServerDelegate
 public:
     CHIP_ERROR Run(chip::Optional<uint16_t> port, WebSocketServerDelegate * delegate);
     void Send(const char * msg);
+    void Stop();
 
     bool OnWebSocketMessageReceived(char * msg) override;
 
 private:
     bool mRunning;
+    struct lws_context * mContext       = nullptr;
     WebSocketServerDelegate * mDelegate = nullptr;
 };


### PR DESCRIPTION
I encountered several issues while establishing WebRTC sessions in CI. This PR addresses multiple bugs in camera‑controller, enhancing the stability of WebRTC session setup. I’ll keep an eye on CI runs and enable this workflow once it proves stable, so we don’t introduce new flakiness.

Key fixes:
The flag --start-websocket-server currently launches a WebSocket server from inside the interactive start command, which creates a second event loop (one for WebSocketServer, one for the interactive command). These loops now run in separate contexts so that the application terminates through a single, clean event loop.

#### Testing

Validated by CI
