### PR TITLE
Adding WiFi Validation

### DIFF
--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -100,7 +100,7 @@ class TC_CNET_4_9(MatterBaseTest):
         return '[TC-CNET-4.9] [Wi-Fi] Verification for RemoveNetwork Command [DUT-Server]'
 
     def pics_TC_CNET_4_9(self):
-        return ['CNET.S']
+        return ['CNET.S.F00']
 
     @run_if_endpoint_matches(has_feature(Clusters.NetworkCommissioning, Clusters.NetworkCommissioning.Bitmaps.Feature.kWiFiNetworkInterface))
     async def test_TC_CNET_4_9(self):
@@ -109,12 +109,6 @@ class TC_CNET_4_9(MatterBaseTest):
 
         # Commissioning is already done
         self.step("Precondition")
-
-        feature_map = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning, attribute=Clusters.NetworkCommissioning.Attributes.FeatureMap)
-        if not (feature_map & Clusters.NetworkCommissioning.Bitmaps.Feature.kWiFiNetworkInterface):
-            logging.info('Device does not support WiFi on endpoint, skipping remaining steps')
-            self.mark_all_remaining_steps_skipped(1)
-            return
 
         # TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900
         self.step(1)

--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -110,6 +110,12 @@ class TC_CNET_4_9(MatterBaseTest):
         # Commissioning is already done
         self.step("Precondition")
 
+        feature_map = await self.read_single_attribute_check_success(cluster=Clusters.NetworkCommissioning, attribute=Clusters.NetworkCommissioning.Attributes.FeatureMap)
+        if not (feature_map & Clusters.NetworkCommissioning.Bitmaps.Feature.kWiFiNetworkInterface):
+            logging.info('Device does not support WiFi on endpoint, skipping remaining steps')
+            self.mark_all_remaining_steps_skipped(1)
+            return
+
         # TH sends ArmFailSafe command to the DUT with ExpiryLengthSeconds set to 900
         self.step(1)
         cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=0)


### PR DESCRIPTION
### Summary

This is a continuation of https://github.com/project-chip/connectedhomeip/pull/37884

It handles comment: https://github.com/project-chip/connectedhomeip/pull/37884#issuecomment-2975706880

PICS value was updated

[# fixes](https://github.com/project-chip/connectedhomeip/issues/39570)

### Testing:

Since this is a wifi test, to reproduce test steps there are some physical devices needed.
You will need:
- ESP32C6

In one terminal:

- Clone esp32 repo, install and export:
  ``` bash
  git clone -b v5.3 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
  cd esp-idf
  ./install.sh
  source export.sh
  cd ~/connectedhomeip
  source ./scripts/activate.sh
  cd examples/all-clusters-app/esp32
  idf.py set-target esp32c6
  cd ~/connectedhomeip
  ```

- Build:
  ``` bash
  idf.py -C examples/all-clusters-app/esp32 build
  ```

- Remove flash:
  ``` bash
  idf.py -C examples/all-clusters-app/esp32 -p /dev/tty.usbmodem101 erase_flash
  ```
- Flash device
  ``` bash
  idf.py -C examples/all-clusters-app/esp32 -p /dev/tty.usbmodem101 flash
  ```

In second terminal:

- Run test:
  ``` bash
  python3 src/python_testing/TC_CNET_4_9.py --commissioning-method ble-wifi --discriminator 3840 --passcode 20202021 --wifi-ssid <YOUR_WIFI_SSID> --wifi-passphrase <YOUR_WIFI_PASSWORD> --endpoint 0
  ```