### PR TITLE
[nrfconnect] Remove MLD API workaround

### DIFF
--- a/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
+++ b/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
@@ -44,10 +44,7 @@
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-// Temporary workaround for lack of the public Zephyr's API for MLDv2.
-// Should be removed after https://github.com/zephyrproject-rtos/zephyr/pull/79274 is merged.
-extern "C" int net_ipv6_mld_join(struct net_if * iface, const struct in6_addr * addr);
-extern "C" int net_ipv6_mld_leave(struct net_if * iface, const struct in6_addr * addr);
+#include <zephyr/net/mld.h>
 #endif
 
 using namespace ::chip::Inet;


### PR DESCRIPTION
Replace function declarations with Zephyr include.


#### Testing
CI will test if the samples would still build correctly. There is no change in functionality.
