### PR TITLE
[Darwin][Network.framework] Add the group interface logged when debug…

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.h
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.h
@@ -23,7 +23,7 @@ namespace chip {
 namespace Inet {
 namespace Darwin {
 void DebugPrintListenerState(nw_listener_state_t state, nw_error_t error);
-void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error);
+void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_interface_t interface, nw_error_t error);
 void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error);
 void DebugPrintConnection(nw_connection_t connection);
 void DebugPrintEndPoint(nw_endpoint_t endpoint);

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
@@ -96,7 +96,7 @@ namespace Inet {
             }
         }
 
-        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error)
+        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_interface_t interface, nw_error_t error)
         {
             const char * str = nullptr;
 
@@ -120,11 +120,12 @@ namespace Inet {
                 chipDie();
             }
 
+            const char * interfaceName = nw_interface_get_name(interface);
             if (error) {
                 CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+                ChipLogDetail(Inet, "%s (%s) - Error: %s", str, interfaceName, chip::ErrorStr(err));
             } else {
-                ChipLogDetail(Inet, "%s", str);
+                ChipLogDetail(Inet, "%s (%s)", str, interfaceName);
             }
         }
 
@@ -258,7 +259,7 @@ namespace Inet {
         }
 #else
         void DebugPrintListenerState(nw_listener_state_t state, nw_error_t error) {};
-        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_error_t error) {};
+        void DebugPrintConnectionGroupState(nw_connection_group_state_t state, nw_interface_t interface, nw_error_t error) {};
         void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error) {};
         void DebugPrintConnection(const nw_connection_t connection) {};
         void DebugPrintEndPoint(nw_endpoint_t endpoint) {};

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListenerGroup.mm
@@ -363,9 +363,10 @@ namespace Inet {
             VerifyOrReturnError(nullptr != cancelSemaphore, CHIP_ERROR_NO_MEMORY);
             group->cancelSemaphore = cancelSemaphore;
 
+            __auto_type interface = group->interface;
             __block CHIP_ERROR err = CHIP_ERROR_INTERNAL;
             nw_connection_group_set_state_changed_handler(connectionGroup, ^(nw_connection_group_state_t state, nw_error_t error) {
-                DebugPrintConnectionGroupState(state, error);
+                DebugPrintConnectionGroupState(state, interface, error);
 
                 switch (state) {
                 case nw_connection_group_state_waiting:


### PR DESCRIPTION
…ging group connections

#### Summary

Include the interface name when logging connection‐group state so that debug output shows which interface (e.g., “en0” or “en11”) each group is on.

#### Related issues

N/A

#### Testing
 - Built on macOS with **Network.framework** enabled.
 - Ran code and verified that `DebugPrintConnectionGroupState` now prints the interface name alongside each state change.
