### PR TITLE
Introduce PEM encoder to CHIPCryptoPAL

### DIFF
--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1281,7 +1281,7 @@ bool PemEncoder::NextLine(char * destStr, size_t destSize)
         {
             size_t encodedLen = static_cast<size_t>(
                 Base64Encode(mDerBytes.data() + mProcessedBytes, static_cast<uint16_t>(chunkSizeBytes), mInternalStringBuf));
-            VerifyOrDie(encodedLen < kMinLineBufferSize);
+            VerifyOrDie(encodedLen < sizeof(mInternalStringBuf));
             mInternalStringBuf[encodedLen] = '\0';
         }
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1296,12 +1296,10 @@ bool PemEncoder::NextLine(char * destStr, size_t destSize)
             // The `.50s` is to make sure the header is not wider than out internal string buffer. We clamp the footer.
             stringBuilder.AddFormat("-----END %.50s-----", mEncodedElement);
         }
-        mState  = State::kEndIterator;
+        mState  = State::kDone;
         hasMore = true;
         break;
     }
-    case State::kEndIterator:
-        [[fallthrough]];
     case State::kDone:
         [[fallthrough]];
     default: {

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1301,7 +1301,9 @@ bool PemEncoder::NextLine(char * destStr, size_t destSize)
         break;
     }
     case State::kEndIterator:
+        [[fallthrough]];
     case State::kDone:
+        [[fallthrough]];
     default: {
         // Default initialized StringBuilder: empty output.
         mState  = State::kDone;

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1304,6 +1304,10 @@ const char * PemEncoder::NextLine()
     }
     }
 
+    // All the string should have fit based on the logic. It would be a public
+    // API invariant failure if this ever fails.
+    VerifyOrDie(mStringBuilder.Fit());
+
     return hasLine ? mStringBuilder.c_str() : nullptr;
 }
 

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1256,57 +1256,58 @@ CHIP_ERROR VerifyCertificateSigningRequestFormat(const uint8_t * csr, size_t csr
     return CHIP_NO_ERROR;
 }
 
-bool PemEncoder::NextLine(char *destStr, size_t destSize)
+bool PemEncoder::NextLine(char * destStr, size_t destSize)
 {
     StringBuilderBase stringBuilder(mInternalStringBuf, sizeof(mInternalStringBuf));
-    bool hasMore = false;
+    bool hasMore        = false;
     bool bufferTooSmall = destSize < kMinLineBufferSize;
 
-    switch(mState)
+    switch (mState)
     {
-        case State::kPrintHeader: {
-            if (!bufferTooSmall)
-            {
-                // The `.48s` is to make sure the header is not wider than out internal string buffer. We clamp the header.
-                stringBuilder.AddFormat("-----BEGIN %.48s-----", mEncodedElement);
-            }
-            mState = mDerBytes.empty() ? State::kPrintFooter : State::kPrintBody;
-            hasMore = true;
-            break;
+    case State::kPrintHeader: {
+        if (!bufferTooSmall)
+        {
+            // The `.48s` is to make sure the header is not wider than out internal string buffer. We clamp the header.
+            stringBuilder.AddFormat("-----BEGIN %.48s-----", mEncodedElement);
         }
-        case State::kPrintBody: {
-            size_t remaining = mDerBytes.size() - mProcessedBytes;
-            size_t chunkSizeBytes = std::min(remaining, static_cast<size_t>(kNumBytesPerLine));
-            if (!bufferTooSmall)
-            {
-                size_t encodedLen = static_cast<size_t>(Base64Encode(mDerBytes.data() + mProcessedBytes, static_cast<uint16_t>(chunkSizeBytes), mInternalStringBuf));
-                VerifyOrDie(encodedLen < kMinLineBufferSize);
-                mInternalStringBuf[encodedLen] = '\0';
-            }
+        mState  = mDerBytes.empty() ? State::kPrintFooter : State::kPrintBody;
+        hasMore = true;
+        break;
+    }
+    case State::kPrintBody: {
+        size_t remaining      = mDerBytes.size() - mProcessedBytes;
+        size_t chunkSizeBytes = std::min(remaining, static_cast<size_t>(kNumBytesPerLine));
+        if (!bufferTooSmall)
+        {
+            size_t encodedLen = static_cast<size_t>(
+                Base64Encode(mDerBytes.data() + mProcessedBytes, static_cast<uint16_t>(chunkSizeBytes), mInternalStringBuf));
+            VerifyOrDie(encodedLen < kMinLineBufferSize);
+            mInternalStringBuf[encodedLen] = '\0';
+        }
 
-            mProcessedBytes += chunkSizeBytes;
-            mState = (mProcessedBytes < mDerBytes.size()) ? State::kPrintBody : State::kPrintFooter;
-            hasMore = true;
-            break;
+        mProcessedBytes += chunkSizeBytes;
+        mState  = (mProcessedBytes < mDerBytes.size()) ? State::kPrintBody : State::kPrintFooter;
+        hasMore = true;
+        break;
+    }
+    case State::kPrintFooter: {
+        if (!bufferTooSmall)
+        {
+            // The `.50s` is to make sure the header is not wider than out internal string buffer. We clamp the footer.
+            stringBuilder.AddFormat("-----END %.50s-----", mEncodedElement);
         }
-        case State::kPrintFooter: {
-            if (!bufferTooSmall)
-            {
-                // The `.50s` is to make sure the header is not wider than out internal string buffer. We clamp the footer.
-                stringBuilder.AddFormat("-----END %.50s-----", mEncodedElement);
-            }
-            mState = State::kEndIterator;
-            hasMore = true;
-            break;
-        }
-        case State::kEndIterator:
-        case State::kDone:
-        default: {
-            // Default initialized StringBuilder: empty output.
-            mState = State::kDone;
-            hasMore = false;
-            break;
-        }
+        mState  = State::kEndIterator;
+        hasMore = true;
+        break;
+    }
+    case State::kEndIterator:
+    case State::kDone:
+    default: {
+        // Default initialized StringBuilder: empty output.
+        mState  = State::kDone;
+        hasMore = false;
+        break;
+    }
     }
 
     // This is safe with any buffer size;

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1276,7 +1276,7 @@ bool PemEncoder::NextLine(char * destStr, size_t destSize)
     }
     case State::kPrintBody: {
         size_t remaining      = mDerBytes.size() - mProcessedBytes;
-        size_t chunkSizeBytes = std::min(remaining, static_cast<size_t>(kNumBytesPerLine));
+        size_t chunkSizeBytes = std::min(remaining, kNumBytesPerLine);
         if (!bufferTooSmall)
         {
             size_t encodedLen = static_cast<size_t>(

--- a/src/crypto/CHIPCryptoPAL.cpp
+++ b/src/crypto/CHIPCryptoPAL.cpp
@@ -1256,7 +1256,7 @@ CHIP_ERROR VerifyCertificateSigningRequestFormat(const uint8_t * csr, size_t csr
     return CHIP_NO_ERROR;
 }
 
-const char* PemEncoder::NextLine()
+const char * PemEncoder::NextLine()
 {
     bool hasLine = false;
 

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1812,6 +1812,9 @@ public:
     /**
      * @brief Construct a PEM encoder for element type `encodedElement` whose DER data is in `derBytes` span.
      *
+     * LIFETIME: both encodedElement and derBytes lifetime must be >= PemEncoder lifetime.
+     *           PemEncoder references these while processing NextLine calls.
+     *
      * @param encodedElement - Element type string to include in header/footer (e.g. "CERTIFICATE"). Caller must provide correct
      * uppercase.
      * @param derBytes - Byte span containing data to encode. May be empty.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1807,22 +1807,24 @@ CHIP_ERROR ExtractIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSp
 
 class PemEncoder
 {
-  public:
-    static constexpr size_t kNumBytesPerLine = 48u;
+public:
+    static constexpr size_t kNumBytesPerLine   = 48u;
     static constexpr size_t kMinLineBufferSize = 64u + 1u; // PEM expects 64 characters wide and a null terminator at least.
-    static_assert(kMinLineBufferSize == (BASE64_ENCODED_LEN(kNumBytesPerLine) + 1), "Internal incoherence of library configuration!");
+    static_assert(kMinLineBufferSize == (BASE64_ENCODED_LEN(kNumBytesPerLine) + 1),
+                  "Internal incoherence of library configuration!");
 
     /**
      * @brief Construct a PEM encoder for element type `encodedElement` whose DER data is in `derBytes` span.
      *
-     * @param encodedElement - Element type string to include in header/footer (e.g. "CERTIFICATE"). Caller must provide correct uppercase.
+     * @param encodedElement - Element type string to include in header/footer (e.g. "CERTIFICATE"). Caller must provide correct
+     * uppercase.
      * @param derBytes - Byte span containing data to encode. May be empty.
      */
-    explicit PemEncoder(const char* encodedElement, ByteSpan derBytes) : mEncodedElement(encodedElement), mDerBytes(derBytes) {}
+    explicit PemEncoder(const char * encodedElement, ByteSpan derBytes) : mEncodedElement(encodedElement), mDerBytes(derBytes) {}
 
     // No copies.
-    PemEncoder(const PemEncoder&) = delete;
-    PemEncoder& operator=(const PemEncoder&) = delete;
+    PemEncoder(const PemEncoder &)             = delete;
+    PemEncoder & operator=(const PemEncoder &) = delete;
 
     /**
      * @brief Returns the next line of the encoding, if anything left to do.
@@ -1841,22 +1843,23 @@ class PemEncoder
      * @return true if there is a line given back to accumulate.
      * @return false if the encoding is complete.
      */
-    bool NextLine(char *destStr, size_t destSize);
+    bool NextLine(char * destStr, size_t destSize);
 
     bool IsDone() const { return mState == State::kDone; }
 
-  private:
-    enum State : int {
+private:
+    enum State : int
+    {
         kPrintHeader = 0,
-        kPrintBody = 1,
+        kPrintBody   = 1,
         kPrintFooter = 2,
         kEndIterator = 3,
-        kDone = 4,
+        kDone        = 4,
     };
 
-    const char* mEncodedElement; // "CERTIFICATE", "EC PUBLIC KEY", etc. Must be capitalized by caller.
+    const char * mEncodedElement; // "CERTIFICATE", "EC PUBLIC KEY", etc. Must be capitalized by caller.
     ByteSpan mDerBytes;
-    State mState = State::kPrintHeader;
+    State mState           = State::kPrintHeader;
     size_t mProcessedBytes = 0;
     char mInternalStringBuf[kMinLineBufferSize]; // Will be copied-out to callers.
 };

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1813,7 +1813,7 @@ public:
      * @brief Construct a PEM encoder for element type `encodedElement` whose DER data is in `derBytes` span.
      *
      * LIFETIME: both encodedElement and derBytes lifetime must be >= PemEncoder lifetime.
-     *           PemEncoder references these while processing NextLine calls.
+     *           PemEncoder references these while processing `NextLine()` calls.
      *
      * @param encodedElement - Element type string to include in header/footer (e.g. "CERTIFICATE"). Caller must provide correct
      * uppercase.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1853,8 +1853,8 @@ private:
         kPrintHeader = 0,
         kPrintBody   = 1,
         kPrintFooter = 2,
-        kEndIterator = 3,
-        kDone        = 4,
+        kEndIterator = 3, // The last run through `NextLine` uses that state to return false on NextLine without being done yet.
+        kDone        = 4, // This is the terminal state that indicates there is nothing more after.
     };
 
     const char * mEncodedElement; // "CERTIFICATE", "EC PUBLIC KEY", etc. Must be capitalized by caller.

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1848,13 +1848,12 @@ public:
      *
      * @return a pointer to the internal line buffer for next line or nullptr when done.
      */
-    const char* NextLine();
+    const char * NextLine();
 
 private:
-    static constexpr size_t kNumBytesPerLine   = 48u;
-    static constexpr size_t kLineBufferSize = 64u + 1u; // PEM expects 64 characters wide and a null terminator at least.
-    static_assert(kLineBufferSize == (BASE64_ENCODED_LEN(kNumBytesPerLine) + 1),
-                  "Internal incoherence of library configuration!");
+    static constexpr size_t kNumBytesPerLine = 48u;
+    static constexpr size_t kLineBufferSize  = 64u + 1u; // PEM expects 64 characters wide and a null terminator at least.
+    static_assert(kLineBufferSize == (BASE64_ENCODED_LEN(kNumBytesPerLine) + 1), "Internal incoherence of library configuration!");
 
     enum State : int
     {

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -1838,6 +1838,18 @@ public:
      * and footer line with `-----END ${encodedElement}-----` are not wider than 64 bytes. This
      * will not happen in practice with the types of things this is meant to encode.
      *
+     * Usage should be in a loop, for example:
+     *
+     *   char lineBuf[PemEncoder::kMinLineBufferSize] = {};
+     *   std::vector<std::string> pemLines;
+     *
+     *   PemEncoder encoder("CERTIFICATE", TestCerts::sTestCert_PAA_FFF1_Cert);
+     *
+     *   while (encoder.NextLine(lineBuf, sizeof(lineBuf)))
+     *   {
+     *       pemLines.push_back(std::string{ lineBuf });
+     *   }
+     *
      * @param destStr - null-terminated char buffer to receive the line.
      * @param destSize - size of the char buffer, including null-terminator.
      * @return true if there is a line given back to accumulate.
@@ -1845,16 +1857,13 @@ public:
      */
     bool NextLine(char * destStr, size_t destSize);
 
-    bool IsDone() const { return mState == State::kDone; }
-
 private:
     enum State : int
     {
         kPrintHeader = 0,
         kPrintBody   = 1,
         kPrintFooter = 2,
-        kEndIterator = 3, // The last run through `NextLine` uses that state to return false on NextLine without being done yet.
-        kDone        = 4, // This is the terminal state that indicates there is nothing more after.
+        kDone        = 3,
     };
 
     const char * mEncodedElement; // "CERTIFICATE", "EC PUBLIC KEY", etc. Must be capitalized by caller.

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -3358,9 +3358,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
             pemLines.push_back(std::string{ outputBufOkSize });
-            EXPECT_FALSE(encoder.IsDone());
         }
-        EXPECT_TRUE(encoder.IsDone());
 
         // One more call should still leave it done, with empty string output.
         outputBufOkSize[0] = 'A';

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -3267,7 +3267,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
     {
         size_t numLines = 0;
         std::vector<std::string> pemLines;
-        const char* pemLine = nullptr;
+        const char * pemLine = nullptr;
 
         PemEncoder encoder("CERTIFICATE", TestCerts::sTestCert_PAA_FFF1_Cert);
         while ((pemLine = encoder.NextLine()))
@@ -3282,15 +3282,15 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
         ASSERT_EQ(encoder.NextLine(), nullptr);
 
         const char * kExpectedPemForPaa =
-    "-----BEGIN "
-    "CERTIFICATE-----"
-    "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
-    "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
-    "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
-    "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
-    "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
-    "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
-    "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----";
+            "-----BEGIN "
+            "CERTIFICATE-----"
+            "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
+            "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
+            "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
+            "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
+            "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----";
 
         std::string finalPem = StringJoin(pemLines, "\n");
         EXPECT_STREQ(finalPem.c_str(), kExpectedPemForPaa);
@@ -3301,7 +3301,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
     {
         size_t numLines = 0;
         std::vector<std::string> pemLines;
-        const char* pemLine = nullptr;
+        const char * pemLine = nullptr;
 
         PemEncoder encoder("ROBOTO", TestCerts::sTestCert_PAA_FFF1_Cert);
         while ((pemLine = encoder.NextLine()))
@@ -3312,16 +3312,16 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
         ASSERT_EQ(pemLine, nullptr);
 
         // Result should match exactly the expected PEM.
-            const char * kExpectedPemForPaa =
-        "-----BEGIN "
-        "ROBOTO-----"
-        "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
-        "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
-        "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
-        "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
-        "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
-        "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
-        "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END ROBOTO-----";
+        const char * kExpectedPemForPaa =
+            "-----BEGIN "
+            "ROBOTO-----"
+            "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
+            "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
+            "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
+            "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
+            "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END ROBOTO-----";
 
         std::string finalPem = StringJoin(pemLines, "\n");
         EXPECT_STREQ(finalPem.c_str(), kExpectedPemForPaa);
@@ -3330,20 +3330,20 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Empty body case shoudld succeed. Casedness is for the client to deal with.
     {
-      size_t numLines = 0;
-      std::vector<std::string> pemLines;
-      const char* pemLine = nullptr;
+        size_t numLines = 0;
+        std::vector<std::string> pemLines;
+        const char * pemLine = nullptr;
 
-      PemEncoder encoder("EMPTY_thing", ByteSpan{});
-      while ((pemLine = encoder.NextLine()))
-      {
-        ++numLines;
-        pemLines.push_back(std::string{ pemLine });
-      }
-      ASSERT_EQ(pemLine, nullptr);
+        PemEncoder encoder("EMPTY_thing", ByteSpan{});
+        while ((pemLine = encoder.NextLine()))
+        {
+            ++numLines;
+            pemLines.push_back(std::string{ pemLine });
+        }
+        ASSERT_EQ(pemLine, nullptr);
 
-      const char * kExpectedPem                            = "-----BEGIN EMPTY_thing-----\n-----END EMPTY_thing-----";
-        std::string finalPem = StringJoin(pemLines, "\n");
+        const char * kExpectedPem = "-----BEGIN EMPTY_thing-----\n-----END EMPTY_thing-----";
+        std::string finalPem      = StringJoin(pemLines, "\n");
         EXPECT_STREQ(finalPem.c_str(), kExpectedPem);
         EXPECT_EQ(numLines, 2u);
     }
@@ -3352,19 +3352,19 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
     {
         size_t numLines = 0;
         std::vector<std::string> pemLines;
-        const char* pemLine = nullptr;
+        const char * pemLine = nullptr;
 
-      const uint8_t kOneByte[1] = { 0 };
-      PemEncoder encoder("SINGLE_BYTE", ByteSpan{ kOneByte });
+        const uint8_t kOneByte[1] = { 0 };
+        PemEncoder encoder("SINGLE_BYTE", ByteSpan{ kOneByte });
         while ((pemLine = encoder.NextLine()))
         {
-          ++numLines;
-          pemLines.push_back(std::string{ pemLine });
+            ++numLines;
+            pemLines.push_back(std::string{ pemLine });
         }
         ASSERT_EQ(pemLine, nullptr);
 
-        const char * kExpectedPem                            = "-----BEGIN SINGLE_BYTE-----\nAA==\n-----END SINGLE_BYTE-----";
-        std::string finalPem = StringJoin(pemLines, "\n");
+        const char * kExpectedPem = "-----BEGIN SINGLE_BYTE-----\nAA==\n-----END SINGLE_BYTE-----";
+        std::string finalPem      = StringJoin(pemLines, "\n");
         EXPECT_STREQ(finalPem.c_str(), kExpectedPem);
         EXPECT_EQ(numLines, 3u);
     }
@@ -3375,16 +3375,16 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
         std::vector<std::string> pemLines;
 
         PemEncoder encoder("SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOPQRSTUVWXYZ_123456789", ByteSpan{});
-        const char* pemLine = encoder.NextLine();
+        const char * pemLine = encoder.NextLine();
         while (pemLine)
         {
-          ++numLines;
-          pemLines.push_back(std::string{ pemLine });
-          pemLine = encoder.NextLine();
+            ++numLines;
+            pemLines.push_back(std::string{ pemLine });
+            pemLine = encoder.NextLine();
         }
         ASSERT_EQ(pemLine, nullptr);
 
-                const char * kExpectedPem = "-----BEGIN SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOP-----\n-----END "
+        const char * kExpectedPem = "-----BEGIN SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOP-----\n-----END "
                                     "SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOPQR-----";
 
         std::string finalPem = StringJoin(pemLines, "\n");

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -96,7 +96,7 @@ using TestHKDF_sha                      = HKDF_sha;
 using TestHMAC_sha                      = HMAC_sha;
 
 // Trivial StringJoin to use for PEM encoding testing.
-std::string StringJoin(const std::vector<std::string>& elements, const std::string& delimiter)
+std::string StringJoin(const std::vector<std::string> & elements, const std::string & delimiter)
 {
     if (elements.empty())
     {
@@ -3266,7 +3266,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Ensure that encoding with empty buffer works to not touch anything.
     {
-        char outputBuf1Byte[1] = {'\1'};
+        char outputBuf1Byte[1] = { '\1' };
         PemEncoder encoder("CERTIFICATE", TestCerts::sTestCert_PAA_FFF1_Cert);
         size_t numLines = 0;
 
@@ -3283,7 +3283,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Ensure that encoding with small buffer
     {
-        char outputBufTooSmall[PemEncoder::kMinLineBufferSize - 1] = {'\1'};
+        char outputBufTooSmall[PemEncoder::kMinLineBufferSize - 1] = { '\1' };
         PemEncoder encoder("CERTIFICATE", TestCerts::sTestCert_PAA_FFF1_Cert);
         size_t numLines = 0;
 
@@ -3301,8 +3301,17 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Known cert case: sTestCert_PAA_FFF1_Cert should succeed
     {
-        const char* kExpectedPemForPaa = "-----BEGIN CERTIFICATE-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----";
-        char outputBufOkSize[PemEncoder::kMinLineBufferSize] = {'\1'};
+        const char * kExpectedPemForPaa =
+            "-----BEGIN "
+            "CERTIFICATE-----"
+            "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
+            "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
+            "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
+            "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
+            "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END CERTIFICATE-----";
+        char outputBufOkSize[PemEncoder::kMinLineBufferSize] = { '\1' };
         std::vector<std::string> pemLines;
 
         PemEncoder encoder("CERTIFICATE", TestCerts::sTestCert_PAA_FFF1_Cert);
@@ -3316,7 +3325,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
 
-            pemLines.push_back(std::string{outputBufOkSize});
+            pemLines.push_back(std::string{ outputBufOkSize });
             outputBufOkSize[0] = '\1';
         }
 
@@ -3327,7 +3336,16 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Known cert case, different heading requested: sTestCert_PAA_FFF1_Cert should succeed with "ROBOTO" instead of "CERTIFICATE".
     {
-        const char* kExpectedPemForPaa = "-----BEGIN ROBOTO-----\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZMBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END ROBOTO-----";
+        const char * kExpectedPemForPaa =
+            "-----BEGIN "
+            "ROBOTO-----"
+            "\nMIIBvTCCAWSgAwIBAgIITqjoMYLUHBwwCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwP\nTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMT"
+            "AgFw0yMTA2Mjgx\nNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3Qg\nUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTBZ"
+            "MBMGByqGSM49AgEGCCqGSM49AwEH\nA0IABLbLY3KIfyko9brIGqnZOuJDHK2p154kL2UXfvnO2TKijs0Duq9qj8oYShpQ\nNUKWDUU/"
+            "MD8fGUIddR6Pjxqam3WjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQEwDgYD\nVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAfBgNV\nHSMEGDAWgBRq/"
+            "SJ3H1Ef7L8WQZdnENzcMaFxfjAKBggqhkjOPQQDAgNHADBEAiBQ\nqoAC9NkyqaAFOPZTaK0P/8jvu8m+t9pWmDXPmqdRDgIgI7rI/"
+            "g8j51RFtlM5CBpH\nmUkpxyqvChVI1A0DTVFLJd4=\n-----END ROBOTO-----";
         char outputBufOkSize[PemEncoder::kMinLineBufferSize] = {};
         std::vector<std::string> pemLines;
 
@@ -3339,7 +3357,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             ++numLines;
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
-            pemLines.push_back(std::string{outputBufOkSize});
+            pemLines.push_back(std::string{ outputBufOkSize });
             EXPECT_FALSE(encoder.IsDone());
         }
         EXPECT_TRUE(encoder.IsDone());
@@ -3358,7 +3376,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Empty body case shoudld succeed. Casedness is for the client to deal with.
     {
-        const char* kExpectedPem = "-----BEGIN EMPTY_thing-----\n-----END EMPTY_thing-----";
+        const char * kExpectedPem                            = "-----BEGIN EMPTY_thing-----\n-----END EMPTY_thing-----";
         char outputBufOkSize[PemEncoder::kMinLineBufferSize] = {};
         std::vector<std::string> pemLines;
 
@@ -3370,7 +3388,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             ++numLines;
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
-            pemLines.push_back(std::string{outputBufOkSize});
+            pemLines.push_back(std::string{ outputBufOkSize });
         }
 
         std::string finalPem = StringJoin(pemLines, "\n");
@@ -3380,12 +3398,12 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Single-byte should also work.
     {
-        const char* kExpectedPem = "-----BEGIN SINGLE_BYTE-----\nAA==\n-----END SINGLE_BYTE-----";
+        const char * kExpectedPem                            = "-----BEGIN SINGLE_BYTE-----\nAA==\n-----END SINGLE_BYTE-----";
         char outputBufOkSize[PemEncoder::kMinLineBufferSize] = {};
         std::vector<std::string> pemLines;
 
         const uint8_t kOneByte[1] = { 0 };
-        PemEncoder encoder("SINGLE_BYTE", ByteSpan{kOneByte});
+        PemEncoder encoder("SINGLE_BYTE", ByteSpan{ kOneByte });
         size_t numLines = 0;
 
         while (encoder.NextLine(outputBufOkSize, sizeof(outputBufOkSize)))
@@ -3393,7 +3411,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             ++numLines;
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
-            pemLines.push_back(std::string{outputBufOkSize});
+            pemLines.push_back(std::string{ outputBufOkSize });
         }
 
         std::string finalPem = StringJoin(pemLines, "\n");
@@ -3403,7 +3421,8 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
 
     // Clamping of very long headings should work.
     {
-        const char* kExpectedPem = "-----BEGIN SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOP-----\n-----END SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOPQR-----";
+        const char * kExpectedPem = "-----BEGIN SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOP-----\n-----END "
+                                    "SOME_EXCESSIVE_LENGTH_123456789_ABCDEDFHIJKLMNOPQR-----";
         char outputBufOkSize[PemEncoder::kMinLineBufferSize] = {};
         std::vector<std::string> pemLines;
 
@@ -3415,7 +3434,7 @@ TEST_F(TestChipCryptoPAL, PemEncodingWorks)
             ++numLines;
             // No lines should have overflowed.
             ASSERT_LT(strnlen(outputBufOkSize, PemEncoder::kMinLineBufferSize), PemEncoder::kMinLineBufferSize);
-            pemLines.push_back(std::string{outputBufOkSize});
+            pemLines.push_back(std::string{ outputBufOkSize });
         }
 
         std::string finalPem = StringJoin(pemLines, "\n");


### PR DESCRIPTION
#### Changes
- Debugging Device Attestation failures is hard, especially without seeing the contents of the certificates.
- This PR introduces a PEM encoder so that DER certificates that are seen during the Device Attestation Procedure can be logged. This could also be used in other settings.
- Usage of the method in DefaultDeviceAttestationVerifier will be done in a follow-up.
- Code is fully portable and does not rely on any crypto library.

Issue: #35608

#### Testing

- Added complete unit test that also shows how to properly use the API. Unit test covers all edges of the public API.
- Currently the code is only referenced by unit tests.
