### PR TITLE
[Zephyr] Set true operational state of interfaces in DiagnosticDataProviderImpl

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -293,8 +293,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         NetworkInterface * ifp = new NetworkInterface();
 
         interfaceIterator.GetInterfaceName(ifp->Name, Inet::InterfaceId::kMaxIfNameLength);
-        ifp->name          = CharSpan::fromCharString(ifp->Name);
-        ifp->isOperational = true;
+        ifp->name = CharSpan::fromCharString(ifp->Name);
         Inet::InterfaceType interfaceType;
         if (interfaceIterator.GetInterfaceType(interfaceType) == CHIP_NO_ERROR)
         {
@@ -328,9 +327,19 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         CHIP_ERROR error;
         uint8_t addressSize;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+        if (interfaceType == Inet::InterfaceType::WiFi)
+        {
+            ifp->isOperational = ConnectivityMgr().IsWiFiStationConnected();
+            error              = interfaceIterator.GetHardwareAddress(ifp->MacAddress, addressSize, sizeof(ifp->MacAddress));
+        }
+        else
+#endif
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
         if (interfaceType == Inet::InterfaceType::Thread)
         {
+            ifp->isOperational = ConnectivityMgr().IsThreadAttached();
+
             static_assert(OT_EXT_ADDRESS_SIZE <= sizeof(ifp->MacAddress), "Unexpected extended address size");
             error       = ThreadStackMgr().GetPrimary802154MACAddress(ifp->MacAddress);
             addressSize = OT_EXT_ADDRESS_SIZE;
@@ -338,7 +347,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         else
 #endif
         {
-            error = interfaceIterator.GetHardwareAddress(ifp->MacAddress, addressSize, sizeof(ifp->MacAddress));
+            ifp->isOperational = true;
+            error              = interfaceIterator.GetHardwareAddress(ifp->MacAddress, addressSize, sizeof(ifp->MacAddress));
         }
 
         if (error != CHIP_NO_ERROR)

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -336,7 +336,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         else
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-        if (interfaceType == Inet::InterfaceType::Thread)
+            if (interfaceType == Inet::InterfaceType::Thread)
         {
             ifp->isOperational = ConnectivityMgr().IsThreadAttached();
 


### PR DESCRIPTION
Set operational flag based on WiFi and Thread current state. Fall back to true for other interfaces.


#### Testing
Verified in nRF Connect SDK with example device having two interfaces (Thread and WiFi) and reading network interfaces attribute from General Diagnostics cluster with:
```
chip-tool generaldiagnostics read network-interfaces 1 0
```
Result for WiFi interace active:
```
[1748267123.180] [3570997:3571006] [TOO] Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0000 DataVersion: 3162296619
[1748267123.180] [3570997:3571006] [TOO]   NetworkInterfaces: 2 entries
[1748267123.180] [3570997:3571006] [TOO]     [1]: {
[1748267123.180] [3570997:3571006] [TOO]       Name: ieee802154
[1748267123.180] [3570997:3571006] [TOO]       IsOperational: FALSE
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267123.180] [3570997:3571006] [TOO]       HardwareAddress: 92334A646C0B9FFF
[1748267123.180] [3570997:3571006] [TOO]       IPv4Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       IPv6Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       Type: 4
[1748267123.180] [3570997:3571006] [TOO]      }
[1748267123.180] [3570997:3571006] [TOO]     [2]: {
[1748267123.180] [3570997:3571006] [TOO]       Name: wlan0
[1748267123.180] [3570997:3571006] [TOO]       IsOperational: TRUE
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267123.180] [3570997:3571006] [TOO]       HardwareAddress: F4CE360046C7
[1748267123.180] [3570997:3571006] [TOO]       IPv4Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       IPv6Addresses: 1 entries
[1748267123.180] [3570997:3571006] [TOO]         [1]: FE80000000000000F6CE36FFFE0046C7
[1748267123.180] [3570997:3571006] [TOO]       Type: 1
[1748267123.180] [3570997:3571006] [TOO]      }
```
Result for Thread interace active:
```
[1748267906.743] [3753424:3753431] [TOO] Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0000 DataVersion: 2532121767
[1748267906.743] [3753424:3753431] [TOO]   NetworkInterfaces: 2 entries
[1748267906.743] [3753424:3753431] [TOO]     [1]: {
[1748267906.743] [3753424:3753431] [TOO]       Name: ieee802154
[1748267906.743] [3753424:3753431] [TOO]       IsOperational: TRUE
[1748267906.743] [3753424:3753431] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267906.743] [3753424:3753431] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267906.743] [3753424:3753431] [TOO]       HardwareAddress: 32F222B355F59C5A
[1748267906.743] [3753424:3753431] [TOO]       IPv4Addresses: 0 entries
[1748267906.743] [3753424:3753431] [TOO]       IPv6Addresses: 3 entries
[1748267906.743] [3753424:3753431] [TOO]         [1]: FDB24D4758982A2651B0F5C72C7B953B
[1748267906.743] [3753424:3753431] [TOO]         [2]: FE8000000000000030F222B355F59C5A
[1748267906.743] [3753424:3753431] [TOO]         [3]: FD1100220000000004BB52643D198808
[1748267906.743] [3753424:3753431] [TOO]       Type: 4
[1748267906.743] [3753424:3753431] [TOO]      }
[1748267906.743] [3753424:3753431] [TOO]     [2]: {
[1748267906.743] [3753424:3753431] [TOO]       Name: wlan0
[1748267906.743] [3753424:3753431] [TOO]       IsOperational: FALSE
[1748267906.743] [3753424:3753431] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267906.743] [3753424:3753431] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267906.743] [3753424:3753431] [TOO]       HardwareAddress: F4CE360046C7
[1748267906.743] [3753424:3753431] [TOO]       IPv4Addresses: 0 entries
[1748267906.743] [3753424:3753431] [TOO]       IPv6Addresses: 0 entries
[1748267906.743] [3753424:3753431] [TOO]       Type: 1
[1748267906.743] [3753424:3753431] [TOO]      }
```