### PR TITLE
vscode: Harmonize vscode's shell-format configu with what restyled is configured with

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -193,7 +193,7 @@
     "files.trimFinalNewlines": true,
     "C_Cpp.default.cppStandard": "gnu++17",
     "C_Cpp.default.cStandard": "gnu11",
-    "shellformat.flag": "-ci",
+    "shellformat.flag": "-i 4 -ci",
     "cmake.configureOnOpen": false,
     "search.followSymlinks": false,
     "[python]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -193,6 +193,7 @@
     "files.trimFinalNewlines": true,
     "C_Cpp.default.cppStandard": "gnu++17",
     "C_Cpp.default.cStandard": "gnu11",
+    "shellformat.flag": "-ci",
     "cmake.configureOnOpen": false,
     "search.followSymlinks": false,
     "[python]": {


### PR DESCRIPTION
#### Summary

The `foxundermoon.shell-format` configuration in `.vscode/settings.json` lacks the `-ci` `shfmt` flag which is specified in restyled.io's configuration. The effect of this is that when a bash script is saved the switch blocks get reformatted causing restyled to complain. Specifically, this:

```
# extract run options
for arg in "$@"; do
    case "$arg" in
        --help)
            help
            exit
            ;;

        --)
            shift
            break
            ;;

        -*)
            runargs+=("$arg")
            shift
            ;;

        *)
            ((!${#runargs[*]})) && break
            runargs+=("$arg")
            shift
            ;;

    esac
done
```

becomes this:

```
for arg in "$@"; do
    case "$arg" in
    --help)
        help
        exit
        ;;

    --)
        shift
        break
        ;;

    -*)
        runargs+=("$arg")
        shift
        ;;

    *)
        ((!${#runargs[*]})) && break
        runargs+=("$arg")
        shift
        ;;

    esac
done
```

And later restyled tries to fix this because it's configuration says:

```
    - name: shfmt
      image: restyled/restyler-shfmt:v3.0.1
      enabled: true
      command:
          - shfmt
          - "-w"
      arguments:
          - "-i"
          - "4"
          - "-ci"
      interpreters:
          - sh
          - bash
      include:
          - "**/*.sh"
          - "**/*.bash"
```


#### Testing

Saving a .bash script in vscode does not reformat the file anymore. No code affected.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X] PR size is short
-   [X] Try to avoid "squashing" and "force-update" in commit history
-   [X] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
