### PR TITLE
[CI] Add build check for chip-camera for arm64

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-crosscompile:138
+            image: ghcr.io/project-chip/chip-build-crosscompile:140
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -72,6 +72,7 @@ jobs:
                         --target linux-arm64-fabric-bridge-no-ble-clang-rpc \
                         --target linux-arm64-fabric-sync-no-ble-clang \
                         --target linux-arm64-camera-controller-clang \
+                        --target linux-arm64-camera-clang \
                         build \
                      "
             - name: Bloat report - chip-tool

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -417,6 +417,26 @@ config("runtime_default") {
   if (sysroot != "") {
     cflags += [ "--sysroot=${sysroot}" ]
     ldflags += [ "--sysroot=${sysroot}" ]
+
+    if (is_clang && current_os == "linux" &&
+        (current_cpu == "arm" || current_cpu == "arm64")) {
+      # The sysroot for linux-arm* targets contains an incompatible libunwind that
+      # conflicts with the one from the LLVM toolchain.
+      #
+      # To solve this, we provide the direct path to the correct libunwind.a
+      # from the pigweed toolchain. This forces the linker to use this exact
+      # file, completely bypassing any library search paths for libunwind.
+
+      if (current_cpu == "arm64") {
+        ldflags += [ rebase_path(
+                "$pw_env_setup_CIPD_PIGWEED/lib/aarch64-unknown-linux-gnu/libunwind.a",
+                root_build_dir) ]
+      } else {  # arm
+        ldflags += [ rebase_path(
+                "$pw_env_setup_CIPD_PIGWEED/lib/armv7-unknown-linux-gnueabihf/libunwind.a",
+                root_build_dir) ]
+      }
+    }
   }
 
   cflags += runtime_library_cflags


### PR DESCRIPTION
#### Summary

1. Add build check for chip-camera for arm64 in CI.

2. Fix the following linking error after chip-build-crosscompile:139 and above

```
ld.lld: error: undefined symbol: _Unwind_Resume
ld.lld: error: undefined symbol: _Unwind_RaiseException
ld.lld: error: undefined symbol: _Unwind_SetGR
ld.lld: error: undefined symbol: _Unwind_SetIP
```

Based on the conversation with Andrei and the BUILD.gn file you provided, here is a breakdown of the issue and the required fix.

The Core Problem
Two libunwinds Exist:

One is provided by the Pigweed/LLVM toolchain. This is the correct one that is compatible with the rest of your C++ toolchain and libraries (libc++).
Another one is present in sysroot (/opt/ubuntu-24.04-aarch64-sysroot). This one is being pulled in as a dependency of another library (GStreamer) and is incompatible.
Linker Precedence: The linker (ld.lld) is configured to search for system libraries in the sysroot path first. Because of this, it finds the incompatible libunwind from the sysroot and ignores the correct one from the Pigweed toolchain.

The Result: This leads to the "undefined symbol" errors for _Unwind_Resume because the sysroot's libunwind doesn't match what the LLVM libc++ expects for exception handling. Andrei confirmed this by manually deleting the sysroot's libunwind, which allowed the build to succeed.

The Solution
The goal is to force the linker to prioritize the Pigweed toolchain's libunwind. Manually deleting files from the sysroot is not a sustainable solution. 

#### Related issues

N/A

#### Testing

Validated by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
