### PR TITLE
[Linux] Check WiFi state before selecting configured network

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -186,6 +186,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
 bool ConnectivityManagerImpl::_IsWiFiInterfaceEnabled()
 {
+    VerifyOrReturnValue(mWpaSupplicant.iface, false);
     // Check if the interface is not disabled, e.g. due to rfkill or some other reasons.
     return g_strcmp0(wpa_supplicant_1_interface_get_state(mWpaSupplicant.iface.get()), "interface_disabled") != 0;
 }

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -194,10 +194,11 @@ public:
     CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
 
 private:
+    void _ConnectWiFiNetworkAsyncDone(GObject * sourceObject, GAsyncResult * res);
+    CHIP_ERROR _ConnectWiFiNetworkAsyncImpl();
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);
-    void _ConnectWiFiNetworkAsyncCallback(GObject * sourceObject, GAsyncResult * res);
 #endif
 
 public:

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -195,8 +195,6 @@ public:
 
 private:
     bool _IsWiFiInterfaceEnabled() CHIP_REQUIRES(mWpaSupplicantMutex);
-    void _ConnectWiFiNetworkAsyncDone(GObject * sourceObject, GAsyncResult * res);
-    CHIP_ERROR _ConnectWiFiNetworkAsyncImpl();
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,
                                         NetworkCommissioning::Internal::WirelessDriver::ConnectCallback * connectCallback)
         CHIP_REQUIRES(mWpaSupplicantMutex);

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -194,6 +194,7 @@ public:
     CHIP_ERROR StartWiFiScan(ByteSpan ssid, NetworkCommissioning::WiFiDriver::ScanCallback * callback);
 
 private:
+    bool _IsWiFiInterfaceEnabled() CHIP_REQUIRES(mWpaSupplicantMutex);
     void _ConnectWiFiNetworkAsyncDone(GObject * sourceObject, GAsyncResult * res);
     CHIP_ERROR _ConnectWiFiNetworkAsyncImpl();
     CHIP_ERROR _ConnectWiFiNetworkAsync(GVariant * networkArgs,


### PR DESCRIPTION
#### Problem

In case when `wlan` is blocked with `rfkill`, commissioning waits until timeout, because it's not possible to associate with AP. Instead of that we can follow fail-fast path and report error right away.

#### Changes

- Check WiFi state (whether it's not blocked) before associating with AP
- Use sync version of `wpa_supplicant_1_interface_call_select_network()` because this call only only selects network (it does not perform AP association), so the call does not take long, and using sync version dramatically simplifies `_ConnectWiFiNetworkAsync` method logic.
- Do not save WPA supplicant configuration when `wpa_supplicant_1_interface_call_select_network` call succeed. The success does not mean that AP association succeeded, but only that the network section (internal WPA supplicant state) succeeded.

#### Testing

Locally tested with `rfkill` and without. Without `rfkill` commissioning works as before. With rfkill the output is as follows:

RPi4:
```console
$ sudo rfkill block wlan
$ chip-lighting-app --wifi
...
[1749025319.386] [13827:13827] [DMG] Decreasing reference count for CommandHandlerImpl, remaining 3                                                                                                                  
[1749025319.386] [13827:13827] [NP] LinuxWiFiDriver: ConnectNetwork 'MATTER-AP'                                                                                                                                      
[1749025319.387] [13827:13827] [DL] WPA supplicant: WiFi interface is disabled (blocked)                                                                                                                             
[1749025319.387] [13827:13827] [NP] Failed to connect to WiFi network: src/platform/Linux/ConnectivityManagerImpl.cpp:1087: CHIP Error 0x00000003: Incorrect state
...
```

Controller:
```console
$ out/linux-x64-chip-tool/chip-tool pairing ble-wifi 1 MATTER-AP password 20202021 3840
...
[1749025319.341] [2219607:2219616] [CTL] Performing next commissioning step 'WiFiNetworkEnable'                                                                                                                      
[1749025319.341] [2219607:2219616] [CTL] SendCommand kWiFiNetworkEnable, supportsConcurrentConnection=true
...
[1749025319.431] [2219607:2219616] [CTL] Received ConnectNetwork response, networkingStatus=12
[1749025319.431] [2219607:2219616] [CTL] Error on commissioning step 'WiFiNetworkEnable': 'src/controller/CHIPDeviceController.cpp:3130: CHIP Error 0x000000AC: Internal error'
...
```