### PR TITLE
Add a new gn argument, chip_ble_platform_config_include_override, to support building a platform with customized BLE header file.

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -264,6 +264,13 @@ if (_chip_device_layer != "none" && chip_device_platform != "external") {
 declare_args() {
   # Enable jlink/segger_rtt support.
   chip_enable_segger_rtt = chip_device_platform != "qpg"
+
+  # Override chip_ble_platform_config_include to support specific BLE dependency.
+  chip_ble_platform_config_override = ""
+}
+
+if (chip_ble_platform_config_override != "") {
+  chip_ble_platform_config_include = chip_ble_platform_config_override
 }
 
 assert(


### PR DESCRIPTION

#### Testing

* Adding an extra macro won't affect any current behavior.