### PR TITLE
[NXP] fix commissioning issue when using EL2GO factory data

### DIFF
--- a/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
+++ b/src/platform/nxp/rt/rw61x/FactoryDataProviderEl2GoImpl.cpp
@@ -215,7 +215,6 @@ CHIP_ERROR FactoryDataProviderImpl::SignWithDacKey(const ByteSpan & digestToSign
     uint8_t hash[MCUXCLHASH_OUTPUT_SIZE_SHA_256]     = { 0 };
     mcuxClEls_KeyIndex_t key_index                   = MCUXCLELS_KEY_SLOTS;
     mcuxClEls_EccByte_t ecc_signature[MCUXCLELS_ECC_SIGNATURE_SIZE];
-    uint8_t digest[kSHA256_Hash_Length];
     uint16_t BlobSize  = 0;
     uint16_t KeyIdSize = 0;
     uint32_t Addr;
@@ -227,8 +226,7 @@ CHIP_ERROR FactoryDataProviderImpl::SignWithDacKey(const ByteSpan & digestToSign
         SearchForId(FactoryDataId::kEl2GoDacKeyId, (uint8_t *) &el2go_dac_key_id, sizeof(el2go_dac_key_id), KeyIdSize));
 
     /* Calculate message HASH to sign */
-    memset(&digest[0], 0, sizeof(digest));
-    res = Hash_SHA256(digestToSign.data(), digestToSign.size(), &digest[0]);
+    res = Hash_SHA256(digestToSign.data(), digestToSign.size(), &hash[0]);
     if (res != CHIP_NO_ERROR)
     {
         return res;


### PR DESCRIPTION
# Description

fix commissioning issue (issue with sign with dac key function, chip tool error: "Failed in verifying 'Attestation Information' command received from the device: err 500. Look at AttestationVerificationResult enum to understand the errors" ) when using NXP EL2GO server for factory data provisioning.

#### Testing

Commissioning successful using secure rw61x board with factory data provisioned by EL2Go server :

- Factory data binary generated using NXP EL2Go server
- Matter binary build using command: gn gen --args="chip_enable_openthread=true chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=true nxp_use_factory_data=true board_version=\"frdm
\" chip_enable_wifi=true chip_enable_ota_requestor=true no_mcuboot=false nxp_enable_secure_EL2GO_factory_data=true" out/debug

No automated tests can catch it as it required to use a secure rw61x board