### PR TITLE
[Silabs] Fix NVM3 Key leak on reboot

### DIFF
--- a/examples/platform/silabs/BaseApplication.cpp
+++ b/examples/platform/silabs/BaseApplication.cpp
@@ -882,10 +882,16 @@ void BaseApplication::ScheduleFactoryReset()
 void BaseApplication::DoProvisioningReset()
 {
     PlatformMgr().ScheduleWork([](intptr_t) {
+        // Force the KeyMap update to make sure nvm3 is updated before anything happens.
+        // If the device reboots before the timer update happens, "shadow" keys are left in nvm3 causing a reduction of the
+        // overall available nvm3 - similar to a memory leak.
+        // FactoryResetThreadStack forces a reboot which was causing a memory loss.
+        chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().ForceKeyMapSave();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
         ConfigurationManagerImpl::GetDefaultInstance().ClearThreadStack();
         ThreadStackMgrImpl().FactoryResetThreadStack();
-        ThreadStackMgr().InitThreadStack();
+        // Triggers a reboot - nothing gets executed after this
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION

--- a/src/platform/silabs/KeyValueStoreManagerImpl.h
+++ b/src/platform/silabs/KeyValueStoreManagerImpl.h
@@ -46,7 +46,18 @@ public:
     static void KvsMapMigration();
 
 private:
+    static KeyValueStoreManagerImpl sInstance;
+
     static void OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState);
+
+    /**
+     * @brief Cleans up unused keys in the key-value store.
+     *
+     * This function iterates over the key map and removes shadow keys (keys that
+     * no longer have corresponding entries in NVM). It ensures that the key map
+     * remains consistent and frees up space for new entries.
+     */
+    static void KvsKeyMapCleanup(void * argument);
 
     void ScheduleKeyMapSave(void);
     bool IsValidKvsNvm3Key(const uint32_t nvm3Key) const;
@@ -56,8 +67,6 @@ private:
     //  ===== Members for internal use by the following friends.
     friend KeyValueStoreManager & KeyValueStoreMgr();
     friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
-
-    static KeyValueStoreManagerImpl sInstance;
 };
 
 /**
@@ -75,7 +84,7 @@ inline KeyValueStoreManager & KeyValueStoreMgr(void)
  * Returns the platform-specific implementation of the KeyValueStoreManager singleton object.
  *
  * Chip applications can use this to gain access to features of the KeyValueStoreManager
- * that are specific to the ESP32 platform.
+ * that are specific to the Silabs platform.
  */
 inline KeyValueStoreManagerImpl & KeyValueStoreMgrImpl(void)
 {


### PR DESCRIPTION
#### Summary

This PR fixes an NVM3 KeyMap leak that occurred when the device rebooted before the KeyMap was persisted in NVM3. When we modify the `KvsKeyMap` during operation, there is a two-second delay between modification of the RAM copy and its persistence in NVM3.

This delay is necessary to avoid flash wear and cannot be removed.

**Key Deletion Flow**
1. Delete NVM3 data.
2. Delete the RAM `KeyMap` entry.
3. Wait two seconds.
4. Persist the updated table to NVM3.

If the device reboots during step 3, it creates a "shadow key"—a `KvsKeyMap` entry that does not point to a valid NVM3 value. This reduces the number of available keys, as the key will never be freed.

This issue occurs systematically when removing the last fabric, because `FactoryResetThreadStack` causes a reboot immediately after updating the `KvsKeyMap`. In other words, rebooting is guaranteed at step 3. After 25 commissioning and unpairing sequences, we were unable to commission anymore because all key entries were consumed by "shadow keys."


This PR implements two solutions:
- When `DoProvisioningReset` is called, we force an update to `KvsKeyMap` to ensure the latest KeyMap is persisted.
- A background task is added, triggered at boot, that cleans up any existing shadow keys. Since shadow keys can be created as part of standard operation, this cleanup runs at every boot, ensuring they will never lead to a failure scenario.


#### Related issues
NA

#### Testing

Automated validation is done in silabs automation. Couldn't write a unit test for the moment since the KVS implementation is heavily tied to the underlying platform and the efr32 test driver requires an update to support the latest pigweed update.

**Background Task Validation**
- Commissioned and unpaired until NVM3 failure (25 times) using a binary without the background task.
- Flashed a binary with the background task, and commissioning worked.
- Read and parsed NVM3 to confirm the KeyMap was emptied.

**`DoProvisioningReset` Validation**
- Ran a stress test without the background task for multiple hours without any failures.



#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
