### PR TITLE
Update chip-build-crosscompile docker to point to the latest version of sysroot

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-138 : Install dbus-daemon required for BLE-WiFi testing
+139 : Update chip-build-crosscompile docker to point to the latest version of sysroot

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt
 RUN set -x \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.01.28' > ensure_file.txt \
+  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.06.05' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \


### PR DESCRIPTION
#### Summary

When cross compile camera-app, I hit the following error

pkg-config can’t find gstreamer‑1.0, gstreamer‑app‑1.0 or gobject‑2.0 inside the AArch64 sysroot at /opt/ubuntu‑24.04‑aarch64‑sysroot, so GN bails out. In cross‑builds the target(arm64) development packages—headers, .pc files and libs—have to live in the sysroot, not on the host.   

We have already update the sysroot to contain gstreamer, but the docker is still using the old version

#### Related issues

N/A

#### Testing
Build new docker.
docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:latest /bin/bash

ls /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/aarch64-linux-gnu/pkgconfig | \
  grep gstreamer
  
 #### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [PULL_REQUEST_GUIDELINES.md](../docs/pull_request_guidelines.md)
