### PR TITLE
[Camera] Add new delegate API to get the reference of the current active WebRTC sessions

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -283,9 +283,8 @@ private:
     CameraError SetV4l2Control(uint32_t controlId, int value);
 
     // Various cluster server delegates
-    ChimeManager mChimeManager;
-    WebRTCProviderManager mWebRTCProviderManager;
-
+    chip::app::Clusters::ChimeManager mChimeManager;
+    chip::app::Clusters::WebRTCTransportProvider::WebRTCProviderManager mWebRTCProviderManager;
     chip::app::Clusters::CameraAvStreamManagement::CameraAVStreamManager mCameraAVStreamManager;
     chip::app::Clusters::CameraAvSettingsUserLevelManagement::CameraAVSettingsUserLevelManager mCameraAVSettingsUserLevelManager;
 

--- a/examples/camera-app/linux/include/clusters/chime/chime-manager.h
+++ b/examples/camera-app/linux/include/clusters/chime/chime-manager.h
@@ -19,9 +19,11 @@
 #pragma once
 #include <app/clusters/chime-server/chime-server.h>
 
-namespace Camera {
+namespace chip {
+namespace app {
+namespace Clusters {
 
-class ChimeManager : public chip::app::Clusters::ChimeDelegate
+class ChimeManager : public ChimeDelegate
 {
 
 public:
@@ -41,4 +43,6 @@ private:
     };
 };
 
-} // namespace Camera
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -28,7 +28,10 @@
 
 #include <unordered_map>
 
-namespace Camera {
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace WebRTCTransportProvider {
 
 using ICEServerDecodableStruct = chip::app::Clusters::Globals::Structs::ICEServerStruct::DecodableType;
 using WebRTCSessionStruct      = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
@@ -36,7 +39,7 @@ using ICECandidateStruct       = chip::app::Clusters::Globals::Structs::ICECandi
 using StreamUsageEnum          = chip::app::Clusters::Globals::StreamUsageEnum;
 using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
 
-class WebRTCProviderManager : public chip::app::Clusters::WebRTCTransportProvider::Delegate
+class WebRTCProviderManager : public Delegate
 {
 public:
     WebRTCProviderManager() :
@@ -157,4 +160,7 @@ private:
     CameraDeviceInterface * mCameraDevice = nullptr;
 };
 
-} // namespace Camera
+} // namespace WebRTCTransportProvider
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp
@@ -26,8 +26,6 @@ using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::Chime;
 using namespace chip::app::Clusters::Chime::Structs;
 
-using namespace Camera;
-
 // Chime Cluster Methods
 CHIP_ERROR ChimeManager::GetChimeSoundByIndex(uint8_t chimeIndex, uint8_t & chimeID, MutableCharSpan & name)
 {

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -32,14 +32,6 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WebRTCTransportProvider;
 
-using ICEServerDecodableStruct = chip::app::Clusters::Globals::Structs::ICEServerStruct::DecodableType;
-using WebRTCSessionStruct      = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
-using ICECandidateStruct       = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;
-using StreamUsageEnum          = chip::app::Clusters::Globals::StreamUsageEnum;
-using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
-
-using namespace Camera;
-
 namespace {
 
 // Constants

--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
@@ -308,6 +308,16 @@ public:
      */
     void Shutdown();
 
+    /**
+     * @brief Get a reference to the current WebRTC sessions.
+     *
+     * This method provides read-only access to the current list of active WebRTC sessions
+     * managed by this server instance.
+     *
+     * @return const std::vector<WebRTCSessionStruct>& Reference to the current sessions list.
+     */
+    const std::vector<WebRTCSessionStruct> & GetCurrentSessions() const { return mCurrentSessions; }
+
 private:
     enum class UpsertResultEnum : uint8_t
     {


### PR DESCRIPTION
#### Summary

1. Currently, End and EndSession commands only provide session ID, we need to know what video/audio stream ids to deference count when handling those commands. We need to provide an new API to get the reference to the list of current active sessions to look up those info using sessionId.

2. Align the namespace within camera-app

#### Related issues
N/A

#### Testing

Validated by the existing CI for regression

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
