### PR TITLE
Fix crash caused by TCP endpoint double free

### DIFF
--- a/src/transport/raw/TCP.cpp
+++ b/src/transport/raw/TCP.cpp
@@ -598,7 +598,6 @@ void TCPBase::HandleIncomingConnection(Inet::TCPEndPoint * listenEndPoint, Inet:
     else
     {
         ChipLogError(Inet, "Insufficient connection space to accept new connections.");
-        endPoint->Free();
         listenEndPoint->OnAcceptError(endPoint, CHIP_ERROR_TOO_MANY_CONNECTIONS);
     }
 }


### PR DESCRIPTION
We observe a crash on Matter device when receiving multiple TCP connection requests during short interval. 

The last TCP connection request fails due to "Insufficient connection space to accept new connections", which is expected. 
Then the incoming connection handler tries to close TCP connection. It first calls endpoint->Free(), which calls Release() on the TCPEndPoint object. Then it calls listenEndPoint->OnAcceptError, during which another endpoint->Free() is triggered: https://github.com/project-chip/connectedhomeip/blob/master/src/transport/raw/TCP.cpp#L608

This causes Release() to be called one more time on the TCPEndPoint object, which triggers a VerifyOrDie call that leads to the crash: https://github.com/project-chip/connectedhomeip/blob/master/src/lib/core/ReferenceCounted.h#L70

#### Testing
To be updated...