### PR TITLE
TC-DA-1.5: step 11 should send 31-byte nonce

### DIFF
--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -174,9 +174,10 @@ class TC_DA_1_5(MatterBaseTest):
         await self.send_single_cmd(cmd=gcomm.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=1))
 
         self.print_step(11, "Send CSRRequest wtih 31-byte nonce")
-        bad_nonce = random.randbytes(32)
+        bad_nonce = random.randbytes(31)
         try:
             await self.send_single_cmd(cmd=opcreds.Commands.CSRRequest(CSRNonce=bad_nonce, isForUpdateNOC=False))
+            asserts.fail("Unexpected success when running command")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.InvalidCommand, "Received incorrect error from CSRRequest command with bad nonce")
 

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -177,7 +177,7 @@ class TC_DA_1_5(MatterBaseTest):
         bad_nonce = random.randbytes(31)
         try:
             await self.send_single_cmd(cmd=opcreds.Commands.CSRRequest(CSRNonce=bad_nonce, isForUpdateNOC=False))
-            asserts.fail("Unexpected success when running command")
+            asserts.fail("CSRRequest with 31-byte nonce was expected to fail but succeeded")
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.InvalidCommand, "Received incorrect error from CSRRequest command with bad nonce")
 


### PR DESCRIPTION
#### Summary
Nonce was the wrong size per the test plan (this step is meant to check bad nonce sizes), test missed the step to fail the test on success

#### Related issues


#### Testing
Runs in CI, ran test locally to see the failure with the 32-byte nonce before swapping to the 31-byte nonce.