### PR TITLE
Remove the SRP timer code that is not used at all

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -199,9 +199,6 @@ MTR_DIRECT_MEMBERS
 static NSString * const kDefaultSubscriptionPoolSizeOverrideKey = @"subscriptionPoolSizeOverride";
 static NSString * const kTestStorageUserDefaultEnabledKey = @"enableTestStorage";
 
-// Declared inside platform, but noting here for reference
-// static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
-
 // Concrete to XPC internal state property dictionary keys
 static NSString * const kMTRDeviceInternalPropertyKeyVendorID = @"MTRDeviceInternalStateKeyVendorID";
 static NSString * const kMTRDeviceInternalPropertyKeyProductID = @"MTRDeviceInternalStateKeyProductID";

--- a/src/platform/Darwin/UserDefaults.h
+++ b/src/platform/Darwin/UserDefaults.h
@@ -23,8 +23,6 @@
 namespace chip {
 namespace Platform {
 
-std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs();
-
 std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread();
 
 std::optional<uint8_t> GetUserDefaultBDXThreadFramesPerBlock();

--- a/src/platform/Darwin/UserDefaults.mm
+++ b/src/platform/Darwin/UserDefaults.mm
@@ -21,8 +21,6 @@
 
 #import <Foundation/Foundation.h>
 
-static NSString * const kSRPTimeoutInMsecsUserDefaultKey = @"SRPTimeoutInMSecsOverride";
-
 static NSString * const kBDXThrottleIntervalInMsecsUserDefaultKey = @"BDXThrottleIntervalForThreadDevicesInMSecs";
 
 static NSString * const kBDXThreadFramesPerBlockDefaultKey = @"BDXThreadFramesPerBlock";
@@ -56,15 +54,6 @@ namespace Platform {
         }
 
     } // namespace
-
-    std::optional<uint16_t> GetUserDefaultDnssdSRPTimeoutInMSecs()
-    {
-        std::optional timeoutinMsecs = GetUserDefault<uint16_t>(kSRPTimeoutInMsecsUserDefaultKey, kAcceptZero);
-        if (timeoutinMsecs.has_value()) {
-            ChipLogProgress(Discovery, "Got a user default value for Dnssd SRP timeout - %d msecs", timeoutinMsecs.value());
-        }
-        return timeoutinMsecs;
-    }
 
     std::optional<System::Clock::Milliseconds16> GetUserDefaultBDXThrottleIntervalForThread()
     {

--- a/src/platform/Darwin/dnssd/DnssdContexts.cpp
+++ b/src/platform/Darwin/dnssd/DnssdContexts.cpp
@@ -491,11 +491,6 @@ ResolveContext::ResolveContext(DiscoverNodeDelegate * delegate, chip::Inet::IPAd
     consumerCounter = std::move(consumerCounterToUse);
 }
 
-ResolveContext::~ResolveContext()
-{
-    CancelSRPTimerIfRunning();
-}
-
 void ResolveContext::DispatchFailure(const char * errorStr, CHIP_ERROR err)
 {
     ChipLogError(Discovery, "Mdns: Resolve failure (%s)", errorStr);
@@ -632,26 +627,6 @@ void ResolveContext::DispatchSuccess()
     VerifyOrDo(interfacesOrder.size(),
                ChipLogError(Discovery, "Successfully finalizing resolve for %s without finding any actual IP addresses.",
                             instanceName.c_str()));
-}
-
-void ResolveContext::SRPTimerExpiredCallback(chip::System::Layer * systemLayer, void * callbackContext)
-{
-    auto sdCtx = static_cast<ResolveContext *>(callbackContext);
-    VerifyOrDie(sdCtx != nullptr);
-    sdCtx->isSRPTimerRunning = false;
-
-    ChipLogProgress(Discovery, "SRP resolve timer for %s expired; completing resolve", sdCtx->instanceName.c_str());
-    sdCtx->Finalize();
-}
-
-void ResolveContext::CancelSRPTimerIfRunning()
-{
-    if (isSRPTimerRunning)
-    {
-        DeviceLayer::SystemLayer().CancelTimer(SRPTimerExpiredCallback, static_cast<void *>(this));
-        ChipLogProgress(Discovery, "SRP resolve timer for %s cancelled; resolve timed out", instanceName.c_str());
-        isSRPTimerRunning = false;
-    }
 }
 
 CHIP_ERROR ResolveContext::OnNewAddress(const InterfaceKey & interfaceKey, const struct sockaddr * address)

--- a/src/platform/Darwin/dnssd/DnssdImpl.h
+++ b/src/platform/Darwin/dnssd/DnssdImpl.h
@@ -276,11 +276,6 @@ struct ResolveContext : public GenericContext
     std::shared_ptr<uint32_t> consumerCounter;
     BrowseContext * const browseThatCausedResolve; // Can be null
 
-    // Indicates whether the timer should be started to give the resolve
-    // on SRP domain some extra time to complete.
-    bool shouldStartSRPTimerForResolve = false;
-    bool isSRPTimerRunning             = false;
-
     ResolveContextWithType resolveContextWithSRPType    = { this, true };
     ResolveContextWithType resolveContextWithNonSRPType = { this, false };
 
@@ -290,7 +285,6 @@ struct ResolveContext : public GenericContext
                    std::shared_ptr<uint32_t> && consumerCounterToUse);
     ResolveContext(DiscoverNodeDelegate * delegate, chip::Inet::IPAddressType cbAddressType, const char * instanceNameToResolve,
                    std::shared_ptr<uint32_t> && consumerCounterToUse);
-    virtual ~ResolveContext();
 
     void DispatchFailure(const char * errorStr, CHIP_ERROR err) override;
     void DispatchSuccess() override;
@@ -302,20 +296,6 @@ struct ResolveContext : public GenericContext
                         const unsigned char * txtRecord, bool isSRPResult);
     bool HasInterface();
     bool Matches(const char * otherInstanceName) const { return instanceName == otherInstanceName; }
-
-    /**
-     * @brief Callback that is called when the timeout for resolving on the kSRPDot domain has expired.
-     *
-     * @param[in] systemLayer The system layer.
-     * @param[in] callbackContext The context passed to the timer callback.
-     */
-    static void SRPTimerExpiredCallback(chip::System::Layer * systemLayer, void * callbackContext);
-
-    /**
-     * @brief Cancels the timer that was started to wait for the resolution on the kSRPDot domain to happen.
-     *
-     */
-    void CancelSRPTimerIfRunning();
 };
 
 } // namespace Dnssd


### PR DESCRIPTION
#### Summary

Some logic was added in the DNS-SD code to wait longer for a resolve on the srp domain for Thread devices but turns out this code is non functional. Hence removing this.


#### Related issues

Fixes: #38230 


#### Testing

Ran darwin tests locally.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [PULL_REQUEST_GUIDELINES.md](../docs/pull_request_guidelines.md)
