### PR TITLE
[E2E][JF] Fix commissioner-vendor-id

### DIFF
--- a/examples/jf-control-app/commands/common/CHIPCommand.cpp
+++ b/examples/jf-control-app/commands/common/CHIPCommand.cpp
@@ -475,7 +475,8 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(CommissionerIdentity & identity, 
     commissioner->SetUdcListenPort(udcListenPort);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
     chip::Controller::SetupParams commissionerParams;
-    chip::CASEAuthTag administratorCAT = chip::GetAdminCATWithVersion(CHIP_CONFIG_ADMINISTRATOR_CAT_INITIAL_VERSION);
+    chip::CASEAuthTag administratorCAT         = chip::GetAdminCATWithVersion(CHIP_CONFIG_ADMINISTRATOR_CAT_INITIAL_VERSION);
+    static chip::VendorId commissionerVendorId = mCommissionerVendorId.ValueOr(chip::VendorId::TestVendor1);
 
     ReturnLogErrorOnFailure(mCredIssuerCmds->SetupDeviceAttestation(commissionerParams, sTrustStore, sRevocationDelegate));
 
@@ -523,7 +524,7 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(CommissionerIdentity & identity, 
 
     // TODO: Initialize IPK epoch key in ExampleOperationalCredentials issuer rather than relying on DefaultIpkValue
     commissionerParams.operationalCredentialsDelegate = mCredIssuerCmds->GetCredentialIssuer();
-    commissionerParams.controllerVendorId             = mCommissionerVendorId.ValueOr(chip::VendorId::TestVendor1);
+    commissionerParams.controllerVendorId             = commissionerVendorId;
 
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().SetupCommissioner(commissionerParams, *(commissioner.get())));
 


### PR DESCRIPTION
Use the commissioner-vendor-id value from the command line invocation for each call to InitializeCommissioner(...).


#### Testing

-   Start jf-admin-app

```
$ cd ~/connectedhomeip/examples/jf-admin-app/linux/out/debug
$ rm -rf jfa_a_kvs && touch jfa_a_kvs
$ ./jfa-app --capabilities 0x4 --passcode 110220033 --secured-device-port 5533 --rpc-server-port 33033 --KVS jfa_a_kvs
```

-   Start jf-control-app

```
$ cd ~/connectedhomeip/examples/jf-control-app/out/debug
$ rm -rf jfc_a_storage_directory && mkdir jfc_a_storage_directory
$ ./jfc-app --rpc-server-port 33033 --storage-directory jfc_a_storage_directory --commissioner-vendor-id 0xFFF2
```

-   Commission jf-admin-app

```
>>> pairing onnetwork 1 110220033 --anchor true
```

Check that a Fabric having `AdminVendorID` set to **0xFFF2** has been installed:

```
>>> operationalcredentials read fabrics 2 0
```