### PR TITLE
Add missing Macros/Includes for actions service on ESP32 / NRF targets

### DIFF
--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -122,6 +122,19 @@ include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
 set(dir_pw_third_party_nanopb "${CHIP_ROOT}/third_party/nanopb/repo" CACHE STRING "" FORCE)
 
+pw_proto_library(actions_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/actions_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/actions_service.options
+  PREFIX
+  actions_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
 pw_proto_library(attributes_service
   SOURCES
     ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.proto
@@ -195,6 +208,7 @@ pw_proto_library(wifi_service
 )
 
 target_link_libraries(${COMPONENT_LIB} PUBLIC
+  actions_service.nanopb_rpc
   attributes_service.nanopb_rpc
   boolean_state_service.nanopb_rpc
   button_service.nanopb_rpc

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -220,6 +220,7 @@ target_link_options(${COMPONENT_LIB}
 )
 
 target_compile_options(${COMPONENT_LIB} PRIVATE
+                       "-DPW_RPC_ACTIONS_SERVICE=1"
                        "-DPW_RPC_ATTRIBUTE_SERVICE=1"
                        "-DPW_RPC_BOOLEAN_STATE_SERVICE=1"
                        "-DPW_RPC_BUTTON_SERVICE=1"

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -232,6 +232,7 @@ target_include_directories(app PRIVATE
   ../../common/pigweed/nrfconnect)
 
 target_compile_options(app PRIVATE
+                       "-DPW_RPC_ACTIONS_SERVICE=1"
                        "-DPW_RPC_ATTRIBUTE_SERVICE=1"
                        "-DPW_RPC_BOOLEAN_STATE_SERVICE=1"
                        "-DPW_RPC_DESCRIPTOR_SERVICE=1"

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -140,6 +140,19 @@ add_subdirectory(third_party/connectedhomeip/examples/platform/nrfconnect/pw_sys
 add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
 add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
 
+pw_proto_library(actions_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/actions_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/actions_service.options
+  PREFIX
+  actions_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
 pw_proto_library(attributes_service
   SOURCES
     ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.proto
@@ -241,6 +254,7 @@ target_compile_options(app PRIVATE
 )
 
 target_link_libraries(app PRIVATE
+  actions_service.nanopb_rpc
   attributes_service.nanopb_rpc
   boolean_state_service.nanopb_rpc
   descriptor_service.nanopb_rpc

--- a/examples/chef/silabs/BUILD.gn
+++ b/examples/chef/silabs/BUILD.gn
@@ -101,6 +101,7 @@ silabs_executable("chef_app") {
   if (chip_enable_pw_rpc) {
     defines += [
       "PW_RPC_ENABLED",
+      "PW_RPC_ACTIONS_SERVICE=1",
       "PW_RPC_ATTRIBUTE_SERVICE=1",
       "PW_RPC_BUTTON_SERVICE=1",
       "PW_RPC_DESCRIPTOR_SERVICE=1",

--- a/examples/common/pigweed/rpc_services/Actions.h
+++ b/examples/common/pigweed/rpc_services/Actions.h
@@ -94,7 +94,8 @@ public:
 
     {
         DeviceLayer::StackLock lock;
-        ChipLogProgress(NotSpecified, " request.endpoint_id=%d, request.cluster_id=%d", request.endpoint_id, request.cluster_id);
+        ChipLogProgress(NotSpecified, " request.endpoint_id=%d, request.cluster_id=%d", (int) request.endpoint_id,
+                        (int) request.cluster_id);
 
         for (int i = 0; i < request.actions_count; i++)
         {

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -29,6 +29,10 @@
 #include "pw_sys_io/sys_io.h"
 #include "support/CodeUtils.h"
 
+#if defined(PW_RPC_ACTIONS_SERVICE) && PW_RPC_ACTIONS_SERVICE
+#include "pigweed/rpc_services/Actions.h"
+#endif // defined(PW_RPC_ACTIONS_SERVICE) && PW_RPC_ACTIONS_SERVICE
+
 #if defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE
 #include "pigweed/rpc_services/Attributes.h"
 #endif // defined(PW_RPC_ATTRIBUTE_SERVICE) && PW_RPC_ATTRIBUTE_SERVICE

--- a/examples/platform/esp32/Rpc.cpp
+++ b/examples/platform/esp32/Rpc.cpp
@@ -20,6 +20,7 @@
 
 #if CONFIG_ENABLE_PW_RPC
 #include "PigweedLoggerMutex.h"
+#include "Rpc.h"
 #include "RpcService.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"

--- a/examples/platform/esp32/Rpc.h
+++ b/examples/platform/esp32/Rpc.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <lib/core/DataModelTypes.h>
+#include <vector>
+
 namespace chip {
 namespace rpc {
 

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -24,6 +24,7 @@
 #include "pw_sys_io_nrfconnect/init.h"
 #include <zephyr/logging/log.h>
 
+#include "Rpc.h"
 #include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_CHIP_APP_LOG_LEVEL);

--- a/examples/platform/nrfconnect/Rpc.h
+++ b/examples/platform/nrfconnect/Rpc.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <lib/core/DataModelTypes.h>
+#include <vector>
 #include <zephyr/kernel.h>
 
 namespace chip {


### PR DESCRIPTION
#### Testing

Successful Compilation + CI

```
./chef.py -br -d rootnode_genericswitch_9866e35d0b -t esp32
./chef.py -br -d rootnode_genericswitch_9866e35d0b -t linux
```
