### PR TITLE
Stop overriding core SDK defaults for Wi-Fi PAF in build_python.sh.

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -99,7 +99,7 @@ while (($#)); do
             shift
             ;;
         --enable_wifi_paf | -p)
-            declare wifi_paf_arg=$2
+            declare wifi_paf_arg="$2"
             if [[ "$wifi_paf_arg" != "true" && "$wifi_paf_arg" != "false" ]]; then
                 echo "enable_wifi_paf should have a true/false value, not '$wifi_paf_arg'"
                 exit

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -42,7 +42,7 @@ declare enable_ipv4=true
 declare wifi_paf_config=""
 declare chip_detail_logging=false
 declare chip_mdns=minimal
-declare case_retry_delta
+declare chip_case_retry_delta
 declare install_virtual_env
 declare clean_virtual_env=yes
 declare install_pytest_requirements=yes
@@ -188,7 +188,7 @@ fi
 echo "  enable_ipv4=\"$enable_ipv4\""
 
 if [[ ${#extra_gn_args[@]} -gt 0 ]]; then
-    echo "In addition, the following extra args will added to gn command line: ${extra_gn_args[@]}"
+    echo "In addition, the following extra args will added to gn command line: ${extra_gn_args[*]}"
 fi
 
 # Ensure we have a compilation environment
@@ -209,20 +209,35 @@ source "$CHIP_ROOT/scripts/activate.sh"
 export SYSTEM_VERSION_COMPAT=0
 
 # Generates ninja files
-[[ -n "$chip_mdns" ]] && chip_mdns_arg="chip_mdns=\"$chip_mdns\"" || chip_mdns_arg=""
-[[ -n "$chip_case_retry_delta" ]] && chip_case_retry_arg="chip_case_retry_delta=$chip_case_retry_delta" || chip_case_retry_arg=""
-[[ -n "$pregen_dir" ]] && pregen_dir_arg="chip_code_pre_generated_directory=\"$pregen_dir\"" || pregen_dir_arg=""
-
-# Make all possible human redable tracing available.
-tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
-
-declare -a gn_args=("$tracing_options" "chip_detail_logging=$chip_detail_logging" "chip_project_config_include_dirs=[\"//config/python\"]" "$chip_mdns_arg" "$chip_case_retry_arg" "$pregen_dir_arg" "chip_config_network_layer_ble=$enable_ble" "chip_enable_ble=$enable_ble" "chip_inet_config_enable_ipv4=$enable_ipv4" "chip_crypto=\"boringssl\"")
+gn_args=(
+    # Make all possible human readable tracing available.
+    "matter_log_json_payload_hex=true"
+    "matter_log_json_payload_decode_full=true"
+    "matter_enable_tracing_support=true"
+    # Setup selected configuration.
+    "chip_detail_logging=$chip_detail_logging"
+    "chip_project_config_include_dirs=[\"//config/python\"]"
+    "chip_config_network_layer_ble=$enable_ble"
+    "chip_enable_ble=$enable_ble"
+    "chip_inet_config_enable_ipv4=$enable_ipv4"
+    "chip_crypto=\"boringssl\""
+)
+if [[ -n "$chip_mdns" ]]; then
+    gn_args+=("chip_mdns=\"$chip_mdns\"")
+fi
+if [[ -n "$chip_case_retry_delta" ]]; then
+    gn_args+=("chip_case_retry_delta=$chip_case_retry_delta")
+fi
+if [[ -n "$pregen_dir" ]]; then
+    gn_args+=("chip_code_pre_generated_directory=\"$pregen_dir\"")
+fi
 if [[ -n $wifi_paf_config ]]; then
     args+=("$wifi_paf_config")
 fi
-gn_args+=extra_gn_args
+# Append extra arguments provided by the user.
+gn_args+=("${extra_gn_args[@]}")
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="${gn_args[@]}"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="${gn_args[*]}"
 
 # Compile Python wheels
 ninja -C "$OUTPUT_ROOT" python_wheels

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -99,13 +99,12 @@ while (($#)); do
             shift
             ;;
         --enable_wifi_paf | -p)
-            declare enable_wifi_paf=true
-            enable_wifi_paf=$2
-            if [[ "$enable_wifi_paf" != "true" && "$enable_wifi_paf" != "false" ]]; then
-                echo "enable_wifi_paf should have a true/false value, not '$enable_wifi_paf'"
+            declare wifi_paf_arg=$2
+            if [[ "$wifi_paf_arg" != "true" && "$wifi_paf_arg" != "false" ]]; then
+                echo "enable_wifi_paf should have a true/false value, not '$wifi_paf_arg'"
                 exit
             fi
-            wifi_paf_config="chip_device_config_enable_wifipaf=$enable_wifi_paf"
+            wifi_paf_config="chip_device_config_enable_wifipaf=$wifi_paf_arg"
             shift
             ;;
         --enable_ipv4 | -4)
@@ -220,7 +219,7 @@ export SYSTEM_VERSION_COMPAT=0
 # Make all possible human redable tracing available.
 tracing_options="matter_log_json_payload_hex=true matter_log_json_payload_decode_full=true matter_enable_tracing_support=true"
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_inet_config_enable_ipv4=$enable_ipv4 $wifi_paf_config chip_crypto=\"boringssl\" $all_extra_gn_args"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="$tracing_options chip_detail_logging=$chip_detail_logging chip_project_config_include_dirs=[\"//config/python\"] $chip_mdns_arg $chip_case_retry_arg $pregen_dir_arg chip_config_network_layer_ble=$enable_ble chip_enable_ble=$enable_ble chip_inet_config_enable_ipv4=$enable_ipv4${wifi_paf_config:+ $wifi_paf_config} chip_crypto=\"boringssl\" $all_extra_gn_args"
 
 # Compile Python wheels
 ninja -C "$OUTPUT_ROOT" python_wheels


### PR DESCRIPTION
We should only pass in the chip_device_config_enable_wifipaf bits if the relevant command-line argument is actually provided.

#### Testing

CI exercises this script.