### PR TITLE
[Darwin][Network.framework] Improve Network.framework code

### DIFF
--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -74,3 +74,12 @@ leak:CRYPTO_set_thread_local
 # Not our leaks, clearly:
 leak:CFXNotificationRegistrarFind
 leak:NSManagedObjectModel
+
+# These leaks are triggered when using Network.framework.
+# The cleanup code correctly sets the associated objects to nullptr,
+# so they should have been released by ARC.
+# However, LeakSanitizer reports them as leaks, likely due to internal Network.framework retention.
+leak:nw_parameters_create_secure_udp
+leak:nw_path_create_evaluator_for_listener
+leak:nw_listener_handle_new_path_on_queue
+leak:nw_endpoint_create_host

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
@@ -25,148 +25,18 @@
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
-#include <inet/UDPEndPoint.h>
-#include <inet/UDPEndPointImplNetworkFramework.h>
+#include "UDPEndPointImplNetworkFramework.h"
+
+#include "UDPEndPointImplNetworkFrameworkDebug.h"
 
 #include <lib/support/CHIPMemString.h>
 
 #define INET_PORTSTRLEN 6
 
-#define NETWORK_FRAMEWORK_DEBUG 0
+using namespace chip::Inet::Darwin;
 
-namespace {
-#if !NETWORK_FRAMEWORK_DEBUG
-void DebugPrintListenerState(nw_listener_state_t state) {};
-void DebugPrintConnectionState(nw_connection_state_t state) {};
-void DebugPrintConnection(const nw_connection_t aConnection) {};
-#else
-constexpr const char * kNilConnection = "The connection is nil.";
-constexpr const char * kNilPath = "The connection path is nil.";
-constexpr const char * kNilPathSourceEndPoint = "The connection path source endpoint is nil.";
-constexpr const char * kNilPathDestinationEndPoint = "The connection path destination endpoint is nil.";
-constexpr const char * kPathStatusInvalid = "This path is not valid.";
-constexpr const char * kPathStatusUnsatisfied = "The path is not available for use.";
-constexpr const char * kPathStatusSatisfied = "The path is available to establish connections and send data.";
-constexpr const char * kPathStatusSatisfiable = "The path is not currently available, but establishing a new connection may activate the path.";
-
-constexpr const char * kListenerStateInvalid = "Listener: Invalid";
-constexpr const char * kListenerStateWaiting = "Listener: Waiting";
-constexpr const char * kListenerStateFailed = "Listener: Failed";
-constexpr const char * kListenerStateReady = "Listener: Ready";
-constexpr const char * kListenerStateCancelled = "Listener: Cancelled";
-
-constexpr const char * kConnectionStateInvalid = "Connection: Invalid";
-constexpr const char * kConnectionStateWaiting = "Connection: Waiting";
-constexpr const char * kConnectionStatePreparing = "Connection: Preparing";
-constexpr const char * kConnectionStateFailed = "Connection: Failed";
-constexpr const char * kConnectionStateReady = "Connection: Ready";
-constexpr const char * kConnectionStateCancelled = "Connection: Cancelled";
-
-void DebugPrintConnectionState(nw_connection_state_t state)
-{
-    const char * str = nullptr;
-
-    switch (state) {
-    case nw_connection_state_invalid:
-        str = kConnectionStateInvalid;
-        break;
-    case nw_connection_state_preparing:
-        str = kConnectionStatePreparing;
-        break;
-    case nw_connection_state_waiting:
-        str = kConnectionStateWaiting;
-        break;
-    case nw_connection_state_failed:
-        str = kConnectionStateFailed;
-        break;
-    case nw_connection_state_ready:
-        str = kConnectionStateReady;
-        break;
-    case nw_connection_state_cancelled:
-        str = kConnectionStateCancelled;
-        break;
-    default:
-        chipDie();
-    }
-
-    ChipLogDetail(Inet, "%s", str);
-}
-
-void DebugPrintListenerState(nw_listener_state_t state)
-{
-    const char * str = nullptr;
-
-    switch (state) {
-    case nw_listener_state_invalid:
-        str = kListenerStateInvalid;
-        break;
-    case nw_listener_state_waiting:
-        str = kListenerStateWaiting;
-        break;
-    case nw_listener_state_failed:
-        str = kListenerStateFailed;
-        break;
-    case nw_listener_state_ready:
-        str = kListenerStateReady;
-        break;
-    case nw_listener_state_cancelled:
-        str = kListenerStateCancelled;
-        break;
-    default:
-        chipDie();
-    }
-
-    ChipLogDetail(Inet, "%s", str);
-}
-
-void DebugPrintConnectionPathStatus(nw_path_t path)
-{
-    const char * str = nullptr;
-
-    __auto_type status = nw_path_get_status(path);
-    switch (status) {
-    case nw_path_status_invalid:
-        str = kPathStatusInvalid;
-        break;
-    case nw_path_status_unsatisfied:
-        str = kPathStatusUnsatisfied;
-        break;
-    case nw_path_status_satisfied:
-        str = kPathStatusSatisfied;
-        break;
-    case nw_path_status_satisfiable:
-        str = kPathStatusSatisfiable;
-        break;
-    default:
-        chipDie();
-    }
-
-    ChipLogError(Inet, "%s", str);
-}
-
-void DebugPrintConnection(const nw_connection_t aConnection)
-{
-    VerifyOrReturn(nil != aConnection, ChipLogError(Inet, "%s", kNilConnection));
-
-    __auto_type path = nw_connection_copy_current_path(aConnection);
-    VerifyOrReturn(nil != path, ChipLogError(Inet, "%s", kNilPath));
-    DebugPrintConnectionPathStatus(path);
-
-    __auto_type srcEndPoint = nw_path_copy_effective_local_endpoint(path);
-    VerifyOrReturn(nil != srcEndPoint, ChipLogError(Inet, "%s", kNilPathSourceEndPoint));
-
-    __auto_type dstEndPoint = nw_path_copy_effective_remote_endpoint(path);
-    VerifyOrReturn(nil != dstEndPoint, ChipLogError(Inet, "%s", kNilPathDestinationEndPoint));
-
-    const __auto_type * srcAddress = nw_endpoint_copy_address_string(srcEndPoint);
-    const __auto_type srcPort = nw_endpoint_get_port(srcEndPoint);
-    const __auto_type * dstAddress = nw_endpoint_copy_address_string(dstEndPoint);
-    const __auto_type dstPort = nw_endpoint_get_port(dstEndPoint);
-
-    ChipLogError(Inet, "Connection source: %s:%u destination: %s:%u", srcAddress, srcPort, dstAddress, dstPort);
-}
-#endif
-}
+constexpr uint64_t kSendTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr const char * kSendCleaningQueueName = "inet_send_cleaning";
 
 namespace chip {
 namespace Inet {
@@ -174,56 +44,31 @@ namespace Inet {
     CHIP_ERROR UDPEndPointImplNetworkFramework::BindImpl(IPAddressType addressType, const IPAddress & address, uint16_t port,
         InterfaceId intfId)
     {
-#if NETWORK_FRAMEWORK_DEBUG
-        ChipLogError(Inet, "%s (%p)", __func__, this);
-#endif
-
-        VerifyOrReturnError(!intfId.IsPresent(), CHIP_ERROR_NOT_IMPLEMENTED);
-
         __auto_type configure_tls = NW_PARAMETERS_DISABLE_PROTOCOL;
         __auto_type parameters = nw_parameters_create_secure_udp(configure_tls, NW_PARAMETERS_DEFAULT_CONFIGURATION);
-        VerifyOrReturnError(nullptr != parameters, CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(nullptr != parameters, CHIP_ERROR_INVALID_ARGUMENT, ReleaseAll());
+
+        nw_parameters_set_reuse_local_address(parameters, true);
 
         // Note: The ConfigureProtocol function uses nw_ip_options_set_version to set the IP version for this endpoint.
         //
         // This works as expected when the IPAddress is specified. However, when using a wildcard address (chip::Inet::IPAddressType::kAny)
         //  for an IPv6 socket, the specified IP version (nw_ip_version_6) may be ignored, allowing both IPv4 and IPv6 connections.
-        ReturnErrorOnFailure(ConfigureProtocol(addressType, parameters));
+        CHIP_ERROR err = ConfigureProtocol(addressType, parameters);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, err, ReleaseAll());
 
-        // Note: Network.framework does not provide an API to set the SO_REUSEPORT socket option.
-        // This limitation is not an issue when the port is set to 0, as the platform will choose a random port.
-        //
-        // However, when both INET_CONFIG_ENABLE_IPV4 and CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY are enabled,
-        // the system attempts to create two endpoints—one over IPv6 and another over IPv4—both using the same port
-        // specified by CHIP_UDC_PORT.
-        //
-        // This results in a binding failure due to "Address already in use" since both IPv4 and IPv6 endpoints
-        // try to use the same port.
-        //
-        // A potential solution would be to define separate ports for IPv4 and IPv6 (e.g., CHIP_UDC_PORT_IPv4 and CHIP_UDC_PORT_IPv6).
-        // For now, as a workaround, we set the port to 0 for IPv4 when a specific port is needed, allowing the platform to
-        // auto-assign an available port and avoid the conflict.
-        if (IPAddressType::kIPv4 == addressType && port != 0) {
-            port = 0;
-        }
-
-        __auto_type endpoint = GetEndPoint(addressType, address, port);
-        VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INTERNAL);
-        nw_parameters_set_local_endpoint(parameters, endpoint);
-
-        mConnectionQueue = dispatch_queue_create("inet_dispatch_global", DISPATCH_QUEUE_SERIAL);
-        VerifyOrReturnError(nullptr != mConnectionQueue, CHIP_ERROR_NO_MEMORY);
-
-        mConnectionSemaphore = dispatch_semaphore_create(0);
-        VerifyOrReturnError(nullptr != mConnectionSemaphore, CHIP_ERROR_NO_MEMORY);
-
-        mSendSemaphore = dispatch_semaphore_create(0);
-        VerifyOrReturnError(nullptr != mSendSemaphore, CHIP_ERROR_NO_MEMORY);
-
-        mSystemQueue = static_cast<System::LayerSocketsLoop &>(GetSystemLayer()).GetDispatchQueue();
         mAddrType = addressType;
-        mConnection = nullptr;
-        mParameters = parameters;
+        mWorkFlagStrong = Platform::MakeShared<WorkFlag>();
+        mWorkFlagWeak = mWorkFlagStrong;
+
+        err = UDPEndPointImplNetworkFrameworkListener::Configure(parameters, addressType, address, port, intfId);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, err, ReleaseAll());
+
+        err = UDPEndPointImplNetworkFrameworkListenerGroup::Configure(parameters, addressType, intfId);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, err, ReleaseAll());
+
+        err = UDPEndPointImplNetworkFrameworkConnection::Configure(parameters, addressType);
+        VerifyOrReturnError(CHIP_NO_ERROR == err, err, ReleaseAll());
 
         return CHIP_NO_ERROR;
     }
@@ -238,36 +83,44 @@ namespace Inet {
         return InterfaceId::Null();
     }
 
-    uint16_t UDPEndPointImplNetworkFramework::GetBoundPort() const
-    {
-        __auto_type endpoint = nw_parameters_copy_local_endpoint(mParameters);
-        return nw_endpoint_get_port(endpoint);
-    }
-
     CHIP_ERROR UDPEndPointImplNetworkFramework::ListenImpl()
     {
-        return StartListener();
+        CHIP_ERROR error = UDPEndPointImplNetworkFrameworkListener::Listen();
+        VerifyOrDo(CHIP_NO_ERROR == error, ReleaseAll());
+        return error;
     }
 
     CHIP_ERROR UDPEndPointImplNetworkFramework::SendMsgImpl(const IPPacketInfo * pktInfo, System::PacketBufferHandle && msg)
     {
-#if NETWORK_FRAMEWORK_DEBUG
-        ChipLogError(Inet, "%s (%p)", __func__, this);
-#endif
-
         // Ensure we have an actual message to send.
         VerifyOrReturnError(!msg.IsNull(), CHIP_ERROR_INVALID_ARGUMENT);
-
-        // Ensure the destination address type is compatible with the endpoint address type.
-        VerifyOrReturnError(mAddrType == pktInfo->DestAddress.Type(), CHIP_ERROR_INVALID_ARGUMENT);
 
         // For now the entire message must fit within a single buffer.
         VerifyOrReturnError(msg->Next() == nullptr, CHIP_ERROR_MESSAGE_TOO_LONG);
 
-        ReturnErrorOnFailure(GetConnection(pktInfo));
+        __auto_type cleaningQueue = dispatch_queue_create(kSendCleaningQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+        VerifyOrReturnError(nullptr != cleaningQueue, CHIP_ERROR_INCORRECT_STATE);
+
+        nw_connection_t connection = RetrieveOrStartConnection(*pktInfo);
+        VerifyOrReturnError(nullptr != connection, CHIP_ERROR_INCORRECT_STATE);
+        HandleDataReceived(connection);
+
+        // Wrap the PacketBufferHandle in a shared_ptr so we can capture it by value
+        __auto_type retainedHandle = std::make_shared<System::PacketBufferHandle>(std::move(msg));
+        __auto_type content = dispatch_data_create(
+            retainedHandle->operator->()->Start(),
+            retainedHandle->operator->()->DataLength(),
+            cleaningQueue,
+            ^{
+                static_cast<System::LayerDispatch &>(GetSystemLayer()).ScheduleWorkWithBlock(^{
+                    // Keep retainedHandle alive until the dispatch_data is released
+                    [[maybe_unused]] auto cleanup = retainedHandle;
+                });
+            });
 
         // Send a message, and wait for it to be dispatched.
-        __auto_type content = dispatch_data_create(msg->Start(), msg->DataLength(), mSystemQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+        __auto_type group = dispatch_group_create();
+        dispatch_group_enter(group);
 
         // If there is a current message pending and the state of the network connection changes (e.g switch to a
         // different network) the connection will enter a nw_connection_state_failed state and the completion handler
@@ -276,68 +129,43 @@ namespace Inet {
         // To make sure our caller knows that sending a message has failed the following code assumes there is an error
         // _unless_ the completion handler says otherwise.
         __block CHIP_ERROR err = CHIP_ERROR_UNEXPECTED_EVENT;
-        nw_connection_send(mConnection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
+        nw_connection_send(connection, content, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true, ^(nw_error_t error) {
             if (error) {
                 err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
             } else {
                 err = CHIP_NO_ERROR;
             }
-            dispatch_semaphore_signal(mSendSemaphore);
+            dispatch_group_leave(group);
         });
 
-        dispatch_semaphore_wait(mSendSemaphore, DISPATCH_TIME_FOREVER);
-
+        __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kSendTimeoutInSeconds);
+        dispatch_group_wait(group, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
         return err;
     }
 
     void UDPEndPointImplNetworkFramework::CloseImpl()
     {
+        if (mWorkFlagStrong) {
+            mWorkFlagStrong->MarkDead();
+            mWorkFlagStrong.reset();
+        }
         ReleaseAll();
     }
 
     void UDPEndPointImplNetworkFramework::ReleaseAll()
     {
-
         OnMessageReceived = nullptr;
         OnReceiveError = nullptr;
 
-        ReleaseConnection();
-        ReleaseListener();
-
-        mParameters = nullptr;
-
-        mConnectionQueue = nullptr;
-        mConnectionSemaphore = nullptr;
-
-        mListenerQueue = nullptr;
-        mListenerSemaphore = nullptr;
-
-        mSendSemaphore = nullptr;
+        UDPEndPointImplNetworkFrameworkConnection::StopAll();
+        UDPEndPointImplNetworkFrameworkListener::Unlisten();
+        UDPEndPointImplNetworkFrameworkListenerGroup::Unlisten();
     }
 
     void UDPEndPointImplNetworkFramework::Free()
     {
         Close();
         Release();
-    }
-
-    CHIP_ERROR UDPEndPointImplNetworkFramework::SetMulticastLoopback(IPVersion aIPVersion, bool aLoopback)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-
-#if INET_CONFIG_ENABLE_IPV4
-    CHIP_ERROR UDPEndPointImplNetworkFramework::IPv4JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress,
-        bool join)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
-    }
-#endif // INET_CONFIG_ENABLE_IPV4
-
-    CHIP_ERROR UDPEndPointImplNetworkFramework::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress,
-        bool join)
-    {
-        return CHIP_ERROR_NOT_IMPLEMENTED;
     }
 
     CHIP_ERROR UDPEndPointImplNetworkFramework::ConfigureProtocol(IPAddressType aAddressType, const nw_parameters_t & aParameters)
@@ -367,9 +195,10 @@ namespace Inet {
         return err;
     }
 
-    void UDPEndPointImplNetworkFramework::GetPacketInfo(const nw_connection_t & aConnection, IPPacketInfo & aPacketInfo)
+    CHIP_ERROR UDPEndPointImplNetworkFramework::GetPacketInfo(const nw_connection_t & aConnection, IPPacketInfo & aPacketInfo)
     {
         nw_path_t path = nw_connection_copy_current_path(aConnection);
+        VerifyOrReturnError(nullptr != path, CHIP_ERROR_INVALID_ARGUMENT);
         nw_endpoint_t dest_endpoint = nw_path_copy_effective_local_endpoint(path);
         nw_endpoint_t src_endpoint = nw_path_copy_effective_remote_endpoint(path);
 
@@ -386,20 +215,14 @@ namespace Inet {
         aPacketInfo.SrcPort = nw_endpoint_get_port(src_endpoint);
         aPacketInfo.DestPort = nw_endpoint_get_port(dest_endpoint);
 
-#if NETWORK_FRAMEWORK_DEBUG
-        char srcAddrStr[IPAddress::kMaxStringLength + 1 /*null terminator */];
-        char dstAddrStr[IPAddress::kMaxStringLength + 1 /*null terminator */];
-        aPacketInfo.SrcAddress.ToString(srcAddrStr);
-        aPacketInfo.DestAddress.ToString(dstAddrStr);
-        ChipLogError(Inet, "Packet received from %s to %s", srcAddrStr, dstAddrStr);
-#endif
+        DebugPrintPacketInfo(aPacketInfo);
+        return CHIP_NO_ERROR;
     }
 
     nw_endpoint_t UDPEndPointImplNetworkFramework::GetEndPoint(const IPAddressType aAddressType,
         const IPAddress & aAddress, uint16_t aPort, InterfaceId interfaceIndex)
     {
         char addrStr[IPAddress::kMaxStringLength + 1 /*%*/ + InterfaceId::kMaxIfNameLength + 1 /*null terminator */];
-        char portStr[INET_PORTSTRLEN];
 
         // Note: aAddress.ToString will return the IPv6 Any address if the address type is Any, but that's not what
         // we want if the local endpoint is IPv4.
@@ -411,7 +234,7 @@ namespace Inet {
 #endif // INET_CONFIG_ENABLE_IPV4
         {
             aAddress.ToString(addrStr);
-            if (interfaceIndex != InterfaceId::Null()) {
+            if (interfaceIndex != InterfaceId::Null() && aAddress.IsIPv6LinkLocal()) {
                 char interface[InterfaceId::kMaxIfNameLength + 1] = {}; // +1 to prepend '%'
                 interface[0] = '%';
                 interface[1] = 0;
@@ -423,165 +246,27 @@ namespace Inet {
             }
         }
 
+        char portStr[INET_PORTSTRLEN];
         snprintf(portStr, sizeof(portStr), "%u", aPort);
 
-        char * target = addrStr;
-
-#if NETWORK_FRAMEWORK_DEBUG
-        ChipLogError(Inet, "Create endpoint for ip(%s) port(%s)", target, portStr);
-#endif
-        return nw_endpoint_create_host(target, portStr);
+        __auto_type endpoint = nw_endpoint_create_host(addrStr, portStr);
+        DebugPrintEndPoint(endpoint);
+        return endpoint;
     }
 
-    CHIP_ERROR UDPEndPointImplNetworkFramework::GetConnection(const IPPacketInfo * aPktInfo)
+    void UDPEndPointImplNetworkFramework::StartConnectionFromListener(nw_connection_t connection)
     {
-        VerifyOrReturnError(nullptr != mParameters, CHIP_ERROR_INCORRECT_STATE);
+        static_cast<System::LayerDispatch &>(GetSystemLayer()).ScheduleWorkWithBlock(^{
+            CHIP_ERROR error = StartConnection(connection);
+            LogErrorOnFailure(error);
 
-        if (mConnection) {
-            __auto_type path = nw_connection_copy_current_path(mConnection);
-            __auto_type remote_endpoint = nw_path_copy_effective_remote_endpoint(path);
-            // TODO Handle return value of IPAddress::GetIPAddressFromSockAdd
-            IPAddress remote_address;
-            IPAddress::GetIPAddressFromSockAddr(*nw_endpoint_get_address(remote_endpoint), remote_address);
-
-            const uint16_t remote_port = nw_endpoint_get_port(remote_endpoint);
-            const bool isDifferentEndPoint = aPktInfo->DestPort != remote_port || aPktInfo->DestAddress != remote_address;
-            // Return without doing anything if we are not changing our endpoint.
-            VerifyOrReturnError(isDifferentEndPoint, CHIP_NO_ERROR);
-
-            ReturnErrorOnFailure(ReleaseConnection());
-        }
-
-        __auto_type endpoint = GetEndPoint(mAddrType, aPktInfo->DestAddress, aPktInfo->DestPort, aPktInfo->Interface);
-        VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INCORRECT_STATE);
-
-        __auto_type connection = nw_connection_create(endpoint, mParameters);
-        VerifyOrReturnError(nullptr != connection, CHIP_ERROR_INCORRECT_STATE);
-
-        return StartConnection(connection);
-    }
-
-    CHIP_ERROR UDPEndPointImplNetworkFramework::StartListener()
-    {
-        VerifyOrReturnError(nullptr == mListener, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr == mListenerSemaphore, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr == mListenerQueue, CHIP_ERROR_INCORRECT_STATE);
-
-        __auto_type listener = nw_listener_create(mParameters);
-        VerifyOrReturnError(nullptr != listener, CHIP_ERROR_INCORRECT_STATE);
-
-        mListenerSemaphore = dispatch_semaphore_create(0);
-        VerifyOrReturnError(nullptr != mListenerSemaphore, CHIP_ERROR_NO_MEMORY);
-
-        mListenerQueue = dispatch_queue_create("inet_dispatch_listener", DISPATCH_QUEUE_CONCURRENT);
-        VerifyOrReturnError(nullptr != mListenerQueue, CHIP_ERROR_NO_MEMORY);
-
-        nw_listener_set_queue(listener, mListenerQueue);
-
-        nw_listener_set_new_connection_handler(listener, ^(nw_connection_t connection) {
-            ReleaseConnection();
-            StartConnection(connection);
-        });
-
-        __block CHIP_ERROR err = CHIP_NO_ERROR;
-        nw_listener_set_state_changed_handler(listener, ^(nw_listener_state_t state, nw_error_t error) {
-            DebugPrintListenerState(state);
-
-            switch (state) {
-            case nw_listener_state_invalid:
-                err = CHIP_ERROR_INCORRECT_STATE;
-                nw_listener_cancel(listener);
-                break;
-
-            case nw_listener_state_waiting:
-                // Nothing to do.
-                break;
-
-            case nw_listener_state_failed:
-                err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                ChipLogError(Inet, "Error: %s", chip::ErrorStr(err));
-                break;
-
-            case nw_listener_state_ready:
-                err = CHIP_NO_ERROR;
-                dispatch_semaphore_signal(mListenerSemaphore);
-                break;
-
-            case nw_listener_state_cancelled:
-                if (err == CHIP_NO_ERROR) {
-                    err = CHIP_ERROR_CONNECTION_ABORTED;
-                }
-
-                dispatch_semaphore_signal(mListenerSemaphore);
-                break;
+            if (CHIP_NO_ERROR == error) {
+                HandleDataReceived(connection);
             }
         });
-
-        nw_listener_start(listener);
-        dispatch_semaphore_wait(mListenerSemaphore, DISPATCH_TIME_FOREVER);
-
-        if (CHIP_NO_ERROR == err) {
-            mListener = listener;
-        }
-
-        return err;
     }
 
-    CHIP_ERROR UDPEndPointImplNetworkFramework::StartConnection(nw_connection_t aConnection)
-    {
-        __block CHIP_ERROR err = CHIP_NO_ERROR;
-
-        nw_connection_set_queue(aConnection, mConnectionQueue);
-
-        nw_connection_set_state_changed_handler(aConnection, ^(nw_connection_state_t state, nw_error_t error) {
-            DebugPrintConnectionState(state);
-
-            switch (state) {
-            case nw_connection_state_invalid:
-                err = CHIP_ERROR_INCORRECT_STATE;
-                nw_connection_cancel(aConnection);
-                break;
-
-            case nw_connection_state_preparing:
-                err = CHIP_ERROR_INCORRECT_STATE;
-                break;
-
-            case nw_connection_state_waiting:
-                nw_connection_cancel(aConnection);
-                break;
-
-            case nw_connection_state_failed:
-                err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                break;
-
-            case nw_connection_state_ready:
-                err = CHIP_NO_ERROR;
-                dispatch_semaphore_signal(mConnectionSemaphore);
-                break;
-
-            case nw_connection_state_cancelled:
-                if (err == CHIP_NO_ERROR) {
-                    err = CHIP_ERROR_CONNECTION_ABORTED;
-                }
-
-                dispatch_semaphore_signal(mConnectionSemaphore);
-                break;
-            }
-        });
-
-        nw_connection_start(aConnection);
-        dispatch_semaphore_wait(mConnectionSemaphore, DISPATCH_TIME_FOREVER);
-
-        if (CHIP_NO_ERROR == err) {
-            DebugPrintConnection(aConnection);
-
-            mConnection = aConnection;
-            HandleDataReceived(mConnection);
-        }
-        return err;
-    }
-
-    void UDPEndPointImplNetworkFramework::HandleDataReceived(const nw_connection_t & aConnection)
+    void UDPEndPointImplNetworkFramework::HandleDataReceived(nw_connection_t aConnection)
     {
         nw_connection_receive_completion_t handler = ^(dispatch_data_t content, nw_content_context_t context, bool is_complete, nw_error_t receive_error) {
             dispatch_block_t schedule_next_receive = ^{
@@ -593,63 +278,62 @@ namespace Inet {
                     if (!(error_domain == nw_error_domain_posix && errno == ECANCELED)) {
                         CHIP_ERROR error = CHIP_ERROR_POSIX(errno);
                         IPPacketInfo packetInfo;
-                        GetPacketInfo(aConnection, packetInfo);
-                        dispatch_async(mSystemQueue, ^{
+                        if (CHIP_NO_ERROR == GetPacketInfo(aConnection, packetInfo)) {
                             OnReceiveError((UDPEndPoint *) this, error, &packetInfo);
-                        });
+                        } else {
+                            OnReceiveError((UDPEndPoint *) this, error, nullptr);
+                        }
                     }
                 }
             };
 
-            if (content != nullptr && OnMessageReceived != nullptr) {
-                size_t count = dispatch_data_get_size(content);
-                auto packetBufferHandle = System::PacketBufferHandle::New(count);
-                auto * packetBuffer = std::move(packetBufferHandle).UnsafeRelease();
-                dispatch_data_apply(content, ^(dispatch_data_t data, size_t offset, const void * buffer, size_t size) {
-                    memmove(packetBuffer->Start() + offset, buffer, size);
-                    return true;
-                });
-                packetBuffer->SetDataLength(count);
+            auto localWeakFlag = mWorkFlagWeak;
+            static_cast<System::LayerDispatch &>(GetSystemLayer()).ScheduleWorkWithBlock(^{
+                auto workFlag = localWeakFlag.lock();
+                if (!workFlag || !workFlag->IsAlive()) {
+                    return;
+                }
 
-                IPPacketInfo packetInfo;
-                GetPacketInfo(aConnection, packetInfo);
-                dispatch_async(mSystemQueue, ^{
+                if (content != nullptr && OnMessageReceived != nullptr) {
+                    VerifyOrReturn(RefreshConnectionTimeout(aConnection));
+                    size_t count = dispatch_data_get_size(content);
+
+                    __auto_type packetBufferHandle = System::PacketBufferHandle::New(count);
+                    __auto_type * packetBuffer = std::move(packetBufferHandle).UnsafeRelease();
+                    dispatch_data_apply(content, ^(dispatch_data_t data, size_t offset, const void * buffer, size_t size) {
+                        memmove(packetBuffer->Start() + offset, buffer, size);
+                        return true;
+                    });
+                    packetBuffer->SetDataLength(count);
+
+                    IPPacketInfo packetInfo;
+                    GetPacketInfo(aConnection, packetInfo);
                     auto handle = System::PacketBufferHandle::Adopt(packetBuffer);
                     OnMessageReceived((UDPEndPoint *) this, std::move(handle), &packetInfo);
-                });
-            }
+                }
 
-            schedule_next_receive();
+                schedule_next_receive();
+            });
         };
 
         nw_connection_receive_message(aConnection, handler);
     }
 
-    CHIP_ERROR UDPEndPointImplNetworkFramework::ReleaseListener()
+    CHIP_ERROR UDPEndPointImplNetworkFramework::SetMulticastLoopback(IPVersion ipVersion, bool loopback)
     {
-        VerifyOrReturnError(nullptr != mListener, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr != mConnectionQueue, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr != mConnectionSemaphore, CHIP_ERROR_INCORRECT_STATE);
-
-        nw_listener_cancel(mListener);
-        dispatch_semaphore_wait(mListenerSemaphore, DISPATCH_TIME_FOREVER);
-        mListener = nullptr;
-
-        return CHIP_NO_ERROR;
+        return UDPEndPointImplNetworkFrameworkListenerGroup::SetMulticastLoopback(ipVersion, loopback);
     }
 
-    CHIP_ERROR UDPEndPointImplNetworkFramework::ReleaseConnection()
+#if INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR UDPEndPointImplNetworkFramework::IPv4JoinLeaveMulticastGroupImpl(InterfaceId interfaceId, const IPAddress & address, bool join)
     {
-        VerifyOrReturnError(nullptr != mConnection, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr != mConnectionQueue, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(nullptr != mConnectionSemaphore, CHIP_ERROR_INCORRECT_STATE);
-
-        nw_connection_cancel(mConnection);
-        dispatch_semaphore_wait(mConnectionSemaphore, DISPATCH_TIME_FOREVER);
-        mConnection = nullptr;
-
-        return CHIP_NO_ERROR;
+        return UDPEndPointImplNetworkFrameworkListenerGroup::IPv4JoinLeaveMulticastGroup(interfaceId, address, join);
     }
+#endif // INET_CONFIG_ENABLE_IPV4
 
+    CHIP_ERROR UDPEndPointImplNetworkFramework::IPv6JoinLeaveMulticastGroupImpl(InterfaceId interfaceId, const IPAddress & address, bool join)
+    {
+        return UDPEndPointImplNetworkFrameworkListenerGroup::IPv6JoinLeaveMulticastGroup(interfaceId, address, join);
+    }
 } // namespace Inet
 } // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.h
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.h
@@ -1,0 +1,79 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <Network/Network.h>
+
+#include <inet/IPPacketInfo.h>
+#include <lib/core/CHIPError.h>
+
+namespace chip {
+namespace Inet {
+namespace Darwin {
+class UDPEndPointImplNetworkFrameworkConnection
+{
+public:
+    virtual ~UDPEndPointImplNetworkFrameworkConnection(){};
+
+    CHIP_ERROR Configure(nw_parameters_t parameters, IPAddressType addressType);
+    CHIP_ERROR StartConnection(nw_connection_t connection);
+    nw_connection_t RetrieveOrStartConnection(const IPPacketInfo & pktInfo);
+    bool RefreshConnectionTimeout(nw_connection_t connection);
+    void StopAll();
+
+    virtual uint16_t GetBoundPort() const                                            = 0;
+    virtual nw_endpoint_t GetEndPoint(const IPAddressType addressType, const IPAddress & address, uint16_t port,
+                                      InterfaceId interfaceId = InterfaceId::Null()) = 0;
+
+private:
+    class ConnectionWrapper
+    {
+    public:
+        ConnectionWrapper(nw_connection_t connection, dispatch_queue_t timeoutQueue, dispatch_block_t onTimeout);
+
+        bool Matches(const IPPacketInfo & pktInfo) const;
+        void RefreshTimeout();
+
+        nw_connection_t mConnection    = nullptr;
+        dispatch_source_t mTimer       = nullptr;
+        dispatch_queue_t mTimeoutQueue = nullptr;
+        dispatch_block_t mTimeoutBlock = nullptr;
+    };
+    CHIP_ERROR AddConnectionWrapper(nw_connection_t connection);
+    void RemoveConnectionWrapper(nw_connection_t connection);
+    static void ReleaseConnectionWrapperCallback(CFAllocatorRef allocator, const void * value);
+
+    CHIP_ERROR WaitForConnectionStateReady(nw_connection_t connection);
+    CHIP_ERROR WaitForConnectionStateCancelled(nw_connection_t connection);
+    CHIP_ERROR WaitForAllConnectionStateCancelled();
+
+    CHIP_ERROR GetConnection(const IPPacketInfo & pktInfo);
+    void PrepareConnections();
+    void ReleaseConnections();
+    void SetConnectionInterface(nw_parameters_t parameters, InterfaceId interfaceId);
+
+    bool HasConnection(nw_connection_t connection);
+    nw_connection_t FindConnection(const IPPacketInfo & pktInfo);
+
+    CFMutableDictionaryRef mConnections = nullptr;
+    dispatch_queue_t mConnectionQueue   = nullptr;
+    nw_parameters_t mLocalParameters    = nullptr;
+    IPAddressType mAddressType          = IPAddressType::kAny;
+};
+
+} // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.mm
@@ -1,0 +1,372 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#include "UDPEndPointImplNetworkFrameworkConnection.h"
+
+#include "UDPEndPointImplNetworkFrameworkDebug.h"
+
+#include <lib/support/CodeUtils.h>
+
+constexpr uint64_t kConnectTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr uint64_t kConnectionCancelledTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr uint64_t kAllConnectionCancelledTimeoutInSeconds = 30 * NSEC_PER_SEC;
+constexpr uint64_t kConnectionAliveTimeoutInSeconds = 60 * NSEC_PER_SEC;
+constexpr uint64_t kSetInterfaceTimeoutInSeconds = 5 * NSEC_PER_SEC;
+constexpr const char * kConnectionQueueName = "inet_connection";
+
+namespace chip {
+namespace Inet {
+    namespace Darwin {
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::Configure(nw_parameters_t parameters, IPAddressType addressType)
+        {
+            VerifyOrReturnError(nullptr == mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr == mConnectionQueue, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr == mConnections, CHIP_ERROR_INCORRECT_STATE);
+
+            mConnectionQueue = dispatch_queue_create(kConnectionQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            VerifyOrReturnError(nil != mConnectionQueue, CHIP_ERROR_NO_MEMORY);
+
+            mLocalParameters = parameters;
+            mAddressType = addressType;
+            PrepareConnections();
+
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::StartConnection(nw_connection_t connection)
+        {
+            if (HasConnection(connection)) {
+                RefreshConnectionTimeout(connection);
+                return CHIP_NO_ERROR;
+            }
+
+            ReturnErrorOnFailure(AddConnectionWrapper(connection));
+            nw_connection_set_queue(connection, mConnectionQueue);
+
+            CHIP_ERROR error = WaitForConnectionStateReady(connection);
+            VerifyOrReturnError(CHIP_NO_ERROR == error, error, RemoveConnectionWrapper(connection));
+
+            DebugPrintConnection(connection);
+            return CHIP_NO_ERROR;
+        }
+
+        nw_connection_t UDPEndPointImplNetworkFrameworkConnection::RetrieveOrStartConnection(const IPPacketInfo & pktInfo)
+        {
+            __auto_type connection = FindConnection(pktInfo);
+
+            if (!connection) {
+                LogErrorOnFailure(GetConnection(pktInfo));
+                connection = FindConnection(pktInfo);
+            }
+
+            return connection;
+        }
+
+        bool UDPEndPointImplNetworkFrameworkConnection::RefreshConnectionTimeout(nw_connection_t connection)
+        {
+            __auto_type wrapper = const_cast<ConnectionWrapper *>(static_cast<const ConnectionWrapper *>(CFDictionaryGetValue(mConnections, (__bridge const void *) connection)));
+            VerifyOrReturnValue(nullptr != wrapper, false);
+
+            wrapper->RefreshTimeout();
+            return true;
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::StopAll()
+        {
+            ReleaseConnections();
+
+            mConnectionQueue = nullptr;
+            mLocalParameters = nullptr;
+            mAddressType = IPAddressType::kAny;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::GetConnection(const IPPacketInfo & pktInfo)
+        {
+            VerifyOrReturnError(nullptr != mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+
+            // Ensure the destination address type is compatible with the endpoint address type.
+            VerifyOrReturnError(mAddressType == pktInfo.DestAddress.Type() || mAddressType == IPAddressType::kAny, CHIP_ERROR_INVALID_ARGUMENT);
+
+            __auto_type endpoint = GetEndPoint(mAddressType, pktInfo.DestAddress, pktInfo.DestPort, pktInfo.Interface);
+            VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INCORRECT_STATE);
+
+            __auto_type parameters = nw_parameters_copy(mLocalParameters);
+            VerifyOrReturnError(parameters != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            __auto_type localEndpoint = GetEndPoint(mAddressType, pktInfo.SrcAddress, pktInfo.SrcPort, pktInfo.Interface);
+            nw_parameters_set_local_endpoint(parameters, localEndpoint);
+            SetConnectionInterface(parameters, pktInfo.Interface);
+
+            __auto_type connection = nw_connection_create(endpoint, parameters); // Let system pick ephemeral port
+            VerifyOrReturnError(nullptr != connection, CHIP_ERROR_INCORRECT_STATE);
+
+            return StartConnection(connection);
+        }
+
+        bool UDPEndPointImplNetworkFrameworkConnection::HasConnection(nw_connection_t connection)
+        {
+            return CFDictionaryContainsKey(mConnections, (__bridge const void *) connection);
+        }
+
+        nw_connection_t UDPEndPointImplNetworkFrameworkConnection::FindConnection(const IPPacketInfo & pktInfo)
+        {
+            CFIndex count = CFDictionaryGetCount(mConnections);
+            __auto_type ** keys = static_cast<const void **>(malloc(sizeof(void *) * static_cast<size_t>(count)));
+            CFDictionaryGetKeysAndValues(mConnections, keys, nullptr);
+
+            nw_connection_t match = nullptr;
+            for (CFIndex i = 0; i < count; ++i) {
+                __auto_type * wrapper = const_cast<ConnectionWrapper *>(static_cast<const ConnectionWrapper *>(CFDictionaryGetValue(mConnections, keys[i])));
+                if (wrapper && wrapper->Matches(pktInfo)) {
+                    match = wrapper->mConnection;
+                    break;
+                }
+            }
+
+            free(keys);
+            return match;
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::PrepareConnections()
+        {
+            CFDictionaryValueCallBacks valueCallbacks = {
+                0, // version
+                nullptr, // retain callback
+                ReleaseConnectionWrapperCallback,
+                nullptr, // copyDescription callback
+                nullptr // equal callback
+            };
+
+            mConnections = CFDictionaryCreateMutable(
+                kCFAllocatorDefault,
+                0,
+                &kCFTypeDictionaryKeyCallBacks,
+                &valueCallbacks);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::AddConnectionWrapper(nw_connection_t connection)
+        {
+            __auto_type onTimeout = ^{
+                ChipLogDetail(Inet, "Connection: Timeout");
+                nw_connection_cancel(connection);
+                RemoveConnectionWrapper(connection);
+            };
+            __auto_type wrapper = new ConnectionWrapper(connection, mConnectionQueue, onTimeout);
+            VerifyOrReturnError(nullptr != wrapper, CHIP_ERROR_NO_MEMORY);
+
+            CFDictionarySetValue(mConnections, (__bridge const void *) connection, wrapper);
+            return CHIP_NO_ERROR;
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::RemoveConnectionWrapper(nw_connection_t connection)
+        {
+            CFDictionaryRemoveValue(mConnections, (__bridge const void *) connection);
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::ReleaseConnections()
+        {
+            VerifyOrReturn(nullptr != mConnectionQueue);
+            VerifyOrReturn(nullptr != mConnections);
+
+            WaitForAllConnectionStateCancelled();
+
+            CFRelease(mConnections);
+            mConnections = nullptr;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::WaitForConnectionStateReady(nw_connection_t connection)
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != semaphore, CHIP_ERROR_NO_MEMORY);
+
+            __block CHIP_ERROR err = CHIP_ERROR_INTERNAL;
+            nw_connection_set_state_changed_handler(connection, ^(nw_connection_state_t state, nw_error_t error) {
+                DebugPrintConnectionState(state, error);
+
+                switch (state) {
+                case nw_connection_state_invalid:
+                case nw_connection_state_waiting:
+                    err = CHIP_ERROR_INCORRECT_STATE;
+                    nw_connection_cancel(connection);
+                    break;
+
+                case nw_connection_state_preparing:
+                    // Nothing to do.
+                    break;
+
+                case nw_connection_state_failed:
+                    err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                    break;
+
+                case nw_connection_state_ready:
+                    err = CHIP_NO_ERROR;
+                    dispatch_semaphore_signal(semaphore);
+                    break;
+
+                case nw_connection_state_cancelled:
+                    if (err == CHIP_NO_ERROR) {
+                        err = CHIP_ERROR_CONNECTION_ABORTED;
+                    }
+                    dispatch_semaphore_signal(semaphore);
+                    break;
+                }
+            });
+
+            nw_connection_start(connection);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kConnectTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+            nw_connection_set_state_changed_handler(connection, nullptr);
+
+            return err;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::WaitForConnectionStateCancelled(nw_connection_t connection)
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != semaphore, CHIP_ERROR_NO_MEMORY);
+
+            nw_connection_set_state_changed_handler(connection, ^(nw_connection_state_t state, nw_error_t error) {
+                DebugPrintConnectionState(state, error);
+
+                if (state == nw_connection_state_cancelled) {
+                    dispatch_semaphore_signal(semaphore);
+                }
+            });
+
+            nw_connection_cancel(connection);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kConnectionCancelledTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+            nw_connection_set_state_changed_handler(connection, nullptr);
+
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkConnection::WaitForAllConnectionStateCancelled()
+        {
+            CFIndex count = CFDictionaryGetCount(mConnections);
+            const void ** keys = static_cast<const void **>(malloc(sizeof(void *) * static_cast<size_t>(count)));
+            CFDictionaryGetKeysAndValues(mConnections, keys, nullptr);
+
+            __auto_type group = dispatch_group_create();
+            VerifyOrReturnError(nullptr != group, CHIP_ERROR_NO_MEMORY);
+
+            for (CFIndex i = 0; i < count; ++i) {
+                __auto_type connection = (__bridge nw_connection_t)(const_cast<void *>(keys[i]));
+
+                dispatch_group_enter(group);
+                nw_connection_set_state_changed_handler(connection, ^(nw_connection_state_t state, nw_error_t error) {
+                    DebugPrintConnectionState(state, error);
+
+                    if (state == nw_connection_state_cancelled) {
+                        dispatch_group_leave(group);
+                    }
+                });
+
+                nw_connection_cancel(connection);
+            }
+            free(keys);
+
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kAllConnectionCancelledTimeoutInSeconds);
+            dispatch_group_wait(group, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+
+            return CHIP_NO_ERROR;
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::SetConnectionInterface(nw_parameters_t parameters, InterfaceId interfaceId)
+        {
+            VerifyOrReturn(InterfaceId::Null() != interfaceId);
+
+            __auto_type workQueue = dispatch_queue_create(kConnectionQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            __auto_type monitor = nw_path_monitor_create();
+            nw_path_monitor_set_queue(monitor, workQueue);
+
+            __auto_type semaphore = dispatch_semaphore_create(0);
+
+            uint32_t interfaceIndex = interfaceId.GetPlatformInterface();
+            nw_path_monitor_set_update_handler(monitor, ^(nw_path_t path) {
+                nw_path_enumerate_interfaces(path, ^(nw_interface_t interface) {
+                    if (interfaceIndex == nw_interface_get_index(interface)) {
+                        nw_parameters_require_interface(parameters, interface);
+                        return false;
+                    }
+                    return true;
+                });
+                nw_path_monitor_cancel(monitor);
+                dispatch_semaphore_signal(semaphore);
+            });
+
+            nw_path_monitor_start(monitor);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kSetInterfaceTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+        }
+
+        UDPEndPointImplNetworkFrameworkConnection::ConnectionWrapper::ConnectionWrapper(nw_connection_t connection, dispatch_queue_t timeoutQueue, dispatch_block_t onTimeout)
+            : mConnection(connection)
+            , mTimeoutQueue(timeoutQueue)
+            , mTimeoutBlock(onTimeout)
+        {
+            RefreshTimeout();
+        }
+
+        bool UDPEndPointImplNetworkFrameworkConnection::ConnectionWrapper::Matches(const IPPacketInfo & pktInfo) const
+        {
+            __auto_type path = nw_connection_copy_current_path(mConnection);
+            VerifyOrReturnValue(nullptr != path, false);
+
+            __auto_type remoteEndpoint = nw_path_copy_effective_remote_endpoint(path);
+            VerifyOrReturnValue(nullptr != remoteEndpoint, false);
+
+            IPAddress remoteAddress;
+            IPAddress::GetIPAddressFromSockAddr(*nw_endpoint_get_address(remoteEndpoint), remoteAddress);
+            const uint16_t remotePort = nw_endpoint_get_port(remoteEndpoint);
+
+            return pktInfo.DestAddress == remoteAddress && pktInfo.DestPort == remotePort;
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::ConnectionWrapper::RefreshTimeout()
+        {
+            mTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, mTimeoutQueue);
+            dispatch_source_set_event_handler(mTimer, mTimeoutBlock);
+
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kConnectionAliveTimeoutInSeconds);
+            uint64_t interval = DISPATCH_TIME_FOREVER;
+            uint64_t leeway = 1 * NSEC_PER_SEC;
+            dispatch_source_set_timer(mTimer, timeout, interval, leeway);
+
+            dispatch_resume(mTimer);
+        }
+
+        void UDPEndPointImplNetworkFrameworkConnection::ReleaseConnectionWrapperCallback(CFAllocatorRef allocator, const void * value)
+        {
+            __auto_type * wrapper = static_cast<ConnectionWrapper *>(const_cast<void *>(value));
+            if (wrapper->mTimer) {
+                dispatch_source_cancel(wrapper->mTimer);
+                wrapper->mTimer = nullptr;
+            }
+            wrapper->mConnection = nullptr;
+            wrapper->mTimeoutQueue = nullptr;
+            wrapper->mTimeoutBlock = nullptr;
+            delete wrapper;
+        }
+
+    } // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.h
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.h
@@ -1,7 +1,6 @@
 /*
  *
- *    Copyright (c) 2020-2021 Project CHIP Authors
- *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    Copyright (c) 2025 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,28 +15,19 @@
  *    limitations under the License.
  */
 
-/**
- *  Shared state for Network Framework implementations of TCPEndPoint and UDPEndPoint.
- */
-
-#pragma once
-
-#include <inet/EndPointBasis.h>
-
-#include <inet/IPAddress.h>
-
 #include <Network/Network.h>
+
+#include <inet/IPPacketInfo.h>
 
 namespace chip {
 namespace Inet {
-
-class DLL_EXPORT EndPointStateNetworkFramework
-{
-protected:
-    EndPointStateNetworkFramework() {}
-
-    IPAddressType mAddrType; /**< Protocol family, i.e. IPv4 or IPv6. */
-};
-
+namespace Darwin {
+void DebugPrintListenerState(nw_listener_state_t state, nw_error_t error);
+void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error);
+void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error);
+void DebugPrintConnection(nw_connection_t connection);
+void DebugPrintEndPoint(nw_endpoint_t endpoint);
+void DebugPrintPacketInfo(IPPacketInfo & packetInfo);
+} // namespace Darwin
 } // namespace Inet
 } // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
@@ -1,0 +1,269 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#include "UDPEndPointImplNetworkFrameworkDebug.h"
+
+#include <lib/support/CodeUtils.h>
+
+#define NETWORK_FRAMEWORK_DEBUG 1
+
+namespace chip {
+namespace Inet {
+    namespace Darwin {
+#if NETWORK_FRAMEWORK_DEBUG
+        constexpr const char * kListenerStateInvalid = "Listener: Invalid";
+        constexpr const char * kListenerStateWaiting = "Listener: Waiting";
+        constexpr const char * kListenerStateFailed = "Listener: Failed";
+        constexpr const char * kListenerStateReady = "Listener: Ready";
+        constexpr const char * kListenerStateCancelled = "Listener: Cancelled";
+
+        constexpr const char * kConnectionGroupStateInvalid = "Connection Group: Invalid";
+        constexpr const char * kConnectionGroupStateWaiting = "Connection Group: Waiting";
+        constexpr const char * kConnectionGroupStateFailed = "Connection Group: Failed";
+        constexpr const char * kConnectionGroupStateReady = "Connection Group: Ready";
+        constexpr const char * kConnectionGroupStateCancelled = "Connection Group: Cancelled";
+
+        constexpr const char * kConnectionStateInvalid = "Connection: Invalid";
+        constexpr const char * kConnectionStateWaiting = "Connection: Waiting";
+        constexpr const char * kConnectionStatePreparing = "Connection: Preparing";
+        constexpr const char * kConnectionStateFailed = "Connection: Failed";
+        constexpr const char * kConnectionStateReady = "Connection: Ready";
+        constexpr const char * kConnectionStateCancelled = "Connection: Cancelled";
+
+        constexpr const char * kNilConnection = "The connection is nil.";
+        constexpr const char * kNilPath = "The connection path is nil.";
+        constexpr const char * kNilPathSourceEndPoint = "The connection path source endpoint is nil.";
+        constexpr const char * kNilPathDestinationEndPoint = "The connection path destination endpoint is nil.";
+
+        constexpr const char * kPathStatusInvalid = "This path is not valid.";
+        constexpr const char * kPathStatusUnsatisfied = "The path is not available for use.";
+        constexpr const char * kPathStatusSatisfied = "The path is available to establish connections and send data.";
+        constexpr const char * kPathStatusSatisfiable = "The path is not currently available, but establishing a new connection may activate the path.";
+
+        constexpr const char * kEndpointTypeInvalid = "Endpoint: Invalid";
+        constexpr const char * kEndpointTypeAddress = "Endpoint: Address";
+        constexpr const char * kEndpointTypeHost = "Endpoint: Host";
+        constexpr const char * kEndpointTypeBonjourService = "Endpoint: Bonjour Service";
+        constexpr const char * kEndpointTypeURL = "Endpoint: URL";
+
+        void DebugPrintListenerState(nw_listener_state_t state, nw_error_t error)
+        {
+            const char * str = nullptr;
+
+            switch (state) {
+            case nw_listener_state_invalid:
+                str = kListenerStateInvalid;
+                break;
+            case nw_listener_state_waiting:
+                str = kListenerStateWaiting;
+                break;
+            case nw_listener_state_failed:
+                str = kListenerStateFailed;
+                break;
+            case nw_listener_state_ready:
+                str = kListenerStateReady;
+                break;
+            case nw_listener_state_cancelled:
+                str = kListenerStateCancelled;
+                break;
+            default:
+                chipDie();
+            }
+
+            if (error) {
+                CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+            } else {
+                ChipLogDetail(Inet, "%s", str);
+            }
+        }
+
+        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error)
+        {
+            const char * str = nullptr;
+
+            switch (state) {
+            case nw_connection_group_state_invalid:
+                str = kConnectionGroupStateInvalid;
+                break;
+            case nw_connection_group_state_waiting:
+                str = kConnectionGroupStateWaiting;
+                break;
+            case nw_connection_group_state_ready:
+                str = kConnectionGroupStateReady;
+                break;
+            case nw_connection_group_state_failed:
+                str = kConnectionGroupStateFailed;
+                break;
+            case nw_connection_group_state_cancelled:
+                str = kConnectionGroupStateCancelled;
+                break;
+            default:
+                chipDie();
+            }
+
+            if (error) {
+                CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+            } else {
+                ChipLogDetail(Inet, "%s", str);
+            }
+        }
+
+        void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error)
+        {
+            const char * str = nullptr;
+
+            switch (state) {
+            case nw_connection_state_invalid:
+                str = kConnectionStateInvalid;
+                break;
+            case nw_connection_state_preparing:
+                str = kConnectionStatePreparing;
+                break;
+            case nw_connection_state_waiting:
+                str = kConnectionStateWaiting;
+                break;
+            case nw_connection_state_failed:
+                str = kConnectionStateFailed;
+                break;
+            case nw_connection_state_ready:
+                str = kConnectionStateReady;
+                break;
+            case nw_connection_state_cancelled:
+                str = kConnectionStateCancelled;
+                break;
+            default:
+                chipDie();
+            }
+
+            if (error) {
+                CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+            } else {
+                ChipLogDetail(Inet, "%s", str);
+            }
+        }
+
+        void DebugPrintConnectionPathStatus(nw_path_t path)
+        {
+            const char * str = nullptr;
+
+            __auto_type status = nw_path_get_status(path);
+            switch (status) {
+            case nw_path_status_invalid:
+                str = kPathStatusInvalid;
+                break;
+            case nw_path_status_unsatisfied:
+                str = kPathStatusUnsatisfied;
+                break;
+            case nw_path_status_satisfied:
+                str = kPathStatusSatisfied;
+                break;
+            case nw_path_status_satisfiable:
+                str = kPathStatusSatisfiable;
+                break;
+            default:
+                chipDie();
+            }
+
+            ChipLogError(Inet, "%s", str);
+        }
+
+        void DebugPrintConnection(nw_connection_t connection)
+        {
+            VerifyOrReturn(nil != connection, ChipLogError(Inet, "%s", kNilConnection));
+
+            __auto_type path = nw_connection_copy_current_path(connection);
+            VerifyOrReturn(nil != path, ChipLogError(Inet, "%s", kNilPath));
+            DebugPrintConnectionPathStatus(path);
+
+            __auto_type srcEndPoint = nw_path_copy_effective_local_endpoint(path);
+            VerifyOrReturn(nil != srcEndPoint, ChipLogError(Inet, "%s", kNilPathSourceEndPoint));
+
+            __auto_type dstEndPoint = nw_path_copy_effective_remote_endpoint(path);
+            VerifyOrReturn(nil != dstEndPoint, ChipLogError(Inet, "%s", kNilPathDestinationEndPoint));
+
+            __auto_type * srcAddress = nw_endpoint_copy_address_string(srcEndPoint);
+            __auto_type srcPort = nw_endpoint_get_port(srcEndPoint);
+            __auto_type * dstAddress = nw_endpoint_copy_address_string(dstEndPoint);
+            __auto_type dstPort = nw_endpoint_get_port(dstEndPoint);
+
+            ChipLogError(Inet, "Connection source: %s:%u destination: %s:%u", srcAddress, srcPort, dstAddress, dstPort);
+
+            free(srcAddress);
+            free(dstAddress);
+        }
+
+        void DebugPrintEndPoint(nw_endpoint_t endpoint)
+        {
+            const char * str = nullptr;
+
+            switch (nw_endpoint_get_type(endpoint)) {
+            case nw_endpoint_type_invalid:
+                str = kEndpointTypeInvalid;
+                break;
+            case nw_endpoint_type_address:
+                str = kEndpointTypeAddress;
+                break;
+
+            case nw_endpoint_type_host:
+                str = kEndpointTypeHost;
+                break;
+            case nw_endpoint_type_bonjour_service:
+                str = kEndpointTypeBonjourService;
+                break;
+            case nw_endpoint_type_url:
+                str = kEndpointTypeURL;
+                break;
+            default:
+                chipDie();
+            }
+
+            if (str == kEndpointTypeAddress) {
+                __auto_type * address = nw_endpoint_copy_address_string(endpoint);
+                __auto_type port = nw_endpoint_get_port(endpoint);
+                ChipLogError(Inet, "%s (%s:%u)", str, address, port);
+                free(address);
+            } else {
+                ChipLogDetail(Inet, "%s", str);
+            }
+        }
+
+        void DebugPrintPacketInfo(IPPacketInfo & packetInfo)
+        {
+            char srcAddrStr[IPAddress::kMaxStringLength + 1 /*null terminator */];
+            char dstAddrStr[IPAddress::kMaxStringLength + 1 /*null terminator */];
+            packetInfo.SrcAddress.ToString(srcAddrStr);
+            packetInfo.DestAddress.ToString(dstAddrStr);
+            ChipLogError(Inet, "Packet received from %s to %s", srcAddrStr, dstAddrStr);
+        }
+#else
+        void DebugPrintListenerState(nw_listener_state_t state, nw_error_t error) {};
+        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error) {};
+        void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error) {};
+        void DebugPrintConnection(const nw_connection_t connection) {};
+        void DebugPrintEndPoint(nw_endpoint_t endpoint) {};
+        void DebugPrintPacketInfo(IPPacketInfo & packetInfo);
+#endif
+    } // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.h
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.h
@@ -1,0 +1,70 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "NetworkMonitor.h"
+
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace Inet {
+namespace Darwin {
+class UDPEndPointImplNetworkFrameworkListener : public NetworkMonitor
+{
+public:
+    virtual ~UDPEndPointImplNetworkFrameworkListener(){};
+    CHIP_ERROR Configure(nw_parameters_t parameters, const IPAddressType addressType, const IPAddress & address, uint16_t port,
+                         InterfaceId interfaceId = InterfaceId::Null());
+    CHIP_ERROR Listen();
+    void Unlisten();
+    uint16_t GetBoundPort() const;
+
+    virtual void StartConnectionFromListener(nw_connection_t aConnection)               = 0;
+    virtual nw_endpoint_t GetEndPoint(const IPAddressType aAddressType, const IPAddress & aAddress, uint16_t aPort,
+                                      InterfaceId interfaceIndex = InterfaceId::Null()) = 0;
+
+private:
+    bool IsAnyAddress() const { return mLocalAddress == IPAddress::Any; }
+    CHIP_ERROR ListenLoopback();
+    CHIP_ERROR ListenAddress();
+    CHIP_ERROR ListenAddress(const IPAddress & address, InterfaceId intfId = InterfaceId::Null());
+    CHIP_ERROR ListenAddress(const IPAddress & address, nw_interface_t interface);
+    CHIP_ERROR ListenInterfaces();
+    template <typename InterfaceVec>
+    void ListenInterfaces(const InterfaceVec & interfaces)
+    {
+        for (const auto & iface : interfaces)
+        {
+            nw_interface_t interface = iface.first;
+            IPAddress address(iface.second);
+            LogErrorOnFailure(ListenAddress(address, interface));
+        }
+    }
+
+    void StopListeners();
+    CHIP_ERROR WaitForListenerReadyState(nw_listener_t listener);
+    CHIP_ERROR WaitForListenerCancelledState(nw_listener_t listener);
+
+    CFMutableArrayRef mListeners     = nullptr;
+    dispatch_queue_t mListenerQueue  = nullptr;
+    nw_parameters_t mLocalParameters = nullptr;
+    IPAddress mLocalAddress          = IPAddress::Any;
+    uint16_t mLocalPort              = 0;
+};
+
+} // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
@@ -1,0 +1,256 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#include "UDPEndPointImplNetworkFrameworkListener.h"
+
+#include "UDPEndPointImplNetworkFrameworkDebug.h"
+
+constexpr uint64_t kInterfacesLookupTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr uint64_t kListenerReadyTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr uint64_t kListenerCancelledTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr const char * kInterfaceMonitorQueueName = "inet_interfaces_monitor";
+constexpr const char * kListenersQueueName = "inet_listeners";
+
+namespace chip {
+namespace Inet {
+    namespace Darwin {
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::Configure(nw_parameters_t parameters, const IPAddressType addressType, const IPAddress & address, uint16_t port, InterfaceId interfaceId)
+        {
+            VerifyOrReturnError(nullptr == mListeners, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr == mListenerQueue, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr == mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(IPAddress::Any == mLocalAddress, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(0 == mLocalPort, CHIP_ERROR_INCORRECT_STATE);
+
+            __auto_type monitorQueue = dispatch_queue_create(kInterfaceMonitorQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            VerifyOrReturnError(nil != monitorQueue, CHIP_ERROR_NO_MEMORY);
+            ReturnErrorOnFailure(NetworkMonitor::Init(monitorQueue, addressType, interfaceId));
+
+            mListenerQueue = dispatch_queue_create(kListenersQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            VerifyOrReturnError(nullptr != mListenerQueue, CHIP_ERROR_NO_MEMORY);
+
+            mLocalParameters = parameters;
+            mLocalAddress = address;
+            mLocalPort = port;
+
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::Listen()
+        {
+            VerifyOrReturnError(nullptr == mListeners, CHIP_ERROR_INCORRECT_STATE);
+
+            mListeners = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+            VerifyOrReturnError(nullptr != mListeners, CHIP_ERROR_NO_MEMORY);
+
+            VerifyOrReturnError(!IsLocalOnly(), ListenLoopback());
+            VerifyOrReturnError(IsAnyAddress(), ListenAddress());
+            return ListenInterfaces();
+        }
+
+        void UDPEndPointImplNetworkFrameworkListener::Unlisten()
+        {
+            NetworkMonitor::Stop();
+            StopListeners();
+            mListenerQueue = nullptr;
+            mLocalParameters = nullptr;
+            mLocalAddress = IPAddress::Any;
+            mLocalPort = 0;
+
+            if (mListeners) {
+                CFRelease(mListeners);
+                mListeners = nullptr;
+            }
+        }
+
+        uint16_t UDPEndPointImplNetworkFrameworkListener::GetBoundPort() const
+        {
+            // If no listeners have been created yet, return the initially requested port.
+            VerifyOrReturnValue(nullptr != mListeners, mLocalPort);
+            VerifyOrReturnValue(CFArrayGetCount(mListeners) != 0, mLocalPort);
+
+            // Otherwise, return the actual port assigned to the first listener.
+            __auto_type listener = static_cast<nw_listener_t>(CFArrayGetValueAtIndex(mListeners, 0));
+            return nw_listener_get_port(listener);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenLoopback()
+        {
+            return ListenAddress(IPAddress::Loopback(IPAddressType::kIPv6));
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenAddress()
+        {
+            return ListenAddress(mLocalAddress, GetInterfaceId());
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenAddress(const IPAddress & address, InterfaceId intfId)
+        {
+            __auto_type parameters = nw_parameters_copy(mLocalParameters);
+            VerifyOrReturnError(nullptr != parameters, CHIP_ERROR_NO_MEMORY);
+
+            __auto_type endpoint = GetEndPoint(address.Type(), address, GetBoundPort(), intfId);
+            VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INVALID_ARGUMENT);
+
+            nw_parameters_set_local_endpoint(parameters, endpoint);
+
+            __auto_type listener = nw_listener_create(parameters);
+            VerifyOrReturnError(nullptr != listener, CHIP_ERROR_INTERNAL);
+
+            nw_listener_set_queue(listener, mListenerQueue);
+            nw_listener_set_new_connection_handler(listener, ^(nw_connection_t connection) {
+                StartConnectionFromListener(connection);
+            });
+
+            ReturnErrorOnFailure(WaitForListenerReadyState(listener));
+
+            CFArrayAppendValue(mListeners, (__bridge const void *) listener);
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenAddress(const IPAddress & address, nw_interface_t interface)
+        {
+            __auto_type parameters = nw_parameters_copy(mLocalParameters);
+            VerifyOrReturnError(nullptr != parameters, CHIP_ERROR_NO_MEMORY);
+
+            __auto_type intfId = static_cast<InterfaceId>(nw_interface_get_index(interface));
+            __auto_type endpoint = GetEndPoint(address.Type(), address, GetBoundPort(), intfId);
+            VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INVALID_ARGUMENT);
+
+            nw_parameters_set_local_endpoint(parameters, endpoint);
+            nw_parameters_require_interface(parameters, interface);
+
+            __auto_type listener = nw_listener_create(parameters);
+            VerifyOrReturnError(nullptr != listener, CHIP_ERROR_INTERNAL);
+
+            nw_listener_set_queue(listener, mListenerQueue);
+            nw_listener_set_new_connection_handler(listener, ^(nw_connection_t connection) {
+                StartConnectionFromListener(connection);
+            });
+
+            ReturnErrorOnFailure(WaitForListenerReadyState(listener));
+
+            CFArrayAppendValue(mListeners, (__bridge const void *) listener);
+            return CHIP_NO_ERROR;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenInterfaces()
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(semaphore != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            CHIP_ERROR err = StartMonitorInterfaces(^(InetInterfacesVector inetInterfaces, Inet6InterfacesVector inet6Interfaces) {
+                StopListeners();
+                ListenInterfaces(inetInterfaces);
+                ListenInterfaces(inet6Interfaces);
+                dispatch_semaphore_signal(semaphore);
+            });
+            VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+
+            // Wait until the first list of interfaces has been handled
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kInterfacesLookupTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+
+            return CHIP_NO_ERROR;
+        }
+
+        void UDPEndPointImplNetworkFrameworkListener::StopListeners()
+        {
+            VerifyOrReturn(nullptr != mListeners);
+
+            CFIndex count = CFArrayGetCount(mListeners);
+            for (CFIndex i = 0; i < count; ++i) {
+                __auto_type listener = static_cast<nw_listener_t>(CFArrayGetValueAtIndex(mListeners, i));
+                LogErrorOnFailure(WaitForListenerCancelledState(listener));
+            }
+
+            CFArrayRemoveAllValues(mListeners);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::WaitForListenerReadyState(nw_listener_t listener)
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != semaphore, CHIP_ERROR_NO_MEMORY);
+
+            __block CHIP_ERROR err = CHIP_ERROR_INTERNAL;
+            nw_listener_set_state_changed_handler(listener, ^(nw_listener_state_t state, nw_error_t error) {
+                DebugPrintListenerState(state, error);
+
+                switch (state) {
+                case nw_listener_state_invalid:
+                    err = CHIP_ERROR_INCORRECT_STATE;
+                    nw_listener_cancel(listener);
+                    break;
+
+                case nw_listener_state_waiting:
+                    // Nothing to do.
+                    break;
+
+                case nw_listener_state_failed:
+                    err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                    nw_listener_cancel(listener);
+                    break;
+
+                case nw_listener_state_ready:
+                    err = CHIP_NO_ERROR;
+                    dispatch_semaphore_signal(semaphore);
+                    break;
+
+                case nw_listener_state_cancelled:
+                    if (err == CHIP_NO_ERROR) {
+                        err = CHIP_ERROR_CONNECTION_ABORTED;
+                    }
+
+                    dispatch_semaphore_signal(semaphore);
+                    break;
+                }
+            });
+
+            nw_listener_start(listener);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kListenerReadyTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+            nw_listener_set_state_changed_handler(listener, nullptr);
+
+            return err;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::WaitForListenerCancelledState(nw_listener_t listener)
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != semaphore, CHIP_ERROR_NO_MEMORY);
+
+            nw_listener_set_state_changed_handler(listener, ^(nw_listener_state_t state, nw_error_t error) {
+                DebugPrintListenerState(state, error);
+                if (state == nw_listener_state_cancelled) {
+                    dispatch_semaphore_signal(semaphore);
+                }
+            });
+
+            nw_listener_cancel(listener);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kListenerCancelledTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+
+            return CHIP_NO_ERROR;
+        }
+
+    } // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.h
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.h
@@ -1,0 +1,72 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "NetworkMonitor.h"
+
+#include <inet/InetConfig.h>
+
+namespace chip {
+namespace Inet {
+namespace Darwin {
+class UDPEndPointImplNetworkFrameworkListenerGroup : public NetworkMonitor
+{
+public:
+    virtual ~UDPEndPointImplNetworkFrameworkListenerGroup() = default;
+
+    CHIP_ERROR Configure(nw_parameters_t parameters, const IPAddressType addressType, InterfaceId interfaceId);
+    void Unlisten();
+
+    CHIP_ERROR SetMulticastLoopback(IPVersion ipVersion, bool loopback) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+#if INET_CONFIG_ENABLE_IPV4
+    CHIP_ERROR IPv4JoinLeaveMulticastGroup(InterfaceId interfaceId, const IPAddress & address, bool join);
+#endif // INET_CONFIG_ENABLE_IPV4
+
+    CHIP_ERROR IPv6JoinLeaveMulticastGroup(InterfaceId interfaceId, const IPAddress & address, bool join);
+
+    virtual uint16_t GetBoundPort() const                                            = 0;
+    virtual nw_endpoint_t GetEndPoint(const IPAddressType addressType, const IPAddress & address, uint16_t port,
+                                      InterfaceId interfaceId = InterfaceId::Null()) = 0;
+
+private:
+    struct InterfaceGroup
+    {
+        nw_interface_t interface;
+        nw_connection_group_t connectionGroup;
+        dispatch_semaphore_t cancelSemaphore;
+    };
+    CFMutableDictionaryRef mInterfaceGroups;
+    static void ReleaseInterfaceGroupCallback(CFAllocatorRef allocator, const void * value);
+
+    void StopListeners(InterfaceGroup * group = nullptr);
+    CHIP_ERROR StartListeners(InterfaceGroup * group, nw_group_descriptor_t groupDescriptor);
+    CHIP_ERROR JoinLeaveMulticastGroup(InterfaceId interfaceId, nw_endpoint_t endpoint, bool join);
+    CHIP_ERROR JoinMulticastGroup(nw_interface_t interface, nw_endpoint_t endpoint);
+    CHIP_ERROR LeaveMulticastGroup(nw_interface_t interface, nw_endpoint_t endpoint);
+    bool IsSameEndPoints(nw_endpoint_t a, nw_endpoint_t b);
+
+    CHIP_ERROR WaitForConnectionGroupReadyState(InterfaceGroup * group, nw_connection_group_t connectionGroup);
+    CHIP_ERROR WaitForConnectionGroupCancelledState(InterfaceGroup * group);
+
+    dispatch_queue_t mConnectionGroupQueue = nullptr;
+    nw_parameters_t mLocalParameters       = nullptr;
+    nw_path_t mLastPath                    = nullptr;
+};
+
+} // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
@@ -1,0 +1,447 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+#include "UDPEndPointImplNetworkFrameworkListenerGroup.h"
+
+#include "UDPEndPointImplNetworkFrameworkDebug.h"
+
+#include <lib/support/CodeUtils.h>
+
+constexpr uint64_t kStartUpInterfaceMonitorTimeoutInSeconds = 3 * NSEC_PER_SEC;
+constexpr uint64_t kConnectionGroupReadyTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr uint64_t kConnectionGroupCancelledTimeoutInSeconds = 10 * NSEC_PER_SEC;
+constexpr const char * kInterfaceMonitorQueueName = "inet_interfaces_monitor";
+constexpr const char * kConnectionGroupQueueName = "inet_connection_group";
+
+namespace chip {
+namespace Inet {
+    namespace Darwin {
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::Configure(nw_parameters_t parameters, const IPAddressType addressType, InterfaceId interfaceId)
+        {
+            VerifyOrReturnError(nullptr == mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr == mConnectionGroupQueue, CHIP_ERROR_INCORRECT_STATE);
+
+            __auto_type monitorQueue = dispatch_queue_create(kInterfaceMonitorQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            VerifyOrReturnError(nil != monitorQueue, CHIP_ERROR_NO_MEMORY);
+            ReturnErrorOnFailure(NetworkMonitor::Init(monitorQueue, addressType, interfaceId));
+
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            __auto_type pathChangeBlock = ^(nw_path_t path) {
+                mLastPath = path;
+                dispatch_semaphore_signal(semaphore);
+            };
+            ReturnErrorOnFailure(StartMonitorPaths(pathChangeBlock));
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kStartUpInterfaceMonitorTimeoutInSeconds);
+            VerifyOrReturnError(0 == dispatch_semaphore_wait(semaphore, timeout), CHIP_ERROR_INCORRECT_STATE);
+
+            mConnectionGroupQueue = dispatch_queue_create(kConnectionGroupQueueName, DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+            VerifyOrReturnError(nil != mConnectionGroupQueue, CHIP_ERROR_NO_MEMORY);
+
+            CFDictionaryValueCallBacks valueCallbacks = {
+                0, // version
+                nullptr, // retain callback
+                ReleaseInterfaceGroupCallback,
+                nullptr, // copyDescription callback
+                nullptr // equal callback
+            };
+
+            mInterfaceGroups = CFDictionaryCreateMutable(
+                kCFAllocatorDefault,
+                0,
+                &kCFTypeDictionaryKeyCallBacks,
+                &valueCallbacks);
+
+            mLocalParameters = parameters;
+
+            return CHIP_NO_ERROR;
+        }
+
+        void UDPEndPointImplNetworkFrameworkListenerGroup::Unlisten()
+        {
+            NetworkMonitor::Stop();
+            StopListeners();
+
+            if (mInterfaceGroups != nullptr) {
+                CFRelease(mInterfaceGroups);
+                mInterfaceGroups = nullptr;
+            }
+
+            mConnectionGroupQueue = nullptr;
+            mLocalParameters = nullptr;
+            mLastPath = nullptr;
+        }
+
+#if INET_CONFIG_ENABLE_IPV4
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::IPv4JoinLeaveMulticastGroup(InterfaceId interfaceId, const IPAddress & address, bool join)
+        {
+            VerifyOrReturnError(nullptr != mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr != mConnectionGroupQueue, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr != mLastPath, CHIP_ERROR_INCORRECT_STATE);
+
+            if (!interfaceId.IsPresent()) {
+                // Do it on all the viable interfaces.
+                __block bool interfaceFound = false;
+
+                nw_path_enumerate_interfaces(mLastPath, ^bool(nw_interface_t interface) {
+                    InterfaceId::PlatformType interfaceIndex = nw_interface_get_index(interface);
+                    InterfaceId infId = static_cast<InterfaceId>(interfaceIndex);
+
+                    IPAddress ifAddr;
+                    if (infId.GetLinkLocalAddr(&ifAddr) != CHIP_NO_ERROR) {
+                        return true;
+                    }
+
+                    if (ifAddr.Type() != IPAddressType::kIPv4) {
+                        // Not the right sort of interface.
+                        return true;
+                    }
+
+                    interfaceFound = true;
+
+                    const char * ifName = nw_interface_get_name(interface);
+
+                    // Ignore errors here, except for logging, because we expect some of
+                    // these interfaces to not work, and some (e.g. loopback) to always
+                    // work.
+                    CHIP_ERROR err = IPv4JoinLeaveMulticastGroup(infId, address, join);
+                    if (err == CHIP_NO_ERROR) {
+                        ChipLogDetail(Inet, "  %s multicast group on interface %s", (join ? "Joined" : "Left"), ifName);
+                    } else {
+                        ChipLogError(Inet, "  Failed to %s multicast group on interface %s", (join ? "join" : "leave"), ifName);
+                    }
+
+                    return true; // In order to continue the enumeration
+                });
+
+                if (interfaceFound) {
+                    // Assume we're good.
+                    return CHIP_NO_ERROR;
+                }
+
+                // Else go ahead and try to work with the default interface.
+                ChipLogError(Inet, "No valid IPv4 multicast interface found");
+            }
+
+            __auto_type endpoint = GetEndPoint(IPAddressType::kIPv4, address, GetBoundPort(), interfaceId);
+            VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INVALID_ARGUMENT);
+
+            return JoinLeaveMulticastGroup(interfaceId, endpoint, join);
+        }
+#endif // INET_CONFIG_ENABLE_IPV4
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::IPv6JoinLeaveMulticastGroup(InterfaceId interfaceId, const IPAddress & address, bool join)
+        {
+            VerifyOrReturnError(nullptr != mLocalParameters, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr != mConnectionGroupQueue, CHIP_ERROR_INCORRECT_STATE);
+            VerifyOrReturnError(nullptr != mLastPath, CHIP_ERROR_INCORRECT_STATE);
+
+            if (!interfaceId.IsPresent()) {
+                // Do it on all the viable interfaces.
+                __block bool interfaceFound = false;
+
+                nw_path_enumerate_interfaces(mLastPath, ^(nw_interface_t interface) {
+                    InterfaceId::PlatformType interfaceIndex = nw_interface_get_index(interface);
+                    InterfaceId infId = static_cast<InterfaceId>(interfaceIndex);
+
+                    IPAddress ifAddr;
+                    if (infId.GetLinkLocalAddr(&ifAddr) != CHIP_NO_ERROR) {
+                        return true;
+                    }
+
+                    if (ifAddr.Type() != IPAddressType::kIPv6) {
+                        // Not the right sort of interface.
+                        return true;
+                    }
+
+                    interfaceFound = true;
+
+                    const char * ifName = nw_interface_get_name(interface);
+
+                    // Ignore errors here, except for logging, because we expect some of
+                    // these interfaces to not work, and some (e.g. loopback) to always
+                    // work.
+                    CHIP_ERROR err = IPv6JoinLeaveMulticastGroup(infId, address, join);
+                    if (err == CHIP_NO_ERROR) {
+                        ChipLogDetail(Inet, "  %s multicast group on interface %s", (join ? "Joined" : "Left"), ifName);
+                    } else {
+                        ChipLogError(Inet, "  Failed to %s multicast group on interface %s", (join ? "join" : "leave"), ifName);
+                    }
+
+                    return true; // In order to continue the enumeration
+                });
+
+                if (interfaceFound) {
+                    // Assume we're good.
+                    return CHIP_NO_ERROR;
+                }
+
+                // Else go ahead and try to work with the default interface.
+                ChipLogError(Inet, "No valid IPv6 multicast interface found");
+            }
+
+            __auto_type endpoint = GetEndPoint(IPAddressType::kIPv6, address, GetBoundPort(), interfaceId);
+            VerifyOrReturnError(nullptr != endpoint, CHIP_ERROR_INVALID_ARGUMENT);
+
+            return JoinLeaveMulticastGroup(interfaceId, endpoint, join);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::JoinLeaveMulticastGroup(InterfaceId interfaceId, nw_endpoint_t endpoint, bool join)
+        {
+            __block nw_interface_t targetInterface = nullptr;
+            nw_path_enumerate_interfaces(mLastPath, ^(nw_interface_t interface) {
+                if (interfaceId.GetPlatformInterface() == nw_interface_get_index(interface)) {
+                    targetInterface = interface;
+                    return false;
+                }
+
+                return true;
+            });
+
+            return (join ? JoinMulticastGroup(targetInterface, endpoint) : LeaveMulticastGroup(targetInterface, endpoint));
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::JoinMulticastGroup(nw_interface_t interface, nw_endpoint_t endpoint)
+        {
+            uint32_t ifIndex = interface ? nw_interface_get_index(interface) : 0;
+            CFNumberRef key = CFNumberCreate(nullptr, kCFNumberIntType, &ifIndex);
+            __auto_type * interfaceGroup = (InterfaceGroup *) CFDictionaryGetValue(mInterfaceGroups, key);
+            CFRelease(key);
+
+            if (nullptr == interfaceGroup) {
+                __auto_type groupDescriptor = nw_group_descriptor_create_multicast(endpoint);
+                VerifyOrReturnError(nullptr != groupDescriptor, CHIP_ERROR_INCORRECT_STATE);
+
+                interfaceGroup = (InterfaceGroup *) calloc(1, sizeof(InterfaceGroup));
+                interfaceGroup->interface = interface;
+
+                CHIP_ERROR error = StartListeners(interfaceGroup, groupDescriptor);
+                VerifyOrReturnError(CHIP_NO_ERROR == error, error, free(interfaceGroup));
+
+                key = CFNumberCreate(nullptr, kCFNumberIntType, &ifIndex);
+                CFDictionarySetValue(mInterfaceGroups, key, interfaceGroup);
+                CFRelease(key);
+                return CHIP_NO_ERROR;
+            }
+
+            VerifyOrReturnError(nullptr != interfaceGroup->connectionGroup, CHIP_ERROR_INCORRECT_STATE);
+            __auto_type oldGroupDescriptor = nw_connection_group_copy_descriptor(interfaceGroup->connectionGroup);
+            StopListeners(interfaceGroup);
+
+            __block nw_group_descriptor_t groupDescriptor = nullptr;
+            __block bool alreadyPresent = false;
+            __block CHIP_ERROR error = CHIP_NO_ERROR;
+            nw_group_descriptor_enumerate_endpoints(oldGroupDescriptor, ^(nw_endpoint_t oldEndpoint) {
+                if (IsSameEndPoints(oldEndpoint, endpoint)) {
+                    alreadyPresent = true;
+                }
+
+                if (nullptr == groupDescriptor) {
+                    groupDescriptor = nw_group_descriptor_create_multicast(oldEndpoint);
+                    VerifyOrReturnValue(nullptr != groupDescriptor, false, error = CHIP_ERROR_INCORRECT_STATE);
+                } else {
+                    bool joined = nw_group_descriptor_add_endpoint(groupDescriptor, oldEndpoint);
+                    VerifyOrReturnValue(joined, false, error = CHIP_ERROR_INCORRECT_STATE);
+                }
+                return true;
+            });
+            ReturnErrorOnFailure(error);
+
+            if (!alreadyPresent) {
+                bool joined = nw_group_descriptor_add_endpoint(groupDescriptor, endpoint);
+                VerifyOrReturnError(joined, CHIP_ERROR_INCORRECT_STATE);
+            }
+
+            return StartListeners(interfaceGroup, groupDescriptor);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::LeaveMulticastGroup(nw_interface_t interface, nw_endpoint_t endpoint)
+        {
+            uint32_t ifIndex = interface ? nw_interface_get_index(interface) : 0;
+            CFNumberRef key = CFNumberCreate(nullptr, kCFNumberIntType, &ifIndex);
+            __auto_type * interfaceGroup = (InterfaceGroup *) CFDictionaryGetValue(mInterfaceGroups, key);
+            CFRelease(key);
+
+            VerifyOrReturnError(nullptr != interfaceGroup, CHIP_ERROR_NOT_FOUND); // Nothing ever joined, can't leave!
+            VerifyOrReturnError(nullptr != interfaceGroup->connectionGroup, CHIP_ERROR_NOT_FOUND); // Nothing ever joined, can't leave!
+
+            __auto_type oldGroupDescriptor = nw_connection_group_copy_descriptor(interfaceGroup->connectionGroup);
+            StopListeners(interfaceGroup);
+
+            __block nw_group_descriptor_t groupDescriptor = nullptr;
+            __block size_t endpointCount = 0;
+            __block CHIP_ERROR error = CHIP_NO_ERROR;
+            nw_group_descriptor_enumerate_endpoints(oldGroupDescriptor, ^(nw_endpoint_t oldEndpoint) {
+                VerifyOrReturnValue(!IsSameEndPoints(oldEndpoint, endpoint), true); // Leaving -> skip adding this one
+
+                if (nullptr == groupDescriptor) {
+                    groupDescriptor = nw_group_descriptor_create_multicast(oldEndpoint);
+                    VerifyOrReturnValue(nullptr != groupDescriptor, false, error = CHIP_ERROR_INCORRECT_STATE);
+                } else {
+                    bool joined = nw_group_descriptor_add_endpoint(groupDescriptor, oldEndpoint);
+                    VerifyOrReturnValue(joined, false, error = CHIP_ERROR_INCORRECT_STATE);
+                }
+
+                endpointCount++;
+                return true;
+            });
+            ReturnErrorOnFailure(error);
+
+            if (endpointCount == 0) {
+                key = CFNumberCreate(nullptr, kCFNumberIntType, &ifIndex);
+                CFDictionaryRemoveValue(mInterfaceGroups, key);
+                CFRelease(key);
+                return CHIP_NO_ERROR;
+            }
+
+            return StartListeners(interfaceGroup, groupDescriptor);
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::StartListeners(InterfaceGroup * group, nw_group_descriptor_t groupDescriptor)
+        {
+            __auto_type parameters = nw_parameters_copy(mLocalParameters);
+            VerifyOrReturnError(nullptr != parameters, CHIP_ERROR_NO_MEMORY);
+            nw_parameters_set_local_endpoint(parameters, nil);
+            nw_parameters_require_interface(parameters, group->interface);
+
+            __auto_type connectionGroup = nw_connection_group_create(groupDescriptor, parameters);
+            VerifyOrReturnError(nullptr != connectionGroup, CHIP_ERROR_INVALID_ARGUMENT);
+
+            nw_connection_group_set_queue(connectionGroup, mConnectionGroupQueue);
+            nw_connection_group_set_receive_handler(connectionGroup, UINT32_MAX, YES, ^(dispatch_data_t content, nw_content_context_t context, bool complete) {
+                ChipLogError(Inet, "%s", __func__);
+            });
+
+            ReturnErrorOnFailure(WaitForConnectionGroupReadyState(group, connectionGroup));
+
+            group->connectionGroup = connectionGroup;
+            return CHIP_NO_ERROR;
+        }
+
+        void UDPEndPointImplNetworkFrameworkListenerGroup::StopListeners(InterfaceGroup * group)
+        {
+            if (nullptr == group) {
+                CFDictionaryApplyFunction(
+                    mInterfaceGroups, [](const void * /*key*/, const void * value, void * context) {
+                    __auto_type * interfaceGroup = (InterfaceGroup *) value;
+                    __auto_type * self = static_cast<UDPEndPointImplNetworkFrameworkListenerGroup *>(context);
+                    self->StopListeners(interfaceGroup); }, this);
+
+                return;
+            }
+
+            VerifyOrReturn(nullptr != group);
+            VerifyOrReturn(nullptr != group->connectionGroup);
+            LogErrorOnFailure(WaitForConnectionGroupCancelledState(group));
+            group->connectionGroup = nullptr;
+            group->cancelSemaphore = nullptr;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::WaitForConnectionGroupReadyState(InterfaceGroup * group, nw_connection_group_t connectionGroup)
+        {
+            __auto_type semaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != semaphore, CHIP_ERROR_NO_MEMORY);
+
+            __auto_type cancelSemaphore = dispatch_semaphore_create(0);
+            VerifyOrReturnError(nullptr != cancelSemaphore, CHIP_ERROR_NO_MEMORY);
+            group->cancelSemaphore = cancelSemaphore;
+
+            __block CHIP_ERROR err = CHIP_ERROR_INTERNAL;
+            nw_connection_group_set_state_changed_handler(connectionGroup, ^(nw_connection_group_state_t state, nw_error_t error) {
+                DebugPrintConnectionGroupState(state, error);
+
+                switch (state) {
+                case nw_connection_group_state_waiting:
+                case nw_connection_group_state_invalid:
+                    err = CHIP_ERROR_INCORRECT_STATE;
+                    nw_connection_group_cancel(connectionGroup);
+                    break;
+                case nw_connection_group_state_ready:
+                    err = CHIP_NO_ERROR;
+                    dispatch_semaphore_signal(semaphore);
+                    break;
+                case nw_connection_group_state_failed:
+                    err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
+                    nw_connection_group_cancel(connectionGroup);
+                    break;
+                case nw_connection_group_state_cancelled:
+                    if (err == CHIP_NO_ERROR) {
+                        err = CHIP_ERROR_CONNECTION_ABORTED;
+                    }
+                    dispatch_semaphore_signal(semaphore);
+                    dispatch_semaphore_signal(cancelSemaphore);
+                    break;
+                default:
+                    break;
+                }
+            });
+
+            nw_connection_group_start(connectionGroup);
+            dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, kConnectionGroupReadyTimeoutInSeconds);
+            dispatch_semaphore_wait(semaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+
+            return err;
+        }
+
+        CHIP_ERROR UDPEndPointImplNetworkFrameworkListenerGroup::WaitForConnectionGroupCancelledState(InterfaceGroup * group)
+        {
+            nw_connection_group_cancel(group->connectionGroup);
+            __auto_type timeout = dispatch_time(DISPATCH_TIME_NOW, kConnectionGroupCancelledTimeoutInSeconds);
+            dispatch_semaphore_wait(group->cancelSemaphore, timeout); // NOLINT(clang-analyzer-optin.performance.GCDAntipattern)
+
+            return CHIP_NO_ERROR;
+        }
+
+        bool UDPEndPointImplNetworkFrameworkListenerGroup::IsSameEndPoints(nw_endpoint_t a, nw_endpoint_t b)
+        {
+            const sockaddr * addrA = nw_endpoint_get_address(a);
+            const sockaddr * addrB = nw_endpoint_get_address(b);
+
+            VerifyOrReturnValue(addrA->sa_family == addrB->sa_family, false);
+
+            uint16_t portA = nw_endpoint_get_port(a);
+            uint16_t portB = nw_endpoint_get_port(b);
+
+            VerifyOrReturnValue(portA == portB, false);
+
+            if (addrA->sa_family == AF_INET) {
+                const sockaddr_in * inA = reinterpret_cast<const sockaddr_in *>(addrA);
+                const sockaddr_in * inB = reinterpret_cast<const sockaddr_in *>(addrB);
+                return (inA->sin_addr.s_addr == inB->sin_addr.s_addr);
+            }
+
+            if (addrA->sa_family == AF_INET6) {
+                const sockaddr_in6 * in6A = reinterpret_cast<const sockaddr_in6 *>(addrA);
+                const sockaddr_in6 * in6B = reinterpret_cast<const sockaddr_in6 *>(addrB);
+                return (memcmp(&in6A->sin6_addr, &in6B->sin6_addr, sizeof(in6A->sin6_addr)) == 0);
+            }
+
+            return false; // Unknown family
+        }
+
+        void UDPEndPointImplNetworkFrameworkListenerGroup::ReleaseInterfaceGroupCallback(CFAllocatorRef allocator, const void * value)
+        {
+            __auto_type * group = static_cast<InterfaceGroup *>(const_cast<void *>(value));
+            free(group);
+        }
+
+    } // namespace Darwin
+} // namespace Inet
+} // namespace chip

--- a/src/platform/Darwin/inet/darwin_sources.gni
+++ b/src/platform/Darwin/inet/darwin_sources.gni
@@ -20,11 +20,19 @@ import("${chip_root}/src/inet/inet.gni")
 # These files are physically located under src/platform/Darwin/inet/,
 # but are considered part of the inet logical layer.
 
-darwin_sources = []
+darwin_sources = [ "${chip_root}/src/platform/Darwin/inet/NetworkMonitor.h" ]
 
 if (chip_inet_config_enable_udp_endpoint) {
   darwin_sources += [
     "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.h",
     "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.h",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.mm",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.h",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.h",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.h",
+    "${chip_root}/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm",
   ]
 }


### PR DESCRIPTION
#### Description

This change consolidates multiple improvements to the Darwin-specific Network.framework implementation:

 - Stability & Safety
   - Fix crash issues by initializing members with  and guarding against disconnected endpoints.
    - Add timeouts to prevent hangs. 
    - Introduce autorelease pools when creating queues to prevent leaks. 
    - Ensure all queue operations are dispatched on the correct thread without unnecessary . 
    - Prevent a leak when logging source/destination addresses.
    
- Improve concurrency safety:
  - Avoid races in  allocation by dispatching onto the CHIP queue. 
  - Avoid unnecessary copies when sending packets. 
  - Free the reception queue safely by dispatching to the CHIP queue. 
  - Prevent multiple callbacks into the listener/connection handler during connection lifecycle changes.

- Add support for:
  - Multiple simultaneous connections.
   - Group messages (multicast scenarios). 
   - Listening on multiple interfaces/IPs rather than a single  listener with  workarounds.

 - Code Structure & Maintainability 
   - Extract listener functionality into: UDPEndPointImplNetworkFrameworkListener. 
   - Extract listener group support into: UDPEndPointImplNetworkFrameworkListenerGroup. 
   - Extract connection management into: UDPEndPointImplNetworkFrameworkConnection. 
   - Extract debugging logging into: UDPEndPointImplNetworkFrameworkDebug.


Please note that this change does not yet enable the feature; enabling it will be handled in a separate PR.

#### Testing

I have updated various components to support continuous integration (see issue #37992). Once enabled, this feature will apply to all Darwin builds—including both commissioner and example applications—so that all tests execute against the new implementation.