### PR TITLE
Add gstreamer-app package to Docker file and sysroot creation

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -64,6 +64,7 @@ RUN set -x \
     libglib2.0-dev \
     libgstreamer1.0-0 \
     libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev \
     libical-dev \
     libjpeg-dev \
     libmbedtls-dev \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-136 : Upgrade docker to remove K32W0 SDK
+137 : Upgrade docker to add gstreamer‑app‑1.0

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/start-sysroot-vm.sh
@@ -121,6 +121,7 @@ packages:
   - libglib2.0-dev
   - libgstreamer1.0-0
   - libgstreamer1.0-dev
+  - libgstreamer-plugins-base1.0-dev
   - libpcsclite-dev
   - libreadline-dev
   - libsdl2-dev


### PR DESCRIPTION
We need GStreamer development package libgstreamer-plugins-base1.0-dev, which provides the gstreamer-app-1.0.pc file that pkg-config is looking for.

#### Testing

Validated by CI
