### PR TITLE
Fix STM32 flashbundle strings.

### DIFF
--- a/scripts/build/builders/stm32.py
+++ b/scripts/build/builders/stm32.py
@@ -36,7 +36,7 @@ class stm32App(Enum):
 
     def FlashBundleName(self):
         if self == stm32App.LIGHT:
-            return 'lighting_app.out.flashbundle.txt'
+            return 'lighting_app.flashbundle.txt'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -79,7 +79,7 @@ class stm32Builder(GnBuilder):
         return self.extra_gn_options
 
     def build_outputs(self):
-        extensions = ["out", "out.hex"]
+        extensions = ["bin", "elf"]
         if self.options.enable_link_map_file:
             extensions.append("out.map")
         for ext in extensions:


### PR DESCRIPTION
It was likely a copy and paste before and the names were not valid.

![image](https://github.com/user-attachments/assets/45e481a8-4f1d-4c64-a232-768d8a19ae7e)

The flashbundle name was not valid and neither were the extensions (we have bin and elf, not out and out.hex)

#### Testing

Compiled `stm32-stm32wb5mm-dk-light` with flashbundle enabled and it did not fail anymore (previously it was saying file not found)

