### PR TITLE
[darwin-framework-tool] Build Mac Catalyst version in CI

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -76,6 +76,10 @@ jobs:
         working-directory: src/darwin/Framework
         run: xcodebuild -target "darwin-framework-tool" -sdk iphoneos -configuration Debug
 
+      - name: Build Mac Catalyst Darwin Framework Tool Build Debug
+        working-directory: src/darwin/Framework
+        run: xcodebuild -scheme "darwin-framework-tool" -sdk macosx -configuration Debug -destination 'platform=macOS,variant=Mac Catalyst' SUPPORTS_MACCATALYST=YES AD_HOC_CODE_SIGNING_ALLOWED=YES
+
       - name: Run macOS Darwin Framework Tool Build Debug
         working-directory: src/darwin/Framework
         run: xcodebuild -target "darwin-framework-tool" -sdk macosx -configuration Debug


### PR DESCRIPTION
#### Summary

This PR adds `Catalyst` build alongside the iOS build in CI - in order to ensure sure it keeps building.

#### Related issues

N/A

#### Testing

A new target should be built by CI.