### PR TITLE
Fix thread leak caused by repeated creation of single-thread scheduled executors

### DIFF
--- a/src/platform/android/BUILD.gn
+++ b/src/platform/android/BUILD.gn
@@ -129,6 +129,7 @@ android_library("java") {
     "java/chip/platform/DiagnosticDataProvider.java",
     "java/chip/platform/DiagnosticDataProviderImpl.java",
     "java/chip/platform/KeyValueStoreManager.java",
+    "java/chip/platform/NamedThreadFactory.java",
     "java/chip/platform/NetworkInterface.java",
     "java/chip/platform/NfcCallback.java",
     "java/chip/platform/NfcCommissioningManager.java",

--- a/src/platform/android/java/chip/platform/NamedThreadFactory.java
+++ b/src/platform/android/java/chip/platform/NamedThreadFactory.java
@@ -1,0 +1,20 @@
+package chip.platform;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NamedThreadFactory implements ThreadFactory {
+  private final String prefix;
+  private final AtomicInteger counter = new AtomicInteger(1);
+
+  public NamedThreadFactory(final String prefix) {
+    this.prefix = prefix;
+  }
+
+  @Override
+  public Thread newThread(Runnable r) {
+    final Thread thread = new Thread(r);
+    thread.setName(prefix + "-" + counter.getAndIncrement());
+    return thread;
+  }
+}


### PR DESCRIPTION
#### Problem Description

Previously, `NsdManagerServiceResolver` created a new `ScheduledExecutorService` via `Executors.newSingleThreadScheduledExecutor()` every time a service resolution was initiated. This occurred in the `resolve()` method, where a new scheduled executor was spawned for each resolve operation to handle timeouts:

```java
ScheduledFuture<?> resolveTimeoutExecutor =
    Executors.newSingleThreadScheduledExecutor()
        .schedule(timeoutRunnable, timeout, TimeUnit.MILLISECONDS);
```

**This pattern leads to a thread leak:**  
- Each call to `Executors.newSingleThreadScheduledExecutor()` creates a new, long-lived thread.
- These executor threads are never explicitly shut down, and there is no reference kept to them outside the scope of the scheduled timeout.
- As a result, triggering repeated resolve operations continuously creates and retains more threads, eventually exhausting system resources and causing instability, especially on Android devices with limited resources.

#### Why This is Bad

- **Resource Exhaustion:** The JVM process will accumulate idle threads that cannot be garbage collected, leading to memory consumption, context switching overhead, and ultimately risking `OutOfMemoryError` or "Too many open files"/threads.
- **Unpredictable Behavior:** Old scheduled executors live forever (unless shutdown) even after the operation is complete, resulting in wasted resources and potential conflicts.
- **Best Practice:** Thread pools and executors should be reused when possible; per-task thread pools are highly discouraged in most cases.

#### Solution

**Refactor:**  
- Introduce a single shared `ScheduledExecutorService` as a class member (`mBackgroundExecutorService`) initialized when the `NsdManagerServiceResolver` instance is created.
- Use this shared executor for all scheduled timeout tasks by scheduling timeouts via `mBackgroundExecutorService.schedule(...)` instead of spawning a new executor for each resolve.

#### Testing

To verify the fix and ensure there are no more thread leaks from repeated resolve operations, follow these steps:

1. **Capture an initial thread dump**  
   - Use Android Studio, `adb shell dumpsys | grep threads`, or any suitable profiler to record the current state of threads running in the host Android process.

2. **Connect a Matter device to the Android host**  
   - Ensure the Android application is running and is able to discover and communicate with the Matter device.

3. **Power cycle the Matter device several times**  
   - Turn off the Matter device, wait for it to fully disconnect, then turn it back on.  
   - Repeat this process several times (e.g., 5–10 times) to trigger multiple resolve operations as the Android host attempts to find the device in the network repeatedly after each power cycle.

4. **Observe device discovery**  
   - Monitor the logs to confirm that the Android application is actively attempting to resolve (find) the Matter device each time it is powered back on.

5. **Take a heap dump after the test**  
   - After completing several power cycles, capture a heap dump of the Android process (using Android Studio profiler or `adb`).

6. **Check for thread/resource leaks**  
   - Examine the heap dump and thread dump.  
   - Verify that the number of `ThreadPoolExecutor` (or ScheduledThreadPoolExecutor) instances does **not** grow with each cycle.  
   - There should be only a fixed (small) number of executor threads present, corresponding to the shared executors, and **no unbounded growth** in threads or executor objects.

