### PR TITLE
Increase unit test code coverage of `ble/` by 2%

### DIFF
--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -408,7 +408,7 @@ TEST_F(TestBleLayer, NewBleConnectionByDiscriminatorThenError)
     ASSERT_EQ(NewBleConnectionByDiscriminator(SetupDiscriminator(), static_cast<BleLayer*>(this)), CHIP_NO_ERROR);
 
     // Simulate error
-    BleConnectionDelegate::OnConnectionError(static_cast<BleLayer*>(this), CHIP_ERROR_CONNECTION_ABORTED);
+    BleConnectionDelegate::OnConnectionError(static_cast<BleLayer *>(this), CHIP_ERROR_CONNECTION_ABORTED);
 
     EXPECT_FALSE(mOnBleConnectionCompleteCalled);
     EXPECT_TRUE(mOnBleConnectionErrorCalled);
@@ -419,7 +419,7 @@ TEST_F(TestBleLayer, NewBleConnectionByObjectThenCancel)
 {
     // Start new connection
     auto connObj = GetConnectionObject();
-    ASSERT_EQ(NewBleConnectionByObject(connObj, static_cast<BleLayer*>(this)), CHIP_NO_ERROR);
+    ASSERT_EQ(NewBleConnectionByObject(connObj, static_cast<BleLayer *>(this)), CHIP_NO_ERROR);
 
     // Cancel the connection
     ASSERT_EQ(CancelBleIncompleteConnection(), CHIP_NO_ERROR);

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -408,7 +408,7 @@ TEST_F(TestBleLayer, NewBleConnectionByDiscriminatorThenError)
     ASSERT_EQ(NewBleConnectionByDiscriminator(SetupDiscriminator(), static_cast<BleLayer*>(this)), CHIP_NO_ERROR);
 
     // Simulate error
-    BleConnectionDelegate::OnConnectionError(static_cast<BleLayer*>(this), CHIP_NO_ERROR);
+    BleConnectionDelegate::OnConnectionError(static_cast<BleLayer*>(this), CHIP_ERROR_CONNECTION_ABORTED);
 
     EXPECT_FALSE(mOnBleConnectionCompleteCalled);
     EXPECT_TRUE(mOnBleConnectionErrorCalled);

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -35,10 +35,10 @@
 
 #define _CHIP_BLE_BLE_H
 #include <ble/BleApplicationDelegate.h>
+#include <ble/BleConnectionDelegate.h>
 #include <ble/BleLayer.h>
 #include <ble/BleLayerDelegate.h>
 #include <ble/BlePlatformDelegate.h>
-#include <ble/BleConnectionDelegate.h>
 
 namespace chip {
 namespace Ble {
@@ -405,7 +405,7 @@ TEST_F(TestBleLayer, ExceedBleConnectionEndPointLimit)
 TEST_F(TestBleLayer, NewBleConnectionByDiscriminatorThenError)
 {
     // Start new connection
-    ASSERT_EQ(NewBleConnectionByDiscriminator(SetupDiscriminator(), static_cast<BleLayer*>(this)), CHIP_NO_ERROR);
+    ASSERT_EQ(NewBleConnectionByDiscriminator(SetupDiscriminator(), static_cast<BleLayer *>(this)), CHIP_NO_ERROR);
 
     // Simulate error
     BleConnectionDelegate::OnConnectionError(static_cast<BleLayer *>(this), CHIP_ERROR_CONNECTION_ABORTED);

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -61,7 +61,7 @@ public:
     // to check if the callbacks are invoked correctly.
     bool mOnBleConnectionCompleteCalled = false;
     bool mOnBleConnectionErrorCalled    = false;
-    
+
     static void SetUpTestSuite()
     {
         ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);

--- a/src/ble/tests/TestBleLayer.cpp
+++ b/src/ble/tests/TestBleLayer.cpp
@@ -57,10 +57,10 @@ class TestBleLayer : public BleLayer,
                      public ::testing::Test
 {
 public:
-    // Add mOnBleConnectionCompleteCalled and mOnBleConnectionErrorCalled
+    // Add mOnBleConnectionCompleteCalls and mOnBleConnectionErrorCalls
     // to check if the callbacks are invoked correctly.
-    bool mOnBleConnectionCompleteCalled = false;
-    bool mOnBleConnectionErrorCalled    = false;
+    int mOnBleConnectionCompleteCalls = 0;
+    int mOnBleConnectionErrorCalls    = 0;
 
     static void SetUpTestSuite()
     {
@@ -77,8 +77,8 @@ public:
     void SetUp() override
     {
         // Reset the connection flags before each test.
-        mOnBleConnectionCompleteCalled = false;
-        mOnBleConnectionErrorCalled    = false;
+        mOnBleConnectionCompleteCalls = 0;
+        mOnBleConnectionErrorCalls    = 0;
         ASSERT_EQ(Init(this, this, this, &DeviceLayer::SystemLayer()), CHIP_NO_ERROR);
         mBleTransport = this;
     }
@@ -139,9 +139,8 @@ public:
     ///
     // Implementation of BleLayerDelegate
 
-    // override OnBleConnectionComplete and OnBleConnectionError to set flags
-    void OnBleConnectionComplete(BLEEndPoint * endpoint) override { mOnBleConnectionCompleteCalled = true; }
-    void OnBleConnectionError(CHIP_ERROR err) override { mOnBleConnectionErrorCalled = true; }
+    void OnBleConnectionComplete(BLEEndPoint * endpoint) override { mOnBleConnectionCompleteCalls++; }
+    void OnBleConnectionError(CHIP_ERROR err) override { mOnBleConnectionErrorCalls++; }
     void OnEndPointConnectComplete(BLEEndPoint * endPoint, CHIP_ERROR err) override {}
     void OnEndPointMessageReceived(BLEEndPoint * endPoint, System::PacketBufferHandle && msg) override {}
     void OnEndPointConnectionClosed(BLEEndPoint * endPoint, CHIP_ERROR err) override {}
@@ -410,8 +409,8 @@ TEST_F(TestBleLayer, NewBleConnectionByDiscriminatorThenError)
     // Simulate error
     BleConnectionDelegate::OnConnectionError(static_cast<BleLayer *>(this), CHIP_ERROR_CONNECTION_ABORTED);
 
-    EXPECT_FALSE(mOnBleConnectionCompleteCalled);
-    EXPECT_TRUE(mOnBleConnectionErrorCalled);
+    EXPECT_EQ(mOnBleConnectionCompleteCalls, 0);
+    EXPECT_EQ(mOnBleConnectionErrorCalls, 1);
 }
 
 // This test creats new ble connection by object and tests cancelation
@@ -424,8 +423,8 @@ TEST_F(TestBleLayer, NewBleConnectionByObjectThenCancel)
     // Cancel the connection
     ASSERT_EQ(CancelBleIncompleteConnection(), CHIP_NO_ERROR);
 
-    EXPECT_FALSE(mOnBleConnectionCompleteCalled);
-    EXPECT_FALSE(mOnBleConnectionErrorCalled);
+    EXPECT_EQ(mOnBleConnectionCompleteCalls, 0);
+    EXPECT_EQ(mOnBleConnectionErrorCalls, 0);
 }
 
 }; // namespace Ble


### PR DESCRIPTION
#### Summary

This PR increases the `src/ble/` folder's unit test coverage from 65.6% to 67.5% by adding several unit tests for the `BleLayer` class. The new tests cover scenarios of 

- trying to create a BLE connection and failing.
- trying to create a BLE connection but canceling it before success or failure.


#### Related issues

Main Issue #37232  

#### Testing

This PR only adds new unit tests. No changes made to production code.
