### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-139 : Update chip-build-crosscompile docker to point to the latest version of sysroot
+140 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=a5fd9e740be88b7158b3d44febbea3695975db1e
-ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
+ARG ZEPHYR_REVISION=19006f8ec3482e91bbddafc0730640998d033d4e
+ARG N22_BIN_REVISION=1f37e056bd06cac9d164a8d1d2c7dbfce940d119
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -17,9 +17,9 @@ RUN set -x \
     && zephyr-sdk-0.17.0/setup.sh -t riscv64-zephyr-elf \
     && : # last line
 
-# Setup Zephyr version: 3.7.0; branch: develop
-ARG ZEPHYR_REVISION=9a6804cde48f744fa33ce782d2f50453abc9a767
-ARG N22_BIN_REVISION=05f9bcecde9df997a7d735ea119bb9a8212b8a8f
+# Setup Zephyr version: 4.1.0; branch: develop
+ARG ZEPHYR_REVISION=050e732c8ba66ece6058aac1591508e0e3510729
+ARG N22_BIN_REVISION=1f37e056bd06cac9d164a8d1d2c7dbfce940d119
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install --break-system-packages -U --no-cache-dir west \


### PR DESCRIPTION
**Change overview**

- telink: config: add network timestamps for W91
- telink: b92: update west.yml
- telink: config: add transmission locking to ot_rcp
- telink: config: change uart baud rate in net_cli, cli, rcp apps
- drivers: hwinfo: add hw and sw reset cause support for tlx and b9x
- telink: ot_rcp: Add border routing Feature
- telink: config: soc: update data processing in ot_rcp functions
- samples: boards: tlsr9x: net_cli: Infra routing
- telink: soc: enable MBEDTLS_AES_ROM_TABLES
- telink: update to v4.1.0

**Changes of N22 binary:**

(latest hash 1f37e056bd06cac9d164a8d1d2c7dbfce940d119)
- Add calculation of serial oversampling
- Update serial RFIFOT and TFIFOT

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully
