### PR TITLE
[QPG] fix OTA by adding the "xp400x" option while generating OTA

### DIFF
--- a/third_party/qpg_sdk/qpg_executable.gni
+++ b/third_party/qpg_sdk/qpg_executable.gni
@@ -165,6 +165,7 @@ template("qpg_executable") {
           rebase_path(qpg_sdk_root, root_build_dir) +
               "/Tools/Binaries/se_firmware_release_xp4002_seuc_upgrade.hex",
         ]
+        ota_header_options += [ "--xp400x" ]
       }
 
       # Use build-time overrules in OTA header creation


### PR DESCRIPTION
#### Summary
- This fixes OTA image generation for QPG platform apps
#### Related issues

N/A

#### Testing
- Current OTA upgrade will trigger a `Header signature verify fail: 6` with `Error CHIP:0x00000013`
- Performing OTA manually on QPG apps to ensure OTA is successfully executed

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
