### PR TITLE
tizen: Match both generic and specific error codes when checking keys in persistent store

### DIFF
--- a/src/platform/Tizen/ErrorUtils.cpp
+++ b/src/platform/Tizen/ErrorUtils.cpp
@@ -31,7 +31,7 @@ CHIP_ERROR TizenToChipError(int tizenError)
     case TIZEN_ERROR_NONE:
         return CHIP_NO_ERROR;
     case TIZEN_ERROR_OUT_OF_MEMORY:
-        return CHIP_NO_ERROR;
+        return CHIP_ERROR_NO_MEMORY;
     default:
         return CHIP_ERROR_INTERNAL;
 

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -49,13 +49,13 @@ CHIP_ERROR TizenWiFiDriver::Init(BaseDriver::NetworkStatusChangeCallback * netwo
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
-    if (err == CHIP_ERROR_NOT_FOUND)
+    if (err == CHIP_ERROR_NOT_FOUND || err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiSSIDKeyName, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid), &ssidLen);
-    if (err == CHIP_ERROR_NOT_FOUND)
+    if (err == CHIP_ERROR_NOT_FOUND || err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -49,13 +49,13 @@ CHIP_ERROR TizenWiFiDriver::Init(BaseDriver::NetworkStatusChangeCallback * netwo
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
                                                    sizeof(mSavedNetwork.credentials), &credentialsLen);
-    if (err == CHIP_ERROR_NOT_FOUND || err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiSSIDKeyName, mSavedNetwork.ssid, sizeof(mSavedNetwork.ssid), &ssidLen);
-    if (err == CHIP_ERROR_NOT_FOUND || err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
#### Summary

This PR fixes ble-wifi commissioning on Tizen due to changes in the error code being returned when a persistent storage key does not exist.

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/39634

#### Testing

Successful ble-wifi commissioning was performed with Tizen 8.0 running on `Raspberry Pi 4 Model B Rev 1.5`. The examples tested were:

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
