### PR TITLE
Fix Matter Cast tv-casting-app crash on Android x86 platform

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -79,7 +79,7 @@ jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr)
         return nullptr;
     }
 
-    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, inErr.AsInteger(), nullptr);
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, (jlong)(inErr.AsInteger()), nullptr);
 }
 
 jobject convertEndpointFromCppToJava(matter::casting::memory::Strong<core::Endpoint> endpoint)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -80,7 +80,7 @@ jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr)
     }
 
     // Explicitly cast to jlong for JNI: Java ctor expects long (64-bit), ensures correct arg size on 32-bit platforms
-    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, (jlong) (inErr.AsInteger()), nullptr);
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, static_cast<jlong>(inErr.AsInteger()), nullptr);
 }
 
 jobject convertEndpointFromCppToJava(matter::casting::memory::Strong<core::Endpoint> endpoint)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -79,7 +79,7 @@ jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr)
         return nullptr;
     }
 
-    // Explicitly cast to jlong for JNI: Java ctor expects long (64-bit), ensures correct arg size via varargs esp on 32-bit platforms
+    // Explicitly cast to jlong for JNI: Java ctor expects long (64-bit), ensures correct arg size on 32-bit platforms
     return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, (jlong) (inErr.AsInteger()), nullptr);
 }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/support/Converters-JNI.cpp
@@ -79,7 +79,8 @@ jobject convertMatterErrorFromCppToJava(CHIP_ERROR inErr)
         return nullptr;
     }
 
-    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, (jlong)(inErr.AsInteger()), nullptr);
+    // Explicitly cast to jlong for JNI: Java ctor expects long (64-bit), ensures correct arg size via varargs esp on 32-bit platforms
+    return env->NewObject(jMatterErrorClass, jMatterErrorConstructor, (jlong) (inErr.AsInteger()), nullptr);
 }
 
 jobject convertEndpointFromCppToJava(matter::casting::memory::Strong<core::Endpoint> endpoint)


### PR DESCRIPTION
#### Summary

When built for Android x86, the `tv-casting-app` is crashing at startup on Matter Cast library init.
(i.e. when running on Android x86-32 emulator)

`./scripts/build/build_examples.py --clean --target android-x86-tv-casting-app build`
 
with:

```
com.matter.casting.ChipTvCastingApplication               A  runtime.cc:663] JNI DETECTED ERROR IN APPLICATION: use of invalid jobject 0xb95a6d4c
runtime.cc:663]     from com.matter.casting.support.MatterError com.matter.casting.core.CastingApp.finishInitialization(com.matter.casting.support.AppParameters)
libc                    com.matter.casting.ChipTvCastingApplication                            A  Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 5837 (com.matter.casting.ChipTvCastingApplication), pid 5837 (com.matter.casting.ChipTvCastingApplication)
DEBUG                   crash_dump32                         A  pid: 5837, tid: 5837, name: com.matter.casting.ChipTvCastingApplication  >>> com.matter.casting.ChipTvCastingApplication <<<
DEBUG                   crash_dump32                         A        #16 pc 002ce1c9  /data/app/~~AV3hDrH5AmMlmboDzmLXeg==/com.sling-6Z-utc9si4UMubsYbcpCtw==/lib/x86/libTvCastingApp.so
DEBUG                   crash_dump32                         A        #17 pc 002e3f68  /data/app/~~AV3hDrH5AmMlmboDzmLXeg==/com.sling-6Z-utc9si4UMubsYbcpCtw==/lib/x86/libTvCastingApp.so
DEBUG                   crash_dump32                         A        #18 pc 002cbbcd  /data/app/~~AV3hDrH5AmMlmboDzmLXeg==/com.sling-6Z-utc9si4UMubsYbcpCtw==/lib/x86/libTvCastingApp.so (Java_com_matter_casting_core_CastingApp_finishInitialization+1181)
DEBUG                   crash_dump32                         A        #26 pc 001a3e6c  [anon:dalvik-classes6.dex extracted in memory from /data/app/~~AV3hDrH5AmMlmboDzmLXeg==/com.sling-6Z-utc9si4UMubsYbcpCtw==/base.apk!classes6.dex] (com.matter.casting.core.CastingApp.initialize+212)
```

#### Related issues

n/a

### Testing

Build the sample app for Android x86 and run it on 32-bit x86 Android emulator image.
`./scripts/build/build_examples.py --clean --target android-x86-tv-casting-app build`


