### PR TITLE
[nrfconnect] Update nRF Connect SDK version in Docekr to 3.0.0

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-143 : Upgrading Silabs Docker - SiSDK 2025.6.0, Wiseconnect SDK 3.5.0 and WC BT 2.12.0
+144 : [nrfconnect] Update nRF Connect SDK version to 3.0.0.

--- a/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nrf-platform/Dockerfile
@@ -1,77 +1,68 @@
 ARG VERSION=1
 
-# ==================================================
-# Temporary image for SDK and dependencies download
-# ==================================================
-
 FROM ghcr.io/project-chip/chip-build:${VERSION} as build
-LABEL org.opencontainers.image.source https://github.com/project-chip/connectedhomeip
-# Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=v2.9.0
 
-# Requirements to clone SDKs in temporary container
+# Compatible Nordic Connect SDK revision and required tools versions
+ARG NCS_REVISION=v3.0.0
+ARG JLINK_VERSION="JLink_Linux_V818_x86_64"
+ARG WEST_VERSION=1.2.0
+ARG CMAKE_VERSION=3.25.0
+
+# Requirements to clone SDKs
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
     xz-utils \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /opt/NordicSemiconductor/nRF5_tools
 RUN set -x \
-    && curl --location https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/desktop-software/nrf-command-line-tools/sw/versions-10-x-x/10-24-2/nrf-command-line-tools-10.24.2_linux-amd64.tar.gz \
-    | tar zxvf - \
-    && tar xvf JLink_Linux_V794e_x86_64.tgz \
-    && rm JLink_Linux_V794e_x86_64.* \
-    && curl --location https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.17.0/zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz --output zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
-    && tar xvf zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
-    && rm -rf zephyr-sdk-0.17.0_linux-x86_64_minimal.tar.xz \
-    && zephyr-sdk-0.17.0/setup.sh -t arm-zephyr-eabi \
+    # Get JLink
+    && curl -d "accept_license_agreement=accepted&submit=Download+software" -X POST -O "https://www.segger.com/downloads/jlink/${JLINK_VERSION}.tgz" \
+    && tar xvf ${JLINK_VERSION}.tgz \
+    && rm ${JLINK_VERSION}.* \
+    # Get nRF Util
+    && curl --location https://files.nordicsemi.com/artifactory/swtools/external/nrfutil/executables/x86_64-unknown-linux-gnu/nrfutil -o nrfutil \
+    && chmod +x ./nrfutil \
+    && ./nrfutil self-upgrade \
+    && ./nrfutil install device \
+    && ./nrfutil install sdk-manager \
+    # Download nRF Connect toolchain
+    && ./nrfutil sdk-manager toolchain install --ncs-version "$NCS_REVISION" --install-dir ./zephyr-sdk \
     && : # last line
 
 WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
-    && python3 -m pip install --break-system-packages -U --no-cache-dir west==1.2.0 \
+    && python3 -m pip install --break-system-packages -U --no-cache-dir west==${WEST_VERSION} \
     && west init -m https://github.com/nrfconnect/sdk-nrf --mr "$NCS_REVISION" \
     && west config update.narrow true \
     && west config update.fetch smart \
     && west update -o=--depth=1 -n -f smart \
     && : # last line
 
-# ==================================================
-# nRF Connect SDK final image
-# ==================================================
-
-FROM ghcr.io/project-chip/chip-build:${VERSION}
-
 # Tools for building, flashing and accessing device logs
 RUN set -x \
     && apt-get update \
-    && apt-get install --no-install-recommends -fy device-tree-compiler gcc-multilib g++-multilib \
+    && apt-get install --no-install-recommends -fy device-tree-compiler gcc-multilib g++-multilib libusb-1.0-0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line
 
-COPY --from=build /opt/NordicSemiconductor/nRF5_tools/ /opt/NordicSemiconductor/nRF5_tools/
-COPY --from=build /opt/NordicSemiconductor/nrfconnect/ /opt/NordicSemiconductor/nrfconnect/
-
-RUN set -x \
-    # python3-yaml and python3-numpy packages conflict with nRF Python requirements
-    && (apt-get remove -fy python3-yaml python3-numpy && apt-get autoremove || exit 0) \
-    && python3 -m pip install --break-system-packages -U --no-cache-dir cmake==3.25.0 \
-    && python3 -m pip install --break-system-packages --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements-base.txt \
-    && python3 -m pip install --break-system-packages --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements-build.txt \
-    && python3 -m pip install --break-system-packages --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/bootloader/mcuboot/scripts/requirements.txt \
-    && python3 -m pip install --break-system-packages --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/modules/lib/matter/scripts/setup/requirements.nrfconnect.txt \
-    && : # last line
-
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
-ENV PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V794e_x86_64:${PATH}
-ENV PATH=${NRF5_TOOLS_ROOT}/nrf-command-line-tools/bin:${PATH}
-ENV LD_LIBRARY_PATH=${NRF5_TOOLS_ROOT}/JLink_Linux_V794e_x86_64:${LD_LIBRARY_PATH}
+ENV PATH=${NRF5_TOOLS_ROOT}:$PATH
+ENV PATH=${NRF5_TOOLS_ROOT}/${JLINK_VERSION}:${PATH}
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
-ENV ZEPHYR_SDK_INSTALL_DIR=${NRF5_TOOLS_ROOT}/zephyr-sdk-0.17.0
-ENV ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-ENV ZEPHYR_TOOLCHAIN_PATH=${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi
+
+# Set up Zephyr SDK environment variables
+RUN set -x \
+    # Setup Zephyr SDK environment variables
+    # Do not use the nrfconnect python environment because the python environment should be created by bootstrap.sh
+    && nrfutil sdk-manager toolchain env --as-script --ncs-version "$NCS_REVISION" --install-dir ${NRF5_TOOLS_ROOT}/zephyr-sdk | grep -v "PYTHONHOME\|PYTHONPATH" | tee -a /root/.bashrc \
+    # Remove redundant directory created by nrfutil
+    && rm -rf ${NRF5_TOOLS_ROOT}/zephyr-sdk/downloads \
+    && : # last line


### PR DESCRIPTION
#### Summary

Regular update of nRF Connect SDK to 3.0.0 version.

#### Testing
Tested manually by building the image locally and building NCS 3.0.0 samples using the image.