### PR TITLE
[Engine.cpp]: Reading attribute data should validate "valid cluster path"

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -166,6 +166,13 @@ DataModel::ActionReturnStatus RetrieveClusterData(DataModel::Provider * dataMode
     //
     //       See https://github.com/project-chip/connectedhomeip/issues/37410
 
+    auto clusterInfo = serverClusterFinder.Find(path);
+
+    if (clusterInfo == std::nullopt)
+    {
+        return Status::UnsupportedCluster;
+    }
+
     if (auto access_status = ValidateReadAttributeACL(dataModel, subjectDescriptor, path); access_status.has_value())
     {
         status = *access_status;


### PR DESCRIPTION
#### Summary

We already have validation for this as part of checking cluster info data version.

See https://github.com/project-chip/connectedhomeip/pull/37345#discussion_r1940446211 for originating comment.

The code would be clearer to follow and maintain if the checks for versioning were clearer. However as it stands today, if we create a trivial error out if the path is not valid we fail tests and we need to determine why (likely due to wildcard expansion logic).

Initial validation for invalid cluster path.

#### Testing

CI checks,