### PR TITLE
[E2E][JF] Fix jf-admin-app README doc

### DIFF
--- a/examples/jf-admin-app/linux/README.md
+++ b/examples/jf-admin-app/linux/README.md
@@ -5,7 +5,7 @@ An example application that acts as a Joint Fabric Administrator.
 <hr>
 
 -   [Matter Joint Fabric Admin Example](#matter-joint-fabric-admin-example)
--   [Building the example Application on Linux](#building-the-example-application-on-linux)
+    -   [Building the example Application on Linux](#building-the-example-application-on-linux)
 
 <hr>
 

--- a/examples/jf-admin-app/linux/README.md
+++ b/examples/jf-admin-app/linux/README.md
@@ -34,7 +34,7 @@ to build and test.
 -   Build the example application:
 
           $ cd examples/jf-admin-app/linux/
-          $ gn gen out/debug/
+          $ gn gen out/debug
           $ ninja -C out/debug/
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/jf-admin-app/linux/README.md
+++ b/examples/jf-admin-app/linux/README.md
@@ -5,24 +5,38 @@ An example application that acts as a Joint Fabric Administrator.
 <hr>
 
 -   [Matter Joint Fabric Admin Example](#matter-joint-fabric-admin-example)
-    -   [Building the example Application on Linux](#building-the-example-application-on-linux)
+-   [Building the example Application on Linux](#building-the-example-application-on-linux)
 
 <hr>
 
+All the instructions given below assumes that we are in the connectedhomeip repo, thus referencing the “top level”.
+
+## Prepare for building
+
+Before running any other build command, the `scripts/activate.sh` environment
+setup script should be sourced at the top level. This script takes care of
+downloading GN, ninja, and setting up a Python environment with libraries used
+to build and test.
+
+-   Run the following command at the top level:
+
+          $ source scripts/activate.sh
+
+## Checking if submodules are up to date
+
+-   Pull the required submodules at the top level:
+
+          $ ./scripts/checkout_submodules.py --shallow --platform linux
+
 ## Building the Example Application on Linux
-
--   Pull the required submodules
-
-          $ scripts/checkout_submodules.py --shallow --platform linux
 
 -   Build the example application:
 
-          $ cd ~/connectedhomeip/examples/jf-admin-app/linux
-          $ source ../third_party/connectedhomeip/scripts/activate.sh
-          $ gn gen out/debug
-          $ ninja -C out/debug
+          $ cd examples/jf-admin-app/linux/
+          $ gn gen out/debug/
+          $ ninja -C out/debug/
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/jf-admin-app/linux
+          $ cd examples/jf-admin-app/linux/
           $ rm -rf out/

--- a/examples/jf-admin-app/linux/README.md
+++ b/examples/jf-admin-app/linux/README.md
@@ -9,7 +9,8 @@ An example application that acts as a Joint Fabric Administrator.
 
 <hr>
 
-All the instructions given below assumes that we are in the connectedhomeip repo, thus referencing the “top level”.
+All the instructions given below assumes that we are in the connectedhomeip
+repo, thus referencing the “top level”.
 
 ## Prepare for building
 

--- a/examples/jf-admin-app/linux/README.md
+++ b/examples/jf-admin-app/linux/README.md
@@ -35,7 +35,7 @@ to build and test.
 
           $ cd examples/jf-admin-app/linux/
           $ gn gen out/debug
-          $ ninja -C out/debug/
+          $ ninja -C out/debug
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/jf-control-app/README.md
+++ b/examples/jf-control-app/README.md
@@ -9,24 +9,38 @@ provider.
 <hr>
 
 -   [Matter Joint Fabric Control Example](#matter-joint-fabric-control-example)
-    -   [Building the example Application on Linux](#building-the-example-application-on-linux)
+-   [Building the example Application on Linux](#building-the-example-application-on-linux)
 
 <hr>
 
+All the instructions given below assumes that we are in the connectedhomeip repo, thus referencing the “top level”.
+
+## Prepare for building
+
+Before running any other build command, the `scripts/activate.sh` environment
+setup script should be sourced at the top level. This script takes care of
+downloading GN, ninja, and setting up a Python environment with libraries used
+to build and test.
+
+-   Run the following command at the top level:
+
+          $ source scripts/activate.sh
+
+## Checking if submodules are up to date
+
+-   Pull the required submodules at the top level:
+
+          $ ./scripts/checkout_submodules.py --shallow --platform linux
+
 ## Building the Example Application on Linux
-
--   Pull the required submodules
-
-          $ scripts/checkout_submodules.py --shallow --platform linux
 
 -   Build the example application:
 
-          $ cd ~/connectedhomeip/examples/jf-control-app
-          $ source third_party/connectedhomeip/scripts/activate.sh
-          $ gn gen out/debug
-          $ ninja -C out/debug
+          $ cd examples/jf-control-app/
+          $ gn gen out/debug/
+          $ ninja -C out/debug/
 
 -   To delete generated executable, libraries and object files use:
 
-          $ cd ~/connectedhomeip/examples/jf-control-app
+          $ cd examples/jf-control-app/
           $ rm -rf out/

--- a/examples/jf-control-app/README.md
+++ b/examples/jf-control-app/README.md
@@ -9,7 +9,7 @@ provider.
 <hr>
 
 -   [Matter Joint Fabric Control Example](#matter-joint-fabric-control-example)
--   [Building the example Application on Linux](#building-the-example-application-on-linux)
+    -   [Building the example Application on Linux](#building-the-example-application-on-linux)
 
 <hr>
 

--- a/examples/jf-control-app/README.md
+++ b/examples/jf-control-app/README.md
@@ -39,7 +39,7 @@ to build and test.
 
           $ cd examples/jf-control-app/
           $ gn gen out/debug
-          $ ninja -C out/debug/
+          $ ninja -C out/debug
 
 -   To delete generated executable, libraries and object files use:
 

--- a/examples/jf-control-app/README.md
+++ b/examples/jf-control-app/README.md
@@ -38,7 +38,7 @@ to build and test.
 -   Build the example application:
 
           $ cd examples/jf-control-app/
-          $ gn gen out/debug/
+          $ gn gen out/debug
           $ ninja -C out/debug/
 
 -   To delete generated executable, libraries and object files use:

--- a/examples/jf-control-app/README.md
+++ b/examples/jf-control-app/README.md
@@ -13,7 +13,8 @@ provider.
 
 <hr>
 
-All the instructions given below assumes that we are in the connectedhomeip repo, thus referencing the “top level”.
+All the instructions given below assumes that we are in the connectedhomeip
+repo, thus referencing the “top level”.
 
 ## Prepare for building
 


### PR DESCRIPTION
Fix https://github.com/project-chip/connectedhomeip/issues/39378

#### Testing

Enhanced and fixed README documentation of jf-admin (jfa) application. 
Addition of 2 sections “Prepare for building” et “Checking if submodules are up to date”. 
Remove the call to activate.sh during the build, as it doesn't work because of pigweed.
