### PR TITLE
Make `chip_platform_*` includes always as `declare_args`.

### DIFF
--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -218,25 +218,6 @@ if (chip_device_platform == "cc13x4_26x4") {
   _chip_device_layer = "stm32"
 }
 
-if (chip_device_platform != "external") {
-  chip_ble_platform_config_include = ""
-  chip_device_platform_config_include = ""
-  chip_platform_config_include = ""
-  chip_inet_platform_config_include = ""
-  chip_system_platform_config_include = ""
-  chip_system_layer_impl_config_file = ""
-} else {
-  declare_args() {
-    chip_ble_platform_config_include = ""
-    chip_device_platform_config_include = ""
-    chip_platform_config_include = ""
-    chip_inet_platform_config_include = ""
-    chip_system_platform_config_include = ""
-    chip_system_layer_impl_config_file = ""
-    chip_external_platform_include_dir = ""
-  }
-}
-
 declare_args() {
   # If true, disables KVS implementation for the platform.  May not be
   # supported on all platforms.
@@ -249,17 +230,31 @@ declare_args() {
 assert(!chip_disable_platform_kvs || chip_device_platform == "darwin",
        "Can only disable KVS on some platforms")
 
-if (_chip_device_layer != "none" && chip_device_platform != "external") {
-  chip_ble_platform_config_include =
-      "<platform/" + _chip_device_layer + "/BlePlatformConfig.h>"
-  chip_device_platform_config_include =
-      "<platform/" + _chip_device_layer + "/CHIPDevicePlatformConfig.h>"
-  chip_platform_config_include =
-      "<platform/" + _chip_device_layer + "/CHIPPlatformConfig.h>"
-  chip_inet_platform_config_include =
-      "<platform/" + _chip_device_layer + "/InetPlatformConfig.h>"
-  chip_system_platform_config_include =
-      "<platform/" + _chip_device_layer + "/SystemPlatformConfig.h>"
+declare_args() {
+  # Overridable for custom platforms ("external" or "none") as well as
+  # individually overridable
+  if (_chip_device_layer != "none" && chip_device_platform != "external") {
+    chip_ble_platform_config_include =
+        "<platform/" + _chip_device_layer + "/BlePlatformConfig.h>"
+    chip_device_platform_config_include =
+        "<platform/" + _chip_device_layer + "/CHIPDevicePlatformConfig.h>"
+    chip_platform_config_include =
+        "<platform/" + _chip_device_layer + "/CHIPPlatformConfig.h>"
+    chip_inet_platform_config_include =
+        "<platform/" + _chip_device_layer + "/InetPlatformConfig.h>"
+    chip_system_platform_config_include =
+        "<platform/" + _chip_device_layer + "/SystemPlatformConfig.h>"
+  } else {
+    chip_ble_platform_config_include = ""
+    chip_device_platform_config_include = ""
+    chip_platform_config_include = ""
+    chip_inet_platform_config_include = ""
+    chip_system_platform_config_include = ""
+  }
+
+  # always overridable, default to nothing
+  chip_system_layer_impl_config_file = ""
+  chip_external_platform_include_dir = ""
 }
 
 declare_args() {


### PR DESCRIPTION
This allows partial override of platforms and makes the flags consistent for all build invocations.

#### Summary

Existing implementations only allow "FULL override" vs "no override". This is inconvenient as it turns out that #39400 attempts to override only some subset (BLE in this case). Allowing full overrides seems more generic and introduces less configuration variables (having a separate 'override' seems more complexity)

#### Testing

CI still expected to pass.
Will ask authors of #39400 to check if this fix works for them.

