### PR TITLE
Add reviewers-geo to reviewers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -126,6 +126,14 @@ groups:
       teams: [reviewers-google]
     reviews:
       request: 0 # Do not auto-add
+  shared-reviewers-geo:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-geo]
+    reviews:
+      request: 0 # Do not auto-add
   shared-reviewers-grundfos:
     type: optional
     conditions:


### PR DESCRIPTION
#### Summary

Add reviewers-geo (https://github.com/orgs/project-chip/teams/reviewers-geo/members) to company reviewers. This expands our review pool

#### Testing

Not applicable