### PR TITLE
[Darwin][Network.framework] Turn off debug logging by default

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
@@ -23,7 +23,7 @@
 
 #include <lib/support/CodeUtils.h>
 
-#define NETWORK_FRAMEWORK_DEBUG 1
+#define NETWORK_FRAMEWORK_DEBUG 0
 
 namespace chip {
 namespace Inet {
@@ -262,7 +262,7 @@ namespace Inet {
         void DebugPrintConnectionState(nw_connection_state_t state, nw_error_t error) {};
         void DebugPrintConnection(const nw_connection_t connection) {};
         void DebugPrintEndPoint(nw_endpoint_t endpoint) {};
-        void DebugPrintPacketInfo(IPPacketInfo & packetInfo);
+        void DebugPrintPacketInfo(IPPacketInfo & packetInfo) {};
 #endif
     } // namespace Darwin
 } // namespace Inet


### PR DESCRIPTION
#### Summary

Disable **Network.framework** debug logs by default by setting `NETWORK_FRAMEWORK_DEBUG` to `0`.

#### Related issues

N/A

#### Testing

- Built on macOS and verified that no Network.framework debug messages appear in the normal log output.