### PR TITLE
[E2E][JF] Added GetJointFabricMode() to DeviceInstanceInfoProvider class

### DIFF
--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -210,6 +210,19 @@ public:
      *          if access fails.
      */
     virtual CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) { return CHIP_ERROR_NOT_IMPLEMENTED; }
+
+    /**
+     * @brief Retrieves the current Joint Fabric mode.
+     *
+     * This method is intended to provide the current Joint Fabric Mode value when the node is capable of being a Joint Fabric
+     * Administrator.
+     * By default, it returns CHIP_ERROR_NOT_IMPLEMENTED and does not modify the output parameter.
+     *
+     * @param[out] jointFabricMode Reference to a uint8_t variable where the joint fabric mode will be stored.
+     * @returns CHIP_NO_ERROR on success or CHIP_ERROR_NOT_IMPLEMENTED when device is not capable of being a Joint Fabric
+     * Administrator.
+     */
+    virtual CHIP_ERROR GetJointFabricMode(uint8_t & jointFabricMode) { return CHIP_ERROR_NOT_IMPLEMENTED; }
 };
 
 /**


### PR DESCRIPTION
#### Summary
Added GetJointFabricMode() to the DeviceInstanceInfoProvider class (an example implementation will be provided in a separate PR), and updated app/server/Dnssd.cpp to advertise the JF TXT value accordingly.

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/39662.

#### Testing
Verified using the below instructions. OJCW functionality will be tested in a follow-up PR that implements it.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```
