### PR TITLE
[CI] Fix WEBRTCP TCs write to read-only attribute issue

### DIFF
--- a/src/python_testing/TC_WEBRTCP_2_1.py
+++ b/src/python_testing/TC_WEBRTCP_2_1.py
@@ -58,11 +58,8 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
             TestStep(1, "Read CurrentSessions attribute => expect 0", is_commissioning=True),
             TestStep(2, "Send SolicitOffer with VideoStreamID that doesn't match AllocatedVideoStreams => expect DYNAMIC_CONSTRAINT_ERROR"),
             TestStep(3, "Send SolicitOffer with AudioStreamID that doesn't match AllocatedAudioStreams => expect DYNAMIC_CONSTRAINT_ERROR"),
-            TestStep(4, "Write SoftLivestreamPrivacyModeEnabled=true, HardPrivacyModeOn=false, send SolicitOffer => expect INVALID_IN_STATE"),
-            TestStep(5, "Write SoftLivestreamPrivacyModeEnabled=false, HardPrivacyModeOn=true, send SolicitOffer => expect INVALID_IN_STATE"),
-            TestStep(6, "Write SoftLivestreamPrivacyModeEnabled=false, HardPrivacyModeOn=false"),
-            TestStep(7, "Send SolicitOffer with valid parameters => expect DeferredOffer=TRUE"),
-            TestStep(8, "Read CurrentSessions attribute => expect 1 with valid session data"),
+            TestStep(4, "Send SolicitOffer with valid parameters => expect DeferredOffer=TRUE"),
+            TestStep(5, "Read CurrentSessions attribute => expect 1 with valid session data"),
         ]
         return steps
 
@@ -74,12 +71,6 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
 
         endpoint = self.get_endpoint(default=1)
         cluster = Clusters.WebRTCTransportProvider
-
-        # Check if privacy feature is supported before testing privacy mode
-        aFeatureMap = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=Clusters.CameraAvStreamManagement, attribute=Clusters.CameraAvStreamManagement.Attributes.FeatureMap
-        )
-        privacySupported = aFeatureMap & Clusters.CameraAvStreamManagement.Bitmaps.Feature.kPrivacy
 
         self.step(1)
         current_sessions = await self.read_single_attribute_check_success(
@@ -109,62 +100,7 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.DynamicConstraintError, "Expected DYNAMIC_CONSTRAINT_ERROR")
 
-        if privacySupported:
-            self.step(4)
-            # Write privacy settings and test INVALID_IN_STATE
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftLivestreamPrivacyModeEnabled(True),
-                endpoint_id=endpoint,
-            )
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.HardPrivacyModeOn(False),
-                endpoint_id=endpoint,
-            )
-
-            cmd = cluster.Commands.SolicitOffer(
-                streamUsage=3, originatingEndpointID=endpoint, videoStreamID=NullValue, audioStreamID=NullValue)
-            try:
-                await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-                asserts.fail("Unexpected success on SolicitOffer with privacy mode enabled")
-            except InteractionModelError as e:
-                asserts.assert_equal(e.status, Status.InvalidInState, "Expected INVALID_IN_STATE")
-
-            self.step(5)
-            # Write different privacy settings and test INVALID_IN_STATE
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftLivestreamPrivacyModeEnabled(False),
-                endpoint_id=endpoint,
-            )
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.HardPrivacyModeOn(True),
-                endpoint_id=endpoint,
-            )
-
-            cmd = cluster.Commands.SolicitOffer(
-                streamUsage=3, originatingEndpointID=endpoint, videoStreamID=NullValue, audioStreamID=NullValue)
-            try:
-                await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-                asserts.fail("Unexpected success on SolicitOffer with hard privacy mode enabled")
-            except InteractionModelError as e:
-                asserts.assert_equal(e.status, Status.InvalidInState, "Expected INVALID_IN_STATE")
-
-            self.step(6)
-            # Disable privacy modes
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftLivestreamPrivacyModeEnabled(False),
-                endpoint_id=endpoint,
-            )
-            await self.write_single_attribute(
-                attribute_value=Clusters.CameraAvStreamManagement.Attributes.HardPrivacyModeOn(False),
-                endpoint_id=endpoint,
-            )
-        else:
-            # Skip these steps if privacy feature is not supported
-            self.skip_step(4)
-            self.skip_step(5)
-            self.skip_step(6)
-
-        self.step(7)
+        self.step(4)
         # Send valid SolicitOffer command
         cmd = cluster.Commands.SolicitOffer(
             streamUsage=3, originatingEndpointID=endpoint, videoStreamID=NullValue, audioStreamID=NullValue)
@@ -174,7 +110,7 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
         asserts.assert_not_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should not be 0.")
         asserts.assert_true(resp.deferredOffer, "Expected 'deferredOffer' to be True.")
 
-        self.step(8)
+        self.step(5)
         # Verify CurrentSessions contains valid session data
         current_sessions = await self.read_single_attribute_check_success(
             endpoint=endpoint,

--- a/src/python_testing/TC_WEBRTCP_2_1.py
+++ b/src/python_testing/TC_WEBRTCP_2_1.py
@@ -58,8 +58,9 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
             TestStep(1, "Read CurrentSessions attribute => expect 0", is_commissioning=True),
             TestStep(2, "Send SolicitOffer with VideoStreamID that doesn't match AllocatedVideoStreams => expect DYNAMIC_CONSTRAINT_ERROR"),
             TestStep(3, "Send SolicitOffer with AudioStreamID that doesn't match AllocatedAudioStreams => expect DYNAMIC_CONSTRAINT_ERROR"),
-            TestStep(4, "Send SolicitOffer with valid parameters => expect DeferredOffer=TRUE"),
-            TestStep(5, "Read CurrentSessions attribute => expect 1 with valid session data"),
+            TestStep(4, "Write SoftLivestreamPrivacyModeEnabled=true, send SolicitOffer => expect INVALID_IN_STATE"),
+            TestStep(5, "Write SoftLivestreamPrivacyModeEnabled=false, send SolicitOffer => expect DeferredOffer=TRUE"),
+            TestStep(6, "Read CurrentSessions attribute => expect 1 with valid session data"),
         ]
         return steps
 
@@ -71,6 +72,12 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
 
         endpoint = self.get_endpoint(default=1)
         cluster = Clusters.WebRTCTransportProvider
+
+        # Check if privacy feature is supported before testing privacy mode
+        aFeatureMap = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=Clusters.CameraAvStreamManagement, attribute=Clusters.CameraAvStreamManagement.Attributes.FeatureMap
+        )
+        privacySupported = aFeatureMap & Clusters.CameraAvStreamManagement.Bitmaps.Feature.kPrivacy
 
         self.step(1)
         current_sessions = await self.read_single_attribute_check_success(
@@ -100,7 +107,33 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.DynamicConstraintError, "Expected DYNAMIC_CONSTRAINT_ERROR")
 
-        self.step(4)
+        if privacySupported:
+            self.step(4)
+            # Write SoftLivestreamPrivacyModeEnabled=true and test INVALID_IN_STATE
+            await self.write_single_attribute(
+                attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftLivestreamPrivacyModeEnabled(True),
+                endpoint_id=endpoint,
+            )
+
+            cmd = cluster.Commands.SolicitOffer(
+                streamUsage=3, originatingEndpointID=endpoint, videoStreamID=NullValue, audioStreamID=NullValue)
+            try:
+                await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
+                asserts.fail("Unexpected success on SolicitOffer with privacy mode enabled")
+            except InteractionModelError as e:
+                asserts.assert_equal(e.status, Status.InvalidInState, "Expected INVALID_IN_STATE")
+        else:
+            # Skip privacy mode test if not supported
+            self.skip_step(4)
+
+        self.step(5)
+        if privacySupported:
+            # Write SoftLivestreamPrivacyModeEnabled=false and send valid SolicitOffer
+            await self.write_single_attribute(
+                attribute_value=Clusters.CameraAvStreamManagement.Attributes.SoftLivestreamPrivacyModeEnabled(False),
+                endpoint_id=endpoint,
+            )
+
         # Send valid SolicitOffer command
         cmd = cluster.Commands.SolicitOffer(
             streamUsage=3, originatingEndpointID=endpoint, videoStreamID=NullValue, audioStreamID=NullValue)
@@ -110,7 +143,7 @@ class TC_WebRTCProvider_2_1(MatterBaseTest):
         asserts.assert_not_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should not be 0.")
         asserts.assert_true(resp.deferredOffer, "Expected 'deferredOffer' to be True.")
 
-        self.step(5)
+        self.step(6)
         # Verify CurrentSessions contains valid session data
         current_sessions = await self.read_single_attribute_check_success(
             endpoint=endpoint,

--- a/src/python_testing/TC_WEBRTCP_2_3.py
+++ b/src/python_testing/TC_WEBRTCP_2_3.py
@@ -165,39 +165,12 @@ class TC_WebRTCProvider_2_3(MatterBaseTest):
             asserts.assert_equal(e.status, Status.InvalidInState, "Expected INVALID_IN_STATE")
 
         self.step(6)
-        # Send VideoStreamAllocate command with valid parameters to create a video stream
-        videoStreamAllocateCmd = Clusters.CameraAvStreamManagement.Commands.VideoStreamAllocate(
-            streamUsage=3,  # kLiveView
-            videoCodec=Clusters.CameraAvStreamManagement.Enums.VideoCodecEnum.kH264,
-            minFrameRate=30,  # kMinFrameRate
-            maxFrameRate=120,  # kMaxFrameRate
-            minResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(
-                width=640, height=360  # kMinWidth, kMinHeight
-            ),
-            maxResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(
-                width=1920, height=1080  # kMaxWidth, kMaxHeight
-            ),
-            minBitRate=10000,  # kDefaultBitRate (10,000 bits per second)
-            maxBitRate=10000,  # kDefaultBitRate
-            minFragmentLen=1,  # kMinFragmentLen
-            maxFragmentLen=10,  # kMaxFragmentLen
-        )
-        videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-        asserts.assert_is_not_none(
-            videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID"
-        )
-
-        # Save the allocated video stream ID for use in the next step
-        allocated_video_stream_id = videoStreamAllocateResponse.videoStreamID
-
-        self.step(7)
         # Send valid ProvideOffer command using the allocated video stream ID
         cmd = cluster.Commands.ProvideOffer(
             webRTCSessionID=NullValue,
             sdp=test_sdp,
             streamUsage=3,
-            originatingEndpointID=endpoint,
-            videoStreamID=allocated_video_stream_id
+            originatingEndpointID=endpoint
         )
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse,

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -142,14 +142,6 @@ not_automated:
           are fully verified.
     - name: TC_WEBRTC_Utils.py
       reason: Helper methods for WebRTC TCs, not a standalone test.
-    - name: TC_WEBRTCP_2_1.py
-      reason:
-          Breaks CI. Temporarily disabling to allow correct fix. See
-          https://github.com/project-chip/connectedhomeip/issues/39529
-    - name: TC_WEBRTCP_2_3.py
-      reason:
-          Breaks CI. Temporarily disabling to allow correct fix. See
-          https://github.com/project-chip/connectedhomeip/issues/39529
 
 # This is a list of slow tests (just arbitrarily picked around 20 seconds)
 # used in some script reporting for "be patient" messages as well as potentially


### PR DESCRIPTION
#### Summary

We have a regression in the WEBRTCP test cases that is causing CI failures. The recently added test steps in both WEBRTCP 2.1 and 2.3 attempt to write to the HardPrivacyModeOn attribute, which is (and always has been) read-only. As a result, the server correctly rejects the write attempts, leading to CI test failures.

Test Plan Fix: https://github.com/CHIP-Specifications/chip-test-plans/pull/5233

#### Related issues

Fixes: #39529


#### Testing

verified by Python test: TC_WEBRTCP_2_1.py and  TC_WEBRTCP_2_3.py

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [PULL_REQUEST_GUIDELINES.md](../docs/pull_request_guidelines.md)
