### PR TITLE
TC-LUNIT-3.1: Update test to be backwards compatible for 1.4.1 and earlier devices

### DIFF
--- a/src/python_testing/TC_LUNIT_3_1.py
+++ b/src/python_testing/TC_LUNIT_3_1.py
@@ -66,9 +66,10 @@ class TC_LUNIT_3_1(MatterBaseTest):
 
     def steps_TC_LUNIT_3_1(self) -> list[TestStep]:
         steps = [
-            TestStep(0, "Commissioning, already done", is_commissioning=True),
+            TestStep(0, "Commission DUT if required", is_commissioning=True),
             TestStep(1, "TH reads from the DUT the TemperatureUnit attribute"),
-            TestStep(2, "If supported, TH reads from the DUT the SupportedTemperatureUnits attribute", "Verify the "),
+            TestStep(2, "If supported, TH reads from the DUT the SupportedTemperatureUnits attribute",
+                     "Verify the list length is between 2 and 3 inclusive.\nVerify that each entry in the list is a valid\nTempUnitEnum value and is unique."),
             TestStep(3, "If the SupportedTemperatureUnits is supported, TH creates a `supported` list With each entry in SupportedUnitsList. If SupportedTemperatureUnits is not supported, TH creates a `supported` list with Celsius and Fahrenheit. TH writes each entry in the `supported` list to the DUT the TemperatureUnit attribute", "Write is successful"),
             TestStep(4, "If the SupportedTemperatureUnits is supported, TH construct a list with valid TempUnitEnum values that are not contained in SupportedUnitsList"),
             TestStep(5, "if the SupportedTemperatureUnits is supported, With each entry in UnsupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute",

--- a/src/python_testing/TC_LUNIT_3_1.py
+++ b/src/python_testing/TC_LUNIT_3_1.py
@@ -116,6 +116,7 @@ class TC_LUNIT_3_1(MatterBaseTest):
                 asserts.assert_less_equal(len(supported_temperature_units), 3,
                                           "SupportedTemperatureUnits may have a maximum of three entries in the list")
             else:
+                # Per CCB 4201, support Kelvin is not enforced for devices that predate SupportedTemperatureUnits
                 supported_temperature_units = [Clusters.UnitLocalization.Enums.TempUnitEnum.kCelsius,
                                                Clusters.UnitLocalization.Enums.TempUnitEnum.kFahrenheit]
             for unit in supported_temperature_units:

--- a/src/python_testing/TC_LUNIT_3_1.py
+++ b/src/python_testing/TC_LUNIT_3_1.py
@@ -51,14 +51,14 @@ class TC_LUNIT_3_1(MatterBaseTest):
                                     endpoint,
                                     temp_unit,
                                     dev_ctrl: ChipDeviceCtrl = None,
-                                    expected_status: Status = Status.Success) -> Status:
+                                    expected_status: list[Status] = [Status.Success]) -> Status:
         if dev_ctrl is None:
             dev_ctrl = self.default_controller
         cluster = Clusters.Objects.UnitLocalization
         result = await dev_ctrl.WriteAttribute(self.dut_node_id, [(endpoint, cluster.Attributes.TemperatureUnit(temp_unit))])
         status = result[0].Status
-        asserts.assert_equal(status, expected_status,
-                             f"TemperatureUnit write returned {status.name}; expected {expected_status.name}")
+        asserts.assert_in(status, expected_status,
+                          f"TemperatureUnit write returned {status.name}; expected {[e.name for e in expected_status]}")
         return status
 
     def desc_TC_LUNIT_3_1(self) -> str:
@@ -68,10 +68,13 @@ class TC_LUNIT_3_1(MatterBaseTest):
         steps = [
             TestStep(0, "Commissioning, already done", is_commissioning=True),
             TestStep(1, "TH reads from the DUT the TemperatureUnit attribute"),
-            TestStep(2, "TH reads from the DUT the SupportedTemperatureUnits attribute"),
-            TestStep(3, "With each entry in SupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute"),
-            TestStep(4, "Construct a list with valid TempUnitEnum values that are not contained in SupportedUnitsList"),
-            TestStep(5, "With each entry in UnsupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute")
+            TestStep(2, "If supported, TH reads from the DUT the SupportedTemperatureUnits attribute", "Verify the "),
+            TestStep(3, "If the SupportedTemperatureUnits is supported, TH creates a `supported` list With each entry in SupportedUnitsList. If SupportedTemperatureUnits is not supported, TH creates a `supported` list with Celsius and Fahrenheit. TH writes each entry in the `supported` list to the DUT the TemperatureUnit attribute", "Write is successful"),
+            TestStep(4, "If the SupportedTemperatureUnits is supported, TH construct a list with valid TempUnitEnum values that are not contained in SupportedUnitsList"),
+            TestStep(5, "if the SupportedTemperatureUnits is supported, With each entry in UnsupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute",
+                     "Write returns CONSTRAINT_ERROR"),
+            TestStep(6, "If SupportedTemperatureUnits is not supported, TH writes Kelvin",
+                     "Write either returns SUCCESS or CONSTRAINT_ERROR")
         ]
         return steps
 
@@ -88,14 +91,16 @@ class TC_LUNIT_3_1(MatterBaseTest):
         attributes = Clusters.UnitLocalization.Attributes
         features = await self.read_lunit_attribute_expect_success(endpoint=endpoint, attribute=attributes.FeatureMap)
         self.supports_TEMP = bool(features & Clusters.UnitLocalization.Bitmaps.Feature.kTemperatureUnit)
+        attribute_list = await self.read_lunit_attribute_expect_success(endpoint=endpoint, attribute=attributes.AttributeList)
+        has_supported_temperature_units = attributes.SupportedTemperatureUnits.attribute_id in attribute_list
 
         # Step 0 - Commissioning, already done", is_commissioning=True)
 
         self.step(0)  # commissioning - already done
 
-        # Step 1 - TH reads from the DUT the TemperatureUnit attribute")
-        self.step(1)
         if self.supports_TEMP:
+            # Step 1 - TH reads from the DUT the TemperatureUnit attribute")
+            self.step(1)
             temperature_unit = await self.read_lunit_attribute_expect_success(endpoint=endpoint, attribute=attributes.TemperatureUnit)
 
             asserts.assert_greater_equal(temperature_unit, Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kFahrenheit,
@@ -105,11 +110,15 @@ class TC_LUNIT_3_1(MatterBaseTest):
 
             # Step 2 - TH reads from the DUT the SupportedTemperatureUnits attribute")
             self.step(2)
-            supported_temperature_units = await self.read_lunit_attribute_expect_success(endpoint=endpoint, attribute=attributes.SupportedTemperatureUnits)
-            asserts.assert_greater_equal(len(supported_temperature_units), 2,
-                                         "SupportedTemperatureUnits must have at least two entry in the list")
-            asserts.assert_less_equal(len(supported_temperature_units), 3,
-                                      "SupportedTemperatureUnits may have a maximum of three entries in the list")
+            if has_supported_temperature_units:
+                supported_temperature_units = await self.read_lunit_attribute_expect_success(endpoint=endpoint, attribute=attributes.SupportedTemperatureUnits)
+                asserts.assert_greater_equal(len(supported_temperature_units), 2,
+                                             "SupportedTemperatureUnits must have at least two entry in the list")
+                asserts.assert_less_equal(len(supported_temperature_units), 3,
+                                          "SupportedTemperatureUnits may have a maximum of three entries in the list")
+            else:
+                supported_temperature_units = [Clusters.UnitLocalization.Enums.TempUnitEnum.kCelsius,
+                                               Clusters.UnitLocalization.Enums.TempUnitEnum.kFahrenheit]
             for unit in supported_temperature_units:
                 asserts.assert_greater_equal(unit, Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kFahrenheit,
                                              "Each entry in SupportedTemperatureUnits has to be Fahrenheit, Celsius or Kelvin")
@@ -119,24 +128,38 @@ class TC_LUNIT_3_1(MatterBaseTest):
             # Step 3 - With each entry in SupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute")
             self.step(3)
             for unit in supported_temperature_units:
-                await self.write_lunit_temp_unit(endpoint=endpoint, temp_unit=unit, expected_status=Status.Success)
+                await self.write_lunit_temp_unit(endpoint=endpoint, temp_unit=unit, expected_status=[Status.Success])
 
             # Step 4 - Construct a list with valid TempUnitEnum values that are not contained in
 
             self.step(4)
-            unsupported_temperature_units = []
-            for unit in [Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kFahrenheit,
-                         Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kCelsius,
-                         Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kKelvin]:
-                if unit not in supported_temperature_units:
-                    unsupported_temperature_units.append(unit)
+            if has_supported_temperature_units:
+                unsupported_temperature_units = []
+                for unit in [Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kFahrenheit,
+                             Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kCelsius,
+                             Clusters.Objects.UnitLocalization.Enums.TempUnitEnum.kKelvin]:
+                    if unit not in supported_temperature_units:
+                        unsupported_temperature_units.append(unit)
+            else:
+                self.mark_current_step_skipped()
 
             # Step 5 - With each entry in UnsupportedUnitsList, TH writes to the DUT the TemperatureUnit attribute")
             self.step(5)
-            for unit in unsupported_temperature_units:
-                await self.write_lunit_temp_unit(endpoint=endpoint, temp_unit=unit, expected_status=Status.ConstraintError)
+            if has_supported_temperature_units:
+                for unit in unsupported_temperature_units:
+                    await self.write_lunit_temp_unit(endpoint=endpoint, temp_unit=unit, expected_status=[Status.ConstraintError])
+            else:
+                self.mark_current_step_skipped()
+
+            self.step(6)
+            if not has_supported_temperature_units:
+                await self.write_lunit_temp_unit(endpoint=endpoint, temp_unit=unit, expected_status=[Status.Success, Status.ConstraintError])
+            else:
+                self.mark_current_step_skipped()
+
         else:
-            logging.info("no TEMP support - all Tests step skipped")
+            self.skip_all_remaining_steps(1)
+            return
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_LUNIT_3_1.py
+++ b/src/python_testing/TC_LUNIT_3_1.py
@@ -32,8 +32,6 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import logging
-
 import chip.clusters as Clusters
 from chip import ChipDeviceCtrl
 from chip.interaction_model import Status


### PR DESCRIPTION
https://github.com/CHIP-Specifications/chip-test-plans/pull/5210

#### Testing

Compiled all-clusters on 1.4 branch, saw this error before test update, see pass on new test. Test passes on ToT on master.

Note that we currently do not have any way to compile example apps on earlier branches for backwards compatibility testing (but perhaps we should).

[2025-05-27 14:11:35.311453][TEST][STDOUT]******************************************************************
[2025-05-27 14:11:35.311484][TEST][STDOUT]*
[2025-05-27 14:11:35.311764][TEST][STDOUT]* Test test_TC_LUNIT_3_1 failed for the following reason:
[2025-05-27 14:11:35.313011][TEST][STDOUT]* Details=Error reading <class 'chip.clusters.Objects.UnitLocalization'>:<class 'chip.clusters.Objects.UnitLocalization.Attributes.SupportedTemperatureUnits'> = ValueDecodeFailure(TLVValue=None, Reason=InteractionModelError(<Status.UnsupportedAttribute: 134>)), Extras=None
[2025-05-27 14:11:35.313054][TEST][STDOUT]*
[2025-05-27 14:11:35.313813][TEST][STDOUT]* File "/usr/local/google/home/cecille/chip/connectedhomeip/out/py/lib/python3.12/site-packages/chip/testing/matter_testing.py", line 1231, in read_single_attribute_check_success
[2025-05-27 14:11:35.314022][TEST][STDOUT]* asserts.assert_true(read_ok, read_err_msg)
[2025-05-27 14:11:35.314051][TEST][STDOUT]*
[2025-05-27 14:11:35.314124][TEST][STDOUT]* Test step:
[2025-05-27 14:11:35.314517][TEST][STDOUT]*     2: TH reads from the DUT the SupportedTemperatureUnits attribute	Expected outcome: 
[2025-05-27 14:11:35.314547][TEST][STDOUT]*
[2025-05-27 14:11:35.314624][TEST][STDOUT]* Endpoint: 0
[2025-05-27 14:11:35.314652][TEST][STDOUT]*
[2025-05-27 14:11:35.314953][TEST][STDOUT]*******************************************************************

