### PR TITLE
Re-enable AVSM-2.10 after reordering test steps

### DIFF
--- a/src/python_testing/TC_AVSM_2_10.py
+++ b/src/python_testing/TC_AVSM_2_10.py
@@ -227,7 +227,8 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=aStreamID))
         except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            asserts.fail(
+                f"Expected SnapshotStreamDeallocate to succeed, but it failed with status: {e.status}")
             pass
 
         self.step(9)

--- a/src/python_testing/TC_AVSM_2_10.py
+++ b/src/python_testing/TC_AVSM_2_10.py
@@ -84,28 +84,28 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 6,
-                "TH sends the SnapshotStreamDeallocate command with SnapshotStreamID set to aStreamID.",
-                "DUT responds with a SUCCESS status code.",
-            ),
-            TestStep(
-                7,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
-                "Verify the number of allocated snapshot streams in the list is 0.",
-            ),
-            TestStep(
-                8,
-                "TH sends the CaptureSnapshot command with SnapshotStreamID set to Null.",
-                "DUT responds with NOT_FOUND status code.",
-            ),
-            TestStep(
-                9,
                 "If DUT supports Privacy feature, TH writes SoftLivestreamPrivacyModeEnabled = true on DUT",
                 "DUT responds with a SUCCESS status code.",
             ),
             TestStep(
-                10,
+                7,
                 "TH sends the CaptureSnapshot command with SnapshotStreamID set to aStreamID.",
                 "DUT responds with INVALID_IN_STATE status code.",
+            ),
+            TestStep(
+                8,
+                "TH sends the SnapshotStreamDeallocate command with SnapshotStreamID set to aStreamID.",
+                "DUT responds with a SUCCESS status code.",
+            ),
+            TestStep(
+                9,
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated snapshot streams in the list is 0.",
+            ),
+            TestStep(
+                10,
+                "TH sends the CaptureSnapshot command with SnapshotStreamID set to Null.",
+                "DUT responds with NOT_FOUND status code.",
             ),
         ]
 

--- a/src/python_testing/TC_AVSM_2_10.py
+++ b/src/python_testing/TC_AVSM_2_10.py
@@ -199,39 +199,14 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
             logger.error(f"Snapshot capture is not supported: {e}")
             pass
 
-        self.step(6)
-        try:
-            await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=aStreamID))
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
-
-        self.step(7)
-        aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
-        )
-        logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
-        asserts.assert_equal(len(aAllocatedSnapshotStreams), 0, "The number of allocated snapshot streams in the list is not 0.")
-
-        self.step(8)
-        try:
-            captureSnapshotResponse = await self.send_single_cmd(
-                cmd=commands.CaptureSnapshot(requestedResolution=aResolution), endpoint=endpoint)
-            asserts.assert_true(False, "Unexpected success when expecting NOT_FOUND due to 0 allocated snapshot streams")
-        except InteractionModelError as e:
-            asserts.assert_equal(
-                e.status, Status.NotFound, "Unexpected error returned when expecting NOT_FOUND due to 0 allocated snapshot streams"
-            )
-            pass
-
         if self.privacySupport:
-            self.step(9)
+            self.step(6)
             result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(True),
                                                        endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
             logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{True}")
 
-            self.step(10)
+            self.step(7)
             try:
                 await self.send_single_cmd(
                     cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID, requestedResolution=aResolution), endpoint=endpoint)
@@ -245,8 +220,33 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
                 pass
 
         else:
-            self.skip_step(9)
-            self.skip_step(10)
+            self.skip_step(6)
+            self.skip_step(7)
+
+        self.step(8)
+        try:
+            await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=aStreamID))
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+
+        self.step(9)
+        aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
+        )
+        logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
+        asserts.assert_equal(len(aAllocatedSnapshotStreams), 0, "The number of allocated snapshot streams in the list is not 0.")
+
+        self.step(10)
+        try:
+            captureSnapshotResponse = await self.send_single_cmd(
+                cmd=commands.CaptureSnapshot(requestedResolution=aResolution), endpoint=endpoint)
+            asserts.assert_true(False, "Unexpected success when expecting NOT_FOUND due to 0 allocated snapshot streams")
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status, Status.NotFound, "Unexpected error returned when expecting NOT_FOUND due to 0 allocated snapshot streams"
+            )
+            pass
 
 
 if __name__ == "__main__":

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -21,10 +21,6 @@ not_automated:
       reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_9.py
       reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_10.py
-      reason:
-          CI failure See
-          https://github.com/project-chip/connectedhomeip/issues/39594
     - name: TC_AVSM_2_11.py
       reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py


### PR DESCRIPTION
#### Summary

Fixes `TC-AVSM-2.10` by reordering the test steps as requested in the test plan [here](https://github.com/CHIP-Specifications/chip-test-plans/pull/5252#discussion_r2154884212), and re-enabling that test case in CI.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/39594

#### Testing

Verified by `TC-AVSM-2.10`