### PR TITLE
[ICD] Remove the aborts for ICD manager checks(v1.4)

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -2064,14 +2064,10 @@ bool InteractionModelEngine::HasSubscriptionsToResume()
 void InteractionModelEngine::DecrementNumSubscriptionsToResume()
 {
     VerifyOrReturn(mNumOfSubscriptionsToResume > 0);
-#if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    VerifyOrDie(mICDManager);
-#endif // CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-
     mNumOfSubscriptionsToResume--;
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP && !CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
-    if (!mNumOfSubscriptionsToResume)
+    if (mICDManager && !mNumOfSubscriptionsToResume)
     {
         mICDManager->SetBootUpResumeSubscriptionExecuted();
     }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -149,8 +149,11 @@ CHIP_ERROR DnssdServer::SetEphemeralDiscriminator(Optional<uint16_t> discriminat
 template <class AdvertisingParams>
 void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 {
-    VerifyOrDieWithMsg(mICDManager != nullptr, Discovery,
-                       "Invalid pointer to the ICDManager which is required for the LIT operating mode");
+    if (mICDManager == nullptr)
+    {
+        ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key");
+        return;
+    }
 
     Dnssd::ICDModeAdvertise ICDModeToAdvertise = Dnssd::ICDModeAdvertise::kNone;
     // Only advertise the ICD key if the device can operate as a LIT

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -149,10 +149,7 @@ CHIP_ERROR DnssdServer::SetEphemeralDiscriminator(Optional<uint16_t> discriminat
 template <class AdvertisingParams>
 void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 {
-    if (mICDManager == nullptr)
-    {
-        ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key");
-        return;
+VerifyOrReturn(mICDManager != nullptr, ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key"));
     }
 
     Dnssd::ICDModeAdvertise ICDModeToAdvertise = Dnssd::ICDModeAdvertise::kNone;

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -149,8 +149,9 @@ CHIP_ERROR DnssdServer::SetEphemeralDiscriminator(Optional<uint16_t> discriminat
 template <class AdvertisingParams>
 void DnssdServer::AddICDKeyToAdvertisement(AdvertisingParams & advParams)
 {
-VerifyOrReturn(mICDManager != nullptr, ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key"));
-    }
+    VerifyOrReturn(
+        mICDManager != nullptr,
+        ChipLogError(Discovery, "Invalid pointer to the ICDManager which is required for adding Dnssd advertisement key"));
 
     Dnssd::ICDModeAdvertise ICDModeToAdvertise = Dnssd::ICDModeAdvertise::kNone;
     // Only advertise the ICD key if the device can operate as a LIT


### PR DESCRIPTION
#### Summary

Cherry-pick #37728 to v1.4 branch so that we can deinitialize ICD manager after server is initialized

#### Related issues

#### Testing

Manual test:
1. Add the unregistration code after the server initialization in the ESP32 ICD example
2. Run the ICD example on ESP32-H2
3. The unregistration works and the device doesn't work as an ICD after that.

