### PR TITLE
[QPG] fix flaky build tests in CI

### DIFF
--- a/third_party/qpg_sdk/make.py
+++ b/third_party/qpg_sdk/make.py
@@ -20,4 +20,4 @@
 import subprocess
 import sys
 
-subprocess.run(['make', '-j'] + sys.argv[1:], check=True)
+subprocess.run(['make'] + sys.argv[1:], check=True)


### PR DESCRIPTION
Removed parallel build execution for make to reduce system resources when make is called for QPG builds.

#### Summary

Before, make was called with '-j' option. This can potential bring system resources on its knees as it will try to do parallel build execution. Removing this make argument will reduce the allocated system resources needed to build QPG platform libraries based on Make.

#### Related issues

Fixes: #39417 

#### Testing

Triggered build script `./scripts/build/build_examples.py --target qpg-qpg6200-light build` with resource monitoring on build machine. Found that with removing the -j option, system resources were more relax.
Also tested timing impact. Without `-j` option, it only takes 2-4 seconds extra for the build compared to a build with `-j`.
