### PR TITLE
[Darwin][Network.framework] Dispatch connection timeout onto the main…

### DIFF
--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkConnection.mm
@@ -166,10 +166,10 @@ namespace Inet {
         {
             __auto_type onTimeout = ^{
                 ChipLogDetail(Inet, "Connection: Timeout");
-                nw_connection_cancel(connection);
+                WaitForConnectionStateCancelled(connection);
                 RemoveConnectionWrapper(connection);
             };
-            __auto_type wrapper = new ConnectionWrapper(connection, mConnectionQueue, onTimeout);
+            __auto_type wrapper = new ConnectionWrapper(connection, dispatch_get_current_queue(), onTimeout);
             VerifyOrReturnError(nullptr != wrapper, CHIP_ERROR_NO_MEMORY);
 
             CFDictionarySetValue(mConnections, (__bridge const void *) connection, wrapper);


### PR DESCRIPTION
… chip queue

#### Summary

Dispatch the Network Framework connection-timeout callback on the CHIP work queue instead of the per-connection queue, so every access to `UDPEndPointImplNetworkFrameworkConnection wrappers now happens on the same thread.

#### Related issues

N/A

#### Testing

Before this patch: the timeout happens onto the connection queue, but the list of wrappers in the rest of the code is only accessed onto the chip queue
After this patch: the timeout happens onto the chip queue, similarly to other accesses to the list of wrappers.