### PR TITLE
Fix test plan generator script import

### DIFF
--- a/src/python_testing/test_plan_table_generator.py
+++ b/src/python_testing/test_plan_table_generator.py
@@ -22,7 +22,8 @@ import sys
 from pathlib import Path
 
 import click
-from chip.testing.matter_testing import MatterTestConfig, generate_mobly_test_config
+from chip.testing.matter_testing import MatterTestConfig
+from chip.testing.runner import generate_mobly_test_config
 
 
 def indent_multiline(multiline: str, num_spaces: int) -> str:


### PR DESCRIPTION
#### Testing

Ran test locally. The script is just a helper that is used to generate adoc from test scripts. Since the resulting adoc is checked into the test plans repo manually, the script doesn't run in any automated jobs.
