### PR TITLE
[Silabs] Update silabs docker to use new SDKS

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-143: Upgrading Silabs Docker - SiSDK 2025.6.0, Wiseconnect SDK 3.5.0 and WC BT 2.12.0
+143 : Upgrading Silabs Docker - SiSDK 2025.6.0, Wiseconnect SDK 3.5.0 and WC BT 2.12.0

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-142 : [NXP] Update NXP SDK Docker image (25.03.00)
+143: Upgrading Silabs Docker - SiSDK 2025.6.0, Wiseconnect SDK 3.5.0 and WC BT 2.12.0

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -28,13 +28,13 @@ RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2025.6
     && find /tmp/simplicity_sdk/platform/Device/SiliconLabs  -mindepth 1 -maxdepth 1 -type d ! \( -name 'EFR32MG24' -o -name 'EFR32MG26' -o -name 'MGM24' -o -name 'MGM26' \) -exec rm -rf {} + \
     && : # last line
 
-# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.11.4 (a18b5dd)
+# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.12.0 (a18b5dd)
 RUN git clone --depth=1 --single-branch --branch=2.12.0 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
     cd /tmp/wiseconnect-wifi-bt-sdk && \
     rm -rf .git examples \
     && : # last line
 
-# Clone WiSeConnect SDK v3.4.2 (ca4c4b0)
+# Clone WiSeConnect SDK v3.5.0 (ca4c4b0)
 RUN git clone --depth=1 --single-branch --branch=v3.5.0 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git examples components/device/stm32 \

--- a/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-efr32/Dockerfile
@@ -12,8 +12,8 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
-# Download Simplicity SDK v2024.12.2 (1f19b37)
-RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.12.2/simplicity-sdk.zip -O /tmp/simplicity_sdk.zip \
+# Download Simplicity SDK v2025.6.0 (f107f75)
+RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2025.6.0/simplicity-sdk.zip -O /tmp/simplicity_sdk.zip \
     && unzip /tmp/simplicity_sdk.zip -d /tmp/simplicity_sdk \
     && rm -rf /tmp/simplicity_sdk.zip \
     # Deleting files that are not needed to save space
@@ -28,14 +28,14 @@ RUN wget https://github.com/SiliconLabs/simplicity_sdk/releases/download/v2024.1
     && find /tmp/simplicity_sdk/platform/Device/SiliconLabs  -mindepth 1 -maxdepth 1 -type d ! \( -name 'EFR32MG24' -o -name 'EFR32MG26' -o -name 'MGM24' -o -name 'MGM26' \) -exec rm -rf {} + \
     && : # last line
 
-# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.11.4 (bf6b600)
-RUN git clone --depth=1 --single-branch --branch=2.11.4 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
+# Clone WiSeConnect Wi-Fi and Bluetooth Software 2.11.4 (a18b5dd)
+RUN git clone --depth=1 --single-branch --branch=2.12.0 https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git /tmp/wiseconnect-wifi-bt-sdk && \
     cd /tmp/wiseconnect-wifi-bt-sdk && \
     rm -rf .git examples \
     && : # last line
 
-# Clone WiSeConnect SDK v3.4.2 (2f93cc4)
-RUN git clone --depth=1 --single-branch --branch=v3.4.2 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
+# Clone WiSeConnect SDK v3.4.2 (ca4c4b0)
+RUN git clone --depth=1 --single-branch --branch=v3.5.0 https://github.com/SiliconLabs/wiseconnect.git /tmp/wifi_sdk && \
     cd /tmp/wifi_sdk && \
     rm -rf .git examples components/device/stm32 \
     && : # last line


### PR DESCRIPTION
Update the Silabs docker image to bump our SDK version:
sisdk 2025.6.0
wiseconnect WifiSDk v3.5.0
wiseconnect wifi bt software 2.12.0

### Testing
CI to build the new Docker image