### PR TITLE
Added code to connect the device to a Thread network.

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -154,6 +154,13 @@ private:
     void HandleNonConcurrentConnectNetwork(void);
     void HandleQueryIdentity(HandlerContext & ctx, const Commands::QueryIdentity::DecodableType & req);
 
+    // Function called when Thread credentials are available
+    // The SDK will add this Thread network and try to join it.
+    void OnThreadCredentialsAvailable(chip::ByteSpan *     pOperationalDataset,
+                                      Optional<uint64_t> * pAddOrUpdateThreadNetworkBreadcrumb,
+                                      chip::ByteSpan *     pNetworkID,
+                                      Optional<uint64_t> * pConnectNetworkBreadcrumb);
+
 public:
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::WiFiDriver * apDelegate);
     Instance(EndpointId aEndpointId, DeviceLayer::NetworkCommissioning::ThreadDriver * apDelegate);

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -260,6 +260,12 @@ enum PublicEventTypes
      * Signals that factory reset has started.
      */
     kFactoryReset,
+
+    /**
+     * Signals that Thread Credentials are available.
+     * The SDK will add this Thread network and try to join it.
+     */
+    kOnThreadCredentialsAvailable,
 };
 
 /**
@@ -561,6 +567,18 @@ struct ChipDeviceEvent final
             // TODO(cecille): This should just specify wifi or thread since we assume at most 1.
             int network;
         } OperationalNetwork;
+
+        struct
+        {
+            // Data from AddOrUpdateThreadNetwork DecodableType
+            chip::ByteSpan *     pOperationalDataset;
+            Optional<uint64_t> * pAddOrUpdateThreadNetworkBreadcrumb;
+
+            // Data from ConnectNetwork DecodableType
+            chip::ByteSpan *     pNetworkID;
+            Optional<uint64_t> * pConnectNetworkBreadcrumb;
+
+        } OnThreadCredentialsAvailable;
 
         struct
         {


### PR DESCRIPTION
This code is used when doing NFC-based commissioning on a Commissionee: 
The NFC tag provides some Commissioning data to the MCU. The MCU will use the current code to configure the operational network and connect to it.