### PR TITLE
[Linux] Improve isolated test network management

### DIFF
--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -45,13 +45,13 @@ def EnsurePrivateState():
     logging.info("Ensuring /run is privately accessible")
 
     logging.debug("Making / private")
-    if os.system("mount --make-private /") != 0:
+    if subprocess.run(["mount", "--make-private", "/"]).returncode != 0:
         logging.error("Failed to make / private")
         logging.error("Are you using --privileged if running in docker?")
         sys.exit(1)
 
     logging.debug("Remounting /run")
-    if os.system("mount -t tmpfs tmpfs /run") != 0:
+    if subprocess.run(["mount", "-t", "tmpfs", "tmpfs", "/run"]).returncode != 0:
         logging.error("Failed to mount /run as a temporary filesystem")
         logging.error("Are you using --privileged if running in docker?")
         sys.exit(1)
@@ -179,7 +179,7 @@ class IsolatedNetworkNamespace:
         command = command.format(app_link_name=self.app_link_name,
                                  tool_link_name=self.tool_link_name)
         logging.debug("Executing: %s", command)
-        if os.system(command) != 0:
+        if subprocess.run(command.split()).returncode != 0:
             logging.error("Failed to execute '%s'" % command)
             logging.error("Are you using --privileged if running in docker?")
             sys.exit(1)

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -32,7 +32,7 @@ test_environ = os.environ.copy()
 def EnsureNetworkNamespaceAvailability():
     if os.getuid() == 0:
         logging.debug("Current user is root")
-        logging.warn("Running as root and this will change global namespaces.")
+        logging.warning("Running as root and this will change global namespaces.")
         return
 
     os.execvpe(
@@ -57,82 +57,63 @@ def EnsurePrivateState():
         sys.exit(1)
 
 
-def CreateNamespacesForAppTest():
-    """
-    Creates appropriate namespaces for a tool and app binaries in a simulated
-    isolated network.
-    """
-    COMMANDS = [
-        # 2 virtual hosts: for app and for the tool
+class IsolatedNetworkNamespace:
+    """Helper class to create and remove network namespaces for tests."""
+
+    # Commands for creating appropriate namespaces for a tool and app binaries
+    # in the simulated isolated network.
+    COMMANDS_SETUP = [
+        # Create 2 virtual hosts: for app and for the tool
         "ip netns add app",
         "ip netns add tool",
 
-        # create links for switch to net connections
-        "ip link add eth-app type veth peer name eth-app-switch",
-        "ip link add eth-tool type veth peer name eth-tool-switch",
+        # Create links for switch to net connections
+        "ip link add {app_link_name} type veth peer name eth-app-switch",
+        "ip link add {tool_link_name} type veth peer name eth-tool-switch",
         "ip link add eth-ci type veth peer name eth-ci-switch",
 
-        # link the connections together
-        "ip link set eth-app netns app",
-        "ip link set eth-tool netns tool",
+        # Link the connections together
+        "ip link set {app_link_name} netns app",
+        "ip link set {tool_link_name} netns tool",
 
+        # Bridge all the connections together.
         "ip link add name br1 type bridge",
         "ip link set br1 up",
         "ip link set eth-app-switch master br1",
         "ip link set eth-tool-switch master br1",
         "ip link set eth-ci-switch master br1",
 
-        # mark connections up
-        "ip netns exec app ip addr add 10.10.10.1/24 dev eth-app",
-        "ip netns exec app ip link set dev eth-app up",
-        "ip netns exec app ip link set dev lo up",
-        "ip link set dev eth-app-switch up",
-
-        "ip netns exec tool ip addr add 10.10.10.2/24 dev eth-tool",
-        "ip netns exec tool ip link set dev eth-tool up",
-        "ip netns exec tool ip link set dev lo up",
-        "ip link set dev eth-tool-switch up",
-
-        # Force IPv6 to use ULAs that we control
-        "ip netns exec tool ip -6 addr flush eth-tool",
-        "ip netns exec app ip -6 addr flush eth-app",
-        "ip netns exec tool ip -6 a add fd00:0:1:1::2/64 dev eth-tool",
-        "ip netns exec app ip -6 a add fd00:0:1:1::3/64 dev eth-app",
-
-        # create link between virtual host 'tool' and the test runner
+        # Create link between virtual host 'tool' and the test runner
         "ip addr add 10.10.10.5/24 dev eth-ci",
         "ip link set dev eth-ci up",
         "ip link set dev eth-ci-switch up",
     ]
 
-    for command in COMMANDS:
-        logging.debug("Executing '%s'" % command)
-        if os.system(command) != 0:
-            logging.error("Failed to execute '%s'" % command)
-            logging.error("Are you using --privileged if running in docker?")
-            sys.exit(1)
+    # Bring up application connection link.
+    COMMANDS_APP_LINK_UP = [
+        "ip netns exec app ip addr add 10.10.10.1/24 dev {app_link_name}",
+        "ip netns exec app ip link set dev {app_link_name} up",
+        "ip netns exec app ip link set dev lo up",
+        "ip link set dev eth-app-switch up",
+        # Force IPv6 to use ULAs that we control.
+        "ip netns exec app ip -6 addr flush {app_link_name}",
+        "ip netns exec app ip -6 a add fd00:0:1:1::3/64 dev {app_link_name}",
 
-    # IPv6 does Duplicate Address Detection even though
-    # we know ULAs provided are isolated. Wait for 'tenative'
-    # address to be gone.
+    ]
 
-    logging.info('Waiting for IPv6 DaD to complete (no tentative addresses)')
-    for i in range(100):  # wait at most 10 seconds
-        output = subprocess.check_output(['ip', 'addr'])
-        if b'tentative' not in output:
-            logging.info('No more tentative addresses')
-            break
-        time.sleep(0.1)
-    else:
-        logging.warn("Some addresses look to still be tentative")
+    # Bring up tool (controller) connection link.
+    COMMANDS_TOOL_LINK_UP = [
+        "ip netns exec tool ip addr add 10.10.10.2/24 dev {tool_link_name}",
+        "ip netns exec tool ip link set dev {tool_link_name} up",
+        "ip netns exec tool ip link set dev lo up",
+        "ip link set dev eth-tool-switch up",
+        # Force IPv6 to use ULAs that we control.
+        "ip netns exec tool ip -6 addr flush {tool_link_name}",
+        "ip netns exec tool ip -6 a add fd00:0:1:1::2/64 dev {tool_link_name}",
+    ]
 
-
-def RemoveNamespaceForAppTest():
-    """
-    Removes namespaces for a tool and app binaries previously created to simulate an
-    isolated network. This tears down what was created in CreateNamespacesForAppTest.
-    """
-    COMMANDS = [
+    # Commands for removing namespaces previously created.
+    COMMANDS_TERMINATE = [
         "ip link set dev eth-ci down",
         "ip link set dev eth-ci-switch down",
         "ip addr del 10.10.10.5/24 dev eth-ci",
@@ -148,25 +129,64 @@ def RemoveNamespaceForAppTest():
         "ip netns del app",
     ]
 
-    for command in COMMANDS:
-        logging.debug("Executing '%s'" % command)
+    def __init__(self, setup_app_link_up=True, setup_tool_link_up=True,
+                 app_link_name='eth-app', tool_link_name='eth-tool',
+                 unshared=False):
+
+        if not unshared:
+            # If not running in an unshared network namespace yet, try
+            # to rerun the script with the 'unshare' command.
+            EnsureNetworkNamespaceAvailability()
+        else:
+            EnsurePrivateState()
+
+        self.app_link_name = app_link_name
+        self.tool_link_name = tool_link_name
+
+        self.setup()
+        if setup_app_link_up:
+            self.setup_app_link_up()
+        if setup_tool_link_up:
+            self.setup_tool_link_up()
+
+        # IPv6 does Duplicate Address Detection even though
+        # we know ULAs provided are isolated. Wait for 'tenative'
+        # address to be gone.
+
+        logging.info('Waiting for IPv6 DaD to complete (no tentative addresses)')
+        for _ in range(100):  # wait at most 10 seconds
+            output = subprocess.check_output(['ip', 'addr'])
+            if b'tentative' not in output:
+                logging.info('No more tentative addresses')
+                break
+            time.sleep(0.1)
+        else:
+            logging.warning("Some addresses look to still be tentative")
+
+    def setup(self):
+        for command in self.COMMANDS_SETUP:
+            self.run(command)
+
+    def setup_app_link_up(self):
+        for command in self.COMMANDS_APP_LINK_UP:
+            self.run(command)
+
+    def setup_tool_link_up(self):
+        for command in self.COMMANDS_TOOL_LINK_UP:
+            self.run(command)
+
+    def run(self, command: str):
+        command = command.format(app_link_name=self.app_link_name,
+                                 tool_link_name=self.tool_link_name)
+        logging.debug("Executing: %s", command)
         if os.system(command) != 0:
-            breakpoint()
             logging.error("Failed to execute '%s'" % command)
+            logging.error("Are you using --privileged if running in docker?")
             sys.exit(1)
 
-
-def PrepareNamespacesForTestExecution(in_unshare: bool):
-    if not in_unshare:
-        EnsureNetworkNamespaceAvailability()
-    elif in_unshare:
-        EnsurePrivateState()
-
-    CreateNamespacesForAppTest()
-
-
-def ShutdownNamespaceForTestExecution():
-    RemoveNamespaceForAppTest()
+    def terminate(self):
+        for command in self.COMMANDS_TERMINATE:
+            self.run(command)
 
 
 def PathsWithNetworkNamespaces(paths: ApplicationPaths) -> ApplicationPaths:

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -368,8 +368,8 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     )
 
     if sys.platform == 'linux':
-        chiptest.linux.PrepareNamespacesForTestExecution(
-            context.obj.in_unshare)
+        ns = chiptest.linux.IsolatedNetworkNamespace(
+            unshared=context.obj.in_unshare)
         paths = chiptest.linux.PathsWithNetworkNamespaces(paths)
 
     logging.info("Each test will be executed %d times" % iterations)
@@ -380,7 +380,7 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     def cleanup():
         apps_register.uninit()
         if sys.platform == 'linux':
-            chiptest.linux.ShutdownNamespaceForTestExecution()
+            ns.terminate()
 
     for i in range(iterations):
         logging.info("Starting iteration %d" % (i+1))
@@ -434,8 +434,7 @@ if sys.platform == 'linux':
               'network namespaces)'))
     @click.pass_context
     def cmd_shell(context):
-        chiptest.linux.PrepareNamespacesForTestExecution(
-            context.obj.in_unshare)
+        chiptest.linux.IsolatedNetworkNamespace(unshared=context.obj.in_unshare)
         os.execvpe("bash", ["bash"], os.environ.copy())
 
 

--- a/src/platform/Linux/ConnectivityUtils.cpp
+++ b/src/platform/Linux/ConnectivityUtils.cpp
@@ -276,6 +276,10 @@ InterfaceTypeEnum ConnectivityUtils::GetInterfaceConnectionType(const char * ifn
     {
         ret = InterfaceTypeEnum::kEthernet;
     }
+    else if (strncmp(ifname, "wl", 2) == 0)
+    {
+        ret = InterfaceTypeEnum::kWiFi;
+    }
 
     close(sock);
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -110,16 +110,17 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
 
                         ChipLogDetail(DeviceLayer, "Got IP address on interface: %s", name);
 
-                        if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
+                        const char * wifiIfName = ConnectivityMgrImpl().GetWiFiIfName();
+                        if (wifiIfName == nullptr)
                         {
                             ChipLogDetail(DeviceLayer, "Ignoring IP update event: No WiFi interface name configured");
                             continue;
                         }
 
-                        if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0)
+                        if (strcmp(name, wifiIfName) != 0)
                         {
                             ChipLogDetail(DeviceLayer, "Ignoring IP update event: Interface name mismatch: %s != %s", name,
-                                          ConnectivityMgrImpl().GetWiFiIfName());
+                                          wifiIfName);
                             continue;
                         }
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -108,14 +108,18 @@ gboolean WiFiIPChangeListener(GIOChannel * ch, GIOCondition /* condition */, voi
                             continue;
                         }
 
+                        ChipLogDetail(DeviceLayer, "Got IP address on interface: %s", name);
+
                         if (ConnectivityMgrImpl().GetWiFiIfName() == nullptr)
                         {
-                            ChipLogDetail(DeviceLayer, "No wifi interface name. Ignoring IP update event.");
+                            ChipLogDetail(DeviceLayer, "Ignoring IP update event: No WiFi interface name configured");
                             continue;
                         }
 
                         if (strcmp(name, ConnectivityMgrImpl().GetWiFiIfName()) != 0)
                         {
+                            ChipLogDetail(DeviceLayer, "Ignoring IP update event: Interface name mismatch: %s != %s", name,
+                                          ConnectivityMgrImpl().GetWiFiIfName());
                             continue;
                         }
 


### PR DESCRIPTION
#### Summary

Changes in https://github.com/project-chip/connectedhomeip/pull/39454 require functionality to allow postponing IP assignment to the interface in the app namespace. This PR refactors isolated test network management on Linux, which adds such functionality.

#### Testing

CI will verify any regressions.
