### PR TITLE
Fix ownership problems in controller storage

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -170,6 +170,7 @@ ALLOW: Dict[str, Set[str]] = {
     'src/controller/SetUpCodePairer.cpp': {'vector'},
 
     'src/controller/ExamplePersistentStorage.cpp': {'fstream', 'string', 'map'},
+    'src/controller/ExamplePersistentStorage.h': {'string'},
 
     # Library meant for non-embedded
     'src/tracing/json/json_tracing.cpp': {'string', 'sstream'},

--- a/src/controller/ExamplePersistentStorage.cpp
+++ b/src/controller/ExamplePersistentStorage.cpp
@@ -55,10 +55,10 @@ std::string GetUsedDirectory(const std::string & directory)
         dir = "/tmp";
     }
 
-    return std::string{dir};
+    return std::string{ dir };
 }
 
-std::string PersistentStorage::GenerateFilename(const std::string  & name) const
+std::string PersistentStorage::GenerateFilename(const std::string & name) const
 {
     std::string dir = mUsedDirectory;
 
@@ -75,7 +75,7 @@ CHIP_ERROR PersistentStorage::Init(const char * name, const char * directory)
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     mUsedDirectory = GetUsedDirectory(directory != nullptr ? directory : "");
-    mUsedFilename = GenerateFilename(name != nullptr ? name : "");
+    mUsedFilename  = GenerateFilename(name != nullptr ? name : "");
 
     std::ifstream ifs;
     ifs.open(mUsedFilename, std::ifstream::in);

--- a/src/controller/ExamplePersistentStorage.cpp
+++ b/src/controller/ExamplePersistentStorage.cpp
@@ -50,7 +50,7 @@ std::string GetUsedDirectory(const std::string & directory)
     }
 
     // Fall-back to environment-provided directory.
-    if (const char *dir = getenv("TMPDIR"); dir != nullptr)
+    if (const char * dir = getenv("TMPDIR"); dir != nullptr)
     {
         return dir;
     }
@@ -76,8 +76,8 @@ CHIP_ERROR PersistentStorage::Init(const char * name, const char * directory)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    mUsedDirectory = GetUsedDirectory(directory != nullptr ? directory : "");
-    mStorageFilePath  = GenerateStoragePath(name != nullptr ? name : "");
+    mUsedDirectory   = GetUsedDirectory(directory != nullptr ? directory : "");
+    mStorageFilePath = GenerateStoragePath(name != nullptr ? name : "");
 
     std::ifstream ifs;
     ifs.open(mStorageFilePath, std::ifstream::in);

--- a/src/controller/ExamplePersistentStorage.cpp
+++ b/src/controller/ExamplePersistentStorage.cpp
@@ -41,11 +41,11 @@ constexpr char kLocalNodeIdKey[]           = "LocalNodeId";
 constexpr char kCommissionerCATsKey[]      = "CommissionerCATs";
 constexpr LogCategory kDefaultLoggingLevel = kLogCategory_Automation;
 
-const char * GetUsedDirectory(const char * directory)
+std::string GetUsedDirectory(const std::string & directory)
 {
-    const char * dir = directory;
+    const char * dir = directory.c_str();
 
-    if (dir == nullptr)
+    if (directory.empty())
     {
         dir = getenv("TMPDIR");
     }
@@ -55,36 +55,37 @@ const char * GetUsedDirectory(const char * directory)
         dir = "/tmp";
     }
 
-    return dir;
+    return std::string{dir};
 }
 
-std::string GetFilename(const char * directory, const char * name)
+std::string PersistentStorage::GenerateFilename(const std::string  & name) const
 {
-    const char * dir = GetUsedDirectory(directory);
+    std::string dir = mUsedDirectory;
 
-    if (name == nullptr)
+    if (name.empty())
     {
-        return std::string(dir) + "/chip_tool_config.ini";
+        return dir + "/chip_tool_config.ini";
     }
 
-    return std::string(dir) + "/chip_tool_config." + std::string(name) + ".ini";
+    return dir + "/chip_tool_config." + name + ".ini";
 }
 
 CHIP_ERROR PersistentStorage::Init(const char * name, const char * directory)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    mUsedDirectory = GetUsedDirectory(directory != nullptr ? directory : "");
+    mUsedFilename = GenerateFilename(name != nullptr ? name : "");
+
     std::ifstream ifs;
-    ifs.open(GetFilename(directory, name), std::ifstream::in);
+    ifs.open(mUsedFilename, std::ifstream::in);
     if (!ifs.good())
     {
-        CommitConfig(directory, name);
-        ifs.open(GetFilename(directory, name), std::ifstream::in);
+        CommitConfig();
+        ifs.open(mUsedFilename, std::ifstream::in);
     }
     VerifyOrExit(ifs.is_open(), err = CHIP_ERROR_OPEN_FAILED);
 
-    mName      = name;
-    mDirectory = directory;
     mConfig.clear();
     mConfig.parse(ifs);
     ifs.close();
@@ -141,7 +142,7 @@ CHIP_ERROR PersistentStorage::SyncSetKeyValue(const char * key, const void * val
     }
 
     mConfig.sections[kDefaultSectionName] = section;
-    return CommitConfig(mDirectory, mName);
+    return CommitConfig();
 }
 
 CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
@@ -154,7 +155,7 @@ CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
     section.erase(escapedKey);
 
     mConfig.sections[kDefaultSectionName] = section;
-    return CommitConfig(mDirectory, mName);
+    return CommitConfig();
 }
 
 bool PersistentStorage::SyncDoesKeyExist(const char * key)
@@ -189,20 +190,20 @@ CHIP_ERROR PersistentStorage::SyncClearAll()
     auto section = mConfig.sections[kDefaultSectionName];
     section.clear();
     mConfig.sections[kDefaultSectionName] = section;
-    return CommitConfig(mDirectory, mName);
+    return CommitConfig();
 }
 
 const char * PersistentStorage::GetDirectory() const
 {
-    return GetUsedDirectory(mDirectory);
+    return mUsedDirectory.c_str();
 }
 
-CHIP_ERROR PersistentStorage::CommitConfig(const char * directory, const char * name)
+CHIP_ERROR PersistentStorage::CommitConfig()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     std::ofstream ofs;
-    std::string tmpPath = GetFilename(directory, name) + ".tmp";
+    std::string tmpPath = mUsedFilename + ".tmp";
     ofs.open(tmpPath, std::ofstream::out | std::ofstream::trunc);
     VerifyOrExit(ofs.good(), err = CHIP_ERROR_WRITE_FAILED);
 
@@ -210,7 +211,7 @@ CHIP_ERROR PersistentStorage::CommitConfig(const char * directory, const char * 
     ofs.close();
     VerifyOrExit(ofs.good(), err = CHIP_ERROR_WRITE_FAILED);
 
-    VerifyOrExit(rename(tmpPath.c_str(), GetFilename(directory, name).c_str()) == 0, err = CHIP_ERROR_WRITE_FAILED);
+    VerifyOrExit(rename(tmpPath.c_str(), mUsedFilename.c_str()) == 0, err = CHIP_ERROR_WRITE_FAILED);
 
 exit:
     return err;

--- a/src/controller/ExamplePersistentStorage.h
+++ b/src/controller/ExamplePersistentStorage.h
@@ -18,11 +18,11 @@
 
 #pragma once
 
-#include <string>
 #include <lib/core/CASEAuthTag.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <string>
 
 #include <inipp/inipp.h>
 

--- a/src/controller/ExamplePersistentStorage.h
+++ b/src/controller/ExamplePersistentStorage.h
@@ -73,6 +73,7 @@ private:
     CHIP_ERROR CommitConfig();
     std::string GenerateStoragePath(const std::string & name) const;
     inipp::Ini<char> mConfig;
+    // The mStorageFilePath is the complete path (directory included) of the persisted data file.
     std::string mStorageFilePath;
     std::string mUsedDirectory;
 };

--- a/src/controller/ExamplePersistentStorage.h
+++ b/src/controller/ExamplePersistentStorage.h
@@ -71,8 +71,8 @@ public:
 
 private:
     CHIP_ERROR CommitConfig();
-    std::string GenerateFilename(const std::string & name) const;
+    std::string GenerateStoragePath(const std::string & name) const;
     inipp::Ini<char> mConfig;
-    std::string mUsedFilename;
+    std::string mStorageFilePath;
     std::string mUsedDirectory;
 };

--- a/src/controller/ExamplePersistentStorage.h
+++ b/src/controller/ExamplePersistentStorage.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <string>
 #include <lib/core/CASEAuthTag.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/core/NodeId.h>
@@ -36,8 +37,6 @@ public:
      * null, falls back to getenv("TMPDIR") and if that is not set falls back
      * to /tmp.
      *
-     * If non-null values are provided, the memory they point to is expected to
-     * outlive this object.
      */
     CHIP_ERROR Init(const char * name = nullptr, const char * directory = nullptr);
 
@@ -71,8 +70,9 @@ public:
     const char * GetDirectory() const;
 
 private:
-    CHIP_ERROR CommitConfig(const char * directory, const char * name);
+    CHIP_ERROR CommitConfig();
+    std::string GenerateFilename(const std::string & name) const;
     inipp::Ini<char> mConfig;
-    const char * mName;
-    const char * mDirectory;
+    std::string mUsedFilename;
+    std::string mUsedDirectory;
 };

--- a/src/platform/Linux/CHIPLinuxStorage.cpp
+++ b/src/platform/Linux/CHIPLinuxStorage.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR ChipLinuxStorage::Init(const char * configFile)
 
     if (mInitialized)
     {
-        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s",
+        ChipLogError(DeviceLayer, "ChipLinuxStorage::Init: Attempt to re-initialize with KVS config file: %s, IGNORING.",
                      StringOrNullMarker(configFile));
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
#### Summary

- Avoid relying on external storage lifetime by using std::string storage.
- Remove complex re-computation of values that always yield the same result.

#### Testing done

- chip-tool works with all clusters-app locally
- Integration tests pass
- Unit tests still pass (for what is unit-tested)
