### PR TITLE
Implement spec behavior for fabric-sensitive fields correctly.

### DIFF
--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -80,7 +80,7 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
     {{#if struct_has_fabric_sensitive_fields}}
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
     {{/if}}
 
     DataModel::WrappedStructEncoder encoder{aWriter, aTag};

--- a/zzz_generated/app-common/clusters/AccessControl/Structs.ipp
+++ b/zzz_generated/app-common/clusters/AccessControl/Structs.ipp
@@ -115,7 +115,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 
@@ -224,7 +225,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 
@@ -302,7 +304,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 

--- a/zzz_generated/app-common/clusters/EcosystemInformation/Structs.ipp
+++ b/zzz_generated/app-common/clusters/EcosystemInformation/Structs.ipp
@@ -76,7 +76,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 
@@ -178,7 +179,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 

--- a/zzz_generated/app-common/clusters/IcdManagement/Structs.ipp
+++ b/zzz_generated/app-common/clusters/IcdManagement/Structs.ipp
@@ -42,7 +42,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 

--- a/zzz_generated/app-common/clusters/ScenesManagement/Structs.ipp
+++ b/zzz_generated/app-common/clusters/ScenesManagement/Structs.ipp
@@ -145,7 +145,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 

--- a/zzz_generated/app-common/clusters/UnitTesting/Structs.ipp
+++ b/zzz_generated/app-common/clusters/UnitTesting/Structs.ipp
@@ -111,7 +111,8 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter & aWriter, TLV::Tag aTag, FabricIn
 
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter & aWriter, TLV::Tag aTag, const Optional<FabricIndex> & aAccessingFabricIndex) const
 {
-    bool includeSensitive = !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex);
+    bool includeSensitive =
+        !aAccessingFabricIndex.HasValue() || (aAccessingFabricIndex.Value() == fabricIndex) || fabricIndex == kUndefinedFabricIndex;
 
     DataModel::WrappedStructEncoder encoder{ aWriter, aTag };
 


### PR DESCRIPTION
Per spec, fabric-sensitive fields are only excluded from a struct when that struct has an associated fabric (we were missing this check) and that fabric is not the accessing fabric.

#### Testing

Hard to test this, since we have no known ways to create fabric-scoped structs not associated with a fabric right now.