### PR TITLE
[ESP32]: move wifi and ethernet commissioning configs to example

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -1214,36 +1214,6 @@ menu "CHIP Device Layer"
             help
                 The endpoint id for the generic Thread network commissioning driver.
 
-        config WIFI_NETWORK_COMMISSIONING_DRIVER
-            bool "Use ESP Wi-Fi network commissioning driver"
-            depends on (ENABLE_WIFI_STATION || ENABLE_WIFI_AP)
-            default y
-            help
-                Option to enable/disable the use of ESP Wi-Fi network commissioning driver.
-
-        config WIFI_NETWORK_ENDPOINT_ID
-            int "Endpoint Id for Wi-Fi network"
-            depends on WIFI_NETWORK_COMMISSIONING_DRIVER
-            range 0 65534
-            default 0
-            help
-                The endpoint id for the ESP Wi-Fi network commissioning driver.
-
-        config ETHERNET_NETWORK_COMMISSIONING_DRIVER
-            bool "Use ESP Ethernet network commissioning driver"
-            depends on ENABLE_ETHERNET_TELEMETRY
-            default y
-            help
-                Option to enable/disable the use of ESP Ethernet network commissioning driver.
-
-        config ETHERNET_NETWORK_ENDPOINT_ID
-            int "Endpoint Id for Ethernet network"
-            depends on ETHERNET_NETWORK_COMMISSIONING_DRIVER
-            range 0 65534
-            default 0
-            help
-                The endpoint id for the ESP Ethernet network commissioning driver.
-
     endmenu
 
     menu "Cluster Configuration Options"

--- a/examples/lighting-app/esp32/main/Kconfig.projbuild
+++ b/examples/lighting-app/esp32/main/Kconfig.projbuild
@@ -185,3 +185,36 @@ depends on ENABLE_PW_RPC
             about available pin numbers for UART.
 
 endmenu
+
+menu "Network Commissioning Driver (Wi-Fi and Ethernet) Endpoint Id"
+        config WIFI_NETWORK_COMMISSIONING_DRIVER
+            bool "Use ESP Wi-Fi network commissioning driver"
+            depends on (ENABLE_WIFI_STATION || ENABLE_WIFI_AP)
+            default y
+            help
+                Option to enable/disable the use of ESP Wi-Fi network commissioning driver.
+
+        config WIFI_NETWORK_ENDPOINT_ID
+            int "Endpoint Id for Wi-Fi network"
+            depends on WIFI_NETWORK_COMMISSIONING_DRIVER
+            range 0 65534
+            default 0
+            help
+                The endpoint id for the ESP Wi-Fi network commissioning driver.
+
+        config ETHERNET_NETWORK_COMMISSIONING_DRIVER
+            bool "Use ESP Ethernet network commissioning driver"
+            depends on ENABLE_ETHERNET_TELEMETRY
+            default y
+            help
+                Option to enable/disable the use of ESP Ethernet network commissioning driver.
+
+        config ETHERNET_NETWORK_ENDPOINT_ID
+            int "Endpoint Id for Ethernet network"
+            depends on ETHERNET_NETWORK_COMMISSIONING_DRIVER
+            range 0 65534
+            default 0
+            help
+                The endpoint id for the ESP Ethernet network commissioning driver.
+
+endmenu


### PR DESCRIPTION
#### Summary
Move Wi-FI and Ethernet network commissioning configs to example.

#### Testing
lighting-app on esp32c6 with both Wi-Fi and Thread enabled.
