### PR TITLE
[camera] Fix CTRL+C left terminal un-usable

### DIFF
--- a/examples/camera-controller/commands/interactive/InteractiveCommands.cpp
+++ b/examples/camera-controller/commands/interactive/InteractiveCommands.cpp
@@ -35,7 +35,7 @@ using namespace chip;
 // Global flag to signal shutdown
 std::atomic<bool> gShutdownRequested{ false };
 
-// Global handle for ReadCommandThread 
+// Global handle for ReadCommandThread
 pthread_t gReadThreadId;
 
 namespace {

--- a/examples/camera-controller/commands/interactive/InteractiveCommands.h
+++ b/examples/camera-controller/commands/interactive/InteractiveCommands.h
@@ -27,6 +27,9 @@
 
 class Commands;
 
+extern std::atomic<bool> gShutdownRequested;
+extern pthread_t gReadThreadId;
+
 class InteractiveCommand : public CHIPCommand
 {
 public:

--- a/examples/camera-controller/main.cpp
+++ b/examples/camera-controller/main.cpp
@@ -40,6 +40,12 @@ namespace {
 
 void StopSignalHandler(int signum)
 {
+    // Tell every thread a shutdown is underway *right now*.
+    gShutdownRequested.store(true);
+
+    /* wake the readline thread right now */
+    pthread_kill(gReadThreadId, SIGUSR1);
+
     DeviceLayer::SystemLayer().ScheduleLambda([]() { StopInteractiveEventLoop(); });
 }
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -81,8 +81,17 @@ CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorD
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    // Schedule the ProvideICECandidates() call to run asynchronously.
-    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() { ProvideAnswer(sessionId, mLocalDescription); });
+    // Store sessionId for the delayed callback
+    mPendingSessionId = sessionId;
+
+    // Schedule the ProvideAnswer() call to run with a small delay to ensure the response is sent first
+    DeviceLayer::SystemLayer().StartTimer(
+        chip::System::Clock::Milliseconds32(300),
+        [](chip::System::Layer * systemLayer, void * appState) {
+            auto * self = static_cast<WebRTCManager *>(appState);
+            self->ProvideAnswer(self->mPendingSessionId, self->mLocalDescription);
+        },
+        this);
 
     return CHIP_NO_ERROR;
 }
@@ -102,8 +111,17 @@ CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & s
     rtc::Description answerDesc(sdp, rtc::Description::Type::Answer);
     mPeerConnection->setRemoteDescription(answerDesc);
 
-    // Schedule the ProvideICECandidates() call to run asynchronously.
-    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() { ProvideICECandidates(sessionId); });
+    // Store sessionId for the delayed callback
+    mPendingSessionId = sessionId;
+
+    // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
+    DeviceLayer::SystemLayer().StartTimer(
+        chip::System::Clock::Milliseconds32(300),
+        [](chip::System::Layer * systemLayer, void * appState) {
+            auto * self = static_cast<WebRTCManager *>(appState);
+            self->ProvideICECandidates(self->mPendingSessionId);
+        },
+        this);
 
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -67,6 +67,7 @@ private:
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
     std::shared_ptr<rtc::DataChannel> mDataChannel;
 
+    uint16_t mPendingSessionId = 0;
     std::string mLocalDescription;
     // Local vector to store the ICE Candidate strings coming from the WebRTC
     // stack


### PR DESCRIPTION
CTRL + C left the terminal un-usable after exit from camera-controller

readline() handles SIGINT by:

1. Resetting the line buffer to "";
2. Returning control to its caller;
3. Leaving the terminal in raw mode until readline() is called again and a normal exit path is taken.

Because the loop in ReadCommandThread immediately calls readline() again when the buffer is
empty, the thread never leaves the readline state, so the terminal is never restored and you cannot
type in the shell after main() is gone.

#### Testing

Confirm CTRL + C exits the camera-controller properly
