### PR TITLE
devcontainers: Typo in short options for build.sh not allowing the -v option to work properly

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -36,8 +36,8 @@ Options:
 EOF
 }
 
-SHORT=t:,u:,h:,v:
-LONG=tag:,uid:,help:,version:
+SHORT=t:,u:,h,v:
+LONG=tag:,uid:,help,version:
 OPTS=$(getopt -n build --options "$SHORT" --longoptions "$LONG" -- "$@")
 
 eval set -- "$OPTS"

--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -36,7 +36,7 @@ Options:
 EOF
 }
 
-SHORT=t:,u:,h:,v
+SHORT=t:,u:,h:,v:
 LONG=tag:,uid:,help:,version:
 OPTS=$(getopt -n build --options "$SHORT" --longoptions "$LONG" -- "$@")
 


### PR DESCRIPTION
#### Summary

The `-v` option in `.devcontainer/build.sh` is not allowing an argument like equivalent `--version` option. This is likely a typo.

#### Testing

Tested by building a devcontainer based on a previous version of Docker image stack. This is achieved by specifying:

```
    "initializeCommand": "bash -- .devcontainer/build.sh -v 142",
```

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
