### PR TITLE
[NXP] Fix DnssdImplBr handling of startup and reset events

### DIFF
--- a/src/platform/nxp/common/ConnectivityManagerImpl.cpp
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.cpp
@@ -340,6 +340,11 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
     return (mWiFiStationState == kWiFiStationState_Connected);
 }
 
+bool ConnectivityManagerImpl::_IsWiFiStationProvisioned()
+{
+    return mWifiIsProvisioned;
+}
+
 bool ConnectivityManagerImpl::_IsWiFiStationApplicationControlled()
 {
     return mWiFiStationMode == ConnectivityManager::kWiFiStationMode_ApplicationControlled;
@@ -645,6 +650,7 @@ CHIP_ERROR ConnectivityManagerImpl::ProvisionWiFiNetwork(const char * ssid, uint
         pNetworkData->security.psk_len = keyLen;
     }
 
+    mWifiIsProvisioned = true;
     ConnectNetworkTimerHandler(NULL, (void *) pNetworkData);
 
 exit:

--- a/src/platform/nxp/common/ConnectivityManagerImpl.h
+++ b/src/platform/nxp/common/ConnectivityManagerImpl.h
@@ -119,6 +119,7 @@ private:
 
     bool _IsWiFiStationEnabled();
     bool _IsWiFiStationConnected();
+    bool _IsWiFiStationProvisioned();
     bool _IsWiFiStationApplicationControlled();
     CHIP_ERROR _DisconnectNetwork(void);
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_WPA */
@@ -151,7 +152,8 @@ private:
     ConnectivityManager::WiFiStationState mWiFiStationState;
     ConnectivityManager::WiFiAPMode mWiFiAPMode;
     uint32_t mWiFiStationReconnectIntervalMS;
-    bool mWifiManagerInit = false;
+    bool mWifiManagerInit   = false;
+    bool mWifiIsProvisioned = false;
 
     enum WiFiEventGroup{
         kWiFiEventGroup_WiFiStationModeBit = (1 << 0),

--- a/src/platform/nxp/common/DnssdImpl.cpp
+++ b/src/platform/nxp/common/DnssdImpl.cpp
@@ -33,20 +33,18 @@ namespace Dnssd {
 
 CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    CHIP_ERROR error = CHIP_ERROR_INCORRECT_STATE;
+
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
-        ReturnErrorOnFailure(NxpChipDnssdInit(initCallback, errorCallback, context));
+        error = NxpChipDnssdInit(initCallback, errorCallback, context);
     }
     else if (ConnectivityMgr().IsThreadProvisioned())
     {
-        ReturnErrorOnFailure(OpenThreadDnssdInit(initCallback, errorCallback, context));
-    }
-    else
-    {
-        initCallback(context, CHIP_ERROR_INCORRECT_STATE);
+        error = OpenThreadDnssdInit(initCallback, errorCallback, context);
     }
 
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 void ChipDnssdShutdown()
@@ -56,7 +54,7 @@ void ChipDnssdShutdown()
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ReturnErrorOnFailure(NxpChipDnssdPublishService(service, callback, context));
     }
@@ -70,7 +68,7 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
 
 CHIP_ERROR ChipDnssdRemoveServices()
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ReturnErrorOnFailure(NxpChipDnssdRemoveServices());
     }
@@ -84,7 +82,7 @@ CHIP_ERROR ChipDnssdRemoveServices()
 
 CHIP_ERROR ChipDnssdFinalizeServiceUpdate()
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ReturnErrorOnFailure(NxpChipDnssdFinalizeServiceUpdate());
     }
@@ -99,7 +97,7 @@ CHIP_ERROR ChipDnssdBrowse(const char * type, DnssdServiceProtocol protocol, chi
                            chip::Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context,
                            intptr_t * browseIdentifier)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ReturnErrorOnFailure(NxpChipDnssdBrowse(type, protocol, addressType, interface, callback, context, browseIdentifier));
     }
@@ -119,7 +117,7 @@ CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier)
 CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                             void * context)
 {
-    if (ConnectivityMgr().IsWiFiStationConnected())
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
     {
         ReturnErrorOnFailure(NxpChipDnssdResolve(service, interface, callback, context));
     }

--- a/src/platform/nxp/common/DnssdImplBr.cpp
+++ b/src/platform/nxp/common/DnssdImplBr.cpp
@@ -167,9 +167,16 @@ CHIP_ERROR NxpChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncRet
         LIST_Init(&mBrowseList, 0);
     }
 
-    initCallback(context, CHIP_NO_ERROR);
-
-    return CHIP_NO_ERROR;
+    // The mDNS module is ready once the WIFI connectivity has been established
+    if (ConnectivityMgr().IsWiFiStationConnected())
+    {
+        initCallback(context, CHIP_NO_ERROR);
+        return CHIP_NO_ERROR;
+    }
+    else
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 }
 
 void NxpChipDnssdShutdown()


### PR DESCRIPTION
This commit fixes the start-up logic of the platform mDNS to return init success only after the wifi interface is connected and the mDNS module is ready.
Also addresses the issue where after reset, in an multi-interface scenario with WIFI and Thread enabled, the platform code will use the Thread mDNS instead of the Wi-Fi one.

#### Testing

Tested on NXP BR hardware by commissioning over WIFI and starting Thread IF using TBRM cluster. After reset observed that correct WIFI platform mDNS is used and the device is still reachable by chip-tool.
Tested also that after an OTA upgrade the board sends Notify Updated applied to the OTA provider. Without current fix the discovery of the OTA provider would fail because it would happen before the mDNS module was not ready.
