### PR TITLE
[CI] Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -64,13 +64,13 @@ jobs:
           scripts/examples/gn_silabs_example.sh examples/lighting-app/silabs ./out/light-app BRD4187C --slc_generate --docker
           rm -rf ./out/
       - name: Build some BRD4187C variants (1)
+      # TODO #39216 : Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues
         run: |
           ./scripts/run_in_build_env.sh \
              "./scripts/build/build_examples.py \
                 --enable-flashbundle \
                 --target efr32-brd4187c-thermostat-use-ot-lib \
                 --target efr32-brd4187c-switch-shell-use-ot-coap-lib \
-                --target efr32-brd4187c-unit-test \
                 build \
                 --copy-artifacts-to out/artifacts \
              "


### PR DESCRIPTION
Deactivated Unit Testing (efr32-brd4187c-unit-test ) due to Pigweed incompatibility issues

- Issue to track change #39216 

#### Testing

CI testing
