### PR TITLE
TC-CC-2.1: Fix checks for nullable attributes

### DIFF
--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -321,7 +321,7 @@ class TC_CC_2_1(MatterBaseTest):
         # Manual check
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds):
             sctmr_val = await self.read_single_attribute_check_success(cluster=self.cluster, endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds)
-            asserts.assert_true(sctmr_val is NullValue or (sctmr_val >= 1) and (sctmr_val <= 65279), "Value is out of range.")
+            asserts.assert_true(sctmr_val is NullValue or ((sctmr_val >= 1) and (sctmr_val <= 65279)), "Value is out of range.")
 
         # NumberOfPrimaries will be used to verify Primary<n>[X|Y|Intensity]
         # Number of primaries cant be 0, it should be greater or equal than 1.

--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -332,7 +332,7 @@ class TC_CC_2_1(MatterBaseTest):
         # Read NumberOfPrimaries from the cluster.
         number_of_primaries_value = await self._verify_attribute(self.attributes.NumberOfPrimaries, ValueTypesEnum.UINT8, min_len=0, max_len=6, nullable=True)
         if number_of_primaries_value is NullValue or number_of_primaries_value == 0:
-            logger.info("NumberOfPrimaries is 0 skipping steps 25 through 42.")
+            logger.info("NumberOfPrimaries is Null or 0 - skipping steps 25 through 42.")
             for i in range(25, 43):
                 self.skip_step(i)
         else:

--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -193,7 +193,7 @@ class TC_CC_2_1(MatterBaseTest):
             logger.info(f"Current value for {attribute} is {attr_val}")
             if nullable and attr_val is NullValue:
                 logger.info("Value is NULL (ok)")
-                return
+                return attr_val
             if data_type == ValueTypesEnum.UINT8:
                 logger.info("Checking is uint8")
                 matter_asserts.assert_valid_uint8(attr_val, "Is not uint8")
@@ -330,8 +330,8 @@ class TC_CC_2_1(MatterBaseTest):
 
         self.step(24)
         # Read NumberOfPrimaries from the cluster.
-        number_of_primaries_value = await self._verify_attribute(self.attributes.NumberOfPrimaries, ValueTypesEnum.UINT8, min_len=0, max_len=6)
-        if number_of_primaries_value == 0:
+        number_of_primaries_value = await self._verify_attribute(self.attributes.NumberOfPrimaries, ValueTypesEnum.UINT8, min_len=0, max_len=6, nullable=True)
+        if number_of_primaries_value is NullValue or number_of_primaries_value == 0:
             logger.info("NumberOfPrimaries is 0 skipping steps 25 through 42.")
             for i in range(25, 43):
                 self.skip_step(i)

--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -42,6 +42,7 @@ from typing import Optional
 import chip.clusters as Clusters
 from chip.clusters import Attribute
 from chip.clusters import ClusterObjects as ClusterObjects
+from chip.clusters.Types import NullValue
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute
 from mobly import asserts
@@ -173,7 +174,7 @@ class TC_CC_2_1(MatterBaseTest):
                 logger.warning(f"PrimaryN<X,Y,Intensity> with index {pindex} was not found in the cluster.")
         return numberofprimaries
 
-    async def _verify_attribute(self, attribute: Attribute, data_type: ValueTypesEnum, enum_range: Optional[list] = None, min_len: Optional[int] = None, max_len: Optional[int] = None):
+    async def _verify_attribute(self, attribute: Attribute, data_type: ValueTypesEnum, enum_range: Optional[list] = None, min_len: Optional[int] = None, max_len: Optional[int] = None, nullable: bool = False):
         """Verify the attribute exists and value is the specific type of value.
 
         Args:
@@ -190,6 +191,9 @@ class TC_CC_2_1(MatterBaseTest):
             # it is so retrieve the value to check the type.
             attr_val = await self.read_single_attribute_check_success(cluster=self.cluster, attribute=attribute, endpoint=self.endpoint)
             logger.info(f"Current value for {attribute} is {attr_val}")
+            if nullable and attr_val is NullValue:
+                logger.info("Value is NULL (ok)")
+                return
             if data_type == ValueTypesEnum.UINT8:
                 logger.info("Checking is uint8")
                 matter_asserts.assert_valid_uint8(attr_val, "Is not uint8")
@@ -317,7 +321,7 @@ class TC_CC_2_1(MatterBaseTest):
         # Manual check
         if await self.attribute_guard(endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds):
             sctmr_val = await self.read_single_attribute_check_success(cluster=self.cluster, endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds)
-            asserts.assert_true(sctmr_val is None or (sctmr_val >= 1) and (sctmr_val <= 65279), "Value is out of range.")
+            asserts.assert_true(sctmr_val is NullValue or (sctmr_val >= 1) and (sctmr_val <= 65279), "Value is out of range.")
 
         # NumberOfPrimaries will be used to verify Primary<n>[X|Y|Intensity]
         # Number of primaries cant be 0, it should be greater or equal than 1.
@@ -359,7 +363,7 @@ class TC_CC_2_1(MatterBaseTest):
                 await self._verify_attribute(getattr(self.attributes, f"Primary{primariesindex}Y"), ValueTypesEnum.UINT16, max_len=65279)
                 current_step += 1
                 self.step(current_step)
-                await self._verify_attribute(getattr(self.attributes, f"Primary{primariesindex}Intensity"), ValueTypesEnum.UINT8)
+                await self._verify_attribute(getattr(self.attributes, f"Primary{primariesindex}Intensity"), ValueTypesEnum.UINT8, nullable=True)
 
         # No more check numberofprimaries at this point
         self.step(43)
@@ -375,7 +379,7 @@ class TC_CC_2_1(MatterBaseTest):
         await self._verify_attribute(self.attributes.ColorPointRY, ValueTypesEnum.UINT16, max_len=65279)
 
         self.step(47)
-        await self._verify_attribute(self.attributes.ColorPointRIntensity, ValueTypesEnum.UINT8)
+        await self._verify_attribute(self.attributes.ColorPointRIntensity, ValueTypesEnum.UINT8, nullable=True)
 
         self.step(48)
         await self._verify_attribute(self.attributes.ColorPointGX, ValueTypesEnum.UINT16, max_len=65279)
@@ -384,7 +388,7 @@ class TC_CC_2_1(MatterBaseTest):
         await self._verify_attribute(self.attributes.ColorPointGY, ValueTypesEnum.UINT16, max_len=65279)
 
         self.step(50)
-        await self._verify_attribute(self.attributes.ColorPointGIntensity, ValueTypesEnum.UINT8)
+        await self._verify_attribute(self.attributes.ColorPointGIntensity, ValueTypesEnum.UINT8, nullable=True)
 
         self.step(51)
         await self._verify_attribute(self.attributes.ColorPointBX, ValueTypesEnum.UINT16, max_len=65279)
@@ -393,7 +397,7 @@ class TC_CC_2_1(MatterBaseTest):
         await self._verify_attribute(self.attributes.ColorPointBY, ValueTypesEnum.UINT16, max_len=65279)
 
         self.step(53)
-        await self._verify_attribute(self.attributes.ColorPointBIntensity, ValueTypesEnum.UINT8)
+        await self._verify_attribute(self.attributes.ColorPointBIntensity, ValueTypesEnum.UINT8, nullable=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the null check for StartUpColorTemperatureMireds, add null checks for other nullable values.

#### Summary
Test was missing handling for some nullable attributes and the null handling for one was incorrect.

#### Related issues
Fixes: https://github.com/project-chip/certification-tool/issues/632

#### Testing
This was tested locally with the lighting app, and is run in the CI. However, it is clear that this condition is not triggered by the CI example apps. I have asked the folks at SVE to check against their device and report here if this PR is an appropriate fix for their issue.
