### PR TITLE
fix List: remove explicit copy constructor from Span

### DIFF
--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -50,14 +50,6 @@ struct List : public Span<T>
     //
     using Span<T>::Span;
 
-    // Inherited copy constructors are _not_ imported by the using statement
-    // above, though, so we need to implement that ourselves.  This is templated
-    // on the span's type to allow us to init a List<const Foo> from Span<Foo>.
-    // Span's constructor handles the checks on the types for us.
-    template <class U>
-    constexpr List(const Span<U> & other) : Span<T>(other)
-    {}
-
     template <size_t N>
     constexpr List & operator=(T (&databuf)[N])
     {


### PR DESCRIPTION
This probably was actual for C++14. But not needed in C++17

#### Testing

CI build
