### PR TITLE
Change HostNameRegistrar::Register to invoke the publish-service callback as soon as any record registers

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -324,10 +324,6 @@ void RegisterContext::DispatchSuccess()
 {
     std::string typeWithoutSubTypes = GetFullTypeWithoutSubTypes(mType);
     callback(context, typeWithoutSubTypes.c_str(), mInstanceName.c_str(), CHIP_NO_ERROR);
-
-    // Once a service has been properly published it is normally unreachable because the hostname has not yet been
-    // registered against the dns daemon. Register the records mapping the hostname to our IP.
-    mHostNameRegistrar.Register();
 }
 
 BrowseContext * BrowseContext::sContextDispatchingSuccess      = nullptr;

--- a/src/platform/Darwin/system/SystemLayerImplDispatch.h
+++ b/src/platform/Darwin/system/SystemLayerImplDispatch.h
@@ -58,6 +58,7 @@ public:
     dispatch_queue_t GetDispatchQueue() override { return mDispatchQueue; };
     void HandleDispatchQueueEvents(Clock::Timeout timeout) override;
     CHIP_ERROR ScheduleWorkWithBlock(dispatch_block_t block) override;
+    CHIP_ERROR StartTimerWithBlock(dispatch_block_t block, Clock::Timeout delay) override;
 
 #if CHIP_SYSTEM_CONFIG_USE_SOCKETS
     // LayerSockets overrides.

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -372,7 +372,8 @@ public:
      *
      * @note This method is thread-safe and can be called from any dispatch queue.
      */
-    virtual CHIP_ERROR ScheduleWorkWithBlock(dispatch_block_t block) = 0;
+    virtual CHIP_ERROR ScheduleWorkWithBlock(dispatch_block_t block)                     = 0;
+    virtual CHIP_ERROR StartTimerWithBlock(dispatch_block_t block, Clock::Timeout delay) = 0;
 };
 #endif
 


### PR DESCRIPTION
#### Description

Change `HostNameRegistrar::Register` to invoke the publish-service callback as soon as any record registers (or on timeout) instead of calling the callback when `OnRegister` is called.

Partial fix for https://github.com/project-chip/connectedhomeip/issues/39313

#### Testing

Ran TestDnssd locally.