### PR TITLE
Fix logging on attestation completion in Matter.framework to not be misleading

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
@@ -28,8 +28,8 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
     chip::Credentials::AttestationVerificationResult attestationResult)
 {
     dispatch_async(mQueue, ^{
-        MTR_LOG("MTRDeviceAttestationDelegateBridge::OnDeviceAttestationFailed completed with result: %hu",
-            chip::to_underlying(attestationResult));
+        MTR_LOG("MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted with result: %hu (%s)",
+            chip::to_underlying(attestationResult), chip::Credentials::GetAttestationResultDescription(attestationResult));
 
         mResult = attestationResult;
 


### PR DESCRIPTION
This codepath includes attestation success, not just attestation failures.

#### Testing

Logging change only.