### PR TITLE
[CP][1.4][ICD][Client] Continue to resubscribe when liveness timeout happens if peer is lit mode and client does't register its icd token

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -1054,7 +1054,11 @@ void ReadClient::OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void *
                  "Subscription Liveness timeout with SubscriptionID = 0x%08" PRIx32 ", Peer = %02x:" ChipLogFormatX64,
                  _this->mSubscriptionId, _this->GetFabricIndex(), ChipLogValueX64(_this->GetPeerNodeId()));
 
-    if (_this->mIsPeerLIT)
+    // If subscription client is able to handle check-in messages and peer operation mode is LIT,
+    // use CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT as subscriptionTerminationCause.
+    // This will cause us to wait for a check-in message before trying to re-subscribe, instead of trying
+    // (and probably failing, because we are dealing with a LIT ICD) off a timer.
+    if (_this->mIsPeerLIT && _this->mReadPrepareParams.mRegisteredCheckInToken)
     {
         subscriptionTerminationCause = CHIP_ERROR_LIT_SUBSCRIBE_INACTIVE_TIMEOUT;
     }
@@ -1176,7 +1180,14 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
         mReadPrepareParams.mSessionHolder = aReadPrepareParams.mSessionHolder;
     }
 
-    mIsPeerLIT = aReadPrepareParams.mIsPeerLIT;
+    mIsPeerLIT                                 = aReadPrepareParams.mIsPeerLIT;
+    mReadPrepareParams.mRegisteredCheckInToken = aReadPrepareParams.mRegisteredCheckInToken;
+
+    if (aReadPrepareParams.mRegisteredCheckInToken)
+    {
+        ChipLogProgress(DataManagement, "ICD Check-In token has been registered in peer device " ChipLogFormatScopedNodeId,
+                        ChipLogValueScopedNodeId(mPeer));
+    }
 
     mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;
 

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -375,6 +375,8 @@ public:
 
     FabricIndex GetFabricIndex() const { return mPeer.GetFabricIndex(); }
     NodeId GetPeerNodeId() const { return mPeer.GetNodeId(); }
+    ScopedNodeId GetPeerScopedId() const { return mPeer; }
+
     bool IsReadType() { return mInteractionType == InteractionType::Read; }
     bool IsSubscriptionType() const { return mInteractionType == InteractionType::Subscribe; };
 

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -47,7 +47,18 @@ struct ReadPrepareParams
     uint16_t mMaxIntervalCeilingSeconds = 0;
     bool mKeepSubscriptions             = false;
     bool mIsFabricFiltered              = true;
-    bool mIsPeerLIT                     = false;
+
+    // If set to true, indicates that the peer device is known to be a LIT ICD. This can be set by the application if it has prior
+    // knowledge of the peer's operating mode (e.g. from previous reads of IcdManagementCluster::OperatingMode). This is useful for
+    // subscriptions that do not include the OperatingMode attribute in the set of paths that are subscribed to.
+    //
+    // This field is ignored for read operations.
+    bool mIsPeerLIT = false;
+
+    // Set mRegisteredCheckInToken to true to indicate that the application has registered a check-in token
+    // with this peer, and therefore subscription drops can usefully wait for a check-in message before trying
+    // to resubscribe. This field is ignored for read operations.
+    bool mRegisteredCheckInToken = false;
 
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
@@ -66,6 +77,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mRegisteredCheckInToken            = other.mRegisteredCheckInToken;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
@@ -91,6 +103,7 @@ struct ReadPrepareParams
         mTimeout                           = other.mTimeout;
         mIsFabricFiltered                  = other.mIsFabricFiltered;
         mIsPeerLIT                         = other.mIsPeerLIT;
+        mRegisteredCheckInToken            = other.mRegisteredCheckInToken;
         other.mpEventPathParamsList        = nullptr;
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2471,8 +2471,8 @@ TEST_F(TestRead, TestSubscribe_OnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2559,8 +2559,8 @@ TEST_F(TestRead, TestSubscribe_SubGoAwayInserverOnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2630,8 +2630,8 @@ TEST_F(TestRead, TestSubscribe_MismatchedSubGoAwayInserverOnActiveModeNotificati
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2686,8 +2686,8 @@ TEST_F(TestRead, TestSubscribeFailed_OnActiveModeNotification)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         GetLoopback().mNumMessagesToDrop = LoopbackTransport::kUnlimitedMessageCount;
@@ -2756,8 +2756,8 @@ TEST_F(TestRead, TestSubscribe_DynamicLITSubscription)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //
@@ -2867,8 +2867,8 @@ TEST_F(TestRead, TestSubscribe_ImmediatelyResubscriptionForLIT)
 
         readPrepareParams.mMaxIntervalCeilingSeconds = maxIntervalCeilingSeconds;
         readPrepareParams.mIsPeerLIT                 = true;
-
-        auto err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        readPrepareParams.mRegisteredCheckInToken    = true;
+        auto err                                     = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         EXPECT_EQ(err, CHIP_NO_ERROR);
 
         //


### PR DESCRIPTION
#### Summary
This is CP for 39065 from master to 1.4 branch

When ecosystem A has not yet been ready for LIT and device has been multi-admin by another controller ecosystem B with LIT, re-subscription scheduler is put on hold in ecosystem A when liveness timeout happens, the expected behavior is to retry subscription.

Fix: Introduce a new parameter, mRegisteredCheckInToken in ReadPrepareParams, if Application has registered the check-in token into the peer device, this mRegisteredCheckInToken needs to be true.
otherwise it should be false. If peer operating mode is LIT and mRegisteredCheckInToken is false, subscription retry would continue once liveness timeout happens and not wait for check-in message since it cannot handle check-in.

#### Testing
This is CP from master to 1.4 branch.
#### Readability checklist
This is CP from master to 1.4 branch.
