### PR TITLE
TC-OPCREDS-3.8: Set PICS to cmd

### DIFF
--- a/src/python_testing/TC_OPCREDS_3_8.py
+++ b/src/python_testing/TC_OPCREDS_3_8.py
@@ -49,7 +49,8 @@ import chip.clusters as Clusters
 import nest_asyncio
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import (AttributeMatcher, AttributeValue, ClusterAttributeChangeAccumulator, MatterBaseTest,
-                                         TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches)
+                                         TestStep, default_matter_test_main, has_command, run_if_endpoint_matches)
+from chip.testing.pics import accepted_cmd_pics_str
 from chip.tlv import TLVReader
 from chip.utils import CommissioningBuildingBlocks
 from ecdsa import NIST256p, VerifyingKey
@@ -358,9 +359,9 @@ class TC_OPCREDS_VidVerify(MatterBaseTest):
         return self.aggregated_steps
 
     def pics_TC_OPCREDS_3_8(self) -> list[str]:
-        return ['OPCREDS.S']
+        return [accepted_cmd_pics_str('OPCREDS', Clusters.OperationalCredentials.Commands.SetVIDVerificationStatement.command_id)]
 
-    @run_if_endpoint_matches(has_cluster(Clusters.OperationalCredentials))
+    @run_if_endpoint_matches(has_command(Clusters.OperationalCredentials.Commands.SetVIDVerificationStatement))
     async def test_TC_OPCREDS_3_8(self):
         # TODO(test_plans#5046): actually make the test follow final test plan. For now
         # it functionally validates the VID Verification parts of Operational Credentials Cluster


### PR DESCRIPTION
Even though this command is now mandatory in 1.4.2, if the TH is going to be used to test earlier spec revisions, then we want to gate this on the command presence so the TH does not mistakenly identify this test as required.


#### Testing

Locally - Tested against a ToT device - passes and runs. Tested against a device build on 1.4 branch - test is skipped.
This test also runs in the CI, but will only run against the current ToT examples.
