### PR TITLE
[Darwin] testSubscriptionPoolManyDevices test should use fewer devices to avoid flakiness

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPerControllerStorageTests.m
@@ -3019,6 +3019,8 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         @(118) : @"MT:0000000000Z1J900000",
         @(119) : @"MT:000008C801FFJ900000",
         @(120) : @"MT:00000GOG02XSJ900000",
+
+        /* Reduce "many devices" to 20 until either a better number or a better testing method is found
         @(121) : @"MT:00000O-O03D4K900000",
         @(122) : @"MT:00000WAX04VHK900000",
         @(123) : @"MT:000002N315BVK900000",
@@ -3049,6 +3051,7 @@ static void OnBrowse(DNSServiceRef serviceRef, DNSServiceFlags flags, uint32_t i
         @(148) : @"MT:00000AZB168QT900000",
         @(149) : @"MT:00000I9K17Q1U900000",
         @(150) : @"MT:00000000007FU900000",
+         */
     };
 
     // Start our helper apps.


### PR DESCRIPTION
Attempts to fix https://github.com/project-chip/connectedhomeip/issues/37312

As @bzbarsky-apple noted, there are instances of test failures where timeouts happen with long gaps of logs. We are suspecting running so many devices in this test may cause thrashing. This patch reduces the number of devices from 50 to 20 to see if this improves the stability.

#### Testing

Will be bumping CI a few times with this PR to see if failures still occur.