### PR TITLE
[NXP][platform][common] Fix wifi commissioning issue due to none register cluster

### DIFF
--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -69,7 +69,9 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(DeviceLayer, "WiFi network SSID not retrieved from persisted storage: %" CHIP_ERROR_FORMAT, err.Format());
-        return err;
+        /* AP ssid has not been set. It's possible after factory-reset. 
+        Do not return an error as it will cancel the cluster registration */
+        return CHIP_NO_ERROR;
     }
 
     err = PersistedStorage::KeyValueStoreMgr().Get(kWiFiCredentialsKeyName, mSavedNetwork.credentials,
@@ -89,10 +91,10 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     mpConnectCallback      = nullptr;
     mpStatusChangeCallback = networkStatusChangeCallback;
 
-    // Connect to saved network
-    err = ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
+    // Try to connect to saved network
+    ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
 
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 void NXPWiFiDriver::Shutdown()

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(DeviceLayer, "WiFi network SSID not retrieved from persisted storage: %" CHIP_ERROR_FORMAT, err.Format());
-        /* AP ssid has not been set. It's possible after factory-reset. 
+        /* AP ssid has not been set. It's possible after factory-reset.
         Do not return an error as it will cancel the cluster registration */
         return CHIP_NO_ERROR;
     }

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -95,14 +95,10 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     mpConnectCallback      = nullptr;
     mpStatusChangeCallback = networkStatusChangeCallback;
 
-    // Try to connect to saved network
+    // Connect to saved network
     err = ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
-    }
 
-    return CHIP_NO_ERROR;
+    return err;
 }
 
 void NXPWiFiDriver::Shutdown()

--- a/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/nxp/common/NetworkCommissioningWiFiDriver.cpp
@@ -69,6 +69,10 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     if (err != CHIP_NO_ERROR)
     {
         ChipLogProgress(DeviceLayer, "WiFi network SSID not retrieved from persisted storage: %" CHIP_ERROR_FORMAT, err.Format());
+        if (err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        {
+            return err;
+        }
         /* AP ssid has not been set. It's possible after factory-reset.
         Do not return an error as it will cancel the cluster registration */
         return CHIP_NO_ERROR;
@@ -92,7 +96,11 @@ CHIP_ERROR NXPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     mpStatusChangeCallback = networkStatusChangeCallback;
 
     // Try to connect to saved network
-    ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
+    err = ConnectWiFiNetwork(mSavedNetwork.ssid, ssidLen, mSavedNetwork.credentials, credentialsLen);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
+    }
 
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
#### Summary

Fix NXP wifi commissioning issue.
Wifi commissioning failed when returning an error if ssid is not stored into file system. Since this [PR](https://github.com/project-chip/connectedhomeip/commit/55b5bf8693135d2bff83ff35981b28911e26b129) commissioning cluster is not registered if an error is return by driver init. 

#### Testing

Wifi commissioning is now passing using NXP frdm rw61x board

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
