### PR TITLE
[Chef] [Pump] Fix: remove unused global constant

### DIFF
--- a/examples/chef/common/chef-pump.cpp
+++ b/examples/chef/common/chef-pump.cpp
@@ -113,7 +113,6 @@ uint16_t getIndexLevelControl(EndpointId endpointId)
 {
     return emberAfGetClusterServerEndpointIndex(endpointId, LevelControl::Id, kLevelControlCount);
 }
-constexpr uint8_t kMinLevel  = 1;
 constexpr uint8_t kMaxLevel  = 254;
 constexpr uint8_t kNullLevel = 255;
 


### PR DESCRIPTION
#### Testing

Error -

```
Step #2 - "CompileAll": /workspace/examples/chef/common/chef-pump.cpp:116:19: error: unused variable 'kMinLevel' [-Werror,-Wunused-const-variable]
Step #2 - "CompileAll":   116 | constexpr uint8_t kMinLevel  = 1;
Step #2 - "CompileAll":       |                   ^~~~~~~~~
Step #2 - "CompileAll": 1 error generated.
```

Compilation successful

```
./chef.py -br -d rootnode_pump_5f904818cc -t linux --cpu_type arm64 -a
```
