### PR TITLE
[Telink] Add vid and pid judgment

### DIFF
--- a/src/platform/telink/OTAImageProcessorImpl.cpp
+++ b/src/platform/telink/OTAImageProcessorImpl.cpp
@@ -246,12 +246,12 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & aBlock)
 
         if (GetDeviceInstanceInfoProvider()->GetVendorId(vendorId) != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "Reject OTA image, wrong vendor ID");
+            ChipLogDetail(DeviceLayer, "Failed to retrieve local Vendor ID for OTA validation");
             return CHIP_ERROR_INCORRECT_STATE;
         }
         if (GetDeviceInstanceInfoProvider()->GetProductId(productId) != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "Reject OTA image, wrong product ID");
+            ChipLogDetail(DeviceLayer, "Failed to retrieve local Product ID for OTA validation");
             return CHIP_ERROR_INCORRECT_STATE;
         }
         if (header.mVendorId != vendorId || header.mProductId != productId)

--- a/src/platform/telink/OTAImageProcessorImpl.cpp
+++ b/src/platform/telink/OTAImageProcessorImpl.cpp
@@ -22,6 +22,7 @@
 #include <app/clusters/ota-requestor/OTADownloader.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/KeyValueStoreManager.h>
 
 #include <zephyr/dfu/mcuboot.h>
@@ -239,6 +240,27 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & aBlock)
         // Needs more data to decode the header
         VerifyOrReturnError(error != CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
         ReturnErrorOnFailure(error);
+
+        uint16_t vendorId  = 0;
+        uint16_t productId = 0;
+
+        if (GetDeviceInstanceInfoProvider()->GetVendorId(vendorId) != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Reject OTA image, wrong vendor ID");
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+        if (GetDeviceInstanceInfoProvider()->GetProductId(productId) != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Reject OTA image, wrong product ID");
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+        if (header.mVendorId != vendorId || header.mProductId != productId)
+        {
+            ChipLogDetail(DeviceLayer, "The argument is invalid, mVendorId: 0x%x - \
+                          mProductId: 0x%x \t vendorId : 0x%x - productId : 0x%x",
+                          header.mVendorId, header.mProductId, vendorId, productId);
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
 
         mParams.totalFileBytes = header.mPayloadSize;
 


### PR DESCRIPTION

### Description

Currently, the OTA update process on our Telink platform does not validate VID/PID when the ota-provider-app applies an OTA image and sends it to our devices.
This poses a risk of "bricking" devices if an incorrect OTA image is applied, as the device might attempt to install firmware intended for a different VID/PID.

We would like to add VID/PID validation in _OTAImageProcessorImpl::ProcessHeader()_ which:

1. Retrieves the device's VID/PID using GetDeviceInstanceInfoProvider().
2. Compares them against the values in the OTA image header.
3. Rejects the OTA update with appropriate error messages if mismatches are found.

This ensures hardware-software compatibility by preventing the installation of firmware meant for different vendor/product lines.

### Testing

Verified by Manual Steps:

1. Generate test OTA images using chip-ota-image

For example:
```
# Correct VID/PID (matches target device)
python3 ${CHIP_ROOT}/src/app/ota_image_tool.py create  --vendor-id 0xfff1 --product-id 0x8005 --version 2 --version-str 1.0.1 --digest-algorithm sha256 -i firmware.bin -o correct.ota

# Incorrect VID
python3 ${CHIP_ROOT}/src/app/ota_image_tool.py create  --vendor-id 0xffff --product-id 0x8005 --version 2 --version-str 1.0.1 --digest-algorithm sha256 -i firmware.bin -o wrong_vid.ota

# Incorrect PID
python3 ${CHIP_ROOT}/src/app/ota_image_tool.py create  --vendor-id 0xfff1 --product-id 0x8004 --version 2 --version-str 1.0.1 --digest-algorithm sha256 -i firmware.bin -o wrong_pid.ota
```

2. Test OTA using ota-provider-app

Expected results:
- Successful OTA: Apply correct.ota and normal OTA progression - OTA update should proceed normally
- VID Mismatch: Apply wrong_vid.ota - should reject OTA update and indicate the mis-match vendor IDs
- PID Mismatch: Apply wrong_pid.ota - should reject OTA update and indicate the mis-match product IDs