### PR TITLE
Move "data version" setup to cluster startup instead of constructors

### DIFF
--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -72,9 +72,7 @@ Span<const DataModel::AttributeEntry> DefaultServerCluster::GlobalAttributes()
     return { kGlobalAttributeEntries.data(), kGlobalAttributeEntries.size() };
 }
 
-DefaultServerCluster::DefaultServerCluster(const ConcreteClusterPath & path) : mPath(path)
-{
-}
+DefaultServerCluster::DefaultServerCluster(const ConcreteClusterPath & path) : mPath(path) {}
 
 CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<AttributeEntry> & builder)
 {

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -74,9 +74,6 @@ Span<const DataModel::AttributeEntry> DefaultServerCluster::GlobalAttributes()
 
 DefaultServerCluster::DefaultServerCluster(const ConcreteClusterPath & path) : mPath(path)
 {
-    // SPEC - 7.10.3. Cluster Data Version
-    //   A cluster data version SHALL be initialized randomly when it is first published.
-    mDataVersion = Crypto::GetRandU32();
 }
 
 CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<AttributeEntry> & builder)
@@ -88,7 +85,13 @@ CHIP_ERROR DefaultServerCluster::Attributes(const ConcreteClusterPath & path, Re
 CHIP_ERROR DefaultServerCluster::Startup(ServerClusterContext & context)
 {
     VerifyOrReturnError(mContext == nullptr, CHIP_ERROR_ALREADY_INITIALIZED);
+
     mContext = &context;
+
+    // SPEC - 7.10.3. Cluster Data Version
+    //   A cluster data version SHALL be initialized randomly when it is first published.
+    mDataVersion = Crypto::GetRandU32();
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Summary

@jmartinez-silabs reported that efr32 crashes at boot in the network commissioning constructor. Since we use globals, it seems we should allow clusters to only initialize after other systems (like RNG) have initialized.

#### Testing

CI expected to still pass. The change is quite small.