### PR TITLE
Install dbus-daemon required for BLE-WiFi testing

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -40,6 +40,7 @@ RUN set -x \
     clang-tidy \
     cmake \
     curl \
+    dbus-daemon \
     flex \
     g++ \
     generate-ninja \

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-137 : Upgrade docker to add gstreamer‑app‑1.0
+138 : Install dbus-daemon required for BLE-WiFi testing


### PR DESCRIPTION
#### Summary

BLE-WiFi CI testing (https://github.com/project-chip/connectedhomeip/pull/39454) required `dbus-daemon` to run integration with BlueZ and WPA supplicant.

#### Testing

Tested locally that BLE-WiFi test works when dbus-daemon was added to installed packets.