### PR TITLE
[Examples] Fix crash when sending to invalidated WebSocket connection

### DIFF
--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -154,9 +154,11 @@ static int OnWebSocketCallback(lws * wsi, lws_callback_reasons reason, void * us
     else if (LWS_CALLBACK_WSI_DESTROY == reason)
     {
         std::lock_guard<std::mutex> lock(gMutex);
-        gMessageQueue.clear();
-
+        // Nullify the instance first under lock to prevent new Send() operations
+        // from successfully queueing messages for this dying instance.
         gWebSocketInstance = nullptr;
+        // Then clear any messages that might have been queued before this point.
+        gMessageQueue.clear();
     }
     else if (LWS_CALLBACK_PROTOCOL_INIT == reason)
     {

--- a/examples/common/websocket-server/WebSocketServer.cpp
+++ b/examples/common/websocket-server/WebSocketServer.cpp
@@ -153,6 +153,9 @@ static int OnWebSocketCallback(lws * wsi, lws_callback_reasons reason, void * us
     }
     else if (LWS_CALLBACK_WSI_DESTROY == reason)
     {
+        std::lock_guard<std::mutex> lock(gMutex);
+        gMessageQueue.clear();
+
         gWebSocketInstance = nullptr;
     }
     else if (LWS_CALLBACK_PROTOCOL_INIT == reason)


### PR DESCRIPTION
#### Description

Fixes a crash that occurs when attempting to send messages to a WebSocket client that has already disconnected...

Fixes #36712

#### Testing

Used the test case provided (Thanks!) in #36712:
 - Crash is reproducible without the patch
 - No crash occurs after applying the patch
