### PR TITLE
Fixing use-after-free error in MdnsAvahi implemenation, and using FreeResolveContext instead of just deletion.

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -873,17 +873,16 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
     resolveContext->mAddressType = ToAvahiProtocol(addressType);
     resolveContext->mFullType    = GetFullType(type, protocol);
 
-    AvahiServiceResolver * resolver =
+    resolveContext->mResolver =
         avahi_service_resolver_new(mClient, avahiInterface, resolveContext->mTransport, name, resolveContext->mFullType.c_str(),
                                    nullptr, resolveContext->mAddressType, static_cast<AvahiLookupFlags>(0), HandleResolve,
                                    reinterpret_cast<void *>(resolveContext->mNumber));
     // Otherwise the resolver will be freed in the callback
-    if (resolver == nullptr)
+    if (resolveContext->mResolver == nullptr)
     {
         error = CHIP_ERROR_INTERNAL;
-        chip::Platform::Delete(resolveContext);
+        FreeResolveContext(resolveContext->mNumber);
     }
-    resolveContext->mResolver = resolver;
 
     return error;
 }


### PR DESCRIPTION
Problems
- When `avahi_service_resolver_new` returns null, we delete the resolve context pointer and then immediately after dereference it by setting the `resolveContext->mResolver` property.
- We are also neglecting to remove the context from `mAllocatedResolves`, which leaves a dangling pointer.

Changes
- This PR moves the setting of `resolveContext->mResolver` to before the deletion, which fixes the use-after-free.
- This PR replaces the call to `Platform::Delete` with a call to `MdnsAvahi::FreeResolveContext` which removes the pointer from `mAllocatedResolves` in addition to deleting it, preventing it from being accessed again.

#### Testing

I'm not sure how to test this bugfix.