### PR TITLE
Implement missing methods of InterfaceIterator for OpenThread endpoints

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -186,6 +186,25 @@ bool InterfaceAddressIterator::HasBroadcastAddress()
     return HasCurrent() && (otIp6GetMulticastAddresses(Inet::globalOtInstance) != nullptr);
 }
 
+CHIP_ERROR InterfaceIterator::GetInterfaceType(InterfaceType & type)
+{
+    type = InterfaceType::Thread;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR InterfaceIterator::GetHardwareAddress(uint8_t * addressBuffer, uint8_t & addressSize, uint8_t addressBufferSize)
+{
+    VerifyOrReturnError(addressBuffer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(addressBufferSize >= sizeof(otExtAddress), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    const otExtAddress * extendedAddr = otLinkGetExtendedAddress(Inet::globalOtInstance);
+    memcpy(addressBuffer, extendedAddr, sizeof(otExtAddress));
+    addressSize = sizeof(otExtAddress);
+
+    return CHIP_NO_ERROR;
+}
+
 #endif
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPENTHREAD_ENDPOINT


### PR DESCRIPTION
Implement `GetInterfaceType` and `GetHardwareAddress`.


#### Testing
Verified by using OpenThread endpoints with Zephyr in nRF Connect SDK.
