### PR TITLE
[Cirque] Use Leaseweb as ubuntu mirror server for cirque image.

### DIFF
--- a/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-cirque-device-base/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 RUN apt-cache policy
 
 # TODO: Use multi stage build for smaller image size.
+# leaseweb seems to be more stable, update it here
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://mirror.us.leaseweb.net/ubuntu|g' /etc/apt/sources.list.d/ubuntu.sources
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
   avahi-daemon \

--- a/integrations/docker/images/stage-2/chip-cirque-device-base/version
+++ b/integrations/docker/images/stage-2/chip-cirque-device-base/version
@@ -1,1 +1,1 @@
-latest : This image tracks the version of ot-br-posix in the CHIP repo.
+latest : update ubuntu mirror server for cirque


### PR DESCRIPTION
Recently ubuntu main server is not stable, try to use leaseweb for ubuntu server
#### Testing
CI run