### PR TITLE
Interop Lab: optionally include files needed for IDT into chip-testing Python wheel

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -126,5 +126,8 @@ pw_python_distribution("chip-testing") {
       extra_files +=
           [ "${file} > chip/testing/idt/" + get_path_info(file, "file") ]
     }
+    foreach(file, credentials_files) {
+      extra_files += [ "${file} > credentials/" + get_path_info(file, "file") ]
+    }
   }
 }

--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -123,7 +123,8 @@ pw_python_distribution("chip-testing") {
   ]
   if (include_idt_files) {
     foreach(file, idt_files) {
-      extra_files += [ "${file} > chip/testing/" + get_path_info(file, "file") ]
+      extra_files +=
+          [ "${file} > chip/testing/idt/" + get_path_info(file, "file") ]
     }
   }
 }

--- a/src/python_testing/matter_testing_infrastructure/BUILD.gn
+++ b/src/python_testing/matter_testing_infrastructure/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 import("//build_overrides/pigweed.gni")
 import("//src/python_testing/matter_testing_infrastructure/data_model_xmls.gni")
+import("//src/python_testing/matter_testing_infrastructure/idt_tools.gni")
 import("$dir_pw_build/python.gni")
 import("$dir_pw_build/python_dist.gni")
 import("$dir_pw_build/zip.gni")
@@ -120,4 +121,9 @@ pw_python_distribution("chip-testing") {
     "${root_out_dir}/data_model/zip_1_4_1.zip > chip/testing/data_model/1.4.1/allfiles.zip",
     "${root_out_dir}/data_model/zip_1_4_2.zip > chip/testing/data_model/1.4.2/allfiles.zip",
   ]
+  if (include_idt_files) {
+    foreach(file, idt_files) {
+      extra_files += [ "${file} > chip/testing/" + get_path_info(file, "file") ]
+    }
+  }
 }

--- a/src/python_testing/matter_testing_infrastructure/idt_tools.gni
+++ b/src/python_testing/matter_testing_infrastructure/idt_tools.gni
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Project CHIP Authors
+# Copyright (c) 2025 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/python_testing/matter_testing_infrastructure/idt_tools.gni
+++ b/src/python_testing/matter_testing_infrastructure/idt_tools.gni
@@ -21,8 +21,9 @@ declare_args() {
 }
 
 idt_files = [
-  "${chip_root}/credentials/fetch_paa_certs_from_dcl.py",
   "${chip_root}/src/python_testing/post_certification_tests/production_device_checks.py",
   "${chip_root}/src/python_testing/TC_DA_1_2.py",
   "${chip_root}/src/python_testing/TC_DA_1_7.py",
 ]
+
+credentials_files = [ "${chip_root}/credentials/fetch_paa_certs_from_dcl.py" ]

--- a/src/python_testing/matter_testing_infrastructure/idt_tools.gni
+++ b/src/python_testing/matter_testing_infrastructure/idt_tools.gni
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+declare_args() {
+  # To build the chip-testing Python wheel with a full set of files
+  # for the Interoperability Debug Tool (IDT), set the following flag to `true`.
+  include_idt_files = false
+}
+
+idt_files = [
+  "${chip_root}/credentials/fetch_paa_certs_from_dcl.py",
+  "${chip_root}/src/python_testing/post_certification_tests/production_device_checks.py",
+  "${chip_root}/src/python_testing/TC_DA_1_2.py",
+  "${chip_root}/src/python_testing/TC_DA_1_7.py",
+]


### PR DESCRIPTION
#### Summary

Include required files for the Interoperability Debug Tool in the Chip-Testing Python wheel based on the command line argument provided,

Build wheels with IDT files included: 

```bash
./scripts/build_python.sh -i out/python_env -g include_idt_files=true 
```

Build wheels without IDT files:

```bash
./scripts/build_python.sh -i out/python_env
```

#### Related issues

Fixes: https://github.com/project-chip/matter-test-scripts/issues/559

#### Testing

Tested manually on Mac. Executed two commands and checked the `out` folder for presence/absence of the IDT files.
