### PR TITLE
[nxp][common][contact-sensor] Use synchronized report scheduler

### DIFF
--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -110,6 +110,10 @@
 #define CONFIG_THREAD_DEVICE_TYPE kThreadDeviceType_Router
 #endif
 
+#if CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED
+#include <app/reporting/SynchronizedReportSchedulerImpl.h>
+#endif
+
 using namespace chip;
 using namespace chip::TLV;
 using namespace ::chip::Credentials;
@@ -167,6 +171,13 @@ void UnlockOpenThreadTask(void)
 void chip::NXP::App::AppTaskBase::InitServer(intptr_t arg)
 {
     GetAppTask().PreInitMatterServerInstance();
+
+#if CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED
+    // Report scheduler and timer delegate instance
+    static chip::app::DefaultTimerDelegate sTimerDelegate;
+    static chip::app::reporting::SynchronizedReportSchedulerImpl sReportScheduler(&sTimerDelegate);
+    initParams.reportScheduler = &sReportScheduler;
+#endif
 
 #if CONFIG_CHIP_TEST_EVENT && CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };


### PR DESCRIPTION
#### Summary
The use of the synchronous reports feature aims to reduce the number of times an ICD needs to wake up to emit reports to its various subscribers.

#### Testing
Manual testing using two subscriptions then checked that the reports are submitted at the same time.