### PR TITLE
Change for NFC-based commissioning (on Commissionee side).

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -242,6 +242,49 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     }
 }
 
+// Function called when NFC-based commissioning has been started.
+// Advertizing can be stopped.
+// FailSafe timer is started
+// PASE session can be expired
+void CommissioningWindowManager::OnNfcBasedCommissioningStarting()
+{
+    ChipLogProgress(AppServer, "OnNfcBasedCommissioningStarting");
+
+    DeviceLayer::SystemLayer().CancelTimer(HandleSessionEstablishmentTimeout, this);
+
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCommissioningSessionStarted();
+    }
+
+    DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
+
+    StopAdvertisement(/* aShuttingDown = */ false);
+
+    auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
+    // This should never be armed because we don't allow CASE sessions to arm the failsafe when the commissioning window is open and
+    // we check that the failsafe is not armed before opening the commissioning window. None the less, it is good to double-check.
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    if (failSafeContext.IsFailSafeArmed())
+    {
+        ChipLogError(AppServer, "Error - arm failsafe is already armed on PASE session establishment completion");
+    }
+    else
+    {
+        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex,
+                                          System::Clock::Seconds16(CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC));
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");
+            HandleFailedAttempt(err);
+        }
+    }
+
+    // When doing NFC-based commissioning, PASE session is done between
+    // the NFC Tag and the Commissioner. MCU is not involved
+    mServer->GetSecureSessionManager().ExpireAllPASESessions();
+}
+
 CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds32 commissioningTimeout)
 {
     VerifyOrReturnError(commissioningTimeout <= MaxCommissioningTimeout() && commissioningTimeout >= MinCommissioningTimeout(),

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -260,29 +260,6 @@ void CommissioningWindowManager::OnNfcBasedCommissioningStarting()
     DeviceLayer::PlatformMgr().AddEventHandler(OnPlatformEventWrapper, reinterpret_cast<intptr_t>(this));
 
     StopAdvertisement(/* aShuttingDown = */ false);
-
-    auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
-    // This should never be armed because we don't allow CASE sessions to arm the failsafe when the commissioning window is open and
-    // we check that the failsafe is not armed before opening the commissioning window. None the less, it is good to double-check.
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    if (failSafeContext.IsFailSafeArmed())
-    {
-        ChipLogError(AppServer, "Error - arm failsafe is already armed on PASE session establishment completion");
-    }
-    else
-    {
-        err = failSafeContext.ArmFailSafe(kUndefinedFabricIndex,
-                                          System::Clock::Seconds16(CHIP_DEVICE_CONFIG_FAILSAFE_EXPIRY_LENGTH_SEC));
-        if (err != CHIP_NO_ERROR)
-        {
-            ChipLogError(AppServer, "Error arming failsafe on PASE session establishment completion");
-            HandleFailedAttempt(err);
-        }
-    }
-
-    // When doing NFC-based commissioning, PASE session is done between
-    // the NFC Tag and the Commissioner. MCU is not involved
-    mServer->GetSecureSessionManager().ExpireAllPASESessions();
 }
 
 CHIP_ERROR CommissioningWindowManager::OpenCommissioningWindow(Seconds32 commissioningTimeout)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -242,10 +242,6 @@ void CommissioningWindowManager::OnSessionEstablished(const SessionHandle & sess
     }
 }
 
-// Function called when NFC-based commissioning has been started.
-// Advertizing can be stopped.
-// FailSafe timer is started
-// PASE session can be expired
 void CommissioningWindowManager::OnNfcBasedCommissioningStarting()
 {
     ChipLogProgress(AppServer, "OnNfcBasedCommissioningStarting");

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -100,6 +100,8 @@ public:
 
     void OnFabricRemoved(FabricIndex removedIndex);
 
+    void OnNfcBasedCommissioningStarting();
+
     // CommissioningModeProvider implementation.
     Dnssd::CommissioningMode GetCommissioningMode() const override;
 

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -100,6 +100,8 @@ public:
 
     void OnFabricRemoved(FabricIndex removedIndex);
 
+    // Function called when NFC-based commissioning has been started.
+    // Advertising can be stopped.
     void OnNfcBasedCommissioningStarting();
 
     // CommissioningModeProvider implementation.


### PR DESCRIPTION
When NFC-based commissioning is starting:
- Advertizing can be stopped.
- FailSafe timer is started.
- PASE session can be expired (PASE session is done between the NFC Tag and the Commissioner. MCU is not involved)

#### Testing
Tested with [TC-OO-2.1] (with nfc-thread pairing mode). NFC-based commissioning is working with this code.
This code adds a new function not used in the SDK so it cannot impact the existing code.

