### PR TITLE
Add the time-out function to cancel the subscription if not finding the commissionee for a long time and refine the shutdown flow

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -73,8 +73,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        chip::WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown(
-            [](uint32_t id, WiFiPAF::WiFiPafRole role) { DeviceLayer::ConnectivityMgr().WiFiPAFShutdown(id, role); });
+        chip::WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown();
 #endif
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -73,7 +73,11 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-        chip::WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown();
+        WiFiPAF::WiFiPAFSession PafSession = {
+            .role   = WiFiPAF::kWiFiPafRole_Subscriber,
+            .nodeId = event->CommissioningComplete.nodeId,
+        };
+        WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().CloseConnection(WiFiPAF::PafInfoAccess::kAccNodeId, PafSession);
 #endif
     }
     else if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired)

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
                            ,
                            Transport::WiFiPAFListenParameters(static_cast<Transport::WiFiPAFBase *>(
-                               DeviceLayer::ConnectivityMgr().GetWiFiPAF()->mWiFiPAFTransport))
+                               DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->mWiFiPAFTransport))
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING
                                ,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -630,7 +630,7 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
     {
         auto peerAddress = device->GetPeerAddress();
         ChipLogProgress(Discovery, "Closing WiFiPAF connections, nodeId: %lu", PeerAddress.GetRemoteId());
-        WiFiPAF::WiFiPAFSession PafSession = {
+        WiFiPAF::WiFiPAFSession pafSession = {
             .role   = WiFiPAF::kWiFiPafRole_Subscriber,
             .nodeId = PeerAddress.GetRemoteId(),
         };

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -632,7 +632,7 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
         (device->IsSecureConnected() == true))
     {
         ChipLogProgress(Discovery, "Closing all WiFiPAF connections");
-        mSystemState->WiFiPayLayer()->CloseAllConnections();
+        mSystemState->WiFiPafLayer()->CloseAllConnections();
     }
 #endif
     // Make sure that there will be no dangling pointer

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -572,8 +572,7 @@ void DeviceCommissioner::Shutdown()
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown(
-        [](uint32_t id, WiFiPAF::WiFiPafRole role) { DeviceLayer::ConnectivityMgr().WiFiPAFShutdown(id, role); });
+    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown();
 #endif
 
     // Release everything from the commissionee device pool here.
@@ -626,6 +625,14 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
         // We only support one BLE connection, so if this is BLE, close it
         ChipLogProgress(Discovery, "Closing all BLE connections");
         mSystemState->BleLayer()->CloseAllBleConnections();
+    }
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if ((mSystemState->WiFiPayLayer() != nullptr) && (device->GetDeviceTransportType() == Transport::Type::kWiFiPAF) &&
+        (device->IsSecureConnected() == true))
+    {
+        ChipLogProgress(Discovery, "Closing all WiFiPAF connections");
+        mSystemState->WiFiPayLayer()->CloseAllConnections();
     }
 #endif
     // Make sure that there will be no dangling pointer
@@ -943,6 +950,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
     {
         ChipLogError(Controller, "WiFi-PAF: Subscription Error, id = %lu, err = %" CHIP_ERROR_FORMAT, device->GetDeviceId(),
                      err.Format());
+        self->CloseWiFiPAFConnection(device->GetDeviceId());
         self->ReleaseCommissioneeDevice(device);
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)
@@ -1831,6 +1839,17 @@ void DeviceCommissioner::CloseBleConnection()
     // We should be able to distinguish different BLE connections if we want
     // to commission multiple devices at the same time over BLE.
     mSystemState->BleLayer()->CloseAllBleConnections();
+}
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+void DeviceCommissioner::CloseWiFiPAFConnection(NodeId remoteDeviceId)
+{
+    WiFiPAF::WiFiPAFSession PafSession = {
+        .role   = WiFiPAF::kWiFiPafRole_Subscriber,
+        .nodeId = remoteDeviceId,
+    };
+    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().CloseConnection(WiFiPAF::PafInfoAccess::kAccNodeId, PafSession);
 }
 #endif
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -628,7 +628,7 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
     }
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    if ((mSystemState->WiFiPayLayer() != nullptr) && (device->GetDeviceTransportType() == Transport::Type::kWiFiPAF) &&
+    if ((mSystemState->WiFiPafLayer() != nullptr) && (device->GetDeviceTransportType() == Transport::Type::kWiFiPAF) &&
         (device->IsSecureConnected() == true))
     {
         ChipLogProgress(Discovery, "Closing all WiFiPAF connections");

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -835,7 +835,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kWiFiPAF)
     {
-        if (DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetWiFiPAFState() != WiFiPAF::State::kConnected)
+        if (DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->GetWiFiPAFState() != WiFiPAF::State::kConnected)
         {
             ChipLogProgress(Controller, "WiFi-PAF: Subscribing to the NAN-USD devices, nodeId: %lu",
                             params.GetPeerAddress().GetRemoteId());
@@ -849,7 +849,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
                                                     .nodeId        = nodeId,
                                                     .discriminator = discriminator };
             ReturnErrorOnFailure(
-                DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+                DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
             DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, reinterpret_cast<void *>(this),
                                                             OnWiFiPAFSubscribeComplete, OnWiFiPAFSubscribeError);
             ExitNow(CHIP_NO_ERROR);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -628,7 +628,7 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
     if ((mSystemState->WiFiPafLayer() != nullptr) && (device->GetDeviceTransportType() == Transport::Type::kWiFiPAF) &&
         (device->IsSecureConnected() == true))
     {
-        auto PeerAddress = device->GetPeerAddress();
+        auto peerAddress = device->GetPeerAddress();
         ChipLogProgress(Discovery, "Closing WiFiPAF connections, nodeId: %lu", PeerAddress.GetRemoteId());
         WiFiPAF::WiFiPAFSession PafSession = {
             .role   = WiFiPAF::kWiFiPafRole_Subscriber,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -950,7 +950,7 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
 
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
-        auto PeerAddr = device->GetPeerAddress();
+        auto peerAddr = device->GetPeerAddress();
         ChipLogError(Controller, "WiFi-PAF: Subscription Error, NodeId = %lu, err = %" CHIP_ERROR_FORMAT, PeerAddr.GetRemoteId(),
                      err.Format());
         self->CloseWiFiPAFConnection(PeerAddr.GetRemoteId());

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -629,12 +629,12 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
         (device->IsSecureConnected() == true))
     {
         auto peerAddress = device->GetPeerAddress();
-        ChipLogProgress(Discovery, "Closing WiFiPAF connections, nodeId: %lu", PeerAddress.GetRemoteId());
+        ChipLogProgress(Discovery, "Closing WiFiPAF connections, nodeId: %lu", peerAddress.GetRemoteId());
         WiFiPAF::WiFiPAFSession pafSession = {
             .role   = WiFiPAF::kWiFiPafRole_Subscriber,
-            .nodeId = PeerAddress.GetRemoteId(),
+            .nodeId = peerAddress.GetRemoteId(),
         };
-        mSystemState->WiFiPafLayer()->CloseConnection(WiFiPAF::PafInfoAccess::kAccNodeId, PafSession);
+        mSystemState->WiFiPafLayer()->CloseConnection(WiFiPAF::PafInfoAccess::kAccNodeId, pafSession);
     }
 #endif
     // Make sure that there will be no dangling pointer
@@ -951,9 +951,9 @@ void DeviceCommissioner::OnWiFiPAFSubscribeError(void * appState, CHIP_ERROR err
     if (nullptr != device && device->GetDeviceTransportType() == Transport::Type::kWiFiPAF)
     {
         auto peerAddr = device->GetPeerAddress();
-        ChipLogError(Controller, "WiFi-PAF: Subscription Error, NodeId = %lu, err = %" CHIP_ERROR_FORMAT, PeerAddr.GetRemoteId(),
+        ChipLogError(Controller, "WiFi-PAF: Subscription Error, NodeId = %lu, err = %" CHIP_ERROR_FORMAT, peerAddr.GetRemoteId(),
                      err.Format());
-        self->CloseWiFiPAFConnection(PeerAddr.GetRemoteId());
+        self->CloseWiFiPAFConnection(peerAddr.GetRemoteId());
         self->ReleaseCommissioneeDevice(device);
         self->mRendezvousParametersForDeviceDiscoveredOverWiFiPAF = RendezvousParameters();
         if (self->mPairingDelegate != nullptr)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -734,7 +734,7 @@ public:
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     /**
      * @brief
-     *   Close the WiFiPAF connection with a specific node which has been requested to connect in PairDevice()
+     *   Close the WiFiPAF connection with a specific device id which has been requested to connect in PairDevice()
      */
     void CloseWiFiPAFConnection(NodeId remoteDeviceId);
 #endif

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -731,6 +731,14 @@ public:
     void CloseBleConnection();
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    /**
+     * @brief
+     *   Close the WiFiPAF connection with a specific node which has been requested to connect in PairDevice()
+     */
+    void CloseWiFiPAFConnection(NodeId remoteDeviceId);
+#endif
+
     /**
      * @brief
      *   Discover all devices advertising as commissionable.

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -91,7 +91,7 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
     params.bleLayer = mSystemState->BleLayer();
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    params.wifipaf_layer = mSystemState->WiFiPayLayer();
+    params.wifipaf_layer = mSystemState->WiFiPafLayer();
 #endif
     params.listenPort                = mListenPort;
     params.fabricIndependentStorage  = mFabricIndependentStorage;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -90,6 +90,9 @@ CHIP_ERROR DeviceControllerFactory::ReinitSystemStateIfNecessary()
 #if CONFIG_NETWORK_LAYER_BLE
     params.bleLayer = mSystemState->BleLayer();
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    params.wifipaf_layer = mSystemState->WiFiPayLayer();
+#endif
     params.listenPort                = mListenPort;
     params.fabricIndependentStorage  = mFabricIndependentStorage;
     params.enableServerInteractions  = mEnableServerInteractions;
@@ -160,10 +163,10 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 #else
     stateParams.bleLayer = params.bleLayer;
 #endif // CONFIG_DEVICE_LAYER
-#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    stateParams.wifipaf_layer = params.wifipaf_layer;
-#endif
     VerifyOrReturnError(stateParams.bleLayer != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    stateParams.wifipaf_layer = &WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
 #endif
 
     stateParams.transportMgr = chip::Platform::New<DeviceTransportMgr>();

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -189,6 +189,9 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+        mWiFiPafLayer = params.wifipaf_layer;
+#endif
         VerifyOrDie(IsInitialized());
     };
 
@@ -241,6 +244,9 @@ public:
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * BleLayer() const { return mBleLayer; };
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    WiFiPAF::WiFiPAFLayer * WiFiPayLayer() const { return mWiFiPafLayer; };
+ #endif
     CASESessionManager * CASESessionMgr() const { return mCASESessionManager; }
     Credentials::GroupDataProvider * GetGroupDataProvider() const { return mGroupDataProvider; }
     chip::app::reporting::ReportScheduler * GetReportScheduler() const { return mReportScheduler; }
@@ -263,6 +269,9 @@ private:
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    WiFiPAF::WiFiPAFLayer * mWiFiPafLayer = nullptr;
+ #endif
     DeviceTransportMgr * mTransportMgr                                             = nullptr;
     SessionManager * mSessionMgr                                                   = nullptr;
     Protocols::SecureChannel::UnsolicitedStatusHandler * mUnsolicitedStatusHandler = nullptr;

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -245,8 +245,8 @@ public:
     Ble::BleLayer * BleLayer() const { return mBleLayer; };
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    WiFiPAF::WiFiPAFLayer * WiFiPayLayer() const { return mWiFiPafLayer; };
- #endif
+    WiFiPAF::WiFiPAFLayer * WiFiPafLayer() const { return mWiFiPafLayer; };
+#endif
     CASESessionManager * CASESessionMgr() const { return mCASESessionManager; }
     Credentials::GroupDataProvider * GetGroupDataProvider() const { return mGroupDataProvider; }
     chip::app::reporting::ReportScheduler * GetReportScheduler() const { return mReportScheduler; }
@@ -271,7 +271,7 @@ private:
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     WiFiPAF::WiFiPAFLayer * mWiFiPafLayer = nullptr;
- #endif
+#endif
     DeviceTransportMgr * mTransportMgr                                             = nullptr;
     SessionManager * mSessionMgr                                                   = nullptr;
     Protocols::SecureChannel::UnsolicitedStatusHandler * mUnsolicitedStatusHandler = nullptr;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -1,28 +1,28 @@
 /*
-*
-*    Copyright (c) 2021 Project CHIP Authors
-*    All rights reserved.
-*
-*    Licensed under the Apache License, Version 2.0 (the "License");
-*    you may not use this file except in compliance with the License.
-*    You may obtain a copy of the License at
-*
-*        http://www.apache.org/licenses/LICENSE-2.0
-*
-*    Unless required by applicable law or agreed to in writing, software
-*    distributed under the License is distributed on an "AS IS" BASIS,
-*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*    See the License for the specific language governing permissions and
-*    limitations under the License.
-*/
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 /**
-*    @file
-*      Implementation of SetUp Code Pairer, a class that parses a given
-*      setup code and uses the extracted informations to discover and
-*      filter commissionables nodes, before initiating the pairing process.
-*
-*/
+ *    @file
+ *      Implementation of SetUp Code Pairer, a class that parses a given
+ *      setup code and uses the extracted informations to discover and
+ *      filter commissionables nodes, before initiating the pairing process.
+ *
+ */
 
 #include <controller/SetUpCodePairer.h>
 
@@ -42,252 +42,252 @@ namespace chip {
 namespace Controller {
 
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
-			       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
+                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
-VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
-VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
 
-std::vector<SetupPayload> payloads;
-ReturnErrorOnFailure(SetupPayload::FromStringRepresentation(setUpCode, payloads));
+    std::vector<SetupPayload> payloads;
+    ReturnErrorOnFailure(SetupPayload::FromStringRepresentation(setUpCode, payloads));
 
-// If the caller has provided a specific single resolution data, and we were
-// only looking for one commissionee, and the caller says that the provided
-// data matches that one commissionee, just go ahead and use the provided data.
-//
-// If we were looking for more than one device (i.e. if either of the
-// payload arrays involved does not have length 1), we can't make use of the
-// incoming resolution data, since it does not contain the long
-// discriminator of the thing that was discovered, and therefore we can't
-// tell which setup passcode to use for it.
-if (resolutionData.HasValue() && payloads.size() == 1 && mSetupPayloads.size() == 1)
-{
-VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, discoveryType != DiscoveryType::kAll,
-			      CHIP_ERROR_INVALID_ARGUMENT);
-if (mRemoteId == remoteId && mSetupPayloads[0].setUpPINCode == payloads[0].setUpPINCode && mConnectionType == commission &&
-    mDiscoveryType == discoveryType)
-{
-    // Not passing a discriminator is ok, since we have only one payload.
-    NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
-    return CHIP_NO_ERROR;
-}
-}
+    // If the caller has provided a specific single resolution data, and we were
+    // only looking for one commissionee, and the caller says that the provided
+    // data matches that one commissionee, just go ahead and use the provided data.
+    //
+    // If we were looking for more than one device (i.e. if either of the
+    // payload arrays involved does not have length 1), we can't make use of the
+    // incoming resolution data, since it does not contain the long
+    // discriminator of the thing that was discovered, and therefore we can't
+    // tell which setup passcode to use for it.
+    if (resolutionData.HasValue() && payloads.size() == 1 && mSetupPayloads.size() == 1)
+    {
+        VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, discoveryType != DiscoveryType::kAll,
+                                      CHIP_ERROR_INVALID_ARGUMENT);
+        if (mRemoteId == remoteId && mSetupPayloads[0].setUpPINCode == payloads[0].setUpPINCode && mConnectionType == commission &&
+            mDiscoveryType == discoveryType)
+        {
+            // Not passing a discriminator is ok, since we have only one payload.
+            NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
+            return CHIP_NO_ERROR;
+        }
+    }
 
-ResetDiscoveryState();
+    ResetDiscoveryState();
 
-mConnectionType = commission;
-mDiscoveryType  = discoveryType;
-mRemoteId       = remoteId;
-mSetupPayloads  = std::move(payloads);
+    mConnectionType = commission;
+    mDiscoveryType  = discoveryType;
+    mRemoteId       = remoteId;
+    mSetupPayloads  = std::move(payloads);
 
-if (resolutionData.HasValue() && mSetupPayloads.size() == 1)
-{
-// No need to pass in a discriminator if we have only one payload, which
-// is good because we don't have a full discriminator here anyway.
-NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
-return CHIP_NO_ERROR;
-}
+    if (resolutionData.HasValue() && mSetupPayloads.size() == 1)
+    {
+        // No need to pass in a discriminator if we have only one payload, which
+        // is good because we don't have a full discriminator here anyway.
+        NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
+        return CHIP_NO_ERROR;
+    }
 
-ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
-auto errorCode =
-mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback, this);
-if (CHIP_NO_ERROR == errorCode)
-{
-MATTER_LOG_METRIC_BEGIN(kMetricSetupCodePairerPairDevice);
-}
-return errorCode;
+    ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
+    auto errorCode =
+        mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback, this);
+    if (CHIP_NO_ERROR == errorCode)
+    {
+        MATTER_LOG_METRIC_BEGIN(kMetricSetupCodePairerPairDevice);
+    }
+    return errorCode;
 }
 
 CHIP_ERROR SetUpCodePairer::Connect()
 {
-if (mDiscoveryType == DiscoveryType::kAll)
-{
-if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
-{
-    CHIP_ERROR err = StartDiscoveryOverBLE();
-    if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
+    if (mDiscoveryType == DiscoveryType::kAll)
     {
-	ChipLogProgress(Controller,
-			"Skipping commissionable node discovery over BLE since not supported by the controller!");
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
+        {
+            CHIP_ERROR err = StartDiscoveryOverBLE();
+            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
+            {
+                ChipLogProgress(Controller,
+                                "Skipping commissionable node discovery over BLE since not supported by the controller!");
+            }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT,
+                             err.Format());
+            }
+        }
+        if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
+        {
+            CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
+            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
+            {
+                ChipLogProgress(Controller,
+                                "Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
+            }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT,
+                             err.Format());
+            }
+        }
     }
-    else if (err != CHIP_NO_ERROR)
-    {
-	ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT,
-		     err.Format());
-    }
-}
-if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
-{
-    CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
-    if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
-    {
-	ChipLogProgress(Controller,
-			"Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
-    }
-    else if (err != CHIP_NO_ERROR)
-    {
-	ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT,
-		     err.Format());
-    }
-}
-}
 
-// We always want to search on network because any node that has already been commissioned will use on-network regardless of the
-// QR code flag.
-CHIP_ERROR err = StartDiscoveryOverDNSSD();
-if (err != CHIP_NO_ERROR)
-{
-ChipLogError(Controller, "Failed to start discovery over DNS-SD: %" CHIP_ERROR_FORMAT, err.Format());
-}
-return err;
+    // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
+    // QR code flag.
+    CHIP_ERROR err = StartDiscoveryOverDNSSD();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Failed to start discovery over DNS-SD: %" CHIP_ERROR_FORMAT, err.Format());
+    }
+    return err;
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverBLE()
 {
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
-mCommissioner->ConnectBleTransportToSelf();
+    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    mCommissioner->ConnectBleTransportToSelf();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-ChipLogProgress(Controller, "Starting commissioning discovery over BLE");
+    ChipLogProgress(Controller, "Starting commissioning discovery over BLE");
 
-// Handle possibly-sync callbacks.
-mWaitingForDiscovery[kBLETransport] = true;
-CHIP_ERROR err;
-// Not all BLE backends support the new NewBleConnectionByDiscriminators
-// API, so use the old one when we can (i.e. when we only have one setup
-// payload), to avoid breaking existing API consumers.
-if (mSetupPayloads.size() == 1)
-{
-err = mBleLayer->NewBleConnectionByDiscriminator(mSetupPayloads[0].discriminator, this, OnDiscoveredDeviceOverBleSuccess,
-						 OnDiscoveredDeviceOverBleError);
-}
-else
-{
-std::vector<SetupDiscriminator> discriminators;
-discriminators.reserve(mSetupPayloads.size());
-for (auto & payload : mSetupPayloads)
-{
-    discriminators.emplace_back(payload.discriminator);
-}
-err = mBleLayer->NewBleConnectionByDiscriminators(Span(discriminators.data(), discriminators.size()), this,
-						  OnDiscoveredDeviceWithDiscriminatorOverBleSuccess,
-						  OnDiscoveredDeviceOverBleError);
-}
-if (err != CHIP_NO_ERROR)
-{
-mWaitingForDiscovery[kBLETransport] = false;
-}
-return err;
+    // Handle possibly-sync callbacks.
+    mWaitingForDiscovery[kBLETransport] = true;
+    CHIP_ERROR err;
+    // Not all BLE backends support the new NewBleConnectionByDiscriminators
+    // API, so use the old one when we can (i.e. when we only have one setup
+    // payload), to avoid breaking existing API consumers.
+    if (mSetupPayloads.size() == 1)
+    {
+        err = mBleLayer->NewBleConnectionByDiscriminator(mSetupPayloads[0].discriminator, this, OnDiscoveredDeviceOverBleSuccess,
+                                                         OnDiscoveredDeviceOverBleError);
+    }
+    else
+    {
+        std::vector<SetupDiscriminator> discriminators;
+        discriminators.reserve(mSetupPayloads.size());
+        for (auto & payload : mSetupPayloads)
+        {
+            discriminators.emplace_back(payload.discriminator);
+        }
+        err = mBleLayer->NewBleConnectionByDiscriminators(Span(discriminators.data(), discriminators.size()), this,
+                                                          OnDiscoveredDeviceWithDiscriminatorOverBleSuccess,
+                                                          OnDiscoveredDeviceOverBleError);
+    }
+    if (err != CHIP_NO_ERROR)
+    {
+        mWaitingForDiscovery[kBLETransport] = false;
+    }
+    return err;
 #else
-return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CONFIG_NETWORK_LAYER_BLE
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverBLE()
 {
-// Make sure to not call CancelBleIncompleteConnection unless we are in fact
-// waiting on BLE discovery.  It will cancel connections that are in fact
-// completed. In particular, if we just established PASE over BLE calling
-// CancelBleIncompleteConnection here unconditionally would cancel the BLE
-// connection underlying the PASE session.  So make sure to only call
-// CancelBleIncompleteConnection if we're still waiting to hear back on the
-// BLE discovery bits.
-if (!mWaitingForDiscovery[kBLETransport])
-{
-return CHIP_NO_ERROR;
-}
+    // Make sure to not call CancelBleIncompleteConnection unless we are in fact
+    // waiting on BLE discovery.  It will cancel connections that are in fact
+    // completed. In particular, if we just established PASE over BLE calling
+    // CancelBleIncompleteConnection here unconditionally would cancel the BLE
+    // connection underlying the PASE session.  So make sure to only call
+    // CancelBleIncompleteConnection if we're still waiting to hear back on the
+    // BLE discovery bits.
+    if (!mWaitingForDiscovery[kBLETransport])
+    {
+        return CHIP_NO_ERROR;
+    }
 
-mWaitingForDiscovery[kBLETransport] = false;
+    mWaitingForDiscovery[kBLETransport] = false;
 #if CONFIG_NETWORK_LAYER_BLE
-VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-ChipLogDetail(Controller, "Stopping commissioning discovery over BLE");
-return mBleLayer->CancelBleIncompleteConnection();
+    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    ChipLogDetail(Controller, "Stopping commissioning discovery over BLE");
+    return mBleLayer->CancelBleIncompleteConnection();
 #else
-return CHIP_NO_ERROR;
+    return CHIP_NO_ERROR;
 #endif // CONFIG_NETWORK_LAYER_BLE
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverDNSSD()
 {
-ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
+    ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
 
-Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone);
-if (mSetupPayloads.size() == 1)
-{
-auto & discriminator = mSetupPayloads[0].discriminator;
-if (discriminator.IsShortDiscriminator())
-{
-    filter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
-    filter.code = discriminator.GetShortValue();
-}
-else
-{
-    filter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
-    filter.code = discriminator.GetLongValue();
-}
-}
+    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone);
+    if (mSetupPayloads.size() == 1)
+    {
+        auto & discriminator = mSetupPayloads[0].discriminator;
+        if (discriminator.IsShortDiscriminator())
+        {
+            filter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
+            filter.code = discriminator.GetShortValue();
+        }
+        else
+        {
+            filter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
+            filter.code = discriminator.GetLongValue();
+        }
+    }
 
-// In theory we could try to filter on the vendor ID if it's the same across all the setup
-// payloads, but DNS-SD advertisements are not required to include the Vendor ID subtype, so in
-// practice that's not doable.
+    // In theory we could try to filter on the vendor ID if it's the same across all the setup
+    // payloads, but DNS-SD advertisements are not required to include the Vendor ID subtype, so in
+    // practice that's not doable.
 
-// Handle possibly-sync callbacks.
-mWaitingForDiscovery[kIPTransport] = true;
-CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
-if (err != CHIP_NO_ERROR)
-{
-mWaitingForDiscovery[kIPTransport] = false;
-}
-return err;
+    // Handle possibly-sync callbacks.
+    mWaitingForDiscovery[kIPTransport] = true;
+    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
+    if (err != CHIP_NO_ERROR)
+    {
+        mWaitingForDiscovery[kIPTransport] = false;
+    }
+    return err;
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverDNSSD()
 {
-ChipLogDetail(Controller, "Stopping commissioning discovery over DNS-SD");
+    ChipLogDetail(Controller, "Stopping commissioning discovery over DNS-SD");
 
-mWaitingForDiscovery[kIPTransport] = false;
+    mWaitingForDiscovery[kIPTransport] = false;
 
-mCommissioner->StopCommissionableDiscovery();
-return CHIP_NO_ERROR;
+    mCommissioner->StopCommissionableDiscovery();
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-if (mSetupPayloads.size() != 1)
-{
-ChipLogError(Controller, "WiFiPAF commissioning does not support concatenated QR codes yet.");
-return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
+    if (mSetupPayloads.size() != 1)
+    {
+        ChipLogError(Controller, "WiFiPAF commissioning does not support concatenated QR codes yet.");
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
 
-auto & payload = mSetupPayloads[0];
+    auto & payload = mSetupPayloads[0];
 
-ChipLogProgress(Controller, "Starting commissioning discovery over WiFiPAF");
-VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    ChipLogProgress(Controller, "Starting commissioning discovery over WiFiPAF");
+    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-const SetupDiscriminator connDiscriminator(payload.discriminator);
-VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
-		ChipLogError(Controller, "Error, Long discriminator is required"));
-uint16_t discriminator              = connDiscriminator.GetLongValue();
-WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
-				    .nodeId        = mRemoteId,
-				    .discriminator = discriminator };
-ReturnErrorOnFailure(
-DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+    const SetupDiscriminator connDiscriminator(payload.discriminator);
+    VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
+                        ChipLogError(Controller, "Error, Long discriminator is required"));
+    uint16_t discriminator              = connDiscriminator.GetLongValue();
+    WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
+                                            .nodeId        = mRemoteId,
+                                            .discriminator = discriminator };
+    ReturnErrorOnFailure(
+        DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
 
-mWaitingForDiscovery[kWiFiPAFTransport] = true;
-CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, (void *) this, OnWiFiPAFSubscribeComplete,
-							     OnWiFiPAFSubscribeError);
-if (err != CHIP_NO_ERROR)
-{
-ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed, err = %" CHIP_ERROR_FORMAT, err.Format());
-mWaitingForDiscovery[kWiFiPAFTransport] = false;
-}
-return err;
+    mWaitingForDiscovery[kWiFiPAFTransport] = true;
+    CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, (void *) this, OnWiFiPAFSubscribeComplete,
+                                                                     OnWiFiPAFSubscribeError);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed, err = %" CHIP_ERROR_FORMAT, err.Format());
+        mWaitingForDiscovery[kWiFiPAFTransport] = false;
+    }
+    return err;
 #else
-return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif
 }
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -464,7 +464,7 @@ void SetUpCodePairer::OnWifiPAFDiscoveryError(CHIP_ERROR err)
     {
         WiFiPAF::WiFiPAFSession InSessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
                                                   .nodeId        = mRemoteId};
-        WiFiPAF::WiFiPAFSession * pSession = DeviceLayer::ConnectivityMgr().GetWiFiPAF()->GetPAFInfo(WiFiPAF::PafInfoAccess::kAccNodeId, InSessionInfo);
+        WiFiPAF::WiFiPAFSession * pSession = DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->GetPAFInfo(WiFiPAF::PafInfoAccess::kAccNodeId, InSessionInfo);
         if (pSession != nullptr)
         {
             DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(pSession->id);

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -1,28 +1,28 @@
 /*
- *
- *    Copyright (c) 2021 Project CHIP Authors
- *    All rights reserved.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
+*
+*    Copyright (c) 2021 Project CHIP Authors
+*    All rights reserved.
+*
+*    Licensed under the Apache License, Version 2.0 (the "License");
+*    you may not use this file except in compliance with the License.
+*    You may obtain a copy of the License at
+*
+*        http://www.apache.org/licenses/LICENSE-2.0
+*
+*    Unless required by applicable law or agreed to in writing, software
+*    distributed under the License is distributed on an "AS IS" BASIS,
+*    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*    See the License for the specific language governing permissions and
+*    limitations under the License.
+*/
 
 /**
- *    @file
- *      Implementation of SetUp Code Pairer, a class that parses a given
- *      setup code and uses the extracted informations to discover and
- *      filter commissionables nodes, before initiating the pairing process.
- *
- */
+*    @file
+*      Implementation of SetUp Code Pairer, a class that parses a given
+*      setup code and uses the extracted informations to discover and
+*      filter commissionables nodes, before initiating the pairing process.
+*
+*/
 
 #include <controller/SetUpCodePairer.h>
 
@@ -42,257 +42,270 @@ namespace chip {
 namespace Controller {
 
 CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
-                                       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
+			       DiscoveryType discoveryType, Optional<Dnssd::CommonResolutionData> resolutionData)
 {
-    VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
+VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, remoteId != kUndefinedNodeId, CHIP_ERROR_INVALID_ARGUMENT);
 
-    std::vector<SetupPayload> payloads;
-    ReturnErrorOnFailure(SetupPayload::FromStringRepresentation(setUpCode, payloads));
+std::vector<SetupPayload> payloads;
+ReturnErrorOnFailure(SetupPayload::FromStringRepresentation(setUpCode, payloads));
 
-    // If the caller has provided a specific single resolution data, and we were
-    // only looking for one commissionee, and the caller says that the provided
-    // data matches that one commissionee, just go ahead and use the provided data.
-    //
-    // If we were looking for more than one device (i.e. if either of the
-    // payload arrays involved does not have length 1), we can't make use of the
-    // incoming resolution data, since it does not contain the long
-    // discriminator of the thing that was discovered, and therefore we can't
-    // tell which setup passcode to use for it.
-    if (resolutionData.HasValue() && payloads.size() == 1 && mSetupPayloads.size() == 1)
-    {
-        VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, discoveryType != DiscoveryType::kAll,
-                                      CHIP_ERROR_INVALID_ARGUMENT);
-        if (mRemoteId == remoteId && mSetupPayloads[0].setUpPINCode == payloads[0].setUpPINCode && mConnectionType == commission &&
-            mDiscoveryType == discoveryType)
-        {
-            // Not passing a discriminator is ok, since we have only one payload.
-            NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
-            return CHIP_NO_ERROR;
-        }
-    }
+// If the caller has provided a specific single resolution data, and we were
+// only looking for one commissionee, and the caller says that the provided
+// data matches that one commissionee, just go ahead and use the provided data.
+//
+// If we were looking for more than one device (i.e. if either of the
+// payload arrays involved does not have length 1), we can't make use of the
+// incoming resolution data, since it does not contain the long
+// discriminator of the thing that was discovered, and therefore we can't
+// tell which setup passcode to use for it.
+if (resolutionData.HasValue() && payloads.size() == 1 && mSetupPayloads.size() == 1)
+{
+VerifyOrReturnErrorWithMetric(kMetricSetupCodePairerPairDevice, discoveryType != DiscoveryType::kAll,
+			      CHIP_ERROR_INVALID_ARGUMENT);
+if (mRemoteId == remoteId && mSetupPayloads[0].setUpPINCode == payloads[0].setUpPINCode && mConnectionType == commission &&
+    mDiscoveryType == discoveryType)
+{
+    // Not passing a discriminator is ok, since we have only one payload.
+    NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
+    return CHIP_NO_ERROR;
+}
+}
 
-    ResetDiscoveryState();
+ResetDiscoveryState();
 
-    mConnectionType = commission;
-    mDiscoveryType  = discoveryType;
-    mRemoteId       = remoteId;
-    mSetupPayloads  = std::move(payloads);
+mConnectionType = commission;
+mDiscoveryType  = discoveryType;
+mRemoteId       = remoteId;
+mSetupPayloads  = std::move(payloads);
 
-    if (resolutionData.HasValue() && mSetupPayloads.size() == 1)
-    {
-        // No need to pass in a discriminator if we have only one payload, which
-        // is good because we don't have a full discriminator here anyway.
-        NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
-        return CHIP_NO_ERROR;
-    }
+if (resolutionData.HasValue() && mSetupPayloads.size() == 1)
+{
+// No need to pass in a discriminator if we have only one payload, which
+// is good because we don't have a full discriminator here anyway.
+NotifyCommissionableDeviceDiscovered(resolutionData.Value(), /* matchedLongDiscriminator = */ std::nullopt);
+return CHIP_NO_ERROR;
+}
 
-    ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
-    auto errorCode =
-        mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback, this);
-    if (CHIP_NO_ERROR == errorCode)
-    {
-        MATTER_LOG_METRIC_BEGIN(kMetricSetupCodePairerPairDevice);
-    }
-    return errorCode;
+ReturnErrorOnFailureWithMetric(kMetricSetupCodePairerPairDevice, Connect());
+auto errorCode =
+mSystemLayer->StartTimer(System::Clock::Milliseconds32(kDeviceDiscoveredTimeout), OnDeviceDiscoveredTimeoutCallback, this);
+if (CHIP_NO_ERROR == errorCode)
+{
+MATTER_LOG_METRIC_BEGIN(kMetricSetupCodePairerPairDevice);
+}
+return errorCode;
 }
 
 CHIP_ERROR SetUpCodePairer::Connect()
 {
-    if (mDiscoveryType == DiscoveryType::kAll)
+if (mDiscoveryType == DiscoveryType::kAll)
+{
+if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
+{
+    CHIP_ERROR err = StartDiscoveryOverBLE();
+    if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
     {
-        if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
-        {
-            CHIP_ERROR err = StartDiscoveryOverBLE();
-            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
-            {
-                ChipLogProgress(Controller,
-                                "Skipping commissionable node discovery over BLE since not supported by the controller!");
-            }
-            else if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT,
-                             err.Format());
-            }
-        }
-        if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
-        {
-            CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
-            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
-            {
-                ChipLogProgress(Controller,
-                                "Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
-            }
-            else if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT,
-                             err.Format());
-            }
-        }
+	ChipLogProgress(Controller,
+			"Skipping commissionable node discovery over BLE since not supported by the controller!");
     }
+    else if (err != CHIP_NO_ERROR)
+    {
+	ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT,
+		     err.Format());
+    }
+}
+if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
+{
+    CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
+    if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
+    {
+	ChipLogProgress(Controller,
+			"Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
+    }
+    else if (err != CHIP_NO_ERROR)
+    {
+	ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT,
+		     err.Format());
+    }
+}
+}
 
-    // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
-    // QR code flag.
-    CHIP_ERROR err = StartDiscoveryOverDNSSD();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Failed to start discovery over DNS-SD: %" CHIP_ERROR_FORMAT, err.Format());
-    }
-    return err;
+// We always want to search on network because any node that has already been commissioned will use on-network regardless of the
+// QR code flag.
+CHIP_ERROR err = StartDiscoveryOverDNSSD();
+if (err != CHIP_NO_ERROR)
+{
+ChipLogError(Controller, "Failed to start discovery over DNS-SD: %" CHIP_ERROR_FORMAT, err.Format());
+}
+return err;
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverBLE()
 {
 #if CONFIG_NETWORK_LAYER_BLE
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    mCommissioner->ConnectBleTransportToSelf();
+VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+mCommissioner->ConnectBleTransportToSelf();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
-    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
 
-    ChipLogProgress(Controller, "Starting commissioning discovery over BLE");
+ChipLogProgress(Controller, "Starting commissioning discovery over BLE");
 
-    // Handle possibly-sync callbacks.
-    mWaitingForDiscovery[kBLETransport] = true;
-    CHIP_ERROR err;
-    // Not all BLE backends support the new NewBleConnectionByDiscriminators
-    // API, so use the old one when we can (i.e. when we only have one setup
-    // payload), to avoid breaking existing API consumers.
-    if (mSetupPayloads.size() == 1)
-    {
-        err = mBleLayer->NewBleConnectionByDiscriminator(mSetupPayloads[0].discriminator, this, OnDiscoveredDeviceOverBleSuccess,
-                                                         OnDiscoveredDeviceOverBleError);
-    }
-    else
-    {
-        std::vector<SetupDiscriminator> discriminators;
-        discriminators.reserve(mSetupPayloads.size());
-        for (auto & payload : mSetupPayloads)
-        {
-            discriminators.emplace_back(payload.discriminator);
-        }
-        err = mBleLayer->NewBleConnectionByDiscriminators(Span(discriminators.data(), discriminators.size()), this,
-                                                          OnDiscoveredDeviceWithDiscriminatorOverBleSuccess,
-                                                          OnDiscoveredDeviceOverBleError);
-    }
-    if (err != CHIP_NO_ERROR)
-    {
-        mWaitingForDiscovery[kBLETransport] = false;
-    }
-    return err;
+// Handle possibly-sync callbacks.
+mWaitingForDiscovery[kBLETransport] = true;
+CHIP_ERROR err;
+// Not all BLE backends support the new NewBleConnectionByDiscriminators
+// API, so use the old one when we can (i.e. when we only have one setup
+// payload), to avoid breaking existing API consumers.
+if (mSetupPayloads.size() == 1)
+{
+err = mBleLayer->NewBleConnectionByDiscriminator(mSetupPayloads[0].discriminator, this, OnDiscoveredDeviceOverBleSuccess,
+						 OnDiscoveredDeviceOverBleError);
+}
+else
+{
+std::vector<SetupDiscriminator> discriminators;
+discriminators.reserve(mSetupPayloads.size());
+for (auto & payload : mSetupPayloads)
+{
+    discriminators.emplace_back(payload.discriminator);
+}
+err = mBleLayer->NewBleConnectionByDiscriminators(Span(discriminators.data(), discriminators.size()), this,
+						  OnDiscoveredDeviceWithDiscriminatorOverBleSuccess,
+						  OnDiscoveredDeviceOverBleError);
+}
+if (err != CHIP_NO_ERROR)
+{
+mWaitingForDiscovery[kBLETransport] = false;
+}
+return err;
 #else
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CONFIG_NETWORK_LAYER_BLE
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverBLE()
 {
-    // Make sure to not call CancelBleIncompleteConnection unless we are in fact
-    // waiting on BLE discovery.  It will cancel connections that are in fact
-    // completed. In particular, if we just established PASE over BLE calling
-    // CancelBleIncompleteConnection here unconditionally would cancel the BLE
-    // connection underlying the PASE session.  So make sure to only call
-    // CancelBleIncompleteConnection if we're still waiting to hear back on the
-    // BLE discovery bits.
-    if (!mWaitingForDiscovery[kBLETransport])
-    {
-        return CHIP_NO_ERROR;
-    }
+// Make sure to not call CancelBleIncompleteConnection unless we are in fact
+// waiting on BLE discovery.  It will cancel connections that are in fact
+// completed. In particular, if we just established PASE over BLE calling
+// CancelBleIncompleteConnection here unconditionally would cancel the BLE
+// connection underlying the PASE session.  So make sure to only call
+// CancelBleIncompleteConnection if we're still waiting to hear back on the
+// BLE discovery bits.
+if (!mWaitingForDiscovery[kBLETransport])
+{
+return CHIP_NO_ERROR;
+}
 
-    mWaitingForDiscovery[kBLETransport] = false;
+mWaitingForDiscovery[kBLETransport] = false;
 #if CONFIG_NETWORK_LAYER_BLE
-    VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
-    ChipLogDetail(Controller, "Stopping commissioning discovery over BLE");
-    return mBleLayer->CancelBleIncompleteConnection();
+VerifyOrReturnError(mBleLayer != nullptr, CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+ChipLogDetail(Controller, "Stopping commissioning discovery over BLE");
+return mBleLayer->CancelBleIncompleteConnection();
 #else
-    return CHIP_NO_ERROR;
+return CHIP_NO_ERROR;
 #endif // CONFIG_NETWORK_LAYER_BLE
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverDNSSD()
 {
-    ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
+ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
 
-    Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone);
-    if (mSetupPayloads.size() == 1)
-    {
-        auto & discriminator = mSetupPayloads[0].discriminator;
-        if (discriminator.IsShortDiscriminator())
-        {
-            filter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
-            filter.code = discriminator.GetShortValue();
-        }
-        else
-        {
-            filter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
-            filter.code = discriminator.GetLongValue();
-        }
-    }
+Dnssd::DiscoveryFilter filter(Dnssd::DiscoveryFilterType::kNone);
+if (mSetupPayloads.size() == 1)
+{
+auto & discriminator = mSetupPayloads[0].discriminator;
+if (discriminator.IsShortDiscriminator())
+{
+    filter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
+    filter.code = discriminator.GetShortValue();
+}
+else
+{
+    filter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
+    filter.code = discriminator.GetLongValue();
+}
+}
 
-    // In theory we could try to filter on the vendor ID if it's the same across all the setup
-    // payloads, but DNS-SD advertisements are not required to include the Vendor ID subtype, so in
-    // practice that's not doable.
+// In theory we could try to filter on the vendor ID if it's the same across all the setup
+// payloads, but DNS-SD advertisements are not required to include the Vendor ID subtype, so in
+// practice that's not doable.
 
-    // Handle possibly-sync callbacks.
-    mWaitingForDiscovery[kIPTransport] = true;
-    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
-    if (err != CHIP_NO_ERROR)
-    {
-        mWaitingForDiscovery[kIPTransport] = false;
-    }
-    return err;
+// Handle possibly-sync callbacks.
+mWaitingForDiscovery[kIPTransport] = true;
+CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
+if (err != CHIP_NO_ERROR)
+{
+mWaitingForDiscovery[kIPTransport] = false;
+}
+return err;
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverDNSSD()
 {
-    ChipLogDetail(Controller, "Stopping commissioning discovery over DNS-SD");
+ChipLogDetail(Controller, "Stopping commissioning discovery over DNS-SD");
 
-    mWaitingForDiscovery[kIPTransport] = false;
+mWaitingForDiscovery[kIPTransport] = false;
 
-    mCommissioner->StopCommissionableDiscovery();
-    return CHIP_NO_ERROR;
+mCommissioner->StopCommissionableDiscovery();
+return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-    if (mSetupPayloads.size() != 1)
-    {
-        ChipLogError(Controller, "WiFiPAF commissioning does not support concatenated QR codes yet.");
-        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-    }
+if (mSetupPayloads.size() != 1)
+{
+ChipLogError(Controller, "WiFiPAF commissioning does not support concatenated QR codes yet.");
+return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
 
-    auto & payload = mSetupPayloads[0];
+auto & payload = mSetupPayloads[0];
 
-    ChipLogProgress(Controller, "Starting commissioning discovery over WiFiPAF");
-    VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
+ChipLogProgress(Controller, "Starting commissioning discovery over WiFiPAF");
+VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    const SetupDiscriminator connDiscriminator(payload.discriminator);
-    VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
-                        ChipLogError(Controller, "Error, Long discriminator is required"));
-    uint16_t discriminator              = connDiscriminator.GetLongValue();
-    WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
-                                            .nodeId        = mRemoteId,
-                                            .discriminator = discriminator };
-    ReturnErrorOnFailure(
-        DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+const SetupDiscriminator connDiscriminator(payload.discriminator);
+VerifyOrReturnValue(!connDiscriminator.IsShortDiscriminator(), CHIP_ERROR_INVALID_ARGUMENT,
+		ChipLogError(Controller, "Error, Long discriminator is required"));
+uint16_t discriminator              = connDiscriminator.GetLongValue();
+WiFiPAF::WiFiPAFSession sessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
+				    .nodeId        = mRemoteId,
+				    .discriminator = discriminator };
+ReturnErrorOnFailure(
+DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
 
-    mWaitingForDiscovery[kWiFiPAFTransport] = true;
-    CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, (void *) this, OnWiFiPAFSubscribeComplete,
-                                                                     OnWiFiPAFSubscribeError);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed, err = %" CHIP_ERROR_FORMAT, err.Format());
-        mWaitingForDiscovery[kWiFiPAFTransport] = false;
-    }
-    return err;
+mWaitingForDiscovery[kWiFiPAFTransport] = true;
+CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, (void *) this, OnWiFiPAFSubscribeComplete,
+							     OnWiFiPAFSubscribeError);
+if (err != CHIP_NO_ERROR)
+{
+ChipLogError(Controller, "Commissioning discovery over WiFiPAF failed, err = %" CHIP_ERROR_FORMAT, err.Format());
+mWaitingForDiscovery[kWiFiPAFTransport] = false;
+}
+return err;
 #else
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverWiFiPAF()
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
+    if (mWaitingForDiscovery[kWiFiPAFTransport] == true)
+    {
+        WiFiPAF::WiFiPAFSession InSessionInfo = { .role = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber, .nodeId = mRemoteId };
+        WiFiPAF::WiFiPAFSession * pSession =
+            DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->GetPAFInfo(WiFiPAF::PafInfoAccess::kAccNodeId, InSessionInfo);
+        if (pSession != nullptr)
+        {
+            DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(pSession->id);
+        }
+    }
+    DeviceLayer::ConnectivityMgr().WiFiPAFCancelIncompleteSubscribe();
+#endif
     mWaitingForDiscovery[kWiFiPAFTransport] = false;
     return CHIP_NO_ERROR;
 }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -275,7 +275,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
                                             .nodeId        = mRemoteId,
                                             .discriminator = discriminator };
     ReturnErrorOnFailure(
-        DeviceLayer::ConnectivityMgr().GetWiFiPAF()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
+        DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->AddPafSession(WiFiPAF::PafInfoAccess::kAccNodeInfo, sessionInfo));
 
     mWaitingForDiscovery[kWiFiPAFTransport] = true;
     CHIP_ERROR err = DeviceLayer::ConnectivityMgr().WiFiPAFSubscribe(discriminator, (void *) this, OnWiFiPAFSubscribeComplete,
@@ -462,9 +462,9 @@ void SetUpCodePairer::OnWifiPAFDiscoveryError(CHIP_ERROR err)
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     if (mWaitingForDiscovery[kWiFiPAFTransport] == true)
     {
-        WiFiPAF::WiFiPAFSession InSessionInfo = { .role          = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber,
-                                                  .nodeId        = mRemoteId};
-        WiFiPAF::WiFiPAFSession * pSession = DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->GetPAFInfo(WiFiPAF::PafInfoAccess::kAccNodeId, InSessionInfo);
+        WiFiPAF::WiFiPAFSession InSessionInfo = { .role = WiFiPAF::WiFiPafRole::kWiFiPafRole_Subscriber, .nodeId = mRemoteId };
+        WiFiPAF::WiFiPAFSession * pSession =
+            DeviceLayer::ConnectivityMgr().GetWiFiPafLayer()->GetPAFInfo(WiFiPAF::PafInfoAccess::kAccNodeId, InSessionInfo);
         if (pSession != nullptr)
         {
             DeviceLayer::ConnectivityMgr().WiFiPAFCancelSubscribe(pSession->id);

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -194,7 +194,7 @@ public:
     CHIP_ERROR WiFiPAFCancelSubscribe(uint32_t SubscribeId);
     CHIP_ERROR WiFiPAFCancelIncompleteSubscribe();
     CHIP_ERROR WiFiPAFSend(const WiFiPAF::WiFiPAFSession & TxInfo, System::PacketBufferHandle && msgBuf);
-    WiFiPAF::WiFiPAFLayer * GetWiFiPAF();
+    WiFiPAF::WiFiPAFLayer * GetWiFiPafLayer();
     void WiFiPafSetApFreq(const uint16_t freq);
     CHIP_ERROR WiFiPAFShutdown(uint32_t id, WiFiPAF::WiFiPafRole role);
     bool WiFiPAFResourceAvailable();
@@ -538,7 +538,7 @@ inline void ConnectivityManager::ResetThreadNetworkDiagnosticsCounts()
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
-inline WiFiPAF::WiFiPAFLayer * ConnectivityManager::GetWiFiPAF()
+inline WiFiPAF::WiFiPAFLayer * ConnectivityManager::GetWiFiPafLayer()
 {
     return &WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer();
 }

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -165,8 +165,7 @@ void GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     ChipLogProgress(DeviceLayer, "WiFi-PAF Layer shutdown");
-    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown(
-        [](uint32_t id, WiFiPAF::WiFiPafRole role) { DeviceLayer::ConnectivityMgr().WiFiPAFShutdown(id, role); });
+    WiFiPAF::WiFiPAFLayer::GetWiFiPAFLayer().Shutdown();
 #endif
 
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC_BASED_COMMISSIONING

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1337,7 +1337,7 @@ void ConnectivityManagerImpl::OnDiscoveryResult(GVariant * discov_info)
     dataValue.reset(value);
     auto ssibuf      = g_variant_get_fixed_array(dataValue.get(), &bufferLen, sizeof(uint8_t));
     auto pPublishSSI = reinterpret_cast<const PAFPublishSSI *>(ssibuf);
-    GetWiFiPAF()->SetWiFiPAFState(WiFiPAF::State::kConnected);
+    GetWiFiPafLayer()->SetWiFiPAFState(WiFiPAF::State::kConnected);
 
     /*
         Error Checking

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -156,6 +156,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     }
     case DeviceEventType::kCHIPoWiFiPAFConnected: {
         ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFConnected");
+        DeviceLayer::SystemLayer().CancelTimer(HandleWiFiPAFScanTimer, this);
         WiFiPAF::WiFiPAFSession SessionInfo;
         memcpy(&SessionInfo, &event->CHIPoWiFiPAFReceived.SessionInfo, sizeof(WiFiPAF::WiFiPAFSession));
         WiFiPafLayer.HandleTransportConnectionInitiated(SessionInfo, mOnPafSubscribeComplete, mAppState, mOnPafSubscribeError);
@@ -163,6 +164,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     }
     case DeviceEventType::kCHIPoWiFiPAFCancelConnect: {
         ChipLogProgress(DeviceLayer, "WiFi-PAF: event: kCHIPoWiFiPAFCancelConnect");
+        DeviceLayer::SystemLayer().CancelTimer(HandleWiFiPAFScanTimer, this);
         if (mOnPafSubscribeError != nullptr)
         {
             mOnPafSubscribeError(mAppState, CHIP_ERROR_CANCELLED);
@@ -1616,8 +1618,21 @@ CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFSubscribe(const uint16_t & connDiscr
             return self->OnNanSubscribeTerminated(term_subscribe_id, reason);
         }),
         this);
+    static constexpr System::Clock::Timeout kNewConnectionScanTimeout = System::Clock::Seconds16(20);
+    CHIP_ERROR timerErr = DeviceLayer::SystemLayer().StartTimer(kNewConnectionScanTimeout, HandleWiFiPAFScanTimer, this);
+    if (timerErr != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to start WiFiPAF scan timeout: %" CHIP_ERROR_FORMAT, timerErr.Format());
+    }
 
     return CHIP_NO_ERROR;
+}
+
+void ConnectivityManagerImpl::HandleWiFiPAFScanTimer(chip::System::Layer *, void * appState)
+{
+    auto * manager = static_cast<ConnectivityManagerImpl *>(appState);
+    manager->mOnPafSubscribeError(manager->mAppState, CHIP_ERROR_TIMEOUT);
+    manager->mOnPafSubscribeError = nullptr;
 }
 
 CHIP_ERROR ConnectivityManagerImpl::_WiFiPAFCancelSubscribe(uint32_t SubscribeId)

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -168,6 +168,7 @@ public:
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     CHIP_ERROR _WiFiPAFSubscribe(const uint16_t & connDiscriminator, void * appState, OnConnectionCompleteFunct onSuccess,
                                  OnConnectionErrorFunct onError);
+    static void HandleWiFiPAFScanTimer(chip::System::Layer * systemLayer, void * appState);
     CHIP_ERROR _WiFiPAFCancelSubscribe(uint32_t SubscribeId);
     CHIP_ERROR _WiFiPAFCancelIncompleteSubscribe();
     void OnDiscoveryResult(GVariant * obj);

--- a/src/transport/raw/WiFiPAF.cpp
+++ b/src/transport/raw/WiFiPAF.cpp
@@ -37,7 +37,7 @@ namespace Transport {
 CHIP_ERROR WiFiPAFBase::Init(const WiFiPAFListenParameters & param)
 {
     ChipLogDetail(Inet, "WiFiPAFBase::Init - setting/overriding transport");
-    mWiFiPAFLayer = DeviceLayer::ConnectivityMgr().GetWiFiPAF();
+    mWiFiPAFLayer = DeviceLayer::ConnectivityMgr().GetWiFiPafLayer();
     SetWiFiPAFLayerTransportToSelf();
     mWiFiPAFLayer->SetWiFiPAFState(State::kInitialized);
     return CHIP_NO_ERROR;

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -268,6 +268,7 @@ void WiFiPAFLayer::CloseAllConnections()
 void WiFiPAFLayer::CloseConnection(PafInfoAccess accType, const WiFiPAFSession & PafSession)
 {
     WiFiPAFSession * pPafSession = GetPAFInfo(accType, PafSession);
+    VerifyOrReturn(pPafSession != nullptr);
     ChipLogProgress(WiFiPAF, "WiFiPAF: Canceling id: %u", pPafSession->id);
 
     WiFiPAFEndPoint * endPoint = sWiFiPAFEndPointPool.Find(reinterpret_cast<WIFIPAF_CONNECTION_OBJECT>(pPafSession));
@@ -278,9 +279,11 @@ void WiFiPAFLayer::CloseConnection(PafInfoAccess accType, const WiFiPAFSession &
         endPoint->DoClose(kWiFiPAFCloseFlag_AbortTransmission, WIFIPAF_ERROR_APP_CLOSED_CONNECTION);
         endPoint->mWiFiPafLayer = nullptr;
     }
-
-    mWiFiPAFTransport->WiFiPAFCloseSession(*pPafSession);
-    CleanPafInfo(*pPafSession);
+    else
+    {
+        // WiFiPAFCloseSession will also be called in DoClose() of WiFiPAFEndPoint
+        mWiFiPAFTransport->WiFiPAFCloseSession(*pPafSession);
+    }
 }
 
 bool WiFiPAFLayer::OnWiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg)

--- a/src/wifipaf/WiFiPAFLayer.h
+++ b/src/wifipaf/WiFiPAFLayer.h
@@ -170,8 +170,10 @@ public:
     static WiFiPAFLayer & GetWiFiPAFLayer();
     CHIP_ERROR Init(chip::System::Layer * systemLayer);
 
-    typedef void (*OnCancelDeviceHandle)(uint32_t id, WiFiPAF::WiFiPafRole role);
-    void Shutdown(OnCancelDeviceHandle OnCancelDevice);
+    void Shutdown();
+    void CloseAllConnections();
+    void CloseConnection(PafInfoAccess accType, const WiFiPAFSession & PafSession);
+
     bool OnWiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg);
     CHIP_ERROR OnWiFiPAFMsgRxComplete(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg);
     State GetWiFiPAFState() { return mAppState; };
@@ -191,7 +193,7 @@ public:
 
     CHIP_ERROR AddPafSession(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
     CHIP_ERROR RmPafSession(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
-    WiFiPAFSession * GetPAFInfo(PafInfoAccess accType, WiFiPAFSession & SessionInfo);
+    WiFiPAFSession * GetPAFInfo(PafInfoAccess accType, const WiFiPAFSession & SessionInfo);
 
 private:
     void InitialPafInfo();

--- a/src/wifipaf/tests/TestWiFiPAFLayer.cpp
+++ b/src/wifipaf/tests/TestWiFiPAFLayer.cpp
@@ -65,7 +65,7 @@ public:
     void TearDown() override
     {
         mWiFiPAFTransport = nullptr;
-        Shutdown([](uint32_t id, WiFiPAF::WiFiPafRole role) {});
+        Shutdown();
     }
 
     CHIP_ERROR WiFiPAFMessageReceived(WiFiPAFSession & RxInfo, System::PacketBufferHandle && msg) override { return CHIP_NO_ERROR; }


### PR DESCRIPTION
This PR is to add the time-out function to cancel the previous subscription and refine the flow to shutdown or close the session.
Changes:
    - Add the time-out function to cancel the subscirption command which is pending to discovery the commissionee
    - Refine the shutdown function to close the specific sessions which were created by the instance, instead of closing all sessions
    - Fix the typo and refine the function name by the suggestion of Gemini
    - 


#### Testing

* Test#1 in the normal mode:
	[commissioner]
	$ ./chip-tool pairing wifipaf-wifi 20 nxp_matter-CSA nxp12345 20202021 3840 --freq 2412
	> # wait until time-out occurs
	[commissionee]
	./chip-all-clusters-app --wifi --wifipaf freq_list=2412
	[commissioner]
	$ ./chip-tool pairing wifipaf-wifi 20 nxp_matter-CSA nxp12345 20202021 3840 --freq 2412
	> # => device can be paired

* Test#2 in the normal mode:
	[commissioner]
	$ ./chip-tool pairing code-wifi 11 nxp_matter-CSA nxp12345 MT:-24J0M3810KA0648G00 --freq 2412
	> # wait until time-out occurs
	[commissionee]
	./chip-all-clusters-app --wifi --wifipaf freq_list=2412
	[commissioner]
	$ ./chip-tool pairing code-wifi 11 nxp_matter-CSA nxp12345 MT:-24J0M3810KA0648G00 --freq 2412
	> # => device can be paired

* Test#3 in the interactive mode:
	[commissioner]
	$ ./chip-tool interactive start
	>>> pairing wifipaf-wifi 20 nxp_matter-CSA nxp12345 20202021 3840 --freq 2412
	> # Wait until time-out
	[commissionee]
	./chip-all-clusters-app --wifi --wifipaf freq_list=2412
	[commissioner]
	>>> pairing wifipaf-wifi 20 nxp_matter-CSA nxp12345 20202021 3840 --freq 2412
	> # => device can be paired

* Test#4 in the interactive mode:
	[commissioner]
	$ ./chip-tool interactive start
	>>> pairing code-wifi 11 nxp_matter-CSA nxp12345 MT:-24J0M3810KA0648G00 --freq 2412
	> # Wait until time-out
	[commissionee]
	./chip-all-clusters-app --wifi --wifipaf freq_list=2412
	[commissioner]
	>>> pairing code-wifi 11 nxp_matter-CSA nxp12345 MT:-24J0M3810KA0648G00 --freq 2412
	> # => device can be paired
