### PR TITLE
[ESP32]: Fix the thread-br-app CI build

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -184,4 +184,13 @@ jobs:
               run: scripts/examples/esp_example.sh lock-app sdkconfig.defaults esp32c6
 
             - name: Build example thread-br-app (Target:ESP32S3)
-              run: scripts/examples/esp_example.sh thread-br-app sdkconfig.defaults esp32s3
+              shell: bash
+              run: |
+                   cd $IDF_PATH
+                   cd examples/openthread/ot_rcp
+                   source $IDF_PATH/export.sh
+                   idf.py set-target esp32h2
+                   idf.py build
+                   source $IDF_PATH/export.sh
+                   cd $GITHUB_WORKSPACE
+                   scripts/examples/esp_example.sh thread-br-app sdkconfig.defaults esp32s3


### PR DESCRIPTION
#### Problem
- The thread-br-app build was failing in CI (on espressif fork) due to few missing steps.
https://github.com/espressif/connectedhomeip/actions/runs/15291947483/job/43012914384

#### Change Overview
- Added the additional steps to build the thread br app in CI.

#### Testing
- Tested the thread-br-app locally with the steps and in the CI as well.
