### PR TITLE
[Python] Fix dangling pointer

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -813,6 +813,13 @@ class AsyncReadTransaction:
         ctypes.pythonapi.Py_DecRef(ctypes.py_object(self))
 
     def handleDone(self):
+        #
+        # At the end of the life cycle, the C++ end memory has been released,
+        # and pReadClient is set to None, otherwise it will cause a dangling pointer.
+        # For example: When a subscription calls Shutdown() after an error occurs,
+        # pReadClient will be referenced, causing a crash
+        #
+        self._pReadClient = None
         self._event_loop.call_soon_threadsafe(self._handleDone)
 
     def handleReportBegin(self):


### PR DESCRIPTION
As title, when a subscription error occurred, calling `Shutdown()` will reference a dangling pointer. This Pull request is to solve this problem.

### Testing
1. `TH1` & `TH2` commissioned with `DUT`
2. TH2 subscribes to DUT properties
3. TH1 `RemoveFabric`(`TH2`)  (Let subscription error occur)
4. Wait for a while
5. Subscription call `Shutdown()
`

_When not fixed, step 5 will crash, after merging PR, it has been fixed_