### PR TITLE
[Darwin][Network.framework] [Darwin][Network.framework] Return loopba…

### DIFF
--- a/src/platform/Darwin/inet/NetworkMonitor.h
+++ b/src/platform/Darwin/inet/NetworkMonitor.h
@@ -50,6 +50,15 @@ namespace Inet {
 
             InterfaceId GetInterfaceId() const { return InterfaceId(static_cast<InterfaceId::PlatformType>(mInterfaceId)); };
 
+            bool IsIPv6() const { return mAddressType == IPAddressType::kIPv6; }
+
+#if INET_CONFIG_ENABLE_IPV4
+            bool IsIPv4() const
+            {
+                return mAddressType == IPAddressType::kIPv4;
+            }
+#endif
+
             CHIP_ERROR StartMonitorInterfaces(OnInterfaceChanges interfaceChangesBlock);
             CHIP_ERROR StartMonitorPaths(OnPathChange pathChangeBlock);
             void Stop();

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
@@ -94,6 +94,11 @@ namespace Inet {
 
         CHIP_ERROR UDPEndPointImplNetworkFrameworkListener::ListenLoopback()
         {
+#if INET_CONFIG_ENABLE_IPV4
+            if (IsIPv4()) {
+                return ListenAddress(IPAddress::Loopback(IPAddressType::kIPv4));
+            }
+#endif
             return ListenAddress(IPAddress::Loopback(IPAddressType::kIPv6));
         }
 


### PR DESCRIPTION
…ck address matching IP type

#### Summary

When **Network.framework** is enabled and a listener is set to loopback only (e.g., via -`-interface -1`), the code was binding both IPv4 and IPv6 sockets to `::1`. 

#### Related issues

N/A

#### Testing
 - Built on macOS with **Network.framework** turned on.
 - Modified `src/app/server/Server.cpp` so that, whenever you launch the example server with `--interface N`, it passes that interface to `UdpListenParameters::SetInterface`.
 
 - Before this patch: running `chip-all-clusters-app` with `--interface -1`bound IPv4 endpoint to `::1`
- After this patch: running `chip-all-clusters-app` with `--interface -1`bound IPv4 endpoint to `127.0.0.1`