### PR TITLE
Separate out the key pair functionality

### DIFF
--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -102,7 +102,11 @@ if (chip_crypto == "openssl") {
   }
 
   source_set("cryptopal_openssl") {
-    sources = [ "CHIPCryptoPALOpenSSL.cpp" ]
+    sources = [
+      "CHIPCryptoPALOpenSSL.cpp",
+      "CHIPCryptoPALOpenSSL.h",
+      "P256KeyPair_Openssl.cpp",
+    ]
     public_configs = [ ":openssl_config" ]
     public_deps = [ ":public_headers" ]
   }
@@ -111,7 +115,11 @@ if (chip_crypto == "openssl") {
 
   source_set("cryptopal_boringssl") {
     # BoringSSL is close enough to OpenSSL that it uses same PAL, with minor #ifdef differences
-    sources = [ "CHIPCryptoPALOpenSSL.cpp" ]
+    sources = [
+      "CHIPCryptoPALOpenSSL.cpp",
+      "CHIPCryptoPALOpenSSL.h",
+      "P256KeyPair_Openssl.cpp",
+    ]
     public_deps = [
       ":public_headers",
       "${boringssl_root}:boringssl",

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -74,6 +74,10 @@ buildconfig_header("crypto_buildconfig") {
     "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
     "CHIP_CRYPTO_PLATFORM=${chip_crypto_platform}",
   ]
+
+  if (chip_with_trusty_os) {
+    defines += [ "CHIP_CRYPTO_TRUSTY_OS=1" ]
+  }
 }
 
 source_set("public_headers") {
@@ -92,6 +96,10 @@ source_set("public_headers") {
     "${chip_root}/src/lib/support",
     "${nlassert_root}:nlassert",
   ]
+
+  if (chip_with_trusty_os) {
+    public_deps += [ "${chip_root}/third_party/libtrustymatter" ]
+  }
 }
 
 if (chip_crypto == "openssl") {
@@ -105,8 +113,14 @@ if (chip_crypto == "openssl") {
     sources = [
       "CHIPCryptoPALOpenSSL.cpp",
       "CHIPCryptoPALOpenSSL.h",
-      "P256KeyPair_Openssl.cpp",
     ]
+
+    if (chip_with_trusty_os) {
+      sources += [ "P256KeyPair_TrustyImpl.cpp" ]
+    } else {
+      sources += [ "P256KeyPair_Openssl.cpp" ]
+    }
+
     public_configs = [ ":openssl_config" ]
     public_deps = [ ":public_headers" ]
   }
@@ -118,8 +132,14 @@ if (chip_crypto == "openssl") {
     sources = [
       "CHIPCryptoPALOpenSSL.cpp",
       "CHIPCryptoPALOpenSSL.h",
-      "P256KeyPair_Openssl.cpp",
     ]
+
+    if (chip_with_trusty_os) {
+      sources += [ "P256KeyPair_TrustyImpl.cpp" ]
+    } else {
+      sources += [ "P256KeyPair_Openssl.cpp" ]
+    }
+
     public_deps = [
       ":public_headers",
       "${boringssl_root}:boringssl",

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -630,6 +630,11 @@ public:
     /** Release resources associated with this key pair */
     void Clear();
 
+#if defined(CHIP_CRYPTO_TRUSTY_OS)
+    uint64_t p256_handler = 0;
+    uint8_t fabricIndex   = 0;
+#endif
+
 protected:
 #if CHIP_WITH_NLFAULTINJECTION
     mutable P256PublicKey mPublicKey;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -20,6 +20,7 @@
  *      openSSL based implementation of CHIP crypto primitives
  */
 
+#include "CHIPCryptoPALOpenSSL.h"
 #include "CHIPCryptoPAL.h"
 
 #include <type_traits>
@@ -66,13 +67,11 @@ namespace Crypto {
 #define RAND_priv_bytes RAND_bytes
 #define BN_CTX_secure_new BN_CTX_new
 #define EC_GROUP_clear_free EC_GROUP_free
-using boringssl_size_t_openssl_int = size_t;
-using boringssl_uint_openssl_int   = unsigned int;
-using libssl_err_type              = uint32_t;
+using boringssl_uint_openssl_int = unsigned int;
+using libssl_err_type            = uint32_t;
 #else
-using boringssl_size_t_openssl_int = int;
-using boringssl_uint_openssl_int   = int;
-using libssl_err_type              = unsigned long;
+using boringssl_uint_openssl_int = int;
+using libssl_err_type            = unsigned long;
 #endif // CHIP_CRYPTO_BORINGSSL
 
 #define kKeyLengthInBits 256
@@ -84,13 +83,7 @@ enum class DigestType
     SHA256
 };
 
-enum class ECName
-{
-    None   = 0,
-    P256v1 = 1,
-};
-
-static int _nidForCurve(ECName name)
+int CryptoPAL_nidForCurve(ECName name)
 {
     switch (name)
     {
@@ -104,7 +97,7 @@ static int _nidForCurve(ECName name)
     }
 }
 
-static void _logSSLError()
+void CryptoPAL_logSSLError()
 {
     unsigned long ssl_err_code = ERR_get_error();
     while (ssl_err_code != 0)
@@ -198,7 +191,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     VerifyOrExit(tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, error = CHIP_ERROR_INVALID_ARGUMENT);
 #else
     VerifyOrExit(tag_length == 8 || tag_length == 12 || tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES,
-                              error = CHIP_ERROR_INVALID_ARGUMENT);
+                            error = CHIP_ERROR_INVALID_ARGUMENT);
 #endif // CHIP_CRYPTO_BORINGSSL
 
 #if CHIP_CRYPTO_BORINGSSL
@@ -251,7 +244,7 @@ CHIP_ERROR AES_CCM_encrypt(const uint8_t * plaintext, size_t plaintext_length, c
     // Encrypt
     VerifyOrExit(CanCastTo<int>(plaintext_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_EncryptUpdate(context, Uint8::to_uchar(ciphertext), &bytesWritten, Uint8::to_const_uchar(plaintext),
-                                            static_cast<int>(plaintext_length));
+                                          static_cast<int>(plaintext_length));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
     VerifyOrExit((ciphertext_was_null && bytesWritten == 0) || (bytesWritten >= 0), error = CHIP_ERROR_INTERNAL);
     ciphertext_length = static_cast<unsigned int>(bytesWritten);
@@ -328,7 +321,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     VerifyOrExit(tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES, error = CHIP_ERROR_INVALID_ARGUMENT);
 #else
     VerifyOrExit(tag_length == 8 || tag_length == 12 || tag_length == CHIP_CRYPTO_AEAD_MIC_LENGTH_BYTES,
-                              error = CHIP_ERROR_INVALID_ARGUMENT);
+                            error = CHIP_ERROR_INVALID_ARGUMENT);
 #endif // CHIP_CRYPTO_BORINGSSL
     VerifyOrExit(nonce != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(nonce_length > 0, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -362,7 +355,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     // we're writing the tag, not reading.
     VerifyOrExit(CanCastTo<int>(tag_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_CCM_SET_TAG, static_cast<int>(tag_length),
-                                              const_cast<void *>(static_cast<const void *>(tag)));
+                                            const_cast<void *>(static_cast<const void *>(tag)));
     VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
 
     // Pass in key + nonce
@@ -388,7 +381,7 @@ CHIP_ERROR AES_CCM_decrypt(const uint8_t * ciphertext, size_t ciphertext_length,
     // Pass in ciphertext. We wont get anything if validation fails.
     VerifyOrExit(CanCastTo<int>(ciphertext_length), error = CHIP_ERROR_INVALID_ARGUMENT);
     result = EVP_DecryptUpdate(context, Uint8::to_uchar(plaintext), &bytesOutput, Uint8::to_const_uchar(ciphertext),
-                                            static_cast<int>(ciphertext_length));
+                                          static_cast<int>(ciphertext_length));
     if (plaintext_was_null)
     {
         VerifyOrExit(bytesOutput <= static_cast<int>(sizeof(placeholder_plaintext)), error = CHIP_ERROR_INTERNAL);
@@ -695,7 +688,7 @@ CHIP_ERROR PBKDF2_sha256::pbkdf2_sha256(const uint8_t * password, size_t plen, c
 exit:
     if (error != CHIP_NO_ERROR)
     {
-        _logSSLError();
+        CryptoPAL_logSSLError();
     }
 
     return error;
@@ -718,7 +711,7 @@ CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
     return CHIP_NO_ERROR;
 }
 
-ECName MapECName(SupportedECPKeyTypes keyType)
+ECName CryptoPAL_MapECName(SupportedECPKeyTypes keyType)
 {
     switch (keyType)
     {
@@ -727,77 +720,6 @@ ECName MapECName(SupportedECPKeyTypes keyType)
     default:
         return ECName::None;
     }
-}
-
-static inline void from_EC_KEY(EC_KEY * key, P256KeypairContext * context)
-{
-    *SafePointerCast<EC_KEY **>(context) = key;
-}
-
-static inline EC_KEY * to_EC_KEY(P256KeypairContext * context)
-{
-    return *SafePointerCast<EC_KEY **>(context);
-}
-
-static inline const EC_KEY * to_const_EC_KEY(const P256KeypairContext * context)
-{
-    return *SafePointerCast<const EC_KEY * const *>(context);
-}
-
-CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
-{
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int nid          = NID_undef;
-    EC_KEY * ec_key  = nullptr;
-    ECDSA_SIG * sig  = nullptr;
-    const BIGNUM * r = nullptr;
-    const BIGNUM * s = nullptr;
-
-    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
-
-    uint8_t digest[kSHA256_Hash_Length];
-    memset(&digest[0], 0, sizeof(digest));
-
-    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
-
-    ERR_clear_error();
-
-    static_assert(P256ECDSASignature::Capacity() >= kP256_ECDSA_Signature_Length_Raw, "P256ECDSASignature must be large enough");
-    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
-    nid = _nidForCurve(MapECName(mPublicKey.Type()));
-    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    ec_key = to_EC_KEY(&mKeypair);
-    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    sig = ECDSA_do_sign(Uint8::to_const_uchar(&digest[0]), static_cast<boringssl_size_t_openssl_int>(sizeof(digest)), ec_key);
-    VerifyOrExit(sig != nullptr, error = CHIP_ERROR_INTERNAL);
-    ECDSA_SIG_get0(sig, &r, &s);
-    VerifyOrExit((r != nullptr) && (s != nullptr), error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(CanCastTo<size_t>(BN_num_bytes(r)) && CanCastTo<size_t>(BN_num_bytes(s)), error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit((static_cast<size_t>(BN_num_bytes(r)) <= kP256_FE_Length) &&
-                     (static_cast<size_t>(BN_num_bytes(s)) <= kP256_FE_Length),
-                 error = CHIP_ERROR_INTERNAL);
-
-    // Concatenate r and s to output. Sizes were checked above.
-    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(BN_bn2binpad(r, out_signature.Bytes() + 0u, kP256_FE_Length) == kP256_FE_Length, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(BN_bn2binpad(s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length) == kP256_FE_Length,
-                 error = CHIP_ERROR_INTERNAL);
-
-exit:
-    if (sig != nullptr)
-    {
-        // SIG owns the memory of r, s
-        ECDSA_SIG_free(sig);
-    }
-
-    if (error != CHIP_NO_ERROR)
-    {
-        _logSSLError();
-    }
-
-    return error;
 }
 
 CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
@@ -830,7 +752,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
     VerifyOrExit(hash_length == kSHA256_Hash_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(signature.Length() == kP256_ECDSA_Signature_Length_Raw, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    nid = _nidForCurve(MapECName(Type()));
+    nid = CryptoPAL_nidForCurve(CryptoPAL_MapECName(Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     ec_group = EC_GROUP_new_by_curve_name(nid);
@@ -869,7 +791,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
     error = CHIP_NO_ERROR;
 
 exit:
-    _logSSLError();
+    CryptoPAL_logSSLError();
     if (ec_sig != nullptr)
     {
         ECDSA_SIG_free(ec_sig);
@@ -902,140 +824,6 @@ exit:
     return error;
 }
 
-// helper function to populate octet key into EVP_PKEY out_evp_pkey. Caller must free out_evp_pkey
-static CHIP_ERROR _create_evp_key_from_binary_p256_key(const P256PublicKey & key, EVP_PKEY ** out_evp_pkey)
-{
-
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    EC_KEY * ec_key  = nullptr;
-    int result       = -1;
-    EC_POINT * point = nullptr;
-    EC_GROUP * group = nullptr;
-    int nid          = NID_undef;
-
-    VerifyOrExit(*out_evp_pkey == nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    nid = _nidForCurve(MapECName(key.Type()));
-    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INTERNAL);
-
-    ec_key = EC_KEY_new_by_curve_name(nid);
-    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    group = EC_GROUP_new_by_curve_name(nid);
-    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    point = EC_POINT_new(group);
-    VerifyOrExit(point != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_POINT_oct2point(group, point, Uint8::to_const_uchar(key), key.Length(), nullptr);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_KEY_set_public_key(ec_key, point);
-
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    *out_evp_pkey = EVP_PKEY_new();
-    VerifyOrExit(*out_evp_pkey != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EVP_PKEY_set1_EC_KEY(*out_evp_pkey, ec_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-exit:
-    if (ec_key != nullptr)
-    {
-        EC_KEY_free(ec_key);
-        ec_key = nullptr;
-    }
-
-    if (error != CHIP_NO_ERROR && *out_evp_pkey)
-    {
-        EVP_PKEY_free(*out_evp_pkey);
-        out_evp_pkey = nullptr;
-    }
-
-    if (point != nullptr)
-    {
-        EC_POINT_free(point);
-        point = nullptr;
-    }
-
-    if (group != nullptr)
-    {
-        EC_GROUP_free(group);
-        group = nullptr;
-    }
-
-    return error;
-}
-
-CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
-{
-    ERR_clear_error();
-    CHIP_ERROR error      = CHIP_NO_ERROR;
-    int result            = -1;
-    EVP_PKEY * local_key  = nullptr;
-    EVP_PKEY * remote_key = nullptr;
-
-    EVP_PKEY_CTX * context = nullptr;
-    size_t out_buf_length  = 0;
-
-    EC_KEY * ec_key = EC_KEY_dup(to_const_EC_KEY(&mKeypair));
-    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
-
-    local_key = EVP_PKEY_new();
-    VerifyOrExit(local_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EVP_PKEY_set1_EC_KEY(local_key, ec_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = _create_evp_key_from_binary_p256_key(remote_public_key, &remote_key);
-    SuccessOrExit(error);
-
-    context = EVP_PKEY_CTX_new(local_key, nullptr);
-    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EVP_PKEY_derive_init(context);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = EVP_PKEY_derive_set_peer(context, remote_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    out_buf_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
-    result         = EVP_PKEY_derive(context, out_secret.Bytes(), &out_buf_length);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-    SuccessOrExit(error = out_secret.SetLength(out_buf_length));
-
-exit:
-    if (ec_key != nullptr)
-    {
-        EC_KEY_free(ec_key);
-        ec_key = nullptr;
-    }
-
-    if (local_key != nullptr)
-    {
-        EVP_PKEY_free(local_key);
-        local_key = nullptr;
-    }
-
-    if (remote_key != nullptr)
-    {
-        EVP_PKEY_free(remote_key);
-        remote_key = nullptr;
-    }
-
-    if (context != nullptr)
-    {
-        EVP_PKEY_CTX_free(context);
-        context = nullptr;
-    }
-
-    _logSSLError();
-    return error;
-}
-
 void ClearSecretData(uint8_t * buf, size_t len)
 {
     OPENSSL_cleanse(buf, len);
@@ -1046,20 +834,20 @@ bool IsBufferContentEqualConstantTime(const void * a, const void * b, size_t n)
     return CRYPTO_memcmp(a, b, n) == 0;
 }
 
-static CHIP_ERROR P256PublicKeyFromECKey(EC_KEY * ec_key, P256PublicKey & pubkey)
+CHIP_ERROR P256PublicKeyFromECKey(EC_KEY * ec_key, P256PublicKey & pubkey)
 {
     ERR_clear_error();
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     int nid            = NID_undef;
-    ECName curve       = MapECName(pubkey.Type());
+    ECName curve       = CryptoPAL_MapECName(pubkey.Type());
     EC_GROUP * group   = nullptr;
     size_t pubkey_size = 0;
 
     const EC_POINT * pubkey_ecp = EC_KEY_get0_public_key(ec_key);
     VerifyOrExit(pubkey_ecp != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    nid = _nidForCurve(curve);
+    nid = CryptoPAL_nidForCurve(curve);
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
 
     group = EC_GROUP_new_by_curve_name(nid);
@@ -1078,240 +866,7 @@ exit:
         group = nullptr;
     }
 
-    _logSSLError();
-    return error;
-}
-
-CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
-{
-    ERR_clear_error();
-
-    Clear();
-
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
-    EC_KEY * ec_key  = nullptr;
-    ECName curve     = MapECName(mPublicKey.Type());
-
-    int nid = _nidForCurve(curve);
-    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    ec_key = EC_KEY_new_by_curve_name(nid);
-    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_KEY_generate_key(ec_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    error = P256PublicKeyFromECKey(ec_key, mPublicKey);
-    SuccessOrExit(error);
-
-    from_EC_KEY(ec_key, &mKeypair);
-    mInitialized = true;
-    ec_key       = nullptr;
-
-exit:
-    if (ec_key != nullptr)
-    {
-        EC_KEY_free(ec_key);
-        ec_key = nullptr;
-    }
-
-    _logSSLError();
-    return error;
-}
-
-CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
-{
-    CHIP_ERROR error = CHIP_NO_ERROR;
-
-    const EC_KEY * ec_key = to_const_EC_KEY(&mKeypair);
-    uint8_t privkey[kP256_PrivateKey_Length];
-
-    int privkey_size          = 0;
-    const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
-    VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    privkey_size = BN_bn2binpad(privkey_bn, privkey, sizeof(privkey));
-    privkey_bn   = nullptr;
-
-    VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit((size_t) privkey_size == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
-
-    {
-        size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
-        Encoding::BufferWriter bbuf(output.Bytes(), len);
-        bbuf.Put(mPublicKey, mPublicKey.Length());
-        bbuf.Put(privkey, sizeof(privkey));
-        VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
-        output.SetLength(bbuf.Needed());
-    }
-
-exit:
-    ClearSecretData(privkey, sizeof(privkey));
-    _logSSLError();
-    return error;
-}
-
-CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
-{
-    Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
-
-    Clear();
-
-    BIGNUM * pvt_key     = nullptr;
-    EC_GROUP * group     = nullptr;
-    EC_POINT * key_point = nullptr;
-
-    EC_KEY * ec_key = nullptr;
-    ECName curve    = MapECName(mPublicKey.Type());
-
-    ERR_clear_error();
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
-    int nid          = NID_undef;
-
-    const uint8_t * privkey = input.ConstBytes() + mPublicKey.Length();
-
-    VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
-    bbuf.Put(input.ConstBytes(), mPublicKey.Length());
-    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
-
-    nid = _nidForCurve(curve);
-    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
-
-    group = EC_GROUP_new_by_curve_name(nid);
-    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    key_point = EC_POINT_new(group);
-    VerifyOrExit(key_point != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_POINT_oct2point(group, key_point, Uint8::to_const_uchar(mPublicKey), mPublicKey.Length(), nullptr);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    ec_key = EC_KEY_new_by_curve_name(nid);
-    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_KEY_set_public_key(ec_key, key_point);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    pvt_key = BN_bin2bn(privkey, kP256_PrivateKey_Length, nullptr);
-    VerifyOrExit(pvt_key != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_KEY_set_private_key(ec_key, pvt_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    from_EC_KEY(ec_key, &mKeypair);
-    mInitialized = true;
-    ec_key       = nullptr;
-
-exit:
-    if (ec_key != nullptr)
-    {
-        EC_KEY_free(ec_key);
-        ec_key = nullptr;
-    }
-
-    if (group != nullptr)
-    {
-        EC_GROUP_free(group);
-        group = nullptr;
-    }
-
-    if (pvt_key != nullptr)
-    {
-        BN_free(pvt_key);
-        pvt_key = nullptr;
-    }
-
-    if (key_point != nullptr)
-    {
-        EC_POINT_free(key_point);
-        key_point = nullptr;
-    }
-    _logSSLError();
-    return error;
-}
-
-void P256Keypair::Clear()
-{
-    if (mInitialized)
-    {
-        EC_KEY * ec_key = to_EC_KEY(&mKeypair);
-        EC_KEY_free(ec_key);
-        mInitialized = false;
-    }
-}
-
-P256Keypair::~P256Keypair()
-{
-    Clear();
-}
-
-CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
-{
-    ERR_clear_error();
-    CHIP_ERROR error     = CHIP_NO_ERROR;
-    int result           = 0;
-    int csr_length_local = 0;
-
-    X509_REQ * x509_req = X509_REQ_new();
-    EVP_PKEY * evp_pkey = nullptr;
-
-    EC_KEY * ec_key = to_EC_KEY(&mKeypair);
-
-    X509_NAME * subject = X509_NAME_new();
-    VerifyOrExit(subject != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
-
-    result = X509_REQ_set_version(x509_req, 0);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = EC_KEY_check_key(ec_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    evp_pkey = EVP_PKEY_new();
-    VerifyOrExit(evp_pkey != nullptr, error = CHIP_ERROR_INTERNAL);
-
-    result = EVP_PKEY_set1_EC_KEY(evp_pkey, ec_key);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = X509_REQ_set_pubkey(x509_req, evp_pkey);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    // TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
-    //       CHIP Spec doesn't specify the subject name that can be used.
-    //       Figure out the correct value and update this code.
-    result = X509_NAME_add_entry_by_txt(subject, "O", MBSTRING_ASC, Uint8::from_const_char("CSR"), -1, -1, 0);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = X509_REQ_set_subject_name(x509_req, subject);
-    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
-
-    result = X509_REQ_sign(x509_req, evp_pkey, EVP_sha256());
-    VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
-
-    csr_length_local = i2d_X509_REQ(x509_req, nullptr);
-    VerifyOrExit(csr_length_local >= 0, error = CHIP_ERROR_INTERNAL);
-    VerifyOrExit(CanCastTo<size_t>(csr_length_local), error = CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrExit(static_cast<size_t>(csr_length_local) <= csr_length, error = CHIP_ERROR_BUFFER_TOO_SMALL);
-    csr_length = static_cast<size_t>(i2d_X509_REQ(x509_req, &out_csr));
-
-exit:
-    ec_key = nullptr;
-
-    if (evp_pkey != nullptr)
-    {
-        EVP_PKEY_free(evp_pkey);
-        evp_pkey = nullptr;
-    }
-
-    X509_NAME_free(subject);
-    subject = nullptr;
-
-    X509_REQ_free(x509_req);
-
-    _logSSLError();
+    CryptoPAL_logSSLError();
     return error;
 }
 
@@ -1360,7 +915,7 @@ exit:
     {
         EVP_PKEY_free(evp_pkey);
     }
-    _logSSLError();
+    CryptoPAL_logSSLError();
     return error;
 }
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.h
+++ b/src/crypto/CHIPCryptoPALOpenSSL.h
@@ -1,0 +1,64 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Header that exposes some ECC-related API which used by P256KeyPair class
+ */
+
+#pragma once
+
+#include "CHIPCryptoPAL.h"
+#include <openssl/x509.h>
+
+namespace chip {
+namespace Crypto {
+
+#if CHIP_CRYPTO_BORINGSSL
+using boringssl_size_t_openssl_int = size_t;
+#else
+using boringssl_size_t_openssl_int = int;
+#endif
+
+enum class ECName
+{
+    None   = 0,
+    P256v1 = 1,
+};
+
+/**
+ * @brief Collect and print SSL-related error information
+ **/
+void CryptoPAL_logSSLError();
+
+/**
+ * @brief Get the NID of an elliptic curve by name
+ **/
+int CryptoPAL_nidForCurve(ECName name);
+
+/**
+ * @brief Get the elliptic curve name by key type
+ **/
+ECName CryptoPAL_MapECName(SupportedECPKeyTypes keyType);
+
+/**
+ * @brief Get public key via EC_KEY
+ **/
+CHIP_ERROR P256PublicKeyFromECKey(EC_KEY * ec_key, P256PublicKey & pubkey);
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/P256KeyPair_Openssl.cpp
+++ b/src/crypto/P256KeyPair_Openssl.cpp
@@ -1,0 +1,483 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      openSSL based implementation of CHIP crypto primitives
+ */
+
+#include "CHIPCryptoPAL.h"
+#include "CHIPCryptoPALOpenSSL.h"
+
+#include <type_traits>
+
+#if CHIP_CRYPTO_BORINGSSL
+#include <openssl/aead.h>
+#endif // CHIP_CRYPTO_BORINGSSL
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+
+#include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/BufferWriter.h>
+#include <lib/support/BytesToHex.h>
+#include <lib/support/CHIPArgParser.hpp>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
+
+namespace chip {
+namespace Crypto {
+
+static inline void from_EC_KEY(EC_KEY * key, P256KeypairContext * context)
+{
+    *SafePointerCast<EC_KEY **>(context) = key;
+}
+
+static inline EC_KEY * to_EC_KEY(P256KeypairContext * context)
+{
+    return *SafePointerCast<EC_KEY **>(context);
+}
+
+static inline const EC_KEY * to_const_EC_KEY(const P256KeypairContext * context)
+{
+    return *SafePointerCast<const EC_KEY * const *>(context);
+}
+
+CHIP_ERROR _create_evp_key_from_binary_p256_key(const P256PublicKey & key, EVP_PKEY ** out_evp_pkey)
+{
+
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    EC_KEY * ec_key  = nullptr;
+    int result       = -1;
+    EC_POINT * point = nullptr;
+    EC_GROUP * group = nullptr;
+    int nid          = NID_undef;
+
+    VerifyOrExit(*out_evp_pkey == nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    nid = CryptoPAL_MapECName(MapECName(key.Type()));
+    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INTERNAL);
+
+    ec_key = EC_KEY_new_by_curve_name(nid);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    group = EC_GROUP_new_by_curve_name(nid);
+    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    point = EC_POINT_new(group);
+    VerifyOrExit(point != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_POINT_oct2point(group, point, Uint8::to_const_uchar(key), key.Length(), nullptr);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_set_public_key(ec_key, point);
+
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    *out_evp_pkey = EVP_PKEY_new();
+    VerifyOrExit(*out_evp_pkey != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EVP_PKEY_set1_EC_KEY(*out_evp_pkey, ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+        ec_key = nullptr;
+    }
+
+    if (error != CHIP_NO_ERROR && *out_evp_pkey)
+    {
+        EVP_PKEY_free(*out_evp_pkey);
+        out_evp_pkey = nullptr;
+    }
+
+    if (point != nullptr)
+    {
+        EC_POINT_free(point);
+        point = nullptr;
+    }
+
+    if (group != nullptr)
+    {
+        EC_GROUP_free(group);
+        group = nullptr;
+    }
+
+    return error;
+}
+
+CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int nid          = NID_undef;
+    EC_KEY * ec_key  = nullptr;
+    ECDSA_SIG * sig  = nullptr;
+    const BIGNUM * r = nullptr;
+    const BIGNUM * s = nullptr;
+
+    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t digest[kSHA256_Hash_Length];
+    memset(&digest[0], 0, sizeof(digest));
+
+    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
+
+    ERR_clear_error();
+
+    static_assert(P256ECDSASignature::Capacity() >= kP256_ECDSA_Signature_Length_Raw, "P256ECDSASignature must be large enough");
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+    nid = CryptoPAL_MapECName(MapECName(mPublicKey.Type()));
+    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    ec_key = to_EC_KEY(&mKeypair);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    sig = ECDSA_do_sign(Uint8::to_const_uchar(&digest[0]), static_cast<boringssl_size_t_openssl_int>(sizeof(digest)), ec_key);
+    VerifyOrExit(sig != nullptr, error = CHIP_ERROR_INTERNAL);
+    ECDSA_SIG_get0(sig, &r, &s);
+    VerifyOrExit((r != nullptr) && (s != nullptr), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<size_t>(BN_num_bytes(r)) && CanCastTo<size_t>(BN_num_bytes(s)), error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit((static_cast<size_t>(BN_num_bytes(r)) <= kP256_FE_Length) &&
+                     (static_cast<size_t>(BN_num_bytes(s)) <= kP256_FE_Length),
+                 error = CHIP_ERROR_INTERNAL);
+
+    // Concatenate r and s to output. Sizes were checked above.
+    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(BN_bn2binpad(r, out_signature.Bytes() + 0u, kP256_FE_Length) == kP256_FE_Length, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(BN_bn2binpad(s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length) == kP256_FE_Length,
+                 error = CHIP_ERROR_INTERNAL);
+
+exit:
+    if (sig != nullptr)
+    {
+        // SIG owns the memory of r, s
+        ECDSA_SIG_free(sig);
+    }
+
+    if (error != CHIP_NO_ERROR)
+    {
+        CryptoPAL_logSSLError();
+    }
+
+    return error;
+}
+
+CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
+{
+    ERR_clear_error();
+    CHIP_ERROR error      = CHIP_NO_ERROR;
+    int result            = -1;
+    EVP_PKEY * local_key  = nullptr;
+    EVP_PKEY * remote_key = nullptr;
+
+    EVP_PKEY_CTX * context = nullptr;
+    size_t out_buf_length  = 0;
+
+    EC_KEY * ec_key = EC_KEY_dup(to_const_EC_KEY(&mKeypair));
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    local_key = EVP_PKEY_new();
+    VerifyOrExit(local_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EVP_PKEY_set1_EC_KEY(local_key, ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    error = _create_evp_key_from_binary_p256_key(remote_public_key, &remote_key);
+    SuccessOrExit(error);
+
+    context = EVP_PKEY_CTX_new(local_key, nullptr);
+    VerifyOrExit(context != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EVP_PKEY_derive_init(context);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = EVP_PKEY_derive_set_peer(context, remote_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    out_buf_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
+    result         = EVP_PKEY_derive(context, out_secret.Bytes(), &out_buf_length);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+    SuccessOrExit(error = out_secret.SetLength(out_buf_length));
+
+exit:
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+        ec_key = nullptr;
+    }
+
+    if (local_key != nullptr)
+    {
+        EVP_PKEY_free(local_key);
+        local_key = nullptr;
+    }
+
+    if (remote_key != nullptr)
+    {
+        EVP_PKEY_free(remote_key);
+        remote_key = nullptr;
+    }
+
+    if (context != nullptr)
+    {
+        EVP_PKEY_CTX_free(context);
+        context = nullptr;
+    }
+
+    CryptoPAL_logSSLError();
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
+{
+    ERR_clear_error();
+
+    Clear();
+
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    EC_KEY * ec_key  = nullptr;
+    ECName curve     = MapECName(mPublicKey.Type());
+
+    int nid = CryptoPAL_MapECName(curve);
+    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    ec_key = EC_KEY_new_by_curve_name(nid);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_generate_key(ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    error = P256PublicKeyFromECKey(ec_key, mPublicKey);
+    SuccessOrExit(error);
+
+    from_EC_KEY(ec_key, &mKeypair);
+    mInitialized = true;
+    ec_key       = nullptr;
+
+exit:
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+        ec_key = nullptr;
+    }
+
+    CryptoPAL_logSSLError();
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
+    const EC_KEY * ec_key = to_const_EC_KEY(&mKeypair);
+    uint8_t privkey[kP256_PrivateKey_Length];
+
+    int privkey_size          = 0;
+    const BIGNUM * privkey_bn = EC_KEY_get0_private_key(ec_key);
+    VerifyOrExit(privkey_bn != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    privkey_size = BN_bn2binpad(privkey_bn, privkey, sizeof(privkey));
+    privkey_bn   = nullptr;
+
+    VerifyOrExit(privkey_size > 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit((size_t) privkey_size == sizeof(privkey), error = CHIP_ERROR_INTERNAL);
+
+    {
+        size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
+        Encoding::BufferWriter bbuf(output.Bytes(), len);
+        bbuf.Put(mPublicKey, mPublicKey.Length());
+        bbuf.Put(privkey, sizeof(privkey));
+        VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+        output.SetLength(bbuf.Needed());
+    }
+
+exit:
+    ClearSecretData(privkey, sizeof(privkey));
+    CryptoPAL_logSSLError();
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
+{
+    Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
+
+    Clear();
+
+    BIGNUM * pvt_key     = nullptr;
+    EC_GROUP * group     = nullptr;
+    EC_POINT * key_point = nullptr;
+
+    EC_KEY * ec_key = nullptr;
+    ECName curve    = MapECName(mPublicKey.Type());
+
+    ERR_clear_error();
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    int nid          = NID_undef;
+
+    const uint8_t * privkey = input.ConstBytes() + mPublicKey.Length();
+
+    VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    bbuf.Put(input.ConstBytes(), mPublicKey.Length());
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+
+    nid = CryptoPAL_MapECName(curve);
+    VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
+
+    group = EC_GROUP_new_by_curve_name(nid);
+    VerifyOrExit(group != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    key_point = EC_POINT_new(group);
+    VerifyOrExit(key_point != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_POINT_oct2point(group, key_point, Uint8::to_const_uchar(mPublicKey), mPublicKey.Length(), nullptr);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    ec_key = EC_KEY_new_by_curve_name(nid);
+    VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_set_public_key(ec_key, key_point);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    pvt_key = BN_bin2bn(privkey, kP256_PrivateKey_Length, nullptr);
+    VerifyOrExit(pvt_key != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_set_private_key(ec_key, pvt_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    from_EC_KEY(ec_key, &mKeypair);
+    mInitialized = true;
+    ec_key       = nullptr;
+
+exit:
+    if (ec_key != nullptr)
+    {
+        EC_KEY_free(ec_key);
+        ec_key = nullptr;
+    }
+
+    if (group != nullptr)
+    {
+        EC_GROUP_free(group);
+        group = nullptr;
+    }
+
+    if (pvt_key != nullptr)
+    {
+        BN_free(pvt_key);
+        pvt_key = nullptr;
+    }
+
+    if (key_point != nullptr)
+    {
+        EC_POINT_free(key_point);
+        key_point = nullptr;
+    }
+    CryptoPAL_logSSLError();
+    return error;
+}
+
+void P256Keypair::Clear()
+{
+    if (mInitialized)
+    {
+        EC_KEY * ec_key = to_EC_KEY(&mKeypair);
+        EC_KEY_free(ec_key);
+        mInitialized = false;
+    }
+}
+
+P256Keypair::~P256Keypair()
+{
+    Clear();
+}
+
+CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
+{
+    ERR_clear_error();
+    CHIP_ERROR error     = CHIP_NO_ERROR;
+    int result           = 0;
+    int csr_length_local = 0;
+
+    X509_REQ * x509_req = X509_REQ_new();
+    EVP_PKEY * evp_pkey = nullptr;
+
+    EC_KEY * ec_key = to_EC_KEY(&mKeypair);
+
+    X509_NAME * subject = X509_NAME_new();
+    VerifyOrExit(subject != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    result = X509_REQ_set_version(x509_req, 0);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = EC_KEY_check_key(ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    evp_pkey = EVP_PKEY_new();
+    VerifyOrExit(evp_pkey != nullptr, error = CHIP_ERROR_INTERNAL);
+
+    result = EVP_PKEY_set1_EC_KEY(evp_pkey, ec_key);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = X509_REQ_set_pubkey(x509_req, evp_pkey);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    // TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
+    //       CHIP Spec doesn't specify the subject name that can be used.
+    //       Figure out the correct value and update this code.
+    result = X509_NAME_add_entry_by_txt(subject, "O", MBSTRING_ASC, Uint8::from_const_char("CSR"), -1, -1, 0);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = X509_REQ_set_subject_name(x509_req, subject);
+    VerifyOrExit(result == 1, error = CHIP_ERROR_INTERNAL);
+
+    result = X509_REQ_sign(x509_req, evp_pkey, EVP_sha256());
+    VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
+
+    csr_length_local = i2d_X509_REQ(x509_req, nullptr);
+    VerifyOrExit(csr_length_local >= 0, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(CanCastTo<size_t>(csr_length_local), error = CHIP_ERROR_BUFFER_TOO_SMALL);
+    VerifyOrExit(static_cast<size_t>(csr_length_local) <= csr_length, error = CHIP_ERROR_BUFFER_TOO_SMALL);
+    csr_length = static_cast<size_t>(i2d_X509_REQ(x509_req, &out_csr));
+
+exit:
+    ec_key = nullptr;
+
+    if (evp_pkey != nullptr)
+    {
+        EVP_PKEY_free(evp_pkey);
+        evp_pkey = nullptr;
+    }
+
+    X509_NAME_free(subject);
+    subject = nullptr;
+
+    X509_REQ_free(x509_req);
+
+    CryptoPAL_logSSLError();
+    return error;
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/P256KeyPair_TrustyImpl.cpp
+++ b/src/crypto/P256KeyPair_TrustyImpl.cpp
@@ -1,0 +1,169 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Trusty OS based implementation of CHIP crypto primitives
+ */
+
+#include "CHIPCryptoPAL.h"
+
+#include <trusty_matter.h>
+
+#include <lib/core/CHIPSafeCasts.h>
+#include <lib/support/CHIPArgParser.hpp>
+
+namespace chip {
+namespace Crypto {
+
+matter::TrustyMatter trusty_matter;
+
+CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    size_t sig_size  = 0;
+    int rc           = 0;
+
+    VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t digest[kSHA256_Hash_Length];
+    uint8_t sig[kP256_ECDSA_Signature_Length_Raw];
+    memset(&digest[0], 0, sizeof(digest));
+    memset(&sig[0], 0, sizeof(sig));
+
+    ReturnErrorOnFailure(Hash_SHA256(msg, msg_length, &digest[0]));
+
+    static_assert(P256ECDSASignature::Capacity() >= kP256_ECDSA_Signature_Length_Raw, "P256ECDSASignature must be large enough");
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    rc = trusty_matter.P256KeypairECSignMsg(p256_handler, digest, kSHA256_Hash_Length, sig, sig_size);
+    VerifyOrExit(rc == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(sig_size == kP256_ECDSA_Signature_Length_Raw, error = CHIP_ERROR_INTERNAL);
+
+    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    memcpy(out_signature.Bytes() + 0u, sig, sig_size);
+
+exit:
+    return error;
+}
+
+CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
+{
+    CHIP_ERROR error      = CHIP_NO_ERROR;
+    int result            = -1;
+    size_t out_buf_length = 0;
+
+    result = trusty_matter.P256KeypairECDH_derive_secret(p256_handler, Uint8::to_const_uchar(remote_public_key),
+                                                         remote_public_key.Length(), out_secret.Bytes(), out_buf_length);
+    VerifyOrExit(result == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit((out_buf_length > 0), error = CHIP_ERROR_INTERNAL);
+    SuccessOrExit(error = out_secret.SetLength(out_buf_length));
+
+exit:
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Initialize(ECPKeyTarget key_target)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    uint8_t public_key[kP256_PublicKey_Length];
+    int rc = 0;
+
+    rc = trusty_matter.P256KeypairInitialize(p256_handler, fabricIndex, public_key);
+    VerifyOrExit(rc == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+
+    memcpy(Uint8::to_uchar(mPublicKey), public_key, kP256_PublicKey_Length);
+
+    mInitialized = true;
+
+exit:
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    uint8_t privkey[kP256_PrivateKey_Length];
+    int rc = 0;
+
+    rc = trusty_matter.P256KeypairSerialize(p256_handler, privkey);
+    VerifyOrExit(rc == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+
+    {
+        size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
+        Encoding::BufferWriter bbuf(output.Bytes(), len);
+        bbuf.Put(mPublicKey, mPublicKey.Length());
+        bbuf.Put(privkey, sizeof(privkey));
+        VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+        output.SetLength(bbuf.Needed());
+    }
+
+exit:
+    ClearSecretData(privkey, sizeof(privkey));
+    return error;
+}
+
+CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
+    int rc = 0;
+
+    uint8_t * pubkey  = input.Bytes();
+    uint8_t * privkey = input.Bytes() + mPublicKey.Length();
+
+    VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
+    bbuf.Put(input.ConstBytes(), mPublicKey.Length());
+    VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
+
+    rc = trusty_matter.P256KeypairDeserialize(p256_handler, pubkey, mPublicKey.Length(), privkey, kP256_PrivateKey_Length);
+    VerifyOrExit(rc == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+
+    mInitialized = true;
+
+exit:
+    return error;
+}
+
+void P256Keypair::Clear()
+{
+    mInitialized = false;
+    p256_handler = 0;
+}
+
+P256Keypair::~P256Keypair()
+{
+    trusty_matter.P256KeypairDestory(p256_handler);
+    Clear();
+}
+
+CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int rc           = 0;
+
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_UNINITIALIZED);
+
+    rc = trusty_matter.P256KeypairNewCSR(p256_handler, out_csr, csr_length);
+    VerifyOrExit(rc == MATTER_ERROR_OK, error = CHIP_ERROR_INTERNAL);
+
+exit:
+    return error;
+}
+
+} // namespace Crypto
+} // namespace chip


### PR DESCRIPTION
1. Move the key pair functionality into a separate file, to make it easier for chip vendors to use their own key pair implementation.
2. i.MX supports Trusty OS. Move the p256keypair operations to Trusty OS to enhance the crypto security.

#### Testing
Testing passed on i.MX8MM platforms.
Successfully pairing between chip-tool and chip-lighting-app.