### PR TITLE
[Camera] Update Matter Camera TC_AVSM TestPlans (TC-AVSM-2.3, TC-AVSM-2.4, TC-AVSM-2.6)

### DIFF
--- a/src/python_testing/TC_AVSMTestBase.py
+++ b/src/python_testing/TC_AVSMTestBase.py
@@ -102,7 +102,7 @@ class AVSMTestBase:
         )
         logger.info(f"Rx'd MicrophoneCapabilities: {aMicrophoneCapabilities}")
         aStreamUsagePriorities = await self.read_single_attribute_check_success(
-            endpoint=endpoint, cluster=cluster, attribute=attr.StreamUsagePrioritiesList
+            endpoint=endpoint, cluster=cluster, attribute=attr.StreamUsagePriorities
         )
         logger.info(f"Rx'd StreamUsagePriorities : {aStreamUsagePriorities}")
         asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")

--- a/src/python_testing/TC_AVSM_2_2.py
+++ b/src/python_testing/TC_AVSM_2_2.py
@@ -88,7 +88,11 @@ class TC_AVSM_2_2(MatterBaseTest):
                 "TH sends the SnapshotStreamAllocate command with values from step 3 except with Quality set to 101(outside of valid range).",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
-            # NOTE: Test Plan has a step 8, which is a duplicate of step 7, so it has not been added here.
+            TestStep(
+                8,
+                "TH sends the SnapshotStreamAllocate command with values from step 3 except with ImageCodec set to 10(outside of valid range).",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
         ]
 
     @run_if_endpoint_matches(
@@ -187,6 +191,27 @@ class TC_AVSM_2_2(MatterBaseTest):
                 e.status,
                 Status.ConstraintError,
                 "Unexpected status returned when expecting CONSTRAINT_ERROR due to Quality set to 101(outside of valid range)",
+            )
+            pass
+
+        self.step(8)
+        try:
+            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+                imageCodec=cluster.Enums.ImageCodecEnum.extend_enum_if_value_doesnt_exist(10),
+                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+                minResolution=aSnapshotCapabilities[0].resolution,
+                maxResolution=aSnapshotCapabilities[0].resolution,
+                quality=90,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+            asserts.assert_true(
+                False, "Unexpected success when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)"
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.ConstraintError,
+                "Unexpected status returned when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)",
             )
             pass
 

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -115,12 +115,17 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
         asserts.assert_equal(len(aAllocatedSnapshotStreams), 1, "The number of allocated snapshot streams in the list is not 1.")
         aStreamID = aAllocatedSnapshotStreams[0].snapshotStreamID
-        # TODO: SnapshotStreamStruct does not have WaterMarkEnabled and OSDEnabled fields. Update This.
+        aWmark = aAllocatedSnapshotStreams[0].watermarkEnabled
+        aOSD = aAllocatedSnapshotStreams[0].OSDEnabled
 
         self.step(3)
         try:
-            # TODO: SnapshotStreamStruct does not have WaterMarkEnabled and OSDEnabled fields. Update This.
-            await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamModify(snapshotStreamID=aStreamID))
+            cmd = commands.SnapshotStreamModify(
+                snapshotStreamID=aStreamID,
+                watermarkEnabled=None if aWmark is None else not aWmark,
+                OSDEnabled=None if aOSD is None else not aOSD,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=cmd)
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
@@ -130,7 +135,12 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
         )
         logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
-        # TODO: SnapshotStreamStruct does not have WaterMarkEnabled and OSDEnabled fields. Update This.
+        if wmarkSupport:
+            asserts.assert_equal(
+                aAllocatedSnapshotStreams[0].watermarkEnabled, not aWmark, "WaterMarkEnabled is not equal to !aWmark"
+            )
+        if osdSupport:
+            asserts.assert_equal(aAllocatedSnapshotStreams[0].OSDEnabled, not aOSD, "OSDEnabled is not equal to !aOSD")
 
 
 if __name__ == "__main__":

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -7,13 +7,7 @@ not_automated:
       reason: Shared code for TC_AVSM, not a standalone test
     - name: TC_AVSM_2_2.py
       reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_3.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_4.py
-      reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_5.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_6.py
       reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_7.py
       reason: Camera App does not support all features required for this TC


### PR DESCRIPTION
This PR Updates and Enables the following Test Cases:

- TC-AVSM-2.3
- TC-AVSM-2.4
- TC-AVSM-2.6

### Testing

Build python wheel and activate venv:

```sh
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
```

For example, to run To run tests for TC-AVSM-2.3:

```sh
./scripts/tests/run_python_test.py --factory-reset --app <chip-camera-app> --app-args "--trace-to json:log" --script src/python_testing/TC_AVSM_2_3.py --script-args "--commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00"
```