### PR TITLE
[Darwin] MTRDeviceTestDelegate properties should be atomic

### DIFF
--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -23,31 +23,31 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 typedef void (^MTRDeviceTestDelegateHandler)(NSError * error);
 
 @interface MTRDeviceTestDelegate : NSObject <MTRDeviceDelegate>
-@property (nonatomic, nullable) dispatch_block_t onReachable;
-@property (nonatomic, nullable) dispatch_block_t onNotReachable;
-@property (nonatomic, nullable) dispatch_block_t onInternalStateChanged;
-@property (nonatomic, nullable) MTRDeviceTestDelegateDataHandler onAttributeDataReceived;
-@property (nonatomic, nullable) MTRDeviceTestDelegateDataHandler onEventDataReceived;
-@property (nonatomic, nullable) dispatch_block_t onReportBegin;
-@property (nonatomic, nullable) dispatch_block_t onReportEnd;
-@property (nonatomic, nullable) dispatch_block_t onDeviceCachePrimed;
-@property (nonatomic) BOOL skipExpectedValuesForWrite;
-@property (nonatomic) BOOL forceAttributeReportsIfMatchingCache;
-@property (nonatomic, nullable) dispatch_block_t onDeviceConfigurationChanged;
-@property (nonatomic) BOOL pretendThreadEnabled;
-@property (nonatomic, nullable) dispatch_block_t onSubscriptionPoolDequeue;
-@property (nonatomic, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
-@property (nonatomic, nullable) dispatch_block_t onClusterDataPersisted;
-@property (nonatomic, nullable) dispatch_block_t onSubscriptionCallbackDelete;
-@property (nonatomic, nullable) dispatch_block_t onSubscriptionReset;
-@property (nonatomic, nullable) NSNumber * subscriptionMaxIntervalOverride;
-@property (nonatomic, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
-@property (nonatomic) BOOL forceTimeUpdateShortDelayToZero;
-@property (nonatomic) BOOL forceTimeSynchronizationLossDetectionCadenceToZero;
+@property (atomic, nullable) dispatch_block_t onReachable;
+@property (atomic, nullable) dispatch_block_t onNotReachable;
+@property (atomic, nullable) dispatch_block_t onInternalStateChanged;
+@property (atomic, nullable) MTRDeviceTestDelegateDataHandler onAttributeDataReceived;
+@property (atomic, nullable) MTRDeviceTestDelegateDataHandler onEventDataReceived;
+@property (atomic, nullable) dispatch_block_t onReportBegin;
+@property (atomic, nullable) dispatch_block_t onReportEnd;
+@property (atomic, nullable) dispatch_block_t onDeviceCachePrimed;
+@property (atomic) BOOL skipExpectedValuesForWrite;
+@property (atomic) BOOL forceAttributeReportsIfMatchingCache;
+@property (atomic, nullable) dispatch_block_t onDeviceConfigurationChanged;
+@property (atomic) BOOL pretendThreadEnabled;
+@property (atomic, nullable) dispatch_block_t onSubscriptionPoolDequeue;
+@property (atomic, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
+@property (atomic, nullable) dispatch_block_t onClusterDataPersisted;
+@property (atomic, nullable) dispatch_block_t onSubscriptionCallbackDelete;
+@property (atomic, nullable) dispatch_block_t onSubscriptionReset;
+@property (atomic, nullable) NSNumber * subscriptionMaxIntervalOverride;
+@property (atomic, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
+@property (atomic) BOOL forceTimeUpdateShortDelayToZero;
+@property (atomic) BOOL forceTimeSynchronizationLossDetectionCadenceToZero;
 @end
 
 @interface MTRDeviceTestDelegateWithSubscriptionSetupOverride : MTRDeviceTestDelegate
-@property (nonatomic) BOOL skipSetupSubscription;
+@property (atomic) BOOL skipSetupSubscription;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRDeviceTestDelegate.h
@@ -23,25 +23,25 @@ typedef void (^MTRDeviceTestDelegateDataHandler)(NSArray<NSDictionary<NSString *
 typedef void (^MTRDeviceTestDelegateHandler)(NSError * error);
 
 @interface MTRDeviceTestDelegate : NSObject <MTRDeviceDelegate>
-@property (atomic, nullable) dispatch_block_t onReachable;
-@property (atomic, nullable) dispatch_block_t onNotReachable;
-@property (atomic, nullable) dispatch_block_t onInternalStateChanged;
-@property (atomic, nullable) MTRDeviceTestDelegateDataHandler onAttributeDataReceived;
-@property (atomic, nullable) MTRDeviceTestDelegateDataHandler onEventDataReceived;
-@property (atomic, nullable) dispatch_block_t onReportBegin;
-@property (atomic, nullable) dispatch_block_t onReportEnd;
-@property (atomic, nullable) dispatch_block_t onDeviceCachePrimed;
+@property (atomic, copy, nullable) dispatch_block_t onReachable;
+@property (atomic, copy, nullable) dispatch_block_t onNotReachable;
+@property (atomic, copy, nullable) dispatch_block_t onInternalStateChanged;
+@property (atomic, copy, nullable) MTRDeviceTestDelegateDataHandler onAttributeDataReceived;
+@property (atomic, copy, nullable) MTRDeviceTestDelegateDataHandler onEventDataReceived;
+@property (atomic, copy, nullable) dispatch_block_t onReportBegin;
+@property (atomic, copy, nullable) dispatch_block_t onReportEnd;
+@property (atomic, copy, nullable) dispatch_block_t onDeviceCachePrimed;
 @property (atomic) BOOL skipExpectedValuesForWrite;
 @property (atomic) BOOL forceAttributeReportsIfMatchingCache;
-@property (atomic, nullable) dispatch_block_t onDeviceConfigurationChanged;
+@property (atomic, copy, nullable) dispatch_block_t onDeviceConfigurationChanged;
 @property (atomic) BOOL pretendThreadEnabled;
-@property (atomic, nullable) dispatch_block_t onSubscriptionPoolDequeue;
-@property (atomic, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
-@property (atomic, nullable) dispatch_block_t onClusterDataPersisted;
-@property (atomic, nullable) dispatch_block_t onSubscriptionCallbackDelete;
-@property (atomic, nullable) dispatch_block_t onSubscriptionReset;
+@property (atomic, copy, nullable) dispatch_block_t onSubscriptionPoolDequeue;
+@property (atomic, copy, nullable) dispatch_block_t onSubscriptionPoolWorkComplete;
+@property (atomic, copy, nullable) dispatch_block_t onClusterDataPersisted;
+@property (atomic, copy, nullable) dispatch_block_t onSubscriptionCallbackDelete;
+@property (atomic, copy, nullable) dispatch_block_t onSubscriptionReset;
 @property (atomic, nullable) NSNumber * subscriptionMaxIntervalOverride;
-@property (atomic, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
+@property (atomic, copy, nullable) MTRDeviceTestDelegateHandler onUTCTimeSet;
 @property (atomic) BOOL forceTimeUpdateShortDelayToZero;
 @property (atomic) BOOL forceTimeSynchronizationLossDetectionCadenceToZero;
 @end


### PR DESCRIPTION
#### Summary

There seems to be some race as Boris noted in #39292 , and this is an attempt to fix it so that CI tests don't fail when there's no actual problem.

#### Related issues

Fixes #39292

#### Testing

I will run this a a few times and see that CI doesn't fail again in the same `test048_MTRDeviceResubscribeOnSubscriptionPool` test.
