### PR TITLE
Add gcovr dependency to chip-build image and update version

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -127,6 +127,7 @@ RUN set -x \
     pygit \
     PyGithub \
     ruff \
+    gcovr \
     && : # last line
 
 # Install bloat comparison tools

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -127,7 +127,7 @@ RUN set -x \
     pygit \
     PyGithub \
     ruff \
-    gcovr \
+    gcovr==8.3 \
     && : # last line
 
 # Install bloat comparison tools

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-134 : [Ameba] Update Docker image
+135 : Upgrade docker to build with gcovr for coverage


### PR DESCRIPTION
Add command to install gcovr by pip

#### Testing

It will test on build_coverage.sh file, to generate coverage on XML format.