### PR TITLE
Disable AVSM 2.10

### DIFF
--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -21,6 +21,10 @@ not_automated:
       reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_9.py
       reason: Camera App does not support all features required for this TC
+    - name: TC_AVSM_2_10.py
+      reason:
+        CI failure
+        See https://github.com/project-chip/connectedhomeip/issues/39594
     - name: TC_AVSM_2_11.py
       reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -23,8 +23,8 @@ not_automated:
       reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_10.py
       reason:
-        CI failure
-        See https://github.com/project-chip/connectedhomeip/issues/39594
+          CI failure See
+          https://github.com/project-chip/connectedhomeip/issues/39594
     - name: TC_AVSM_2_11.py
       reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py


### PR DESCRIPTION
#### Summary

CI seems broken after #39545

#### Related issues

Opened #39594 to track fixing that issue

#### Testing

This just disables the test (instead of rolling back that entire PR).

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
