### PR TITLE
Improve enable/disable of Wi-Fi PAF for build_python.sh

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -38,6 +38,8 @@ CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/python_lib"
 
 declare enable_ble=true
+declare enable_ipv4=false
+declare enable_wifi_paf=true
 declare chip_detail_logging=false
 declare chip_mdns
 declare case_retry_delta
@@ -46,15 +48,20 @@ declare clean_virtual_env=yes
 declare install_pytest_requirements=yes
 declare install_jupyterlab=no
 declare -a extra_packages
+declare -a extra_gn_args
 
 help() {
 
-    echo "Usage: $file_name [ options ... ] [ -chip_detail_logging ChipDetailLoggingValue  ] [ -chip_mdns ChipMDNSValue  ]"
+    echo "Usage: $file_name [ options ... ]"
 
     echo "General Options:
   -h, --help                Display this information.
 Input Options:
+  -g, --gn_args ARGS                                        Additional verbatim arguments to pass to the gn command.
+                                                            May be specified multiple times.
   -b, --enable_ble          <true/false>                    Enable BLE in the controller (default=true)
+  -p, --enable_wifi_paf     <true/false                     Enable Wi-Fi PAF discovery in the controller (default=true)
+  -4, --enable_ipv4         <true/false>                    Enable IPv4 in the controller (default=false)
   -d, --chip_detail_logging <true/false>                    Specify ChipDetailLoggingValue as true or false.
                                                             By default it is false.
   -m, --chip_mdns           ChipMDNSValue                   Specify ChipMDNSValue as platform or minimal.
@@ -86,7 +93,23 @@ while (($#)); do
         --enable_ble | -b)
             enable_ble=$2
             if [[ "$enable_ble" != "true" && "$enable_ble" != "false" ]]; then
-                echo "chip_detail_logging should have a true/false value, not '$enable_ble'"
+                echo "enable_ble should have a true/false value, not '$enable_ble'"
+                exit
+            fi
+            shift
+            ;;
+        --enable_wifi_paf | -p)
+            enable_wifi_paf=$2
+            if [[ "$enable_wifi_paf" != "true" && "$enable_wifi_paf" != "false" ]]; then
+                echo "enable_wifi_paf should have a true/false value, not '$enable_wifi_paf'"
+                exit
+            fi
+            shift
+            ;;
+        --enable_ipv4 | -4)
+            enable_ipv4=$2
+            if [[ "$enable_ipv4" != "true" && "$enable_ipv4" != "false" ]]; then
+                echo "enable_ipv4 should have a true/false value, not '$enable_ipv4'"
                 exit
             fi
             shift
@@ -131,12 +154,17 @@ while (($#)); do
             extra_packages+=("$2")
             shift
             ;;
+        --gn_args | -g)
+            extra_gn_args+=("$2")
+            shift
+            ;;
         --pregen_dir | -z)
             pregen_dir=$2
             shift
             ;;
         --jupyter-lab | -j)
             install_jupyterlab=yes
+            shift
             ;;
         -*)
             help
@@ -147,8 +175,22 @@ while (($#)); do
     shift
 done
 
+# Expand extra GN args properly
+all_extra_gn_args="${extra_gn_args[@]}"
+
 # Print input values
-echo "Input values: chip_detail_logging = $chip_detail_logging , chip_mdns = \"$chip_mdns\", chip_case_retry_delta=\"$chip_case_retry_delta\", pregen_dir=\"$pregen_dir\", enable_ble=\"$enable_ble\""
+echo "Building Python environment with the following configuration:"
+echo "  chip_detail_logging=\"$chip_detail_logging\""
+echo "  chip_mdns=\"$chip_mdns\""
+echo "  chip_case_retry_delta=\"$chip_case_retry_delta\""
+echo "  pregen_dir=\"$pregen_dir\""
+echo "  enable_ble=\"$enable_ble\""
+echo "  enable_wifi_paf=\"$enable_wifi_paf\""
+echo "  enable_ipv4=\"$enable_ipv4\""
+
+if [[ -n "${all_extra_gn_args}" ]]; then
+    echo "In addition, the following extra args will added to gn command line: $all_extra_gn_args"
+fi
 
 # Ensure we have a compilation environment
 source "$CHIP_ROOT/scripts/activate.sh"
@@ -175,7 +217,7 @@ export SYSTEM_VERSION_COMPAT=0
 # Make all possible human redable tracing available.
 tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_crypto=\"boringssl\""
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_inet_config_enable_ipv4=$enable_ipv4 chip_device_config_enable_wifipaf=$enable_wifi_paf chip_crypto=\"boringssl\" $all_extra_gn_args"
 
 # Compile Python wheels
 ninja -C "$OUTPUT_ROOT" python_wheels

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -60,7 +60,7 @@ Input Options:
   -g, --gn_args ARGS                                        Additional verbatim arguments to pass to the gn command.
                                                             May be specified multiple times.
   -b, --enable_ble          <true/false>                    Enable BLE in the controller (default=true)
-  -p, --enable_wifi_paf     <true/false                     Enable Wi-Fi PAF discovery in the controller (default=true)
+  -p, --enable_wifi_paf     <true/false>                    Enable Wi-Fi PAF discovery in the controller (default=true)
   -4, --enable_ipv4         <true/false>                    Enable IPv4 in the controller (default=false)
   -d, --chip_detail_logging <true/false>                    Specify ChipDetailLoggingValue as true or false.
                                                             By default it is false.

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -38,7 +38,7 @@ CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/python_lib"
 
 declare enable_ble=true
-declare enable_ipv4=false
+declare enable_ipv4=true
 declare enable_wifi_paf=true
 declare chip_detail_logging=false
 declare chip_mdns

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -164,7 +164,6 @@ while (($#)); do
             ;;
         --jupyter-lab | -j)
             install_jupyterlab=yes
-            shift
             ;;
         -*)
             help

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -104,17 +104,25 @@ CHIP_ERROR SetUpCodePairer::Connect()
         if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
         {
             CHIP_ERROR err = StartDiscoveryOverBLE();
-            if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE))
+            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
             {
-                ChipLogError(Controller, "Failed to start discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogProgress(Controller, "Skipping commissionable node discovery over BLE since not supported by the controller!");
+            }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
         if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
         {
             CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
-            if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE))
+            if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
             {
-                ChipLogError(Controller, "Failed to start discovery over WiFiPAF: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogProgress(Controller, "Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
+            }
+            else if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -106,11 +106,13 @@ CHIP_ERROR SetUpCodePairer::Connect()
             CHIP_ERROR err = StartDiscoveryOverBLE();
             if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
             {
-                ChipLogProgress(Controller, "Skipping commissionable node discovery over BLE since not supported by the controller!");
+                ChipLogProgress(Controller,
+                                "Skipping commissionable node discovery over BLE since not supported by the controller!");
             }
             else if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogError(Controller, "Failed to start commissionable node discovery over BLE: %" CHIP_ERROR_FORMAT,
+                             err.Format());
             }
         }
         if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
@@ -118,11 +120,13 @@ CHIP_ERROR SetUpCodePairer::Connect()
             CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
             if ((CHIP_ERROR_NOT_IMPLEMENTED == err) || (CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err))
             {
-                ChipLogProgress(Controller, "Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
+                ChipLogProgress(Controller,
+                                "Skipping commissionable node discovery over Wi-Fi PAF since not supported by the controller!");
             }
             else if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT, err.Format());
+                ChipLogError(Controller, "Failed to start commissionable node discovery over Wi-Fi PAF: %" CHIP_ERROR_FORMAT,
+                             err.Format());
             }
         }
     }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -104,26 +104,15 @@ CHIP_ERROR SetUpCodePairer::Connect()
         if (ShouldDiscoverUsing(RendezvousInformationFlag::kBLE))
         {
             CHIP_ERROR err = StartDiscoveryOverBLE();
-            if (err != CHIP_NO_ERROR)
+            if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE))
             {
                 ChipLogError(Controller, "Failed to start discovery over BLE: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
-
-        if (ShouldDiscoverUsing(RendezvousInformationFlag::kSoftAP))
-        {
-            CHIP_ERROR err = StartDiscoveryOverSoftAP();
-            if (err != CHIP_NO_ERROR)
-            {
-                ChipLogError(Controller, "Failed to start discovery over SoftAP: %" CHIP_ERROR_FORMAT, err.Format());
-            }
-        }
         if (ShouldDiscoverUsing(RendezvousInformationFlag::kWiFiPAF))
         {
-            ChipLogProgress(Controller,
-                            "WiFi-PAF: has RendezvousInformationFlag::kWiFiPAF or has no discovery capabilities bitmask");
             CHIP_ERROR err = StartDiscoveryOverWiFiPAF();
-            if (err != CHIP_NO_ERROR)
+            if ((err != CHIP_NO_ERROR) && (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE))
             {
                 ChipLogError(Controller, "Failed to start discovery over WiFiPAF: %" CHIP_ERROR_FORMAT, err.Format());
             }
@@ -252,17 +241,6 @@ CHIP_ERROR SetUpCodePairer::StopDiscoveryOverDNSSD()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SetUpCodePairer::StartDiscoveryOverSoftAP()
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-CHIP_ERROR SetUpCodePairer::StopDiscoveryOverSoftAP()
-{
-    mWaitingForDiscovery[kSoftAPTransport] = false;
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
@@ -298,7 +276,7 @@ CHIP_ERROR SetUpCodePairer::StartDiscoveryOverWiFiPAF()
     return err;
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-#endif // CONFIG_NETWORK_LAYER_BLE
+#endif // CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
 }
 
 CHIP_ERROR SetUpCodePairer::StopDiscoveryOverWiFiPAF()
@@ -625,7 +603,6 @@ void SetUpCodePairer::StopAllDiscoveryAttempts()
 {
     LogErrorOnFailure(StopDiscoveryOverBLE());
     LogErrorOnFailure(StopDiscoveryOverDNSSD());
-    LogErrorOnFailure(StopDiscoveryOverSoftAP());
     LogErrorOnFailure(StopDiscoveryOverWiFiPAF());
 
     // Just in case any of those failed to reset the waiting state properly.

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -124,7 +124,6 @@ private:
     CHIP_ERROR StopDiscoveryOverBLE();
     CHIP_ERROR StartDiscoveryOverDNSSD();
     CHIP_ERROR StopDiscoveryOverDNSSD();
-    CHIP_ERROR StartDiscoveryOverSoftAP();
     CHIP_ERROR StopDiscoveryOverSoftAP();
     CHIP_ERROR StartDiscoveryOverWiFiPAF();
     CHIP_ERROR StopDiscoveryOverWiFiPAF();
@@ -170,7 +169,6 @@ private:
     {
         kBLETransport = 0,
         kIPTransport,
-        kSoftAPTransport,
         kWiFiPAFTransport,
         kTransportTypeCount,
     };

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -124,7 +124,6 @@ private:
     CHIP_ERROR StopDiscoveryOverBLE();
     CHIP_ERROR StartDiscoveryOverDNSSD();
     CHIP_ERROR StopDiscoveryOverDNSSD();
-    CHIP_ERROR StopDiscoveryOverSoftAP();
     CHIP_ERROR StartDiscoveryOverWiFiPAF();
     CHIP_ERROR StopDiscoveryOverWiFiPAF();
 


### PR DESCRIPTION
#### Changes done
- Removes dead code related to Soft-AP in SetUpCodePairer
- Removes non-normalized logs related to PAF that confused readers that PAF was enabled when it's not
- Add a flag to build_python.sh to disable Wi-Fi PAF
- Add a flag to allow disabling IPv4  in build_python.sh (which was supposed to be the case a long time ago), to match the config of chip-tool for certification builds.
- Add a way to add additional `--gn_args` to the command line so that we don't have to special case every config for python builds, and so that trials to test Python controller changes are easier to build.
- Fixed a couple cut'n'paste mistakes in build_python.sh and SetUpCodePairer.cpp that were seen during the PR workflow.

#### Testing

- Ran certification tests in Python with `--enable_wifi_paf false` and no longer see the Wi-Fi PAF logs about errors to run it (since it's not an error if it's not implemented).
- Tested `scripts/build_python.sh -i out/python_env --gn_args 'chip_crypto="mbedtls"' and validated the the gn command line (via a `set -x`) has the correct argument and that the crypto backend is replaced by mbedtls.
