### PR TITLE
Increase unit test code coverage of `ble/` by 1.3%

### DIFF
--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -628,10 +628,11 @@ TEST_F(TestBtpEngine, NewestUnackedSentSequenceNumberSend)
 {
     // Create a 1-byte packet and fill it with data.
     auto packet0 = System::PacketBufferHandle::New(10);
+    ASSERT_FALSE(packet0.IsNull());
     packet0->SetDataLength(1);
     auto * data0 = packet0->Start();
     ASSERT_NE(data0, nullptr);
-    std::iota(data0, data0 + 1, 0);
+    data0[0] = 0;
 
     // Send the packet and check that the newest unacked sent sequence number is 0.
     EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), false));

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -612,4 +612,55 @@ TEST_F(TestBtpEngine, IsValidAckOnSequenceWraparound)
     EXPECT_EQ(receivedAck, invalidAckValue);
 }
 
+// Test that the initial sequence numbers are set correctly when the BtpEngine is initialized.
+TEST_F(TestBtpEngine, InitialSequenceNumbers)
+{
+    // inline function completely omitted from the LCOV report, no function symbols are generated.
+    EXPECT_EQ(mBtpEngine.GetLastReceivedSequenceNumber(), 0);
+    // inline function appears in the LCOV report as uncovered (red), even though is actually covered/executed in the test cases,
+    // function symbols are generated.
+    EXPECT_EQ(mBtpEngine.GetNewestUnackedSentSequenceNumber(), 0);
+}
+
+// Test that sending a packet updates the unacknowledged sequence number correctly,
+// and that receiving an acknowledgment updates the state as expected.
+TEST_F(TestBtpEngine, NewestUnackedSentSequenceNumberSend)
+{
+    // Create a 1-byte packet and fill it with data.
+    auto packet0 = System::PacketBufferHandle::New(10);
+    packet0->SetDataLength(1);
+    auto * data0 = packet0->Start();
+    ASSERT_NE(data0, nullptr);
+    std::iota(data0, data0 + 1, 0);
+
+    // Send the packet and check that the newest unacked sent sequence number is 0.
+    EXPECT_TRUE(mBtpEngine.HandleCharacteristicSend(packet0.Retain(), false));
+    EXPECT_EQ(mBtpEngine.GetNewestUnackedSentSequenceNumber(), 0);
+
+    // Confirm that there is unacknowledged data.
+    EXPECT_TRUE(mBtpEngine.ExpectingAck());
+
+    // Prepare an acknowledgment packet for sequence number 0.
+    uint8_t ackData[] = {
+        to_underlying(BtpEngine::HeaderFlags::kFragmentAck),
+        0x00,
+        0x01,
+    };
+
+    auto ackPacket = System::PacketBufferHandle::NewWithData(ackData, sizeof(ackData));
+
+    SequenceNumber_t seqNum;
+    bool didRecieveAck;
+
+    // Handle the acknowledgment and verify the result.
+    EXPECT_EQ(mBtpEngine.HandleCharacteristicReceived(std::move(ackPacket), seqNum, didRecieveAck), CHIP_NO_ERROR);
+    EXPECT_TRUE(didRecieveAck);
+    EXPECT_EQ(seqNum, 0);
+
+    // After acknowledgment, we are no longer expecting an ack
+    EXPECT_FALSE(mBtpEngine.ExpectingAck());
+    // After acknowledgment, the newest unacked sent sequence number should still be 0 (no new sends).
+    EXPECT_EQ(mBtpEngine.GetNewestUnackedSentSequenceNumber(), 0);
+}
+
 } // namespace


### PR DESCRIPTION
#### Summary

This PR adds three new test cases to `TestBtpEngine.cpp` to improve coverage of the `BtpEngine`’s sequence number and acknowledgment handling. These tests verify the initial state of sequence numbers and the correct update of state after sending and acknowledging packets.


1. `LastReceivedSequenceNumberInitial` verifies that the initial value of the last received sequence number is zero when the BtpEngine is initialized.

2. `NewestUnackedSentSequenceNumberInitial` ensures that the newest unacknowledged sent sequence number is zero at initialization.

3. `NewestUnackedSentSequenceNumberSend` tests the update of the unacknowledged sent sequence number after sending a packet and receiving an acknowledgment.

#### Related issues

Main issue N [37232](https://github.com/project-chip/connectedhomeip/issues/37232)

#### Testing

This PR only adds new unit tests. No changes made to production code.

#### Coverage Impact  of `BtpEngine.cpp`

| Metric                | Before     | After     |
|-----------------------|------------|-----------|
| Line Coverage      | 81.2% (182/224) | 87.9% (197/224)|
| Function Coverage     | 80.0% (12/15) | 93.3% (14/15)  |
| `/ble` folder | 67.2% (760/1131)                |68.5%(775/1131)|	

**Note:** The test cases in this PR target inline functions, which I verified that LCOV correctly identifies and generates symbols for.
Nevertheless, LCOV doesn't seem to be very good at attributing line coverage back to their original definitions for inlined functions (probably when the functions are trivial and the compiler optimizes more aggressively).
As a result:
- Some inline functions appear in the LCOV report as uncovered (red), even though they _are_ actually covered in the test cases (false negative).
- Some inline functions are completely omitted from the LCOV report (no color - i.e. it doesn't recognize them as functions to be covered), no function symbols are generated.
- The tests increased the coverage of `BtpEngine.cpp` instead of `BtpEngine.h` where those inline functions are defined. 