### PR TITLE
[nrfconnect] Fix implementation of _IsWiFiStationConnected

### DIFF
--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -70,7 +70,7 @@ bool ConnectivityManagerImplWiFi::_IsWiFiStationApplicationControlled(void)
 
 bool ConnectivityManagerImplWiFi::_IsWiFiStationConnected(void)
 {
-    return (WiFiManager::StationStatus::CONNECTED == WiFiManager::Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::FULLY_PROVISIONED == WiFiManager::Instance().GetStationStatus());
 }
 
 System::Clock::Timeout ConnectivityManagerImplWiFi::_GetWiFiStationReconnectInterval(void)


### PR DESCRIPTION
`_IsWiFiStationConnected` should return true when the interface is operational, which maps to `FULLY_PROVISIONED` enumeration.


#### Testing
Verified in nRF Connect SDK with example device having two interfaces (Thread and WiFi) and reading network interfaces attribute from General Diagnostics cluster with:
```
chip-tool generaldiagnostics read network-interfaces 1 0
```
Result:
```
[1748267123.180] [3570997:3571006] [TOO] Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0000 DataVersion: 3162296619
[1748267123.180] [3570997:3571006] [TOO]   NetworkInterfaces: 2 entries
[1748267123.180] [3570997:3571006] [TOO]     [1]: {
[1748267123.180] [3570997:3571006] [TOO]       Name: ieee802154
[1748267123.180] [3570997:3571006] [TOO]       IsOperational: FALSE
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267123.180] [3570997:3571006] [TOO]       HardwareAddress: 92334A646C0B9FFF
[1748267123.180] [3570997:3571006] [TOO]       IPv4Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       IPv6Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       Type: 4
[1748267123.180] [3570997:3571006] [TOO]      }
[1748267123.180] [3570997:3571006] [TOO]     [2]: {
[1748267123.180] [3570997:3571006] [TOO]       Name: wlan0
[1748267123.180] [3570997:3571006] [TOO]       IsOperational: TRUE
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv4: null
[1748267123.180] [3570997:3571006] [TOO]       OffPremiseServicesReachableIPv6: null
[1748267123.180] [3570997:3571006] [TOO]       HardwareAddress: F4CE360046C7
[1748267123.180] [3570997:3571006] [TOO]       IPv4Addresses: 0 entries
[1748267123.180] [3570997:3571006] [TOO]       IPv6Addresses: 1 entries
[1748267123.180] [3570997:3571006] [TOO]         [1]: FE80000000000000F6CE36FFFE0046C7
[1748267123.180] [3570997:3571006] [TOO]       Type: 1
[1748267123.180] [3570997:3571006] [TOO]      }
```