### PR TITLE
[FuzzTest] fixes in Local Coverage report generating script

### DIFF
--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -140,12 +140,12 @@ def run_fuzz_test(context):
             subprocess.run([context.fuzz_test_binary_path, ], env=env, check=True)
             logging.info("Fuzz Test Suite executed in Unit Test Mode.\n")
         elif context.run_mode == FuzzTestMode.CONTINUOUS_FUZZ_MODE:
+            cmd_args = [context.fuzz_test_binary_path, f"--fuzz={context.selected_fuzz_test_case}"]
             # Use Popen instead of run() so we can always terminate cleanly and avoid profraw file issues
-            process = subprocess.Popen(
-                [context.fuzz_test_binary_path, f"--fuzz={context.selected_fuzz_test_case}"],
-                env=env
-            )
-            process.wait()
+            process = subprocess.Popen(cmd_args, env=env)
+            return_code = process.wait()
+            if return_code != 0:
+                raise subprocess.CalledProcessError(process.returncode, cmd_args)
 
     except KeyboardInterrupt:
         logging.info("\nFuzzing Interrupted by the user \n")

--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -214,7 +214,7 @@ def generate_coverage_report(context, output_dir_arg):
     cmd = ["genhtml"]
 
     errors_to_ignore = [
-        "inconsistent", "source"
+        "inconsistent", "source", "unmapped"
     ]
     for e in errors_to_ignore:
         cmd.append("--ignore-errors")

--- a/scripts/tests/run_fuzztest_coverage.py
+++ b/scripts/tests/run_fuzztest_coverage.py
@@ -350,9 +350,11 @@ def run_script_in_normal_mode(fuzz_test, test_case, list_test_cases, help):
 
     if test_case.strip().lower() == "all":
         context.run_mode = FuzzTestMode.UNIT_TEST_MODE
-    else:
+    elif test_case in test_cases:
         context.run_mode = FuzzTestMode.CONTINUOUS_FUZZ_MODE
         context.selected_fuzz_test_case = test_case
+    else:
+        raise ValueError(f"Test case '{test_case}' not found in the list of test cases for {context.fuzz_test_binary_name} ")
 
     return context
 


### PR DESCRIPTION
#### Problem

- when running a FuzzTest using `run_fuzztest_coverage.py` in continuous Mode and interrupting execution using Keyboard, I sometimes got empty Coverage reports.
- this happened because we got an empty profiling `.profraw` file in those cases.
- The issue is that execution was not cleanly terminated

#### Solution
- instead of using `subprocess.run()` ; use `subprocess.Popen()` with `wait()` to ensure the subprocess is cleanly terminated 

#### Testing

- Testing Locally by running multiple FuzzTests in continuous Mode and checking Coverage Reports.

```shell
scripts/tests/run_fuzztest_coverage.py --fuzz-test out/linux-x64-tests-clang-pw-fuzztest-coverage/chip_pw_fuzztest/tests/fuzz-PASE-pw --test-case FuzzPASE_PW.HandlePake3

```