### PR TITLE
Update Audio/VideoStream reference counts in AVSM allocatedStreams  when handling WebRTC commands.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -96,6 +96,10 @@ public:
 
     CHIP_ERROR PersistentAttributesLoadedCallback();
 
+    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
+
+    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
+
     void Init();
 
     CameraAVStreamManager()  = default;

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -278,7 +278,23 @@ CameraAVStreamManager::LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamSt
 CHIP_ERROR
 CameraAVStreamManager::PersistentAttributesLoadedCallback()
 {
-    ChipLogError(Zcl, "Persistent attributes loaded");
+    ChipLogDetail(Zcl, "Persistent attributes loaded");
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+{
+    ChipLogDetail(Zcl, "Transport acquired audio/video streams");
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+{
+    ChipLogDetail(Zcl, "Transport released audio/video streams");
 
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -75,6 +75,10 @@ public:
 
     CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
+    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
+
+    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
+
     CameraAVStreamManager()  = default;
     ~CameraAVStreamManager() = default;
 

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -69,6 +69,8 @@ public:
                                    const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & videoStreamId,
                                    const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & audioStreamId) override;
 
+    void SetCameraDevice(CameraDeviceInterface * aCameraDevice);
+
 private:
     enum class CommandType : uint8_t
     {
@@ -103,6 +105,10 @@ private:
 
     CHIP_ERROR SendICECandidatesCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
 
+    CHIP_ERROR AcquireAudioVideoStreams();
+
+    CHIP_ERROR ReleaseAudioVideoStreams();
+
     static void OnDeviceConnected(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                   const chip::SessionHandle & sessionHandle);
 
@@ -135,6 +141,10 @@ private:
     uint16_t mAudioStreamID;
 
     MediaController * mMediaController = nullptr;
+
+    // Handle to the Camera Device interface. For accessing other
+    // clusters, if required.
+    CameraDeviceInterface * mCameraDevice = nullptr;
 };
 
 } // namespace Camera

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -333,6 +333,9 @@ CameraDevice::CameraDevice()
 
     // Provider manager uses the Media controller to register WebRTC Transport with media controller for AV source data
     mWebRTCProviderManager.SetMediaController(&mMediaController);
+
+    // Set the CameraDevice interface in WebRTCManager
+    mWebRTCProviderManager.SetCameraDevice(this);
 }
 
 CameraDevice::~CameraDevice()

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -416,8 +416,15 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
     }
 
     // Update the counts in the SDK allocated stream attributes
-    GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true);
-    GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true);
+    if (GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true) != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "Failed to increment audio stream %u ref count in SDK", audioStreamID);
+    }
+
+    if (GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true) != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "Failed to increment video stream %u ref count in SDK", videoStreamID);
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -458,8 +465,15 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
     }
 
     // Update the counts in the SDK allocated stream attributes
-    GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false);
-    GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false);
+    if (GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false) != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "Failed to decrement audio stream %u ref count in SDK", audioStreamID);
+    }
+
+    if (GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false) != CHIP_NO_ERROR)
+    {
+        ChipLogError(Camera, "Failed to decrement video stream %u ref count in SDK", videoStreamID);
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -388,7 +388,14 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
     {
         if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
         {
-            stream.audioStreamParams.referenceCount++;
+            if (stream.audioStreamParams.referenceCount < UINT8_MAX)
+            {
+                stream.audioStreamParams.referenceCount++;
+            }
+            else
+            {
+                ChipLogError(Camera, "Attempted to increment audio stream %u ref count beyond max limit", audioStreamID);
+            }
         }
     }
 
@@ -397,7 +404,14 @@ CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamI
     {
         if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
         {
-            stream.videoStreamParams.referenceCount++;
+            if (stream.videoStreamParams.referenceCount < UINT8_MAX)
+            {
+                stream.videoStreamParams.referenceCount++;
+            }
+            else
+            {
+                ChipLogError(Camera, "Attempted to increment video stream %u ref count beyond max limit", videoStreamID);
+            }
         }
     }
 
@@ -416,7 +430,14 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
     {
         if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
         {
-            stream.audioStreamParams.referenceCount--;
+            if (stream.audioStreamParams.referenceCount > 0)
+            {
+                stream.audioStreamParams.referenceCount--;
+            }
+            else
+            {
+                ChipLogError(Camera, "Attempted to decrement audio stream %u ref count when it was already 0", audioStreamID);
+            }
         }
     }
 
@@ -425,7 +446,14 @@ CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamI
     {
         if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
         {
-            stream.videoStreamParams.referenceCount--;
+            if (stream.videoStreamParams.referenceCount > 0)
+            {
+                stream.videoStreamParams.referenceCount--;
+            }
+            else
+            {
+                ChipLogError(Camera, "Attempted to decrement video stream %u ref count when it was already 0", videoStreamID);
+            }
         }
     }
 

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -379,3 +379,59 @@ CameraAVStreamManager::PersistentAttributesLoadedCallback()
 
     return CHIP_NO_ERROR;
 }
+
+CHIP_ERROR
+CameraAVStreamManager::OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+{
+    // Update the available audio stream in the HAL
+    for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
+    {
+        if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
+        {
+            stream.audioStreamParams.referenceCount++;
+        }
+    }
+
+    // Update the available video stream in the HAL
+    for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
+    {
+        if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
+        {
+            stream.videoStreamParams.referenceCount++;
+        }
+    }
+
+    // Update the counts in the SDK allocated stream attributes
+    GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ true);
+    GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ true);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+CameraAVStreamManager::OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID)
+{
+    // Update the available audio stream in the HAL
+    for (AudioStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableAudioStreams())
+    {
+        if (stream.audioStreamParams.audioStreamID == audioStreamID && stream.isAllocated)
+        {
+            stream.audioStreamParams.referenceCount--;
+        }
+    }
+
+    // Update the available video stream in the HAL
+    for (VideoStream & stream : mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams())
+    {
+        if (stream.videoStreamParams.videoStreamID == videoStreamID && stream.isAllocated)
+        {
+            stream.videoStreamParams.referenceCount--;
+        }
+    }
+
+    // Update the counts in the SDK allocated stream attributes
+    GetCameraAVStreamMgmtServer()->UpdateAudioStreamRefCount(audioStreamID, /* shouldIncrement = */ false);
+    GetCameraAVStreamMgmtServer()->UpdateVideoStreamRefCount(videoStreamID, /* shouldIncrement = */ false);
+
+    return CHIP_NO_ERROR;
+}

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -332,6 +332,73 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveSnapshotStream(uint16_t snapshotStrea
     return CHIP_NO_ERROR;
 }
 
+
+CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRefCount(uint16_t videoStreamId, bool shouldIncrement)
+{
+    auto it = std::find_if(mAllocatedVideoStreams.begin(), mAllocatedVideoStreams.end(),
+                           [videoStreamId](const VideoStreamStruct & vStream) { return vStream.videoStreamID == videoStreamId; });
+
+    if (it == mAllocatedVideoStreams.end())
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    if (shouldIncrement)
+    {
+        it->referenceCount++;
+    }
+    else
+    {
+        it->referenceCount--;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CameraAVStreamMgmtServer::UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement)
+{
+    auto it = std::find_if(mAllocatedAudioStreams.begin(), mAllocatedAudioStreams.end(),
+                           [audioStreamId](const AudioStreamStruct & aStream) { return aStream.audioStreamID == audioStreamId; });
+
+    if (it == mAllocatedAudioStreams.end())
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    if (shouldIncrement)
+    {
+        it->referenceCount++;
+    }
+    else
+    {
+        it->referenceCount--;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement)
+{
+    auto it = std::find_if(mAllocatedSnapshotStreams.begin(), mAllocatedSnapshotStreams.end(),
+                           [snapshotStreamId](const SnapshotStreamStruct & sStream) { return sStream.snapshotStreamID == snapshotStreamId; });
+
+    if (it == mAllocatedSnapshotStreams.end())
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    if (shouldIncrement)
+    {
+        it->referenceCount++;
+    }
+    else
+    {
+        it->referenceCount--;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 // AttributeAccessInterface
 CHIP_ERROR CameraAVStreamMgmtServer::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -344,28 +344,10 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRefCount(uint16_t videoStr
 
     if (shouldIncrement)
     {
-        if (it->referenceCount < UINT8_MAX)
-        {
-            it->referenceCount++;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to increment video stream %u ref count beyond max limit", videoStreamId);
-        }
-    }
-    else
-    {
-        if (it->referenceCount > 0)
-        {
-            it->referenceCount--;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to decrement video stream %u ref count when it was already 0", videoStreamId);
-        }
+        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
     }
 
-    return CHIP_NO_ERROR;
+    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement)
@@ -380,28 +362,10 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateAudioStreamRefCount(uint16_t audioStr
 
     if (shouldIncrement)
     {
-        if (it->referenceCount < UINT8_MAX)
-        {
-            it->referenceCount++;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to increment audio stream %u ref count beyond max limit", audioStreamId);
-        }
-    }
-    else
-    {
-        if (it->referenceCount > 0)
-        {
-            it->referenceCount--;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to decrement audio stream %u ref count when it was already 0", audioStreamId);
-        }
+        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
     }
 
-    return CHIP_NO_ERROR;
+    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement)
@@ -417,28 +381,10 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRefCount(uint16_t snaps
 
     if (shouldIncrement)
     {
-        if (it->referenceCount < UINT8_MAX)
-        {
-            it->referenceCount++;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to increment snapshot stream %u ref count beyond max limit", snapshotStreamId);
-        }
-    }
-    else
-    {
-        if (it->referenceCount > 0)
-        {
-            it->referenceCount--;
-        }
-        else
-        {
-            ChipLogError(Camera, "Attempted to decrement snapshot stream %u ref count when it was already 0", snapshotStreamId);
-        }
+        return (it->referenceCount < UINT8_MAX) ? (it->referenceCount++, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
     }
 
-    return CHIP_NO_ERROR;
+    return (it->referenceCount > 0) ? (it->referenceCount--, CHIP_NO_ERROR) : CHIP_ERROR_INVALID_INTEGER_VALUE;
 }
 
 // AttributeAccessInterface

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -332,7 +332,6 @@ CHIP_ERROR CameraAVStreamMgmtServer::RemoveSnapshotStream(uint16_t snapshotStrea
     return CHIP_NO_ERROR;
 }
 
-
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRefCount(uint16_t videoStreamId, bool shouldIncrement)
 {
     auto it = std::find_if(mAllocatedVideoStreams.begin(), mAllocatedVideoStreams.end(),
@@ -345,11 +344,25 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRefCount(uint16_t videoStr
 
     if (shouldIncrement)
     {
-        it->referenceCount++;
+        if (it->referenceCount < UINT8_MAX)
+        {
+            it->referenceCount++;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to increment video stream %u ref count beyond max limit", videoStreamId);
+        }
     }
     else
     {
-        it->referenceCount--;
+        if (it->referenceCount > 0)
+        {
+            it->referenceCount--;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to decrement video stream %u ref count when it was already 0", videoStreamId);
+        }
     }
 
     return CHIP_NO_ERROR;
@@ -367,11 +380,25 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateAudioStreamRefCount(uint16_t audioStr
 
     if (shouldIncrement)
     {
-        it->referenceCount++;
+        if (it->referenceCount < UINT8_MAX)
+        {
+            it->referenceCount++;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to increment audio stream %u ref count beyond max limit", audioStreamId);
+        }
     }
     else
     {
-        it->referenceCount--;
+        if (it->referenceCount > 0)
+        {
+            it->referenceCount--;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to decrement audio stream %u ref count when it was already 0", audioStreamId);
+        }
     }
 
     return CHIP_NO_ERROR;
@@ -379,8 +406,9 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateAudioStreamRefCount(uint16_t audioStr
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement)
 {
-    auto it = std::find_if(mAllocatedSnapshotStreams.begin(), mAllocatedSnapshotStreams.end(),
-                           [snapshotStreamId](const SnapshotStreamStruct & sStream) { return sStream.snapshotStreamID == snapshotStreamId; });
+    auto it = std::find_if(
+        mAllocatedSnapshotStreams.begin(), mAllocatedSnapshotStreams.end(),
+        [snapshotStreamId](const SnapshotStreamStruct & sStream) { return sStream.snapshotStreamID == snapshotStreamId; });
 
     if (it == mAllocatedSnapshotStreams.end())
     {
@@ -389,11 +417,25 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateSnapshotStreamRefCount(uint16_t snaps
 
     if (shouldIncrement)
     {
-        it->referenceCount++;
+        if (it->referenceCount < UINT8_MAX)
+        {
+            it->referenceCount++;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to increment snapshot stream %u ref count beyond max limit", snapshotStreamId);
+        }
     }
     else
     {
-        it->referenceCount--;
+        if (it->referenceCount > 0)
+        {
+            it->referenceCount--;
+        }
+        else
+        {
+            ChipLogError(Camera, "Attempted to decrement snapshot stream %u ref count when it was already 0", snapshotStreamId);
+        }
     }
 
     return CHIP_NO_ERROR;

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -523,6 +523,7 @@ public:
     CHIP_ERROR UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement);
 
     CHIP_ERROR UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement);
+
 private:
     CameraAVStreamMgmtDelegate & mDelegate;
     EndpointId mEndpointId;

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -251,6 +251,18 @@ public:
      */
     virtual CHIP_ERROR PersistentAttributesLoadedCallback() = 0;
 
+    /**
+     * @brief Called by transports when they start using the corresponding audio and video streams.
+     *
+     */
+    virtual CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
+
+    /**
+     * @brief Called by transports when they release the corresponding audio and video streams.
+     *
+     */
+    virtual CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) = 0;
+
 private:
     friend class CameraAVStreamMgmtServer;
 
@@ -506,6 +518,11 @@ public:
 
     CHIP_ERROR RemoveSnapshotStream(uint16_t snapshotStreamId);
 
+    CHIP_ERROR UpdateVideoStreamRefCount(uint16_t videoStreamId, bool shouldIncrement);
+
+    CHIP_ERROR UpdateAudioStreamRefCount(uint16_t audioStreamId, bool shouldIncrement);
+
+    CHIP_ERROR UpdateSnapshotStreamRefCount(uint16_t snapshotStreamId, bool shouldIncrement);
 private:
     CameraAVStreamMgmtDelegate & mDelegate;
     EndpointId mEndpointId;


### PR DESCRIPTION
#### Summary
Provide logic to manage the reference count for Audio/Video streams when handling WebRTC session commands.
This is also tied to AVSM DeAllocate commands which are not allowed to de-allocate a stream when ref count > 0.

* Increment the ref count during HandleProvideOffer and HandleSolicitOffer. 
* Decrement the ref count during HandleEndSession.

Currently, the streamIDs are expected to be passed in for the WebRTC commands.
Filed https://github.com/project-chip/connectedhomeip/issues/39476 to tackle the case of them being Null or empty as a separate PR.

#### Testing
* Start chip-camera-app and pair it with camera-controller
* Allocate VideoStream and start livestream from controller 
** `liveview start 1`. This sends WebRTC ProvideOffer  
* Camera-app updates ref count on video stream
** Verify by reading allocated video streams attribute
** `cameraavstreammanagement read-by-id 0x0F 1 1` 
* Send De-Allocate for streamID. Get back _InvalidInState_ status code.
** `cameraavstreammanagement video-stream-deallocate 1 1 1`
*** `Run command failure: IM Error 0x000005CB: General error: 0xcb (INVALID_IN_STATE)` 