### PR TITLE
[groups] Fix #38823 - filter group keys by session_id during decrypt

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -33,7 +33,6 @@
 #include <app/util/basic-types.h>
 #include <credentials/GroupDataProvider.h>
 #include <credentials/GroupDataProviderImpl.h>
-#include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPKeyIds.h>
 #include <lib/core/Global.h>
 #include <lib/support/AutoRelease.h>
@@ -42,7 +41,6 @@
 #include <lib/support/logging/Constants.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <protocols/Protocols.h>
-#include <protocols/secure_channel/Constants.h>
 #include <tracing/macros.h>
 #include <transport/GroupPeerMessageCounter.h>
 #include <transport/GroupSession.h>
@@ -1113,9 +1111,10 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & partialPack
 
     // Trial decryption with GroupDataProvider
     Credentials::GroupDataProvider::GroupSession groupContext;
+    uint16_t sessionId = partialPacketHeader.GetSessionId();
 
     AutoRelease<Credentials::GroupDataProvider::GroupSessionIterator> iter(
-        groups->IterateGroupSessions(partialPacketHeader.GetSessionId()));
+        groups->IterateGroupSessions(sessionId));
 
     if (iter.IsNull())
     {
@@ -1148,7 +1147,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & partialPack
         uint16_t keySessionId = keyContext->GetKeyHash();
 
         // Only try to decrypt if the session IDs match
-        if (keySessionId != partialPacketHeader.GetSessionId())
+        if (keySessionId != sessionId)
         {
             continue;
         }


### PR DESCRIPTION
Fix #38823 

The receive handler for a group message can try to decrypt against multiple keys, but right now it tries *every* key when it should only try keys where session_id matches hash(key).

This change will extract the hash of the key from CryptoContext and only attempt decryption when that is equal to the session_id in PacketHeader.

### Testing 
- adding in separate commit