### PR TITLE
[Silabs] Bugfix/fault log fix

### DIFF
--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -28,6 +28,13 @@
 #include <platform/DiagnosticDataProvider.h>
 #include <uart.h>
 
+// Macro to flush UART TX queue if enabled
+#if SILABS_LOG_OUT_UART
+#define SILABS_UART_FLUSH() uartFlushTxQueue()
+#else
+#define SILABS_UART_FLUSH() ((void) 0)
+#endif
+
 #if !defined(SLI_SI91X_MCU_INTERFACE) || !defined(SLI_SI91X_ENABLE_BLE)
 #include "rail_types.h"
 
@@ -94,10 +101,8 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
     char faultMessage[kMaxFaultStringLen] = { 0 };
     snprintf(faultMessage, sizeof faultMessage, "Assert failed: %s:%d", filename, linenumber);
     ChipLogError(NotSpecified, "%s", faultMessage);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
-#endif
+    SILABS_UART_FLUSH();
+#endif // SILABS_LOG_ENABLED
     configASSERT((volatile void *) NULL);
 }
 #endif
@@ -137,9 +142,7 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
     ChipLogError(NotSpecified, "LR          0x%08lx", lr);
     ChipLogError(NotSpecified, "PC          0x%08lx", pc);
     ChipLogError(NotSpecified, "PSR         0x%08lx", psr);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
 
     configASSERTNULL(NULL);
@@ -204,6 +207,7 @@ extern "C" void vApplicationMallocFailedHook(void)
     const char * faultMessage = "Failed to allocate memory on HEAP.";
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
@@ -223,9 +227,7 @@ extern "C" void vApplicationStackOverflowHook(TaskHandle_t pxTask, char * pcTask
     snprintf(faultMessage, sizeof faultMessage, "%s Task overflowed", pcTaskName);
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
@@ -307,9 +309,7 @@ extern "C" void RAILCb_AssertFailed(RAIL_Handle_t railHandle, uint32_t errorCode
 #else
     ChipLogError(NotSpecified, "%s", faultMessage);
 #endif // RAIL_ASSERT_DEBUG_STRING
-#if SILABS_LOG_OUT_UART
-    uartFlushTxQueue();
-#endif // SILABS_LOG_OUT_UART
+    SILABS_UART_FLUSH();
 #endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -165,10 +165,6 @@ extern "C" __attribute__((naked)) void LogFault_Handler(void)
 }
 
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
-extern "C" __attribute__((naked)) void NMI_Handler(void)
-{
-    __asm volatile("b LogFault_Handler");
-}
 extern "C" __attribute__((naked)) void HardFault_Handler(void)
 {
     __asm volatile("b LogFault_Handler");

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -86,8 +86,6 @@ void OnSoftwareFaultEventHandler(const char * faultRecordString)
 } // namespace DeviceLayer
 } // namespace chip
 
-<<<<<<< HEAD
-=======
 // This method is already implemented in the Zigbee stack and is required by the Zigbee
 #ifndef SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
@@ -104,7 +102,6 @@ extern "C" void halInternalAssertFailed(const char * filename, int linenumber)
 }
 #endif
 
->>>>>>> 87176944ed (Added a uart flush to force a uart output without relying on the yart task when we hit a fault, added handlers for faults other than hardfault to get logts)
 #if HARD_FAULT_LOG_ENABLE
 /**
  * Log register contents to UART when a hard fault occurs.
@@ -152,9 +149,8 @@ extern "C" __attribute__((used)) void debugHardfault(uint32_t * sp)
  * Log a fault to the debugHardfault function.
  * This function is called by the fault handlers to log the fault details.
  */
-<<<<<<< HEAD
-=======
-extern "C" void LogFault_Handler(void)
+
+extern "C" __attribute__((naked)) void LogFault_Handler(void)
 {
     uint32_t * sp;
     __asm volatile("tst lr, #4 \n"
@@ -170,7 +166,6 @@ extern "C" __attribute__((naked)) void NMI_Handler(void)
 {
     __asm volatile("b LogFault_Handler");
 }
->>>>>>> 87176944ed (Added a uart flush to force a uart output without relying on the yart task when we hit a fault, added handlers for faults other than hardfault to get logts)
 extern "C" __attribute__((naked)) void HardFault_Handler(void)
 {
     __asm volatile("b LogFault_Handler");

--- a/examples/platform/silabs/SoftwareFaultReports.cpp
+++ b/examples/platform/silabs/SoftwareFaultReports.cpp
@@ -192,6 +192,7 @@ extern "C" __attribute__((naked)) void DebugMon_Handler(void)
 {
     __asm volatile("b LogFault_Handler");
 }
+#endif // !SL_CATALOG_ZIGBEE_STACK_COMMON_PRESENT
 
 extern "C" void vApplicationMallocFailedHook(void)
 {
@@ -203,7 +204,7 @@ extern "C" void vApplicationMallocFailedHook(void)
     const char * faultMessage = "Failed to allocate memory on HEAP.";
 #if SILABS_LOG_ENABLED
     ChipLogError(NotSpecified, "%s", faultMessage);
-#endif
+#endif // SILABS_LOG_ENABLED
     Silabs::OnSoftwareFaultEventHandler(faultMessage);
 
     /* Force an assert. */

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -587,7 +587,7 @@ void uartSendBytes(UartTxStruct_t & bufferStruct)
 
 /**
  * @brief Flush the UART TX queue in a blocking manner.
- *   UART logs are non blocking, so we need to flush the queue here other wise the logs will not get logged in case of a hard
+ *   UART logs are non blocking, so we need to flush the queue here otherwise the logs will not get logged in case of a hard
  *   fault as they rely on the UART task to send the logs.
  */
 void uartFlushTxQueue(void)

--- a/examples/platform/silabs/uart.cpp
+++ b/examples/platform/silabs/uart.cpp
@@ -587,6 +587,8 @@ void uartSendBytes(UartTxStruct_t & bufferStruct)
 
 /**
  * @brief Flush the UART TX queue in a blocking manner.
+ *   UART logs are non blocking, so we need to flush the queue here other wise the logs will not get logged in case of a hard
+ *   fault as they rely on the UART task to send the logs.
  */
 void uartFlushTxQueue(void)
 {

--- a/src/platform/silabs/Logging.cpp
+++ b/src/platform/silabs/Logging.cpp
@@ -113,7 +113,7 @@ static size_t AddTimeStampAndPrefixStr(char * logBuffer, const char * prefix, si
 }
 
 /**
- * Print a log message to RTT
+ * Print a log message
  */
 static void PrintLog(const char * msg)
 {
@@ -144,7 +144,7 @@ static void PrintLog(const char * msg)
 #endif // SILABS_LOG_ENABLED
 
 /**
- * Initialize Segger RTT for logging
+ * Initialize logging
  */
 extern "C" void silabsInitLog(void)
 {


### PR DESCRIPTION
#### Summary
Added a uart flush to force a uart output without relying on the uart task when we hit a fault, added handlers for faults other than hardfault to get logs.

#### Testing
Simulated faults with a wrongly addressed pointer by dereferencing it, observed logs would be generated.