### PR TITLE
Move data model types from basic-types.h to DataModelTypes.h

### DIFF
--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -30,16 +30,6 @@
 
 namespace chip {
 
-typedef uint8_t Percent;
-typedef uint16_t Percent100ths;
-typedef int64_t Energy_mWh;
-typedef int64_t Energy_mVAh;
-typedef int64_t Energy_mVARh;
-typedef int64_t Amperage_mA;
-typedef int64_t Power_mW;
-typedef int64_t Power_mVA;
-typedef int64_t Power_mVAR;
-typedef int64_t Voltage_mV;
-typedef int64_t Money;
+
 
 } // namespace chip

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -28,8 +28,4 @@
 // Pull in core types
 #include <lib/core/DataModelTypes.h>
 
-namespace chip {
-
-
-
-} // namespace chip
+namespace chip {} // namespace chip

--- a/src/app/util/basic-types.h
+++ b/src/app/util/basic-types.h
@@ -23,9 +23,5 @@
 
 #pragma once
 
-#include <cstdint>
-
 // Pull in core types
 #include <lib/core/DataModelTypes.h>
-
-namespace chip {} // namespace chip

--- a/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
@@ -7,6 +7,7 @@
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
 #include <app/util/basic-types.h>
+$include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
@@ -6,7 +6,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-$include <lib/core/DataModelTypes.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
+++ b/src/app/zap-templates/templates/app/clusters-Structs.h.zapt
@@ -6,7 +6,6 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
 $include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>

--- a/src/lib/core/DataModelTypes.h
+++ b/src/lib/core/DataModelTypes.h
@@ -51,6 +51,18 @@ typedef uint8_t InteractionModelRevision;
 typedef uint32_t SubscriptionId;
 typedef uint8_t SceneId;
 
+typedef uint8_t Percent;
+typedef uint16_t Percent100ths;
+typedef int64_t Energy_mWh;
+typedef int64_t Energy_mVAh;
+typedef int64_t Energy_mVARh;
+typedef int64_t Amperage_mA;
+typedef int64_t Power_mW;
+typedef int64_t Power_mVA;
+typedef int64_t Power_mVAR;
+typedef int64_t Voltage_mV;
+typedef int64_t Money;
+
 inline constexpr CompressedFabricId kUndefinedCompressedFabricId = 0ULL;
 inline constexpr FabricId kUndefinedFabricId                     = 0ULL;
 

--- a/zzz_generated/app-common/clusters/AccessControl/Structs.h
+++ b/zzz_generated/app-common/clusters/AccessControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/AccountLogin/Structs.h
+++ b/zzz_generated/app-common/clusters/AccountLogin/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Actions/Structs.h
+++ b/zzz_generated/app-common/clusters/Actions/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Structs.h
+++ b/zzz_generated/app-common/clusters/ActivatedCarbonFilterMonitoring/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/AdministratorCommissioning/Structs.h
+++ b/zzz_generated/app-common/clusters/AdministratorCommissioning/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/AirQuality/Structs.h
+++ b/zzz_generated/app-common/clusters/AirQuality/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ApplicationBasic/Structs.h
+++ b/zzz_generated/app-common/clusters/ApplicationBasic/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ApplicationLauncher/Structs.h
+++ b/zzz_generated/app-common/clusters/ApplicationLauncher/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/AudioOutput/Structs.h
+++ b/zzz_generated/app-common/clusters/AudioOutput/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/BallastConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/BallastConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/BasicInformation/Structs.h
+++ b/zzz_generated/app-common/clusters/BasicInformation/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Binding/Structs.h
+++ b/zzz_generated/app-common/clusters/Binding/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/BooleanState/Structs.h
+++ b/zzz_generated/app-common/clusters/BooleanState/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/BooleanStateConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/BooleanStateConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Structs.h
+++ b/zzz_generated/app-common/clusters/BridgedDeviceBasicInformation/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/CameraAvSettingsUserLevelManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CameraAvStreamManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/CameraAvStreamManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/CarbonDioxideConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/CarbonMonoxideConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Channel/Structs.h
+++ b/zzz_generated/app-common/clusters/Channel/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Chime/Structs.h
+++ b/zzz_generated/app-common/clusters/Chime/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ClosureControl/Structs.h
+++ b/zzz_generated/app-common/clusters/ClosureControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ClosureDimension/Structs.h
+++ b/zzz_generated/app-common/clusters/ClosureDimension/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ColorControl/Structs.h
+++ b/zzz_generated/app-common/clusters/ColorControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CommissionerControl/Structs.h
+++ b/zzz_generated/app-common/clusters/CommissionerControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CommodityMetering/Structs.h
+++ b/zzz_generated/app-common/clusters/CommodityMetering/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CommodityPrice/Structs.h
+++ b/zzz_generated/app-common/clusters/CommodityPrice/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/CommodityTariff/Structs.h
+++ b/zzz_generated/app-common/clusters/CommodityTariff/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ContentAppObserver/Structs.h
+++ b/zzz_generated/app-common/clusters/ContentAppObserver/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ContentControl/Structs.h
+++ b/zzz_generated/app-common/clusters/ContentControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ContentLauncher/Structs.h
+++ b/zzz_generated/app-common/clusters/ContentLauncher/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Descriptor/Structs.h
+++ b/zzz_generated/app-common/clusters/Descriptor/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Structs.h
+++ b/zzz_generated/app-common/clusters/DeviceEnergyManagementMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DiagnosticLogs/Structs.h
+++ b/zzz_generated/app-common/clusters/DiagnosticLogs/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DishwasherAlarm/Structs.h
+++ b/zzz_generated/app-common/clusters/DishwasherAlarm/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DishwasherMode/Structs.h
+++ b/zzz_generated/app-common/clusters/DishwasherMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/DoorLock/Structs.h
+++ b/zzz_generated/app-common/clusters/DoorLock/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/EcosystemInformation/Structs.h
+++ b/zzz_generated/app-common/clusters/EcosystemInformation/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/ElectricalEnergyMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ElectricalGridConditions/Structs.h
+++ b/zzz_generated/app-common/clusters/ElectricalGridConditions/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/ElectricalPowerMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/EnergyEvse/Structs.h
+++ b/zzz_generated/app-common/clusters/EnergyEvse/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/EnergyEvseMode/Structs.h
+++ b/zzz_generated/app-common/clusters/EnergyEvseMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/EnergyPreference/Structs.h
+++ b/zzz_generated/app-common/clusters/EnergyPreference/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Structs.h
+++ b/zzz_generated/app-common/clusters/EthernetNetworkDiagnostics/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/FanControl/Structs.h
+++ b/zzz_generated/app-common/clusters/FanControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/FaultInjection/Structs.h
+++ b/zzz_generated/app-common/clusters/FaultInjection/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/FixedLabel/Structs.h
+++ b/zzz_generated/app-common/clusters/FixedLabel/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/FlowMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/FlowMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/FormaldehydeConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/GeneralCommissioning/Structs.h
+++ b/zzz_generated/app-common/clusters/GeneralCommissioning/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/GeneralDiagnostics/Structs.h
+++ b/zzz_generated/app-common/clusters/GeneralDiagnostics/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/GroupKeyManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/GroupKeyManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Groups/Structs.h
+++ b/zzz_generated/app-common/clusters/Groups/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/HepaFilterMonitoring/Structs.h
+++ b/zzz_generated/app-common/clusters/HepaFilterMonitoring/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/IcdManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/IcdManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Identify/Structs.h
+++ b/zzz_generated/app-common/clusters/Identify/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/IlluminanceMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/IlluminanceMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/JointFabricAdministrator/Structs.h
+++ b/zzz_generated/app-common/clusters/JointFabricAdministrator/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/JointFabricDatastore/Structs.h
+++ b/zzz_generated/app-common/clusters/JointFabricDatastore/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/KeypadInput/Structs.h
+++ b/zzz_generated/app-common/clusters/KeypadInput/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LaundryDryerControls/Structs.h
+++ b/zzz_generated/app-common/clusters/LaundryDryerControls/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LaundryWasherControls/Structs.h
+++ b/zzz_generated/app-common/clusters/LaundryWasherControls/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LaundryWasherMode/Structs.h
+++ b/zzz_generated/app-common/clusters/LaundryWasherMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LevelControl/Structs.h
+++ b/zzz_generated/app-common/clusters/LevelControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LocalizationConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/LocalizationConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/LowPower/Structs.h
+++ b/zzz_generated/app-common/clusters/LowPower/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/MediaInput/Structs.h
+++ b/zzz_generated/app-common/clusters/MediaInput/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/MediaPlayback/Structs.h
+++ b/zzz_generated/app-common/clusters/MediaPlayback/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Messages/Structs.h
+++ b/zzz_generated/app-common/clusters/Messages/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/MeterIdentification/Structs.h
+++ b/zzz_generated/app-common/clusters/MeterIdentification/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/MicrowaveOvenControl/Structs.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/MicrowaveOvenMode/Structs.h
+++ b/zzz_generated/app-common/clusters/MicrowaveOvenMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ModeSelect/Structs.h
+++ b/zzz_generated/app-common/clusters/ModeSelect/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/NetworkCommissioning/Structs.h
+++ b/zzz_generated/app-common/clusters/NetworkCommissioning/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/NitrogenDioxideConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OccupancySensing/Structs.h
+++ b/zzz_generated/app-common/clusters/OccupancySensing/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OnOff/Structs.h
+++ b/zzz_generated/app-common/clusters/OnOff/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OperationalCredentials/Structs.h
+++ b/zzz_generated/app-common/clusters/OperationalCredentials/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OperationalState/Structs.h
+++ b/zzz_generated/app-common/clusters/OperationalState/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Structs.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateProvider/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Structs.h
+++ b/zzz_generated/app-common/clusters/OtaSoftwareUpdateRequestor/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OvenCavityOperationalState/Structs.h
+++ b/zzz_generated/app-common/clusters/OvenCavityOperationalState/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OvenMode/Structs.h
+++ b/zzz_generated/app-common/clusters/OvenMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/OzoneConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/Pm10ConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/Pm1ConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/Pm25ConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PowerSource/Structs.h
+++ b/zzz_generated/app-common/clusters/PowerSource/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PowerSourceConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/PowerSourceConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PowerTopology/Structs.h
+++ b/zzz_generated/app-common/clusters/PowerTopology/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PressureMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/PressureMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ProxyConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/ProxyConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ProxyDiscovery/Structs.h
+++ b/zzz_generated/app-common/clusters/ProxyDiscovery/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ProxyValid/Structs.h
+++ b/zzz_generated/app-common/clusters/ProxyValid/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PulseWidthModulation/Structs.h
+++ b/zzz_generated/app-common/clusters/PulseWidthModulation/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Structs.h
+++ b/zzz_generated/app-common/clusters/PumpConfigurationAndControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/PushAvStreamTransport/Structs.h
+++ b/zzz_generated/app-common/clusters/PushAvStreamTransport/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/RadonConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RefrigeratorAlarm/Structs.h
+++ b/zzz_generated/app-common/clusters/RefrigeratorAlarm/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Structs.h
+++ b/zzz_generated/app-common/clusters/RefrigeratorAndTemperatureControlledCabinetMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/RelativeHumidityMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RvcCleanMode/Structs.h
+++ b/zzz_generated/app-common/clusters/RvcCleanMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RvcOperationalState/Structs.h
+++ b/zzz_generated/app-common/clusters/RvcOperationalState/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/RvcRunMode/Structs.h
+++ b/zzz_generated/app-common/clusters/RvcRunMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/SampleMei/Structs.h
+++ b/zzz_generated/app-common/clusters/SampleMei/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ScenesManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/ScenesManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ServiceArea/Structs.h
+++ b/zzz_generated/app-common/clusters/ServiceArea/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/SmokeCoAlarm/Structs.h
+++ b/zzz_generated/app-common/clusters/SmokeCoAlarm/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/SoftwareDiagnostics/Structs.h
+++ b/zzz_generated/app-common/clusters/SoftwareDiagnostics/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/SoilMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/SoilMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Switch/Structs.h
+++ b/zzz_generated/app-common/clusters/Switch/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TargetNavigator/Structs.h
+++ b/zzz_generated/app-common/clusters/TargetNavigator/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TemperatureControl/Structs.h
+++ b/zzz_generated/app-common/clusters/TemperatureControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TemperatureMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/TemperatureMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Thermostat/Structs.h
+++ b/zzz_generated/app-common/clusters/Thermostat/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/Structs.h
+++ b/zzz_generated/app-common/clusters/ThermostatUserInterfaceConfiguration/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/ThreadBorderRouterManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Structs.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDiagnostics/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Structs.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TimeFormatLocalization/Structs.h
+++ b/zzz_generated/app-common/clusters/TimeFormatLocalization/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TimeSynchronization/Structs.h
+++ b/zzz_generated/app-common/clusters/TimeSynchronization/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/Timer/Structs.h
+++ b/zzz_generated/app-common/clusters/Timer/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TlsCertificateManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/TlsCertificateManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TlsClientManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/TlsClientManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/Structs.h
+++ b/zzz_generated/app-common/clusters/TotalVolatileOrganicCompoundsConcentrationMeasurement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/UnitLocalization/Structs.h
+++ b/zzz_generated/app-common/clusters/UnitLocalization/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/UnitTesting/Structs.h
+++ b/zzz_generated/app-common/clusters/UnitTesting/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/UserLabel/Structs.h
+++ b/zzz_generated/app-common/clusters/UserLabel/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Structs.h
+++ b/zzz_generated/app-common/clusters/ValveConfigurationAndControl/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WakeOnLan/Structs.h
+++ b/zzz_generated/app-common/clusters/WakeOnLan/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WaterHeaterManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WaterHeaterMode/Structs.h
+++ b/zzz_generated/app-common/clusters/WaterHeaterMode/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WebRTCTransportProvider/Structs.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportProvider/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Structs.h
+++ b/zzz_generated/app-common/clusters/WebRTCTransportRequestor/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Structs.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkDiagnostics/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WiFiNetworkManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/WiFiNetworkManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/WindowCovering/Structs.h
+++ b/zzz_generated/app-common/clusters/WindowCovering/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>

--- a/zzz_generated/app-common/clusters/ZoneManagement/Structs.h
+++ b/zzz_generated/app-common/clusters/ZoneManagement/Structs.h
@@ -23,7 +23,7 @@
 #include <app/data-model/DecodableList.h>
 #include <app/data-model/List.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/basic-types.h>
+#include <lib/core/DataModelTypes.h>
 #include <lib/core/Optional.h>
 #include <lib/core/TLV.h>
 #include <lib/support/BitMask.h>


### PR DESCRIPTION
Fixes #38417 

#### Testing

Tested with the same workflows in my own repo, passing most and some only failed due to not pulling docker images properly.
