### PR TITLE
[Fix] Fix for CADMIN_1_19 test step 3 fabric filtered issue #636

### DIFF
--- a/src/python_testing/TC_CADMIN_1_19.py
+++ b/src/python_testing/TC_CADMIN_1_19.py
@@ -95,7 +95,7 @@ class TC_CADMIN_1_19(MatterBaseTest):
         self.max_window_duration = duration.maxCumulativeFailsafeSeconds
 
         self.step(3)
-        fabrics = await self.support.get_fabrics(th=self.th1)
+        fabrics = await self.support.get_fabrics(th=self.th1, fabric_filtered=False)
         initial_number_of_fabrics = len(fabrics)
 
         self.step(4)


### PR DESCRIPTION
#### Summary
- Changed to make test step 3 unfiltered now as mentioned in issue #[636](https://github.com/project-chip/certification-tool/issues/636) as the test module in test step was out of sync with test plan.

#### Related issues
- Fixes: #[636](https://github.com/project-chip/certification-tool/issues/636)

#### Testing
- Updated TC_CADMIN_1_19.py with change needed
