### PR TITLE
[Darwin][Network.framework] Add a missing #ifdef INET_CONFIG_ENABLE_IPV4

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkListener.mm
@@ -164,7 +164,9 @@ namespace Inet {
 
             CHIP_ERROR err = StartMonitorInterfaces(^(InetInterfacesVector inetInterfaces, Inet6InterfacesVector inet6Interfaces) {
                 StopListeners();
+#if INET_CONFIG_ENABLE_IPV4
                 ListenInterfaces(inetInterfaces);
+#endif
                 ListenInterfaces(inet6Interfaces);
                 dispatch_semaphore_signal(semaphore);
             });


### PR DESCRIPTION
#### Summary

This PR adds a missing `#ifdef INET_CONFIG_ENABLE_IPV4`.

#### Related issues

N/A

#### Testing

Run the following command: 
```
$ (SDKROOT=macosx ./scripts/examples/gn_build_example.sh examples/darwin-framework-tool out/debug/standalone-dft chip_inet_config_enable_ipv4=false chip_system_config_use_network_framework=true)
$ vi out/debug/standalone-dft/darwin_framework_build.log
```

Without the patch, there is a build error. With the patch, the error is gone.