### PR TITLE
TestDnssd: use ASSERTs rather than EXPECTs for required conditions

### DIFF
--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -78,8 +78,8 @@ class TestDnssd : public ::testing::Test
 public: // protected
     static void SetUpTestSuite()
     {
-        EXPECT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-        EXPECT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+        ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
     }
     static void TearDownTestSuite()
     {
@@ -110,7 +110,7 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     auto * ctx = static_cast<TestDnssd *>(context);
     char addrBuf[100];
 
-    EXPECT_NE(result, nullptr);
+    ASSERT_NE(result, nullptr);
     EXPECT_EQ(error, CHIP_NO_ERROR);
 
     if (!addresses.empty())
@@ -120,6 +120,8 @@ static void HandleResolve(void * context, DnssdService * result, const chip::Spa
     }
 
     EXPECT_EQ(result->mTextEntrySize, 1u);
+    // must have at least 1 entry to check next key/val expectations.
+    ASSERT_GE(result->mTextEntrySize, 1u);
     EXPECT_STREQ(result->mTextEntries[0].mKey, "key");
     EXPECT_STREQ(reinterpret_cast<const char *>(result->mTextEntries[0].mData), "val");
 


### PR DESCRIPTION
Using `EXPECT` macros rather than `ASSERT`s was leading to segfaults (null pointer dereferences) in some scenarios - for example, on Darwin as of `0db703a`.  If the condition is necessary to avoid nonsensical test results and/or a crash, use `ASSERT`.

#### Dependencies
This should be tested with changes from, and land after, #39363.

#### Testing

- [x] run `TestDnssd` manually.  ensure there are no segfaults. (a failure case, in fact, triggers the segfault pre-fix)
  - [x] Darwin (arm64) (`out/host/mac_arm64_gcc/tests/TestDnssd`)
  - [x] Linux (arm64) (`out/host/tests/TestDnssd`)

CI should cover these and other architectures as well.