### PR TITLE
[Darwin] Enable ARC globally for darwin builds

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -678,3 +678,9 @@ config("link_as_needed") {
     ldflags = [ "-Wl,--as-needed" ]
   }
 }
+
+config("arc_default") {
+  if (current_os == "mac" || current_os == "ios") {
+    cflags = [ "-fobjc-arc" ]
+  }
+}

--- a/build/config/defaults.gni
+++ b/build/config/defaults.gni
@@ -98,6 +98,9 @@ declare_args() {
   default_configs_prefix_mappings =
       [ "${build_root}/config/compiler:prefix_mappings_default" ]
 
+  # Defaults ARC configs.
+  default_configs_arc = [ "${build_root}/config/compiler:arc_default" ]
+
   # Extra default configs.
   default_configs_extra = []
 }
@@ -124,6 +127,7 @@ default_configs += default_configs_coverage
 default_configs += default_configs_target
 default_configs += default_configs_dead_code
 default_configs += default_configs_prefix_mappings
+default_configs += default_configs_arc
 default_configs += default_configs_extra
 
 executable_default_configs = []

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -175,10 +175,7 @@ config("config") {
     "MTR_NO_AVAILABILITY=1",
   ]
 
-  cflags = [
-    "-Wconversion",
-    "-fobjc-arc",
-  ]
+  cflags = [ "-Wconversion" ]
 }
 
 executable("darwin-framework-tool") {

--- a/examples/darwin-framework-tool/main.mm
+++ b/examples/darwin-framework-tool/main.mm
@@ -16,6 +16,10 @@
  *
  */
 
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
 #import <Matter/Matter.h>
 
 #import "debug/LeakChecker.h"

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -205,6 +205,5 @@ static_library("inet") {
     cflags -= [ "-Wconversion" ]
   } else if (chip_system_config_use_network_framework) {
     sources += darwin_sources
-    cflags += [ "-fobjc-arc" ]
   }
 }

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -37,10 +37,7 @@ config("darwin_config") {
     ]
   }
 
-  cflags = [
-    "-fobjc-arc",
-    "-Wconversion",
-  ]
+  cflags = [ "-Wconversion" ]
 }
 
 static_library("Darwin") {
@@ -174,9 +171,6 @@ static_library("logging") {
   ]
 
   configs += [ "${chip_root}/src:includes" ]
-  cflags = [
-    "-fobjc-arc",
-    "-Wconversion",
-  ]
+  cflags = [ "-Wconversion" ]
   frameworks = [ "Foundation.framework" ]
 }


### PR DESCRIPTION
#### Description

This PR enables *ARC* by default for all Darwin-based builds. This way, we don’t need to repeatedly specify `-fobjc-arc` in each GN target. It also ensures we won’t accidentally fall back on manual memory management in .mm files where ARC is available

#### Testing

Build-system change only—verified that builds succeed. No functional changes.