### PR TITLE
[NXP][platform][common] Fix GetSoftwareVersionString issue

### DIFF
--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
@@ -492,6 +492,14 @@ CHIP_ERROR FactoryDataProvider::GetHardwareVersionString(char * buf, size_t bufS
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FactoryDataProvider::GetSoftwareVersionString(char * buf, size_t bufSize)
+{
+    /* The FactoryDataProvider instance is registered as a DeviceInstanceInfoProvider, which requires SoftwareVersionString support.
+    This information is not stored in the factory data, as it may change after an OTA update. */
+    CHIP_ERROR err = ConfigurationMgr().GetSoftwareVersionString(buf, bufSize);
+    return err;
+}
+
 CHIP_ERROR FactoryDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
 {
     CHIP_ERROR err = CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
@@ -495,8 +495,12 @@ CHIP_ERROR FactoryDataProvider::GetHardwareVersionString(char * buf, size_t bufS
 CHIP_ERROR FactoryDataProvider::GetSoftwareVersionString(char * buf, size_t bufSize)
 {
     /* The FactoryDataProvider instance is registered as a DeviceInstanceInfoProvider, which requires SoftwareVersionString support.
-    This information is not stored in the factory data, as it may change after an OTA update. */
+     This information is not stored in the factory data, as it may change after an OTA update. */
     CHIP_ERROR err = ConfigurationMgr().GetSoftwareVersionString(buf, bufSize);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to get software version string from ConfigurationMgr: %s", ErrorStr(err));
+    }
     return err;
 }
 

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.h
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.h
@@ -195,6 +195,7 @@ public:
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
     CHIP_ERROR GetProductFinish(app::Clusters::BasicInformation::ProductFinishEnum * finish) override;
     CHIP_ERROR GetProductPrimaryColor(app::Clusters::BasicInformation::ColorEnum * primaryColor) override;
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
 
 protected:
     // Use when factory data are encrypted using aes key


### PR DESCRIPTION
#### Summary

Due to Matter SDK update ( https://github.com/project-chip/connectedhomeip/commit/0694ea08c742999ab7ce35fd8270891d743186f9#diff-ada498b819f2d3cbb36b3edc48539c5a3d877b9d48e6f7817372317a913415daR165-R181 ) chip-tool command "./chip-tool basicinformation read software-version-string 1 0" failed.

#### Testing

- Setup: NXP frdm rw61x board with thermostat ethernet application

- build command: west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=/home/nxf94103/Documents/workspace/connectedhomeip/examples/platform/nxp/config/prj_eth_fdata.conf
- flash factory data binary
- Commissioning on-network: ./chip-tool pairing onnetwork-long 1 14014 2560 --paa-trust-store-path ./factory_data/
- Chip-tool command: ./chip-tool pairing onnetwork-long 1 14014 2560 --paa-trust-store-path ./factory_data/
- Command response: SoftwareVersionString: 1.4

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
