### PR TITLE
Adding coverage report link to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@
 [![Cirque](https://github.com/project-chip/connectedhomeip/workflows/Cirque/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/cirque.yaml)
 [![QEMU](https://github.com/project-chip/connectedhomeip/workflows/QEMU/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/qemu.yaml)
 
+-   [Matter SDK Coverage Report](https://matter-build-automation.ue.r.appspot.com/)
+
 **Tools**
 
 [![ZAP Templates](https://github.com/project-chip/connectedhomeip/workflows/ZAP/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/zap_templates.yaml)


### PR DESCRIPTION
- Add link to SDK Coverage Report in front page

#### Testing

just a minor change, testing by viewing rich diff
