### PR TITLE
[Silabs] Add software-string-version in DeviceInfo and fix 917SoC Hang

### DIFF
--- a/examples/platform/silabs/ldscripts/SiWx917-common.ld
+++ b/examples/platform/silabs/ldscripts/SiWx917-common.ld
@@ -1,11 +1,4 @@
-/***************************************************************************//**
- * GCC Linker script for Silicon Labs devices
- *******************************************************************************
- * # License
- * <b>Copyright 2020 Silicon Laboratories Inc. www.silabs.com</b>
- *******************************************************************************
- *
- * SPDX-License-Identifier: Zlib
+/* 
  *
  * The licensor of this software is Silicon Laboratories Inc.
  *
@@ -29,186 +22,236 @@
  MEMORY
  {
    rom   (rx)  : ORIGIN = 0x8202000, LENGTH = 0x1fe000
-
-   ram   (rwx) : ORIGIN = 0xc, LENGTH = 0x4fbf4
- }
- MEMORY
- {
-   udma0   (rwx)  : ORIGIN = 0x4fc00, LENGTH = 0x400
-   udma1   (rwx)  : ORIGIN = 0x24061c00, LENGTH = 0x400
+   ram     (rwx) : ORIGIN = 0x400, LENGTH = 0x4fc00
  }
 
 ENTRY(Reset_Handler)
- 
+
 SECTIONS
 {
 	.text :
 	{
 		KEEP(*(.isr_vector))
-     	  	KEEP(*(.reset_handler))
-			*(EXCLUDE_FILE(*sl_si91x_bus.o *sl_si91x_driver.o *sli_si91x_multithreaded.o *rsi_deepsleep_soc.o *rsi_hal_mcu_m4_ram.o *rsi_hal_mcu_m4_rom.o *UDMA.o *sl_sleeptimer.o *sl_sleeptimer_hal_si91x_sysrtc.o *rsi_sysrtc.o *sl_si91x_low_power_tickless_mode.o *croutine.o *event_groups.o *list.o *queue.o *stream_buffer.o *tasks.o *timers.o *cmsis_os2.o *freertos_umm_malloc_host.o *malloc_buffers.o *sl_rsi_utility.o *port.o *heap_*.o) .text*)
-		
-		/* .ctors */
-		*crtbegin.o(.ctors)
-		*crtbegin?.o(.ctors)
-		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
-		*(SORT(.ctors.*))
-		*(.ctors)
-		
-		/* .dtors */
-		*crtbegin.o(.dtors)
-		*crtbegin?.o(.dtors)
-		*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
-		*(SORT(.dtors.*))
-		*(.dtors)
-		*(.rodata*)
-		
-		KEEP(*(.eh_fram e*))			
-	} > rom	
-	
-	.ARM.extab : 
-	{
-		*(.ARM.extab* .gnu.linkonce.armextab.*)			
-	} > rom
-	
-	__exidx_start = .;
-	.ARM.exidx :
-	{
-		*(.ARM.exidx* .gnu.linkonce.armexidx.*)			
-	} > rom 
+		. = ALIGN(32);
+		KEEP(*(.reset_handler))
+		*(EXCLUDE_FILE(*sl_si91x_bus.c.o *sl_si91x_driver.c.o *sli_si91x_multithreaded.c.o *rsi_hal_mcu_m4_ram.c.o *rsi_hal_mcu_m4_rom.c.o *rsi_deepsleep_soc.c.o *croutine.c.o *event_groups.c.o *list.c.o *queue.c.o *stream_buffer.c.o *tasks.c.o *timers.c.o *cmsis_os2.c.o *freertos_umm_malloc_host.c.o *malloc_buffers.c.o *sl_rsi_utility.c.o *port.c.o *sl_sleeptimer.c.o *sl_sleeptimer_hal_si91x_sysrtc.c.o *rsi_sysrtc.c.o *sl_si91x_low_power_tickless_mode.c.o *heap_*.c.o *sl_core_cortexm.c.o) .text*)
+
+    /* .ctors */
+    *crtbegin.o(.ctors)
+    *crtbegin?.o(.ctors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+    *(SORT(.ctors.*))
+    *(.ctors)
+
+    /* .dtors */
+    *crtbegin.o(.dtors)
+    *crtbegin?.o(.dtors)
+    *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+    *(SORT(.dtors.*))
+    *(.dtors)
+
+    *(.rodata*)
+    *(.eh_frame*)
+  } > rom
+
+  .ARM.extab :
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } > rom
+
+  __exidx_start = .;
+  .ARM.exidx :
+  {
+    *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+  } > rom
+  __exidx_end = .;
+
+    .copy.table :
+  {
+    . = ALIGN(4);
+    __copy_table_start__ = .;
+
+    LONG (__etext)
+    LONG (__data_start__)
+    LONG ((__data_end__ - __data_start__) / 4)
+
+    /* Add each additional data section here */
+/*
+    LONG (__etext2)
+    LONG (__data2_start__)
+    LONG ((__data2_end__ - __data2_start__) / 4)
+*/
+    __copy_table_end__ = .;
+  } > rom
+
+    .zero.table :
+  {
+    . = ALIGN(4);
+    __zero_table_start__ = .;
+    /* Add each additional bss section here */
+/*
+    LONG (__bss2_start__)
+    LONG ((__bss2_end__ - __bss2_start__) / 4)
+*/
+    __zero_table_end__ = .;
+  } > rom
+
 	__exidx_end = .;
 	__etext = .;
 
-	/* _sidata is used in code startup code */
-	_sidata = __etext;
+	/* _sidata is used in coide startup code */
+	_sidata = __etext; 
 
-	.data :
+  /* Start placing output sections which are loaded into RAM */
+  . = ORIGIN(ram);
 
-	{
-		__data_start__ = .;
-		
-		/* _sdata is used in startup code */
-		_sdata = __data_start__;
-		KEEP(*(.ramVector))	
+  .noinit . (NOLOAD):
+  {
+    *(.noinit*);
+  } > ram
+
+  .data . : AT (__etext)
+  {
+    . = ALIGN(4);
+    __data_start__ = .;
+        _sdata = __data_start__;
+        KEEP(*(.ramVector))	
 		KEEP(*(.init))
 		KEEP(*(.fini))
+		*(.rodata*)
+		*(vtable)
 		*(.data*)
-		*rsi_hal_mcu_m4_ram.o(.text*)
-		*rsi_hal_mcu_m4_rom.o(.text*)
-		*sl_si91x_driver.o(.text*)
-		*sl_si91x_bus.o(.text*)
-		*UDMA.o(.text*)
-		*sl_sleeptimer.o(.text*)
-		*sl_sleeptimer_hal_si91x_sysrtc.o(.text*) 
-		*rsi_sysrtc.o(.text*)
-		*sl_si91x_low_power_tickless_mode.o(.text*)
-		*sli_si91x_multithreaded.o(.text*)
-		*rsi_deepsleep_soc.o(.text*)
-		*croutine.o(.text*)
-		*event_groups.o(.text*)
-		*list.o(.text*)
-		*queue.o(.text*)
-		*cmsis_os2.o(.text*)
-		*stream_buffer.o(.text*)
-		*tasks.o(.text*)
-		*timers.o(.text*)
-		*freertos_umm_malloc_host.o(.text*)
-		*malloc_buffers.o(.text*)
-		*sl_rsi_utility.o(.text*)
-		*port.o(.text*)
-		*heap_*.o(.text*)
-		
-		/* ipmu calibration data */
-		*(.common_ipmu_ram*)
-		
-		. = ALIGN(4);
-		/* preinit data */
-		PROVIDE_HIDDEN (__preinit_array_start = .);
-		KEEP(*(.preinit_array))
-		PROVIDE_HIDDEN (__preinit_array_end = .);
-		
-		. = ALIGN(4);
-		/* init data */
-		
-		PROVIDE_HIDDEN (__init_array_start = .);
-		KEEP(*(SORT(.init_array.*)))
-		KEEP(*(.init_array))
-		PROVIDE_HIDDEN (__init_array_end = .);
-		
-		. = ALIGN(4);
-		/* finit data */
-		PROVIDE_HIDDEN (__fini_array_start = .);
-		KEEP(*(SORT(.fini_array.*)))
-		KEEP(*(.fini_array))
-		PROVIDE_HIDDEN (__fini_array_end = .);
-		
-		KEEP(*(.jcr*))
-		. = ALIGN(4);
-		/* All data end */
-		__data_end__ = .;
-		
-		/* _edata is used in startup code */
-		_edata = __data_end__; 
-	} > ram AT> rom
-	
-	.bss (NOLOAD) :
-	{
-		. = ALIGN(4);
-		__bss_start__ = .;
-		*(.bss*)
-		*(COMMON)
-		. = ALIGN(4);
-		__bss_end__ = .;
-	} > ram 
+		*sl_si91x_bus.c.o(.text*)
+		*sl_si91x_driver.c.o(.text*)
+		*sli_si91x_multithreaded.c.o(.text*)
+		*rsi_hal_mcu_m4_ram.c.o(.text*)
+		*rsi_hal_mcu_m4_rom.c.o(.text*)
+  	    *rsi_deepsleep_soc.c.o(.text*)
+		*croutine.c.o(.text*)
+		*event_groups.c.o(.text*)
+		*list.c.o(.text*)
+		*queue.c.o(.text*)
+		*cmsis_os2.c.o(.text*)
+		*stream_buffer.c.o(.text*)
+		*tasks.c.o(.text*)
+		*timers.c.o(.text*)
+		*freertos_umm_malloc_host.c.o(.text*)
+		*malloc_buffers.c.o(.text*)
+		*sl_rsi_utility.c.o(.text*)
+		*port.c.o(.text*)
+		*heap_*.c.o(.text*)
+    *sl_sleeptimer.c.o(.text*)
+    *sl_sleeptimer_hal_si91x_sysrtc.c.o(.text*)
+    *rsi_sysrtc.c.o(.text*)
+    *sl_si91x_low_power_tickless_mode.c.o(.text*)
+    *sl_core_cortexm.c.o(.text*)
 
-	
-	.stack (NOLOAD):
+    /* ipmu calibration data */
+    *(.common_ipmu_ram*)
+
+    . = ALIGN(4);
+    /* preinit data */
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP(*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+
+    . = ALIGN(4);
+    /* init data */
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP(*(SORT(.init_array.*)))
+    KEEP(*(.init_array))
+    PROVIDE_HIDDEN (__init_array_end = .);
+
+    . = ALIGN(4);
+    /* finit data */
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP(*(SORT(.fini_array.*)))
+    KEEP(*(.fini_array))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+
+    . = ALIGN(4);
+    /* All data end */
+    __data_end__ = .;
+
+   /* _edata is used in coide startup code */
+	_edata = __data_end__;
+
+  } > ram
+
+  .bss . :
+  {
+    . = ALIGN(4);
+    __bss_start__ = .;
+    _sbss = __bss_start__;
+    *(SORT_BY_ALIGNMENT(.bss*))
+    *(COMMON)
+    . = ALIGN(4);
+    __bss_end__ = .;
+    _ebss = __bss_end__;
+  } > ram
+
+	/* .stack_dummy section doesn't contains any symbols. It is only
+	* used for linker to calculate size of stack sections, and assign
+	* values to stack symbols later */
+	Co_Stack_Size = 0x3000;	
+	.co_stack ALIGN(8) (NOLOAD):
+	{
+		__co_stackLimit = .;
+		KEEP(*(.co_stack*))
+		. = ALIGN(4);
+		. += Co_Stack_Size;
+		__co_stackTop = .;
+	} > ram
+
+	StackSize = 0x1400;
+	.stack ALIGN(8) (NOLOAD):
 	{
 		__StackLimit = .;
 		KEEP(*(.stack*))
 		. = ALIGN(4);
+		. += StackSize;
 		__StackTop = .;
 		PROVIDE(__stack = __StackTop);			
 	} > ram
-  	.heap (COPY):
-  	{
+
+  .heap (COPY):
+  {
 		__HeapBase = .;
 		__end__ = .;
 		end = __end__;
 		_end = __end__;
-		KEEP(*(.heap*))
+		KEEP(*(.heap*))	
 		. = ORIGIN(ram) + LENGTH(ram);
+
 		__HeapLimit = .;			
-  	} > ram
- 
+  } > ram
+  
 	__heap_size = __HeapLimit - __HeapBase;
-	.udma_addr0 :
-	{
-		*(.udma_addr0*)
-	} > udma0 AT> rom
+  __ram_end__ = 0x400 + 0x4fc00;
+  __main_flash_end__ = 0x8202000 + 0x1fe000;
 
-	.udma_addr1 :
-	{
-		*(.udma_addr1*)		
-	} > udma1 AT> rom	
-
-  __ram_end__ = 0xc + 0x4fbf4;
-   __main_flash_end__ = 0x8202000 + 0x1fe000;
 	   /* This is where we handle flash storage blocks. We use dummy sections for finding the configured
    * block sizes and then "place" them at the end of flash when the size is known. */
-  .internal_storage1 (DSECT) : {
-    KEEP(*(.internal_storage1*))
+  .internal_storage (DSECT) : {
+    KEEP(*(.internal_storage*))
   } > rom
+
+
   .nvm (DSECT) : {
     KEEP(*(.simee*))
   } > rom
- 
+
+  /* Last page of flash is reserved for the manufacturing token space */
   linker_nvm_end = __main_flash_end__ - 4096;
   linker_nvm_begin = linker_nvm_end - SIZEOF(.nvm);
   linker_nvm_size = SIZEOF(.nvm);
   linker_storage_end = linker_nvm_begin;
-  __nvm3Base = linker_nvm_begin;	
-  linker_storage_begin = linker_storage_end - SIZEOF(.internal_storage1);
-  linker_storage_size = SIZEOF(.internal_storage1);
-  ASSERT((linker_storage_begin >= (__etext + SIZEOF(.data))), "FLASH memory overflowed !")   
+  __nvm3Base = linker_nvm_begin;
+
+  linker_storage_begin = linker_storage_end - SIZEOF(.internal_storage);
+  linker_storage_size = SIZEOF(.internal_storage);
+  ASSERT((linker_storage_begin >= (__etext + SIZEOF(.data))), "FLASH memory overflowed !")
+
+  app_flash_end = 0x8202000 + 0x1fe000;
+  ASSERT( (linker_nvm_begin + SIZEOF(.nvm)) <= app_flash_end, "NVM3 is excessing the flash size !")
 }

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -695,8 +695,19 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
 
 CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)
 {
-    // TODO: Implement this function if needed.
+#ifdef SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
+    constexpr size_t kEnableKeyLength = 16; // Expected byte size of the EnableKey
+
+    // Verify that the provided key has the correct length
+    VerifyOrReturnError(value.size() == kEnableKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Write the key to the configuration storage
+    ReturnErrorOnFailure(SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_Test_Event_Trigger_Key, value.data(), value.size()));
+
+    return CHIP_NO_ERROR;
+#else
     return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // SL_MATTER_TEST_EVENT_TRIGGER_ENABLED
 }
 
 CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -365,6 +365,28 @@ CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & 
     return SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_PersistentUniqueId, value, max, size);
 }
 
+CHIP_ERROR Storage::SetSoftwareVersionString(const char * value, size_t len)
+{
+    return SilabsConfig::WriteConfigValueStr(SilabsConfig::kConfigKey_SoftwareVersionString, value, len);
+}
+
+CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
+{
+    size_t hw_version_len = 0; // @ithout counting null-terminator
+
+    CHIP_ERROR err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_SoftwareVersionString, value, max, hw_version_len);
+#if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
+    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == err)
+    {
+        VerifyOrReturnError(value != nullptr, CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(max > strlen(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
+        Platform::CopyString(value, max, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+        err = CHIP_NO_ERROR;
+    }
+#endif
+    return err;
+}
+
 //
 // CommissionableDataProvider
 //
@@ -670,6 +692,12 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     return SilabsConfig::WriteConfigValue(SilabsConfig::kOtaTlvEncryption_KeyId, key.GetId());
 }
 #endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
+
+CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)
+{
+    // TODO: Implement this function if needed.
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
 
 CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
 {

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -702,7 +702,8 @@ CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)
     VerifyOrReturnError(value.size() == kEnableKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
 
     // Write the key to the configuration storage
-    ReturnErrorOnFailure(SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_Test_Event_Trigger_Key, value.data(), value.size()));
+    ReturnErrorOnFailure(
+        SilabsConfig::WriteConfigValueBin(SilabsConfig::kConfigKey_Test_Event_Trigger_Key, value.data(), value.size()));
 
     return CHIP_NO_ERROR;
 #else

--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -372,7 +372,7 @@ CHIP_ERROR Storage::SetSoftwareVersionString(const char * value, size_t len)
 
 CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
 {
-    size_t hw_version_len = 0; // @ithout counting null-terminator
+    size_t hw_version_len = 0; // Without counting null-terminator
 
     CHIP_ERROR err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_SoftwareVersionString, value, max, hw_version_len);
 #if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -484,6 +484,28 @@ CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & 
     return Flash::Get(Parameters::ID::kPersistentUniqueId, value, max, size);
 }
 
+CHIP_ERROR Storage::SetSoftwareVersionString(const char * value, size_t len)
+{
+    return Flash::Set(Parameters::ID::kSwVersionStr, value, len);
+}
+
+CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
+{
+    size_t size    = 0;
+    CHIP_ERROR err = Flash::Get(Parameters::ID::kSwVersionStr, value, max, size);
+
+#if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
+    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == err)
+    {
+        VerifyOrReturnError(value != nullptr, CHIP_ERROR_NO_MEMORY);
+        VerifyOrReturnError(max > strlen(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
+        Platform::CopyString(value, max, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+        err = CHIP_NO_ERROR;
+    }
+#endif
+    return err;
+}
+
 //
 // CommissionableDataProvider
 //
@@ -729,6 +751,12 @@ CHIP_ERROR Storage::SetOtaTlvEncryptionKey(const ByteSpan & value)
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 #endif // SL_MATTER_ENABLE_OTA_ENCRYPTION
+
+CHIP_ERROR Storage::SetTestEventTriggerKey(const ByteSpan & value)
+{
+    // TODO: Implement this function if needed.
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
 
 CHIP_ERROR Storage::GetTestEventTriggerKey(MutableByteSpan & keySpan)
 {

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -121,6 +121,7 @@ public:
     static constexpr Key kConfigKey_clientid               = SilabsConfigKey(kMatterFactory_KeyBase, 0x16);
     static constexpr Key kConfigKey_Test_Event_Trigger_Key = SilabsConfigKey(kMatterFactory_KeyBase, 0x17);
     static constexpr Key kConfigKey_HardwareVersion        = SilabsConfigKey(kMatterFactory_KeyBase, 0x18);
+    static constexpr Key kConfigKey_SoftwareVersionString  = SilabsConfigKey(kMatterFactory_KeyBase, 0x19);
     // kConfigKey_PersistentUniqueId is the inputkey in the generating of the Rotating Device ID
     // SHALL NOT be the same as the UniqueID attribute exposed in the Basic Information cluster.
     static constexpr Key kConfigKey_PersistentUniqueId = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);


### PR DESCRIPTION
#### Summary

The software-version-string was moved to device info from the PR: https://github.com/project-chip/connectedhomeip/pull/38813/files ,hence the device hanged during try to read the software-string-version

Added the software-string-version fix 

917 SoC was hanged randomly during commissioning/bootup. After a bit of degugging noticed, the linker was causing the issue. Follow up this, to fix why the wifi sdk linker file is causing the random hangs. For now reverted the linker file.

#### Testing

Tested with 917SoC
