### PR TITLE
Fix flaky Test failure for TC_WebRTCRequestor_2_X

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -81,7 +81,7 @@ CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorD
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    // Schedule the ProvideICECandidates() call to run asynchronously.
+    // Schedule the ProvideAnswer() call to run asynchronously.
     DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() { ProvideAnswer(sessionId, mLocalDescription); });
 
     return CHIP_NO_ERROR;

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR WebRTCManager::HandleOffer(uint16_t sessionId, const WebRTCRequestorD
 
     // Schedule the ProvideAnswer() call to run with a small delay to ensure the response is sent first
     DeviceLayer::SystemLayer().StartTimer(
-        chip::System::Clock::Milliseconds32(300), // 100ms delay
+        chip::System::Clock::Milliseconds32(300),
         [](chip::System::Layer * systemLayer, void * appState) {
             auto * self = static_cast<WebRTCManager *>(appState);
             self->ProvideAnswer(self->mPendingSessionId, self->mLocalDescription);
@@ -116,7 +116,7 @@ CHIP_ERROR WebRTCManager::HandleAnswer(uint16_t sessionId, const std::string & s
 
     // Schedule the ProvideICECandidates() call to run with a small delay to ensure the response is sent first
     DeviceLayer::SystemLayer().StartTimer(
-        chip::System::Clock::Milliseconds32(300), // 100ms delay
+        chip::System::Clock::Milliseconds32(300),
         [](chip::System::Layer * systemLayer, void * appState) {
             auto * self = static_cast<WebRTCManager *>(appState);
             self->ProvideICECandidates(self->mPendingSessionId);

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -67,6 +67,7 @@ private:
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
     std::shared_ptr<rtc::DataChannel> mDataChannel;
 
+    uint16_t mPendingSessionId = 0;
     std::string mLocalDescription;
     // Local vector to store the ICE Candidate strings coming from the WebRTC
     // stack

--- a/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCProviderClient.cpp
@@ -282,7 +282,7 @@ void WebRTCProviderClient::OnDone(CommandSender * client)
     mCommandType = CommandType::kUndefined;
     mCommandSender.reset();
 
-    if (mState == State::AwaitingResponse)
+    if (mState == State::AwaitingResponse || mState == State::Connecting)
     {
         MoveToState(State::Idle);
     }

--- a/src/python_testing/TC_WEBRTCR_2_3.py
+++ b/src/python_testing/TC_WEBRTCR_2_3.py
@@ -182,9 +182,9 @@ class TC_WebRTCRequestor_2_3(MatterBaseTest):
 
             try:
                 await self.send_command("webrtc solicit-offer 3")
-                # Wait up to 30s until the provider logs that the data‑channel opened
-                if not self.th_server.event.wait(30):
-                    raise TimeoutError("DataChannel did not open within 30s")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("DataChannel did not open within 90s")
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'

--- a/src/python_testing/TC_WEBRTCR_2_4.py
+++ b/src/python_testing/TC_WEBRTCR_2_4.py
@@ -181,9 +181,9 @@ class TC_WebRTCRequestor_2_4(MatterBaseTest):
 
             try:
                 await self.send_command("webrtc provide-offer 3")
-                # Wait up to 30s until the provider logs that the data‑channel opened
-                if not self.th_server.event.wait(30):
-                    raise TimeoutError("DataChannel did not open within 30s")
+                # Wait up to 90s until the provider logs that the data‑channel opened
+                if not self.th_server.event.wait(90):
+                    raise TimeoutError("DataChannel did not open within 90s")
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'


### PR DESCRIPTION
TC_WebRTCRequestor_2_3 has failed in Flaky Test for two different reasons in CI

The conflict arises because the controller sends a new command via ScheduleLambda during the handling of a prior one. This causes the previous command's response to be sent immediately upon handler return, scheduleLambda will also execute immediately in the next event loop iteration. 

As long as we guarantee the next command is scheduled after the response of the preceding command. The transport manager should ensure the previous response is re-transmitted, even with RTP re-transmissions, before the next command is dispatched.

Fix: https://github.com/project-chip/connectedhomeip/issues/39224, https://github.com/project-chip/connectedhomeip/issues/39251

#### Testing

Validated by CI
