### PR TITLE
Create a Python wheel with tests needed for the Interoperability Debugging Tool (IDT)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -129,6 +129,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/scripts/py_matter_yamltests:matter-yamltests.wheel",
         "${chip_root}/src/controller/python:chip-repl",
         "${chip_root}/src/python_testing/matter_testing_infrastructure:chip-testing.wheel",
+        "${chip_root}/src/python_testing/post_certification_tests:matter-post-certification-tests.wheel",
       ]
     }
   }

--- a/src/python_testing/post_certification_tests/BUILD.gn
+++ b/src/python_testing/post_certification_tests/BUILD.gn
@@ -25,14 +25,20 @@ idt_files = [
 
 credentials_files = [ "${chip_root}/credentials/fetch_paa_certs_from_dcl.py" ]
 
+_version = "1.4.2"
+
 pw_python_package("post-certification-tests-module") {
   generate_setup = {
     metadata = {
       name = "post-certification-tests-module"
-      version = "1.4.2"
+      version = _version
     }
   }
 
+  # NOTE: production_device_checks.py is included here because `sources` is
+  # a mandatory parameter. It is also included in `extra_files` to place it
+  # in the correct directory in the final wheel. This duplication is a known
+  # issue due to build system limitations.
   sources = [ "production_device_checks.py" ]
 }
 
@@ -41,7 +47,7 @@ pw_python_distribution("matter-post-certification-tests") {
 
   generate_setup_cfg = {
     name = "matter-post-certification-tests"
-    version = "1.4.2"
+    version = _version
     include_default_pyproject_file = true
     include_extra_files_in_package_data = true
   }

--- a/src/python_testing/post_certification_tests/BUILD.gn
+++ b/src/python_testing/post_certification_tests/BUILD.gn
@@ -1,0 +1,61 @@
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("//build_overrides/pigweed.gni")
+import("$dir_pw_build/python_dist.gni")
+
+idt_files = [
+  "${chip_root}/src/python_testing/post_certification_tests/production_device_checks.py",
+  "${chip_root}/src/python_testing/TC_DA_1_2.py",
+  "${chip_root}/src/python_testing/TC_DA_1_7.py",
+]
+
+credentials_files = [ "${chip_root}/credentials/fetch_paa_certs_from_dcl.py" ]
+
+pw_python_package("post-certification-tests-module") {
+  generate_setup = {
+    metadata = {
+      name = "post-certification-tests-module"
+      version = "1.4.2"
+      author = "Project CHIP Authors"
+      license_expression = "Apache-2.0"  # Consistent license format
+      url = "https://github.com/project-chip/connectedhomeip"
+    }
+  }
+
+  sources = [ "production_device_checks.py" ]
+}
+
+pw_python_distribution("matter-post-certification-tests") {
+  packages = [ ":post-certification-tests-module" ]
+
+  generate_setup_cfg = {
+    name = "matter-post-certification-tests"
+    version = "1.4.2"
+    include_default_pyproject_file = true
+    include_extra_files_in_package_data = true
+  }
+
+  extra_files = []
+
+  foreach(file, idt_files) {
+    extra_files +=
+        [ "${file} > chip/testing/idt/" + get_path_info(file, "file") ]
+  }
+  foreach(file, credentials_files) {
+    extra_files += [ "${file} > credentials/" + get_path_info(file, "file") ]
+  }
+}

--- a/src/python_testing/post_certification_tests/BUILD.gn
+++ b/src/python_testing/post_certification_tests/BUILD.gn
@@ -30,9 +30,6 @@ pw_python_package("post-certification-tests-module") {
     metadata = {
       name = "post-certification-tests-module"
       version = "1.4.2"
-      author = "Project CHIP Authors"
-      license_expression = "Apache-2.0"  # Consistent license format
-      url = "https://github.com/project-chip/connectedhomeip"
     }
   }
 


### PR DESCRIPTION
This PR creates a Python wheel with files needed for the Interoperability Debug Tool (IDT). 
We need to pickup files from different places of the project (using `extra_files`), not only from one package. We need to maintain the same relative structure of the exported files. 

This PR is created as an alternative solution proposed in https://github.com/project-chip/connectedhomeip/pull/39554 

The disadvantage of this approach is that we export the `production_device_checks.py` twice (as a source and then as an extra file). This may lead to situation that the users of this Python wheel will uncertain which exactly file they need to import. 

The `source` parameter is mandatory in the `pw_python_package` target. If it is empty it leads to error:

```
ERROR at //third_party/pigweed/repo/pw_build/mirror_tree.gni:43:11 (//third_party/pigweed/repo/pw_build/python_toolchain:python): Assignment had no effect.
  _deps = []
          ^
You set the variable "_deps" here and it was unused before it went
out of scope.
```

#### Related issues
Fixes: https://github.com/project-chip/matter-test-scripts/issues/559

#### Testing 
Building Python wheel manually using `build_python.sh` and verifying manually that all necessary files are included.