### PR TITLE
[Darwin] In DnssdHostNameRegistrar.mm the timeout outlives the instan…

### DIFF
--- a/src/platform/Darwin/inet/NetworkMonitor.h
+++ b/src/platform/Darwin/inet/NetworkMonitor.h
@@ -63,6 +63,13 @@ namespace Inet {
             CHIP_ERROR StartMonitorPaths(OnPathChange pathChangeBlock);
             void Stop();
 
+        protected:
+            // We use mLivenessTracker to indicate to blocks that close over us that
+            // we've been destroyed.  This is needed because we're not a refcounted
+            // object, so the blocks can't keep us alive; they just close over the
+            // raw pointer to "this".
+            std::shared_ptr<bool> mLivenessTracker;
+
         private:
             nw_path_monitor_t CreatePathMonitor(nw_interface_type_t type, nw_path_monitor_update_handler_t handler, bool once);
             void EnumeratePathInterfaces(nw_path_t path, InetInterfacesVector & out4, Inet6InterfacesVector & out6, bool searchLoopBackOnly);
@@ -73,12 +80,6 @@ namespace Inet {
             // with un-registration if we never get Init() called.
             uint32_t mInterfaceId = kDNSServiceInterfaceIndexLocalOnly;
             IPAddressType mAddressType;
-
-            // We use mLivenessTracker to indicate to blocks that close over us that
-            // we've been destroyed.  This is needed because we're not a refcounted
-            // object, so the blocks can't keep us alive; they just close over the
-            // raw pointer to "this".
-            std::shared_ptr<bool> mLivenessTracker;
 
             dispatch_queue_t mWorkQueue = nullptr;
         };


### PR DESCRIPTION
…ce which results into a crash

#### Summary

This patch fixes a crash in which the `onTimeout callback can access an already-deallocated object. It adds a lifetime check to ensure the target object is still alive before invoking the callback.

#### Related issues

N/A. Discovered while validating https://github.com/project-chip/connectedhomeip/pull/37992 against CI failures.

#### Testing

Enable the Network.framework  then run:
```
$  xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx -only-testing "MatterTests/MTRPerControllerStorageTests" GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENABLE_LEAK_DETECTION=1'
```

Before this patch: the above test crashes due to accessing a dead object.
After applying this patch: the test completes successfully with no crashes.