### PR TITLE
[Ameba] [1.4 branch] fix platform wifi issue

### DIFF
--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ameba:81
+            image: ghcr.io/project-chip/chip-build-ameba:134
             options: --user root
 
         steps:

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -27,11 +27,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
 
 -   Setup build environment:
 

--- a/examples/all-clusters-minimal-app/ameba/README.md
+++ b/examples/all-clusters-minimal-app/ameba/README.md
@@ -27,13 +27,13 @@ The CHIP demo application is supported on
 -   Pull docker image:
 
           ```
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
           ```
 
 -   Run docker container:
 
           ```
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
           ```
 
 -   Setup build environment:

--- a/examples/all-clusters-minimal-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-minimal-app/ameba/chip_main.cmake
@@ -128,9 +128,9 @@ endif (matter_enable_ota_requestor)
 list(
     APPEND ${list_chip_main_sources}
 
-    ${chip_dir}/examples/all-clusters-minimal-app/all-clusters-common/src/bridged-actions-stub.cpp
-    ${chip_dir}/examples/all-clusters-minimal-app/all-clusters-common/src/smco-stub.cpp
-    ${chip_dir}/examples/all-clusters-minimal-app/all-clusters-common/src/static-supported-modes-manager.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/smco-stub.cpp
+    ${chip_dir}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp
 
     ${chip_dir}/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
     ${chip_dir}/examples/all-clusters-minimal-app/ameba/main/DeviceCallbacks.cpp

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -26,11 +26,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
 
 -   Setup build environment:
 

--- a/examples/lighting-app/ameba/README.md
+++ b/examples/lighting-app/ameba/README.md
@@ -23,11 +23,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
 
 -   Setup build environment:
 

--- a/examples/ota-requestor-app/ameba/README.md
+++ b/examples/ota-requestor-app/ameba/README.md
@@ -6,11 +6,11 @@ A prototype application that demonstrates OTA Requestor capabilities.
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
 
 -   Setup build environment:
 

--- a/examples/pigweed-app/ameba/README.md
+++ b/examples/pigweed-app/ameba/README.md
@@ -31,11 +31,11 @@ following features are available:
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:81
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:134
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:81
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:134
 
 -   Setup build environment:
 

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -51,7 +51,6 @@
 #include <lwip/netif.h>
 
 #include <chip_porting.h>
-#include <lwip_netconf.h>
 
 using namespace ::chip;
 using namespace ::chip::Inet;
@@ -176,8 +175,9 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImpl::_GetWiFiStationMod
 {
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
-        mWiFiStationMode = (wifi_mode == RTW_MODE_STA) ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
+        mWiFiStationMode = (matter_wifi_is_station_mode() == RTW_SUCCESS) ? kWiFiStationMode_Enabled : kWiFiStationMode_Disabled;
     }
+
     return mWiFiStationMode;
 }
 
@@ -479,8 +479,6 @@ void ConnectivityManagerImpl::DriveStationState()
     if (mWiFiStationMode != kWiFiStationMode_ApplicationControlled)
     {
         err = Internal::AmebaUtils::StartWiFi();
-        SuccessOrExit(err);
-        err = Internal::AmebaUtils::EnableStationMode();
         SuccessOrExit(err);
     }
 

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -282,74 +282,40 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiVersion(app::Clusters::WiFiNetwork
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum & securityType)
 {
+    using app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum;
     CHIP_ERROR err;
     int32_t error;
+    uint32_t wifi_security = 0;
 
-    using app::Clusters::WiFiNetworkDiagnostics::SecurityTypeEnum;
-
-    unsigned int _auth_type;
-    unsigned short security = 0;
-    rtw_wifi_setting_t setting;
-
-    error = matter_wifi_get_security_type(WLAN0_IDX, &security, &setting.key_idx, setting.password);
+    error = matter_wifi_get_security_type(WLAN0_IDX, &wifi_security);
     err   = AmebaUtils::MapError(error, AmebaErrorType::kWiFiError);
     if (err != CHIP_NO_ERROR)
     {
         securityType = SecurityTypeEnum::kUnspecified;
     }
-#ifdef CONFIG_PLATFORM_8721D
     else
     {
-        switch (security)
+        if (wifi_security & WPA3_SECURITY)
         {
-        case IW_ENCODE_ALG_NONE:
-            securityType = SecurityTypeEnum::kNone;
-            break;
-        case IW_ENCODE_ALG_WEP:
-            securityType = SecurityTypeEnum::kWep;
-            break;
-        case IW_ENCODE_ALG_TKIP:
-            securityType = SecurityTypeEnum::kWpa;
-            break;
-        case IW_ENCODE_ALG_CCMP:
+            securityType = SecurityTypeEnum::kWpa3;
+        }
+        else if (wifi_security & WPA2_SECURITY)
+        {
             securityType = SecurityTypeEnum::kWpa2;
-            break;
-        default:
-            securityType = SecurityTypeEnum::kUnspecified;
-            break;
         }
-    }
-#else
-    else
-    {
-        switch (security)
+        else if (wifi_security & WPA_SECURITY)
         {
-        case IW_ENCODE_ALG_NONE:
-            securityType = SecurityTypeEnum::kNone;
-            break;
-        case IW_ENCODE_ALG_WEP:
+            securityType = SecurityTypeEnum::kWpa;
+        }
+        else if (wifi_security & WEP_ENABLED)
+        {
             securityType = SecurityTypeEnum::kWep;
-            break;
-        case IW_ENCODE_ALG_TKIP:
-            if (_auth_type == WPA_SECURITY)
-                securityType = SecurityTypeEnum::kWpa;
-            else if (_auth_type == WPA2_SECURITY)
-                securityType = SecurityTypeEnum::kWpa2;
-            break;
-        case IW_ENCODE_ALG_CCMP:
-            if (_auth_type == WPA_SECURITY)
-                securityType = SecurityTypeEnum::kWpa;
-            else if (_auth_type == WPA2_SECURITY)
-                securityType = SecurityTypeEnum::kWpa2;
-            else if (_auth_type == WPA3_SECURITY)
-                securityType = SecurityTypeEnum::kWpa3;
-            break;
-        default:
-            securityType = SecurityTypeEnum::kUnspecified;
-            break;
+        }
+        else
+        {
+            securityType = SecurityTypeEnum::kNone;
         }
     }
-#endif
 
     return err;
 }


### PR DESCRIPTION
This commit fixes

1.  WiFi security type obtain through WiFi Network Diagnostics.
Issue: The intial issue was that reading of WiFi Network Diagnostics's Security Type is always 0
Fix: Correct the security type obtain through `matter_wifi_get_security_type()` and modifies `GetWiFiSecurityType()` to return the corresponding results accordingly to the results of `matter_wifi_get_security_type()`.

2. Ensuring that the platform wifi mode bare requirement of station mode is met.
Issue: Ameba platform supposes different wifi mode that could be station mode only or a combination of station mode.
Fix: Adding of `matter_wifi_is_station_mode()` in `_GetWiFiStationMode()` to check if station mode has been enabled and in use. This is also to make it user-friendly, and easier for platform maintenance.

3.  Fix build issue with all-cluster-minimal-app due to indicating of incorrect source path.
Fix: replacing source file that does not exist with all-cluster-app source file.

#### Testing

Security type verification: tested against chip-tool with: ./chip-tool wifinetworkdiagnostics read security-type 1 0
- When router is set to open security type, result is 1.
- When router is set to WEP security type, result is 2.
- When router is set to WPA security type, result is 3.
- When router is set to WPA2 security type, result is 4.
- When router is set to WPA3 security type, result is 5.

Additional wifi mode support: ensures that the minimum requirement of station mode is supported.

all-cluster-minimal-app build: manually checked and tested by CI.