### PR TITLE
Disable wifi paf due to long running CI

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -23,6 +23,9 @@ declare_args() {
 
   # Substitute fake platform when building with chip_device_platform=auto.
   chip_fake_platform = false
+
+  # Include wifi-paf to commission the device or not
+  chip_device_config_enable_wifipaf = false
 }
 
 if (chip_device_platform == "auto") {
@@ -123,14 +126,6 @@ declare_args() {
 declare_args() {
   # Enable Joint Fabric features
   chip_device_config_enable_joint_fabric = false
-}
-
-declare_args() {
-  # Include wifi-paf to commission the device or not
-  # This is a feature of Wi-Fi spec that it can be enabled if wifi is enabled
-  # and the supplicant can support.
-  chip_device_config_enable_wifipaf =
-      chip_enable_wifi && chip_device_platform == "linux"
 }
 
 declare_args() {


### PR DESCRIPTION
Fixes #38890

#### Changes
- Disabling wifi paf in device.gni, which was originally added in [this PR](https://github.com/project-chip/connectedhomeip/pull/34764/files#diff-507b5b784184e3fe7c74287153119cd8b07d1211621859093c92bfe4b0af281e). This should reduce the run time of individual yaml tests from ~25 seconds, to ~3 seconds

#### Testing

- Integration tests still pass
- Ran a yaml test like so: 
```
./scripts/tests/local.py chip-tool-tests --target-glob '*FAN*3_6*'
```
and saw the aforementioned run time decrease locally

