### PR TITLE
Fix error reporting for tests

### DIFF
--- a/scripts/tests/chiptest/runner.py
+++ b/scripts/tests/chiptest/runner.py
@@ -157,8 +157,8 @@ class Runner:
                 break
             # dependencies MUST NOT be done
             s.kill()
-            raise Exception("Unexpected return %d for %r" %
-                            (process.returncode, userdata))
+            raise Exception("Unexpected return %d for %r/%r" %
+                            (process.returncode, process, userdata))
 
         if s.returncode != 0:
             if wait.timed_out:

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -42,6 +42,18 @@ class App:
         self.options = None
         self.killed = False
 
+    def __repr__(self) -> str:
+        return f'App[{self.command!r} - status {self.returncode}]'
+
+    @property
+    def returncode(self):
+        """Exposes return code of the underlying process, so that
+           common code can be used between subprocess.Popen and Apps.
+        """
+        if not self.process:
+            return None
+        return self.process.returncode
+
     def start(self, options=None):
         if not self.process:
             # Cache command line options to be used for reboots


### PR DESCRIPTION
#### Summary

Secondary applications are registered and our test running logic assumes that they are `subprocess` which is not the case. https://github.com/project-chip/connectedhomeip/blob/master/scripts/tests/chiptest/runner.py#L155 has:

```py
        for process, userdata in iter(wait.queue.get, None):
            if process == s:
                break
            # dependencies MUST NOT be done
            s.kill()
            raise Exception("Unexpected return %d for %r" %
                            (process.returncode, userdata))
```

and process here can be an App that is running.

I added the returncode property to the App class and also added some extra repr/data for logging when things fail. Now I would clearly see a `Unexpected return -11 for ...` when applicable rather than some `returncode property not available` exception.

#### Testing

This worked for me when I was debugging python test failures. Since this is test code, adding tests for tests (that are failing) is rough, so the remaining test is "CI still passes".