### PR TITLE
Last round of improvements & cleanup to FabricTableImpl for TLS

### DIFF
--- a/src/app/clusters/scenes-server/SceneTableImpl.cpp
+++ b/src/app/clusters/scenes-server/SceneTableImpl.cpp
@@ -96,7 +96,7 @@ enum class TagScene : uint8_t
 using FabricSceneData =
     FabricEntryData<SceneStorageId, SceneData, Serializer::kEntryMaxBytes(), Serializer::kFabricMaxBytes(), kMaxScenesPerFabric>;
 
-template class chip::app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData, kIteratorsMax>;
+template class chip::app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData>;
 
 CHIP_ERROR DefaultSceneTableImpl::Init(PersistentStorageDelegate & storage)
 {
@@ -131,7 +131,9 @@ CHIP_ERROR DefaultSceneTableImpl::GetRemainingCapacity(FabricIndex fabric_index,
 
 CHIP_ERROR DefaultSceneTableImpl::SetSceneTableEntry(FabricIndex fabric_index, const SceneTableEntry & entry)
 {
-    return this->SetTableEntry(fabric_index, entry.mStorageId, entry.mStorageData);
+    // Scene data is small, buffer can be allocated on stack
+    PersistentStore<Serializer::kEntryMaxBytes()> writeBuffer;
+    return this->SetTableEntry(fabric_index, entry.mStorageId, entry.mStorageData, writeBuffer);
 }
 
 CHIP_ERROR DefaultSceneTableImpl::GetSceneTableEntry(FabricIndex fabric_index, SceneStorageId scene_id, SceneTableEntry & entry)

--- a/src/app/clusters/scenes-server/SceneTableImpl.h
+++ b/src/app/clusters/scenes-server/SceneTableImpl.h
@@ -50,12 +50,11 @@ static constexpr uint16_t kMaxScenesPerFabric = (kMaxScenesPerEndpoint - 1) / 2;
  * on the device.
  */
 using SceneTableBase = SceneTable<scenes::ExtensionFieldSetsImpl>;
-class DefaultSceneTableImpl
-    : public SceneTableBase,
-      public app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData, kIteratorsMax>
+class DefaultSceneTableImpl : public SceneTableBase,
+                              public app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData>
 {
 public:
-    using Super = app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData, kIteratorsMax>;
+    using Super = app::Storage::FabricTableImpl<SceneTableBase::SceneStorageId, SceneTableBase::SceneData>;
 
     DefaultSceneTableImpl() : Super(kMaxScenesPerFabric, kMaxScenesPerEndpoint) {}
     ~DefaultSceneTableImpl() { Finish(); };

--- a/src/app/storage/FabricTableImpl.h
+++ b/src/app/storage/FabricTableImpl.h
@@ -83,7 +83,12 @@ public:
     using EntryIterator = CommonIterator<TableEntry>;
     using EntryIndex    = Data::EntryIndex;
     using Serializer    = DefaultSerializer<StorageId, StorageData>;
-    using IterateFnType = std::function<CHIP_ERROR(EntryIterator & certBuffer)>;
+
+    /**
+     * @brief a function to process an EntryIterator; the iterator parameter has a lifetime of the function call & is destroyed when
+     * the function completes.
+     */
+    using IterateFnType = std::function<CHIP_ERROR(EntryIterator & iterator)>;
 
     virtual ~FabricTableImpl() { Finish(); };
 
@@ -149,6 +154,13 @@ public:
     void SetTableSize(uint16_t endpointEntryTableSize, uint16_t maxPerFabric);
     bool IsInitialized() { return (mStorage != nullptr); }
 
+    /**
+     * @brief Iterates through all entries in fabric, calling iterateFn with the allocated iterator.
+     * @param fabric the fabric to iterate entries for
+     * @param store the in-memory buffer that an entry will be read into
+     * @param iterateFn the function that will be called with the iterator; the resulting CHIP_ERROR is proxied as a result of the
+     * method
+     */
     template <size_t kEntryMaxBytes>
     CHIP_ERROR IterateEntries(FabricIndex fabric, PersistentStore<kEntryMaxBytes> & store, IterateFnType iterateFn);
 

--- a/src/app/storage/FabricTableImpl.ipp
+++ b/src/app/storage/FabricTableImpl.ipp
@@ -19,7 +19,6 @@
 
 #include <app/storage/FabricTableImpl.h>
 #include <app/util/endpoint-config-api.h>
-#include <lib/support/AutoRelease.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/TypeTraits.h>
 #include <stdlib.h>
@@ -794,14 +793,13 @@ void FabricTableImpl<StorageId, StorageData>::SetTableSize(uint16_t endpointTabl
 }
 
 template <class StorageId, class StorageData>
-template <size_t kEntryMaxBytes>
+template <size_t kEntryMaxBytes, class UnaryFunc>
 CHIP_ERROR FabricTableImpl<StorageId, StorageData>::IterateEntries(FabricIndex fabric, PersistentStore<kEntryMaxBytes> & store,
-                                                                   IterateFnType iterateFn)
+                                                                   UnaryFunc iterateFn)
 {
     VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INTERNAL);
 
     EntryIteratorImpl<kEntryMaxBytes> iterator(*this, fabric, mEndpointId, mMaxPerFabric, mMaxPerEndpoint, store);
-    AutoRelease<EntryIteratorImpl<kEntryMaxBytes>> iteratorRelease(&iterator);
     return iterateFn(iterator);
 }
 

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -27,13 +27,19 @@
 namespace chip {
 
 /// RAII class for iterators that guarantees that Release() will be called
-/// on the underlying type
+/// on the underlying type.  This is effectively a simple unique_ptr, except
+/// calling Release instead of delete
 template <typename Releasable>
 class AutoRelease
 {
 public:
     AutoRelease(Releasable * releasable) : mReleasable(releasable) {}
     ~AutoRelease() { Release(); }
+
+    // Not copyable or movable
+    AutoRelease(const AutoRelease &)             = delete;
+    AutoRelease(const AutoRelease &&)            = delete;
+    AutoRelease & operator=(const AutoRelease &) = delete;
 
     inline Releasable * operator->() { return mReleasable; }
     inline const Releasable * operator->() const { return mReleasable; }

--- a/src/lib/support/AutoRelease.h
+++ b/src/lib/support/AutoRelease.h
@@ -1,0 +1,54 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *          Contains a standard RAII class which calls Release on dtor.
+ */
+
+#pragma once
+
+#include <stddef.h>
+
+namespace chip {
+
+/// RAII class for iterators that guarantees that Release() will be called
+/// on the underlying type
+template <typename Releasable>
+class AutoRelease
+{
+public:
+    AutoRelease(Releasable * releasable) : mReleasable(releasable) {}
+    ~AutoRelease() { Release(); }
+
+    inline Releasable * operator->() { return mReleasable; }
+    inline const Releasable * operator->() const { return mReleasable; }
+
+    inline bool IsNull() const { return mReleasable == nullptr; }
+
+    void Release()
+    {
+        VerifyOrReturn(mReleasable != nullptr);
+        mReleasable->Release();
+        mReleasable = nullptr;
+    }
+
+private:
+    Releasable * mReleasable = nullptr;
+};
+
+} // namespace chip

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -183,6 +183,7 @@ static_library("support") {
   output_name = "libSupportLayer"
 
   sources = [
+    "AutoRelease.h",
     "Base64.cpp",
     "Base64.h",
     "BitFlags.h",

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -35,6 +35,7 @@
 #include <inttypes.h>
 #include <lib/core/CHIPKeyIds.h>
 #include <lib/core/Global.h>
+#include <lib/support/AutoRelease.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -57,31 +58,6 @@ using Transport::SecureSession;
 
 namespace {
 Global<GroupPeerTable> gGroupPeerTable;
-
-/// RAII class for iterators that guarantees that Release() will be called
-/// on the underlying type
-template <typename Releasable>
-class AutoRelease
-{
-public:
-    AutoRelease(Releasable * iter) : mIter(iter) {}
-    ~AutoRelease() { Release(); }
-
-    Releasable * operator->() { return mIter; }
-    const Releasable * operator->() const { return mIter; }
-
-    bool IsNull() const { return mIter == nullptr; }
-
-    void Release()
-    {
-        VerifyOrReturn(mIter != nullptr);
-        mIter->Release();
-        mIter = nullptr;
-    }
-
-private:
-    Releasable * mIter = nullptr;
-};
 
 // Helper function that strips off the interface ID from a peer address that is
 // not an IPv6 link-local address.  For any other address type we should rely on


### PR DESCRIPTION
#### Summary

* Remove no-longer-used `kIteratorsMax`
* Add iteration support via `IterateEntries`, allowing caller to allocate buffer in stack/heap
* Remove last usage of stack allocation of buffer
* Pull out common `AutoRelease` from `SessionManager.cpp`

#### Related issues

Needed for #38895

#### Testing
 CI