### PR TITLE
[Ameba] platform updates for wifi

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -51,7 +51,6 @@
 #include <lwip/netif.h>
 
 #include <chip_porting.h>
-#include <lwip_netconf.h>
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -176,8 +175,9 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        mWiFiStationMode = (wifi_mode == RTW_MODE_STA) ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
+        mWiFiStationMode = (matter_wifi_is_station_mode() == RTW_SUCCESS) ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
     }
+
     return mWiFiStationMode;
 }
 
@@ -479,8 +479,6 @@ void ConnectivityManagerImpl::DriveStationState()
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
         err = Internal::AmebaUtils::StartWiFi();
-        SuccessOrExit(err);
-        err = Internal::AmebaUtils::EnableStationMode();
         SuccessOrExit(err);
     }
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -282,74 +282,40 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType)
 {
+    using app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum;
     CHIP_ERROR err;
     int32_t error;
+    uint32_t wifi_security = 0;
 
-    using app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum;
-
-    unsigned int _auth_type;
-    unsigned short security = 0;
-    rtw_wifi_setting_t setting;
-
-    error = matter_wifi_get_security_type(WLAN0_IDX, &security, &setting.key_idx, setting.password);
+    error = matter_wifi_get_security_type(WLAN0_IDX, &wifi_security);
     err   = AmebaUtils::MapError(error, AmebaErrorType::kWiFiError);
     if (err != CHIP_NO_ERROR)
     {
         securityType = SecurityTypeEnum::kUnspecified;
     }
-#ifdef CONFIG_PLATFORM_8721D
     else
     {
-        switch (security)
+        if (wifi_security & WPA3_SECURITY)
         {
-        case IW_ENCODE_ALG_NONE:
-            securityType = SecurityTypeEnum::kNone;
-            break;
-        case IW_ENCODE_ALG_WEP:
-            securityType = SecurityTypeEnum::kWep;
-            break;
-        case IW_ENCODE_ALG_TKIP:
-            securityType = SecurityTypeEnum::kWpa;
-            break;
-        case IW_ENCODE_ALG_CCMP:
+            securityType = SecurityTypeEnum::kWpa3;
+        }
+        else if (wifi_security & WPA2_SECURITY)
+        {
             securityType = SecurityTypeEnum::kWpa2;
-            break;
-        default:
-            securityType = SecurityTypeEnum::kUnspecified;
-            break;
         }
-    }
-#else
-    else
-    {
-        switch (security)
+        else if (wifi_security & WPA_SECURITY)
         {
-        case IW_ENCODE_ALG_NONE:
-            securityType = SecurityTypeEnum::kNone;
-            break;
-        case IW_ENCODE_ALG_WEP:
+            securityType = SecurityTypeEnum::kWpa;
+        }
+        else if (wifi_security & WEP_ENABLED)
+        {
             securityType = SecurityTypeEnum::kWep;
-            break;
-        case IW_ENCODE_ALG_TKIP:
-            if (_auth_type == WPA_SECURITY)
-                securityType = SecurityTypeEnum::kWpa;
-            else if (_auth_type == WPA2_SECURITY)
-                securityType = SecurityTypeEnum::kWpa2;
-            break;
-        case IW_ENCODE_ALG_CCMP:
-            if (_auth_type == WPA_SECURITY)
-                securityType = SecurityTypeEnum::kWpa;
-            else if (_auth_type == WPA2_SECURITY)
-                securityType = SecurityTypeEnum::kWpa2;
-            else if (_auth_type == WPA3_SECURITY)
-                securityType = SecurityTypeEnum::kWpa3;
-            break;
-        default:
-            securityType = SecurityTypeEnum::kUnspecified;
-            break;
+        }
+        else
+        {
+            securityType = SecurityTypeEnum::kNone;
         }
     }
-#endif
 
     return err;
 }


### PR DESCRIPTION
* Correcting the inorrect reading of wifi security type
* Adding more wifi mode support for platform


#### Testing
Conducted test with all-clusters-app for ameba 
**Security type verification:** tested against chip-tool with the following command
- ./chip-tool wifinetworkdiagnostics read security-type 1 0
- When router is set to open security type, result is 1.
- When router is set to WEP security type, result is 2.
- When router is set to WPA security type, result is 3.
- When router is set to WPA2 security type, result is 4.
- When router is set to WPA3 security type, result is 5.

**Additional wifi mode suppor**t: ensures that the minimum requirement of station mode is supported.
- Test: Commissioning with chip-tool
- Results: Commissioning is successful.