### PR TITLE
[1.4] Fix Door Lock cluster to not repond DUPLICATE when there is no duplication of credentials.

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -726,6 +726,17 @@ void DoorLockServer::setCredentialCommandHandler(
     // appclusters, 5.2.4.41.1: we should return DUPLICATE in the response if we're trying to create duplicated credential entry
     for (uint16_t i = 1; CredentialTypeEnum::kProgrammingPIN != credentialType && (i <= maxNumberOfCredentials); ++i)
     {
+        // Ignore the slot we are trying to set, because setting a credential to
+        // the same value as it already has should be just fine.
+        //
+        // This is not clearly defined in the spec;
+        // https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/11707
+        // tracks that.
+        if (i == credentialIndex)
+        {
+            continue;
+        }
+
         EmberAfPluginDoorLockCredentialInfo currentCredential;
         if (!emberAfPluginDoorLockGetCredential(commandPath.mEndpointId, i, credentialType, currentCredential))
         {

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -1310,6 +1310,32 @@ tests:
               - name: "NextCredentialIndex"
                 value: null
 
+    - label: "Verify setting credential to same value is allowed"
+      command: "SetCredential"
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "OperationType"
+                value: 2 # Modify
+              - name: "Credential"
+                value: { CredentialType: 1, CredentialIndex: 1 }
+              - name: "CredentialData"
+                value: "000000"
+              - name: "UserIndex"
+                value: 1
+              - name: "UserStatus"
+                value: null
+              - name: "UserType"
+                value: null
+      response:
+          values:
+              - name: "Status"
+                value: 0x00
+              - name: "UserIndex"
+                value: null
+              - name: "NextCredentialIndex"
+                value: 2
+
     - label: "Create new PIN credential and user with index 0 fails"
       command: "SetCredential"
       timedInteractionTimeoutMs: 10000
@@ -2381,10 +2407,10 @@ tests:
     - label: "Make sure a LockUserChange event was generated"
       command: "readEvent"
       event: "LockUserChange"
-      # I wish there were a way to not hardcode this 27, but it's experimentally
-      # determined: doing a read without an eventNumber filter here shows 26
+      # I wish there were a way to not hardcode this 28, but it's experimentally
+      # determined: doing a read without an eventNumber filter here shows 27
       # LockUserChange events before this removal.
-      eventNumber: 27
+      eventNumber: 28
       response:
           value:
               {


### PR DESCRIPTION
Spec issue tracking the spec not being clear:
https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/11707

Cherry-pick of https://github.com/project-chip/connectedhomeip/pull/39254

#### Testing

YAML tests added.