### PR TITLE
[Darwin][Network.framework] Fix a crash if mInterfaceGroups is nil wh…

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
@@ -337,6 +337,8 @@ namespace Inet {
 
         void UDPEndPointImplNetworkFrameworkListenerGroup::StopListeners(InterfaceGroup * group)
         {
+            VerifyOrReturn(nullptr != mInterfaceGroups);
+
             if (nullptr == group) {
                 CFDictionaryApplyFunction(
                     mInterfaceGroups, [](const void * /*key*/, const void * value, void * context) {
@@ -347,7 +349,6 @@ namespace Inet {
                 return;
             }
 
-            VerifyOrReturn(nullptr != group);
             VerifyOrReturn(nullptr != group->connectionGroup);
             LogErrorOnFailure(WaitForConnectionGroupCancelledState(group));
             group->connectionGroup = nullptr;


### PR DESCRIPTION
…ich can happen if something goes wrong during Init

#### Summary

If an UDP endpoint initialization fails, `mInterfaceGroups` can stay `nullptr`. Later, calling `UDPEndpointImplNetworkFrameworkListenerGroup::StopListeners` tries to use `mInterfaceGroups` without checking, which crashes. 
This patch adds a check so we only call `CFDictionaryApplyFunction` when `mInterfaceGroups` is not null. 

#### Related issues

N/A

#### Testing
 - Built on macOS with **Network.framework** turned on.
 - Modified `src/app/server/Server.cpp` so that, whenever you launch the example server with `--interface N`, it passes that interface to `UdpListenParameters::SetInterface`.

- Before this patch: running `chip-all-clusters-app` with `--interface N` always crashed
- After this patch: running with `--interface N` no longer crashes.
