### PR TITLE
Remove a leak in ExtendTimerTo by deferring to StartTimer.

### DIFF
--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -186,12 +186,8 @@ CHIP_ERROR LayerImplSelect::ExtendTimerTo(Clock::Timeout delay, TimerCompleteCal
     Clock::Timeout remainingTime = mTimerList.GetRemainingTime(onComplete, appState);
     if (remainingTime.count() < delay.count())
     {
-        if (remainingTime == Clock::kZero)
-        {
-            // If remaining time is Clock::kZero, it might possible that our timer is in
-            // the mExpiredTimers list and about to be fired. Remove it from that list, since we are extending it.
-            mExpiredTimers.Remove(onComplete, appState);
-        }
+        // Just call StartTimer; it will invoke CancelTimer(), then start a new timer.  That handles
+        // all the various "timer was about to fire" edge cases correctly too.
         return StartTimer(delay, onComplete, appState);
     }
 


### PR DESCRIPTION
#### Description 

This PR fix a leak in SystemLayerImplSelect::ExtendTimerTo. The current version of the code never calls `Release`.

#### Testing

No functional behavior changed.
