### PR TITLE
Start and commission test app before creating MTRDevice for it.

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -6232,6 +6232,12 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRDeviceController * controller = [self createControllerOnTestFabric];
     XCTAssertNotNil(controller);
 
+    MTRTestCaseServerApp * app = [self startCommissionedAppWithName:@"all-clusters"
+                                                          arguments:@[]
+                                                         controller:controller
+                                                            payload:kOnboardingPayload2
+                                                             nodeID:@(kDeviceId2)];
+
     __auto_type * device = [MTRDevice deviceWithNodeID:@(kDeviceId2) controller:controller];
     dispatch_queue_t queue = dispatch_get_main_queue();
 
@@ -6244,12 +6250,6 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     };
 
     [device setDelegate:delegate queue:queue];
-
-    MTRTestCaseServerApp * app = [self startCommissionedAppWithName:@"all-clusters"
-                                                          arguments:@[]
-                                                         controller:controller
-                                                            payload:kOnboardingPayload2
-                                                             nodeID:@(kDeviceId2)];
 
     [self waitForExpectations:@[ reachableExpectation ] timeout:60];
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/39477

What was happening is that we had an MTRDevice set up with a delegate already while commissioning.  When the server advertised over DND-SD after AddNOC, the MTRDevice canceled existing CASE setup attempts so it could try to set up a CASE session to it, and this canceled the CASE setup attempt for CommissioningComplete, so commissioning failed.

The fix is just to make sure commissioning is done before we set up our MTRDevice in test049_CorrectTimeOnDevice.

#### Summary

Fixes flaky test; see commit message.

#### Testing

Change to unit tests.

