### PR TITLE
Add missing header to platform sources

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -519,6 +519,7 @@ if (chip_device_platform != "none") {
       "../include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp",
       "../include/platform/internal/GenericPlatformManagerImpl_POSIX.h",
       "../include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp",
+      "../include/platform/internal/GenericPlatformManagerImpl_Zephyr.h",
       "../include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp",
       "../include/platform/internal/testing/ConfigUnitTest.h",
       "CommissionableDataProvider.cpp",


### PR DESCRIPTION
Add `GenericPlatformManagerImpl_Zephyr.h` to platform source files.

#### Testing
Verified by CI.
