### PR TITLE
[E2E][JF] Add jcm/TrustedIcacPublicKeyB parameters for OwnershipTrans…

### DIFF
--- a/examples/common/pigweed/protos/joint_fabric_service.options
+++ b/examples/common/pigweed/protos/joint_fabric_service.options
@@ -1,0 +1,1 @@
+OwnershipContext.trustedIcacPublicKeyB max_size:65    // Maximum size of trustedIcacPublicKeyB

--- a/examples/common/pigweed/protos/joint_fabric_service.proto
+++ b/examples/common/pigweed/protos/joint_fabric_service.proto
@@ -19,7 +19,9 @@ syntax = "proto3";
 import 'pw_protobuf_protos/common.proto';
 
 message OwnershipContext {
-  uint64 node_id = 1;
+  uint64 node_id = 1; // jf-admin-app should finalize commissioning with this specific node_id
+  bool jcm = 2; // should be set to true if jf-admin-app has to finalize the jcm process
+  bytes trustedIcacPublicKeyB = 3; // see spec., JCM steps
 }
 
 service JointFabric {

--- a/examples/common/pigweed/rpc_services/JointFabric.h
+++ b/examples/common/pigweed/rpc_services/JointFabric.h
@@ -1,9 +1,11 @@
 #include "JFAManager.h"
 #include "joint_fabric_service/joint_fabric_service.rpc.pb.h"
 
+#include <crypto/CHIPCryptoPAL.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
+using namespace chip::Crypto;
 
 namespace joint_fabric_service {
 
@@ -15,15 +17,23 @@ public:
 private:
     struct OwnershipTransferContext
     {
-        OwnershipTransferContext(uint64_t nodeId) : mNodeId(nodeId) {}
+        OwnershipTransferContext(uint64_t nodeId, bool jcm, ByteSpan trustedIcacPublicKeyB) : mNodeId(nodeId), mJCM(jcm)
+        {
+            memcpy(keyRawBytes, trustedIcacPublicKeyB.data(), kP256_PublicKey_Length);
+            mTrustedIcacPublicKeyBSerialized = keyRawBytes;
+        }
 
         uint64_t mNodeId;
+        bool mJCM;
+
+        uint8_t keyRawBytes[kP256_PublicKey_Length] = { 0 };
+        P256PublicKey mTrustedIcacPublicKeyBSerialized;
     };
 
     static void FinalizeCommissioningWork(intptr_t arg)
     {
         OwnershipTransferContext * data = reinterpret_cast<OwnershipTransferContext *>(arg);
-        JFAMgr().FinalizeCommissioning(data->mNodeId);
+        JFAMgr().FinalizeCommissioning(data->mNodeId, data->mJCM, data->mTrustedIcacPublicKeyBSerialized);
         Platform::Delete(data);
     }
 };

--- a/examples/jf-admin-app/linux/JFAManager.cpp
+++ b/examples/jf-admin-app/linux/JFAManager.cpp
@@ -30,6 +30,7 @@ using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::Controller;
+using namespace chip::Crypto;
 
 JFAManager JFAManager::sJFA;
 
@@ -41,12 +42,15 @@ CHIP_ERROR JFAManager::Init(Server & server)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR JFAManager::FinalizeCommissioning(NodeId nodeId)
+CHIP_ERROR JFAManager::FinalizeCommissioning(NodeId nodeId, bool isJCM, P256PublicKey & trustedIcacPublicKeyB)
 {
     if (jfFabricIndex == kUndefinedFabricId)
     {
         return CHIP_ERROR_INCORRECT_STATE;
     }
+
+    ChipLogProgress(JointFabric, "FinalizeCommissioning for NodeID: 0x" ChipLogFormatX64 ", isJCM = %d", ChipLogValueX64(nodeId),
+                    isJCM);
 
     ScopedNodeId scopedNodeId = ScopedNodeId(nodeId, jfFabricIndex);
 

--- a/examples/jf-admin-app/linux/include/JFAManager.h
+++ b/examples/jf-admin-app/linux/include/JFAManager.h
@@ -36,7 +36,7 @@ public:
 
     CHIP_ERROR Init(Server & server);
     void HandleCommissioningCompleteEvent();
-    CHIP_ERROR FinalizeCommissioning(NodeId nodeId);
+    CHIP_ERROR FinalizeCommissioning(NodeId nodeId, bool isJCM, chip::Crypto::P256PublicKey & trustedIcacPublicKeyB);
 
 private:
     // Various actions to take when OnConnected callback is called

--- a/examples/jf-admin-app/linux/rpc/RpcServer.cpp
+++ b/examples/jf-admin-app/linux/rpc/RpcServer.cpp
@@ -10,9 +10,22 @@ namespace joint_fabric_service {
 
 ::pw::Status JointFabric::TransferOwnership(const ::OwnershipContext & request, ::pw_protobuf_Empty & response)
 {
-    ChipLogProgress(chipTool, "Ownership Transfer for NodeId: " ChipLogFormatX64, ChipLogValueX64(request.node_id));
+    ChipLogProgress(JointFabric, "Ownership Transfer for NodeId: 0x" ChipLogFormatX64 ", jcm=%d", ChipLogValueX64(request.node_id),
+                    request.jcm);
 
-    OwnershipTransferContext * data = Platform::New<OwnershipTransferContext>(request.node_id);
+    if (request.jcm && (Crypto::kP256_PublicKey_Length != request.trustedIcacPublicKeyB.size))
+    {
+        return pw::Status::OutOfRange();
+        ChipLogError(JointFabric, "Invalid ICAC Public Key Size");
+    }
+
+    for (size_t i = 0; i < Crypto::kP256_PublicKey_Length; ++i)
+    {
+        ChipLogProgress(JointFabric, "trustedIcacPublicKeyB[%li] = %02X", i, request.trustedIcacPublicKeyB.bytes[i]);
+    }
+
+    OwnershipTransferContext * data = Platform::New<OwnershipTransferContext>(
+        request.node_id, request.jcm, ByteSpan(request.trustedIcacPublicKeyB.bytes, request.trustedIcacPublicKeyB.size));
     VerifyOrReturnValue(data, pw::Status::Internal());
     DeviceLayer::PlatformMgr().ScheduleWork(FinalizeCommissioningWork, reinterpret_cast<intptr_t>(data));
 

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -228,7 +228,8 @@ public:
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
-    void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) override;
+    void OnCommissioningComplete(NodeId nodeId, const chip::Optional<chip::Crypto::P256PublicKey> & trustedIcacPublicKeyB,
+                                 CHIP_ERROR err) override;
     void OnICDRegistrationComplete(chip::ScopedNodeId deviceId, uint32_t icdCounter) override;
     void OnICDStayActiveComplete(chip::ScopedNodeId deviceId, uint32_t promisedActiveDuration) override;
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -1120,6 +1120,10 @@ private:
     Credentials::AttestationVerificationResult mAttestationResult;
     Platform::UniquePtr<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo> mAttestationDeviceInfo;
     Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier = nullptr;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    chip::Optional<chip::Crypto::P256PublicKey> mTrustedIcacPublicKeyB;
+#endif
 };
 
 } // namespace Controller

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -70,6 +70,18 @@ public:
      *   Called when the commissioning process is complete (with success or error)
      */
     virtual void OnCommissioningComplete(NodeId deviceId, CHIP_ERROR error) {}
+
+    /**
+     *   Called when the commissioning process is complete (with success or error)
+     *   Should be overriden by DevicePairingDelegates which are JF compatible
+     *   - trustedIcacPublicKeyB has a value only when Joint Commissioning Method is executed
+     */
+    virtual void OnCommissioningComplete(NodeId deviceId, const Optional<Crypto::P256PublicKey> & trustedIcacPublicKeyB,
+                                         CHIP_ERROR error)
+    {
+        OnCommissioningComplete(deviceId, error);
+    }
+
     virtual void OnCommissioningSuccess(PeerId peerId) {}
     virtual void OnCommissioningFailure(PeerId peerId, CHIP_ERROR error, CommissioningStage stageFailed,
                                         Optional<Credentials::AttestationVerificationResult> additionalErrorInfo)


### PR DESCRIPTION
Fix https://github.com/project-chip/connectedhomeip/issues/39025

This PR adds two new parameters for the RPC call between jf-control-app and jf-admin-app:
- jcm. This boolean signals if the in-progress commissioning session is the standard one or the joint commissioning one;
- TrustedIcacPublicKeyB. In case jcm is true then the bytes of the ICAC's PK of the onboarded Administrator are also transferred. This is required later in the JCM process for some checks during the cross-signing process (see "ICAC Cross Signing" chapter in the spec for the exact usage)

#### Testing

- For setting up the two Ecosystem followed the exact same steps from https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/joint_fabric_guide.md
- On Ecosystem B read the public key bytes of jf-admin-app (`operationalcredentials read nocs 11 0` followed by parsing of the ICAC bytes using chip-cert)
- On Ecosystem B, used jf-control-app for opening a commissioning window in jf-admin-app (`pairing open-commissioning-window 11 1 400 1000 1261`)
- On Ecosystem A, used jf-control-app for commissioning jf-admin-app@EcosystemB (`pairing onnetwork 15 passcode --execute-jcm true`)
- Checked the logs on jf-control-app@EcosystemA and jf-admin-app@EcosystemA and compared the trustedIcacPublicKeyB printings with the ICAC bytes read previously (and made sure those bytes match)