### PR TITLE
[Darwin] Add missing return to avoid nil passed to dispatch_async

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectivityMonitor.mm
@@ -279,6 +279,7 @@ static void ResolveCallback(
     std::lock_guard lock(sConnectivityMonitorLock);
     if (!sSharedResolverConnection || !sSharedResolverQueue) {
         MTR_LOG("%@ shared resolver connection already stopped - nothing to do", self);
+        return;
     }
 
     // DNSServiceRefDeallocate must be called on the same queue set on the shared connection.


### PR DESCRIPTION
#### Description

This PR just add a missing `return`.

#### Testing

I have not tested it but I assume  we don't want to pass `nil` to `dispatch_async` and the comment clearly says: "nothing to do".