### PR TITLE
Improve template deduction rules for Span and List.

### DIFF
--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -70,6 +70,9 @@ struct List : public Span<T>
     //
     static constexpr bool kIsFabricScoped = DataModel::IsFabricScoped<T>::value;
 };
+
+// Template deduction guides to allow construction of List from a pointer or
+// array without having to specify the type of the list entries explicitly.
 template <class T>
 List(T * data, size_t size) -> List<T>;
 template <class T, size_t N>

--- a/src/app/data-model/List.h
+++ b/src/app/data-model/List.h
@@ -70,6 +70,10 @@ struct List : public Span<T>
     //
     static constexpr bool kIsFabricScoped = DataModel::IsFabricScoped<T>::value;
 };
+template <class T>
+List(T * data, size_t size) -> List<T>;
+template <class T, size_t N>
+List(T (&databuf)[N]) -> List<T>;
 
 template <typename X>
 inline CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, List<X> list)

--- a/src/app/data-model/tests/BUILD.gn
+++ b/src/app/data-model/tests/BUILD.gn
@@ -18,9 +18,13 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 chip_test_suite("tests") {
   output_name = "libAppDataModelTests"
 
-  test_sources = [ "TestNullable.cpp" ]
+  test_sources = [
+    "TestList.cpp",
+    "TestNullable.cpp",
+  ]
 
   public_deps = [
+    "${chip_root}/src/app/data-model:data-model",
     "${chip_root}/src/app/data-model:nullable",
     "${chip_root}/src/lib/core:error",
     "${chip_root}/src/lib/core:string-builder-adapters",

--- a/src/app/data-model/tests/TestList.cpp
+++ b/src/app/data-model/tests/TestList.cpp
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+
+#include <lib/core/StringBuilderAdapters.h>
+#include <pw_unit_test/framework.h>
+
+#include <app/data-model/List.h>
+
+using namespace chip;
+using namespace chip::app::DataModel;
+
+namespace {
+template <typename T>
+void PassListArg(const List<T> &)
+{}
+} // namespace
+
+TEST(TestList, TestConstructorTypeDeduction)
+{
+    const uint8_t nums[]      = { 1, 2 };
+    const uint8_t otherNums[] = { 1, 2, 3 };
+
+    // These will fail to compile if type deduction is not working correctly.
+    PassListArg(List(nums));
+    PassListArg(List(nums, 1));
+
+    List a(nums);
+    EXPECT_TRUE(a.data_equal(List<const uint8_t>(otherNums, 2)));
+
+    List b(nums, 1);
+    EXPECT_TRUE(b.data_equal(List<const uint8_t>(otherNums, 1)));
+}

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -203,6 +203,9 @@ private:
     pointer mDataBuf;
     size_t mDataLen;
 };
+
+// Template deduction guides to allow construction of Span from a pointer or
+// array without having to specify the type of the entries explicitly.
 template <class T>
 Span(T * data, size_t size) -> Span<T>;
 template <class T, size_t N>

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -205,6 +205,8 @@ private:
 };
 template <class T>
 Span(T * data, size_t size) -> Span<T>;
+template <class T, size_t N>
+Span(T (&databuf)[N]) -> Span<T>;
 
 inline namespace literals {
 

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -357,3 +357,25 @@ TEST(TestSpan, TestConversionConstructors)
     // The following should not compile
     // Span<const Foo> error1 = std::array<Foo, 3>(); // Span would point into a temporary value
 }
+
+namespace {
+template <typename T>
+void PassSpanArg(const Span<T> &)
+{}
+} // namespace
+
+TEST(TestSpan, TestConstructorTypeDeduction)
+{
+    const uint8_t nums[]      = { 1, 2 };
+    const uint8_t otherNums[] = { 1, 2, 3 };
+
+    // These will fail to compile if type deduction is not working correctly.
+    PassSpanArg(Span(nums));
+    PassSpanArg(Span(nums, 1));
+
+    Span a(nums);
+    EXPECT_TRUE(a.data_equal(Span<const uint8_t>(otherNums, 2)));
+
+    Span b(nums, 1);
+    EXPECT_TRUE(b.data_equal(Span<const uint8_t>(otherNums, 1)));
+}


### PR DESCRIPTION
This allows writing List(someArray) instead of having to specify the type of the thing stored in the array, and same for Span.

#### Testing

Unit tests added.