### PR TITLE
DO NOT SUBMIT - Hacking KVS filename to include port number

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -137,7 +137,17 @@
         "any": "cpp",
         "future": "cpp",
         "list": "cpp",
-        "unordered_set": "cpp"
+        "unordered_set": "cpp",
+        "charconv": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "forward_list": "cpp",
+        "source_location": "cpp",
+        "format": "cpp",
+        "numbers": "cpp",
+        "semaphore": "cpp",
+        "span": "cpp",
+        "stop_token": "cpp"
     },
     "[ini]": {
         "editor.formatOnSave": false

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -149,6 +149,10 @@ using namespace chip::app::Clusters;
 using namespace chip::Access;
 using namespace chip::Platform;
 
+extern "C" {
+extern uint16_t gFoobarPort;
+}
+
 // Network comissioning implementation
 namespace {
 // If secondaryNetworkCommissioningEndpoint has a value and both Thread and WiFi
@@ -621,6 +625,7 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions,
     pthread_sigmask(SIG_BLOCK, &set, nullptr);
 #endif
 
+    gFoobarPort = LinuxDeviceOptions::GetInstance().securedDevicePort;
     err = DeviceLayer::PlatformMgr().InitChipStack();
     SuccessOrExit(err);
 

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -24,6 +24,8 @@
  *          key-value config calls to the correct partition.
  */
 
+#include <string>
+
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 #include <platform/internal/testing/ConfigUnitTest.h>
 
@@ -31,6 +33,10 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/Linux/CHIPLinuxStorage.h>
 #include <platform/Linux/PosixConfig.h>
+
+extern "C" {
+uint16_t gFoobarPort = 0;
+}
 
 namespace chip {
 namespace DeviceLayer {
@@ -462,7 +468,9 @@ CHIP_ERROR PosixConfig::EnsureNamespace(const char * ns)
     if (strcmp(ns, kConfigNamespace_ChipFactory) == 0)
     {
         storage = &gChipLinuxFactoryStorage;
-        err     = storage->Init(CHIP_DEFAULT_FACTORY_PATH);
+        char buffer[128];
+        snprintf(buffer, sizeof(buffer), "/tmp/chip_factory_%hu.ini", gFoobarPort);
+        err     = storage->Init(buffer);
     }
     else if (strcmp(ns, kConfigNamespace_ChipConfig) == 0)
     {


### PR DESCRIPTION
#### Summary
When running multiple lighting instance without containerization in order for kvs of the multiple instance to not overwrite eachother they need different names. This "solves" that problem by hacking the filename to contain the port number.


