### PR TITLE
Fix access levels of ThreadNetworkDirectory cluster

### DIFF
--- a/examples/network-manager-app/network-manager-common/network-manager-app.matter
+++ b/examples/network-manager-app/network-manager-common/network-manager-app.matter
@@ -1635,8 +1635,8 @@ cluster ThreadNetworkDirectory = 1107 {
     int64u activeTimestamp = 3;
   }
 
-  attribute access(read: manage, write: manage) nullable octet_string<8> preferredExtendedPanID = 0;
-  readonly attribute access(read: operate) ThreadNetworkStruct threadNetworks[] = 1;
+  attribute access(write: manage) nullable octet_string<8> preferredExtendedPanID = 0;
+  readonly attribute ThreadNetworkStruct threadNetworks[] = 1;
   readonly attribute int8u threadNetworkTableSize = 2;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -1665,7 +1665,7 @@ cluster ThreadNetworkDirectory = 1107 {
   /** Removes an entry from the ThreadNetworks list. */
   timed command access(invoke: manage) RemoveNetwork(RemoveNetworkRequest): DefaultSuccess = 1;
   /** Retrieves a Thread Operational Dataset from the ThreadNetworks list. */
-  command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
+  command access(invoke: manage) GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
 }
 
 endpoint 0 {

--- a/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/thread-network-directory-cluster.xml
@@ -39,12 +39,12 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="1"/>
     
     <attribute side="server" code="0x0000" name="PreferredExtendedPanID" define="PREFERRED_EXTENDED_PAN_ID" type="octet_string" length="8" writable="true" isNullable="true" optional="false">
-      <access op="read" privilege="manage"/>
+      <access op="read" privilege="view"/>
       <access op="write" privilege="manage"/>
       <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x0001" name="ThreadNetworks" define="THREAD_NETWORKS" type="array" entryType="ThreadNetworkStruct" writable="false" optional="false">
-      <access op="read" privilege="operate"/>
+      <access op="read" privilege="view"/>
       <mandatoryConform/>
     </attribute>
     <attribute side="server" code="0x0002" name="ThreadNetworkTableSize" define="THREAD_NETWORK_TABLE_SIZE" type="int8u" writable="false" optional="false">
@@ -65,7 +65,7 @@ limitations under the License.
     </command>
     <command source="client" code="0x02" name="GetOperationalDataset" optional="false" response="OperationalDatasetResponse">
       <description>Retrieves a Thread Operational Dataset from the ThreadNetworks list.</description>
-      <access op="invoke" privilege="operate"/>
+      <access op="invoke" privilege="manage"/>
       <arg name="ExtendedPanID" type="octet_string" length="8"/>
       <mandatoryConform/>
     </command>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -8524,8 +8524,8 @@ cluster ThreadNetworkDirectory = 1107 {
     int64u activeTimestamp = 3;
   }
 
-  attribute access(read: manage, write: manage) nullable octet_string<8> preferredExtendedPanID = 0;
-  readonly attribute access(read: operate) ThreadNetworkStruct threadNetworks[] = 1;
+  attribute access(write: manage) nullable octet_string<8> preferredExtendedPanID = 0;
+  readonly attribute ThreadNetworkStruct threadNetworks[] = 1;
   readonly attribute int8u threadNetworkTableSize = 2;
   readonly attribute command_id generatedCommandList[] = 65528;
   readonly attribute command_id acceptedCommandList[] = 65529;
@@ -8554,7 +8554,7 @@ cluster ThreadNetworkDirectory = 1107 {
   /** Removes an entry from the ThreadNetworks list. */
   timed command access(invoke: manage) RemoveNetwork(RemoveNetworkRequest): DefaultSuccess = 1;
   /** Retrieves a Thread Operational Dataset from the ThreadNetworks list. */
-  command GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
+  command access(invoke: manage) GetOperationalDataset(GetOperationalDatasetRequest): OperationalDatasetResponse = 2;
 }
 
 /** This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol. */

--- a/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Metadata.h
+++ b/zzz_generated/app-common/clusters/ThreadNetworkDirectory/Metadata.h
@@ -21,12 +21,12 @@ inline constexpr uint32_t kRevision = 1;
 namespace Attributes {
 namespace PreferredExtendedPanID {
 inline constexpr DataModel::AttributeEntry kMetadataEntry(PreferredExtendedPanID::Id, BitFlags<DataModel::AttributeQualityFlags>(),
-                                                          Access::Privilege::kManage, Access::Privilege::kManage);
+                                                          Access::Privilege::kView, Access::Privilege::kManage);
 } // namespace PreferredExtendedPanID
 namespace ThreadNetworks {
 inline constexpr DataModel::AttributeEntry
     kMetadataEntry(ThreadNetworks::Id, BitFlags<DataModel::AttributeQualityFlags>(DataModel::AttributeQualityFlags::kListAttribute),
-                   Access::Privilege::kOperate, std::nullopt);
+                   Access::Privilege::kView, std::nullopt);
 } // namespace ThreadNetworks
 namespace ThreadNetworkTableSize {
 inline constexpr DataModel::AttributeEntry kMetadataEntry(ThreadNetworkTableSize::Id, BitFlags<DataModel::AttributeQualityFlags>(),
@@ -48,7 +48,7 @@ inline constexpr DataModel::AcceptedCommandEntry
 } // namespace RemoveNetwork
 namespace GetOperationalDataset {
 inline constexpr DataModel::AcceptedCommandEntry
-    kMetadataEntry(GetOperationalDataset::Id, BitFlags<DataModel::CommandQualityFlags>(), Access::Privilege::kOperate);
+    kMetadataEntry(GetOperationalDataset::Id, BitFlags<DataModel::CommandQualityFlags>(), Access::Privilege::kManage);
 } // namespace GetOperationalDataset
 
 } // namespace Commands


### PR DESCRIPTION
This aligns the ZAP XML with the spec changes from https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/10159

Fixes #39174

#### Testing

TBC... I thought we were running the cert suite against example apps in CI, so I'm surprised this issue wasn't caught in CI