### PR TITLE
Add example Vacuum then Mop mode to RVC example app

### DIFF
--- a/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
+++ b/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
@@ -47,15 +47,13 @@ private:
     ModeTagStructType ModeTagsMapping[1]  = { { .value = to_underlying(ModeTag::kMapping) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Idle"_span,
-                                                 .mode     = ModeIdle,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Idle"_span, .mode = ModeIdle, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
         detail::Structs::ModeOptionStruct::Type{ .label    = "Cleaning"_span,
                                                  .mode     = ModeCleaning,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsCleaning) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Mapping"_span,
-                                                 .mode     = ModeMapping,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Mapping"_span, .mode = ModeMapping, .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
     };
 
     CHIP_ERROR Init() override;
@@ -117,21 +115,17 @@ private:
                                                 { .value = to_underlying(ModeTag::kVacuumThenMop) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[6] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Quick"_span,
-                                                 .mode     = ModeQuick,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuick) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Auto"_span,
-                                                 .mode     = ModeAuto,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsAuto) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Quick"_span, .mode = ModeQuick, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuick) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Auto"_span, .mode = ModeAuto, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsAuto) },
         detail::Structs::ModeOptionStruct::Type{ .label    = "Deep Clean"_span,
                                                  .mode     = ModeDeepClean,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDeepClean) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Quiet"_span,
-                                                 .mode     = ModeQuiet,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuiet) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = "Max Vac"_span,
-                                                 .mode     = ModeMaxVac,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMaxVac) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Quiet"_span, .mode = ModeQuiet, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuiet) },
+        detail::Structs::ModeOptionStruct::Type{
+            .label = "Max Vac"_span, .mode = ModeMaxVac, .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMaxVac) },
         detail::Structs::ModeOptionStruct::Type{ .label    = "Vacuum Then Mop"_span,
                                                  .mode     = ModeVacThenMop,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVacThenMop) }

--- a/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
+++ b/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
@@ -84,11 +84,12 @@ void Shutdown();
 
 namespace RvcCleanMode {
 
-const uint8_t ModeQuick     = 0;
-const uint8_t ModeAuto      = 1;
-const uint8_t ModeDeepClean = 2;
-const uint8_t ModeQuiet     = 3;
-const uint8_t ModeMaxVac    = 4;
+const uint8_t ModeQuick      = 0;
+const uint8_t ModeAuto       = 1;
+const uint8_t ModeDeepClean  = 2;
+const uint8_t ModeQuiet      = 3;
+const uint8_t ModeMaxVac     = 4;
+const uint8_t ModeVacThenMop = 5;
 
 /// This is an application level delegate to handle RvcClean commands according to the specific business logic.
 class RvcCleanModeDelegate : public ModeBase::Delegate
@@ -111,7 +112,11 @@ private:
     ModeTagStructType modeTagsMaxVac[2] = { { .value = to_underlying(ModeTag::kVacuum) },
                                             { .value = to_underlying(ModeTag::kDeepClean) } };
 
-    const detail::Structs::ModeOptionStruct::Type kModeOptions[5] = {
+    ModeTagStructType modeTagsVacThenMop[3] = { { .value = to_underlying(ModeTag::kVacuum) },
+                                                { .value = to_underlying(ModeTag::kMop) },
+                                                { .value = to_underlying(ModeTag::kVacuumThenMop) } };
+
+    const detail::Structs::ModeOptionStruct::Type kModeOptions[6] = {
         detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Quick"),
                                                  .mode     = ModeQuick,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuick) },
@@ -127,6 +132,9 @@ private:
         detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Max Vac"),
                                                  .mode     = ModeMaxVac,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMaxVac) },
+        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Vacuum Then Mop"),
+                                                 .mode     = ModeVacThenMop,
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVacThenMop) }
     };
 
     CHIP_ERROR Init() override;

--- a/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
+++ b/examples/rvc-app/rvc-common/include/rvc-mode-delegates.h
@@ -47,13 +47,13 @@ private:
     ModeTagStructType ModeTagsMapping[1]  = { { .value = to_underlying(ModeTag::kMapping) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Idle"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Idle"_span,
                                                  .mode     = ModeIdle,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsIdle) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Cleaning"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Cleaning"_span,
                                                  .mode     = ModeCleaning,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsCleaning) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Mapping"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Mapping"_span,
                                                  .mode     = ModeMapping,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(ModeTagsMapping) },
     };
@@ -117,22 +117,22 @@ private:
                                                 { .value = to_underlying(ModeTag::kVacuumThenMop) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[6] = {
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Quick"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Quick"_span,
                                                  .mode     = ModeQuick,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuick) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Auto"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Auto"_span,
                                                  .mode     = ModeAuto,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsAuto) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Deep Clean"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Deep Clean"_span,
                                                  .mode     = ModeDeepClean,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsDeepClean) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Quiet"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Quiet"_span,
                                                  .mode     = ModeQuiet,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsQuiet) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Max Vac"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Max Vac"_span,
                                                  .mode     = ModeMaxVac,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsMaxVac) },
-        detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Vacuum Then Mop"),
+        detail::Structs::ModeOptionStruct::Type{ .label    = "Vacuum Then Mop"_span,
                                                  .mode     = ModeVacThenMop,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsVacThenMop) }
     };

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -44,7 +44,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
-                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
+                "Change to the mapping or cleaning mode is only allowed from idle"_span);
             return;
         }
 
@@ -62,7 +62,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
             response.statusText.SetValue(
-                chip::CharSpan::fromCharString("Change to the mapping or cleaning mode is only allowed from idle"));
+                "Change to the mapping or cleaning mode is only allowed from idle"_span);
             return;
         }
 
@@ -78,7 +78,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
 
     // If we fall through at any point, it's because the change is not supported in the current state.
     response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-    response.statusText.SetValue(chip::CharSpan::fromCharString("This change is not allowed at this time"));
+    response.statusText.SetValue("This change is not allowed at this time"_span);
 }
 
 void RvcDevice::HandleRvcCleanChangeToMode(uint8_t newMode, ModeBase::Commands::ChangeToModeResponse::Type & response)
@@ -88,7 +88,7 @@ void RvcDevice::HandleRvcCleanChangeToMode(uint8_t newMode, ModeBase::Commands::
     if (rvcRunCurrentMode != RvcRunMode::ModeIdle)
     {
         response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-        response.statusText.SetValue(chip::CharSpan::fromCharString("Change of the cleaning mode is only allowed in Idle."));
+        response.statusText.SetValue("Change of the cleaning mode is only allowed in Idle."_span);
         return;
     }
 

--- a/examples/rvc-app/rvc-common/src/rvc-device.cpp
+++ b/examples/rvc-app/rvc-common/src/rvc-device.cpp
@@ -43,8 +43,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         if (currentMode != RvcRunMode::ModeIdle && newMode != RvcRunMode::ModeIdle)
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-            response.statusText.SetValue(
-                "Change to the mapping or cleaning mode is only allowed from idle"_span);
+            response.statusText.SetValue("Change to the mapping or cleaning mode is only allowed from idle"_span);
             return;
         }
 
@@ -61,8 +60,7 @@ void RvcDevice::HandleRvcRunChangeToMode(uint8_t newMode, ModeBase::Commands::Ch
         if (newMode != RvcRunMode::ModeIdle)
         {
             response.status = to_underlying(ModeBase::StatusCode::kInvalidInMode);
-            response.statusText.SetValue(
-                "Change to the mapping or cleaning mode is only allowed from idle"_span);
+            response.statusText.SetValue("Change to the mapping or cleaning mode is only allowed from idle"_span);
             return;
         }
 


### PR DESCRIPTION
Vacuum then Mop is a new mode tag (CHIP-Specifications/connectedhomeip-spec#10624) for RVCs that describes order of operations, which wasn't possible with just the `Vacuum` and `Mop` tags.  This demonstrates a mode using the tag.

#### Testing

Ran RVC Run Mode test scripts TC 1.1/2.1/2.2 [as described in rvc-app README](https://project-chip.github.io/connectedhomeip-doc/examples/rvc-app/README.html#rvc-run-mode-cluster) to check for regressions.
