### PR TITLE
Increase unit test code coverage of `ble/` by 1.6%

### DIFF
--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -206,7 +206,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
 
-    // Try to continue sending the next fragment, also attempting to send an ack when the sequence  is incorrect and check the transmission state.
+    // Try to continue sending the next fragment, also attempting to send an ack
+    // when the sequence is incorrect and check the transmission state.
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
 

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -273,7 +273,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
     // Create a new packet buffer with maximum size and set its data length to the maximum.
     auto packet0 = PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize, 0);
     packet0->SetDataLength(packet0->MaxDataLength());
-    
+
     // Attempt to send the packet with acknowledgment required, which should fail due to insufficient headroom.
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Error);

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -181,4 +181,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendThreePacket)
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(8));
 }
 
+TEST_F(TestBtpEngine, HandleCharacteristicSendEmptyPacket)
+{
+    EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
+}
+
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -185,8 +185,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendThreePacket)
 TEST_F(TestBtpEngine, HandleCharacteristicSendOnePacketWithAck)
 {
     // Create a new packet buffer with space for a 15-byte payload and set its data length to 15.
-    auto dataLength = 15;
-    auto packet0    = System::PacketBufferHandle::New(dataLength);
+    size_t dataLength = 15;
+    auto packet0      = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Send the packet with acknowledgment required, checking the transmission state and the packet buffer.
@@ -199,8 +199,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendOnePacketWithAck)
 TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto dataLength = 30;
-    auto packet0    = System::PacketBufferHandle::New(dataLength);
+    size_t dataLength = 30;
+    auto packet0      = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Start sending the payload with acknowledgment required, checking the transmission state and the packet buffer.
@@ -226,8 +226,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
 TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto dataLength = 30;
-    auto packet0    = System::PacketBufferHandle::New(dataLength);
+    size_t dataLength = 30;
+    auto packet0      = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
@@ -253,8 +253,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
 TEST_F(TestBtpEngine, HandleCharacteristicSendRejectsNewSendUntilPreviousAcked)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto dataLength = 30;
-    auto packet0    = System::PacketBufferHandle::New(dataLength);
+    size_t dataLength = 30;
+    auto packet0      = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
@@ -294,8 +294,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
     EXPECT_EQ(packet0->DataLength(), packet0->MaxDataLength());
 
     // Create a new packet buffer with space for a 15-byte payload and zero headroom, then set its data length to 15.
-    auto dataLength = 15;
-    auto packet1    = System::PacketBufferHandle::New(dataLength, 0);
+    size_t dataLength = 15;
+    auto packet1      = System::PacketBufferHandle::New(dataLength, 0);
     packet1->SetDataLength(dataLength);
 
     // Attempt to send another packet with insufficient headroom, which should also fail.

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -257,9 +257,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
     auto packet1 = System::PacketBufferHandle::New(15, 0);
     packet1->SetDataLength(15);
 
-    EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), true));
+    EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(packet1.Retain(), true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Error);
-    EXPECT_EQ(packet0->DataLength(), packet0->MaxDataLength());
+    EXPECT_EQ(packet1->DataLength(), packet1->MaxDataLength());
 }
 
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -186,7 +186,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendOnePacketWithAck)
 {
     // Create a new packet buffer with space for a 15-byte payload and set its data length to 15.
     auto dataLength = 15;
-    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    auto packet0    = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Send the packet with acknowledgment required, checking the transmission state and the packet buffer.
@@ -200,7 +200,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
     auto dataLength = 30;
-    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    auto packet0    = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Start sending the payload with acknowledgment required, checking the transmission state and the packet buffer.
@@ -217,8 +217,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
     // Continue sending without acknowledgment, checking the transmission state and the packet buffer.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, false));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
-        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
+    EXPECT_EQ(packet0->DataLength(),
+              static_cast<size_t>(dataLength - (data0MaxLength - (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) +
+                                  kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test sending a 30-byte payload with correct acknowledgment sequence.
@@ -226,7 +227,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
     auto dataLength = 30;
-    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    auto packet0    = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
@@ -243,8 +244,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
     // Continue sending second fragment with acknowledgment required.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
-        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
+    EXPECT_EQ(packet0->DataLength(),
+              static_cast<size_t>(dataLength - (data0MaxLength - (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) +
+                                  kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test that the engine prevents sending a new payload until the previous payload has been acknowledged.
@@ -252,7 +254,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendRejectsNewSendUntilPreviousAcked)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
     auto dataLength = 30;
-    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    auto packet0    = System::PacketBufferHandle::New(dataLength);
     packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
@@ -274,8 +276,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendRejectsNewSendUntilPreviousAcked)
     // Send the second fragment of the first payload with acknowledgment required.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
-        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
+    EXPECT_EQ(packet0->DataLength(),
+              static_cast<size_t>(dataLength - (data0MaxLength - (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) +
+                                  kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test sending a payload when there is not enough headroom in the packet buffer.
@@ -292,7 +295,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
 
     // Create a new packet buffer with space for a 15-byte payload and zero headroom, then set its data length to 15.
     auto dataLength = 15;
-    auto packet1 = System::PacketBufferHandle::New(dataLength, 0);
+    auto packet1    = System::PacketBufferHandle::New(dataLength, 0);
     packet1->SetDataLength(dataLength);
 
     // Attempt to send another packet with insufficient headroom, which should also fail.

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -206,7 +206,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
 
-    // Try to continue sending with an incorrect acknowledgment, checking the transmission state.
+    // Try to continue sending the next fragment, also attempting to send an ack when the sequence  is incorrect and check the transmission state.
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
 

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -184,6 +184,13 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendThreePacket)
 TEST_F(TestBtpEngine, HandleCharacteristicSendEmptyPacket)
 {
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
+
+    auto packet0 = System::PacketBufferHandle::New(20);
+    packet0->SetDataLength(20);
+
+    EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), true));
+    EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
 }
 
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -193,4 +193,14 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendEmptyPacket)
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
 }
 
+TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
+{
+    auto packet0 = PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize, 0);
+    packet0->SetDataLength(packet0->MaxDataLength());
+    
+    EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(std::move(packet0).Retain(), true));
+    EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Error);
+    EXPECT_EQ(packet0->DataLength(), packet0->MaxDataLength());
+}
+
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -185,26 +185,29 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendThreePacket)
 TEST_F(TestBtpEngine, HandleCharacteristicSendOnePacketWithAck)
 {
     // Create a new packet buffer with space for a 15-byte payload and set its data length to 15.
-    auto packet0 = System::PacketBufferHandle::New(15);
-    packet0->SetDataLength(15);
+    auto dataLength = 15;
+    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    packet0->SetDataLength(dataLength);
 
     // Send the packet with acknowledgment required, checking the transmission state and the packet buffer.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20)); // protocol header (5 bytes) + payload (15 bytes)
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength + 5)); // protocol header (5 bytes) + payload (15 bytes)
 }
 
 // Test sending a 30-byte payload with acknowledgment required, but providing incorrect ack sequence.
 TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto packet0 = System::PacketBufferHandle::New(30);
-    packet0->SetDataLength(30);
+    auto dataLength = 30;
+    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    packet0->SetDataLength(dataLength);
 
     // Start sending the payload with acknowledgment required, checking the transmission state and the packet buffer.
+    auto data0MaxLength = BtpEngine::sDefaultFragmentSize;
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(data0MaxLength));
 
     // Try to continue sending the next fragment, also attempting to send an ack
     // when the sequence is incorrect and check the transmission state.
@@ -214,58 +217,65 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
     // Continue sending without acknowledgment, checking the transmission state and the packet buffer.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, false));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(17));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
+        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test sending a 30-byte payload with correct acknowledgment sequence.
 TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto packet0 = System::PacketBufferHandle::New(30);
-    packet0->SetDataLength(30);
+    auto dataLength = 30;
+    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
     auto data0 = packet0->Start();
     ASSERT_NE(data0, nullptr);
-    std::iota(data0, data0 + 30, 0);
+    std::iota(data0, data0 + dataLength, 0);
 
     // Start sending the payload without requiring an acknowledgment for the first fragment.
+    auto data0MaxLength = BtpEngine::sDefaultFragmentSize;
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), false));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(data0MaxLength));
 
     // Continue sending second fragment with acknowledgment required.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(17));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
+        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test that the engine prevents sending a new payload until the previous payload has been acknowledged.
 TEST_F(TestBtpEngine, HandleCharacteristicSendRejectsNewSendUntilPreviousAcked)
 {
     // Create a new packet buffer with space for a 30-byte payload and set its data length to 30.
-    auto packet0 = System::PacketBufferHandle::New(30);
-    packet0->SetDataLength(30);
+    auto dataLength = 30;
+    auto packet0 = System::PacketBufferHandle::New(dataLength);
+    packet0->SetDataLength(dataLength);
 
     // Initialize the payload data with sequential values for testing.
     auto data0 = packet0->Start();
     ASSERT_NE(data0, nullptr);
-    std::iota(data0, data0 + 30, 0);
+    std::iota(data0, data0 + dataLength, 0);
 
     // Start sending the payload without requiring an acknowledgment for the first fragment.
+    auto data0MaxLength = BtpEngine::sDefaultFragmentSize;
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), false));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(data0MaxLength));
 
     // Attempt to send another payload while the first one is still in progress.
-    auto packet1 = System::PacketBufferHandle::New(30);
-    packet1->SetDataLength(30);
+    auto packet1 = System::PacketBufferHandle::New(dataLength);
+    packet1->SetDataLength(dataLength);
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(packet1.Retain(), false));
 
     // Send the second fragment of the first payload with acknowledgment required.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
-    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(17));
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(dataLength - (data0MaxLength -
+        (kTransferProtocolMaxHeaderSize - kTransferProtocolAckSize)) + kTransferProtocolMidFragmentMaxHeaderSize));
 }
 
 // Test sending a payload when there is not enough headroom in the packet buffer.
@@ -281,8 +291,9 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)
     EXPECT_EQ(packet0->DataLength(), packet0->MaxDataLength());
 
     // Create a new packet buffer with space for a 15-byte payload and zero headroom, then set its data length to 15.
-    auto packet1 = System::PacketBufferHandle::New(15, 0);
-    packet1->SetDataLength(15);
+    auto dataLength = 15;
+    auto packet1 = System::PacketBufferHandle::New(dataLength, 0);
+    packet1->SetDataLength(dataLength);
 
     // Attempt to send another packet with insufficient headroom, which should also fail.
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(packet1.Retain(), true));

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -196,7 +196,7 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendOnePacketWithAck)
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
 }
 
-TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithAck)
+TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithIncorrectAck)
 {
     auto packet0 = System::PacketBufferHandle::New(30);
     packet0->SetDataLength(30);
@@ -206,8 +206,24 @@ TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithAck)
     EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
     EXPECT_FALSE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
     EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
+    EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, false));
+    EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
+}
 
-    //add correct test
+TEST_F(TestBtpEngine, HandleCharacteristicSendTwoPacketWithCorrectAck)
+{
+    auto packet0 = System::PacketBufferHandle::New(30);
+    packet0->SetDataLength(30);
+
+    auto data0 = packet0->Start();
+    ASSERT_NE(data0, nullptr);
+    std::iota(data0, data0 + 30, 0);
+
+    EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), false));
+    EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_InProgress);
+    EXPECT_EQ(packet0->DataLength(), static_cast<size_t>(20));
+    EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(nullptr, true));
+    EXPECT_EQ(mBtpEngine.TxState(), BtpEngine::kState_Complete);
 }
 
 TEST_F(TestBtpEngine, HandleCharacteristicSendInsufficientHeadroom)


### PR DESCRIPTION
#### Summary

This PR increases `ble` unit test coverage from 65.6% to 67.2% by adding comprehensive unit tests for the `BtpEngine::HandleCharacteristicSend` method in `TestBtpEngine`. The new tests cover various scenarios for BLE packet transmission, including:

- Sending a single payload in one packet with acknowledgment.
- Sending a payload split across two packets, testing both correct and incorrect acknowledgment sequences.
- Ensuring the engine rejects new sends until the previous payload is fully acknowledged.
- Handling cases where the packet buffer lacks sufficient headroom, verifying error handling.

#### Related issues

Main issue #37232

#### Testing

This PR only adds new unit tests. No changes made to production code.
