### PR TITLE
Log information about the Certification Declaration during device attestation verification.

### DIFF
--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -733,7 +733,8 @@ AttestationVerificationResult DefaultDACVerifier::ValidateCertificateDeclaration
     {
         ChipLogProgress(NotSpecified, "Device certification declaration details:");
         ChipLogProgress(NotSpecified, "--> VID: 0x%04X", cdContent.vendorId);
-        // TODO: Figure out how to log the product_id_array, which is not in cdContent.
+        // TODO (https://github.com/project-chip/connectedhomeip/issues/39714): Figure out how to
+        // log the product_id_array, which is not in cdContent.
         ChipLogProgress(NotSpecified, "--> Device type ID: " ChipLogFormatMEI, ChipLogValueMEI(cdContent.deviceTypeId));
         ChipLogProgress(NotSpecified, "--> Certification type: %d (%s)", cdContent.certificationType,
                         CertificationTypeAsString(static_cast<CertificationType>(cdContent.certificationType)));

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -409,6 +409,24 @@ void LogCertDebugData(AttestationChainElement element, ByteSpan derBuffer)
     LogOneKeyId(KeyIdType::kAuthorityKeyId, element, derBuffer);
 }
 
+#if CHIP_PROGRESS_LOGGING
+const char * CertificationTypeAsString(CertificationType certificationType)
+{
+    switch (certificationType)
+    {
+    case CertificationType::kDevelopmentAndTest:
+        return "Development and testing";
+    case CertificationType::kProvisional:
+        return "Provisional certification";
+    case CertificationType::kOfficial:
+        return "Certified device";
+    default:
+        break;
+    }
+    return "<UNKNOWN>";
+}
+#endif
+
 } // namespace
 
 void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVerifier::AttestationInfo & info,
@@ -601,10 +619,25 @@ AttestationVerificationResult DefaultDACVerifier::ValidateCertificationDeclarati
     CHIP_ERROR err = mCdKeysTrustStore.LookupVerifyingKey(kid, verifyingKey);
     VerifyOrReturnError(err == CHIP_NO_ERROR, AttestationVerificationResult::kCertificationDeclarationNoCertificateFound);
 
-    // Disallow test key if support not enabled
-    if (mCdKeysTrustStore.IsCdTestKey(kid) && !IsCdTestKeySupported())
+#if CHIP_PROGRESS_LOGGING
+    if (AreVerboseLogsEnabled())
     {
-        return AttestationVerificationResult::kCertificationDeclarationNoCertificateFound;
+        KeyIdStringifier cdAkidWriter;
+        const char * cdAkidHexString = cdAkidWriter.KeyIdToHex(kid);
+        ChipLogProgress(NotSpecified, "CD signing key identifier: %s", cdAkidHexString);
+    }
+#endif
+
+    if (mCdKeysTrustStore.IsCdTestKey(kid))
+    {
+        // Disallow test key if support not enabled
+        if (!IsCdTestKeySupported())
+        {
+            ChipLogError(NotSpecified, "Disallowing CD signed by test key");
+            return AttestationVerificationResult::kCertificationDeclarationNoCertificateFound;
+        }
+
+        ChipLogProgress(NotSpecified, "Allowing CD signed by test key");
     }
 
     VerifyOrReturnError(CMS_Verify(cmsEnvelopeBuffer, verifyingKey, certDeclBuffer) == CHIP_NO_ERROR,
@@ -694,6 +727,21 @@ AttestationVerificationResult DefaultDACVerifier::ValidateCertificateDeclaration
         // in the Certification Declaration.
         VerifyOrReturnError(cdElementsDecoder.HasAuthorizedPAA(certDeclBuffer, ByteSpan(deviceInfo.paaSKID)),
                             AttestationVerificationResult::kCertificationDeclarationInvalidPAA);
+    }
+
+    if (AreVerboseLogsEnabled())
+    {
+        ChipLogProgress(NotSpecified, "Device certification declaration details:");
+        ChipLogProgress(NotSpecified, "--> VID: 0x%04X", cdContent.vendorId);
+        // TODO: Figure out how to log the product_id_array, which is not in cdContent.
+        ChipLogProgress(NotSpecified, "--> Device type ID: " ChipLogFormatMEI, ChipLogValueMEI(cdContent.deviceTypeId));
+        ChipLogProgress(NotSpecified, "--> Certification type: %d (%s)", cdContent.certificationType,
+                        CertificationTypeAsString(static_cast<CertificationType>(cdContent.certificationType)));
+        if (cdContent.dacOriginVIDandPIDPresent)
+        {
+            ChipLogProgress(NotSpecified, "--> DAC origin VID: 0x%04X, PID: 0x%04X", cdContent.dacOriginVendorId,
+                            cdContent.dacOriginProductId);
+        }
     }
 
     return AttestationVerificationResult::kSuccess;


### PR DESCRIPTION
#### Summary

Logs some of the CD fields and the key id of the signing key.

#### Testing

Manually observed the logs during commissioning.

