### PR TITLE
Disable test004_Subscribe on darwin.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -736,6 +736,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
 - (void)test004_Subscribe
 {
+    XCTSkip("Skipping due to flakyness/failing. https://github.com/project-chip/connectedhomeip/issues/27449");
+
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
 
     MTRBaseDevice * device = GetConnectedDevice();
@@ -898,14 +900,14 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * fields = [NSDictionary
         dictionaryWithObjectsAndKeys:@"Structure", @"type",
         [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0], @"contextTag",
-                                                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                                                              [NSNumber numberWithUnsignedInteger:0], @"value", nil],
-                                                @"data", nil],
-                 [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"contextTag",
-                               [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil],
-                               @"data", nil],
-                 nil],
+                                      [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                          [NSNumber numberWithUnsignedInteger:0], @"value", nil],
+                                      @"data", nil],
+            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"contextTag",
+                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                    [NSNumber numberWithUnsignedInteger:10], @"value", nil],
+                @"data", nil],
+            nil],
         @"value", nil];
     [device
         invokeCommandWithEndpointID:@1

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -900,14 +900,14 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * fields = [NSDictionary
         dictionaryWithObjectsAndKeys:@"Structure", @"type",
         [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:0], @"contextTag",
-                                      [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                                          [NSNumber numberWithUnsignedInteger:0], @"value", nil],
-                                      @"data", nil],
-            [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"contextTag",
-                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
-                    [NSNumber numberWithUnsignedInteger:10], @"value", nil],
-                @"data", nil],
-            nil],
+                                                [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                                              [NSNumber numberWithUnsignedInteger:0], @"value", nil],
+                                                @"data", nil],
+                 [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithUnsignedInteger:1], @"contextTag",
+                               [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type",
+                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil],
+                               @"data", nil],
+                 nil],
         @"value", nil];
     [device
         invokeCommandWithEndpointID:@1


### PR DESCRIPTION
#### Summary

This test is flaky and the issue about it being flaky has not been resolved in 2 years.

The flake rate of this is actually quite low, however it is compounded by the fact that other parts are flaky, which makes darwin tests very frequently fail

#### Related issues

#27449 was opened and then closed as "not happening anymore", however then it turns out it does happen and we had several recent examples.

#### Testing

This is a trivial test disable.