### PR TITLE
Fix null termination for config manager: we should ensure null termination

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -532,9 +532,11 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf,
     err                = ReadConfigValueStr(ConfigClass::kConfigKey_UniqueId, buf, bufSize, uniqueIdLen);
 
     ReturnErrorOnFailure(err);
-
     VerifyOrReturnError(uniqueIdLen < bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
-    VerifyOrReturnError(buf[uniqueIdLen] == 0, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    // ensure null termination if the string read is not null terminting (e.g. posix config on darwin
+    // returns data without null terminators as it reads data as binary.)
+    buf[uniqueIdLen] = 0;
 
     return err;
 }


### PR DESCRIPTION
#### Summary

Current code asserts a null terminator is pre-seeded in the output string, which seems like a very odd interface. It works because  https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/basic-information/basic-information.cpp#L255 has:

```cpp
        char uniqueId[kMaxLen + 1] = { 0 };

        status = configManager.GetUniqueId(uniqueId, sizeof(uniqueId));
```

#### Testing

- CI should still pass.
- Change is trivial
- I tested this functionality as part of a basic information conversion to code driven.