### PR TITLE
Make `scripts/build_coverage.sh` work locally

### DIFF
--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -222,28 +222,41 @@ lcov --initial --capture --directory "$OUTPUT_ROOT/obj/src" \
     --exclude="$PWD"/zzz_generated/* \
     --exclude="$PWD"/third_party/* \
     --exclude=/usr/include/* \
-    --ignore-errors inconsistent \
+    --ignore-errors format,unsupported,inconsistent \
     --output-file "$COVERAGE_ROOT/lcov_base.info"
 
 lcov --capture --directory "$OUTPUT_ROOT/obj/src" \
-    --ignore-errors inconsistent \
+    --ignore-errors format,unsupported,inconsistent \
     --exclude="$PWD"/zzz_generated/* \
     --exclude="$PWD"/third_party/* \
     --exclude=/usr/include/* \
     --ignore-errors inconsistent \
     --output-file "$COVERAGE_ROOT/lcov_test.info"
 
-lcov --ignore-errors inconsistent \
+lcov --ignore-errors format,unsupported,inconsistent \
     --add-tracefile "$COVERAGE_ROOT/lcov_base.info" \
     --add-tracefile "$COVERAGE_ROOT/lcov_test.info" \
     --ignore-errors inconsistent \
     --output-file "$COVERAGE_ROOT/lcov_final.info"
 
 genhtml "$COVERAGE_ROOT/lcov_final.info" \
-    --ignore-errors inconsistent \
+    --ignore-errors inconsistent,category,count \
+    --rc max_message_count=1000 \
     --output-directory "$COVERAGE_ROOT/html" \
     --title "SHA:$(git rev-parse HEAD)" \
     --header-title "Matter SDK Coverage Report"
 
 cp "$CHIP_ROOT/integrations/appengine/webapp_config.yaml" \
     "$COVERAGE_ROOT/webapp_config.yaml"
+
+HTML_INDEX=$(_normpath "$COVERAGE_ROOT/html/index.html")
+if [ -f "$HTML_INDEX" ]; then
+    echo
+    echo "============================================================"
+    echo "Coverage report successfully generated:"
+    echo "    file://$HTML_INDEX"
+    echo "============================================================"
+else
+    echo "WARNING: Coverage HTML index was not found at expected path:"
+    echo "    $HTML_INDEX"
+fi

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -230,13 +230,11 @@ lcov --capture --directory "$OUTPUT_ROOT/obj/src" \
     --exclude="$PWD"/zzz_generated/* \
     --exclude="$PWD"/third_party/* \
     --exclude=/usr/include/* \
-    --ignore-errors inconsistent \
     --output-file "$COVERAGE_ROOT/lcov_test.info"
 
 lcov --ignore-errors format,unsupported,inconsistent \
     --add-tracefile "$COVERAGE_ROOT/lcov_base.info" \
     --add-tracefile "$COVERAGE_ROOT/lcov_test.info" \
-    --ignore-errors inconsistent \
     --output-file "$COVERAGE_ROOT/lcov_final.info"
 
 genhtml "$COVERAGE_ROOT/lcov_final.info" \


### PR DESCRIPTION
#### Summary

Updated `lcov` error handling and added coverage report confirmation message, which will include the path to the generated `index.html` coverage report file.

The `lcov` and `genhtml` tools emit newer metadata entries (e.g., synthetic prologue functions, line 0, UNK categories) when used with modern compilers like GCC ≥9 or Apple Clang. These cause the default parser to crash even though the data is harmless. The added `--ignore-errors` flags selectively suppress these without affecting real coverage results. These changes ensure the script works both locally (macOS/Linux) and in CI, while still surfacing meaningful coverage stats.

#### Testing

Does not require unit / integration tests; tested by running locally as well as using the daily trigger run that's displayed here: https://matter-build-automation.ue.r.appspot.com
