### PR TITLE
[Test Fix] Fix TC_ACL_2_6 and TC_ACL_2_8 event count and filtering issues

### DIFF
--- a/src/python_testing/TC_ACL_2_6.py
+++ b/src/python_testing/TC_ACL_2_6.py
@@ -275,5 +275,6 @@ class TC_ACL_2_6(MatterBaseTest):
 
         logging.info("No events found for invalid entry, as expected")
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_ACL_2_6.py
+++ b/src/python_testing/TC_ACL_2_6.py
@@ -96,6 +96,8 @@ class TC_ACL_2_6(MatterBaseTest):
         events_callback = EventChangeCallback(Clusters.AccessControl)
         await events_callback.start(self.default_controller, self.dut_node_id, 0)
 
+        latest_event_number = await self.get_latest_event_number(acec_event)
+
         # Read initial events
         events_response = await self.th1.ReadEvent(
             self.dut_node_id,
@@ -165,7 +167,8 @@ class TC_ACL_2_6(MatterBaseTest):
         events_response = await self.th1.ReadEvent(
             self.dut_node_id,
             events=[(0, acec_event)],
-            fabricFiltered=True
+            fabricFiltered=True,
+            eventNumberFilter=latest_event_number + 1
         )
         logging.info(f"Read events response: {events_response}")
 
@@ -244,12 +247,12 @@ class TC_ACL_2_6(MatterBaseTest):
 
         self.step(7)
         # Verify no events for invalid entry via read as well
-        latest_event_num = await self.get_latest_event_number(acec_event)
+        latest_event_number = await self.get_latest_event_number(acec_event)
         events_response = await self.th1.ReadEvent(
             self.dut_node_id,
             events=[(0, acec_event)],
             fabricFiltered=True,
-            eventNumberFilter=latest_event_num + 1
+            eventNumberFilter=latest_event_number + 1
         )
 
         # Check if any of the read events correspond to the invalid entry
@@ -260,7 +263,6 @@ class TC_ACL_2_6(MatterBaseTest):
                 asserts.fail(f"Found event for invalid entry in read response: {event.Data}")
 
         logging.info("No events found for invalid entry, as expected")
-
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -150,7 +150,7 @@ class TC_ACL_2_8(MatterBaseTest):
         # Read CurrentFabricIndex for TH2
         f2 = await self.read_single_attribute_check_success(dev_ctrl=self.th2, endpoint=0, cluster=oc_cluster, attribute=cfi_attribute)
         logging.info(f"CurrentFabricIndex F2 {str(f2)}")
-        
+
         self.step(5)
         # Get latest event number before writing events
         acec_event = Clusters.AccessControl.Events.AccessControlEntryChanged
@@ -252,14 +252,14 @@ class TC_ACL_2_8(MatterBaseTest):
         # Below event filtering and parsing is currently required in the event that the DUT is not reset before running this test.
         # First find the most recent "added" event
         added_events = [e for e in events if (
-            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kAdded and 
+            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kAdded and
             e.Data.latestValue.subjects == [self.th1.nodeId]
         )]
         added_event = sorted(added_events, key=lambda e: e.Header.EventNumber)[-1]
 
         # Then find the most recent "changed" event that occurred after the "added" event
         changed_events = [e for e in events if (
-            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kChanged and 
+            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kChanged and
             e.Data.latestValue.subjects == [self.th1.nodeId, 1111] and
             e.Header.EventNumber > added_event.Header.EventNumber
         )]
@@ -300,14 +300,14 @@ class TC_ACL_2_8(MatterBaseTest):
 
         # First find the most recent "added" event
         added_events = [e for e in events if (
-            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kAdded and 
+            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kAdded and
             e.Data.latestValue.subjects == [self.th2.nodeId]
         )]
         added_event = sorted(added_events, key=lambda e: e.Header.EventNumber)[-1]
 
         # Then find the most recent "changed" event that occurred after the "added" event
         changed_events = [e for e in events if (
-            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kChanged and 
+            e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kChanged and
             e.Data.latestValue.subjects == [self.th2.nodeId, 2222] and
             e.Header.EventNumber > added_event.Header.EventNumber
         )]

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -53,12 +53,12 @@ class TC_ACL_2_8(MatterBaseTest):
     def _get_relevant_acl_events(self, all_events: list, expected_add_subject_node_id: int, expected_change_subject_node_ids: list) -> list:
         """
         Extracts the most recent 'added' and 'changed' events for a specific node from all events.
-        
+
         Args:
             all_events: List of all AccessControlEntryChanged events
             expected_add_subject_node_id: Node ID expected in the 'added' event subjects
             expected_change_subject_node_ids: List of node IDs expected in the 'changed' event subjects
-            
+
         Returns:
             List containing the relevant 'added' and 'changed' events in chronological order
         """
@@ -76,7 +76,8 @@ class TC_ACL_2_8(MatterBaseTest):
             e.Data.latestValue.subjects == expected_change_subject_node_ids and
             e.Header.EventNumber > added_event.Header.EventNumber
         )]
-        asserts.assert_true(len(changed_events) > 0, f"Expected 'changed' event for node {expected_add_subject_node_id} not found after the 'added' event")
+        asserts.assert_true(len(changed_events) > 0,
+                            f"Expected 'changed' event for node {expected_add_subject_node_id} not found after the 'added' event")
         changed_event = sorted(changed_events, key=lambda e: e.Header.EventNumber)[-1]
 
         return [added_event, changed_event]

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -249,6 +249,7 @@ class TC_ACL_2_8(MatterBaseTest):
             fabricFiltered=True
         )
 
+        # Below event filtering and parsing is currently required in the event that the DUT is not reset before running this test.
         # First find the most recent "added" event
         added_events = [e for e in events if (
             e.Data.changeType == Clusters.AccessControl.Enums.ChangeTypeEnum.kAdded and 

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -69,7 +69,7 @@ class TC_ACL_2_8(MatterBaseTest):
         )]
         asserts.assert_true(len(added_events) > 0, f"Expected 'added' event for node {expected_add_subject_node_id} not found")
         added_event = sorted(added_events, key=lambda e: e.Header.EventNumber)[-1]
-        
+
         # Guarantee we have a valid added_event
         asserts.assert_is_not_none(added_event, f"Added event for node {expected_add_subject_node_id} must not be None")
 
@@ -82,7 +82,7 @@ class TC_ACL_2_8(MatterBaseTest):
         asserts.assert_true(len(changed_events) > 0,
                             f"Expected 'changed' event for node {expected_add_subject_node_id} not found after the 'added' event")
         changed_event = sorted(changed_events, key=lambda e: e.Header.EventNumber)[-1]
-        
+
         # Guarantee we have a valid changed_event
         asserts.assert_is_not_none(changed_event, f"Changed event for node {expected_add_subject_node_id} must not be None")
 

--- a/src/python_testing/TC_ACL_2_8.py
+++ b/src/python_testing/TC_ACL_2_8.py
@@ -138,9 +138,6 @@ class TC_ACL_2_8(MatterBaseTest):
         logging.info(f"CurrentFabricIndex F2 {str(f2)}")
 
         self.step(5)
-        # Get latest event number before writing events
-        acec_event = Clusters.AccessControl.Events.AccessControlEntryChanged
-
         # TH1 writes ACL attribute
         acl_struct = Clusters.AccessControl.Structs.AccessControlEntryStruct(
             privilege=5,


### PR DESCRIPTION
#### Testing
- Fixes issue found by Cecille for ACL_2_8 here: [579](https://github.com/project-chip/matter-test-scripts/issues/579)
- Added additional event filtering to test step 9 and 10 in ACL_2_8 to make sure that if the device is pre-commissioned before running the test that we have captured the correct events and verified those events accordingly
- Added eventNumberFilter to events to help with ACL_2_6 not having the correct events during test step 3 if device was pre-commissioned
- Adds check for 1 event during test step 3 to match with test plan in ACL_2_6
