### PR TITLE
[NXP] Update NXP docker image

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-141 : [Tizen] Add crashlog to QEMU workflow
+142 : [NXP] Update NXP SDK Docker image (25.03.00)

--- a/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
@@ -10,15 +10,14 @@ RUN set -x \
 
 WORKDIR /opt/nxp/
 
-ARG NXP_SDK_EXAMPLE_PATH=github_sdk/sdk_next/repo/mcuxsdk/examples
-
 RUN set -x \
     && git clone https://github.com/NXP/nxp_matter_support.git \
     && cd nxp_matter_support \
+    # Checkout commit aligned with updated west manifest using MCUX SDK 25.03.00,
+    # including patches for Matter support in specific components
     && git checkout 873a8c4c5425652613cde447b0f0a8f321b51618 \
     && pip3 install --break-system-packages -U --no-cache-dir west \
     && ./scripts/update_nxp_sdk.py --platform common \
-    && cd $NXP_SDK_EXAMPLE_PATH \
     && : # last line
 
 FROM ghcr.io/project-chip/chip-build:${VERSION}

--- a/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
@@ -10,12 +10,14 @@ RUN set -x \
 
 WORKDIR /opt/nxp/
 
-ARG NXP_SDK_EXAMPLE_PATH=nxp_matter_support/github_sdk/sdk_next/repo/mcuxsdk/examples
+ARG NXP_SDK_EXAMPLE_PATH=github_sdk/sdk_next/repo/mcuxsdk/examples
 
 RUN set -x \
-    && git clone --branch manifest-update-for-sdk-25-03 https://github.com/NXP/nxp_matter_support.git \
+    && git clone https://github.com/NXP/nxp_matter_support.git \
+    && cd nxp_matter_support \
+    && git checkout 873a8c4c5425652613cde447b0f0a8f321b51618 \
     && pip3 install --break-system-packages -U --no-cache-dir west \
-    && ./nxp_matter_support/scripts/update_nxp_sdk.py --platform common \
+    && ./scripts/update_nxp_sdk.py --platform common \
     && cd $NXP_SDK_EXAMPLE_PATH \
     && : # last line
 


### PR DESCRIPTION
#### Summary

This PR is updating the NXP SDK docker image to get latest updates based on MCUX SDK 25.03.00.

#### Testing

Testing done by building and running locally the docker image.