### PR TITLE
PR description validation: expect initial instructions to be removed instead of <!-- sequence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,6 @@
     See guidelines: https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#pr-summary-description
     See title formatting: https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting
 
-    Examples:
-       [TODO] – find an example of a good PR description
-
     Please replace this HTML comment with the actual PR summary.
 -->
 

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -26,7 +26,7 @@ jobs:
           ${{ github.event.pull_request.body }}
           EndMarkerForPrSummary
 
-          python -c 'import sys; pr_summary = open("/tmp/pr-summary.txt", "rt").read(); sys.exit(1 if "<!--" in pr_summary or "-->" in pr_summary else 0)'
+          python -c 'import sys; pr_summary = open("/tmp/pr-summary.txt", "rt").read(); sys.exit(1 if "Please replace this HTML comment" in pr_summary else 0)'
 
       # NOTE: comments disabled for now as separate permissions are required
       #       failing CI step may be sufficient to start (although it contains less information about why it failed)

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Fail if PR instructions were not deleted
         if: (steps.check-instructions.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot[bot]')
         run: |
-          python -c 'import sys; print("PR instructions were not replaced"); sys.exit(1)'
+          python -c 'import sys; print("The string \"Please replace this HTML comment\" is found in the PR description."); sys.exit(1)'
 
       # - name: Add comment (missing testing)
       #   if: steps.check-testing.outcome == 'failure'

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Fail if PR instructions were not deleted
         if: (steps.check-instructions.outcome == 'failure') && (github.event.pull_request.user.login != 'dependabot[bot]')
         run: |
-          python -c 'import sys; print("The string \"Please replace this HTML comment\" is found in the PR description."); sys.exit(1)'
+          python -c 'import sys; print("Please remove the HTML comment blocks that include \"Please replace this HTML comment\" text."); sys.exit(1)'
 
       # - name: Add comment (missing testing)
       #   if: steps.check-testing.outcome == 'failure'


### PR DESCRIPTION
Change PR validation script so that it expects all instructions are removed from the PR description.

Currently the PR validation script checks inclusions of the `<!--` sequence and fails this check. Thus, XML blocks with comments in the PR description will not pass this check. 

This PR changes the validation script to check for another inclusion instead of `<!--`.

#### Testing

Manually tested: changing PR description to trigger PR validation checks in CI.
