### PR TITLE
Don't build OpenThread when OS is Zephyr

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -22,7 +22,8 @@ import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
 import("inet.gni")
 
-if (chip_system_config_use_openthread_inet_endpoints && current_os != "zephyr") {
+if (chip_system_config_use_openthread_inet_endpoints &&
+    current_os != "zephyr") {
   import("//build_overrides/openthread.gni")
 }
 
@@ -128,7 +129,8 @@ static_library("inet") {
     public_deps += [ "${lwip_root}:lwip" ]
   }
 
-  if (chip_system_config_use_openthread_inet_endpoints && current_os != "zephyr") {
+  if (chip_system_config_use_openthread_inet_endpoints &&
+      current_os != "zephyr") {
     public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
   }
 

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -22,7 +22,7 @@ import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/platform/device.gni")
 import("inet.gni")
 
-if (chip_system_config_use_openthread_inet_endpoints) {
+if (chip_system_config_use_openthread_inet_endpoints && current_os != "zephyr") {
   import("//build_overrides/openthread.gni")
 }
 
@@ -128,7 +128,7 @@ static_library("inet") {
     public_deps += [ "${lwip_root}:lwip" ]
   }
 
-  if (chip_system_config_use_openthread_inet_endpoints) {
+  if (chip_system_config_use_openthread_inet_endpoints && current_os != "zephyr") {
     public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
   }
 


### PR DESCRIPTION
Don't build OpenThread when OpenThread endpoints are enabled and OS is Zephyr, as OpenThread is a Zephyr module.

#### Testing
Verified by using OpenThread endpoints with Zephyr in nRF Connect SDK.