### PR TITLE
[NXP][zap][thermostat] update device versions and cluster revisions

### DIFF
--- a/examples/thermostat/nxp/zap/thermostat_matter_br.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_br.matter
@@ -2413,7 +2413,6 @@ endpoint 0 {
     handle command ScanNetworks;
     handle command ScanNetworksResponse;
     handle command AddOrUpdateWiFiNetwork;
-    handle command AddOrUpdateThreadNetwork;
     handle command RemoveNetwork;
     handle command NetworkConfigResponse;
     handle command ConnectNetwork;
@@ -2555,7 +2554,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_thermostat = 769, version 1;
+  device type ma_thermostat = 769, version 4;
 
 
   server cluster Identify {
@@ -2627,13 +2626,13 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x3;
-    ram      attribute clusterRevision default = 8;
+    ram      attribute clusterRevision default = 9;
 
     handle command SetpointRaiseLower;
   }
 }
 endpoint 2 {
-  device type ma_thread_border_router = 145, version 1;
+  device type ma_thread_border_router = 145, version 2;
   device type ma_secondary_network_interface = 25, version 1;
 
 

--- a/examples/thermostat/nxp/zap/thermostat_matter_br.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_br.zap
@@ -1241,14 +1241,6 @@
               "isEnabled": 1
             },
             {
-              "name": "AddOrUpdateThreadNetwork",
-              "code": 3,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
               "name": "RemoveNetwork",
               "code": 4,
               "mfgCode": null,
@@ -3030,7 +3022,7 @@
         }
       ],
       "deviceVersions": [
-        1
+        4
       ],
       "deviceIdentifiers": [
         769
@@ -3879,7 +3871,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "8",
+              "defaultValue": "9",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -3917,7 +3909,7 @@
       ],
       "deviceVersions": [
         1,
-        1
+        2
       ],
       "deviceIdentifiers": [
         25,

--- a/examples/thermostat/nxp/zap/thermostat_matter_eth.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_eth.matter
@@ -2033,7 +2033,7 @@ cluster Thermostat = 513 {
 }
 
 endpoint 0 {
-  device type ma_rootdevice = 22, version 1;
+  device type ma_rootdevice = 22, version 3;
   device type ma_otarequestor = 18, version 1;
 
   binding cluster OtaSoftwareUpdateProvider;
@@ -2245,7 +2245,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_thermostat = 769, version 1;
+  device type ma_thermostat = 769, version 4;
 
 
   server cluster Identify {
@@ -2323,7 +2323,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x3;
-    ram      attribute clusterRevision default = 8;
+    ram      attribute clusterRevision default = 9;
 
     handle command SetpointRaiseLower;
   }

--- a/examples/thermostat/nxp/zap/thermostat_matter_eth.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_eth.zap
@@ -62,7 +62,7 @@
       ],
       "deviceVersions": [
         1,
-        1
+        3
       ],
       "deviceIdentifiers": [
         18,
@@ -2553,7 +2553,7 @@
         }
       ],
       "deviceVersions": [
-        1
+        4
       ],
       "deviceIdentifiers": [
         769
@@ -3460,7 +3460,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "8",
+              "defaultValue": "9",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.matter
@@ -2482,7 +2482,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_thermostat = 769, version 1;
+  device type ma_thermostat = 769, version 4;
 
 
   server cluster Identify {
@@ -2554,7 +2554,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x3;
-    ram      attribute clusterRevision default = 8;
+    ram      attribute clusterRevision default = 9;
 
     handle command SetpointRaiseLower;
   }

--- a/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_thread.zap
@@ -3783,7 +3783,7 @@
         }
       ],
       "deviceVersions": [
-        1
+        4
       ],
       "deviceIdentifiers": [
         769
@@ -4632,7 +4632,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "8",
+              "defaultValue": "9",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.matter
@@ -2203,7 +2203,6 @@ endpoint 0 {
     handle command ScanNetworks;
     handle command ScanNetworksResponse;
     handle command AddOrUpdateWiFiNetwork;
-    handle command AddOrUpdateThreadNetwork;
     handle command RemoveNetwork;
     handle command NetworkConfigResponse;
     handle command ConnectNetwork;
@@ -2345,7 +2344,7 @@ endpoint 0 {
   }
 }
 endpoint 1 {
-  device type ma_thermostat = 769, version 1;
+  device type ma_thermostat = 769, version 4;
 
 
   server cluster Identify {
@@ -2417,7 +2416,7 @@ endpoint 1 {
     callback attribute acceptedCommandList;
     callback attribute attributeList;
     ram      attribute featureMap default = 0x3;
-    ram      attribute clusterRevision default = 8;
+    ram      attribute clusterRevision default = 9;
 
     handle command SetpointRaiseLower;
   }

--- a/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
+++ b/examples/thermostat/nxp/zap/thermostat_matter_wifi.zap
@@ -1241,14 +1241,6 @@
               "isEnabled": 1
             },
             {
-              "name": "AddOrUpdateThreadNetwork",
-              "code": 3,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
               "name": "RemoveNetwork",
               "code": 4,
               "mfgCode": null,
@@ -3030,7 +3022,7 @@
         }
       ],
       "deviceVersions": [
-        1
+        4
       ],
       "deviceIdentifiers": [
         769
@@ -3879,7 +3871,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "8",
+              "defaultValue": "9",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,


### PR DESCRIPTION

#### Summary

Update device versions and cluster revisions to align with matter 1.4.2.
Remove unnecessary 'AddOrUpdateThreadNetwork' command in Network Commissioning cluster for Wi-Fi transport ZAP file. 


#### Testing

TC-IDM-10.3/10.4/10.6 passed at matter 1.4.2 SVE


