### PR TITLE
[Linux/Tizen] Replace g_free usages with GAutoPtr

### DIFF
--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -97,12 +97,6 @@ struct GAutoPtrDeleter<char>
 };
 
 template <>
-struct GAutoPtrDeleter<unsigned char>
-{
-    using deleter = GFree;
-};
-
-template <>
 struct GAutoPtrDeleter<const char *>
 {
     using deleter = GFree;

--- a/src/platform/GLibTypeDeleter.h
+++ b/src/platform/GLibTypeDeleter.h
@@ -97,6 +97,12 @@ struct GAutoPtrDeleter<char>
 };
 
 template <>
+struct GAutoPtrDeleter<unsigned char>
+{
+    using deleter = GFree;
+};
+
+template <>
 struct GAutoPtrDeleter<const char *>
 {
     using deleter = GFree;

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -554,7 +554,8 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -287,7 +287,7 @@ CHIP_ERROR BluezEndpoint::RegisterGattApplicationImpl()
     GVariant * options = g_variant_builder_end(&optionsBuilder);
 
     bluez_gatt_manager1_call_register_application(
-        gattMgr.get(), mpRootPath, options, nullptr,
+        gattMgr.get(), mpRootPath.get(), options, nullptr,
         +[](GObject * aObj, GAsyncResult * aResult, void * self) {
             reinterpret_cast<BluezEndpoint *>(self)->RegisterGattApplicationDone(aObj, aResult);
         },
@@ -335,8 +335,8 @@ void BluezEndpoint::HandleNewDevice(BluezDevice1 & aDevice)
     VerifyOrExit(conn != nullptr, err = CHIP_ERROR_NO_MEMORY);
     SuccessOrExit(err = conn->Init(*this));
 
-    mpPeerDevicePath           = g_strdup(objectPath);
-    mConnMap[mpPeerDevicePath] = conn;
+    mpPeerDevicePath.reset(g_strdup(objectPath));
+    mConnMap[mpPeerDevicePath.get()] = conn;
 
     ChipLogDetail(DeviceLayer, "New BLE connection: conn=%p device=%s path=%s", conn, conn->GetPeerAddress(), objectPath);
 
@@ -369,9 +369,9 @@ BluezGattService1 * BluezEndpoint::CreateGattService(const char * aUUID)
     BluezObjectSkeleton * object;
     BluezGattService1 * service;
 
-    mpServicePath = g_strdup_printf("%s/service", mpRootPath);
-    ChipLogDetail(DeviceLayer, "CREATE service object at %s", mpServicePath);
-    object = bluez_object_skeleton_new(mpServicePath);
+    mpServicePath.reset(g_strdup_printf("%s/service", mpRootPath.get()));
+    ChipLogDetail(DeviceLayer, "CREATE service object at %s", mpServicePath.get());
+    object = bluez_object_skeleton_new(mpServicePath.get());
 
     service = bluez_gatt_service1_skeleton_new();
     bluez_gatt_service1_set_uuid(service, aUUID);
@@ -394,7 +394,7 @@ BluezConnection * BluezEndpoint::GetBluezConnection(const char * aPath)
 
 BluezConnection * BluezEndpoint::GetBluezConnectionViaDevice()
 {
-    return GetBluezConnection(mpPeerDevicePath);
+    return GetBluezConnection(mpPeerDevicePath.get());
 }
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING
@@ -520,8 +520,8 @@ void BluezEndpoint::SetupGattServer(GDBusConnection * aConn)
 {
     VerifyOrReturn(!mIsCentral);
 
-    mpRootPath = g_strdup_printf("/chipoble/%04x", getpid() & 0xffff);
-    mRoot.reset(g_dbus_object_manager_server_new(mpRootPath));
+    mpRootPath.reset(g_strdup_printf("/chipoble/%04x", getpid() & 0xffff));
+    mRoot.reset(g_dbus_object_manager_server_new(mpRootPath.get()));
 
     SetupGattService();
 
@@ -554,8 +554,7 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -585,10 +584,6 @@ void BluezEndpoint::Shutdown()
             return CHIP_NO_ERROR;
         },
         this);
-
-    g_free(mpRootPath);
-    g_free(mpServicePath);
-    g_free(mpPeerDevicePath);
 
     mIsInitialized = false;
 }

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -118,8 +118,8 @@ private:
     bool mIsInitialized = false;
 
     // Paths for objects published by this service
-    GAutoPtr<char> mpRootPath;
-    GAutoPtr<char> mpServicePath;
+    GAutoPtr<char> mRootPath;
+    GAutoPtr<char> mServicePath;
 
     // Objects (interfaces) published by this service
     GAutoPtr<GDBusObjectManagerServer> mRoot;
@@ -133,7 +133,7 @@ private:
 
     std::unordered_map<std::string, BluezConnection *> mConnMap;
     GAutoPtr<GCancellable> mConnectCancellable;
-    GAutoPtr<char> mpPeerDevicePath;
+    GAutoPtr<char> mPeerDevicePath;
 
     // Allow BluezConnection to access our private members
     friend class BluezConnection;

--- a/src/platform/Linux/bluez/BluezEndpoint.h
+++ b/src/platform/Linux/bluez/BluezEndpoint.h
@@ -118,8 +118,8 @@ private:
     bool mIsInitialized = false;
 
     // Paths for objects published by this service
-    char * mpRootPath    = nullptr;
-    char * mpServicePath = nullptr;
+    GAutoPtr<char> mpRootPath;
+    GAutoPtr<char> mpServicePath;
 
     // Objects (interfaces) published by this service
     GAutoPtr<GDBusObjectManagerServer> mRoot;
@@ -133,7 +133,7 @@ private:
 
     std::unordered_map<std::string, BluezConnection *> mConnMap;
     GAutoPtr<GCancellable> mConnectCancellable;
-    char * mpPeerDevicePath = nullptr;
+    GAutoPtr<char> mpPeerDevicePath;
 
     // Allow BluezConnection to access our private members
     friend class BluezConnection;

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -406,7 +406,8 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) :
+    GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -430,7 +431,8 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) :
+    GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -450,7 +452,8 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) :
+    GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -338,7 +338,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
         ChipLogError(DeviceLayer, "chip::Inet::InterfaceId::InterfaceNameToId() failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
     ret = dnssd_service_get_all_txt_record(service, &rCtx->mResultTxtRecordLen,
-                                           reinterpret_cast<void **>(rCtx->mResultTxtRecord.out()));
+                                           reinterpret_cast<void **>(&rCtx->mResultTxtRecord.GetReceiver()));
     VerifyOrExit(ret == DNSSD_ERROR_NONE,
                  ChipLogError(DeviceLayer, "dnssd_service_get_all_txt_record() failed: %s", get_error_message(ret)));
 
@@ -407,8 +407,7 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -432,8 +431,7 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -453,8 +451,7 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -29,7 +29,6 @@
 // Note: Include dns-sd-internal.h is needed, this source file uses some undocumented functions.
 #include <dns-sd-internal.h>
 #include <dns-sd.h>
-#include <glib-object.h>
 #include <glib.h>
 
 #include <inet/InetConfig.h>
@@ -407,8 +406,7 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -432,8 +430,7 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -453,8 +450,7 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);
@@ -463,6 +459,8 @@ ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const c
     mCallback  = callback;
     mCbContext = context;
 }
+
+ResolveContext::~ResolveContext() = default;
 
 void ResolveContext::Finalize(CHIP_ERROR error)
 {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -336,7 +336,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
         err == CHIP_NO_ERROR,
         ChipLogError(DeviceLayer, "chip::Inet::InterfaceId::InterfaceNameToId() failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    ret = dnssd_service_get_all_txt_record(service, &rCtx->mResultTxtRecordLen, reinterpret_cast<void **>(&rCtx->mResultTxtRecord));
+    ret = dnssd_service_get_all_txt_record(service, &rCtx->mResultTxtRecordLen, reinterpret_cast<void **>(rCtx->mResultTxtRecord.out()));
     VerifyOrExit(ret == DNSSD_ERROR_NONE,
                  ChipLogError(DeviceLayer, "dnssd_service_get_all_txt_record() failed: %s", get_error_message(ret)));
 
@@ -462,11 +462,6 @@ ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const c
     mCbContext = context;
 }
 
-ResolveContext::~ResolveContext()
-{
-    g_free(mResultTxtRecord);
-}
-
 void ResolveContext::Finalize(CHIP_ERROR error)
 {
     ChipLogProgress(DeviceLayer, "DNSsd %s", __func__);
@@ -474,7 +469,7 @@ void ResolveContext::Finalize(CHIP_ERROR error)
     VerifyOrReturn(error == CHIP_NO_ERROR, mCallback(mCbContext, nullptr, chip::Span<chip::Inet::IPAddress>(), error));
 
     std::vector<chip::Dnssd::TextEntry> textEntries;
-    GetTextEntries(mResultTxtRecordLen, mResultTxtRecord, textEntries);
+    GetTextEntries(mResultTxtRecordLen, mResultTxtRecord.get(), textEntries);
     mResult.mTextEntries   = textEntries.empty() ? nullptr : textEntries.data();
     mResult.mTextEntrySize = textEntries.size();
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -406,8 +406,7 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -431,8 +430,7 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -452,8 +450,7 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);
@@ -462,8 +459,6 @@ ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const c
     mCallback  = callback;
     mCbContext = context;
 }
-
-ResolveContext::~ResolveContext() = default;
 
 void ResolveContext::Finalize(CHIP_ERROR error)
 {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -29,6 +29,7 @@
 // Note: Include dns-sd-internal.h is needed, this source file uses some undocumented functions.
 #include <dns-sd-internal.h>
 #include <dns-sd.h>
+#include <glib-object.h>
 #include <glib.h>
 
 #include <inet/InetConfig.h>
@@ -406,8 +407,7 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -431,8 +431,7 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -452,8 +451,7 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -407,8 +407,7 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) :
-    GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -432,8 +431,7 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) :
-    GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -453,8 +451,7 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) :
-    GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);
@@ -471,7 +468,7 @@ void ResolveContext::Finalize(CHIP_ERROR error)
     VerifyOrReturn(error == CHIP_NO_ERROR, mCallback(mCbContext, nullptr, chip::Span<chip::Inet::IPAddress>(), error));
 
     std::vector<chip::Dnssd::TextEntry> textEntries;
-    GetTextEntries(mResultTxtRecordLen, mResultTxtRecord.get(), textEntries);
+    GetTextEntries(mResultTxtRecordLen, reinterpret_cast<uint8_t *>(mResultTxtRecord.get()), textEntries);
     mResult.mTextEntries   = textEntries.empty() ? nullptr : textEntries.data();
     mResult.mTextEntrySize = textEntries.size();
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -407,7 +407,8 @@ namespace Dnssd {
 DnssdTizen DnssdTizen::sInstance;
 
 RegisterContext::RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service,
-                                 DnssdPublishCallback callback, void * context) : GenericContext(ContextType::Register, instance)
+                                 DnssdPublishCallback callback, void * context) :
+    GenericContext(ContextType::Register, instance)
 {
     Platform::CopyString(mName, service.mName);
     Platform::CopyString(mType, type);
@@ -431,7 +432,8 @@ RegisterContext::~RegisterContext()
 }
 
 BrowseContext::BrowseContext(DnssdTizen * instance, const char * type, Dnssd::DnssdServiceProtocol protocol, uint32_t interfaceId,
-                             DnssdBrowseCallback callback, void * context) : GenericContext(ContextType::Browse, instance)
+                             DnssdBrowseCallback callback, void * context) :
+    GenericContext(ContextType::Browse, instance)
 {
     Platform::CopyString(mType, type);
     mProtocol    = protocol;
@@ -451,7 +453,8 @@ BrowseContext::~BrowseContext()
 }
 
 ResolveContext::ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId,
-                               DnssdResolveCallback callback, void * context) : GenericContext(ContextType::Resolve, instance)
+                               DnssdResolveCallback callback, void * context) :
+    GenericContext(ContextType::Resolve, instance)
 {
     Platform::CopyString(mName, name);
     Platform::CopyString(mType, type);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -336,7 +336,8 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * userData)
         err == CHIP_NO_ERROR,
         ChipLogError(DeviceLayer, "chip::Inet::InterfaceId::InterfaceNameToId() failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    ret = dnssd_service_get_all_txt_record(service, &rCtx->mResultTxtRecordLen, reinterpret_cast<void **>(rCtx->mResultTxtRecord.out()));
+    ret = dnssd_service_get_all_txt_record(service, &rCtx->mResultTxtRecordLen,
+                                           reinterpret_cast<void **>(rCtx->mResultTxtRecord.out()));
     VerifyOrExit(ret == DNSSD_ERROR_NONE,
                  ChipLogError(DeviceLayer, "dnssd_service_get_all_txt_record() failed: %s", get_error_message(ret)));
 

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include <dns-sd.h>
-#include <glib-object.h>
 #include <glib.h>
 
 #include <inet/IPAddress.h>

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -113,7 +113,7 @@ struct ResolveContext : public GenericContext
 
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                    void * context);
-    ~ResolveContext() = default;
+    ~ResolveContext() override;
 
     void Finalize(CHIP_ERROR error);
 };

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -106,7 +106,7 @@ struct ResolveContext : public GenericContext
     bool mIsResolving              = false;
 
     // Resolved service
-    DnssdService mResult               = {};
+    DnssdService mResult = {};
     GAutoPtr<uint8_t> mResultTxtRecord;
     unsigned short mResultTxtRecordLen = 0;
 

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include <dns-sd.h>
+#include <glib-object.h>
 #include <glib.h>
 
 #include <inet/IPAddress.h>
@@ -32,6 +33,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/dnssd/Constants.h>
 #include <lib/dnssd/platform/Dnssd.h>
+#include <platform/GLibTypeDeleter.h>
 
 namespace chip {
 namespace Dnssd {

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -113,7 +113,7 @@ struct ResolveContext : public GenericContext
 
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                    void * context);
-    ~ResolveContext() override;
+    ~ResolveContext() override = default;
 
     void Finalize(CHIP_ERROR error);
 };

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -113,7 +113,7 @@ struct ResolveContext : public GenericContext
 
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
                    void * context);
-    ~ResolveContext() override;
+    ~ResolveContext() = default;
 
     void Finalize(CHIP_ERROR error);
 };

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -107,7 +107,7 @@ struct ResolveContext : public GenericContext
 
     // Resolved service
     DnssdService mResult               = {};
-    uint8_t * mResultTxtRecord         = nullptr;
+    GAutoPtr<uint8_t> mResultTxtRecord;
     unsigned short mResultTxtRecordLen = 0;
 
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -109,7 +109,7 @@ struct ResolveContext : public GenericContext
 
     // Resolved service
     DnssdService mResult = {};
-    GAutoPtr<uint8_t> mResultTxtRecord;
+    GAutoPtr<char> mResultTxtRecord;
     unsigned short mResultTxtRecordLen = 0;
 
     ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,


### PR DESCRIPTION
### Problem
Code uses `g_free` to manually manage memory when RAII alternative would work just fine in that situation.

### Solution
Replace some `g_free` usages with `GAutoPtr`.
- `T*` is now accessed via `.get()`.
- `T**` is now accessed via `.out()`.
- Reassignments are now performed using `.reset()`.

### Testing
Performing all tests (unit and integration) results in success