### PR TITLE
[NXP] Update NXP examples' CMake files to export CHIP_ROOT via COMMON_KCONFIG_ENV_SETTINGS

### DIFF
--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -43,7 +43,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp:140
+            image: ghcr.io/project-chip/chip-build-nxp:142
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
         steps:
@@ -176,7 +176,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-nxp-zephyr:140
+            image: ghcr.io/project-chip/chip-build-nxp-zephyr:142
 
         steps:
             - name: Checkout

--- a/examples/all-clusters-app/nxp/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 # Export CHIP_ROOT as an environment variable to be recognized by Kconfig
-set(ENV{CHIP_ROOT} ${CHIP_ROOT})
+set(COMMON_KCONFIG_ENV_SETTINGS CHIP_ROOT=${CHIP_ROOT})
 
 get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
 get_filename_component(ALL_CLUSTERS_COMMON_DIR ${CHIP_ROOT}/examples/all-clusters-app/all-clusters-common REALPATH)

--- a/examples/thermostat/nxp/CMakeLists.txt
+++ b/examples/thermostat/nxp/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 # Export CHIP_ROOT as an environment variable to be recognized by Kconfig
-set(ENV{CHIP_ROOT} ${CHIP_ROOT})
+set(COMMON_KCONFIG_ENV_SETTINGS CHIP_ROOT=${CHIP_ROOT})
 
 get_filename_component(GEN_DIR ${CHIP_ROOT}/zzz_generated/ REALPATH)
 get_filename_component(NXP_EXAMPLE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common REALPATH)


### PR DESCRIPTION
#### Summary

This PR is introducing a minor update in NXP examples CMake files. It adds "CHIP_ROOT" to the "COMMON_KCONFIG_ENV_SETTINGS" variable, which is used by the build system. This change enables easier launching of guiconfig and menuconfig for NXP Matter applications, without the need to manually export "CHIP_ROOT".

#### Testing

This change was tested by building the NXP Matter example, and launching the menuconfig.
Example of commands to reproduce :
- Build NXP example : "west build -d build_matter -b rdrw612bga examples/thermostat/nxp"
- Launch the menuconfig : "west build -d build_matter -t menuconfig"

This PR depends on NXP docker image update done in PR : https://github.com/project-chip/connectedhomeip/pull/39561 