### PR TITLE
Fix InterfaceIterator for OpenThread endpoints

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -106,6 +106,7 @@ CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & i
 bool InterfaceIterator::Next()
 {
     // TODO : Cleanup #17346
+    mHasCurrent = false;
     return false;
 }
 

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -49,10 +49,6 @@ struct net_if_ipv4;
 struct net_if_ipv6;
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 
-#if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
-struct otIp6AddressInfo;
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
 
@@ -369,8 +365,8 @@ protected:
     net_if * mCurrentInterface           = nullptr;
 #endif // CHIP_SYSTEM_CONFIG_USE_ZEPHYR_NET_IF
 #if CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
-    struct otIp6AddressInfo * mCurNetif;
-#endif
+    bool mHasCurrent = true;
+#endif // CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT
 };
 
 /**
@@ -569,7 +565,7 @@ inline InterfaceIterator::~InterfaceIterator()               = default;
 inline InterfaceAddressIterator::~InterfaceAddressIterator() = default;
 inline bool InterfaceIterator::HasCurrent(void)
 {
-    return mCurNetif != NULL;
+    return mHasCurrent;
 }
 #endif
 


### PR DESCRIPTION
Previously `mCurNetif` was not initialized which resulted in infinite loop when iterating over interfaces.

As only one OpenThread interface is supported, the new implementation uses just a flag to indicate state of the iterator.


#### Testing
Verified by using OpenThread endpoints and reading network interfaces attribute from General Diagnostics cluster with:
```
chip-tool generaldiagnostics read network-interfaces 1 0
```
