### PR TITLE
[Camera] Use separate GStreamer snapshot pipelines

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -386,26 +386,25 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
     g_object_set(source, "device", device.c_str(), nullptr);
 #endif
 
-    if (!pipeline || !source || !capsfilter || !jpegdec || !videoconvert || !x264enc || !rtph264pay || !udpsink)
+    // Check for any nullptr among the created elements
+    const std::vector<std::pair<GstElement *, const char *>> elements = {
+        { pipeline, "pipeline" },         //
+        { source, "source" },             //
+        { capsfilter, "mjpeg_caps" },     //
+        { jpegdec, "jpegdec" },           //
+        { videoconvert, "videoconvert" }, //
+        { x264enc, "encoder" },           //
+        { rtph264pay, "rtph264" },        //
+        { udpsink, "udpsink" }            //
+    };
+    const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
+
+    // If any element creation failed, log the error and unreference the elements
+    if (isElementFactoryMakeFailed)
     {
         ChipLogError(Camera, "Not all elements could be created.");
-
-        if (pipeline)
-            gst_object_unref(pipeline);
-        if (source)
-            gst_object_unref(source);
-        if (capsfilter)
-            gst_object_unref(capsfilter);
-        if (videoconvert)
-            gst_object_unref(videoconvert);
-        if (jpegdec)
-            gst_object_unref(jpegdec);
-        if (x264enc)
-            gst_object_unref(x264enc);
-        if (rtph264pay)
-            gst_object_unref(rtph264pay);
-        if (udpsink)
-            gst_object_unref(udpsink);
+        // Unreference the elements that were created
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, jpegdec, videoconvert, x264enc, rtph264pay, udpsink);
 
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;
@@ -457,24 +456,25 @@ GstElement * CameraDevice::CreateAudioPipeline(const std::string & device, int c
     source = gst_element_factory_make("pulsesrc", "source");
 #endif
 
-    if (!pipeline || !source || !capsfilter || !audioconvert || !opusenc || !rtpopuspay || !udpsink)
+    // Check for any nullptr among the created elements
+    const std::vector<std::pair<GstElement *, const char *>> elements = {
+        { pipeline, "pipeline" },          //
+        { source, "source" },              //
+        { capsfilter, "filter" },          //
+        { audioconvert, "audio-convert" }, //
+        { opusenc, "opus-encoder" },       //
+        { rtpopuspay, "rtpopuspay" },      //
+        { udpsink, "udpsink" }             //
+    };
+    const bool isElementFactoryMakeFailed = GstreamerPipepline::isGstElementsNull(elements);
+
+    // If any element creation failed, log the error and unreference the elements
+    if (isElementFactoryMakeFailed)
     {
         ChipLogError(Camera, "Not all elements could be created.");
 
-        if (pipeline)
-            gst_object_unref(pipeline);
-        if (source)
-            gst_object_unref(source);
-        if (capsfilter)
-            gst_object_unref(capsfilter);
-        if (audioconvert)
-            gst_object_unref(audioconvert);
-        if (opusenc)
-            gst_object_unref(opusenc);
-        if (rtpopuspay)
-            gst_object_unref(rtpopuspay);
-        if (udpsink)
-            gst_object_unref(udpsink);
+        // Unreference the elements that were created
+        GstreamerPipepline::unrefGstElements(pipeline, source, capsfilter, audioconvert, opusenc, rtpopuspay, udpsink);
 
         error = CameraError::ERROR_INIT_FAILED;
         return nullptr;


### PR DESCRIPTION
#### Problem

When using a Raspberry Pi 4 with the Camera Module 3 connected via the Camera Serial Interface (CSI), an error occurred during the creation of the GStreamer pipeline upon executing the command:
`cameraavstreammanagement snapshot-stream-allocate`

Two specific issues were identified:
1. The `CameraDevice::CreateSnapshotPipeline` function was designed to process only JPEG sources via a `capsfilter`. However, the CSI camera does not directly support JPEG output — it provides raw formats instead. As a result, the pipeline could not be created.

2. After adjusting the pipeline to accept a raw source, the resulting snapshot appeared entirely green. This was due to the use of V4L2, which is not suitable for CSI cameras on the Raspberry Pi. Such cameras should be accessed through libcamera for proper operation.

#### Solution

- Added detection logic to determine the type of camera connected (USB or CSI).

- Split pipeline creation logic into two dedicated functions:

    - `CreateSnapshotPipelineV4l2()` — retains the original implementation for USB webcams.

    - `CreateSnapshotPipelineLibcamerasrc()` — added for CSI cameras using `libcamerasrc`.

- Updated `CameraDevice::CreateSnapshotPipeline()` to detect the camera type and delegate to the appropriate pipeline function.

- Unref gstreamer elements more globally

#### Testing

✅ x64 Target (Webcam):
Verified that existing functionality remains unchanged — no regressions observed.

✅ Raspberry Pi 4 with CSI Camera:

1. Configure the CSI camera using the [official Raspberry Pi documentation](https://www.raspberrypi.com/documentation/computers/camera_software.html#configuration).

2. Install required packages:

`sudo apt install libcamera-dev libcamera-ipa libcamera0.2`

3. Validate your GStreamer pipeline manually:

`gst-launch-1.0 libcamerasrc ! jpegenc ! filesink location=snapshot.jpg & sleep 0.5; pkill gst-launch-1.0`

4. Launch camera-app and camera-controller.

5. Pair the controller with the device and run:

`cameraavstreammanagement snapshot-stream-allocate 0 30 '{"width":640, "height":480}' '{"width":1270, "height":720}' 90 0x12344321 1`

6. Confirm that:

- No errors are logged by the app.

- A valid snapshot is successfully taken.