### PR TITLE
ThreadOperationalDataset: Fix typo in SetLength

### DIFF
--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -73,7 +73,7 @@ public:
 
     void SetLength(uint8_t aLength)
     {
-        assert(mLength != kLengthEscape);
+        assert(aLength != kLengthEscape);
         mLength = aLength;
     }
 


### PR DESCRIPTION
I think we should call assert on the new value we are setting not mLength. mLength may be uninitialized yet.

This should fix https://github.com/project-chip/connectedhomeip/issues/39222

#### Testing

The existing TestThreadOperationalDataset should be sufficient to test this change.
