### PR TITLE
[ESP32]: Fix the build for energy-gateway-app esp32

### DIFF
--- a/examples/energy-gateway-app/esp32/main/CMakeLists.txt
+++ b/examples/energy-gateway-app/esp32/main/CMakeLists.txt
@@ -25,6 +25,7 @@ set(PRIV_INCLUDE_DIRS_LIST
   "${ENERGY_GATEWAY_DIR}/commodity-price/include"
   "${ENERGY_GATEWAY_DIR}/common/include"
   "${ENERGY_GATEWAY_DIR}/electrical-grid-conditions/include"
+  "${ENERGY_GATEWAY_DIR}/meter-identification/include"
   "${CMAKE_CURRENT_LIST_DIR}/include"
   "${CHIP_ROOT}/examples/platform/esp32"
 )
@@ -36,6 +37,7 @@ set(SRC_DIRS_LIST
   "${ENERGY_GATEWAY_DIR}/commodity-price/src"
   "${ENERGY_GATEWAY_DIR}/common/src"
   "${ENERGY_GATEWAY_DIR}/electrical-grid-conditions/src"
+  "${ENERGY_GATEWAY_DIR}/meter-identification/src"
   "${CHIP_ROOT}/examples/platform/esp32/ota"
   "${CHIP_ROOT}/examples/platform/esp32/common"
   "${CHIP_ROOT}/examples/platform/esp32/time"


### PR DESCRIPTION
#### Problem
- The energy-gateway-app build fails in the CI actions [failed esp32 job](https://github.com/espressif/connectedhomeip/actions/runs/15470502598/job/43553356172)  post 
https://github.com/project-chip/connectedhomeip/pull/39063. 

#### Change Overview
-  Added the missing file paths in CMakeLists.txt which were added in Linux but missing in esp32.

#### Testing
```
- Tested the flow using below commands:
 cd /path/to/energy-gateway-app/esp32
 idf.py set-target esp32c3
 idf.py build
 idf.py flash monitor

```
**CI Build:** https://github.com/project-chip/connectedhomeip/actions/runs/15778362916/job/44477833087?pr=39635