### PR TITLE
Drop unused ConnectivityManager::CanStartWiFiScan function

### DIFF
--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -262,7 +262,6 @@ private:
 
     CHIP_ERROR Init();
     void OnPlatformEvent(const ChipDeviceEvent * event);
-    bool CanStartWiFiScan();
     void OnWiFiScanDone();
     void OnWiFiStationProvisionChange();
 
@@ -636,11 +635,6 @@ inline CHIP_ERROR ConnectivityManager::Init()
 inline void ConnectivityManager::OnPlatformEvent(const ChipDeviceEvent * event)
 {
     static_cast<ImplClass *>(this)->_OnPlatformEvent(event);
-}
-
-inline bool ConnectivityManager::CanStartWiFiScan()
-{
-    return static_cast<ImplClass *>(this)->_CanStartWiFiScan();
 }
 
 inline void ConnectivityManager::OnWiFiScanDone()

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoWiFi.h
@@ -71,7 +71,6 @@ public:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
     static const char * _WiFiStationModeToStr(ConnectivityManager::WiFiStationMode mode);
@@ -183,12 +182,6 @@ template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_GetAndLogWiFiStatsCounters(void)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline bool GenericConnectivityManagerImpl_NoWiFi<ImplClass>::_CanStartWiFiScan()
-{
-    return false;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_WiFi.h
@@ -74,7 +74,6 @@ public:
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWiFiStatsCounters();
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 // TODO ICD rework: ambiguous declaration of _SetPollingInterval when thread and wifi are both build together
@@ -170,12 +169,6 @@ template <class ImplClass>
 inline CHIP_ERROR GenericConnectivityManagerImpl_WiFi<ImplClass>::_GetAndLogWiFiStatsCounters()
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ImplClass>
-inline bool GenericConnectivityManagerImpl_WiFi<ImplClass>::_CanStartWiFiScan()
-{
-    return false;
 }
 
 template <class ImplClass>

--- a/src/platform/ASR/ConnectivityManagerImpl.h
+++ b/src/platform/ASR/ConnectivityManagerImpl.h
@@ -100,7 +100,6 @@ private:
 
     CHIP_ERROR _Init(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
@@ -173,11 +172,6 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPActive(void)
 inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout(void)
 {
     return mWiFiAPIdleTimeout;
-}
-
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
 }
 
 /**

--- a/src/platform/Ameba/ConnectivityManagerImpl.h
+++ b/src/platform/Ameba/ConnectivityManagerImpl.h
@@ -114,7 +114,6 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
@@ -198,10 +197,6 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout(voi
     return mWiFiAPIdleTimeout;
 }
 
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
-}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 /**

--- a/src/platform/Beken/ConnectivityManagerImpl.h
+++ b/src/platform/Beken/ConnectivityManagerImpl.h
@@ -110,7 +110,6 @@ private:
     System::Clock::Timeout _GetWiFiAPIdleTimeout(void);
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
@@ -192,10 +191,6 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout(voi
     return mWiFiAPIdleTimeout;
 }
 
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
-}
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
 /**

--- a/src/platform/Darwin/ConnectivityManagerImpl.h
+++ b/src/platform/Darwin/ConnectivityManagerImpl.h
@@ -105,7 +105,6 @@ private:
     bool _IsWiFiStationConnected();
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
-    bool _CanStartWiFiScan();
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/Darwin/WiFi/ConnectivityManagerImplWiFi.mm
+++ b/src/platform/Darwin/WiFi/ConnectivityManagerImplWiFi.mm
@@ -97,8 +97,6 @@ namespace DeviceLayer {
         ConfigurationManagerImpl::GetDefaultInstance().ClearWiFiNetworkInformations();
     }
 
-    bool ConnectivityManagerImpl::_CanStartWiFiScan() { return _IsWiFiStationConnected(); }
-
     CHIP_ERROR ConnectivityManagerImpl::GetWiFiInterfaceName(char * outName, size_t maxLen)
     {
         auto interface = GetDefaultWiFiInterface();

--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -116,7 +116,6 @@ private:
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
@@ -219,11 +218,6 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPApplicationControlled(void)
     return mWiFiAPMode == kWiFiAPMode_ApplicationControlled;
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP
-
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
-}
 
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 

--- a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.h
+++ b/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.h
@@ -99,7 +99,6 @@ private:
 
     CHIP_ERROR _Init(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 
@@ -167,11 +166,6 @@ inline bool ConnectivityManagerImpl::_IsWiFiAPActive(void)
 inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiAPIdleTimeout(void)
 {
     return mWiFiAPIdleTimeout;
-}
-
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
 }
 
 /**

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -295,16 +295,6 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WpaState::INTERFACE_CONNECTED &&
-        mWpaSupplicant.scanState == GDBusWpaSupplicant::WpaScanningState::IDLE;
-
-    return ret;
-}
-
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -235,7 +235,6 @@ private:
     bool _IsWiFiStationApplicationControlled();
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
-    bool _CanStartWiFiScan();
 
     WiFiAPMode _GetWiFiAPMode();
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);

--- a/src/platform/NuttX/ConnectivityManagerImpl.cpp
+++ b/src/platform/NuttX/ConnectivityManagerImpl.cpp
@@ -276,16 +276,6 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED &&
-        mWpaSupplicant.scanState == GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
-
-    return ret;
-}
-
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/NuttX/ConnectivityManagerImpl.h
+++ b/src/platform/NuttX/ConnectivityManagerImpl.h
@@ -193,7 +193,6 @@ private:
     bool _IsWiFiStationApplicationControlled();
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
-    bool _CanStartWiFiScan();
 
     WiFiAPMode _GetWiFiAPMode();
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);

--- a/src/platform/Tizen/ConnectivityManagerImpl.cpp
+++ b/src/platform/Tizen/ConnectivityManagerImpl.cpp
@@ -207,11 +207,6 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     Internal::WiFiMgr().RemoveAllConfigs();
 }
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return false;
-}
-
 ConnectivityManager::WiFiAPMode ConnectivityManagerImpl::_GetWiFiAPMode()
 {
     return mWiFiAPMode;

--- a/src/platform/Tizen/ConnectivityManagerImpl.h
+++ b/src/platform/Tizen/ConnectivityManagerImpl.h
@@ -112,7 +112,6 @@ private:
     bool _IsWiFiStationApplicationControlled(void);
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
-    bool _CanStartWiFiScan(void);
 
     WiFiAPMode _GetWiFiAPMode(void);
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);

--- a/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.cpp
@@ -102,13 +102,6 @@ void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
     }
 }
 
-bool ConnectivityManagerImplWiFi::_CanStartWiFiScan()
-{
-    return (WiFiManager::StationStatus::DISABLED != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::SCANNING != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus());
-}
-
 void ConnectivityManagerImplWiFi::_OnWiFiStationProvisionChange()
 {
     // do nothing

--- a/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.h
+++ b/src/platform/Zephyr/wifi/ConnectivityManagerImplWiFi.h
@@ -51,7 +51,6 @@ private:
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 

--- a/src/platform/android/ConnectivityManagerImpl.cpp
+++ b/src/platform/android/ConnectivityManagerImpl.cpp
@@ -121,11 +121,6 @@ bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
 
 void ConnectivityManagerImpl::_ClearWiFiStationProvision() {}
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return false;
-}
-
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/android/ConnectivityManagerImpl.h
+++ b/src/platform/android/ConnectivityManagerImpl.h
@@ -125,7 +125,6 @@ private:
     bool _IsWiFiStationApplicationControlled();
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
-    bool _CanStartWiFiScan();
 
     WiFiAPMode _GetWiFiAPMode();
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);

--- a/src/platform/cc32xx/ConnectivityManagerImpl.h
+++ b/src/platform/cc32xx/ConnectivityManagerImpl.h
@@ -103,7 +103,6 @@ private:
     bool _HaveServiceConnectivity(void);
     CHIP_ERROR _Init(void);
     void _OnPlatformEvent(const ChipDeviceEvent * event);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 

--- a/src/platform/mt793x/ConnectivityManagerImpl.h
+++ b/src/platform/mt793x/ConnectivityManagerImpl.h
@@ -114,7 +114,6 @@ private:
     bool _IsWiFiStationConnected(void);
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
     System::Clock::Timeout _GetWiFiStationReconnectInterval(void);
@@ -200,11 +199,6 @@ inline bool ConnectivityManagerImpl::_IsWiFiStationConnected(void)
 inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectInterval(void)
 {
     return mWiFiStationReconnectInterval;
-}
-
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
 }
 #endif
 

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -102,13 +102,6 @@ void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
     }
 }
 
-bool ConnectivityManagerImplWiFi::_CanStartWiFiScan()
-{
-    return (WiFiManager::StationStatus::DISABLED != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::SCANNING != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus());
-}
-
 void ConnectivityManagerImplWiFi::_OnWiFiStationProvisionChange()
 {
     // do nothing

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
@@ -51,7 +51,6 @@ private:
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 

--- a/src/platform/silabs/ConnectivityManagerImpl.h
+++ b/src/platform/silabs/ConnectivityManagerImpl.h
@@ -102,7 +102,6 @@ private:
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     CHIP_ERROR _GetAndLogWifiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
@@ -167,12 +166,8 @@ inline System::Clock::Timeout ConnectivityManagerImpl::_GetWiFiStationReconnectI
 {
     return mWiFiStationReconnectInterval;
 }
-
-inline bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    return mWiFiStationState != kWiFiStationState_Connecting;
-}
 #endif
+
 #if 0 // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 inline bool ConnectivityManagerImpl::_HaveServiceConnectivity(void)
 {

--- a/src/platform/telink/wifi/3.3.99.0/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/telink/wifi/3.3.99.0/ConnectivityManagerImplWiFi.cpp
@@ -102,13 +102,6 @@ void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
     }
 }
 
-bool ConnectivityManagerImplWiFi::_CanStartWiFiScan()
-{
-    return (WiFiManager::StationStatus::DISABLED != WiFiManager().Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::SCANNING != WiFiManager().Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::CONNECTING != WiFiManager().Instance().GetStationStatus());
-}
-
 void ConnectivityManagerImplWiFi::_OnWiFiStationProvisionChange()
 {
     // do nothing

--- a/src/platform/telink/wifi/3.7.99.0/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/telink/wifi/3.7.99.0/ConnectivityManagerImplWiFi.cpp
@@ -102,13 +102,6 @@ void ConnectivityManagerImplWiFi::_ClearWiFiStationProvision(void)
     }
 }
 
-bool ConnectivityManagerImplWiFi::_CanStartWiFiScan()
-{
-    return (WiFiManager::StationStatus::DISABLED != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::SCANNING != WiFiManager::Instance().GetStationStatus() &&
-            WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus());
-}
-
 void ConnectivityManagerImplWiFi::_OnWiFiStationProvisionChange()
 {
     // do nothing

--- a/src/platform/telink/wifi/ConnectivityManagerImplWiFi.h
+++ b/src/platform/telink/wifi/ConnectivityManagerImplWiFi.h
@@ -51,7 +51,6 @@ private:
     bool _IsWiFiStationProvisioned(void);
     void _ClearWiFiStationProvision(void);
     CHIP_ERROR _GetAndLogWiFiStatsCounters(void);
-    bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
 

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -268,16 +268,6 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision()
     }
 }
 
-bool ConnectivityManagerImpl::_CanStartWiFiScan()
-{
-    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
-
-    bool ret = mWpaSupplicant.state == GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED &&
-        mWpaSupplicant.scanState == GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
-
-    return ret;
-}
-
 CHIP_ERROR ConnectivityManagerImpl::_SetWiFiAPMode(WiFiAPMode val)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/src/platform/webos/ConnectivityManagerImpl.h
+++ b/src/platform/webos/ConnectivityManagerImpl.h
@@ -178,7 +178,6 @@ private:
     bool _IsWiFiStationApplicationControlled();
     bool _IsWiFiStationProvisioned();
     void _ClearWiFiStationProvision();
-    bool _CanStartWiFiScan();
 
     WiFiAPMode _GetWiFiAPMode();
     CHIP_ERROR _SetWiFiAPMode(WiFiAPMode val);


### PR DESCRIPTION
The  `CanStartWiFiScan()` function is in the private section of the `ConnectivityManager` class and it is not used anywhere.

#### Testing

CI will verify potential build breaks.