### PR TITLE
[Silabs] Adjust main task priority based on SLI_SI91X_MCU_INTERFACE configuration i.e. for SiWx917 SoC

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -159,7 +159,12 @@ constexpr osThreadAttr_t kMainTaskAttr = { .name       = "main",
                                            .cb_size    = 0U,
                                            .stack_mem  = NULL,
                                            .stack_size = kMainTaskStackSize,
-                                           .priority   = osPriorityRealtime7 };
+#ifdef SLI_SI91X_MCU_INTERFACE
+                                           .priority = osPriorityRealtime4
+#else
+                                           .priority = osPriorityRealtime7
+#endif // SLI_SI91X_MCU_INTERFACE
+};
 osThreadId_t sMainTaskHandle;
 static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 

--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -258,6 +258,10 @@ template("siwx917_sdk") {
       "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
       "SUPPORT_CPLUSPLUS=1",
       "SLI_SI91X_LWIP_HOSTED_NETWORK_STACK=1",
+
+      # TODO: This is a workaround for the init issue with the SiWx917
+      "SL_WLAN_EVENT_THREAD_PRIORITY=osPriorityRealtime6",
+      "SL_WLAN_COMMAND_ENGINE_THREAD_PRIORITY=osPriorityRealtime5",
     ]
 
     if (silabs_log_enabled && chip_logging) {


### PR DESCRIPTION
- Priority inversion of the tasks happening because initialization task is getting blocked during the storage initialization causing the already lower priority BLE task to pick up pending events with clearing the event buffer but without clearing the flags from the event. Hence the higher priority task loops thinking that there is an event for it but since the clean-up is not done gracefully, it loops.
 - Temporary fix being made from the application by elevating the command engine and event task priority, since the above mentioned scenario won't happen. The SDK was designed with this presumption that the command engine and event task are the highest priority task.

### Testing
Tested internally in lab environments.