### PR TITLE
Add missing stdio include for vsnprintf

### DIFF
--- a/src/platform/logging/impl/Syslog.cpp
+++ b/src/platform/logging/impl/Syslog.cpp
@@ -21,6 +21,7 @@
 #include <lib/support/logging/Constants.h>
 
 #include <mutex>
+#include <stdio.h>
 #include <syslog.h>
 
 #ifndef CHIP_SYSLOG_IDENT


### PR DESCRIPTION
Add missing stdio include for vsnprintf. This fixes a compile error on Linux / OpenWrt:

```
../../examples/network-manager-app/linux/third_party/connectedhomeip/src/platform/logging/impl/Syslog.cpp: In function 'void chip::Logging::Platform::LogV(const char*, uint8_t, const char*, va_list)':
../../examples/network-manager-app/linux/third_party/connectedhomeip/src/platform/logging/impl/Syslog.cpp:67:5: error: 'vsnprintf' was not declared in this scope
   67 |     vsnprintf(sBuffer, sizeof(sBuffer), msg, v);
      |     ^~~~~~~~~
```

#### Testing

Compiles as expected now.
