### PR TITLE
Updated TC-OPCREDS-3.5

### DIFF
--- a/src/python_testing/TC_OPCREDS_3_5.py
+++ b/src/python_testing/TC_OPCREDS_3_5.py
@@ -50,7 +50,7 @@ class TC_OPCREDS_3_5(MatterBaseTest):
         return ["OPCREDS.S"]
 
     def steps_TC_OPCREDS_3_5(self):
-        return [TestStep(1, "TH0 adds TH1 over CASE", "Commissioning is successful"),
+        return [TestStep(1, "TH0 adds TH1 over CASE", "Commissioning is successful", is_commissioning=True),
                 TestStep(2, "TH1 reads the NOCs attribute from the Node Operational Credentials cluster using a fabric-filtered read",
                          "Verify that the returned list has a single entry. Save the NOC field as noc_original and the ICAC field as icac_original"),
                 TestStep(3, "TH1 reads the TrustedRootCertificates attribute from the Node Operational Credentials cluster",


### PR DESCRIPTION
Fixes issue https://github.com/project-chip/matter-test-scripts/issues/562. 

The script was updated to indicate that this test requires commissioning by adding is_commissioning=True

### Testing

Tested and passed on the following apps:

darwin-x64-all-clusters-no-ble/chip-all-clusters-app
