### PR TITLE
[Camera] Remove DataChannel from WebRTC session establishment process

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -109,7 +109,7 @@ private:
     static void OnDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
-    std::shared_ptr<rtc::DataChannel> mDataChannel;
+    std::shared_ptr<rtc::Track> mTrack;
 
     chip::ScopedNodeId mPeerId;
     chip::EndpointId mOriginatingEndpointId;

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -189,8 +189,10 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
 
 #ifdef AV_STREAM_GST_USE_TEST_SRC
     source = gst_element_factory_make("videotestsrc", "source");
+    g_object_set(source, "pattern", kBallAnimationPattern, nullptr);
 #else
     source = gst_element_factory_make("v4l2src", "source");
+    g_object_set(source, "device", device.c_str(), nullptr);
 #endif
 
     if (!pipeline || !source || !capsfilter || !jpegdec || !videoconvert || !x264enc || !rtph264pay || !udpsink)
@@ -224,14 +226,7 @@ GstElement * CameraDevice::CreateVideoPipeline(const std::string & device, int w
     g_object_set(capsfilter, "caps", caps, nullptr);
     gst_caps_unref(caps);
 
-    // Configure source device
-#ifdef AV_STREAM_GST_USE_TEST_SRC
-    g_object_set(source, "pattern", kBallAnimationPattern, nullptr);
-#else
-    g_object_set(source, "device", device.c_str(), nullptr);
-#endif
-
-    // Configure encoder / sink for low‑latency RTP
+    // Configure encoder for low‑latency
     gst_util_set_object_arg(G_OBJECT(x264enc), "tune", "zerolatency");
     g_object_set(udpsink, "host", STREAM_GST_DEST_IP, "port", VIDEO_STREAM_GST_DEST_PORT, "sync", FALSE, "async", FALSE, nullptr);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -44,8 +44,8 @@ namespace {
 
 // Constants
 constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
-constexpr int kVideoH264Codec                 = 96;
-constexpr int kVideoBitRate                   = 3000;
+constexpr int kVideoH264PayloadType = 96; // 96 is just the first value in the dynamic RTP payload‑type range (96‑127).
+constexpr int kVideoBitRate         = 3000;
 
 const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
 {
@@ -213,7 +213,7 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
     MoveToState(State::SendingOffer);
 
     rtc::Description::Video media("video", rtc::Description::Direction::SendOnly);
-    media.addH264Codec(kVideoH264Codec);
+    media.addH264Codec(kVideoH264PayloadType);
     media.setBitrate(kVideoBitRate);
     mTrack = mPeerConnection->addTrack(media);
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -44,6 +44,49 @@ namespace {
 
 // Constants
 constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
+constexpr int kVideoH264Codec                 = 96;
+constexpr int kVideoBitRate                   = 3000;
+
+const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::State::New:
+        return "New";
+
+    case rtc::PeerConnection::State::Connecting:
+        return "Connecting";
+
+    case rtc::PeerConnection::State::Connected:
+        return "Connected";
+
+    case rtc::PeerConnection::State::Disconnected:
+        return "Disconnected";
+
+    case rtc::PeerConnection::State::Failed:
+        return "Failed";
+
+    case rtc::PeerConnection::State::Closed:
+        return "Closed";
+    }
+    return "N/A";
+}
+
+const char * GetGatheringStateStr(rtc::PeerConnection::GatheringState state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::GatheringState::New:
+        return "New";
+
+    case rtc::PeerConnection::GatheringState::InProgress:
+        return "InProgress";
+
+    case rtc::PeerConnection::GatheringState::Complete:
+        return "Complete";
+    }
+    return "N/A";
+}
 
 } // namespace
 
@@ -86,7 +129,7 @@ void WebRTCProviderManager::Init()
 
     mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
         // Convert the enum to an integer or string as needed
-        ChipLogProgress(Camera, "[State: %u]", static_cast<unsigned>(state));
+        ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
         if (state == rtc::PeerConnection::State::Connected)
         {
             RegisterWebrtcTransport(mCurrentSessionId);
@@ -94,21 +137,7 @@ void WebRTCProviderManager::Init()
     });
 
     mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
-        ChipLogProgress(Camera, "[Gathering State: %u]", static_cast<unsigned>(state));
-    });
-
-    mPeerConnection->onDataChannel([&](std::shared_ptr<rtc::DataChannel> _dc) {
-        ChipLogProgress(Camera, "[Got a DataChannel with label: %s]", _dc->label().c_str());
-        mDataChannel = _dc;
-
-        mDataChannel->onClosed([&]() { ChipLogProgress(Camera, "[DataChannel closed: %s]", mDataChannel->label().c_str()); });
-
-        mDataChannel->onMessage([](auto data) {
-            if (std::holds_alternative<std::string>(data))
-            {
-                ChipLogProgress(Camera, "[Received message: %s]", std::get<std::string>(data).c_str());
-            }
-        });
+        ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
     });
 }
 
@@ -117,13 +146,7 @@ void WebRTCProviderManager::CloseConnection()
     // Clean up all the Webrtc Transports
     mWebrtcTransportMap.clear();
 
-    // Close the data channel and peer connection if they exist
-    if (mDataChannel)
-    {
-        mDataChannel->close();
-        mDataChannel.reset();
-    }
-
+    // Close the peer connection if they exist
     if (mPeerConnection)
     {
         mPeerConnection->close();
@@ -189,12 +212,13 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     MoveToState(State::SendingOffer);
 
-    if (!mDataChannel)
-    {
-        mDataChannel = mPeerConnection->createDataChannel(kWebRTCDataChannelName);
-    }
+    rtc::Description::Video media("video", rtc::Description::Direction::SendOnly);
+    media.addH264Codec(kVideoH264Codec);
+    media.setBitrate(kVideoBitRate);
+    mTrack = mPeerConnection->addTrack(media);
 
-    mPeerConnection->createOffer();
+    ChipLogProgress(Camera, "Generate and set the SDP");
+    mPeerConnection->setLocalDescription();
 
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -84,7 +84,7 @@ out/linux-x64-camera/chip-camera-app.
 ./out/linux-x64-camera-controller/chip-camera-controller
 ```
 
-5. Commission the camera device At the controller prompt, pair over the local
+6. Commission the camera device At the controller prompt, pair over the local
    network using the default setup PIN 20202021 and an arbitrary nodeID 1:
 
 ```
@@ -93,7 +93,7 @@ pairing onnetwork 1 20202021
 
 Wait until commissioning succeeds.
 
-6. Start a live‑view stream Still in the controller shell, request a live view
+7. Start a live‑view stream Still in the controller shell, request a live view
    from the camera you just paired:
 
 ```

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -34,8 +34,8 @@ namespace {
 
 // Constants
 constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
-constexpr int kVideoH264Codec                 = 96;
-constexpr int kVideoBitRate                   = 3000;
+constexpr int kVideoH264PayloadType = 96; // 96 is just the first value in the dynamic RTP payload‑type range (96‑127).
+constexpr int kVideoBitRate         = 3000;
 
 const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
 {
@@ -244,7 +244,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
     });
 
     rtc::Description::Video media("video", rtc::Description::Direction::RecvOnly);
-    media.addH264Codec(kVideoH264Codec);
+    media.addH264Codec(kVideoH264PayloadType);
     media.setBitrate(kVideoBitRate);
     mTrack = mPeerConnection->addTrack(media);
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -34,6 +34,49 @@ namespace {
 
 // Constants
 constexpr const char * kWebRTCDataChannelName = "urn:csa:matter:av-metadata";
+constexpr int kVideoH264Codec                 = 96;
+constexpr int kVideoBitRate                   = 3000;
+
+const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::State::New:
+        return "New";
+
+    case rtc::PeerConnection::State::Connecting:
+        return "Connecting";
+
+    case rtc::PeerConnection::State::Connected:
+        return "Connected";
+
+    case rtc::PeerConnection::State::Disconnected:
+        return "Disconnected";
+
+    case rtc::PeerConnection::State::Failed:
+        return "Failed";
+
+    case rtc::PeerConnection::State::Closed:
+        return "Closed";
+    }
+    return "N/A";
+}
+
+const char * GetGatheringStateStr(rtc::PeerConnection::GatheringState state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::GatheringState::New:
+        return "New";
+
+    case rtc::PeerConnection::GatheringState::InProgress:
+        return "InProgress";
+
+    case rtc::PeerConnection::GatheringState::Complete:
+        return "Complete";
+    }
+    return "N/A";
+}
 
 } // namespace
 
@@ -41,13 +84,7 @@ WebRTCManager::WebRTCManager() : mWebRTCRequestorServer(kWebRTCRequesterDynamicE
 
 WebRTCManager::~WebRTCManager()
 {
-    // Close the data channel and peer connection if they exist
-    if (mDataChannel)
-    {
-        mDataChannel->close();
-        mDataChannel.reset();
-    }
-
+    // Close the peer connection if they exist
     if (mPeerConnection)
     {
         mPeerConnection->close();
@@ -182,6 +219,7 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
 
     // Create the peer connection
     rtc::Configuration config;
+    config.iceServers.emplace_back("stun:stun.l.google.com:19302");
     mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
 
     mPeerConnection->onLocalDescription([this](rtc::Description desc) {
@@ -197,36 +235,21 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
         ChipLogProgress(Camera, "%s", candidateStr.c_str());
     });
 
-    mPeerConnection->onStateChange(
-        [](rtc::PeerConnection::State state) { ChipLogProgress(Camera, "[PeerConnection State: %d]", static_cast<int>(state)); });
-
-    mPeerConnection->onSignalingStateChange([](rtc::PeerConnection::SignalingState state) {
-        ChipLogProgress(Camera, "[SignalingState State: %d]", static_cast<int>(state));
+    mPeerConnection->onStateChange([](rtc::PeerConnection::State state) {
+        ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
     });
 
     mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
-        ChipLogProgress(Camera, "[Gathering State: %d]", static_cast<int>(state));
+        ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
     });
 
-    // Create a data channel for this offerer
-    mDataChannel = mPeerConnection->createDataChannel(kWebRTCDataChannelName);
+    rtc::Description::Video media("video", rtc::Description::Direction::RecvOnly);
+    media.addH264Codec(kVideoH264Codec);
+    media.setBitrate(kVideoBitRate);
+    mTrack = mPeerConnection->addTrack(media);
 
-    if (mDataChannel)
-    {
-        mDataChannel->onOpen(
-            [&]() { ChipLogProgress(Camera, "[DataChannel open: %s]", mDataChannel ? mDataChannel->label().c_str() : "unknown"); });
-
-        mDataChannel->onClosed([&]() {
-            ChipLogProgress(Camera, "[DataChannel closed: %s]", mDataChannel ? mDataChannel->label().c_str() : "unknown");
-        });
-
-        mDataChannel->onMessage([](auto data) {
-            if (std::holds_alternative<std::string>(data))
-            {
-                ChipLogProgress(Camera, "[Received: %s]", std::get<std::string>(data).c_str());
-            }
-        });
-    }
+    ChipLogProgress(Camera, "Generate and set the SDP");
+    mPeerConnection->setLocalDescription();
 
     return CHIP_NO_ERROR;
 }
@@ -234,6 +257,12 @@ CHIP_ERROR WebRTCManager::Connnect(Controller::DeviceCommissioner & commissioner
 CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId, StreamUsageEnum streamUsage)
 {
     ChipLogProgress(Camera, "Sending ProvideOffer command to the peer device");
+
+    if (mLocalDescription.empty())
+    {
+        ChipLogError(Camera, "No local SDP to send");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     CHIP_ERROR err =
         mWebRTCProviderClient.ProvideOffer(sessionId, mLocalDescription, streamUsage, kWebRTCRequesterDynamicEndpointId,

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -65,11 +65,12 @@ private:
     WebRTCRequestorDelegate mWebRTCRequestorDelegate;
 
     std::shared_ptr<rtc::PeerConnection> mPeerConnection;
-    std::shared_ptr<rtc::DataChannel> mDataChannel;
 
     uint16_t mPendingSessionId = 0;
     std::string mLocalDescription;
     // Local vector to store the ICE Candidate strings coming from the WebRTC
     // stack
     std::vector<std::string> mLocalCandidates;
+
+    std::shared_ptr<rtc::Track> mTrack;
 };

--- a/src/python_testing/TC_WEBRTCR_2_3.py
+++ b/src/python_testing/TC_WEBRTCR_2_3.py
@@ -177,14 +177,14 @@ class TC_WebRTCRequestor_2_3(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            self.th_server.set_output_match("Got a DataChannel with label")
+            self.th_server.set_output_match("PeerConnection State: Connected")
             self.th_server.event.clear()
 
             try:
                 await self.send_command("webrtc solicit-offer 3")
                 # Wait up to 90s until the provider logs that the data‑channel opened
                 if not self.th_server.event.wait(90):
-                    raise TimeoutError("DataChannel did not open within 90s")
+                    raise TimeoutError("PeerConnection is not connected within 90s")
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'

--- a/src/python_testing/TC_WEBRTCR_2_4.py
+++ b/src/python_testing/TC_WEBRTCR_2_4.py
@@ -176,14 +176,14 @@ class TC_WebRTCRequestor_2_4(MatterBaseTest):
         )
 
         if self.is_pics_sdk_ci_only:
-            self.th_server.set_output_match("Got a DataChannel with label")
+            self.th_server.set_output_match("PeerConnection State: Connected")
             self.th_server.event.clear()
 
             try:
                 await self.send_command("webrtc provide-offer 3")
                 # Wait up to 90s until the provider logs that the data‑channel opened
                 if not self.th_server.event.wait(90):
-                    raise TimeoutError("DataChannel did not open within 90s")
+                    raise TimeoutError("PeerConnection is not connected within 90s")
                 resp = 'Y'
             except TimeoutError:
                 resp = 'N'


### PR DESCRIPTION
We don't need to establish Data Channels when establish WebRTC, The spec only use WebRTC for Camera audio and video, and use Matter command directly for real-time communication for other types of data.

#### Testing

Validated by CI
