### PR TITLE
TC-IDM-4.2: indicate the DUT needs to be commissioned

### DIFF
--- a/src/python_testing/TC_IDM_4_2.py
+++ b/src/python_testing/TC_IDM_4_2.py
@@ -66,7 +66,8 @@ https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/interacti
 class TC_IDM_4_2(MatterBaseTest):
 
     def steps_TC_IDM_4_2(self):
-        return [TestStep(0, "CR1 reads the ServerList attribute from the Descriptor cluster on EP0.",
+        return [TestStep('precondition', "TH commissions DUT if required", is_commissioning=True),
+                TestStep(0, "CR1 reads the ServerList attribute from the Descriptor cluster on EP0.",
                          "If the ICD Management cluster ID (70,0x46) is present, set SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_SEC = IdleModeDuration and min_interval_floor_s to 0, otherwise, set SUBSCRIPTION_MAX_INTERVAL_PUBLISHER_LIMIT_SEC = 60 mins and min_interval_floor_s to 3."),
                 TestStep(1, "CR1 sends a subscription message to the DUT with MaxIntervalCeiling set to a value greater than subscription_max_interval_publisher_limit_sec. DUT sends a report data action to the TH. CR1 sends a success status response to the DUT. DUT sends a Subscribe Response Message to the CR1 to activate the subscription.",
                          "Verify on the CR1, a report data message is received. Verify it contains the following data Report data - data of the attribute/event requested earlier. Verify on the CR1 the Subscribe Response has the following fields, SubscriptionId - Verify it is of type uint32. MaxInterval - Verify it is of type uint32. Verify that the MaxInterval is less than or equal to MaxIntervalCeiling."),
@@ -172,6 +173,8 @@ class TC_IDM_4_2(MatterBaseTest):
 
     @async_test_body
     async def test_TC_IDM_4_2(self):
+        # commissioning step - done prior to test start
+        self.step('precondition')
 
         # Test setup
         cluster_rev_attr = Clusters.BasicInformation.Attributes.ClusterRevision


### PR DESCRIPTION
Side note - yes, I know how terrible this is. It's now written into the TH and will take a while to fix. We're working on it.

#### Summary
The TH uses the is_commissionable marking to understand if a device needs to be commissioned. 
This test needs the device to be commissioned.

#### Related issues
Fixes: https://github.com/project-chip/certification-tool/issues/640

#### Testing
Runs in the CI, tested locally