### PR TITLE
Fix reading ExtendedAddress from otbr-agent

### DIFF
--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -568,7 +568,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
         if (response == nullptr)
         {
             ChipLogError(DeviceLayer, "openthread: failed to get a response for ExtendedAddress property");
-            return CHIP_ERROR_INTERNAL;
+            return CHIP_ERROR_KEY_NOT_FOUND;
         }
 
         GAutoPtr<GVariant> tupleContent(g_variant_get_child_value(response.get(), 0));
@@ -576,7 +576,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
         if (tupleContent == nullptr)
         {
             ChipLogError(DeviceLayer, "openthread: failed to find tuple in ExtendedAddress response");
-            return CHIP_ERROR_INTERNAL;
+            return CHIP_ERROR_KEY_NOT_FOUND;
         }
 
         GAutoPtr<GVariant> value(g_variant_get_variant(tupleContent.get()));
@@ -584,7 +584,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
         if (value == nullptr)
         {
             ChipLogError(DeviceLayer, "openthread: failed to find tuple value in ExtendedAddress response");
-            return CHIP_ERROR_INTERNAL;
+            return CHIP_ERROR_KEY_NOT_FOUND;
         }
 
         if (g_variant_is_of_type(value.get(), G_VARIANT_TYPE_UINT64))
@@ -600,6 +600,7 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
         {
             ChipLogError(DeviceLayer, "ERROR: Property 'ExtendedAddress' returned unexpected type: %s",
                     g_variant_get_type_string(value.get()));
+            return CHIP_ERROR_KEY_NOT_FOUND;
         }
      }
 

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -545,15 +545,14 @@ CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyFull()
 
 CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
 {
-     VerifyOrReturnError(mProxy, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mProxy, CHIP_ERROR_INCORRECT_STATE);
 
     // The ExtendedAddress d-bus property from otbr-agent is defined to not emit changed signals.
     // This means the generated api, which uses a caching proxy underneath, will not obtain a value
     // and will always return NULL. In order to retrieve the value in this case, we must directly
     // call the Get function to get it, then we manually cache locally since it does not change.
-    if (std::all_of(mExtendedAddress, mExtendedAddress + sizeof(mExtendedAddress),
-                     [](uint8_t v) { return v == 0; }))
-     {
+    if (std::all_of(mExtendedAddress, mExtendedAddress + sizeof(mExtendedAddress), [](uint8_t v) { return v == 0; }))
+    {
         GAutoPtr<GError> err;
         GAutoPtr<GVariant> response(g_dbus_proxy_call_sync(G_DBUS_PROXY(mProxy.get()), "org.freedesktop.DBus.Properties.Get",
                                                            g_variant_new("(ss)", "io.openthread.BorderRouter", "ExtendedAddress"),
@@ -599,10 +598,10 @@ CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
         else
         {
             ChipLogError(DeviceLayer, "ERROR: Property 'ExtendedAddress' returned unexpected type: %s",
-                    g_variant_get_type_string(value.get()));
+                         g_variant_get_type_string(value.get()));
             return CHIP_ERROR_KEY_NOT_FOUND;
         }
-     }
+    }
 
     memcpy(buf, mExtendedAddress, sizeof(mExtendedAddress));
     return CHIP_NO_ERROR;

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -165,6 +165,7 @@ private:
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
 
     bool mAttached;
+    uint8_t mExtendedAddress[8];
 };
 
 inline void ThreadStackManagerImpl::_OnThreadAttachFinished(void)

--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
@@ -75,7 +75,7 @@ the OpenThread integration with the Matter SDK.
       bool device_type        // ftd or mtd
       bool network_data       // full or stable
     -->
-    <property name="LinkMode" type="(bbb)" access="readwrite">
+    <property name="LinkMode" type="(bbb)" access="write">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
@@ -94,13 +94,6 @@ the OpenThread integration with the Matter SDK.
     </property>
 
     <!--
-    The 64-bit extended address.
-    -->
-    <property name="ExtendedAddress" type="t" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!--
     The list of current external route rules.
 
     The structure definition for a single route rule:
@@ -115,14 +108,14 @@ the OpenThread integration with the Matter SDK.
         bool next_hop_is_self
       }
     -->
-    <property name="ExternalRoutes" type="a((ayy)qybb)" access="read">
+    <property name="ExternalRoutes" type="a((ayy)qybb)" access="write">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
     <!--
     The Thread active dataset TLV in binary form.
     -->
-    <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
+    <property name="ActiveDatasetTlvs" type="ay" access="write">
       <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>

--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
@@ -68,18 +68,6 @@ the OpenThread integration with the Matter SDK.
     <method name="Reset" />
 
     <!--
-    The current link mode.
-
-    This property is a struct with the following fields:
-      bool rx_on_when_idle    // whether the radio receiving is on when idle
-      bool device_type        // ftd or mtd
-      bool network_data       // full or stable
-    -->
-    <property name="LinkMode" type="(bbb)" access="readwrite">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!--
     The current device role.
 
     Possible values are:
@@ -91,40 +79,6 @@ the OpenThread integration with the Matter SDK.
     -->
     <property name="DeviceRole" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
-    </property>
-
-    <!--
-    The 64-bit extended address.
-    -->
-    <property name="ExtendedAddress" type="t" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!--
-    The list of current external route rules.
-
-    The structure definition for a single route rule:
-      struct {
-        struct {
-          uint8[] prefix_bytes
-          uint8 prefix_length
-        }
-        uint16 rloc
-        uint8 preference
-        bool stable
-        bool next_hop_is_self
-      }
-    -->
-    <property name="ExternalRoutes" type="a((ayy)qybb)" access="read">
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
-    </property>
-
-    <!--
-    The Thread active dataset TLV in binary form.
-    -->
-    <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
-      <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
-      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
   </interface>

--- a/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
+++ b/src/platform/Linux/dbus/openthread/DBusOpenthread.xml
@@ -68,6 +68,18 @@ the OpenThread integration with the Matter SDK.
     <method name="Reset" />
 
     <!--
+    The current link mode.
+
+    This property is a struct with the following fields:
+      bool rx_on_when_idle    // whether the radio receiving is on when idle
+      bool device_type        // ftd or mtd
+      bool network_data       // full or stable
+    -->
+    <property name="LinkMode" type="(bbb)" access="readwrite">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
+    <!--
     The current device role.
 
     Possible values are:
@@ -79,6 +91,40 @@ the OpenThread integration with the Matter SDK.
     -->
     <property name="DeviceRole" type="s" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true"/>
+    </property>
+
+    <!--
+    The 64-bit extended address.
+    -->
+    <property name="ExtendedAddress" type="t" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
+    <!--
+    The list of current external route rules.
+
+    The structure definition for a single route rule:
+      struct {
+        struct {
+          uint8[] prefix_bytes
+          uint8 prefix_length
+        }
+        uint16 rloc
+        uint8 preference
+        bool stable
+        bool next_hop_is_self
+      }
+    -->
+    <property name="ExternalRoutes" type="a((ayy)qybb)" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    </property>
+
+    <!--
+    The Thread active dataset TLV in binary form.
+    -->
+    <property name="ActiveDatasetTlvs" type="ay" access="readwrite">
+      <annotation name="org.gtk.GDBus.C.ForceGVariant" value="true"/>
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
     </property>
 
   </interface>


### PR DESCRIPTION
#### Summary

The property is defined to not emit signals on changes, which means the generated caching proxy will never have a value. Instead, we must directly read the value with the Get function and cache it ourselves.

#### Related issues

Fixes: #39722

#### Testing

Build and run examples/lighting-app/linux example with the --thread option and with otbr-agent running.

Before the fix, output contains (note 0000000000000000.local):

[1750947235.348] [620813:620813] [DL] Using Thread extended MAC for hostname.
[1750947235.348] [620813:620813] [DIS] Advertise commission parameter vendorID=65521 productID=32769 discriminator=3840/15 cm=1 cp=0
[1750947235.348] [620813:620813] [DIS] Responding with _matterc._udp.local
[1750947235.348] [620813:620813] [DIS] Responding with 52A63BCD348800B8._matterc._udp.local
[1750947235.348] [620813:620813] [DIS] Responding with 0000000000000000.local

After the fix, output contains:

[1750949673.937] [490770:490770] [DL] Using Thread extended MAC for hostname.
[1750949673.937] [490770:490770] [DIS] Advertise commission parameter vendorID=65521 productID=32769 discriminator=3840/15 cm=1 cp=0
[1750949673.937] [490770:490770] [DIS] Responding with _matterc._udp.local
[1750949673.937] [490770:490770] [DIS] Responding with 43DA52909547070B._matterc._udp.local
[1750949673.937] [490770:490770] [DIS] Responding with 6A58CF8656C9F369.local

and

"ot-ctl extaddr" in the above example test returns:
6a58cf8656c9f369
Done