### PR TITLE
Adding TC-SC-3.5 script and CASESession Fault Injection Points

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -198,10 +198,5 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "autopep8.args": ["--max-line-length", "132"],
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#213308",
-        "titleBar.activeBackground": "#2E470C",
-        "titleBar.activeForeground": "#F7FCEF"
-    }
+    "autopep8.args": ["--max-line-length", "132"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -198,5 +198,10 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
     },
-    "autopep8.args": ["--max-line-length", "132"]
+    "autopep8.args": ["--max-line-length", "132"],
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#213308",
+        "titleBar.activeBackground": "#2E470C",
+        "titleBar.activeForeground": "#F7FCEF"
+    }
 }

--- a/src/controller/python/chip/fault_injection/__init__.py
+++ b/src/controller/python/chip/fault_injection/__init__.py
@@ -45,6 +45,11 @@ class CHIPFaultId(IntEnum):
     CASECorruptSigma3Signature = 25
     CASECorruptSigma3InitiatorEphPubKey = 26
     CASECorruptSigma3ResponderEphPubKey = 27
+    CASECorruptTBEData2Encrypted = 28
+    CASECorruptSigma2NOC = 29
+    CASECorruptSigma2ICAC = 30
+    CASECorruptSigma2Signature = 31
+
 
 # END-IF-CHANGE-ALSO-CHANGE(/src/lib/support/CHIPFaultInjection.h)
 # IMPORTANT: CHIPFaultId enum above must be kept in sync with the 'Id' enum in src/lib/support/CHIPFaultInjection.h

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -74,7 +74,11 @@ namespace FaultInjection {
     X(CASECorruptSigma3ICAC, 24)                         /**< Send Sigma3 with invalid initiatorICAC */                            \
     X(CASECorruptSigma3Signature, 25)                    /**< Send Sigma3 with invalid signature */                                \
     X(CASECorruptSigma3InitiatorEphPubKey, 26)           /**< Send Sigma3 with invalid initiator ephemeral public key */           \
-    X(CASECorruptSigma3ResponderEphPubKey, 27)           /**< Send Sigma3 with invalid responder ephemeral public key */
+    X(CASECorruptSigma3ResponderEphPubKey, 27)           /**< Send Sigma3 with invalid responder ephemeral public key */           \
+    X(CASECorruptTBEData2Encrypted, 28)                  /**< Send Sigma2 with improperly generated TBEData2Encrypted */           \
+    X(CASECorruptSigma2NOC, 29)                          /**< Send Sigma2 with invalid responderNOC */                             \
+    X(CASECorruptSigma2ICAC, 30)                         /**< Send Sigma2 with invalid responderICAC */                            \
+    X(CASECorruptSigma2Signature, 31)                    /**< Send Sigma2 with invalid signature */
 
 // END-IF-CHANGE-ALSO-CHANGE(src/controller/python/chip/fault_injection/__init__.py)
 // WARNING: When adding/modifying Faults to the below macro, make sure the changes are duplicated to the CHIPFaultId enum in the

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1271,6 +1271,10 @@ CHIP_ERROR CASESession::PrepareSigma2(EncodeSigma2Inputs & outSigma2Data)
     TLVType outerContainerType = kTLVType_NotSpecified;
 
     ReturnErrorOnFailure(tlvWriter.StartContainer(AnonymousTag(), kTLVType_Structure, outerContainerType));
+
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma2NOC, *nocCert.data() ^= 0xFF);
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma2ICAC, *icaCert.data() ^= 0xFF);
+
     ReturnErrorOnFailure(tlvWriter.Put(AsTlvContextTag(TBEDataTags::kSenderNOC), nocCert));
     if (!icaCert.empty())
     {
@@ -1285,6 +1289,8 @@ CHIP_ERROR CASESession::PrepareSigma2(EncodeSigma2Inputs & outSigma2Data)
         nocBuf.Free();
         nocCert = MutableByteSpan{};
     }
+
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptSigma2Signature, *tbsData2Signature.Bytes() ^= 0xFF);
 
     ReturnErrorOnFailure(tlvWriter.PutBytes(AsTlvContextTag(TBEDataTags::kSignature), tbsData2Signature.ConstBytes(),
                                             static_cast<uint32_t>(tbsData2Signature.Length())));
@@ -1339,6 +1345,8 @@ CHIP_ERROR CASESession::EncodeSigma2(System::PacketBufferHandle & msgR2, EncodeS
 
     ReturnErrorOnFailure(tlvWriterMsg2.PutBytes(AsTlvContextTag(Sigma2Tags::kResponderEphPubKey), *input.responderEphPubKey,
                                                 static_cast<uint32_t>(input.responderEphPubKey->Length())));
+
+    CHIP_FAULT_INJECT(FaultInjection::kFault_CASECorruptTBEData2Encrypted, *input.msgR2Encrypted.Get() ^= 0xFF);
 
     ReturnErrorOnFailure(tlvWriterMsg2.PutBytes(AsTlvContextTag(Sigma2Tags::kEncrypted2), input.msgR2Encrypted.Get(),
                                                 static_cast<uint32_t>(input.encrypted2Length)));

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -24,6 +24,7 @@
 #       --storage-path admin_storage.json
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#       --PICS src/app/tests/suites/certification/ci-pics-values
 # === END CI TEST ARGUMENTS ===
 
 import logging

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -34,7 +34,7 @@ from time import sleep
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.fault_injection import CHIPFaultId
-from chip.interaction_model import InteractionModelError, Status
+from chip.interaction_model import InteractionModelError
 from chip.testing.apps import AppServerSubprocess
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from mobly import asserts
@@ -185,9 +185,8 @@ class TC_SC_3_5(MatterBaseTest):
                 endpoint=0,  # Fault‑Injection cluster lives on EP0
                 payload=command,
             )
-        except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.Success, "Fault Injection Command Failed, is the TH_SERVER app built with the FaultInjection Cluster ?")
+        except InteractionModelError:
+            asserts.fail("Fault Injection Command Failed, is the TH_SERVER app built with the FaultInjection Cluster?")
 
     @async_test_body
     async def test_TC_SC_3_5(self):

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -1,0 +1,343 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     factory-reset: true
+#     quiet: true
+#     script-args: >
+#       ----string-arg th_server_app_path:out/linux-x64-camera/chip-camera-app
+#       --storage-path admin_storage.json
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+# === END CI TEST ARGUMENTS ===
+
+import logging
+import os
+import tempfile
+from time import sleep
+
+import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
+from chip.fault_injection import CHIPFaultId
+from chip.testing.apps import AppServerSubprocess
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
+
+
+class TC_SC_3_5(MatterBaseTest):
+    def setup_class(self):
+        super().setup_class()
+
+        self.th_server = None
+        self.storage = None
+
+        self.th_client = self.default_controller
+        self.th_server_local_nodeid = 1111
+        self.th_server_discriminator = 1234
+        self.th_server_passcode = 20202021
+
+        self.th_server_app = self.user_params.get("th_server_app_path", None)
+        if not self.th_server_app:
+            asserts.fail("This test requires a TH_SERVER app. Specify app path with --string-arg th_server_app_path:<path_to_app>")
+        if not os.path.exists(self.th_server_app):
+            asserts.fail(f"The path {self.th_server_app} does not exist")
+
+        # Start TH Server
+        self.start_th_server()
+
+    def teardown_class(self):
+
+        if self.th_server is not None:
+            self.th_server.terminate()
+        if self.storage is not None:
+            self.storage.cleanup()
+        super().teardown_class()
+
+    def desc_TC_SC_3_5(self) -> str:
+        return "[TC-SC-3.5] CASE Error Handling [DUT_Initiator] "
+
+    def steps_TC_SC_3_5(self) -> list[TestStep]:
+        steps = [
+
+            TestStep("precondition", "TH_SERVER has been commissioned to TH_CLIENT", is_commissioning=True),
+
+            TestStep(1, "TH Client sends an OpenCommissioningWindow command to TH_SERVER to allow it to be commissioned by DUT_Initiator and trigger CASE Handshake",
+                     "Verify that the DUT returns SUCCESS"),
+
+            TestStep(2, "TH Client sends FailAtFault command to FaultInjection cluster on TH_SERVER to include a corrupt TBEData2Encrypted in the Sigma2 it will send during CASE Handshake",
+                     "Make sure command's response indicates it was successful."),
+
+            TestStep(3, "TH prompts the user to Commission DUT_Initiator to TH_SERVER",
+                     "Verify that the DUT sends a status report to TH_SERVER with a FAILURE general code (value 1), protocol ID of SECURE_CHANNEL (0x0000), and Protocol code of INVALID_PARAMETER (0X0002)."),
+
+            TestStep(4, "TH Client revokes the Commissioning Window and resends an OpenCommissioningWindow command to TH_SERVER to allow commissioning by DUT_Initiator again and re-trigger the CASE handshake.",
+                     "Verify that the DUT returns SUCCESS"),
+
+            TestStep(5, "TH Client sends FailAtFault command to FaultInjection cluster on TH_SERVER to include a corrupt responderNOC in the Sigma2 it will send during CASE Handshake",
+                     "Make sure command's response indicates it was successful."),
+
+            TestStep(6, "TH prompts the user to Commission DUT_Initiator to TH_SERVER again",
+                     "Verify that the DUT sends a status report to TH_SERVER with a FAILURE general code (value 1), protocol ID of SECURE_CHANNEL (0x0000), and Protocol code of INVALID_PARAMETER (0X0002)."),
+
+            TestStep(7, "TH Client revokes the Commissioning Window and resends an OpenCommissioningWindow command to TH_SERVER to allow commissioning by DUT_Initiator again and re-trigger the CASE handshake.",
+                     "Verify that the DUT returns SUCCESS"),
+
+            TestStep(8, "TH Client sends FailAtFault command to FaultInjection cluster on TH_SERVER to include a corrupt responderICAC in the Sigma2 it will send during CASE Handshake",
+                     "Make sure command's response indicates it was successful."),
+
+
+            TestStep(9, "TH prompts the user to Commission DUT_Initiator to TH_SERVER again",
+                     "Verify that the DUT sends a status report to TH_SERVER with a FAILURE general code (value 1), protocol ID of SECURE_CHANNEL (0x0000), and Protocol code of INVALID_PARAMETER (0X0002)."),
+
+
+            TestStep(10, "TH Client revokes the Commissioning Window and resends an OpenCommissioningWindow command to TH_SERVER to allow commissioning by DUT_Initiator again and re-trigger the CASE handshake.",
+                     "Verify that the DUT returns SUCCESS"),
+
+            TestStep(11, "TH Client sends FailAtFault command to FaultInjection cluster on TH_SERVER to include a corrupt Signature in the Sigma2 it will send during CASE Handshake",
+                     "Make sure command's response indicates it was successful."),
+
+
+            TestStep(12, "TH prompts the user to Commission DUT_Initiator to TH_SERVER again",
+                     "Verify that the DUT sends a status report to TH_SERVER with a FAILURE general code (value 1), protocol ID of SECURE_CHANNEL (0x0000), and Protocol code of INVALID_PARAMETER (0X0002)."),
+
+
+
+        ]
+        return steps
+
+    def start_th_server(self):
+
+        if self.th_server is not None:
+            self.th_server.terminate()
+        if self.storage is not None:
+            self.storage.cleanup()
+
+        # Create a temporary storage directory for keeping KVS files.
+        self.storage = tempfile.TemporaryDirectory(prefix=self.__class__.__name__)
+        logging.info("Temporary storage directory: %s", self.storage.name)
+
+        self.th_server = AppServerSubprocess(
+            self.th_server_app,
+            storage_dir=self.storage.name,
+            discriminator=self.th_server_discriminator,
+            passcode=self.th_server_passcode
+        )
+
+        self.th_server.start(
+            expected_output="Server initialization complete",
+            timeout=60)
+
+    async def open_commissioning_window(self):
+
+        # Instructing TH Server to accept a new Commissioner, which is the DUT
+        params = await self.th_client.OpenCommissioningWindow(
+            nodeid=self.th_server_local_nodeid, timeout=3*60, iteration=10000, discriminator=self.th_server_discriminator, option=1)
+        new_random_passcode = params.setupPinCode
+        sleep(1)
+        logging.info("OpenCommissioningWindow complete")
+
+        return new_random_passcode
+
+    async def reopen_commissioning_window(self):
+        ''' Before reopening Commissioning Window, we need to instruct TH_Server to revoke any active OpenCommissioningWindows '''
+
+        revokeCmd = Clusters.AdministratorCommissioning.Commands.RevokeCommissioning()
+        await self.th_client.SendCommand(nodeid=self.th_server_local_nodeid, endpoint=0, payload=revokeCmd, timedRequestTimeoutMs=9000)
+        sleep(1)
+
+        return await self.open_commissioning_window()
+
+    @async_test_body
+    async def test_TC_SC_3_5(self):
+
+        self.step("precondition")
+        await self.th_client.CommissionOnNetwork(nodeId=self.th_server_local_nodeid, setupPinCode=self.th_server_passcode, filterType=ChipDeviceCtrl.DiscoveryFilterType.LONG_DISCRIMINATOR, filter=self.th_server_discriminator)
+        logging.info("Commissioning TH_SERVER complete")
+
+        '''------------------------------------------- Inject Fault into Sigma2 TBEData2Encrypted--------------------------------------------- '''
+
+        self.step(1)
+        th_server_passcode = await self.open_commissioning_window()
+
+        self.step(2)
+        # Inject Fault in TH_SERVER, by sending fault injection Cluster Command from TH_CLIENT
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=CHIPFaultId.CASECorruptTBEData2Encrypted,
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.th_client.SendCommand(
+            nodeid=self.th_server_local_nodeid,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+
+        self.step(3)
+        prompt_msg = (
+            "\nPlease commission the TH server app from DUT:\n"
+            f"  pairing onnetwork 1 {th_server_passcode}\n"
+            "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
+            "Input 'N' if commissioner DUT commissions successfully \n "
+            "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
+        )
+
+        if self.is_pics_sdk_ci_only:
+            resp = 'Y'
+        else:
+            resp = self.wait_for_user_input(prompt_msg)
+
+        expected_error_found = resp.lower() == 'y'
+
+        # Verify results
+        asserts.assert_equal(
+            expected_error_found,
+            True,
+            f"Expected Error in TH_SERVER logs is {'found' if expected_error_found else 'not found'}"
+        )
+
+        '''------------------------------------------- Inject Fault into Sigma2 responderNOC--------------------------------------------- '''
+
+        self.step(4)
+        th_server_passcode = await self.reopen_commissioning_window()
+
+        self.step(5)
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=CHIPFaultId.CASECorruptSigma2NOC,
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.th_client.SendCommand(
+            nodeid=self.th_server_local_nodeid,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+
+        self.step(6)
+        prompt_msg = (
+            "\nPlease commission the TH server app from DUT:\n"
+            "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
+            f"  pairing onnetwork 2 {th_server_passcode}\n"
+            "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
+            "Input 'N' if commissioner DUT commissions successfully \n "
+            "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
+        )
+
+        if self.is_pics_sdk_ci_only:
+            resp = 'Y'
+        else:
+            resp = self.wait_for_user_input(prompt_msg)
+
+        expected_error_found = resp.lower() == 'y'
+
+        # Verify results
+        asserts.assert_equal(
+            expected_error_found,
+            True,
+            f"Expected Error in TH_SERVER logs is {'found' if expected_error_found else 'not found'}"
+        )
+
+        '''------------------------------------------- Inject Fault into Sigma2 responderICAC--------------------------------------------- '''
+
+        self.step(7)
+        th_server_passcode = await self.reopen_commissioning_window()
+
+        self.step(8)
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=CHIPFaultId.CASECorruptSigma2ICAC,
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.th_client.SendCommand(
+            nodeid=self.th_server_local_nodeid,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+
+        self.step(9)
+        prompt_msg = (
+            "\nPlease commission the TH server app from DUT:\n"
+            "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
+            f"  pairing onnetwork 3 {th_server_passcode}\n"
+            "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
+            "Input 'N' if commissioner DUT commissions successfully \n "
+            "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
+        )
+
+        if self.is_pics_sdk_ci_only:
+            resp = 'Y'
+        else:
+            resp = self.wait_for_user_input(prompt_msg)
+
+        expected_error_found = resp.lower() == 'y'
+
+        # Verify results
+        asserts.assert_equal(
+            expected_error_found,
+            True,
+            f"Expected Error in TH_SERVER logs is {'found' if expected_error_found else 'not found'}"
+        )
+
+        '''------------------------------------------- Inject Fault into Sigma2 Signature--------------------------------------------- '''
+
+        self.step(10)
+        th_server_passcode = await self.reopen_commissioning_window()
+
+        self.step(11)
+        command = Clusters.FaultInjection.Commands.FailAtFault(
+            type=Clusters.FaultInjection.Enums.FaultType.kChipFault,
+            id=CHIPFaultId.CASECorruptSigma2Signature,
+            numCallsToFail=1,
+            takeMutex=False,
+        )
+        await self.th_client.SendCommand(
+            nodeid=self.th_server_local_nodeid,
+            endpoint=0,  # Fault‑Injection cluster lives on EP0
+            payload=command,
+        )
+
+        self.step(12)
+        prompt_msg = (
+            "\nPlease commission the TH server app from DUT:\n"
+            "\nWARNING: Make sure that the Commissioner restarts commissioning from scratch, such as by changing NodeID or by restarting the commissioner\n"
+            f"  pairing onnetwork 4 {th_server_passcode}\n"
+            "Input 'Y' if commissioner DUT fails commissioning AND TH Server Logs display CHIP ERROR = 0x00000054 (INVALID CASE PARAMETER) equivalent to Status Report with protocol code 2 \n"
+            "Input 'N' if commissioner DUT commissions successfully \n "
+            "Or failure in TH Server Logs IS NOT = 'INVALID CASE PARAMETER'\n"
+        )
+
+        print(f"self.is_pics_sdk_ci_only = {self.is_pics_sdk_ci_only}")
+        if self.is_pics_sdk_ci_only:
+            resp = 'Y'
+        else:
+            resp = self.wait_for_user_input(prompt_msg)
+
+        expected_error_found = resp.lower() == 'y'
+
+        # Verify results
+        asserts.assert_equal(
+            expected_error_found,
+            True,
+            f"Expected Error in TH_SERVER logs is {'found' if expected_error_found else 'not found'}"
+        )
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -27,16 +27,16 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
-import tempfile
-from mobly import asserts
 import os
+import tempfile
 from time import sleep
 
-from chip import ChipDeviceCtrl
 import chip.clusters as Clusters
+from chip import ChipDeviceCtrl
 from chip.fault_injection import CHIPFaultId
-from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.testing.apps import AppServerSubprocess
+from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
+from mobly import asserts
 
 
 class TC_SC_3_5(MatterBaseTest):

--- a/src/python_testing/TC_SC_3_5.py
+++ b/src/python_testing/TC_SC_3_5.py
@@ -20,7 +20,7 @@
 #     factory-reset: true
 #     quiet: true
 #     script-args: >
-#       ----string-arg th_server_app_path:out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app
+#       --string-arg th_server_app_path:out/linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app
 #       --storage-path admin_storage.json
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto


### PR DESCRIPTION

- related Test Plan Changes: https://github.com/CHIP-Specifications/chip-test-plans/pull/5207

#### Testing

Tested Manually in the sequence:
1. Adding Delays after Opening Commissiong Windows
2. initate commissioning using a Seperate Chip-repl instance acting as DUT
3. Read the TH_Server Logs to make sure required errors showed up
