### PR TITLE
add check for manual control PICS to RVC test scripts per test plans

### DIFF
--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -139,7 +139,9 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
         ret = await self.send_clean_change_to_mode_cmd(newMode=old_current_mode)
         asserts.assert_true(ret.status == CommonCodes.SUCCESS.value, "Changing the mode to the current mode should be a no-op")
 
-        if self.check_pics("RVCCLEANM.S.M.CAN_TEST_MODE_FAILURE") and self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED"):
+        can_test_mode_failure = self.check_pics("RVCCLEANM.S.M.CAN_TEST_MODE_FAILURE")
+        can_manually_control = self.check_pics("RVCCLEANM.S.M.CAN_MANUALLY_CONTROLLED")
+        if can_test_mode_failure and can_manually_control:
             asserts.assert_true(self.mode_fail in modes,
                                 "The MODE_CHANGE_FAIL PIXIT value (%d) is not a supported mode" % (self.mode_fail))
             self.print_step(5, "Manually put the device in a state from which it will FAIL to transition to mode %d" % (self.mode_fail))

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -139,7 +139,7 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
         ret = await self.send_clean_change_to_mode_cmd(newMode=old_current_mode)
         asserts.assert_true(ret.status == CommonCodes.SUCCESS.value, "Changing the mode to the current mode should be a no-op")
 
-        if self.check_pics("RVCCLEANM.S.M.CAN_TEST_MODE_FAILURE"):
+        if self.check_pics("RVCCLEANM.S.M.CAN_TEST_MODE_FAILURE") and self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED"):
             asserts.assert_true(self.mode_fail in modes,
                                 "The MODE_CHANGE_FAIL PIXIT value (%d) is not a supported mode" % (self.mode_fail))
             self.print_step(5, "Manually put the device in a state from which it will FAIL to transition to mode %d" % (self.mode_fail))

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -133,7 +133,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
 
         ret = await self.send_change_to_mode_cmd(newMode=old_current_mode)
         asserts.assert_true(ret.status == CommonCodes.SUCCESS.value, "Changing the mode to the current mode should be a no-op")
-        
+
         can_test_mode_failure = self.check_pics("RVCRUNM.S.M.CAN_TEST_MODE_FAILURE")
         can_manually_control = self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED")
         if can_test_mode_failure and can_manually_control:

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -134,7 +134,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
         ret = await self.send_change_to_mode_cmd(newMode=old_current_mode)
         asserts.assert_true(ret.status == CommonCodes.SUCCESS.value, "Changing the mode to the current mode should be a no-op")
 
-        if self.check_pics("RVCRUNM.S.M.CAN_TEST_MODE_FAILURE"):
+        if self.check_pics("RVCRUNM.S.M.CAN_TEST_MODE_FAILURE") and self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED"):
             asserts.assert_true(self.mode_fail in modes,
                                 "The MODE_CHANGE_FAIL PIXIT value (%d) is not a supported mode" % (self.mode_fail))
             self.print_step(5, "Manually put the device in a state from which it will FAIL to transition to mode %d" % (self.mode_fail))

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -133,8 +133,10 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
 
         ret = await self.send_change_to_mode_cmd(newMode=old_current_mode)
         asserts.assert_true(ret.status == CommonCodes.SUCCESS.value, "Changing the mode to the current mode should be a no-op")
-
-        if self.check_pics("RVCRUNM.S.M.CAN_TEST_MODE_FAILURE") and self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED"):
+        
+        can_test_mode_failure = self.check_pics("RVCRUNM.S.M.CAN_TEST_MODE_FAILURE")
+        can_manually_control = self.check_pics("RVCRUNM.S.M.CAN_MANUALLY_CONTROLLED")
+        if can_test_mode_failure and can_manually_control:
             asserts.assert_true(self.mode_fail in modes,
                                 "The MODE_CHANGE_FAIL PIXIT value (%d) is not a supported mode" % (self.mode_fail))
             self.print_step(5, "Manually put the device in a state from which it will FAIL to transition to mode %d" % (self.mode_fail))


### PR DESCRIPTION
fixes #37103 

#### Testing

**run test scripts against RVC example app**
(`scripts/examples/gn_build_example.sh examples/rvc-app/linux examples/rvc-app/linux/out/rvc-app`)
- [x] TC_RVCCLEANM_2_1.py
   - [x] `scripts/run_in_python_env.sh pyenv-kmo "./scripts/tests/run_python_test.py --script src/python_testing/TC_RVCRUNM_2_1.py --script-args '--storage-path admin_storage.json --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --int-arg PIXIT.RVCRUNM.MODE_CHANGE_OK:0 PIXIT.RVCRUNM.MODE_CHANGE_FAIL:2 --app-pid 38235 --app-pipe_prefix /tmp/chip_rvc_fifo_'"`
- [x] TC_RVCRUNM_2_1.py
   - [x] `scripts/run_in_python_env.sh pyenv-kmo "./scripts/tests/run_python_test.py --script src/python_testing/TC_RVCCLEANM_2_1.py --script-args '--storage-path admin_storage.json --commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values --endpoint 1 --int-arg PIXIT.RVCCLEANM.MODE_CHANGE_OK:0 PIXIT.RVCCLEANM.MODE_CHANGE_FAIL:2 --app-pid 38425 --app-pipe_prefix /tmp/chip_rvc_fifo_'"`