### PR TITLE
[Camera] Take the dptzStreams parameter by reference

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-settings-user-level-management-instance.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-settings-user-level-management-instance.h
@@ -35,7 +35,7 @@ public:
     bool CanChangeMPTZ() override;
 
     CHIP_ERROR LoadMPTZPresets(std::vector<MPTZPresetHelper> & mptzPresetHelpers) override;
-    CHIP_ERROR LoadDPTZStreams(std::vector<Structs::DPTZStruct::Type> dptzStream) override;
+    CHIP_ERROR LoadDPTZStreams(std::vector<Structs::DPTZStruct::Type> & dptzStreams) override;
     CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
     virtual void VideoStreamAllocated(uint16_t aStreamID) override;

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-settings-user-level-management-stub.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-settings-user-level-management-stub.cpp
@@ -144,7 +144,7 @@ CHIP_ERROR AVSettingsUserLevelManagementDelegate::LoadMPTZPresets(std::vector<MP
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AVSettingsUserLevelManagementDelegate::LoadDPTZStreams(std::vector<DPTZStruct> dptzStreams)
+CHIP_ERROR AVSettingsUserLevelManagementDelegate::LoadDPTZStreams(std::vector<DPTZStruct> & dptzStreams)
 {
     dptzStreams.clear();
     return CHIP_NO_ERROR;

--- a/examples/camera-app/linux/include/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.h
@@ -39,7 +39,7 @@ public:
     bool CanChangeMPTZ() override;
 
     CHIP_ERROR LoadMPTZPresets(std::vector<MPTZPresetHelper> & mptzPresetHelpers) override;
-    CHIP_ERROR LoadDPTZStreams(std::vector<DPTZStruct> dptzStreams) override;
+    CHIP_ERROR LoadDPTZStreams(std::vector<DPTZStruct> & dptzStreams) override;
     CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
     /**

--- a/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avsettingsuserlevel-mgmt/camera-avsettingsuserlevel-manager.cpp
@@ -311,7 +311,7 @@ CHIP_ERROR CameraAVSettingsUserLevelManager::LoadMPTZPresets(std::vector<MPTZPre
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CameraAVSettingsUserLevelManager::LoadDPTZStreams(std::vector<DPTZStruct> dptzStreams)
+CHIP_ERROR CameraAVSettingsUserLevelManager::LoadDPTZStreams(std::vector<DPTZStruct> & dptzStreams)
 {
     dptzStreams.clear();
     return CHIP_NO_ERROR;

--- a/src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h
+++ b/src/app/clusters/camera-av-settings-user-level-management-server/camera-av-settings-user-level-management-server.h
@@ -376,7 +376,7 @@ public:
      *  server list, at initialization.
      */
     virtual CHIP_ERROR LoadMPTZPresets(std::vector<MPTZPresetHelper> & mptzPresetHelpers) = 0;
-    virtual CHIP_ERROR LoadDPTZStreams(std::vector<DPTZStruct> dptzStreams)               = 0;
+    virtual CHIP_ERROR LoadDPTZStreams(std::vector<DPTZStruct> & dptzStreams)             = 0;
 
     CameraAvSettingsUserLevelMgmtServer * mServer = nullptr;
 


### PR DESCRIPTION
#### Summary

CHIP_ERROR LoadDPTZStreams(std::vector dptzStreams) override = 0;

Consider taking the dptzStreams parameter by & for consistency with other Load... functions (e.g., LoadMPTZPresets). Passing by value can be inefficient due to the copy operation. Also, the current stub implementation in CameraAVSettingsUserLevelManager operates on a local copy, making dptzStreams.clear() ineffective for the caller.

#### Related issues
        Fixes: #39646

#### Testing

Validated by CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
