### PR TITLE
[DFT] Split examples/darwin-framework-tool/BUILD.gn into multiple fil…

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -18,7 +18,6 @@ import("//build_overrides/jsoncpp.gni")
 
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/build/config/compiler/compiler.gni")
-import("${chip_root}/build/config/mac/mac_sdk.gni")
 import("${chip_root}/examples//chip-tool/chip-tool.gni")
 import("${chip_root}/src/inet/inet.gni")
 
@@ -26,127 +25,15 @@ if (config_use_interactive_mode) {
   import("//build_overrides/editline.gni")
 }
 
+import("//build/args.gni")
+
 assert(chip_build_tools)
 
 declare_args() {
-  chip_codesign = current_os == "ios"
-
-  if (!defined(chip_config_network_layer_ble)) {
-    chip_config_network_layer_ble = true
-  }
-  if (!defined(is_clang)) {
-    is_clang = false
-  }
-
-  enable_provisional_features = config_enable_yaml_tests
-
-  # Disable generating compiler database by default
-  generate_compilation_database = false
+  chip_codesign = false
 
   # Enable automatic leak checks before the application exits
   enable_leak_checking = !is_asan && target_os == "mac"
-
-  # Use Network.framework instead of POSIX sockets
-  use_network_framework = false
-}
-
-sdk = "macosx"
-sdk_build_dir_suffix = ""
-if (getenv("SDKROOT") != "") {
-  sdk = getenv("SDKROOT")
-  sdk_root_parts = string_split(getenv("SDKROOT"), ".")
-  if (sdk_root_parts[0] != "macosx") {
-    sdk_build_dir_suffix = "-${sdk_root_parts[0]}"
-  }
-}
-output_sdk_type = "Debug${sdk_build_dir_suffix}"
-
-action("build-darwin-framework") {
-  script = "${chip_root}/scripts/build/build_darwin_framework.py"
-
-  inputs = [
-    "${chip_root}/src/darwin/Framework/CHIP",
-    "${chip_root}/src/darwin/Framework/CHIP/zap-generated",
-    "${chip_root}/src/darwin/Framework/Matter.xcodeproj",
-  ]
-
-  args = [
-    "--project_path",
-    rebase_path("${chip_root}/src/darwin/Framework/Matter.xcodeproj",
-                root_build_dir),
-    "--out_path",
-    "macos_framework_output",
-    "--target",
-    "Matter Framework",
-    "--log_path",
-    rebase_path("${root_build_dir}/darwin_framework_build.log", root_build_dir),
-    "--target_arch",
-    mac_target_arch,
-  ]
-
-  if (sdk != "macosx") {
-    args += [
-      "--target_sdk",
-      sdk,
-    ]
-  }
-
-  if (defined(chip_inet_config_enable_ipv4) && chip_inet_config_enable_ipv4) {
-    args += [ "--ipv4" ]
-  } else {
-    args += [ "--no-ipv4" ]
-  }
-
-  if (defined(is_asan) && is_asan) {
-    args += [ "--asan" ]
-  } else {
-    args += [ "--no-asan" ]
-  }
-
-  if (defined(chip_config_network_layer_ble) && chip_config_network_layer_ble) {
-    args += [ "--ble" ]
-  } else {
-    args += [ "--no-ble" ]
-  }
-
-  if (defined(is_clang) && is_clang) {
-    args += [ "--clang" ]
-  } else {
-    args += [ "--no-clang" ]
-  }
-
-  if (generate_compilation_database) {
-    args += [ "--compdb" ]
-  } else {
-    args += [ "--no-compdb" ]
-  }
-
-  if (config_enable_yaml_tests) {
-    args += [ "--enable-encoding-sentinel-enum-values" ]
-  } else {
-    args += [ "--no-enable-encoding-sentinel-enum-values" ]
-  }
-
-  if (defined(use_network_framework) && use_network_framework) {
-    args += [ "--use-network-framework" ]
-  } else {
-    args += [ "--no-use-network-framework" ]
-  }
-
-  output_name = "Matter.framework"
-  outputs = [
-    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/${output_name}",
-    "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/gen/include",
-    "${root_build_dir}/darwin_framework_build.log",
-    "${root_out_dir}/macos_framework_output/ModuleCache.noindex/",
-    "${root_out_dir}/macos_framework_output/Logs",
-    "${root_out_dir}/macos_framework_output/Index",
-    "${root_out_dir}/macos_framework_output/Build",
-  ]
-
-  if (sdk == "macosx" || sdk_root_parts[0] == "macosx") {
-    outputs += [ "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/lib/libCHIP.a" ]
-  }
 }
 
 config("config") {
@@ -159,12 +46,10 @@ config("config") {
     "${chip_root}/zzz_generated/controller-clusters",
     "${chip_root}/examples/chip-tool",
     "${chip_root}/zzz_generated/chip-tool",
-    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/",
+    "${root_out_dir}/${darwin_framework_products_dir}",
   ]
 
-  framework_dirs = [
-    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/",
-  ]
+  framework_dirs = [ "${root_out_dir}/${darwin_framework_products_dir}" ]
 
   defines = [
     "CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
@@ -260,9 +145,9 @@ executable("darwin-framework-tool") {
   check_includes = false
 
   deps = [
-    ":build-darwin-framework",
     "${chip_root}/src/app/common:ids",
     "${chip_root}/third_party/libwebsockets",
+    "//build/framework:framework",
     jsoncpp_root,
   ]
 
@@ -274,12 +159,17 @@ executable("darwin-framework-tool") {
 
   ldflags = [
     "-rpath",
-    "@executable_path/macos_framework_output/Build/Products/${output_sdk_type}/",
+    "@executable_path/${darwin_framework_products_dir}",
   ]
 
   frameworks = [
     "Matter.framework",
     "Security.framework",
+    "CoreFoundation.framework",
+    "Foundation.framework",
+    "CoreBluetooth.framework",
+    "Network.framework",
+    "IOKit.framework",
   ]
 
   include_dirs = [
@@ -292,24 +182,10 @@ executable("darwin-framework-tool") {
     "${chip_root}/third_party/nlio/repo/include/",
     "${chip_root}/zzz_generated/app-common/",
     "${root_gen_dir}/include",
-    "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/gen/include",
+    "${root_out_dir}/${darwin_framework_intermediates_dir}/gen/include",
   ]
 
   defines = [ "CHIP_HAVE_CONFIG_H=1" ]
-
-  frameworks += [
-    "CoreFoundation.framework",
-    "Foundation.framework",
-    "CoreBluetooth.framework",
-    "Network.framework",
-    "IOKit.framework",
-  ]
-
-  # Other SDKs are linked statically to Matter.framework but the macosx SDK is linked dynamically but needs some symbols that are
-  # not exposed by the dylib.
-  if (sdk == "macosx" || sdk_root_parts[0] == "macosx") {
-    libs = [ "${root_out_dir}/macos_framework_output/Build/Intermediates.noindex/Matter.build/${output_sdk_type}/Matter.build/out/lib/libCHIP.a" ]
-  }
 
   if (enable_provisional_features) {
     defines += [ "MTR_ENABLE_PROVISIONAL=1" ]
@@ -319,30 +195,24 @@ executable("darwin-framework-tool") {
     defines += [ "DFT_ENABLE_LEAK_CHECKING=1" ]
   }
 
+  # Other SDKs are linked statically to Matter.framework but the macosx SDK is linked dynamically but needs some symbols that are
+  # not exposed by the dylib.
+  if (target_sdk_is_macosx) {
+    libs = [
+      "${root_out_dir}/${darwin_framework_intermediates_dir}/lib/libCHIP.a",
+    ]
+  }
+
   public_configs = [ ":config" ]
 
   output_dir = root_out_dir
-}
-
-if (chip_codesign) {
-  action("codesign") {
-    script = "entitlements/codesign.py"
-    public_deps = [ ":darwin-framework-tool" ]
-
-    args = [
-      "--target_path",
-      rebase_path("${root_build_dir}/darwin-framework-tool", root_build_dir),
-      "--log_path",
-      rebase_path("${root_build_dir}/codesign_log.txt", root_build_dir),
-    ]
-
-    output_name = "codesign_log.txt"
-    outputs = [ "${root_build_dir}/${output_name}" ]
-  }
 }
 
 # Make sure we only build darwin-framework-tool, and not extraneous
 # things like address-resolve, by default.
 group("default") {
   deps = [ ":darwin-framework-tool" ]
+  if (chip_codesign) {
+    deps += [ "//build/codesign:codesign" ]
+  }
 }

--- a/examples/darwin-framework-tool/build/args.gni
+++ b/examples/darwin-framework-tool/build/args.gni
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/build/config/compiler/compiler.gni")
+import("${chip_root}/examples//chip-tool/chip-tool.gni")
+
+declare_args() {
+  if (!defined(chip_config_network_layer_ble)) {
+    chip_config_network_layer_ble = true
+  }
+
+  if (!defined(is_clang)) {
+    is_clang = false
+  }
+
+  enable_provisional_features = config_enable_yaml_tests
+
+  # Disable generating compiler database by default
+  generate_compilation_database = false
+
+  # Use Network.framework instead of POSIX sockets
+  use_network_framework = false
+}
+
+sdk = "macosx"
+sdk_build_dir_suffix = ""
+sdk_root_parts = []
+
+if (getenv("SDKROOT") != "") {
+  sdk = getenv("SDKROOT")
+  sdk_root_parts = string_split(getenv("SDKROOT"), ".")
+  if (sdk_root_parts[0] != "macosx") {
+    sdk_build_dir_suffix = "-${sdk_root_parts[0]}"
+  }
+}
+
+target_sdk_is_macosx = sdk == "macosx" || (len(sdk_root_parts) > 0 &&
+                                           sdk_root_parts[0] == "macosx")
+
+darwin_framework_out_dir = "macos_framework_output"
+darwin_sdk_build_config = "Debug${sdk_build_dir_suffix}"
+darwin_framework_products_dir =
+    "${darwin_framework_out_dir}/Build/Products/${darwin_sdk_build_config}"
+darwin_framework_intermediates_dir = "${darwin_framework_out_dir}/Build/Intermediates.noindex/Matter.build/${darwin_sdk_build_config}/Matter.build/out"

--- a/examples/darwin-framework-tool/build/codesign/BUILD.gn
+++ b/examples/darwin-framework-tool/build/codesign/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+action("codesign") {
+  script = "../../entitlements/codesign.py"
+
+  args = [
+    "--target_path",
+    rebase_path("${root_build_dir}/darwin-framework-tool", root_build_dir),
+    "--log_path",
+    rebase_path("${root_build_dir}/codesign_log.txt", root_build_dir),
+  ]
+
+  output_name = "codesign_log.txt"
+  outputs = [ "${root_build_dir}/${output_name}" ]
+}

--- a/examples/darwin-framework-tool/build/framework/BUILD.gn
+++ b/examples/darwin-framework-tool/build/framework/BUILD.gn
@@ -1,0 +1,113 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/jsoncpp.gni")
+
+import("${chip_root}/build/config/compiler/compiler.gni")
+import("${chip_root}/build/config/mac/mac_sdk.gni")
+import("${chip_root}/src/inet/inet.gni")
+
+import("//build/args.gni")
+
+action("framework") {
+  script = "${chip_root}/scripts/build/build_darwin_framework.py"
+
+  inputs = [
+    "${chip_root}/src/darwin/Framework/CHIP",
+    "${chip_root}/src/darwin/Framework/CHIP/zap-generated",
+    "${chip_root}/src/darwin/Framework/Matter.xcodeproj",
+  ]
+
+  args = [
+    "--project_path",
+    rebase_path("${chip_root}/src/darwin/Framework/Matter.xcodeproj",
+                root_build_dir),
+    "--out_path",
+    "${darwin_framework_out_dir}",
+    "--target",
+    "Matter Framework",
+    "--log_path",
+    rebase_path("${root_build_dir}/darwin_framework_build.log", root_build_dir),
+    "--target_arch",
+    mac_target_arch,
+  ]
+
+  if (sdk != "macosx") {
+    args += [
+      "--target_sdk",
+      sdk,
+    ]
+  }
+
+  if (defined(chip_inet_config_enable_ipv4) && chip_inet_config_enable_ipv4) {
+    args += [ "--ipv4" ]
+  } else {
+    args += [ "--no-ipv4" ]
+  }
+
+  if (defined(is_asan) && is_asan) {
+    args += [ "--asan" ]
+  } else {
+    args += [ "--no-asan" ]
+  }
+
+  if (defined(chip_config_network_layer_ble) && chip_config_network_layer_ble) {
+    args += [ "--ble" ]
+  } else {
+    args += [ "--no-ble" ]
+  }
+
+  if (defined(is_clang) && is_clang) {
+    args += [ "--clang" ]
+  } else {
+    args += [ "--no-clang" ]
+  }
+
+  if (generate_compilation_database) {
+    args += [ "--compdb" ]
+  } else {
+    args += [ "--no-compdb" ]
+  }
+
+  if (config_enable_yaml_tests) {
+    args += [ "--enable-encoding-sentinel-enum-values" ]
+  } else {
+    args += [ "--no-enable-encoding-sentinel-enum-values" ]
+  }
+
+  if (defined(use_network_framework) && use_network_framework) {
+    args += [ "--use-network-framework" ]
+  } else {
+    args += [ "--no-use-network-framework" ]
+  }
+
+  output_name = "Matter.framework"
+  outputs = [
+    "${root_out_dir}/${darwin_framework_products_dir}/${output_name}",
+    "${root_out_dir}/${darwin_framework_intermediates_dir}/gen/include",
+    "${root_build_dir}/darwin_framework_build.log",
+    "${root_out_dir}/${darwin_framework_out_dir}/ModuleCache.noindex/",
+    "${root_out_dir}/${darwin_framework_out_dir}/Logs",
+    "${root_out_dir}/${darwin_framework_out_dir}/Index",
+    "${root_out_dir}/${darwin_framework_out_dir}/Build",
+  ]
+
+  if (target_sdk_is_macosx) {
+    outputs += [
+      "${root_out_dir}/${darwin_framework_intermediates_dir}/lib/libCHIP.a",
+    ]
+  }
+}


### PR DESCRIPTION
…es to make it easier to update/maintain

#### Summary

This PR split `darwin-framework-tool/BUILD.gn` files into multiple files to make it easier to read/maintain. It also do a bit of renaming/cleaning.

#### Related issues

N/A

#### Testing

I have locally checked that it keeps building. Now I would expect CI to catch regressions if any.
