### PR TITLE
[Darwin][Network.framework] Set IPPacketInfo::Interface from sin6_sco…

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
@@ -204,13 +204,25 @@ namespace Inet {
 
         aPacketInfo.Clear();
 
-        // TODO Handle return value of IPAddress::GetIPAddressFromSockAdd
         const auto * srcAddress = nw_endpoint_get_address(src_endpoint);
-        IPAddress::GetIPAddressFromSockAddr(*srcAddress, aPacketInfo.SrcAddress);
+        VerifyOrReturnError(nullptr != srcAddress, CHIP_ERROR_INVALID_ADDRESS);
+        ReturnErrorOnFailure(IPAddress::GetIPAddressFromSockAddr(*srcAddress, aPacketInfo.SrcAddress));
 
-        // TODO Handle return value of IPAddress::GetIPAddressFromSockAdd
+        // The IPPacketInfo that comes out of this function flows up the stack
+        // (UDP::OnUdpReceive → SessionManager::OnMessageReceived → SetPeerAddress)
+        // to build the PeerAddress for the newly-received message.  For IPv6
+        // link-local traffic the interface index (scope-id) is part of the
+        // address itself, so we must copy the scope from the incoming packet
+        // to ensure later replies are sent out on the same link.
+        if (aPacketInfo.SrcAddress.IsIPv6LinkLocal()) {
+            __auto_type in6 = reinterpret_cast<const struct sockaddr_in6 *>(srcAddress);
+            uint32_t interfaceIndex = static_cast<uint32_t>(in6->sin6_scope_id);
+            aPacketInfo.Interface = InterfaceId(interfaceIndex);
+        }
+
         const auto * dstAddress = nw_endpoint_get_address(dest_endpoint);
-        IPAddress::GetIPAddressFromSockAddr(*dstAddress, aPacketInfo.DestAddress);
+        VerifyOrReturnError(nullptr != dstAddress, CHIP_ERROR_INVALID_ADDRESS);
+        ReturnErrorOnFailure(IPAddress::GetIPAddressFromSockAddr(*dstAddress, aPacketInfo.DestAddress));
 
         aPacketInfo.SrcPort = nw_endpoint_get_port(src_endpoint);
         aPacketInfo.DestPort = nw_endpoint_get_port(dest_endpoint);

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFramework.mm
@@ -215,7 +215,7 @@ namespace Inet {
         // address itself, so we must copy the scope from the incoming packet
         // to ensure later replies are sent out on the same link.
         if (aPacketInfo.SrcAddress.IsIPv6LinkLocal()) {
-            __auto_type in6 = reinterpret_cast<const struct sockaddr_in6 *>(srcAddress);
+            auto in6 = reinterpret_cast<const struct sockaddr_in6 *>(srcAddress);
             uint32_t interfaceIndex = static_cast<uint32_t>(in6->sin6_scope_id);
             aPacketInfo.Interface = InterfaceId(interfaceIndex);
         }


### PR DESCRIPTION
…pe_id for IPv6 link-local packets in GetPacketInfo

#### Summary

When an incoming UDP packet originates from an IPv6 link-local address, we now copy the scope-ID (sin6_scope_id) into IPPacketInfo::Interface inside UDPEndPointImplNetworkFramework::GetPacketInfo().

#### Related issues

N/A

#### Testing

1. Enable Network.framework
2. Commission a device so it is reachable only via its IPv6 link-local address.
3. Run the interactive tool
```
$ ./out/debug/standalone/darwin-framework-tool interactive start
# inside the interactive prompt
onoff toggle 0x12344321 1      # succeeds
# …wait ≈60 s until “Connection: onTimeout” appears
onoff toggle 0x12344321 1      # succeeds with this patch (used to fail)
```

Before the patch: the second toggle fails; log shows the link-local address no longer carries an interface index.
After the patch: both toggles succeed; logs show the scope‐id (%<ifname>) is preserved on every outbound message.
