### PR TITLE
Add EndpointProviderInterface, SpanEndpointProvider and EndpointProvi…

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -59,6 +59,7 @@ if (chip_build_tests) {
       "${chip_root}/src/app/data-model/tests",
       "${chip_root}/src/app/icd/server/tests",
       "${chip_root}/src/crypto/tests",
+      "${chip_root}/src/data-model-providers/endpoint/tests",
       "${chip_root}/src/inet/tests",
       "${chip_root}/src/lib/address_resolve/tests",
       "${chip_root}/src/app/server-cluster/tests",

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -123,7 +123,8 @@ struct AttributeEntry
     _StartBitFieldInit; // Disabling '-Wconversion' & '-Wnarrowing'
     constexpr AttributeEntry(AttributeId id, BitMask<AttributeQualityFlags> attrQualityFlags,
                              std::optional<Access::Privilege> readPriv, std::optional<Access::Privilege> writePriv) :
-        attributeId{ id }, mask{
+        attributeId{ id },
+        mask{
             .flags          = attrQualityFlags.Raw() & kAttrQualityMask,
             .readPrivilege  = readPriv.has_value() ? (to_underlying(*readPriv) & kPrivilegeMask) : 0,
             .writePrivilege = writePriv.has_value() ? (to_underlying(*writePriv) & kPrivilegeMask) : 0,
@@ -228,7 +229,8 @@ struct AcceptedCommandEntry
 
     constexpr AcceptedCommandEntry(CommandId id = 0, BitMask<CommandQualityFlags> cmdQualityFlags = BitMask<CommandQualityFlags>(),
                                    Access::Privilege invokePriv = Access::Privilege::kOperate) :
-        commandId(id), mask{
+        commandId(id),
+        mask{
             .flags           = cmdQualityFlags.Raw() & kCmdQualityMask,
             .invokePrivilege = to_underlying(invokePriv) & kPrivilegeMask,
         }

--- a/src/app/data-model-provider/MetadataTypes.h
+++ b/src/app/data-model-provider/MetadataTypes.h
@@ -64,6 +64,10 @@ struct EndpointEntry
     // for endpoints other than endpoint 0).
     EndpointId parentId;
     EndpointCompositionPattern compositionPattern;
+    bool operator==(const EndpointEntry & rhs) const
+    {
+        return id == rhs.id && parentId == rhs.parentId && compositionPattern == rhs.compositionPattern;
+    }
 };
 
 enum class ClusterQualityFlags : uint32_t
@@ -119,8 +123,7 @@ struct AttributeEntry
     _StartBitFieldInit; // Disabling '-Wconversion' & '-Wnarrowing'
     constexpr AttributeEntry(AttributeId id, BitMask<AttributeQualityFlags> attrQualityFlags,
                              std::optional<Access::Privilege> readPriv, std::optional<Access::Privilege> writePriv) :
-        attributeId{ id },
-        mask{
+        attributeId{ id }, mask{
             .flags          = attrQualityFlags.Raw() & kAttrQualityMask,
             .readPrivilege  = readPriv.has_value() ? (to_underlying(*readPriv) & kPrivilegeMask) : 0,
             .writePrivilege = writePriv.has_value() ? (to_underlying(*writePriv) & kPrivilegeMask) : 0,
@@ -225,8 +228,7 @@ struct AcceptedCommandEntry
 
     constexpr AcceptedCommandEntry(CommandId id = 0, BitMask<CommandQualityFlags> cmdQualityFlags = BitMask<CommandQualityFlags>(),
                                    Access::Privilege invokePriv = Access::Privilege::kOperate) :
-        commandId(id),
-        mask{
+        commandId(id), mask{
             .flags           = cmdQualityFlags.Raw() & kCmdQualityMask,
             .invokePrivilege = to_underlying(invokePriv) & kPrivilegeMask,
         }

--- a/src/data-model-providers/endpoint/BUILD.gn
+++ b/src/data-model-providers/endpoint/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright (c) 2025 Project CHIP Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+source_set("endpoint") {
+  sources = [
+    "EndpointProviderInterface.h",
+    "EndpointProviderRegistry.cpp",
+    "EndpointProviderRegistry.h",
+    "SpanEndpointProvider.cpp",
+    "SpanEndpointProvider.h",
+  ]
+
+  public_deps = [
+    "${chip_root}/src/app:paths",
+    "${chip_root}/src/app/server-cluster",
+    "${chip_root}/src/lib/core:types",
+    "${chip_root}/src/lib/support",
+  ]
+}

--- a/src/data-model-providers/endpoint/EndpointProviderInterface.h
+++ b/src/data-model-providers/endpoint/EndpointProviderInterface.h
@@ -1,0 +1,95 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/data-model-provider/MetadataTypes.h>
+#include <app/server-cluster/ServerClusterInterface.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/ReadOnlyBuffer.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * @brief Defines the interface for an object that can provide information about a Matter endpoint.
+ *
+ * This interface is used describe the structure and capabilities of an endpoint, including its device
+ * types, client clusters, server clusters, and semantic tags.
+ *
+ * Implementations of this interface are responsible for providing instances of ServerClusterInterface
+ * for each server cluster they expose.
+ */
+class EndpointProviderInterface
+{
+public:
+    virtual ~EndpointProviderInterface() = default;
+
+    using SemanticTag = chip::app::Clusters::Descriptor::Structs::SemanticTagStruct::Type;
+
+    /**
+     * @brief Retrieves the basic information about the endpoint.
+     *
+     * @return A constant reference to the DataModel::EndpointEntry struct containing
+     *         the endpoint ID, parent endpoint ID, and composition pattern.
+     */
+    virtual const DataModel::EndpointEntry & GetEndpointEntry() const = 0;
+
+    /**
+     * @brief Populates the provided ReadOnlyBufferBuilder with the semantic tags for this endpoint.
+     *
+     * @param[out] out The ReadOnlyBufferBuilder to fill with SemanticTagStruct instances.
+     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
+     */
+    virtual CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const = 0;
+
+    /**
+     * @brief Populates the provided ReadOnlyBufferBuilder with the device types for this endpoint.
+     *
+     * @param[out] out The ReadOnlyBufferBuilder to fill with DataModel::DeviceTypeEntry instances.
+     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
+     */
+    virtual CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const = 0;
+
+    /**
+     * @brief Populates the provided ReadOnlyBufferBuilder with the client cluster IDs for this endpoint.
+     *
+     * @param[out] out The ReadOnlyBufferBuilder to fill with ClusterId instances.
+     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
+     */
+    virtual CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const = 0;
+
+    /**
+     * @brief Retrieves a pointer to the ServerClusterInterface for the given cluster ID.
+     *
+     * @param clusterId The ID of the server cluster to retrieve.
+     * @return A pointer to the ServerClusterInterface if found, otherwise nullptr.
+     */
+    virtual ServerClusterInterface * GetServerCluster(ClusterId clusterId) const = 0;
+
+    /**
+     * @brief Populates the provided ReadOnlyBufferBuilder with pointers to all ServerClusterInterface instances
+     *        hosted on this endpoint.
+     *
+     * @param[out] out The ReadOnlyBufferBuilder to fill with ServerClusterInterface pointers.
+     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
+     */
+    virtual CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/data-model-providers/endpoint/EndpointProviderInterface.h
+++ b/src/data-model-providers/endpoint/EndpointProviderInterface.h
@@ -16,9 +16,9 @@
  */
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model-provider/MetadataTypes.h>
 #include <app/server-cluster/ServerClusterInterface.h>
+#include <clusters/Descriptor/Structs.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/ReadOnlyBuffer.h>
 
@@ -41,40 +41,17 @@ public:
 
     using SemanticTag = chip::app::Clusters::Descriptor::Structs::SemanticTagStruct::Type;
 
-    /**
-     * @brief Retrieves the basic information about the endpoint.
-     *
-     * @return A constant reference to the DataModel::EndpointEntry struct containing
-     *         the endpoint ID, parent endpoint ID, and composition pattern.
-     */
     virtual const DataModel::EndpointEntry & GetEndpointEntry() const = 0;
 
-    /**
-     * @brief Populates the provided ReadOnlyBufferBuilder with the semantic tags for this endpoint.
-     *
-     * @param[out] out The ReadOnlyBufferBuilder to fill with SemanticTagStruct instances.
-     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
-     */
     virtual CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const = 0;
 
-    /**
-     * @brief Populates the provided ReadOnlyBufferBuilder with the device types for this endpoint.
-     *
-     * @param[out] out The ReadOnlyBufferBuilder to fill with DataModel::DeviceTypeEntry instances.
-     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
-     */
     virtual CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const = 0;
 
-    /**
-     * @brief Populates the provided ReadOnlyBufferBuilder with the client cluster IDs for this endpoint.
-     *
-     * @param[out] out The ReadOnlyBufferBuilder to fill with ClusterId instances.
-     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
-     */
     virtual CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const = 0;
 
     /**
      * @brief Retrieves a pointer to the ServerClusterInterface for the given cluster ID.
+     * The returned pointer shall be valid as long as the EndpointProviderInterface instance is valid.
      *
      * @param clusterId The ID of the server cluster to retrieve.
      * @return A pointer to the ServerClusterInterface if found, otherwise nullptr.
@@ -82,11 +59,12 @@ public:
     virtual ServerClusterInterface * GetServerCluster(ClusterId clusterId) const = 0;
 
     /**
-     * @brief Populates the provided ReadOnlyBufferBuilder with pointers to all ServerClusterInterface instances
-     *        hosted on this endpoint.
+     * @brief Populates the provided buffer with pointers to all ServerClusterInterface instances
+     *        hosted on this endpoint. The returned pointers shall be valid as long as the
+     *        EndpointProviderInterface instance is valid.
      *
-     * @param[out] out The ReadOnlyBufferBuilder to fill with ServerClusterInterface pointers.
-     * @return CHIP_NO_ERROR on success, or an error code if the operation fails (e.g., buffer too small).
+     * @param[out] out The buffer to fill with ServerClusterInterface pointers.
+     * @return CHIP_NO_ERROR on success or CHIP_ERROR_NO_MEMORY if the buffer is too small.
      */
     virtual CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const = 0;
 };

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.cpp
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.cpp
@@ -1,0 +1,127 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <data-model-providers/endpoint/EndpointProviderRegistry.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace app {
+
+EndpointProviderRegistry::~EndpointProviderRegistry()
+{
+    // The registry does not own the EndpointProviderInterface instances,
+    // nor the EndpointProviderRegistration nodes. It just clears its list.
+    mRegistrations    = nullptr;
+    mCachedInterface  = nullptr;
+    mCachedEndpointId = kInvalidEndpointId;
+}
+
+CHIP_ERROR EndpointProviderRegistry::Register(EndpointProviderRegistration & entry)
+{
+    VerifyOrReturnError(entry.next == nullptr, CHIP_ERROR_INVALID_ARGUMENT); // Should not be part of another list
+    VerifyOrReturnError(entry.endpointProviderInterface != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    EndpointId newEndpointId = entry.endpointProviderInterface->GetEndpointEntry().id;
+    VerifyOrReturnError(newEndpointId != kInvalidEndpointId, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Check for duplicates
+    if (Get(newEndpointId) != nullptr)
+    {
+        return CHIP_ERROR_DUPLICATE_KEY_ID;
+    }
+
+    entry.next     = mRegistrations;
+    mRegistrations = &entry;
+
+    // Invalidate cache as the list structure changed
+    mCachedInterface  = nullptr;
+    mCachedEndpointId = kInvalidEndpointId;
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR EndpointProviderRegistry::Unregister(EndpointId endpointId)
+{
+    VerifyOrReturnError(endpointId != kInvalidEndpointId, CHIP_ERROR_INVALID_ARGUMENT);
+
+    EndpointProviderRegistration * prev    = nullptr;
+    EndpointProviderRegistration * current = mRegistrations;
+
+    while (current != nullptr)
+    {
+        if (current->endpointProviderInterface->GetEndpointEntry().id == endpointId)
+        {
+            if (prev == nullptr) // Node to remove is the head
+            {
+                mRegistrations = current->next;
+            }
+            else
+            {
+                prev->next = current->next;
+            }
+            current->next = nullptr; // Clear the registration's next pointer
+
+            if (mCachedEndpointId == endpointId) // Invalidate cache if the unregistered endpoint was cached
+            {
+                mCachedInterface  = nullptr;
+                mCachedEndpointId = kInvalidEndpointId;
+            }
+            return CHIP_NO_ERROR;
+        }
+        prev    = current;
+        current = current->next;
+    }
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+EndpointProviderInterface * EndpointProviderRegistry::Get(EndpointId endpointId)
+{
+    if (mCachedEndpointId == endpointId && mCachedInterface != nullptr)
+    {
+        return mCachedInterface;
+    }
+
+    // The endpoint searched for is not cached, do a linear search for it
+    EndpointProviderRegistration * current = mRegistrations;
+
+    while (current != nullptr)
+    {
+        if (current->endpointProviderInterface != nullptr &&
+            current->endpointProviderInterface->GetEndpointEntry().id == endpointId)
+        {
+            mCachedInterface  = current->endpointProviderInterface;
+            mCachedEndpointId = endpointId;
+            return mCachedInterface;
+        }
+        current = current->next;
+    }
+
+    // not found
+    return nullptr;
+}
+
+size_t EndpointProviderRegistry::Count() const
+{
+    size_t count = 0;
+    for (auto * current = mRegistrations; current != nullptr; current = current->next)
+    {
+        count++;
+    }
+    return count;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -24,110 +24,109 @@
 namespace chip {
 namespace app {
 
-    /**
-     * @brief Represents a registration entry for an EndpointProviderInterface within the EndpointProviderRegistry.
-     *
-     * This struct acts as a node in a singly-linked list used by the EndpointProviderRegistry.
-     * It contains a pointer to the actual EndpointProviderInterface and a pointer to the next
-     * registration in the list.
-     *
-     * Callers are responsible for ensuring that both this registration object and the
-     * EndpointProviderInterface it points to outlive their registration with the EndpointProviderRegistry.
-     */
-    struct EndpointProviderRegistration {
-        EndpointProviderInterface * const endpointProviderInterface;
-        EndpointProviderRegistration * next;
+/**
+ * @brief Represents a registration entry for an EndpointProviderInterface within the EndpointProviderRegistry.
+ *
+ * This struct acts as a node in a singly-linked list used by the EndpointProviderRegistry.
+ * It contains a pointer to the actual EndpointProviderInterface and a pointer to the next
+ * registration in the list.
+ *
+ * Callers are responsible for ensuring that both this registration object and the
+ * EndpointProviderInterface it points to outlive their registration with the EndpointProviderRegistry.
+ */
+struct EndpointProviderRegistration
+{
+    EndpointProviderInterface * const endpointProviderInterface;
+    EndpointProviderRegistration * next;
 
-        constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
-            EndpointProviderRegistration * next_item = nullptr)
-            : endpointProviderInterface(&interface)
-            , next(next_item)
-        {
-        }
-        EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
+    constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
+                                           EndpointProviderRegistration * next_item = nullptr) :
+        endpointProviderInterface(&interface),
+        next(next_item)
+    {}
+    EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
 
-        EndpointProviderRegistration(const EndpointProviderRegistration & other) = delete;
-        EndpointProviderRegistration & operator=(const EndpointProviderRegistration & other) = delete;
-    };
+    EndpointProviderRegistration(const EndpointProviderRegistration & other)             = delete;
+    EndpointProviderRegistration & operator=(const EndpointProviderRegistration & other) = delete;
+};
 
-    /**
-     * @brief Manages a collection of EndpointProviderInterface instances.
-     *
-     * The EndpointProviderRegistry can be used to discover and interact programmatically
-     * with Matter endpoints. It maintains a linked list of EndpointProviderRegistration
-     * objects.
-     *
-     * Responsibilities:
-     * - Allows registration and unregistration of endpoint providers.
-     * - Provides a way to retrieve a specific endpoint provider by its EndpointId.
-     * - Offers an iterator to traverse all registered endpoint providers.
-     *
-     * Lifetime Management:
-     * - The registry stores raw pointers to EndpointProviderInterface and EndpointProviderRegistration objects.
-     * - It does NOT take ownership of these objects.
-     * - Callers MUST ensure that any registered EndpointProviderInterface and its corresponding
-     *   EndpointProviderRegistration object outlive the EndpointProviderRegistry or are unregistered
-     *   before being destroyed.
-     */
-    class EndpointProviderRegistry {
+/**
+ * @brief Manages a collection of EndpointProviderInterface instances.
+ *
+ * The EndpointProviderRegistry can be used to discover and interact programmatically
+ * with Matter endpoints. It maintains a linked list of EndpointProviderRegistration
+ * objects.
+ *
+ * Responsibilities:
+ * - Allows registration and unregistration of endpoint providers.
+ * - Provides a way to retrieve a specific endpoint provider by its EndpointId.
+ * - Offers an iterator to traverse all registered endpoint providers.
+ *
+ * Lifetime Management:
+ * - The registry stores raw pointers to EndpointProviderInterface and EndpointProviderRegistration objects.
+ * - It does NOT take ownership of these objects.
+ * - Callers MUST ensure that any registered EndpointProviderInterface and its corresponding
+ *   EndpointProviderRegistration object outlive the EndpointProviderRegistry or are unregistered
+ *   before being destroyed.
+ */
+class EndpointProviderRegistry
+{
+public:
+    class Iterator
+    {
     public:
-        class Iterator {
-        public:
-            explicit Iterator(EndpointProviderRegistration * registration)
-                : mCurrent(registration)
-            {
-            }
+        explicit Iterator(EndpointProviderRegistration * registration) : mCurrent(registration) {}
 
-            Iterator & operator++()
-            {
-                mCurrent = (mCurrent ? mCurrent->next : nullptr);
-                return *this;
-            }
-            bool operator==(const Iterator & other) const { return mCurrent == other.mCurrent; }
-            bool operator!=(const Iterator & other) const { return mCurrent != other.mCurrent; }
-            EndpointProviderInterface * operator*() { return mCurrent->endpointProviderInterface; }
-            EndpointProviderInterface * operator->() { return mCurrent->endpointProviderInterface; }
-
-        private:
-            EndpointProviderRegistration * mCurrent;
-        };
-
-        /**
-         * @brief Registers an endpoint provider.
-         *
-         * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
-         * (i.e., `entry.next` must be nullptr). The EndpointProviderInterface within the entry must
-         * be valid and have a valid EndpointId.
-         *
-         * @param entry The EndpointProviderRegistration containing the provider to register.
-         *              The lifetime of this object must be managed by the caller.
-         * @return CHIP_NO_ERROR on success.
-         *         CHIP_ERROR_INVALID_ARGUMENT if entry.next is not nullptr,
-         *                                     entry.endpointProviderInterface is nullptr,
-         *                                     or the endpoint ID is kInvalidEndpointId.
-         *         CHIP_ERROR_DUPLICATE_KEY_ID if an endpoint with the same ID is already registered.
-         */
-        CHIP_ERROR Register(EndpointProviderRegistration & entry);
-
-        /**
-         * @brief Unregisters an endpoint provider with the given EndpointId.
-         * @param endpointId The ID of the endpoint provider to unregister.
-         * @return CHIP_NO_ERROR on success.
-         *         CHIP_ERROR_NOT_FOUND if no provider with the given ID is found.
-         *         CHIP_ERROR_INVALID_ARGUMENT if endpointId is kInvalidEndpointId.
-         */
-        CHIP_ERROR Unregister(EndpointId endpointId);
-
-        /** @return A pointer to the EndpointProviderInterface for the given endpointId, or nullptr if not found. */
-        EndpointProviderInterface * Get(EndpointId endpointId);
-        Iterator begin() { return Iterator(mRegistrations); }
-        Iterator end() { return Iterator(nullptr); }
+        Iterator & operator++()
+        {
+            mCurrent = (mCurrent ? mCurrent->next : nullptr);
+            return *this;
+        }
+        bool operator==(const Iterator & other) const { return mCurrent == other.mCurrent; }
+        bool operator!=(const Iterator & other) const { return mCurrent != other.mCurrent; }
+        EndpointProviderInterface * operator*() { return mCurrent->endpointProviderInterface; }
+        EndpointProviderInterface * operator->() { return mCurrent->endpointProviderInterface; }
 
     private:
-        EndpointProviderRegistration * mRegistrations = nullptr;
-        EndpointProviderInterface * mCachedInterface = nullptr;
-        EndpointId mCachedEndpointId = kInvalidEndpointId;
+        EndpointProviderRegistration * mCurrent;
     };
+
+    /**
+     * @brief Registers an endpoint provider.
+     *
+     * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
+     * (i.e., `entry.next` must be nullptr). The EndpointProviderInterface within the entry must
+     * be valid and have a valid EndpointId.
+     *
+     * @param entry The EndpointProviderRegistration containing the provider to register.
+     *              The lifetime of this object must be managed by the caller.
+     * @return CHIP_NO_ERROR on success.
+     *         CHIP_ERROR_INVALID_ARGUMENT if entry.next is not nullptr,
+     *                                     entry.endpointProviderInterface is nullptr,
+     *                                     or the endpoint ID is kInvalidEndpointId.
+     *         CHIP_ERROR_DUPLICATE_KEY_ID if an endpoint with the same ID is already registered.
+     */
+    CHIP_ERROR Register(EndpointProviderRegistration & entry);
+
+    /**
+     * @brief Unregisters an endpoint provider with the given EndpointId.
+     * @param endpointId The ID of the endpoint provider to unregister.
+     * @return CHIP_NO_ERROR on success.
+     *         CHIP_ERROR_NOT_FOUND if no provider with the given ID is found.
+     *         CHIP_ERROR_INVALID_ARGUMENT if endpointId is kInvalidEndpointId.
+     */
+    CHIP_ERROR Unregister(EndpointId endpointId);
+
+    /** @return A pointer to the EndpointProviderInterface for the given endpointId, or nullptr if not found. */
+    EndpointProviderInterface * Get(EndpointId endpointId);
+    Iterator begin() { return Iterator(mRegistrations); }
+    Iterator end() { return Iterator(nullptr); }
+
+private:
+    EndpointProviderRegistration * mRegistrations = nullptr;
+    EndpointProviderInterface * mCachedInterface  = nullptr;
+    EndpointId mCachedEndpointId                  = kInvalidEndpointId;
+};
 
 } // namespace app
 } // namespace chip

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -1,0 +1,141 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/data-model-provider/MetadataTypes.h>
+#include <data-model-providers/endpoint/EndpointProviderInterface.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+namespace app {
+
+/**
+ * @brief Represents a registration entry for an EndpointProviderInterface within the EndpointProviderRegistry.
+ *
+ * This struct acts as a node in a singly-linked list used by the EndpointProviderRegistry.
+ * It contains a pointer to the actual EndpointProviderInterface and a pointer to the next
+ * registration in the list.
+ *
+ * Callers are responsible for ensuring that both this registration object and the
+ * EndpointProviderInterface it points to outlive their registration with the EndpointProviderRegistry.
+ */
+struct EndpointProviderRegistration
+{
+    EndpointProviderInterface * const endpointProviderInterface;
+    EndpointProviderRegistration * next;
+    /**
+     * @param interface The EndpointProviderInterface to be registered.
+     * @param next_item Pointer to the next registration in a list, defaults to nullptr.
+     */
+    constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
+                                           EndpointProviderRegistration * next_item = nullptr) :
+        endpointProviderInterface(&interface), next(next_item)
+    {}
+    EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
+
+    EndpointProviderRegistration(const EndpointProviderRegistration & other)             = delete;
+    EndpointProviderRegistration & operator=(const EndpointProviderRegistration & other) = delete;
+};
+
+/**
+ * @brief Manages a collection of EndpointProviderInterface instances.
+ *
+ * The EndpointProviderRegistry is used by the CodeDrivenDataModelProvider to discover
+ * and interact with programmatically defined Matter endpoints. It maintains a
+ * singly-linked list of EndpointProviderRegistration objects.
+ *
+ * Responsibilities:
+ * - Allows registration and unregistration of endpoint providers.
+ * - Provides a way to retrieve a specific endpoint provider by its EndpointId.
+ * - Offers an iterator to traverse all registered endpoint providers.
+ *
+ * Lifetime Management:
+ * - The registry stores raw pointers to EndpointProviderInterface and EndpointProviderRegistration objects.
+ * - It does NOT take ownership of these objects.
+ * - Callers MUST ensure that any registered EndpointProviderInterface and its corresponding
+ *   EndpointProviderRegistration object outlive the EndpointProviderRegistry or are unregistered
+ *   before being destroyed.
+ */
+class EndpointProviderRegistry
+{
+public:
+    class Iterator
+    {
+    public:
+        explicit Iterator(EndpointProviderRegistration * registration) : mCurrent(registration) {}
+
+        Iterator & operator++()
+        {
+            mCurrent = (mCurrent ? mCurrent->next : nullptr);
+            return *this;
+        }
+        bool operator==(const Iterator & other) const { return mCurrent == other.mCurrent; }
+        bool operator!=(const Iterator & other) const { return mCurrent != other.mCurrent; }
+        EndpointProviderInterface * operator*() { return mCurrent->endpointProviderInterface; }
+        EndpointProviderInterface * operator->() { return mCurrent->endpointProviderInterface; }
+
+    private:
+        EndpointProviderRegistration * mCurrent;
+    };
+
+    /**
+     * @brief Destructor. Clears the internal list of registrations but does not
+     *        deallocate the EndpointProviderInterface or EndpointProviderRegistration objects themselves.
+     */
+    ~EndpointProviderRegistry();
+
+    /**
+     * @brief Registers an endpoint provider.
+     *
+     * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
+     * (i.e., `entry.next` must be nullptr). The EndpointProviderInterface within the entry must
+     * be valid and have a valid EndpointId.
+     *
+     * @param entry The EndpointProviderRegistration containing the provider to register.
+     *              The lifetime of this object must be managed by the caller.
+     * @return CHIP_NO_ERROR on success.
+     *         CHIP_ERROR_INVALID_ARGUMENT if entry.next is not nullptr,
+     *                                     entry.endpointProviderInterface is nullptr,
+     *                                     or the endpoint ID is kInvalidEndpointId.
+     *         CHIP_ERROR_DUPLICATE_KEY_ID if an endpoint with the same ID is already registered.
+     */
+    CHIP_ERROR Register(EndpointProviderRegistration & entry);
+
+    /**
+     * @brief Unregisters an endpoint provider with the given EndpointId.
+     * @param endpointId The ID of the endpoint provider to unregister.
+     * @return CHIP_NO_ERROR on success.
+     *         CHIP_ERROR_NOT_FOUND if no provider with the given ID is found.
+     *         CHIP_ERROR_INVALID_ARGUMENT if endpointId is kInvalidEndpointId.
+     */
+    CHIP_ERROR Unregister(EndpointId endpointId);
+
+    /** @return A pointer to the EndpointProviderInterface for the given endpointId, or nullptr if not found. */
+    EndpointProviderInterface * Get(EndpointId endpointId);
+    Iterator begin() { return Iterator(mRegistrations); }
+    Iterator end() { return Iterator(nullptr); }
+    size_t Count() const;
+
+private:
+    EndpointProviderRegistration * mRegistrations = nullptr;
+    EndpointProviderInterface * mCachedInterface  = nullptr;
+    EndpointId mCachedEndpointId                  = kInvalidEndpointId;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -44,7 +44,8 @@ struct EndpointProviderRegistration
      */
     constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
                                            EndpointProviderRegistration * next_item = nullptr) :
-        endpointProviderInterface(&interface), next(next_item)
+        endpointProviderInterface(&interface),
+        next(next_item)
     {}
     EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
 

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -41,7 +41,8 @@ struct EndpointProviderRegistration
 
     constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
                                            EndpointProviderRegistration * next_item = nullptr) :
-        endpointProviderInterface(&interface), next(next_item)
+        endpointProviderInterface(&interface),
+        next(next_item)
     {}
     EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
 

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -38,14 +38,10 @@ struct EndpointProviderRegistration
 {
     EndpointProviderInterface * const endpointProviderInterface;
     EndpointProviderRegistration * next;
-    /**
-     * @param interface The EndpointProviderInterface to be registered.
-     * @param next_item Pointer to the next registration in a list, defaults to nullptr.
-     */
+
     constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
                                            EndpointProviderRegistration * next_item = nullptr) :
-        endpointProviderInterface(&interface),
-        next(next_item)
+        endpointProviderInterface(&interface), next(next_item)
     {}
     EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
 
@@ -95,12 +91,6 @@ public:
     };
 
     /**
-     * @brief Destructor. Clears the internal list of registrations but does not
-     *        deallocate the EndpointProviderInterface or EndpointProviderRegistration objects themselves.
-     */
-    ~EndpointProviderRegistry();
-
-    /**
      * @brief Registers an endpoint provider.
      *
      * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
@@ -130,7 +120,6 @@ public:
     EndpointProviderInterface * Get(EndpointId endpointId);
     Iterator begin() { return Iterator(mRegistrations); }
     Iterator end() { return Iterator(nullptr); }
-    size_t Count() const;
 
 private:
     EndpointProviderRegistration * mRegistrations = nullptr;

--- a/src/data-model-providers/endpoint/EndpointProviderRegistry.h
+++ b/src/data-model-providers/endpoint/EndpointProviderRegistry.h
@@ -24,109 +24,110 @@
 namespace chip {
 namespace app {
 
-/**
- * @brief Represents a registration entry for an EndpointProviderInterface within the EndpointProviderRegistry.
- *
- * This struct acts as a node in a singly-linked list used by the EndpointProviderRegistry.
- * It contains a pointer to the actual EndpointProviderInterface and a pointer to the next
- * registration in the list.
- *
- * Callers are responsible for ensuring that both this registration object and the
- * EndpointProviderInterface it points to outlive their registration with the EndpointProviderRegistry.
- */
-struct EndpointProviderRegistration
-{
-    EndpointProviderInterface * const endpointProviderInterface;
-    EndpointProviderRegistration * next;
+    /**
+     * @brief Represents a registration entry for an EndpointProviderInterface within the EndpointProviderRegistry.
+     *
+     * This struct acts as a node in a singly-linked list used by the EndpointProviderRegistry.
+     * It contains a pointer to the actual EndpointProviderInterface and a pointer to the next
+     * registration in the list.
+     *
+     * Callers are responsible for ensuring that both this registration object and the
+     * EndpointProviderInterface it points to outlive their registration with the EndpointProviderRegistry.
+     */
+    struct EndpointProviderRegistration {
+        EndpointProviderInterface * const endpointProviderInterface;
+        EndpointProviderRegistration * next;
 
-    constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
-                                           EndpointProviderRegistration * next_item = nullptr) :
-        endpointProviderInterface(&interface),
-        next(next_item)
-    {}
-    EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
-
-    EndpointProviderRegistration(const EndpointProviderRegistration & other)             = delete;
-    EndpointProviderRegistration & operator=(const EndpointProviderRegistration & other) = delete;
-};
-
-/**
- * @brief Manages a collection of EndpointProviderInterface instances.
- *
- * The EndpointProviderRegistry is used by the CodeDrivenDataModelProvider to discover
- * and interact with programmatically defined Matter endpoints. It maintains a
- * singly-linked list of EndpointProviderRegistration objects.
- *
- * Responsibilities:
- * - Allows registration and unregistration of endpoint providers.
- * - Provides a way to retrieve a specific endpoint provider by its EndpointId.
- * - Offers an iterator to traverse all registered endpoint providers.
- *
- * Lifetime Management:
- * - The registry stores raw pointers to EndpointProviderInterface and EndpointProviderRegistration objects.
- * - It does NOT take ownership of these objects.
- * - Callers MUST ensure that any registered EndpointProviderInterface and its corresponding
- *   EndpointProviderRegistration object outlive the EndpointProviderRegistry or are unregistered
- *   before being destroyed.
- */
-class EndpointProviderRegistry
-{
-public:
-    class Iterator
-    {
-    public:
-        explicit Iterator(EndpointProviderRegistration * registration) : mCurrent(registration) {}
-
-        Iterator & operator++()
+        constexpr EndpointProviderRegistration(EndpointProviderInterface & interface,
+            EndpointProviderRegistration * next_item = nullptr)
+            : endpointProviderInterface(&interface)
+            , next(next_item)
         {
-            mCurrent = (mCurrent ? mCurrent->next : nullptr);
-            return *this;
         }
-        bool operator==(const Iterator & other) const { return mCurrent == other.mCurrent; }
-        bool operator!=(const Iterator & other) const { return mCurrent != other.mCurrent; }
-        EndpointProviderInterface * operator*() { return mCurrent->endpointProviderInterface; }
-        EndpointProviderInterface * operator->() { return mCurrent->endpointProviderInterface; }
+        EndpointProviderRegistration(EndpointProviderRegistration && other) = default;
 
-    private:
-        EndpointProviderRegistration * mCurrent;
+        EndpointProviderRegistration(const EndpointProviderRegistration & other) = delete;
+        EndpointProviderRegistration & operator=(const EndpointProviderRegistration & other) = delete;
     };
 
     /**
-     * @brief Registers an endpoint provider.
+     * @brief Manages a collection of EndpointProviderInterface instances.
      *
-     * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
-     * (i.e., `entry.next` must be nullptr). The EndpointProviderInterface within the entry must
-     * be valid and have a valid EndpointId.
+     * The EndpointProviderRegistry can be used to discover and interact programmatically
+     * with Matter endpoints. It maintains a linked list of EndpointProviderRegistration
+     * objects.
      *
-     * @param entry The EndpointProviderRegistration containing the provider to register.
-     *              The lifetime of this object must be managed by the caller.
-     * @return CHIP_NO_ERROR on success.
-     *         CHIP_ERROR_INVALID_ARGUMENT if entry.next is not nullptr,
-     *                                     entry.endpointProviderInterface is nullptr,
-     *                                     or the endpoint ID is kInvalidEndpointId.
-     *         CHIP_ERROR_DUPLICATE_KEY_ID if an endpoint with the same ID is already registered.
+     * Responsibilities:
+     * - Allows registration and unregistration of endpoint providers.
+     * - Provides a way to retrieve a specific endpoint provider by its EndpointId.
+     * - Offers an iterator to traverse all registered endpoint providers.
+     *
+     * Lifetime Management:
+     * - The registry stores raw pointers to EndpointProviderInterface and EndpointProviderRegistration objects.
+     * - It does NOT take ownership of these objects.
+     * - Callers MUST ensure that any registered EndpointProviderInterface and its corresponding
+     *   EndpointProviderRegistration object outlive the EndpointProviderRegistry or are unregistered
+     *   before being destroyed.
      */
-    CHIP_ERROR Register(EndpointProviderRegistration & entry);
+    class EndpointProviderRegistry {
+    public:
+        class Iterator {
+        public:
+            explicit Iterator(EndpointProviderRegistration * registration)
+                : mCurrent(registration)
+            {
+            }
 
-    /**
-     * @brief Unregisters an endpoint provider with the given EndpointId.
-     * @param endpointId The ID of the endpoint provider to unregister.
-     * @return CHIP_NO_ERROR on success.
-     *         CHIP_ERROR_NOT_FOUND if no provider with the given ID is found.
-     *         CHIP_ERROR_INVALID_ARGUMENT if endpointId is kInvalidEndpointId.
-     */
-    CHIP_ERROR Unregister(EndpointId endpointId);
+            Iterator & operator++()
+            {
+                mCurrent = (mCurrent ? mCurrent->next : nullptr);
+                return *this;
+            }
+            bool operator==(const Iterator & other) const { return mCurrent == other.mCurrent; }
+            bool operator!=(const Iterator & other) const { return mCurrent != other.mCurrent; }
+            EndpointProviderInterface * operator*() { return mCurrent->endpointProviderInterface; }
+            EndpointProviderInterface * operator->() { return mCurrent->endpointProviderInterface; }
 
-    /** @return A pointer to the EndpointProviderInterface for the given endpointId, or nullptr if not found. */
-    EndpointProviderInterface * Get(EndpointId endpointId);
-    Iterator begin() { return Iterator(mRegistrations); }
-    Iterator end() { return Iterator(nullptr); }
+        private:
+            EndpointProviderRegistration * mCurrent;
+        };
 
-private:
-    EndpointProviderRegistration * mRegistrations = nullptr;
-    EndpointProviderInterface * mCachedInterface  = nullptr;
-    EndpointId mCachedEndpointId                  = kInvalidEndpointId;
-};
+        /**
+         * @brief Registers an endpoint provider.
+         *
+         * The provided `entry` (EndpointProviderRegistration) must not already be part of another list
+         * (i.e., `entry.next` must be nullptr). The EndpointProviderInterface within the entry must
+         * be valid and have a valid EndpointId.
+         *
+         * @param entry The EndpointProviderRegistration containing the provider to register.
+         *              The lifetime of this object must be managed by the caller.
+         * @return CHIP_NO_ERROR on success.
+         *         CHIP_ERROR_INVALID_ARGUMENT if entry.next is not nullptr,
+         *                                     entry.endpointProviderInterface is nullptr,
+         *                                     or the endpoint ID is kInvalidEndpointId.
+         *         CHIP_ERROR_DUPLICATE_KEY_ID if an endpoint with the same ID is already registered.
+         */
+        CHIP_ERROR Register(EndpointProviderRegistration & entry);
+
+        /**
+         * @brief Unregisters an endpoint provider with the given EndpointId.
+         * @param endpointId The ID of the endpoint provider to unregister.
+         * @return CHIP_NO_ERROR on success.
+         *         CHIP_ERROR_NOT_FOUND if no provider with the given ID is found.
+         *         CHIP_ERROR_INVALID_ARGUMENT if endpointId is kInvalidEndpointId.
+         */
+        CHIP_ERROR Unregister(EndpointId endpointId);
+
+        /** @return A pointer to the EndpointProviderInterface for the given endpointId, or nullptr if not found. */
+        EndpointProviderInterface * Get(EndpointId endpointId);
+        Iterator begin() { return Iterator(mRegistrations); }
+        Iterator end() { return Iterator(nullptr); }
+
+    private:
+        EndpointProviderRegistration * mRegistrations = nullptr;
+        EndpointProviderInterface * mCachedInterface = nullptr;
+        EndpointId mCachedEndpointId = kInvalidEndpointId;
+    };
 
 } // namespace app
 } // namespace chip

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
@@ -132,8 +132,8 @@ SpanEndpointProvider::SpanEndpointProvider(EndpointId id, DataModel::EndpointCom
                                            Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
                                            Span<const SemanticTag> semanticTags,
                                            Span<const DataModel::DeviceTypeEntry> deviceTypes) :
-    mEndpointEntry({ id, parentId, composition }), mDeviceTypes(deviceTypes), mSemanticTags(semanticTags),
-    mClientClusters(clientClusters), mServerClusters(serverClusters)
+    mEndpointEntry({ id, parentId, composition }),
+    mDeviceTypes(deviceTypes), mSemanticTags(semanticTags), mClientClusters(clientClusters), mServerClusters(serverClusters)
 {}
 
 } // namespace app

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
@@ -131,8 +131,8 @@ SpanEndpointProvider::SpanEndpointProvider(EndpointId id, DataModel::EndpointCom
                                            Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
                                            Span<const SemanticTag> semanticTags,
                                            Span<const DataModel::DeviceTypeEntry> deviceTypes) :
-    mEndpointEntry({ id, parentId, composition }), mDeviceTypes(deviceTypes), mSemanticTags(semanticTags),
-    mClientClusters(clientClusters), mServerClusters(serverClusters)
+    mEndpointEntry({ id, parentId, composition }),
+    mDeviceTypes(deviceTypes), mSemanticTags(semanticTags), mClientClusters(clientClusters), mServerClusters(serverClusters)
 {}
 
 } // namespace app

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
@@ -1,0 +1,140 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include "SpanEndpointProvider.h"
+
+#include <app/ConcreteClusterPath.h>
+#include <app/server-cluster/ServerClusterContext.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/Span.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+namespace chip {
+namespace app {
+
+// Builder implementation
+SpanEndpointProvider::Builder::Builder(EndpointId id) : mEndpointId(id) {}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetComposition(DataModel::EndpointCompositionPattern composition)
+{
+    mComposition = composition;
+    return *this;
+}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetParentId(EndpointId parentId)
+{
+    mParentId = parentId;
+    return *this;
+}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetServerClusters(Span<ServerClusterInterface *> serverClusters)
+{
+    mServerClusters = serverClusters;
+    return *this;
+}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetClientClusters(Span<const ClusterId> clientClusters)
+{
+    mClientClusters = clientClusters;
+    return *this;
+}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetSemanticTags(Span<const SemanticTag> semanticTags)
+{
+    mSemanticTags = semanticTags;
+    return *this;
+}
+
+SpanEndpointProvider::Builder & SpanEndpointProvider::Builder::SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes)
+{
+    mDeviceTypes = deviceTypes;
+    return *this;
+}
+
+std::pair<SpanEndpointProvider, CHIP_ERROR> SpanEndpointProvider::Builder::build()
+{
+    if (mEndpointId == kInvalidEndpointId)
+    {
+        return { SpanEndpointProvider(), CHIP_ERROR_INVALID_ARGUMENT };
+    }
+
+    for (auto * cluster : mServerClusters)
+    {
+        if (cluster == nullptr || cluster->GetPaths().empty())
+        {
+            ChipLogError(DataManagement, "Builder: Attempted to build with an invalid server cluster entry.");
+            return { SpanEndpointProvider(), CHIP_ERROR_INVALID_ARGUMENT };
+        }
+    }
+
+    return { SpanEndpointProvider(mEndpointId, mComposition, mParentId, mServerClusters, mClientClusters, mSemanticTags,
+                                  mDeviceTypes),
+             CHIP_NO_ERROR };
+}
+
+// SpanEndpointProvider implementation
+SpanEndpointProvider::SpanEndpointProvider() :
+    mEndpointEntry({ kInvalidEndpointId, kInvalidEndpointId, DataModel::EndpointCompositionPattern::kFullFamily })
+// Other members are default-initialzed (empty spans)
+{}
+
+CHIP_ERROR
+SpanEndpointProvider::SemanticTags(
+    ReadOnlyBufferBuilder<chip::app::Clusters::Descriptor::Structs::SemanticTagStruct::Type> & out) const
+{
+    return out.ReferenceExisting(mSemanticTags);
+}
+
+CHIP_ERROR SpanEndpointProvider::DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const
+{
+    return out.ReferenceExisting(mDeviceTypes);
+}
+
+CHIP_ERROR SpanEndpointProvider::ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const
+{
+    return out.ReferenceExisting(mClientClusters);
+}
+
+ServerClusterInterface * SpanEndpointProvider::GetServerCluster(ClusterId clusterId) const
+{
+    for (auto * serverCluster : mServerClusters)
+    {
+        // Check serverCluster is not null before dereferencing
+        if (serverCluster != nullptr && !serverCluster->GetPaths().empty() &&
+            serverCluster->GetPaths().front().mClusterId == clusterId)
+        {
+            return serverCluster;
+        }
+    }
+    return nullptr;
+}
+
+CHIP_ERROR SpanEndpointProvider::ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const
+{
+    return out.ReferenceExisting(mServerClusters);
+}
+
+// Private constructor for Builder
+SpanEndpointProvider::SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
+                                           Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
+                                           Span<const SemanticTag> semanticTags,
+                                           Span<const DataModel::DeviceTypeEntry> deviceTypes) :
+    mEndpointEntry({ id, parentId, composition }), mDeviceTypes(deviceTypes), mSemanticTags(semanticTags),
+    mClientClusters(clientClusters), mServerClusters(serverClusters)
+{}
+
+} // namespace app
+} // namespace chip

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.cpp
@@ -139,8 +139,8 @@ SpanEndpointProvider::SpanEndpointProvider(EndpointId id, DataModel::EndpointCom
                                            Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
                                            Span<const SemanticTag> semanticTags,
                                            Span<const DataModel::DeviceTypeEntry> deviceTypes) :
-    mEndpointEntry({ id, parentId, composition }), mDeviceTypes(deviceTypes), mSemanticTags(semanticTags),
-    mClientClusters(clientClusters), mServerClusters(serverClusters)
+    mEndpointEntry({ id, parentId, composition }),
+    mDeviceTypes(deviceTypes), mSemanticTags(semanticTags), mClientClusters(clientClusters), mServerClusters(serverClusters)
 {}
 
 } // namespace app

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.h
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.h
@@ -27,87 +27,89 @@
 namespace chip {
 namespace app {
 
-    /**
-     * @brief An implementation of EndpointProviderInterface that uses `chip::Span` to refer to its data.
-     *
-     * This provider is constructed using its `Builder` class. It stores `chip::Span` members that
-     * point to externally managed arrays for its configuration (device types, server/client clusters,
-     * semantic tags, etc.).
-     *
-     * @warning Lifetime of Span-Referenced Data:
-     * `SpanEndpointProvider` does NOT take ownership of the data arrays referenced by its
-     * internal `chip::Span` members. The caller who provides these Spans (usually via the
-     * `Builder`) MUST ensure that the underlying data remains valid for the entire lifetime
-     * of the `SpanEndpointProvider` instance.
-     *   - For `Span<T>` (e.g., `Span<const ClusterId>`, `Span<const DeviceTypeEntry>`), the
-     *     array of `T` elements must outlive the `SpanEndpointProvider`.
-     *   - For `Span<T*>` (e.g., `Span<ServerClusterInterface *>`), both the array of pointers
-     *     (`T*`) and the objects (`T`) pointed to by those pointers must outlive the
-     *     `SpanEndpointProvider`.
-     * Failure to adhere to these lifetime requirements will lead to undefined behavior.
-     */
-    class SpanEndpointProvider : public EndpointProviderInterface {
+/**
+ * @brief An implementation of EndpointProviderInterface that uses `chip::Span` to refer to its data.
+ *
+ * This provider is constructed using its `Builder` class. It stores `chip::Span` members that
+ * point to externally managed arrays for its configuration (device types, server/client clusters,
+ * semantic tags, etc.).
+ *
+ * @warning Lifetime of Span-Referenced Data:
+ * `SpanEndpointProvider` does NOT take ownership of the data arrays referenced by its
+ * internal `chip::Span` members. The caller who provides these Spans (usually via the
+ * `Builder`) MUST ensure that the underlying data remains valid for the entire lifetime
+ * of the `SpanEndpointProvider` instance.
+ *   - For `Span<T>` (e.g., `Span<const ClusterId>`, `Span<const DeviceTypeEntry>`), the
+ *     array of `T` elements must outlive the `SpanEndpointProvider`.
+ *   - For `Span<T*>` (e.g., `Span<ServerClusterInterface *>`), both the array of pointers
+ *     (`T*`) and the objects (`T`) pointed to by those pointers must outlive the
+ *     `SpanEndpointProvider`.
+ * Failure to adhere to these lifetime requirements will lead to undefined behavior.
+ */
+class SpanEndpointProvider : public EndpointProviderInterface
+{
+public:
+    class Builder
+    {
     public:
-        class Builder {
-        public:
-            explicit Builder(EndpointId id);
+        explicit Builder(EndpointId id);
 
-            Builder & SetComposition(DataModel::EndpointCompositionPattern composition);
-            Builder & SetParentId(EndpointId parentId);
-            Builder & SetServerClusters(Span<ServerClusterInterface *> serverClusters);
-            Builder & SetClientClusters(Span<const ClusterId> clientClusters);
-            Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
-            Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
+        Builder & SetComposition(DataModel::EndpointCompositionPattern composition);
+        Builder & SetParentId(EndpointId parentId);
+        Builder & SetServerClusters(Span<ServerClusterInterface *> serverClusters);
+        Builder & SetClientClusters(Span<const ClusterId> clientClusters);
+        Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
+        Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
 
-            // Builds the SpanEndpointProvider.
-            // Returns a std::variant containing either the successfully built SpanEndpointProvider
-            // or a CHIP_ERROR if the build failed (e.g., due to invalid arguments).
-            // Callers should check the variant's active alternative before use.
-            std::variant<SpanEndpointProvider, CHIP_ERROR> build();
-
-        private:
-            EndpointId mEndpointId;
-            DataModel::EndpointCompositionPattern mComposition = DataModel::EndpointCompositionPattern::kFullFamily;
-            EndpointId mParentId = kInvalidEndpointId;
-            Span<ServerClusterInterface *> mServerClusters;
-            Span<const ClusterId> mClientClusters;
-            Span<const SemanticTag> mSemanticTags;
-            Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
-        };
-
-        ~SpanEndpointProvider() override = default;
-
-        // Delete copy and move constructors and assignment operators
-        SpanEndpointProvider(const SpanEndpointProvider &) = delete;
-        SpanEndpointProvider & operator=(const SpanEndpointProvider &) = delete;
-        SpanEndpointProvider(SpanEndpointProvider &&) = default; // Allow move
-        SpanEndpointProvider & operator=(SpanEndpointProvider &&) = default; // Allow move
-
-        const DataModel::EndpointEntry & GetEndpointEntry() const override { return mEndpointEntry; }
-
-        // Iteration methods
-        CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
-        CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
-        CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
-
-        // Getter for ServerClusterInterface, returns nullptr if the cluster is not found.
-        ServerClusterInterface * GetServerCluster(ClusterId clusterId) const override;
-        CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const override;
+        // Builds the SpanEndpointProvider.
+        // Returns a std::variant containing either the successfully built SpanEndpointProvider
+        // or a CHIP_ERROR if the build failed (e.g., due to invalid arguments).
+        // Callers should check the variant's active alternative before use.
+        std::variant<SpanEndpointProvider, CHIP_ERROR> build();
 
     private:
-        // Private constructor for Builder
-        SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
-            Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
-            Span<const SemanticTag> semanticTags, Span<const DataModel::DeviceTypeEntry> deviceTypes);
-
-        // Iteration methods
-        // GetEndpointEntry is already public
-        DataModel::EndpointEntry mEndpointEntry;
-        Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
-        Span<const SemanticTag> mSemanticTags;
-        Span<const ClusterId> mClientClusters;
+        EndpointId mEndpointId;
+        DataModel::EndpointCompositionPattern mComposition = DataModel::EndpointCompositionPattern::kFullFamily;
+        EndpointId mParentId                               = kInvalidEndpointId;
         Span<ServerClusterInterface *> mServerClusters;
+        Span<const ClusterId> mClientClusters;
+        Span<const SemanticTag> mSemanticTags;
+        Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
     };
+
+    ~SpanEndpointProvider() override = default;
+
+    // Delete copy and move constructors and assignment operators
+    SpanEndpointProvider(const SpanEndpointProvider &)             = delete;
+    SpanEndpointProvider & operator=(const SpanEndpointProvider &) = delete;
+    SpanEndpointProvider(SpanEndpointProvider &&)                  = default; // Allow move
+    SpanEndpointProvider & operator=(SpanEndpointProvider &&)      = default; // Allow move
+
+    const DataModel::EndpointEntry & GetEndpointEntry() const override { return mEndpointEntry; }
+
+    // Iteration methods
+    CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
+    CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
+    CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
+
+    // Getter for ServerClusterInterface, returns nullptr if the cluster is not found.
+    ServerClusterInterface * GetServerCluster(ClusterId clusterId) const override;
+    CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const override;
+
+private:
+    // Private constructor for Builder
+    SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
+                         Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
+                         Span<const SemanticTag> semanticTags, Span<const DataModel::DeviceTypeEntry> deviceTypes);
+
+    // Iteration methods
+    // GetEndpointEntry is already public
+    DataModel::EndpointEntry mEndpointEntry;
+    Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
+    Span<const SemanticTag> mSemanticTags;
+    Span<const ClusterId> mClientClusters;
+    Span<ServerClusterInterface *> mServerClusters;
+};
 
 } // namespace app
 } // namespace chip

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.h
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.h
@@ -27,93 +27,87 @@
 namespace chip {
 namespace app {
 
-/**
- * @brief An implementation of EndpointProviderInterface that uses `chip::Span` to refer to its data.
- *
- * This provider is constructed using its `Builder` class. It stores `chip::Span` members that
- * point to externally managed arrays for its configuration (device types, server/client clusters,
- * semantic tags, etc.).
- *
- * @warning Lifetime of Span-Referenced Data:
- * `SpanEndpointProvider` does NOT take ownership of the data arrays referenced by its
- * internal `chip::Span` members. The caller who provides these Spans (usually via the
- * `Builder`) MUST ensure that the underlying data remains valid for the entire lifetime
- * of the `SpanEndpointProvider` instance.
- *   - For `Span<T>` (e.g., `Span<const ClusterId>`, `Span<const DeviceTypeEntry>`), the
- *     array of `T` elements must outlive the `SpanEndpointProvider`.
- *   - For `Span<T*>` (e.g., `Span<ServerClusterInterface *>`), both the array of pointers
- *     (`T*`) and the objects (`T`) pointed to by those pointers must outlive the
- *     `SpanEndpointProvider`.
- * Failure to adhere to these lifetime requirements will lead to undefined behavior.
- */
-class SpanEndpointProvider : public EndpointProviderInterface
-{
-public:
-    class Builder
-    {
+    /**
+     * @brief An implementation of EndpointProviderInterface that uses `chip::Span` to refer to its data.
+     *
+     * This provider is constructed using its `Builder` class. It stores `chip::Span` members that
+     * point to externally managed arrays for its configuration (device types, server/client clusters,
+     * semantic tags, etc.).
+     *
+     * @warning Lifetime of Span-Referenced Data:
+     * `SpanEndpointProvider` does NOT take ownership of the data arrays referenced by its
+     * internal `chip::Span` members. The caller who provides these Spans (usually via the
+     * `Builder`) MUST ensure that the underlying data remains valid for the entire lifetime
+     * of the `SpanEndpointProvider` instance.
+     *   - For `Span<T>` (e.g., `Span<const ClusterId>`, `Span<const DeviceTypeEntry>`), the
+     *     array of `T` elements must outlive the `SpanEndpointProvider`.
+     *   - For `Span<T*>` (e.g., `Span<ServerClusterInterface *>`), both the array of pointers
+     *     (`T*`) and the objects (`T`) pointed to by those pointers must outlive the
+     *     `SpanEndpointProvider`.
+     * Failure to adhere to these lifetime requirements will lead to undefined behavior.
+     */
+    class SpanEndpointProvider : public EndpointProviderInterface {
     public:
-        explicit Builder(EndpointId id);
+        class Builder {
+        public:
+            explicit Builder(EndpointId id);
 
-        Builder & SetComposition(DataModel::EndpointCompositionPattern composition);
-        Builder & SetParentId(EndpointId parentId);
-        Builder & SetServerClusters(Span<ServerClusterInterface *> serverClusters);
-        Builder & SetClientClusters(Span<const ClusterId> clientClusters);
-        Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
-        Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
+            Builder & SetComposition(DataModel::EndpointCompositionPattern composition);
+            Builder & SetParentId(EndpointId parentId);
+            Builder & SetServerClusters(Span<ServerClusterInterface *> serverClusters);
+            Builder & SetClientClusters(Span<const ClusterId> clientClusters);
+            Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
+            Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
 
-        // Builds the SpanEndpointProvider.
-        // Returns a std::variant containing either the successfully built SpanEndpointProvider
-        // or a CHIP_ERROR if the build failed (e.g., due to invalid arguments).
-        // Callers should check the variant's active alternative before use.
-        std::variant<SpanEndpointProvider, CHIP_ERROR> build();
+            // Builds the SpanEndpointProvider.
+            // Returns a std::variant containing either the successfully built SpanEndpointProvider
+            // or a CHIP_ERROR if the build failed (e.g., due to invalid arguments).
+            // Callers should check the variant's active alternative before use.
+            std::variant<SpanEndpointProvider, CHIP_ERROR> build();
+
+        private:
+            EndpointId mEndpointId;
+            DataModel::EndpointCompositionPattern mComposition = DataModel::EndpointCompositionPattern::kFullFamily;
+            EndpointId mParentId = kInvalidEndpointId;
+            Span<ServerClusterInterface *> mServerClusters;
+            Span<const ClusterId> mClientClusters;
+            Span<const SemanticTag> mSemanticTags;
+            Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
+        };
+
+        ~SpanEndpointProvider() override = default;
+
+        // Delete copy and move constructors and assignment operators
+        SpanEndpointProvider(const SpanEndpointProvider &) = delete;
+        SpanEndpointProvider & operator=(const SpanEndpointProvider &) = delete;
+        SpanEndpointProvider(SpanEndpointProvider &&) = default; // Allow move
+        SpanEndpointProvider & operator=(SpanEndpointProvider &&) = default; // Allow move
+
+        const DataModel::EndpointEntry & GetEndpointEntry() const override { return mEndpointEntry; }
+
+        // Iteration methods
+        CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
+        CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
+        CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
+
+        // Getter for ServerClusterInterface, returns nullptr if the cluster is not found.
+        ServerClusterInterface * GetServerCluster(ClusterId clusterId) const override;
+        CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const override;
 
     private:
-        EndpointId mEndpointId;
-        DataModel::EndpointCompositionPattern mComposition = DataModel::EndpointCompositionPattern::kFullFamily;
-        EndpointId mParentId                               = kInvalidEndpointId;
-        Span<ServerClusterInterface *> mServerClusters;
-        Span<const ClusterId> mClientClusters;
-        Span<const SemanticTag> mSemanticTags;
+        // Private constructor for Builder
+        SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
+            Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
+            Span<const SemanticTag> semanticTags, Span<const DataModel::DeviceTypeEntry> deviceTypes);
+
+        // Iteration methods
+        // GetEndpointEntry is already public
+        DataModel::EndpointEntry mEndpointEntry;
         Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
+        Span<const SemanticTag> mSemanticTags;
+        Span<const ClusterId> mClientClusters;
+        Span<ServerClusterInterface *> mServerClusters;
     };
-
-    // Default constructor is private, use Builder.
-
-    ~SpanEndpointProvider() override = default;
-
-    // Delete copy and move constructors and assignment operators
-    SpanEndpointProvider(const SpanEndpointProvider &)             = delete;
-    SpanEndpointProvider & operator=(const SpanEndpointProvider &) = delete;
-    SpanEndpointProvider(SpanEndpointProvider &&)                  = default; // Allow move
-    SpanEndpointProvider & operator=(SpanEndpointProvider &&)      = default; // Allow move
-
-    const DataModel::EndpointEntry & GetEndpointEntry() const override { return mEndpointEntry; }
-
-    // Iteration methods
-    CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
-    CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
-    CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
-
-    // Getter for ServerClusterInterface, returns nullptr if the cluster is not found.
-    ServerClusterInterface * GetServerCluster(ClusterId clusterId) const override;
-    CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const override;
-
-private:
-    SpanEndpointProvider(); // Used by Builder for error cases
-
-    // Private constructor for Builder
-    SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
-                         Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
-                         Span<const SemanticTag> semanticTags, Span<const DataModel::DeviceTypeEntry> deviceTypes);
-
-    // Iteration methods
-    // GetEndpointEntry is already public
-    DataModel::EndpointEntry mEndpointEntry;
-    Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
-    Span<const SemanticTag> mSemanticTags;
-    Span<const ClusterId> mClientClusters;
-    Span<ServerClusterInterface *> mServerClusters;
-};
 
 } // namespace app
 } // namespace chip

--- a/src/data-model-providers/endpoint/SpanEndpointProvider.h
+++ b/src/data-model-providers/endpoint/SpanEndpointProvider.h
@@ -1,0 +1,100 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/data-model-provider/MetadataTypes.h>
+#include <app/server-cluster/ServerClusterInterface.h>
+#include <data-model-providers/endpoint/EndpointProviderInterface.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/Span.h>
+
+#include <utility> // For std::pair
+
+namespace chip {
+namespace app {
+
+class SpanEndpointProvider : public EndpointProviderInterface
+{
+public:
+    class Builder
+    {
+    public:
+        explicit Builder(EndpointId id);
+
+        Builder & SetComposition(DataModel::EndpointCompositionPattern composition);
+        Builder & SetParentId(EndpointId parentId);
+        Builder & SetServerClusters(Span<ServerClusterInterface *> serverClusters);
+        Builder & SetClientClusters(Span<const ClusterId> clientClusters);
+        Builder & SetSemanticTags(Span<const SemanticTag> semanticTags);
+        Builder & SetDeviceTypes(Span<const DataModel::DeviceTypeEntry> deviceTypes);
+
+        // Builds the SpanEndpointProvider.
+        // Returns a pair containing the provider and a CHIP_ERROR status.
+        // If an error occurs during build (e.g. invalid arguments), the error status will be set,
+        // and the returned provider will be in a default/invalid state.
+        std::pair<SpanEndpointProvider, CHIP_ERROR> build();
+
+    private:
+        EndpointId mEndpointId;
+        DataModel::EndpointCompositionPattern mComposition = DataModel::EndpointCompositionPattern::kFullFamily;
+        EndpointId mParentId                               = kInvalidEndpointId;
+        Span<ServerClusterInterface *> mServerClusters;
+        Span<const ClusterId> mClientClusters;
+        Span<const SemanticTag> mSemanticTags;
+        Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
+    };
+
+    // Default constructor is private, use Builder.
+
+    ~SpanEndpointProvider() override = default;
+
+    // Delete copy and move constructors and assignment operators
+    SpanEndpointProvider(const SpanEndpointProvider &)             = delete;
+    SpanEndpointProvider & operator=(const SpanEndpointProvider &) = delete;
+    SpanEndpointProvider(SpanEndpointProvider &&)                  = default; // Allow move
+    SpanEndpointProvider & operator=(SpanEndpointProvider &&)      = default; // Allow move
+
+    const DataModel::EndpointEntry & GetEndpointEntry() const override { return mEndpointEntry; }
+
+    // Iteration methods
+    CHIP_ERROR SemanticTags(ReadOnlyBufferBuilder<SemanticTag> & out) const override;
+    CHIP_ERROR DeviceTypes(ReadOnlyBufferBuilder<DataModel::DeviceTypeEntry> & out) const override;
+    CHIP_ERROR ClientClusters(ReadOnlyBufferBuilder<ClusterId> & out) const override;
+
+    // Getter for ServerClusterInterface, returns nullptr if the cluster is not found.
+    ServerClusterInterface * GetServerCluster(ClusterId clusterId) const override;
+    CHIP_ERROR ServerClusterInterfaces(ReadOnlyBufferBuilder<ServerClusterInterface *> & out) const override;
+
+private:
+    SpanEndpointProvider(); // Used by Builder for error cases
+
+    // Private constructor for Builder
+    SpanEndpointProvider(EndpointId id, DataModel::EndpointCompositionPattern composition, EndpointId parentId,
+                         Span<ServerClusterInterface *> serverClusters, Span<const ClusterId> clientClusters,
+                         Span<const SemanticTag> semanticTags, Span<const DataModel::DeviceTypeEntry> deviceTypes);
+
+    // Iteration methods
+    // GetEndpointEntry is already public
+    DataModel::EndpointEntry mEndpointEntry;
+    Span<const DataModel::DeviceTypeEntry> mDeviceTypes;
+    Span<const SemanticTag> mSemanticTags;
+    Span<const ClusterId> mClientClusters;
+    Span<ServerClusterInterface *> mServerClusters;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/data-model-providers/endpoint/tests/BUILD.gn
+++ b/src/data-model-providers/endpoint/tests/BUILD.gn
@@ -25,6 +25,7 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
 
   public_deps = [
+    "${chip_root}/src/app/clusters/descriptor",
     "${chip_root}/src/app/data-model-provider:string-builder-adapters",
     "${chip_root}/src/app/server-cluster/testing",
     "${chip_root}/src/data-model-providers/endpoint",

--- a/src/data-model-providers/endpoint/tests/BUILD.gn
+++ b/src/data-model-providers/endpoint/tests/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libEndpointProviderTests"
+
+  test_sources = [
+    "TestEndpointProviderRegistry.cpp",
+    "TestSpanEndpointProvider.cpp",
+  ]
+
+  cflags = [ "-Wconversion" ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model-provider:string-builder-adapters",
+    "${chip_root}/src/app/server-cluster/testing",
+    "${chip_root}/src/data-model-providers/endpoint",
+  ]
+}

--- a/src/data-model-providers/endpoint/tests/TestEndpointProviderRegistry.cpp
+++ b/src/data-model-providers/endpoint/tests/TestEndpointProviderRegistry.cpp
@@ -1,0 +1,319 @@
+/*
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <pw_unit_test/framework.h>
+
+#include <app/data-model-provider/MetadataTypes.h>
+#include <data-model-providers/endpoint/EndpointProviderRegistry.h>
+#include <data-model-providers/endpoint/SpanEndpointProvider.h>
+
+#include <algorithm> // For std::shuffle
+#include <list>      // For std::list in stress test
+#include <random>    // For std::default_random_engine
+#include <vector>    // For std::vector in stress test
+using namespace chip;
+using namespace chip::app;
+
+TEST(TestEndpointProviderRegistry, CreateAndDestroy)
+{
+    EndpointProviderRegistry registry;
+
+    // Create a provider
+    auto build_pair_provider =
+        SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair_provider.second, CHIP_NO_ERROR);
+    auto provider = std::make_unique<SpanEndpointProvider>(std::move(build_pair_provider.first));
+    ASSERT_NE(provider, nullptr);
+    EndpointProviderInterface * provider_ptr = provider.get(); // Save raw pointer for comparison
+
+    // Register it
+    EndpointProviderRegistration registration(*provider);
+    ASSERT_EQ(registry.Register(registration), CHIP_NO_ERROR);
+
+    // Check if it can be retrieved
+    ASSERT_EQ(registry.Get(1), provider_ptr);
+
+    // Unregister the provider
+    ASSERT_EQ(registry.Unregister(1), CHIP_NO_ERROR);
+
+    // Destroy the provider
+    provider.reset();
+
+    // Check if it is no longer retrievable
+    // After unregistering, Get(1) should return nullptr.
+    ASSERT_EQ(registry.Get(1), nullptr);
+}
+
+TEST(TestEndpointProviderRegistry, RegisterMultipleProviders)
+{
+    EndpointProviderRegistry registry;
+
+    auto build_pair1 = SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair1.second, CHIP_NO_ERROR);
+    auto provider1 = std::make_unique<SpanEndpointProvider>(std::move(build_pair1.first));
+
+    auto build_pair2 = SpanEndpointProvider::Builder(2).SetComposition(DataModel::EndpointCompositionPattern::kTree).build();
+    ASSERT_EQ(build_pair2.second, CHIP_NO_ERROR);
+    auto provider2 = std::make_unique<SpanEndpointProvider>(std::move(build_pair2.first));
+    ASSERT_NE(provider1, nullptr);
+    ASSERT_NE(provider2, nullptr);
+
+    EndpointProviderRegistration registration1(*provider1);
+    EndpointProviderRegistration registration2(*provider2);
+
+    ASSERT_EQ(registry.Register(registration1), CHIP_NO_ERROR);
+    ASSERT_EQ(registry.Register(registration2), CHIP_NO_ERROR);
+
+    ASSERT_EQ(registry.Get(1), provider1.get());
+    ASSERT_EQ(registry.Get(2), provider2.get());
+    ASSERT_EQ(registry.Count(), 2u);
+
+    ASSERT_EQ(registry.Unregister(1), CHIP_NO_ERROR);
+    ASSERT_EQ(registry.Get(1), nullptr);
+    ASSERT_EQ(registry.Get(2), provider2.get());
+    ASSERT_EQ(registry.Count(), 1u);
+
+    ASSERT_EQ(registry.Unregister(2), CHIP_NO_ERROR);
+    ASSERT_EQ(registry.Get(2), nullptr);
+    ASSERT_EQ(registry.Count(), 0u);
+}
+
+TEST(TestEndpointProviderRegistry, RegisterDuplicateProviderId)
+{
+    EndpointProviderRegistry registry;
+
+    auto build_pair1a = SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair1a.second, CHIP_NO_ERROR);
+    auto provider1a = std::make_unique<SpanEndpointProvider>(std::move(build_pair1a.first));
+
+    auto build_pair1b =
+        SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kTree).build(); // Same ID
+    ASSERT_EQ(build_pair1b.second, CHIP_NO_ERROR);
+    auto provider1b = std::make_unique<SpanEndpointProvider>(std::move(build_pair1b.first));
+    ASSERT_NE(provider1a, nullptr);
+    ASSERT_NE(provider1b, nullptr);
+
+    EndpointProviderRegistration registration1a(*provider1a);
+    EndpointProviderRegistration registration1b(*provider1b);
+
+    ASSERT_EQ(registry.Register(registration1a), CHIP_NO_ERROR);
+    ASSERT_EQ(registry.Get(1), provider1a.get());
+
+    // Attempt to register another provider with the same ID
+    ASSERT_EQ(registry.Register(registration1b), CHIP_ERROR_DUPLICATE_KEY_ID);
+    ASSERT_EQ(registry.Get(1), provider1a.get()); // Should still be the first one
+    ASSERT_EQ(registry.Count(), 1u);
+}
+
+TEST(TestEndpointProviderRegistry, RegisterSameRegistrationObject)
+{
+    EndpointProviderRegistry registry;
+    auto build_pair = SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair.second, CHIP_NO_ERROR);
+    auto provider = std::make_unique<SpanEndpointProvider>(std::move(build_pair.first));
+    ASSERT_NE(provider, nullptr);
+
+    EndpointProviderRegistration registration(*provider);
+    ASSERT_EQ(registry.Register(registration), CHIP_NO_ERROR);
+
+    // Attempt to register the exact same registration object again
+    ASSERT_EQ(registry.Register(registration), CHIP_ERROR_DUPLICATE_KEY_ID); // Because registration.next is no longer nullptr
+    ASSERT_EQ(registry.Count(), 1u);
+}
+
+TEST(TestEndpointProviderRegistry, UnregisterNonExistentProvider)
+{
+    EndpointProviderRegistry registry;
+    ASSERT_EQ(registry.Unregister(1), CHIP_ERROR_NOT_FOUND);
+
+    auto build_pair = SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair.second, CHIP_NO_ERROR);
+    auto provider = std::make_unique<SpanEndpointProvider>(std::move(build_pair.first));
+    ASSERT_NE(provider, nullptr);
+    EndpointProviderRegistration registration(*provider);
+    ASSERT_EQ(registry.Register(registration), CHIP_NO_ERROR);
+
+    ASSERT_EQ(registry.Unregister(2), CHIP_ERROR_NOT_FOUND); // Different ID
+    ASSERT_EQ(registry.Count(), 1u);
+}
+
+TEST(TestEndpointProviderRegistry, GetNonExistentProvider)
+{
+    EndpointProviderRegistry registry;
+    ASSERT_EQ(registry.Get(1), nullptr);
+}
+
+TEST(TestEndpointProviderRegistry, IteratorTest)
+{
+    EndpointProviderRegistry registry;
+
+    auto build_pair1 = SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair1.second, CHIP_NO_ERROR);
+    auto provider1 = std::make_unique<SpanEndpointProvider>(std::move(build_pair1.first));
+
+    auto build_pair2 = SpanEndpointProvider::Builder(2).SetComposition(DataModel::EndpointCompositionPattern::kTree).build();
+    ASSERT_EQ(build_pair2.second, CHIP_NO_ERROR);
+    auto provider2 = std::make_unique<SpanEndpointProvider>(std::move(build_pair2.first));
+    EndpointProviderRegistration registration1(*provider1);
+    EndpointProviderRegistration registration2(*provider2);
+
+    registry.Register(registration1);
+    registry.Register(registration2); // Registry stores in LIFO order for simple list prepend
+
+    size_t count = 0;
+    bool found1  = false;
+    bool found2  = false;
+    for (auto * ep : registry)
+    {
+        ASSERT_NE(ep, nullptr);
+        if (ep->GetEndpointEntry().id == 1)
+            found1 = true;
+        if (ep->GetEndpointEntry().id == 2)
+            found2 = true;
+        count++;
+    }
+    ASSERT_EQ(count, 2u);
+    ASSERT_TRUE(found1);
+    ASSERT_TRUE(found2);
+
+    // Test empty iteration
+    EndpointProviderRegistry emptyRegistry;
+    count = 0;
+    for (auto * ep : emptyRegistry)
+    {
+        (void) ep; // unused
+        count++;
+    }
+    ASSERT_EQ(count, 0u);
+}
+
+TEST(TestEndpointProviderRegistry, RegisterInvalidArgs)
+{
+    EndpointProviderRegistry registry;
+    auto build_pair_valid =
+        SpanEndpointProvider::Builder(1).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair_valid.second, CHIP_NO_ERROR);
+    auto providerValid = std::make_unique<SpanEndpointProvider>(std::move(build_pair_valid.first));
+    ASSERT_NE(providerValid, nullptr);
+
+    // Case 2: EndpointProviderInterface returns kInvalidEndpointId
+    auto build_pair_invalid = SpanEndpointProvider::Builder(kInvalidEndpointId).build();
+    ASSERT_NE(build_pair_invalid.second, CHIP_NO_ERROR); // Expecting an error for invalid ID
+    auto providerInvalidId = std::make_unique<SpanEndpointProvider>(std::move(build_pair_invalid.first));
+    ASSERT_NE(providerInvalidId, nullptr);
+    ASSERT_EQ(providerInvalidId->GetEndpointEntry().id, kInvalidEndpointId);
+    EndpointProviderRegistration registrationInvalidId(*providerInvalidId);
+    EXPECT_EQ(registry.Register(registrationInvalidId), CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Case 3: EndpointProviderRegistration already part of a list (entry.next != nullptr)
+    // To test this, we need two valid providers and registrations.
+    auto build_pair_list1 =
+        SpanEndpointProvider::Builder(10).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair_list1.second, CHIP_NO_ERROR);
+    auto providerForList1 = std::make_unique<SpanEndpointProvider>(std::move(build_pair_list1.first));
+    auto build_pair_list2 =
+        SpanEndpointProvider::Builder(11).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+    ASSERT_EQ(build_pair_list2.second, CHIP_NO_ERROR);
+    auto providerForList2 = std::make_unique<SpanEndpointProvider>(std::move(build_pair_list2.first));
+    EndpointProviderRegistration registrationInList1(*providerForList1);
+    EndpointProviderRegistration registrationInList2(*providerForList2);
+
+    // Manually link to simulate it being in another list
+    // This simulates registrationInList2 being part of a list where registrationInList1 is its successor.
+    registrationInList2.next = &registrationInList1;
+    EXPECT_EQ(registry.Register(registrationInList2), CHIP_ERROR_INVALID_ARGUMENT);
+    registrationInList2.next = nullptr; // Reset for other tests or cleanup
+
+    // Test that registering a valid provider after these failures still works
+    EndpointProviderRegistration registrationValid(*providerValid);
+    EXPECT_EQ(registry.Register(registrationValid), CHIP_NO_ERROR);
+    EXPECT_EQ(registry.Count(), 1u);
+    EXPECT_EQ(registry.Get(1), providerValid.get());
+}
+
+TEST(TestEndpointProviderRegistry, StressTestRegistration)
+{
+    constexpr int kNumProviders = 100;
+    EndpointProviderRegistry registry;
+    std::vector<std::unique_ptr<SpanEndpointProvider>> providers_storage; // Owns the providers
+    std::list<EndpointProviderRegistration> registrations;                // Owns the registration objects, stable addresses
+    std::vector<EndpointId> ids;
+
+    providers_storage.reserve(kNumProviders);
+    for (int i = 0; i < kNumProviders; ++i)
+    {
+        EndpointId id = static_cast<EndpointId>(i + 1);
+        auto build_pair =
+            SpanEndpointProvider::Builder(id).SetComposition(DataModel::EndpointCompositionPattern::kFullFamily).build();
+        ASSERT_EQ(build_pair.second, CHIP_NO_ERROR);
+        providers_storage.push_back(std::make_unique<SpanEndpointProvider>(std::move(build_pair.first)));
+        ids.push_back(id);
+        registrations.emplace_back(*providers_storage.back()); // Create registration from the provider
+    }
+
+    // Register all
+    auto reg_it = registrations.begin();
+    for (size_t i = 0; i < static_cast<size_t>(kNumProviders); ++i, ++reg_it)
+    {
+        ASSERT_EQ(registry.Register(*reg_it), CHIP_NO_ERROR) << "Failed to register provider with ID " << ids[i];
+    }
+    ASSERT_EQ(registry.Count(), static_cast<size_t>(kNumProviders));
+
+    // Verify all can be retrieved
+    std::vector<EndpointId> shuffled_ids = ids;
+    std::shuffle(shuffled_ids.begin(), shuffled_ids.end(), std::default_random_engine(0));
+    for (EndpointId id : shuffled_ids)
+    {
+        ASSERT_NE(registry.Get(id), nullptr) << "Failed to get provider with ID " << id;
+        ASSERT_EQ(registry.Get(id)->GetEndpointEntry().id, id);
+    }
+
+    // Unregister all in shuffled order
+    std::shuffle(shuffled_ids.begin(), shuffled_ids.end(), std::default_random_engine(1));
+    for (EndpointId id : shuffled_ids)
+    {
+        ASSERT_EQ(registry.Unregister(id), CHIP_NO_ERROR) << "Failed to unregister provider with ID " << id;
+        ASSERT_EQ(registry.Get(id), nullptr) << "Provider with ID " << id << " still found after unregistration";
+    }
+    ASSERT_EQ(registry.Count(), 0u);
+
+    // Re-register all
+    // Reset next pointers in registrations before re-registering
+    for (auto & reg : registrations)
+    {
+        reg.next = nullptr;
+    }
+    std::shuffle(shuffled_ids.begin(), shuffled_ids.end(), std::default_random_engine(2));
+    for (EndpointId id_to_register : shuffled_ids)
+    {
+        bool found_and_registered = false;
+        for (auto & reg : registrations)
+        { // Iterate through the list of registrations
+            if (reg.endpointProviderInterface->GetEndpointEntry().id == id_to_register)
+            {
+                ASSERT_EQ(registry.Register(reg), CHIP_NO_ERROR) << "Failed to re-register provider with ID " << id_to_register;
+                found_and_registered = true;
+                break;
+            }
+        }
+        ASSERT_TRUE(found_and_registered);
+    }
+    ASSERT_EQ(registry.Count(), static_cast<size_t>(kNumProviders));
+    for (EndpointId id : ids)
+    {
+        ASSERT_NE(registry.Get(id), nullptr) << "Failed to get provider with ID " << id << " after re-registration";
+    }
+}


### PR DESCRIPTION
#### Overview

This Pull Request (PR) is part of a series of PRs aimed at enabling a more dynamic approach to defining data models within the Matter SDK.

This specific PR, introduces an  `EndpointProviderInterface`, `EndpointProviderRegistry` and a SpanEndpointProvider` with accompanying unit tests.

The main goal of this PR is to enable a future `CodeDrivenDataModelProvider` to hold an `EndpointProviderRegistry` and manage multiple `EndpointProviderInterface` instances. Each `EndpointProviderInterface`, such as the `SpanEndpointProvider`, can be configured in code to define its metadata, device types, semantic tags and server/client clusters.

In a follow up PR, we'll introduce a ` CodeDrivenDataModelProvider` which will aggregate a collection of Endpoints as show in the following diagram:

```mermaid
graph TD
    subgraph "New Data Model Provider"
        CDDMP[CodeDrivenDataModelProvider]
        EPR[EndpointProviderRegistry]
    end

    subgraph "Endpoint Provisioning"
        EPI["EndpointProviderInterface (Interface)"]
        SEP[SpanEndpointProvider]
    end

    subgraph "Server Cluster Abstraction"
        SCI["ServerClusterInterface (Interface)"]
        CSC[CodegenServerCluster]
    end

    CDDMP -- "Uses" --> EPR;
    EPR -- "Manages 1..*" --> EPI;
    SEP -- "Implements" --> EPI;
    EPI -- "Provides 0..*" --> SCI;
    CSC -- "Implements (wraps Ember clusters)" --> SCI;

    style CDDMP fill:#f9f,stroke:#333,stroke-width:2px
    style EPR fill:#fbf,stroke:#333,stroke-width:2px
    style SEP fill:#ccf,stroke:#333,stroke-width:2px
    style CSC fill:#cfc,stroke:#333,stroke-width:2px
    style EPI fill:#eee,stroke:#333,stroke-width:1px,stroke-dasharray: 5 5
    style SCI fill:#eee,stroke:#333,stroke-width:1px,stroke-dasharray: 5 5

```

If you would like more context on how these things are stitched together. See the following PR in my private fork  https://github.com/soares-sergio/connectedhomeip/pull/3
I split it into 3 smaller PRs so it's easier to code review but you can see it all together there.

#### Testing

Unit tests included. Details on how to build and run those tests are as follows:

* `ninja -C out src/data-model-providers/codedriven/tests:TestEndpointProviderRegistry && ./out/tests/TestEndpointProviderRegistry`
* `ninja -C out src/data-model-providers/codedriven/tests:TestSpanEndpointProvider && ./out/tests/TestSpanEndpointProvider`

