### PR TITLE
[darwin-framework-tool] Remove some dependencies for HomeConnector.mm to resolve some build issues

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -27,11 +27,6 @@
 
 #include "../provider/OTAProviderDelegate.h"
 
-inline constexpr char kIdentityAlpha[] = "alpha";
-inline constexpr char kIdentityBeta[] = "beta";
-inline constexpr char kIdentityGamma[] = "gamma";
-inline constexpr char kControllerIdPrefix[] = "8DCADB14-AF1F-45D0-B084-00000000000";
-
 class CHIPCommandBridge : public Command {
 public:
     CHIPCommandBridge(const char * commandName, const char * helpText = nullptr)
@@ -70,8 +65,6 @@ public:
     }
 
     static OTAProviderDelegate * mOTADelegate;
-
-    static NSNumber * GetCommissionerFabricId(const char * identity);
 
 protected:
     // Will be called in a setting in which it's safe to touch the CHIP

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -27,6 +27,7 @@
 
 #import "CHIPCommandStorageDelegate.h"
 #import "CertificateIssuer.h"
+#import "CommissionerInfos.h"
 #import "ControllerStorage.h"
 #import "DeviceDelegate.h"
 #include "MTRError_Utils.h"
@@ -305,23 +306,6 @@ MTRDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mCurrent
 NSNumber * CHIPCommandBridge::CurrentCommissionerFabricId()
 {
     return GetCommissionerFabricId(mCurrentIdentity.c_str());
-}
-
-NSNumber * CHIPCommandBridge::GetCommissionerFabricId(const char * identity)
-{
-    if (strcmp(identity, kIdentityAlpha) == 0) {
-        return @(1);
-    } else if (strcmp(identity, kIdentityBeta) == 0) {
-        return @(2);
-    } else if (strcmp(identity, kIdentityGamma) == 0) {
-        return @(3);
-    } else {
-        ChipLogError(chipTool, "Unknown commissioner name: %s. Supported names are [%s, %s, %s]", identity, kIdentityAlpha,
-            kIdentityBeta, kIdentityGamma);
-        chipDie();
-    }
-
-    return @(0); // This should never happens.
 }
 
 MTRDeviceController * CHIPCommandBridge::GetCommissioner(const char * identity) { return mControllers[identity]; }

--- a/examples/darwin-framework-tool/commands/common/CommissionerInfos.h
+++ b/examples/darwin-framework-tool/commands/common/CommissionerInfos.h
@@ -1,0 +1,38 @@
+/*
+ *   Copyright (c) 2025 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+inline constexpr char kIdentityAlpha[] = "alpha";
+inline constexpr char kIdentityBeta[] = "beta";
+inline constexpr char kIdentityGamma[] = "gamma";
+inline constexpr char kControllerIdPrefix[] = "8DCADB14-AF1F-45D0-B084-00000000000";
+
+static NSNumber * GetCommissionerFabricId(const char * identity)
+{
+    if (strcmp(identity, kIdentityAlpha) == 0) {
+        return @(1);
+    } else if (strcmp(identity, kIdentityBeta) == 0) {
+        return @(2);
+    } else if (strcmp(identity, kIdentityGamma) == 0) {
+        return @(3);
+    } else {
+        NSLog(@"Unknown commissioner name: %s. Supported names are [%s, %s, %s]", identity, kIdentityAlpha, kIdentityBeta, kIdentityGamma);
+        exit(EXIT_FAILURE);
+    }
+
+    return @(0); // This should never happens.
+}

--- a/examples/darwin-framework-tool/commands/common/xpc/HomeKitConnector.mm
+++ b/examples/darwin-framework-tool/commands/common/xpc/HomeKitConnector.mm
@@ -17,7 +17,7 @@
  */
 
 #import "HomeKitConnector.h"
-#import "../CHIPCommandBridge.h"
+#import "../CommissionerInfos.h"
 #import <lib/support/logging/CHIPLogging.h>
 
 #import <HomeKit/HomeKit.h>
@@ -89,7 +89,7 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
         __auto_type * fabricIdString = [controllerID substringFromIndex:kControllerIdPrefixStr.length];
         fabricId = @([fabricIdString integerValue]);
     } else {
-        fabricId = CHIPCommandBridge::GetCommissionerFabricId([controllerID UTF8String]);
+        fabricId = GetCommissionerFabricId([controllerID UTF8String]);
     }
 
     // When multiple homes exist, the first controller corresponds to the first home, the second controller to the second home, etc.

--- a/examples/darwin-framework-tool/commands/common/xpc/HomeKitConnector.mm
+++ b/examples/darwin-framework-tool/commands/common/xpc/HomeKitConnector.mm
@@ -18,7 +18,6 @@
 
 #import "HomeKitConnector.h"
 #import "../CommissionerInfos.h"
-#import <lib/support/logging/CHIPLogging.h>
 
 #import <HomeKit/HomeKit.h>
 
@@ -47,7 +46,9 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
 
 - (void)start
 {
-    VerifyOrReturn(!_connectorStarted);
+    if (_connectorStarted) {
+        return;
+    }
     _connectorStarted = YES;
 
     _homeManagerReady = NO;
@@ -65,7 +66,9 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
 
 - (void)stop
 {
-    VerifyOrReturn(_connectorStarted);
+    if (!_connectorStarted) {
+        return;
+    }
 
     _homeManager.delegate = nil;
     _homeManager = nil;
@@ -73,7 +76,9 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
 
 - (void)homeManagerDidUpdateHomes:(HMHomeManager *)manager
 {
-    VerifyOrReturn(!_homeManagerReady);
+    if (_homeManagerReady) {
+        return;
+    }
     dispatch_group_leave(_homeManagerReadyGroup);
 }
 
@@ -82,7 +87,10 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
     [[HomeKitConnector sharedInstance] start];
 
     __auto_type * homes = _homeManager.homes;
-    VerifyOrReturnValue(0 != homes.count, nil, ChipLogError(chipTool, "HomeKit is not configured with any homes."));
+    if (homes.count == 0) {
+        NSLog(@"HomeKit is not configured with any homes.");
+        return nil;
+    }
 
     NSNumber * fabricId = nil;
     if ([controllerID hasPrefix:kControllerIdPrefixStr]) {
@@ -178,14 +186,14 @@ NSString * kControllerIdPrefixStr = @(kControllerIdPrefix);
 - (NSXPCConnection * (^)(void) )connectBlockFor:(NSString *)controllerID
 {
     __auto_type * home = [self homeFor:controllerID];
-    ChipLogProgress(chipTool, "Controller '%s' will be associated with home '%s'.", [controllerID UTF8String], [home.matterControllerID UTF8String]);
+    NSLog(@"Controller '%s' will be associated with home '%s'.", [controllerID UTF8String], [home.matterControllerID UTF8String]);
 
     if ([controllerID hasPrefix:kControllerIdPrefixStr]) {
         if ([home respondsToSelector:NSSelectorFromString(@"matterStartupParametersXPCConnectBlock")]) {
             return [home valueForKey:@"matterStartupParametersXPCConnectBlock"];
         }
 
-        ChipLogError(chipTool, "Error: 'matterStartupParametersXPCConnectBlock' not available for controller '%s'.", [controllerID UTF8String]);
+        NSLog(@"Error: 'matterStartupParametersXPCConnectBlock' not available for controller '%s'.", [controllerID UTF8String]);
         return nil;
     } else {
         return home.matterControllerXPCConnectBlock;

--- a/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.mm
+++ b/examples/darwin-framework-tool/commands/storage/StorageManagementCommand.mm
@@ -17,6 +17,7 @@
  */
 
 #include "../common/CHIPCommandStorageDelegate.h"
+#include "../common/CommissionerInfos.h"
 #include "../common/ControllerStorage.h"
 #include "../common/PreferencesStorage.h"
 
@@ -60,7 +61,7 @@ CHIP_ERROR StorageViewAll::Run()
     }
 
     const char * commissionerName = mCommissionerName.Value();
-    __auto_type * fabricId = CHIPCommandBridge::GetCommissionerFabricId(commissionerName);
+    __auto_type * fabricId = GetCommissionerFabricId(commissionerName);
     __auto_type * uuidString = [NSString stringWithFormat:@"%@%@", @(kControllerIdPrefix), fabricId];
     __auto_type * controllerId = [[NSUUID alloc] initWithUUIDString:uuidString];
     __auto_type * storage = [[ControllerStorage alloc] initWithControllerID:controllerId];


### PR DESCRIPTION
#### Summary

This PR refactors `HomeKitConnector.mm` to reduce unnecessary dependencies on the Matter SDK and avoid build issues under certain configurations, notably Catalyst::
 - Replaces the dependency on `CHIPCommandBridge.h` with a new `CommissionerInfos.h` header that only exposes what is needed (`kControllerIdPrefix` and `GetCommissionerFabricId`).
 - Removes the use of `CHIPLogging.h` and replaces `ChipLog*` macros with standard `NSLog` statements.
 - Uses explicit conditionals (if) instead of `VerifyOrReturn` macros to avoid pulling in additional logging headers.

#### Related issues

N/A

#### Testing

The code compiles, and all tests pass. No functional changes introduced.
