### PR TITLE
[TC-SC-3.4] Adding a Precondition of having an Established CASE Session with DUT before start of test

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1188,7 +1188,7 @@ CHIP_ERROR CASESession::SendSigma2Resume(System::PacketBufferHandle && msgR2Resu
 
     mState = State::kSentSigma2Resume;
 
-    ChipLogDetail(SecureChannel, "Sent Sigma2Resume msg");
+    ChipLogProgress(SecureChannel, "Sent Sigma2Resume msg");
 
     return CHIP_NO_ERROR;
 }

--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -28,7 +28,15 @@
 #       --passcode 20202021
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
-#       --endpoint 1
+#   run2:
+#     app: ${ALL_CLUSTERS_APP}
+#     factory-reset: false
+#     quiet: true
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --storage-path admin_storage.json
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 # === END CI TEST ARGUMENTS ===
 
 

--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -50,6 +50,9 @@ class TC_SC_3_4(MatterBaseTest):
 
     def steps_TC_SC_3_4(self) -> list[TestStep]:
         steps = [
+
+            TestStep("precondition", "DUT is commissioned and TH has an open CASE Session with DUT"),
+
             TestStep(1, "TH constructs and sends a Sigma1 message with a resumptionID and NO initiatorResumeMIC to DUT",
                      "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),
 
@@ -109,8 +112,17 @@ class TC_SC_3_4(MatterBaseTest):
     @async_test_body
     async def test_TC_SC_3_4(self):
 
-        self.step(1)
         self.th = self.default_controller
+
+        self.step("precondition")
+        # DUT Should be Commissioned Already, Now we try to Establish a CASE Session with it
+        try:
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+        except ChipStackError as e:
+            asserts.fail(
+                f"Unexpected Failure, TH Should be able to establish a CASE Session with DUT \nError = {e}")
+
+        self.step(1)
         # using FaultInjection to skip InitiatorResumeMIC from Sigma1 with Resumption
         FailAtFault(faultID=CHIPFaultId.CASESkipInitiatorResumeMIC,
                     numCallsToSkip=0,


### PR DESCRIPTION
- Test Script needs the DUT to have an Open CASE Session with TH Controller  before beginning.
- We were not doing that at the start of test (it worked because it was freshly commissioned
#### Fix

- Open CASE Session as a precondition using `GetConnectedDevice`

- Added a "precondition" step to TestPlan in https://github.com/CHIP-Specifications/chip-test-plans/pull/5207
#### Testing

Tested Manually with the following Sequence:

1. Run Test with Factory Reset + commissioning OnNetwork
2. Rerun test WITHOUT factoryreset  and WITHOUT Commissioning
3. Test Passed