### PR TITLE
Fix one more path added to objdir-clone in tests.yaml for linux repl tests.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -708,7 +708,7 @@ jobs:
                   mkdir -p out/trace_data
                   scripts/run_in_python_env.sh out/venv 'scripts/tests/run_python_test.py --load-from-env /tmp/test_env.yaml --script src/controller/python/test/test_scripts/mobile-device-test.py'
                   scripts/run_in_python_env.sh out/venv 'src/python_testing/execute_python_tests.py --env-file /tmp/test_env.yaml --search-directory src/python_testing'
-                  scripts/run_in_python_env.sh out/venv "scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py --all-clusters out/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test/chip-all-clusters-app"
+                  scripts/run_in_python_env.sh out/venv "scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py --all-clusters objdir-clone/linux-x64-all-clusters-${BUILD_VARIANT}-tsan-clang-test/chip-all-clusters-app"
 
             - name: Execute Jupyter Notebooks
               run: |

--- a/scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py
+++ b/scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py
@@ -26,7 +26,7 @@ DEFAULT_CHIP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'
 
 DEFAULT_ALL_CLUSTERS = os.path.join(
     DEFAULT_CHIP_ROOT,
-    'objdir-clone',
+    'out',
     'linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test',
     'chip-all-clusters-app')
 DEFAULT_TEST_RUNNER = os.path.join(DEFAULT_CHIP_ROOT, 'scripts', 'tests', 'run_python_test.py')

--- a/scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py
+++ b/scripts/tests/TestTimeSyncTrustedTimeSourceRunner.py
@@ -26,7 +26,7 @@ DEFAULT_CHIP_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'
 
 DEFAULT_ALL_CLUSTERS = os.path.join(
     DEFAULT_CHIP_ROOT,
-    'out',
+    'objdir-clone',
     'linux-x64-all-clusters-ipv6only-no-ble-no-wifi-tsan-clang-test',
     'chip-all-clusters-app')
 DEFAULT_TEST_RUNNER = os.path.join(DEFAULT_CHIP_ROOT, 'scripts', 'tests', 'run_python_test.py')


### PR DESCRIPTION
#### Summary

Edit one more passed-in path for objdir-clone.

#### Testing

This is a hotfix to unblock CI.