### PR TITLE
Fixing wrong provider call in Linux ExampleDeviceInstanceInfoProvider

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -465,7 +465,7 @@ public:
 
     CHIP_ERROR GetProductId(uint16_t & productId) override { return mDefaultProvider->GetProductId(productId); }
     CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return mDefaultProvider->GetPartNumber(buf, bufSize); }
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return mDefaultProvider->GetPartNumber(buf, bufSize); }
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return mDefaultProvider->GetProductURL(buf, bufSize); }
     CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return mDefaultProvider->GetProductLabel(buf, bufSize); }
 
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override


### PR DESCRIPTION
Problem

- In ExampleDeviceInstanceInfoProvider GetProductURL is calling GetPartNumber from the default provider instead of GetProductURL.
- This is apparently a typo that has existed for about 2 years but had not shown up because GenericDeviceInstanceInfoProvider does not support GetProductURL and no Linux-like platforms have defined a custom DeviceInstanceInfoProvider to use instead of the generic one.

Change

- `mDefaultProvider->GetPartNumber` was changed to `mDefaultProvider->GetProductURL`.

#### Testing

This was tested by building the all-clusters app with a modified version of GenericDeviceInstanceInfoProvider that returns a hardcoded test string for GetPartNumber and GetProductURL.  chip-tool was used to query the all-clusters app for `product-url`.

Automated testing does not cover this case, since neither GetProductURL nor GetPartNumber are currently implemented in GenericDeviceInstanceInfoProvider.
