### PR TITLE
DM XML parsing for device types: Add check that cluster ID exists

### DIFF
--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -341,6 +341,10 @@ def dump_ids_from_prebuilt_dirs():
             print(f"checking device type for {d.name} for {dir}")
             dt_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
                 [], 0, 0).decision == ConformanceDecision.MANDATORY]
+            print(dt_mandatory)
+            if any(c for c in dt_mandatory if c not in clusters.keys()):
+                print("found it")
+            return "C"
             provisional = [clusters[c].name for c in dt_mandatory if clusters[c].is_provisional]
             if provisional:
                 print(f"Found provisional mandatory clusters {provisional} in device type {d.name} for revision {dir.dirname}")

--- a/scripts/spec_xml/generate_spec_xml.py
+++ b/scripts/spec_xml/generate_spec_xml.py
@@ -341,10 +341,6 @@ def dump_ids_from_prebuilt_dirs():
             print(f"checking device type for {d.name} for {dir}")
             dt_mandatory = [id for id, requirement in d.server_clusters.items() if requirement.conformance(
                 [], 0, 0).decision == ConformanceDecision.MANDATORY]
-            print(dt_mandatory)
-            if any(c for c in dt_mandatory if c not in clusters.keys()):
-                print("found it")
-            return "C"
             provisional = [clusters[c].name for c in dt_mandatory if clusters[c].is_provisional]
             if provisional:
                 print(f"Found provisional mandatory clusters {provisional} in device type {d.name} for revision {dir.dirname}")

--- a/src/python_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/TestSpecParsingDeviceType.py
@@ -252,13 +252,21 @@ class TestSpecParsingDeviceType(MatterBaseTest):
         one_four_one, one_four_one_problems = build_xml_device_types(PrebuiltDataModelDirectory.k1_4_1)
         one_four_two, one_four_two_problems = build_xml_device_types(PrebuiltDataModelDirectory.k1_4_2)
 
+        for p in one_three_problems:
+            print(p)
         asserts.assert_equal(len(one_three_problems), 0, "Problems found when parsing 1.3 spec")
+        for p in one_four_problems:
+            print(p)
         asserts.assert_equal(len(one_four_problems), 0, "Problems found when parsing 1.4 spec")
+        for p in one_four_one_problems:
+            print(p)
         asserts.assert_equal(len(one_four_one_problems), 0, "Problems found when parsing 1.4.1 spec")
 
         # Current ballot has a bunch of problems related to IDs being allocated for closures and TBR. These should all
         # mention ID-TBD as the id, so let's pull those out for now and make sure there are no UNKNOWN problems.
         filtered_ballot_problems = [p for p in one_four_two_problems if 'ID-TBD' not in p.problem]
+        for p in one_four_two_problems:
+            print(p)
         asserts.assert_equal(len(filtered_ballot_problems), 0, "Problems found when parsing master spec")
 
         asserts.assert_greater(len(set(one_four_two.keys()) - set(one_three.keys())),

--- a/src/python_testing/TestSpecParsingDeviceType.py
+++ b/src/python_testing/TestSpecParsingDeviceType.py
@@ -264,10 +264,9 @@ class TestSpecParsingDeviceType(MatterBaseTest):
 
         # Current ballot has a bunch of problems related to IDs being allocated for closures and TBR. These should all
         # mention ID-TBD as the id, so let's pull those out for now and make sure there are no UNKNOWN problems.
-        filtered_ballot_problems = [p for p in one_four_two_problems if 'ID-TBD' not in p.problem]
         for p in one_four_two_problems:
             print(p)
-        asserts.assert_equal(len(filtered_ballot_problems), 0, "Problems found when parsing master spec")
+        asserts.assert_equal(len(one_four_two_problems), 0, "Problems found when parsing master spec")
 
         asserts.assert_greater(len(set(one_four_two.keys()) - set(one_three.keys())),
                                0, "Master dir does not contain any device types not in 1.3")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/spec_parsing.py
@@ -30,8 +30,9 @@ from typing import Callable, Optional, Union
 import chip.clusters as Clusters
 import chip.testing.conformance as conformance_support
 from chip.testing.conformance import (OPTIONAL_CONFORM, TOP_LEVEL_CONFORMANCE_TAGS, ConformanceDecisionWithChoice,
-                                      ConformanceException, ConformanceParseParameters, conformance_allowed, feature, is_disallowed, mandatory, optional,
-                                      or_operation, parse_callable_from_xml, parse_device_type_callable_from_xml)
+                                      ConformanceException, ConformanceParseParameters, conformance_allowed, feature, is_disallowed,
+                                      mandatory, optional, or_operation, parse_callable_from_xml,
+                                      parse_device_type_callable_from_xml)
 from chip.testing.global_attribute_ids import GlobalAttributeIds
 from chip.testing.matter_testing import (AttributePathLocation, ClusterPathLocation, CommandPathLocation, DeviceTypePathLocation,
                                          EventPathLocation, FeaturePathLocation, ProblemLocation, ProblemNotice, ProblemSeverity)


### PR DESCRIPTION
#### Summary
Adds a check that cluster IDs provided in the device library exist. Note that this cannot go in until the spec is updated because the current version of the spec has a device type that uses a cluster that does't exist.

#### Related issues
None - found during 1.2 update, no issue opened, just the fix.

#### Testing
Tested by unit tests in TestSpecParsingDeviceType. Note that this test is currently (correctly) failing due to this real error in the spec.