### PR TITLE
[NXP][CMake] Refactor Matter-related CMake calls for cross-platform compatibility

### DIFF
--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -61,8 +61,8 @@ function(chip_codegen TARGET_NAME)
         endforeach()
 
         # Python is expected to be in the path
-        #
-        # find_package(Python3 REQUIRED)
+        # Forcing a call to find find_package here as ${Python3_EXECUTABLE} would be used
+        find_package(Python3 REQUIRED)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
             COMMAND "${Python3_EXECUTABLE}" "${CHIP_ROOT}/scripts/codegen.py"
@@ -181,8 +181,8 @@ function(chip_zapgen TARGET_NAME)
         endif()
 
         # Python is expected to be in the path
-        #
-        # find_package(Python3 REQUIRED)
+        # Forcing a call to find find_package here as ${Python3_EXECUTABLE} would be used
+        find_package(Python3 REQUIRED)
         #
         # TODO: lockfile support should be removed as this serializes zap
         # (slower), however this is currently done because on Darwin zap startup

--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -65,7 +65,7 @@ function(chip_codegen TARGET_NAME)
         # find_package(Python3 REQUIRED)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND "${CHIP_ROOT}/scripts/codegen.py"
+            COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/scripts/codegen.py
             ARGS "--generator" "${ARG_GENERATOR}"
                  "--output-dir" "${GEN_FOLDER}"
                  "--expected-outputs" "${GEN_FOLDER}/expected.outputs"
@@ -190,7 +190,7 @@ function(chip_zapgen TARGET_NAME)
         #    Error: EEXIST: file already exists, mkdir '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pkg/465fcc8a6282e28dc7a166859d5814d34e2fb94249a72fa9229033b5b32dff1a'
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND "${CHIP_ROOT}/scripts/tools/zap/generate.py"
+            COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/scripts/tools/zap/generate.py
             ARGS
                 "--no-prettify-output"
                 "--templates" "${TEMPLATE_PATH}"

--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -65,7 +65,7 @@ function(chip_codegen TARGET_NAME)
         # find_package(Python3 REQUIRED)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/scripts/codegen.py
+            COMMAND "${Python3_EXECUTABLE}" "${CHIP_ROOT}/scripts/codegen.py"
             ARGS "--generator" "${ARG_GENERATOR}"
                  "--output-dir" "${GEN_FOLDER}"
                  "--expected-outputs" "${GEN_FOLDER}/expected.outputs"
@@ -190,7 +190,7 @@ function(chip_zapgen TARGET_NAME)
         #    Error: EEXIST: file already exists, mkdir '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pkg/465fcc8a6282e28dc7a166859d5814d34e2fb94249a72fa9229033b5b32dff1a'
         add_custom_command(
             OUTPUT ${OUT_NAMES}
-            COMMAND ${Python3_EXECUTABLE} ${CHIP_ROOT}/scripts/tools/zap/generate.py
+            COMMAND "${Python3_EXECUTABLE}" "${CHIP_ROOT}/scripts/tools/zap/generate.py"
             ARGS
                 "--no-prettify-output"
                 "--templates" "${TEMPLATE_PATH}"

--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -134,7 +134,7 @@ macro(matter_build target)
         BUILD_COMMAND           ${CMAKE_COMMAND} -E echo "Starting Matter library build in ${CMAKE_CURRENT_BINARY_DIR}"
         COMMAND                 ${Python3_EXECUTABLE} ${CHIP_ROOT}/config/common/cmake/make_gn_args.py @args.tmp > args.gn.tmp
         # Replace the config only if it has changed to avoid triggering unnecessary rebuilds
-        COMMAND                 bash -c "(! diff -q args.gn.tmp args.gn && mv args.gn.tmp args.gn) || true"
+        COMMAND                 ${CMAKE_COMMAND} -E copy_if_different args.gn.tmp args.gn
         # Regenerate the ninja build system
         COMMAND                 ${GN_EXECUTABLE}
                                     --root=${CHIP_ROOT}

--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -134,7 +134,7 @@ macro(matter_build target)
         BUILD_COMMAND           ${CMAKE_COMMAND} -E echo "Starting Matter library build in ${CMAKE_CURRENT_BINARY_DIR}"
         COMMAND                 ${Python3_EXECUTABLE} ${CHIP_ROOT}/config/common/cmake/make_gn_args.py @args.tmp > args.gn.tmp
         # Replace the config only if it has changed to avoid triggering unnecessary rebuilds
-        COMMAND                 ${CMAKE_COMMAND} -E copy_if_different args.gn.tmp args.gn
+        COMMAND                 "${CMAKE_COMMAND}" -E copy_if_different "args.gn.tmp" "args.gn"
         # Regenerate the ninja build system
         COMMAND                 ${GN_EXECUTABLE}
                                     --root=${CHIP_ROOT}


### PR DESCRIPTION
#### Summary

Enhance the portability of Matter CMake wrappers to support cross-platform usage.
This update addresses issues encountered when using Matter CMake files on Windows, aiming to make them more adaptable and functional across different operating systems.

#### Testing
Verified successful builds on the NXP CMake platform for both Linux and Windows environments.
