### PR TITLE
[BUG FIX] Regen-all fails on Python 3.10.12 with glob.glob(include_hidden=True)

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -269,7 +269,7 @@ def expandPlaceholderWildcards(path: str) -> Generator[str, None, None]:
         path = path[:s] + '*' + path[e+1:]
 
     # path is a glob target, expand it
-    for result in glob.glob(path, include_hidden=True):
+    for result in glob.glob(path):
         yield result
 
 


### PR DESCRIPTION
When trying to run regen_all it fails on Python 3.10.12 and bombs out during reformatting step.

```
File "workspace/connectedhomeip/./scripts/tools/zap/generate.py", line 289, in runClangPrettifier
    clangOutputs.extend(expandPlaceholderWildcards(path))
  File "workspace/connectedhomeip/./scripts/tools/zap/generate.py", line 272, in expandPlaceholderWildcards
    for result in glob.glob(path, include_hidden=True):
TypeError: glob() got an unexpected keyword argument 'include_hidden'"

```

- [x] Fixed glob.glob(include_hidden=True) which isn't available in Python 3.10.12


#### Testing

- Cleaned .environment
- ran bootstrap
- ./scripts/tools/zap_regen_all.py
Now passes