### PR TITLE
[Darwin][Network.framework] Append interface scope for IPv6 multicast…

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
@@ -234,7 +234,7 @@ namespace Inet {
 #endif // INET_CONFIG_ENABLE_IPV4
         {
             aAddress.ToString(addrStr);
-            if (interfaceIndex != InterfaceId::Null() && aAddress.IsIPv6LinkLocal()) {
+            if (interfaceIndex != InterfaceId::Null() && (aAddress.IsIPv6LinkLocal() || aAddress.IsIPv6Multicast())) {
                 char interface[InterfaceId::kMaxIfNameLength + 1] = {}; // +1 to prepend '%'
                 interface[0] = '%';
                 interface[1] = 0;


### PR DESCRIPTION
… and match incoming packets by interface in Connections

#### Summary

With **Network.framework** enabled, the existing code ignored the interface when matching  connections. On macOS with both Wi-Fi and Ethernet up, this could pick a connection on the wrong interface and fail to send or receive multicast messages. 

#### Related issues

N/A

#### Testing
 - Built on macOS with **Network.framework** enabled.
 - Used a test setup where the machine had both Wi-Fi and Ethernet active.
 - Run `./scripts/tests/chipyaml/chiptool.py tests TestGroupMessaging --PICS src/app/tests/suites/certification/ci-pics-values --server_path ./out/debug/standalone/chip-tool --show_adapter_logs true`

