### PR TITLE
[TC-SOIL-2.2] Mandate specific simulated values when running on CI

### DIFF
--- a/src/python_testing/TC_SOIL_2_2.py
+++ b/src/python_testing/TC_SOIL_2_2.py
@@ -35,7 +35,6 @@
 # === END CI TEST ARGUMENTS ===
 
 import logging
-from random import randrange
 
 import chip.clusters as Clusters
 from chip.clusters.Types import NullValue

--- a/src/python_testing/TC_SOIL_2_2.py
+++ b/src/python_testing/TC_SOIL_2_2.py
@@ -96,6 +96,12 @@ class TC_SOIL_2_2(MatterBaseTest):
         if self.is_pics_sdk_ci_only:
             # Simulate a change in soil moisture. Pick a random value between min_bound and max_bound
             irand = randrange(min_bound, max_bound)
+
+            while irand == measurement:
+                # In the case it picks the same value as is currently is the measurement,
+                # continue to pick until that is not the case
+                irand = randrange(min_bound, max_bound)
+
             logging.info(f"Simulated soil moisture value: {irand}")
             self.write_to_app_pipe({"Name": "SetSimulatedSoilMoisture", "SoilMoistureValue": irand, "EndpointId": endpoint})
 

--- a/src/python_testing/TC_SOIL_2_2.py
+++ b/src/python_testing/TC_SOIL_2_2.py
@@ -81,10 +81,9 @@ class TC_SOIL_2_2(MatterBaseTest):
         max_bound = soil_moisture_limits.maxMeasuredValue
 
         if self.is_pics_sdk_ci_only:
-            # Set the initial soil moisture, since it inits as null. Pick a random value between min_bound and max_bound
-            irand = randrange(min_bound, max_bound)
-            logging.info(f"Simulated soil moisture value: {irand}")
-            self.write_to_app_pipe({"Name": "SetSimulatedSoilMoisture", "SoilMoistureValue": irand, "EndpointId": endpoint})
+            # Set the initial soil moisture to the min_bound value, since it inits as null.
+            logging.info(f"Simulated soil moisture value: {min_bound}")
+            self.write_to_app_pipe({"Name": "SetSimulatedSoilMoisture", "SoilMoistureValue": min_bound, "EndpointId": endpoint})
 
         self.step(3)
         measurement = await self.read_soil_attribute_expect_success(endpoint=endpoint, attribute=attributes.SoilMoistureMeasuredValue)
@@ -94,16 +93,9 @@ class TC_SOIL_2_2(MatterBaseTest):
 
         self.step(4)
         if self.is_pics_sdk_ci_only:
-            # Simulate a change in soil moisture. Pick a random value between min_bound and max_bound
-            irand = randrange(min_bound, max_bound)
-
-            while irand == measurement:
-                # In the case it picks the same value as is currently is the measurement,
-                # continue to pick until that is not the case
-                irand = randrange(min_bound, max_bound)
-
-            logging.info(f"Simulated soil moisture value: {irand}")
-            self.write_to_app_pipe({"Name": "SetSimulatedSoilMoisture", "SoilMoistureValue": irand, "EndpointId": endpoint})
+            # Simulate a change in soil moisture, changing to max_bound.
+            logging.info(f"Simulated soil moisture value: {max_bound}")
+            self.write_to_app_pipe({"Name": "SetSimulatedSoilMoisture", "SoilMoistureValue": max_bound, "EndpointId": endpoint})
 
         else:
             self.wait_for_user_input(


### PR DESCRIPTION
This PR changes the CI runs to use min and max values, ensuring these are different when doing the validation of the values.

Fixes #39712

#### Testing

Successful CI pass.