### PR TITLE
Remove EFR32 unit tests from cloudbuild

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -76,7 +76,6 @@ steps:
               --target efr32-brd4187c-light-rpc
               --target efr32-brd4187c-lock-openthread-mtd
               --target efr32-brd4187c-lock-rpc-openthread-mtd
-              --target efr32-brd4187c-unit-test
               build
               --create-archives /workspace/artifacts/
       waitFor:


### PR DESCRIPTION
Cloudbuild trying to build EFR32 unit tests fails since #39280 

#39216 tracks fixing unit tests and adding them back.

#### Testing

N/A - cloudbuild not testable by github CI. Change is small.