### PR TITLE
[Darwin] Simplify Darwin timer code a bit.

### DIFF
--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -362,7 +362,6 @@ class LayerDispatch :
 {
 public:
     virtual void SetDispatchQueue(dispatch_queue_t dispatchQueue)  = 0;
-    virtual dispatch_queue_t GetDispatchQueue()                    = 0;
     virtual void HandleDispatchQueueEvents(Clock::Timeout timeout) = 0;
 
     /**

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -90,10 +90,7 @@ private:
     Clock::Timestamp mAwakenTime;
     Callback mCallback;
 
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    friend class LayerImplDispatch;
-    dispatch_source_t mTimerSource = nullptr;
-#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
     friend class LayerImplSelect;
     struct ev_timer mLibEvTimer;
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH


### PR DESCRIPTION
#### Summary

Disentangle the Darwin timer code using dispatch queues from the generic timer code. We won't be creating a `TimerPool` and `TimerList`, but simply hold a vector of `dispatch_source_t`s. Every `dispatch_source_t` has a struct as its context that holds data about the timer (expiry time, callback and callback context).

For builds with `CONFIG_BUILD_FOR_HOST_UNIT_TEST` defined, we will still use the `TimerPool` and `TimerList` in case there is no main dispatch queue available.

#### Testing

Ran all the Darwin-specific tests locally.
