### PR TITLE
Add ack latency to TransmitEvent for MRP transmit analytics

### DIFF
--- a/src/messaging/ReliableMessageAnalyticsDelegate.h
+++ b/src/messaging/ReliableMessageAnalyticsDelegate.h
@@ -74,7 +74,7 @@ public:
         // When eventType is kAcknowledged, this will be populated with the number of milliseconds
         // that have elapsed between when the initial message was sent and when we received
         // acknowledgment for the message.
-        std::optional<uint64_t> ackLatency;
+        std::optional<uint64_t> ackLatencyMs;
     };
 
     virtual void OnTransmitEvent(const TransmitEvent & event) = 0;

--- a/src/messaging/ReliableMessageAnalyticsDelegate.h
+++ b/src/messaging/ReliableMessageAnalyticsDelegate.h
@@ -71,6 +71,10 @@ public:
         // retransmission attempt. A value of 1 indicates the first retransmission (i.e. the second
         // transmission of the message). This value should never be 0.
         std::optional<uint8_t> retransmissionCount;
+        // When eventType is kAcknowledged, this will be populated with the number of milliseconds
+        // that have elapsed between when the initial message was sent and when we received
+        // acknowledgment for the message.
+        std::optional<uint64_t> ackLatency;
     };
 
     virtual void OnTransmitEvent(const TransmitEvent & event) = 0;

--- a/src/messaging/ReliableMessageAnalyticsDelegate.h
+++ b/src/messaging/ReliableMessageAnalyticsDelegate.h
@@ -74,7 +74,7 @@ public:
         // When eventType is kAcknowledged, this will be populated with the number of milliseconds
         // that have elapsed between when the initial message was sent and when we received
         // acknowledgment for the message.
-        std::optional<uint64_t> ackLatencyMs;
+        std::optional<System::Clock::Milliseconds64> ackLatencyMs;
     };
 
     virtual void OnTransmitEvent(const TransmitEvent & event) = 0;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -134,8 +134,7 @@ void ReliableMessageMgr::NotifyMessageSendAnalytics(const RetransTableEntry & en
     if (eventType == ReliableMessageAnalyticsDelegate::EventType::kAcknowledged)
     {
         auto now           = System::SystemClock().GetMonotonicTimestamp();
-        auto latency       = now - entry.initialSentTime;
-        event.ackLatencyMs = latency.count();
+        event.ackLatencyMs = now - entry.initialSentTime;
     }
 
     mAnalyticsDelegate->OnTransmitEvent(event);

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -117,7 +117,6 @@ void ReliableMessageMgr::NotifyMessageSendAnalytics(const RetransTableEntry & en
         return;
     }
 
-
     uint32_t messageCounter                               = entry.retainedBuf.GetMessageCounter();
     auto fabricIndex                                      = sessionHandle->GetFabricIndex();
     auto destination                                      = secureSession->GetPeerNodeId();
@@ -132,9 +131,10 @@ void ReliableMessageMgr::NotifyMessageSendAnalytics(const RetransTableEntry & en
     {
         event.retransmissionCount = entry.sendCount;
     }
-    if (eventType == ReliableMessageAnalyticsDelegate::EventType::kAcknowledged) {
-        auto now = System::SystemClock().GetMonotonicTimestamp();
-        auto latency = now - entry.initialSentTime;
+    if (eventType == ReliableMessageAnalyticsDelegate::EventType::kAcknowledged)
+    {
+        auto now         = System::SystemClock().GetMonotonicTimestamp();
+        auto latency     = now - entry.initialSentTime;
         event.ackLatency = latency.count();
     }
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -133,8 +133,8 @@ void ReliableMessageMgr::NotifyMessageSendAnalytics(const RetransTableEntry & en
     }
     if (eventType == ReliableMessageAnalyticsDelegate::EventType::kAcknowledged)
     {
-        auto now         = System::SystemClock().GetMonotonicTimestamp();
-        auto latency     = now - entry.initialSentTime;
+        auto now           = System::SystemClock().GetMonotonicTimestamp();
+        auto latency       = now - entry.initialSentTime;
         event.ackLatencyMs = latency.count();
     }
 

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -135,7 +135,7 @@ void ReliableMessageMgr::NotifyMessageSendAnalytics(const RetransTableEntry & en
     {
         auto now         = System::SystemClock().GetMonotonicTimestamp();
         auto latency     = now - entry.initialSentTime;
-        event.ackLatency = latency.count();
+        event.ackLatencyMs = latency.count();
     }
 
     mAnalyticsDelegate->OnTransmitEvent(event);

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -69,7 +69,7 @@ public:
                                                        including both successfully and failure send. */
 #if CHIP_CONFIG_MRP_ANALYTICS_ENABLED
         System::Clock::Timestamp initialSentTime; /**< Timestamp when the initial message was sent */
-#endif // CHIP_CONFIG_MRP_ANALYTICS_ENABLED
+#endif                                            // CHIP_CONFIG_MRP_ANALYTICS_ENABLED
     };
 
     ReliableMessageMgr(ObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -67,6 +67,9 @@ public:
         System::Clock::Timestamp nextRetransTime; /**< A counter representing the next retransmission time for the message. */
         uint8_t sendCount;                        /**< The number of times we have tried to send this entry,
                                                        including both successfully and failure send. */
+#if CHIP_CONFIG_MRP_ANALYTICS_ENABLED
+        System::Clock::Timestamp initialSentTime; /**< Timestamp when the initial message was sent */
+#endif // CHIP_CONFIG_MRP_ANALYTICS_ENABLED
     };
 
     ReliableMessageMgr(ObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> & contextPool);

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -2053,7 +2053,7 @@ TEST_F(TestReliableMessageProtocol, CheckApplicationResponseNeverComes)
 }
 
 #if CHIP_CONFIG_MRP_ANALYTICS_ENABLED
-TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEventualSuccessForEsablishedCase)
+TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEventualSuccessForEstablishedCase)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Make sure we are using CASE sessions, because there is no defunct-marking for PASE.
@@ -2076,9 +2076,10 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     TestReliablityAnalyticDelegate testAnalyticsDelegate;
     rm->RegisterAnalyticsDelegate(&testAnalyticsDelegate);
 
+    constexpr auto kTestRetryInterval = 30_ms32;
     exchange->GetSessionHandle()->AsSecureSession()->SetRemoteSessionParameters(ReliableMessageProtocolConfig({
-        30_ms32, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
-        30_ms32, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+        kTestRetryInterval, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
+        kTestRetryInterval, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
     }));
 
     const auto expectedFabricIndex = exchange->GetSessionHandle()->GetFabricIndex();
@@ -2102,7 +2103,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(loopback.mDroppedMessageCount, 1u);
     EXPECT_EQ(rm->TestGetCountRetransTable(), 1);
 
-    // Wait for the initial message to fail (should take 330-413ms)
+    // Wait for the initial message to fail (should take less than 50ms)
     GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     DrainAndServiceIO();
 
@@ -2145,6 +2146,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(firstTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(firstTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kInitialSend);
     EXPECT_EQ(firstTransmitEvent.retransmissionCount, std::nullopt);
+    EXPECT_EQ(firstTransmitEvent.ackLatency, std::nullopt);
     // We have no way of validating the first messageCounter since this is a randomly generated value, but it should
     // remain constant for all subsequent transmit events in this test.
     const uint32_t messageCounter = firstTransmitEvent.messageCounter;
@@ -2155,6 +2157,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(secondTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(secondTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(secondTransmitEvent.retransmissionCount, 1);
+    EXPECT_EQ(secondTransmitEvent.ackLatency, std::nullopt);
     EXPECT_EQ(messageCounter, secondTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2163,6 +2166,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(thirdTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(thirdTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(thirdTransmitEvent.retransmissionCount, 2);
+    EXPECT_EQ(thirdTransmitEvent.ackLatency, std::nullopt);
     EXPECT_EQ(messageCounter, thirdTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2171,6 +2175,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(fourthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(fourthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(fourthTransmitEvent.retransmissionCount, 3);
+    EXPECT_EQ(fourthTransmitEvent.ackLatency, std::nullopt);
     EXPECT_EQ(messageCounter, fourthTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2179,6 +2184,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(fifthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(fifthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(fifthTransmitEvent.retransmissionCount, 4);
+    EXPECT_EQ(fifthTransmitEvent.ackLatency, std::nullopt);
     EXPECT_EQ(messageCounter, fifthTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2187,10 +2193,13 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(sixthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(sixthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kAcknowledged);
     EXPECT_EQ(sixthTransmitEvent.retransmissionCount, std::nullopt);
+    EXPECT_TRUE(sixthTransmitEvent.ackLatency.has_value());
+    auto expectedMinimumAckLatencyTime = kTestRetryInterval * 5;
+    EXPECT_GT(sixthTransmitEvent.ackLatency, expectedMinimumAckLatencyTime.count());
     EXPECT_EQ(messageCounter, sixthTransmitEvent.messageCounter);
 }
 
-TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitFailureForEsablishedCase)
+TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitFailureForEstablishedCase)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     // Make sure we are using CASE sessions, because there is no defunct-marking for PASE.
@@ -2332,7 +2341,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitFail
     EXPECT_EQ(messageCounter, sixthTransmitEvent.messageCounter);
 }
 
-TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEsablishedPase)
+TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEstablishedPase)
 {
     CHIP_ERROR err                          = CHIP_NO_ERROR;
     chip::System::PacketBufferHandle buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -2076,7 +2076,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     TestReliablityAnalyticDelegate testAnalyticsDelegate;
     rm->RegisterAnalyticsDelegate(&testAnalyticsDelegate);
 
-    constexpr auto kTestRetryInterval = 30_ms32;
+    constexpr auto kTestRetryInterval = System::Clock::Milliseconds32(30_ms32);
     exchange->GetSessionHandle()->AsSecureSession()->SetRemoteSessionParameters(ReliableMessageProtocolConfig({
         kTestRetryInterval, // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
         kTestRetryInterval, // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
@@ -2194,8 +2194,8 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(sixthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kAcknowledged);
     EXPECT_EQ(sixthTransmitEvent.retransmissionCount, std::nullopt);
     EXPECT_TRUE(sixthTransmitEvent.ackLatencyMs.has_value());
-    auto expectedMinimumAckLatencyTime = kTestRetryInterval * 5;
-    EXPECT_GT(sixthTransmitEvent.ackLatencyMs, expectedMinimumAckLatencyTime.count());
+    auto expectedMinimumAckLatencyTime = System::Clock::Milliseconds64(kTestRetryInterval * 5);
+    EXPECT_GT(sixthTransmitEvent.ackLatencyMs, expectedMinimumAckLatencyTime);
     EXPECT_EQ(messageCounter, sixthTransmitEvent.messageCounter);
 }
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -2146,7 +2146,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(firstTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(firstTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kInitialSend);
     EXPECT_EQ(firstTransmitEvent.retransmissionCount, std::nullopt);
-    EXPECT_EQ(firstTransmitEvent.ackLatency, std::nullopt);
+    EXPECT_EQ(firstTransmitEvent.ackLatencyMs, std::nullopt);
     // We have no way of validating the first messageCounter since this is a randomly generated value, but it should
     // remain constant for all subsequent transmit events in this test.
     const uint32_t messageCounter = firstTransmitEvent.messageCounter;
@@ -2157,7 +2157,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(secondTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(secondTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(secondTransmitEvent.retransmissionCount, 1);
-    EXPECT_EQ(secondTransmitEvent.ackLatency, std::nullopt);
+    EXPECT_EQ(secondTransmitEvent.ackLatencyMs, std::nullopt);
     EXPECT_EQ(messageCounter, secondTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2166,7 +2166,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(thirdTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(thirdTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(thirdTransmitEvent.retransmissionCount, 2);
-    EXPECT_EQ(thirdTransmitEvent.ackLatency, std::nullopt);
+    EXPECT_EQ(thirdTransmitEvent.ackLatencyMs, std::nullopt);
     EXPECT_EQ(messageCounter, thirdTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2175,7 +2175,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(fourthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(fourthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(fourthTransmitEvent.retransmissionCount, 3);
-    EXPECT_EQ(fourthTransmitEvent.ackLatency, std::nullopt);
+    EXPECT_EQ(fourthTransmitEvent.ackLatencyMs, std::nullopt);
     EXPECT_EQ(messageCounter, fourthTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2184,7 +2184,7 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(fifthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(fifthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kRetransmission);
     EXPECT_EQ(fifthTransmitEvent.retransmissionCount, 4);
-    EXPECT_EQ(fifthTransmitEvent.ackLatency, std::nullopt);
+    EXPECT_EQ(fifthTransmitEvent.ackLatencyMs, std::nullopt);
     EXPECT_EQ(messageCounter, fifthTransmitEvent.messageCounter);
 
     testAnalyticsDelegate.mTransmitEvents.pop();
@@ -2193,9 +2193,9 @@ TEST_F(TestReliableMessageProtocol, CheckReliableMessageAnalyticsForTransmitEven
     EXPECT_EQ(sixthTransmitEvent.fabricIndex, expectedFabricIndex);
     EXPECT_EQ(sixthTransmitEvent.eventType, ReliableMessageAnalyticsDelegate::EventType::kAcknowledged);
     EXPECT_EQ(sixthTransmitEvent.retransmissionCount, std::nullopt);
-    EXPECT_TRUE(sixthTransmitEvent.ackLatency.has_value());
+    EXPECT_TRUE(sixthTransmitEvent.ackLatencyMs.has_value());
     auto expectedMinimumAckLatencyTime = kTestRetryInterval * 5;
-    EXPECT_GT(sixthTransmitEvent.ackLatency, expectedMinimumAckLatencyTime.count());
+    EXPECT_GT(sixthTransmitEvent.ackLatencyMs, expectedMinimumAckLatencyTime.count());
     EXPECT_EQ(messageCounter, sixthTransmitEvent.messageCounter);
 }
 


### PR DESCRIPTION
Add way for ack latency analytics to be reported to registered MRP analytics delegate.

Also minor fix of typo of `Esablished` to `Established`

#### Testing
* Amended existing unit test that passes