### PR TITLE
Cherry-pick [ICD] Add a Configurable SlowPollInterval fallback value when and ICD…

### DIFF
--- a/src/app/icd/server/ICDConfigurationData.cpp
+++ b/src/app/icd/server/ICDConfigurationData.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR ICDConfigurationData::SetSlowPollingInterval(System::Clock::Milliseco
 
     mLITPollingInterval = slowPollInterval;
     return CHIP_NO_ERROR;
-};
+}
 
 CHIP_ERROR ICDConfigurationData::SetSITPollingInterval(System::Clock::Milliseconds32 pollingInterval)
 {

--- a/src/app/icd/server/ICDConfigurationData.h
+++ b/src/app/icd/server/ICDConfigurationData.h
@@ -123,8 +123,33 @@ private:
     friend class chip::Test::ICDConfigurationDataTestAccess;
 
     void SetICDMode(ICDMode mode) { mICDMode = mode; };
-    void SetSlowPollingInterval(System::Clock::Milliseconds32 slowPollInterval) { mSlowPollingInterval = slowPollInterval; };
     void SetFastPollingInterval(System::Clock::Milliseconds32 fastPollInterval) { mFastPollingInterval = fastPollInterval; };
+
+    /**
+     * @brief Sets the slow polling interval for the ICD.
+     *
+     * If LIT support is not enabled, the interval cannot be set higher than the SIT polling threshold.
+     * If LIT support is enabled, any value is accepted.
+     *
+     * @param[in] slowPollInterval The slow polling interval in milliseconds.
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_ARGUMENT if the value is invalid.
+     */
+    CHIP_ERROR SetSlowPollingInterval(System::Clock::Milliseconds32 slowPollInterval);
+
+    /**
+     * @brief Sets the SIT Idle polling interval.
+     *
+     * This function sets the slow/idle polling interval, which is used when the configured
+     * slow polling interval exceeds the allowed threshold for SIT mode. The provided value must
+     * be less than, or equal to the SIT polling threshold (kSITPollingThreshold).
+     *
+     * This SIT Slow Polling configuration allows ICD LIT device to configure a longer SlowPollingInterval
+     * when operating as LIT, but use a faster SlowPollingInterval when the device must operate in SIT mode
+     *
+     * @param[in] pollingInterval The SIT slow polling interval in milliseconds.
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_ARGUMENT if the value is invalid.
+     */
+    CHIP_ERROR SetSITPollingInterval(System::Clock::Milliseconds32 pollingInterval);
 
     static constexpr System::Clock::Milliseconds16 kMinLitActiveModeThreshold = System::Clock::Milliseconds16(5000);
 
@@ -187,8 +212,16 @@ private:
     static_assert((CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL <= kSitIcdSlowPollMaximum),
                   "LIT support is required for slow polling intervals superior to 15 seconds");
 #endif
-    System::Clock::Milliseconds32 mSlowPollingInterval = CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
+    // The Polling interval used in Idle mode
+    System::Clock::Milliseconds32 mLITPollingInterval = CHIP_DEVICE_CONFIG_ICD_SLOW_POLL_INTERVAL;
+    // The Polling interval used in Active mode
     System::Clock::Milliseconds32 mFastPollingInterval = CHIP_DEVICE_CONFIG_ICD_FAST_POLL_INTERVAL;
+
+    static_assert((CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL <= kSitIcdSlowPollMaximum),
+                  "The SIT polling intervals must not exceed 15 seconds");
+    // The Polling interval used in Idle mode when a LIT capable device operates in SIT mode and that is mLITPollingInterval is
+    // greater than mSITPollingInterval
+    System::Clock::Milliseconds32 mSITPollingInterval = CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL;
 
     BitFlags<app::Clusters::IcdManagement::Feature> mFeatureMap;
 

--- a/src/app/icd/server/tests/BUILD.gn
+++ b/src/app/icd/server/tests/BUILD.gn
@@ -23,6 +23,7 @@ chip_test_suite("tests") {
 
   test_sources = [
     "TestDefaultICDCheckInBackOffStrategy.cpp",
+    "TestICDConfigurationData.cpp",
     "TestICDManager.cpp",
     "TestICDMonitoringTable.cpp",
   ]

--- a/src/app/icd/server/tests/ICDConfigurationDataTestAccess.h
+++ b/src/app/icd/server/tests/ICDConfigurationDataTestAccess.h
@@ -20,6 +20,7 @@
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/icd/server/ICDConfigurationData.h>
 #include <lib/support/BitFlags.h>
+#include <system/SystemLayerImpl.h>
 
 namespace chip {
 namespace Test {
@@ -35,13 +36,16 @@ public:
     ICDConfigurationDataTestAccess() = delete;
     ICDConfigurationDataTestAccess(ICDConfigurationData * data) : mData(data) {}
 
-    CHIP_ERROR SetModeDurations(Optional<System::Clock::Milliseconds32> activeModeDuration,
-                                Optional<System::Clock::Milliseconds32> idleModeDuration)
-    {
-        return mData->SetModeDurations(activeModeDuration, idleModeDuration);
-    }
-
+    // Add wrappers for private methods used in tests
     void SetFeatureMap(BitFlags<app::Clusters::IcdManagement::Feature> featureMap) { mData->SetFeatureMap(featureMap); }
+    void SetICDMode(ICDConfigurationData::ICDMode mode) { mData->SetICDMode(mode); }
+    CHIP_ERROR SetSlowPollingInterval(System::Clock::Milliseconds32 interval) { return mData->SetSlowPollingInterval(interval); }
+    CHIP_ERROR SetSITPollingInterval(System::Clock::Milliseconds32 interval) { return mData->SetSITPollingInterval(interval); }
+    CHIP_ERROR SetModeDurations(Optional<System::Clock::Milliseconds32> active, Optional<System::Clock::Milliseconds32> idle)
+    {
+        return mData->SetModeDurations(active, idle);
+    }
+    System::Clock::Milliseconds32 GetSitSlowPollMaximum() { return mData->kSitIcdSlowPollMaximum; }
 
 private:
     ICDConfigurationData * mData = nullptr;

--- a/src/app/icd/server/tests/TestICDConfigurationData.cpp
+++ b/src/app/icd/server/tests/TestICDConfigurationData.cpp
@@ -1,0 +1,202 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app-common/zap-generated/cluster-enums.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/icd/server/ICDConfigurationData.h>
+#include <app/icd/server/tests/ICDConfigurationDataTestAccess.h>
+#include <lib/core/StringBuilderAdapters.h>
+#include <lib/support/TimeUtils.h>
+#include <messaging/tests/MessagingContext.h>
+#include <system/SystemLayerImpl.h>
+
+using namespace chip;
+using namespace chip::Test;
+using namespace chip::app;
+using namespace chip::System;
+using namespace chip::System::Clock;
+using namespace chip::System::Clock::Literals;
+
+namespace {} // namespace
+
+namespace chip {
+namespace app {
+
+class TestICDConfigurationData : public Test::LoopbackMessagingContext
+{
+public:
+    // Performs shared setup for all tests in the test suite
+    static void SetUpTestSuite()
+    {
+        LoopbackMessagingContext::SetUpTestSuite();
+        VerifyOrReturn(!HasFailure());
+
+        ASSERT_EQ(chip::DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+    }
+
+    // Performs shared teardown for all tests in the test suite
+    static void TearDownTestSuite()
+    {
+        DeviceLayer::SetSystemLayerForTesting(nullptr);
+
+        DeviceLayer::PlatformMgr().Shutdown();
+
+        LoopbackMessagingContext::TearDownTestSuite();
+    }
+
+    // Performs setup for each individual test in the test suite
+    void SetUp() override
+    {
+        LoopbackMessagingContext::SetUp();
+        VerifyOrReturn(!HasFailure());
+    }
+
+    // Performs teardown for each individual test in the test suite
+    void TearDown() override { LoopbackMessagingContext::TearDown(); }
+};
+
+TEST_F(TestICDConfigurationData, TestICDModeSwitching)
+{
+    auto & configData = ICDConfigurationData::GetInstance();
+    chip::Test::ICDConfigurationDataTestAccess privateConfigData(&configData);
+
+    // Default mode should be SIT
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::SIT);
+
+    // Switch to LIT and check
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::LIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::LIT);
+
+    // Switch back to SIT and check
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::SIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::SIT);
+}
+
+TEST_F(TestICDConfigurationData, TestSetSITPollingInterval)
+{
+    ICDConfigurationDataTestAccess privateConfigData(&ICDConfigurationData::GetInstance());
+    System::Clock::Milliseconds32 validSITPollInterval(10000);
+    System::Clock::Milliseconds32 invalidSITPollInterval =
+        privateConfigData.GetSitSlowPollMaximum() + System::Clock::Milliseconds32(1000); // Above SIT threshold
+
+    // Should succeed for valid value
+    EXPECT_EQ(privateConfigData.SetSITPollingInterval(validSITPollInterval), CHIP_NO_ERROR);
+
+    // Should fail for invalid value
+    EXPECT_EQ(privateConfigData.SetSITPollingInterval(invalidSITPollInterval), CHIP_ERROR_INVALID_ARGUMENT);
+}
+
+TEST_F(TestICDConfigurationData, TestGetAndSetSlowPollingInterval)
+{
+    auto & configData = ICDConfigurationData::GetInstance();
+    ICDConfigurationDataTestAccess privateConfigData(&configData);
+
+    // Set featuremap to include LIT support
+    using Feature = Clusters::IcdManagement::Feature;
+    BitFlags<Feature> featureMap;
+    featureMap.Set(Feature::kLongIdleTimeSupport);
+    privateConfigData.SetFeatureMap(featureMap);
+
+    // Set a ICD SIT Slow Poll Interval
+    System::Clock::Milliseconds32 SITPollInterval(10000);
+    EXPECT_EQ(privateConfigData.SetSITPollingInterval(SITPollInterval), CHIP_NO_ERROR);
+
+    // Set operation mode to LIT and confirm mode
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::LIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::LIT);
+
+    // Set a slow polling interval of 60s, used in LIT mode and verify
+    System::Clock::Milliseconds32 newInterval(60000);
+    EXPECT_EQ(privateConfigData.SetSlowPollingInterval(newInterval), CHIP_NO_ERROR);
+
+    // In LIT mode Standard SlowPollingInterval is always used
+    EXPECT_EQ(configData.GetSlowPollingInterval(), newInterval);
+
+    // Switch operation mode to SIT and confirm mode
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::SIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::SIT);
+
+    // In SIT mode The shortest interval between SlowPollingInterval and SITPollingInterval is used
+    // In this case the the SITPollInterval interval is used
+    EXPECT_EQ(configData.GetSlowPollingInterval(), SITPollInterval);
+
+    // Reduce slow polling interval to 5s, shorter than SITPollingInterval
+    System::Clock::Milliseconds32 shortSlowPollInterval(5000);
+    privateConfigData.SetSlowPollingInterval(shortSlowPollInterval);
+    EXPECT_EQ(privateConfigData.SetSlowPollingInterval(shortSlowPollInterval), CHIP_NO_ERROR);
+    EXPECT_EQ(configData.GetSlowPollingInterval(), shortSlowPollInterval);
+
+    // Switch operation mode to LIT and confirm mode
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::LIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::LIT);
+    // slow polling interval remains in use
+    EXPECT_EQ(configData.GetSlowPollingInterval(), shortSlowPollInterval);
+
+    // increase slow polling interval to 20s, longer than SITPollingInterval
+    System::Clock::Milliseconds32 longerSlowPollInterval(20000);
+    EXPECT_EQ(privateConfigData.SetSlowPollingInterval(longerSlowPollInterval), CHIP_NO_ERROR);
+    // longerSlowPollInterval is used
+    EXPECT_EQ(configData.GetSlowPollingInterval(), longerSlowPollInterval);
+
+    // Switch operation mode to SIT and confirm mode
+    privateConfigData.SetICDMode(ICDConfigurationData::ICDMode::SIT);
+    EXPECT_EQ(configData.GetICDMode(), ICDConfigurationData::ICDMode::SIT);
+    //  SIT Polling Interval is used
+    EXPECT_EQ(configData.GetSlowPollingInterval(), SITPollInterval);
+
+    featureMap.Clear(Feature::kLongIdleTimeSupport);
+    privateConfigData.SetFeatureMap(featureMap);
+    // Without LIT support, the slow polling interval cannot bet set greater than the SIT polling threshold
+    EXPECT_EQ(privateConfigData.SetSlowPollingInterval(longerSlowPollInterval), CHIP_ERROR_INVALID_ARGUMENT);
+    // Set a Valid Slow Polling Interval greater than the SIT Polling Interval
+    System::Clock::Milliseconds32 validSlowPollInterval(12000);
+    EXPECT_EQ(privateConfigData.SetSlowPollingInterval(validSlowPollInterval), CHIP_NO_ERROR);
+    //  Without LIT support, the slow polling interval is used and the SIT Polling Interval value is not taken into account
+    EXPECT_EQ(configData.GetSlowPollingInterval(), validSlowPollInterval);
+}
+
+TEST_F(TestICDConfigurationData, TestSetModeDurations)
+{
+    auto & configData = ICDConfigurationData::GetInstance();
+    ICDConfigurationDataTestAccess privateConfigData(&configData);
+    using namespace System::Clock;
+
+    // Save original values
+    Seconds32 origIdle        = configData.GetIdleModeDuration();
+    Milliseconds32 origActive = configData.GetActiveModeDuration();
+
+    // Set valid durations
+    Milliseconds32 newActive(2000);
+    Seconds32 newIdle(10);
+    EXPECT_EQ(privateConfigData.SetModeDurations(MakeOptional(newActive), MakeOptional(Milliseconds32(newIdle.count() * 1000))),
+              CHIP_NO_ERROR);
+    EXPECT_EQ(configData.GetActiveModeDuration(), newActive);
+    EXPECT_EQ(configData.GetIdleModeDuration(), newIdle);
+
+    // Set invalid: active > idle
+    EXPECT_EQ(privateConfigData.SetModeDurations(MakeOptional(Milliseconds32(20000)), MakeOptional(Milliseconds32(1000))),
+              CHIP_ERROR_INVALID_ARGUMENT);
+
+    // Restore original values
+    EXPECT_EQ(privateConfigData.SetModeDurations(MakeOptional(origActive), MakeOptional(Milliseconds32(origIdle.count() * 1000))),
+              CHIP_NO_ERROR);
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/icd/server/tests/TestICDConfigurationData.cpp
+++ b/src/app/icd/server/tests/TestICDConfigurationData.cpp
@@ -138,7 +138,6 @@ TEST_F(TestICDConfigurationData, TestGetAndSetSlowPollingInterval)
 
     // Reduce slow polling interval to 5s, shorter than SITPollingInterval
     System::Clock::Milliseconds32 shortSlowPollInterval(5000);
-    privateConfigData.SetSlowPollingInterval(shortSlowPollInterval);
     EXPECT_EQ(privateConfigData.SetSlowPollingInterval(shortSlowPollInterval), CHIP_NO_ERROR);
     EXPECT_EQ(configData.GetSlowPollingInterval(), shortSlowPollInterval);
 
@@ -162,7 +161,7 @@ TEST_F(TestICDConfigurationData, TestGetAndSetSlowPollingInterval)
 
     featureMap.Clear(Feature::kLongIdleTimeSupport);
     privateConfigData.SetFeatureMap(featureMap);
-    // Without LIT support, the slow polling interval cannot bet set greater than the SIT polling threshold
+    // Without LIT support, the slow polling interval cannot be set greater than the SIT polling threshold
     EXPECT_EQ(privateConfigData.SetSlowPollingInterval(longerSlowPollInterval), CHIP_ERROR_INVALID_ARGUMENT);
     // Set a Valid Slow Polling Interval greater than the SIT Polling Interval
     System::Clock::Milliseconds32 validSlowPollInterval(12000);

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -160,6 +160,19 @@
 #endif
 
 /**
+ * CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL
+ *
+ * The SIT slow polling interval (in milliseconds) is a configuration that allows LIT capable devices
+ * operating in SIT mode to use a shorter slow polling interval than their typical
+ * Slow polling interval.
+ *
+ * The SIT slow polling interval cannot be set to a value greater than CHIP_DEVICE_CONFIG_ICD_SIT_SLOW_POLL_LIMIT
+ */
+#ifndef CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL
+#define CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL CHIP_DEVICE_CONFIG_ICD_SIT_SLOW_POLL_LIMIT
+#endif // CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL
+
+/**
  * CHIP_DEVICE_CONFIG_ICD_FAST_POLL_INTERVAL
  *
  * The default amount of time in milliseconds that the sleepy end device will use as an active interval.


### PR DESCRIPTION
…e is operating as SIT. 

#### Summary
ICD LIT users want the ability to poll more frequently than the current maximum threshold when operating in SIT mode.
This PR introduces a configuration that allows ICD LIT devices, normally using a longer Slow Poll Interval, to adopt a faster polling rate when acting as SIT, instead of being limited to reducing their slow poll interval to the fixed 15s threshold (kSITPollingThreshold).

- Create a Configurable Slow Poll interval fallback that allows ICD LIT to configure a long Slow Poll interval while they are operating as a LIT, but fall back to a shorter Slow Poll interval when the ICD must operate as SIT.
- New define `CHIP_DEVICE_CONFIG_ICD_SIT_POLLING_INTERVAL` allows configuring the Default sit slow poll fallback used at build time.
- A private function, `SetSlowPollingFallback`, also allows changing the fallback value at runtime within the ICD context.

- Create a unit test `TestICDConfigurationData` for testing the old and new APIs of ICDConfigurationData

#### Related issues
fixes #39240

#### Testing
Added unit test `TestICDConfigurationData` 