### PR TITLE
[Camera] Update TC_AVSM Test Cases for CI

### DIFF
--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1691,25 +1691,25 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
 
     VerifyOrReturn(commandData.videoCodec != VideoCodecEnum::kUnknownEnumValue, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid video codec", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError);
     });
 
     VerifyOrReturn(commandData.minFrameRate >= 1 && commandData.minFrameRate <= commandData.maxFrameRate &&
                        commandData.maxFrameRate >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.minResolution.width >= 1 && commandData.minResolution.height >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.maxResolution.width >= 1 && commandData.maxResolution.height >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.minBitRate >= 1 && commandData.minBitRate <= commandData.maxBitRate && commandData.maxBitRate >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.minKeyFrameInterval <= commandData.maxKeyFrameInterval &&
                        commandData.maxKeyFrameInterval <= kMaxKeyFrameIntervalMaxValue,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     bool streamUsageSupported = std::find_if(mStreamUsagePriorities.begin(), mStreamUsagePriorities.end(),
                                              [&commandData](const Globals::StreamUsageEnum & entry) {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1915,23 +1915,23 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamAllocate(HandlerContext & ctx
 
     VerifyOrReturn(commandData.imageCodec != ImageCodecEnum::kUnknownEnumValue, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid image codec", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError);
     });
 
     VerifyOrReturn(commandData.maxFrameRate > 0, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid maxFrameRate", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError);
     });
 
     VerifyOrReturn(commandData.minResolution.width >= 1 && commandData.minResolution.height >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.maxResolution.width >= 1 && commandData.maxResolution.height >= 1,
-                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError));
+                   ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError));
 
     VerifyOrReturn(commandData.quality > 0 && commandData.quality <= kMaxImageQualityMetric, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid image quality", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::DynamicConstraintError);
     });
 
     SnapshotStreamStruct snapshotStreamArgs;

--- a/src/python_testing/TC_AVSM_2_1.py
+++ b/src/python_testing/TC_AVSM_2_1.py
@@ -107,7 +107,7 @@ class TC_AVSM_2_1(MatterBaseTest):
             TestStep(
                 19,
                 "TH reads AllocatedSnapshotStreams attribute.",
-                "Verify that the DUT response contains a list of AudioStreamStruct entries.",
+                "Verify that the DUT response contains a list of SnapshotStreamStruct entries.",
             ),
             TestStep(
                 20,

--- a/src/python_testing/TC_AVSM_2_2.py
+++ b/src/python_testing/TC_AVSM_2_2.py
@@ -55,43 +55,66 @@ class TC_AVSM_2_2(MatterBaseTest):
     def steps_TC_AVSM_2_2(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify SNP is supported"
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify SNP is supported"),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads SnapshotCapabilities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads SnapshotCapabilities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aSnapshotCapabilities.",
             ),
             TestStep(
                 4,
-                "TH sends the SnapshotStreamAllocate command with valid values of ImageCodec, MaxFrameRate, MinResolution=MaxResolution=Resolution from aSnapshotCapabilities and Quality set to 90.",
-                "DUT responds with SnapshotStreamAllocateResponse command with a valid SnapshotStreamID.",
+                "If WMARK is supported, TH sets it’s local aWatermark to True, otherwise this is Null",
+                "",
             ),
             TestStep(
                 5,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
-                "Verify the number of allocated snapshot streams in the list is 1.",
+                "If OSD is supported, TH sets its local aOSD to True, otherwise this is Null",
+                "",
             ),
             TestStep(
                 6,
-                "TH sends the SnapshotStreamAllocate command with values from step 3 except with MaxFrameRate set to 0(outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH sends the SnapshotStreamAllocate command with valid values of ImageCodec, MaxFrameRate, MinResolution=MaxResolution=Resolution from aSnapshotCapabilities, WatermarkEnabled to aWatermark, OSDEnabled to aOSD, and Quality set to 90.",
+                "DUT responds with SnapshotStreamAllocateResponse command with a valid SnapshotStreamID.",
             ),
             TestStep(
                 7,
-                "TH sends the SnapshotStreamAllocate command with values from step 3 except with Quality set to 101(outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated snapshot streams in the list is 1.",
             ),
             TestStep(
                 8,
-                "TH sends the SnapshotStreamAllocate command with values from step 3 except with ImageCodec set to 10(outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with MaxFrameRate set to 0(outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                9,
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with Quality set to 0(below valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                10,
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with Quality set to 101(above valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                11,
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with ImageCodec set to 10(outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                12,
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with MinResolution set to {0,0} (outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                13,
+                "TH sends the SnapshotStreamAllocate command with values from step 6 except with MaxResolution set to {0,0} (outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
             ),
         ]
 
@@ -127,6 +150,16 @@ class TC_AVSM_2_2(MatterBaseTest):
         logger.info(f"Rx'd SnapshotCapabilities: {aSnapshotCapabilities}")
 
         self.step(4)
+        aWatermark = None
+        if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) > 0:
+            aWatermark = True
+
+        self.step(5)
+        aOSD = None
+        if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) > 0:
+            aOSD = True
+
+        self.step(6)
         asserts.assert_greater(len(aSnapshotCapabilities), 0, "SnapshotCapabilities list is empty")
         try:
             snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
@@ -135,6 +168,8 @@ class TC_AVSM_2_2(MatterBaseTest):
                 minResolution=aSnapshotCapabilities[0].resolution,
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
             logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
@@ -145,14 +180,14 @@ class TC_AVSM_2_2(MatterBaseTest):
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(5)
+        self.step(7)
         aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
         )
         logger.info(f"Rx'd AllocatedSnapshotStreams: {aAllocatedSnapshotStreams}")
         asserts.assert_equal(len(aAllocatedSnapshotStreams), 1, "The number of allocated snapshot streams in the list is not 1.")
 
-        self.step(6)
+        self.step(8)
         try:
             snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
                 imageCodec=aSnapshotCapabilities[0].imageCodec,
@@ -160,20 +195,46 @@ class TC_AVSM_2_2(MatterBaseTest):
                 minResolution=aSnapshotCapabilities[0].resolution,
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
             asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)"
+                False,
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)",
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected status returned when expecting CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)",
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)",
             )
             pass
 
-        self.step(7)
+        self.step(9)
+        try:
+            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+                imageCodec=aSnapshotCapabilities[0].imageCodec,
+                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+                minResolution=aSnapshotCapabilities[0].resolution,
+                maxResolution=aSnapshotCapabilities[0].resolution,
+                quality=0,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+            asserts.assert_true(
+                False, "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to Quality set to 0(below valid range)"
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to Quality set to 0(below valid range)",
+            )
+            pass
+
+        self.step(10)
         try:
             snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
                 imageCodec=aSnapshotCapabilities[0].imageCodec,
@@ -181,20 +242,22 @@ class TC_AVSM_2_2(MatterBaseTest):
                 minResolution=aSnapshotCapabilities[0].resolution,
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=101,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
             asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to Quality set to 101(outside of valid range)"
+                False, "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to Quality set to 101(above valid range)."
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected status returned when expecting CONSTRAINT_ERROR due to Quality set to 101(outside of valid range)",
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to Quality set to 101(above valid range).",
             )
             pass
 
-        self.step(8)
+        self.step(11)
         try:
             snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
                 imageCodec=cluster.Enums.ImageCodecEnum.extend_enum_if_value_doesnt_exist(10),
@@ -202,16 +265,67 @@ class TC_AVSM_2_2(MatterBaseTest):
                 minResolution=aSnapshotCapabilities[0].resolution,
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
             asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)"
+                False,
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)",
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected status returned when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)",
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)",
+            )
+            pass
+
+        self.step(12)
+        try:
+            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+                imageCodec=aSnapshotCapabilities[0].imageCodec,
+                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+                minResolution=cluster.Structs.VideoResolutionStruct(width=0, height=0),
+                maxResolution=aSnapshotCapabilities[0].resolution,
+                quality=90,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+            asserts.assert_true(
+                False,
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinResolution set to {0,0} (outside of valid range).",
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinResolution set to {0,0} (outside of valid range).",
+            )
+            pass
+
+        self.step(13)
+        try:
+            snpStreamAllocateCmd = commands.SnapshotStreamAllocate(
+                imageCodec=aSnapshotCapabilities[0].imageCodec,
+                maxFrameRate=aSnapshotCapabilities[0].maxFrameRate,
+                minResolution=aSnapshotCapabilities[0].resolution,
+                maxResolution=cluster.Structs.VideoResolutionStruct(width=0, height=0),
+                quality=90,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
+            asserts.assert_true(
+                False,
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MaxResolution set to {0,0} (outside of valid range).",
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.DynamicConstraintError,
+                "Unexpected status returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MaxResolution set to {0,0} (outside of valid range).",
             )
             pass
 

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -58,12 +58,12 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
             TestStep(
                 1,
-                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify SNP & (WMARK|OSD) is supported.",
             ),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1. Store StreamID as aStreamID. If WMARK is supported, store WaterMarkEnabled as aWmark. If OSD is supported, store OSDEnabled as aOSD.",
             ),
             TestStep(
@@ -73,7 +73,7 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 4,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the following: If WMARK is supported, verify WaterMarkEnabled == !aWmark. If OSD is supported, verify OSDEnabled == !aOSD.",
             ),
         ]
@@ -104,7 +104,6 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         logger.info(f"Rx'd snpSupport: {snpSupport}, wmarkSupport: {wmarkSupport}, osdSupport: {osdSupport}")
         asserts.assert_true(
             (snpSupport and (wmarkSupport or osdSupport)),
-            cluster.Bitmaps.Feature.kSnapshot,
             "SNP & (WMARK|OSD) is supported is not supported.",
         )
 

--- a/src/python_testing/TC_AVSM_2_4.py
+++ b/src/python_testing/TC_AVSM_2_4.py
@@ -56,12 +56,10 @@ class TC_AVSM_2_4(MatterBaseTest, AVSMTestBase):
     def steps_TC_AVSM_2_4(self) -> list[TestStep]:
         return [
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify SNP is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify SNP is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -76,7 +74,7 @@ class TC_AVSM_2_4(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 0.",
             ),
         ]

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -38,6 +38,7 @@
 import logging
 
 import chip.clusters as Clusters
+from chip.clusters import Globals
 from chip.interaction_model import InteractionModelError, Status
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 from mobly import asserts
@@ -55,52 +56,65 @@ class TC_AVSM_2_5(MatterBaseTest):
     def steps_TC_AVSM_2_5(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify ADO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify ADO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads MicrophoneCapabilities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MicrophoneCapabilities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMicrophoneCapabilities.",
             ),
             TestStep(
                 4,
-                "TH reads StreamUsagePrioritie attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
-                "Store this value in aStreamUsagePriorities.",
+                "The TH selects a value for BitRate depending on the first codec in aMicrophoneCapabilities.supportedCodecs: * if 0 (OPUS) then BitRate is 30000 * if 1 (AAC-LC) then BitRate is 40000",
+                "Store this value in aBitRate",
             ),
             TestStep(
                 5,
-                "TH sends the AudioStreamAllocate command with valid values of AudioCodec, ChannelCount, SampleRate and BitDepth from aMicrophoneCapabilities and StreamUsage from aStreamUsagePriorities.",
-                "DUT responds with AudioStreamAllocateResponse command with a valid AudioStreamID.",
+                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on DUT.",
+                "Store this value in aStreamUsagePriorities.",
             ),
             TestStep(
                 6,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
-                "Verify the number of allocated audio streams in the list is 1.",
+                "TH sends the AudioStreamAllocate command with valid values of AudioCodec, ChannelCount, SampleRate and BitDepth from aMicrophoneCapabilities, a StreamUsage from aStreamUsagePriorities and aBitRate set as above.",
+                "DUT responds with AudioStreamAllocateResponse command with a valid AudioStreamID.",
             ),
             TestStep(
                 7,
-                "TH sends the AudioStreamAllocate command with values from step 4 except with ChannelCount set to 16(outside of valid range)",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated audio streams in the list is 1.",
             ),
             TestStep(
                 8,
-                "TH sends the AudioStreamAllocate command with values from step 4 except with BitDepth set to 48(outside of valid range)",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH sends the AudioStreamAllocate command with the values from step 6 except StreamUsage set to a value not in aStreamUsagePriorities.",
+                "DUT responds with a INVALID_IN_STATE status code.",
             ),
             TestStep(
                 9,
-                "TH sends the AudioStreamAllocate command with values from step 4 except with Samplerate set to 0(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with ChannelCount set to 16(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 10,
-                "TH sends the AudioStreamAllocate command with values from step 4 except with BitRate set to 0(outside of valid range)",
+                "TH sends the AudioStreamAllocate command with values from step 6 except with BitDepth set to 48(outside of valid range)",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                11,
+                "TH sends the AudioStreamAllocate command with values from step 6 except with Samplerate set to 0(outside of valid range)",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                12,
+                "TH sends the AudioStreamAllocate command with values from step 6 except with BitRate set to 0(outside of valid range)",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                13,
+                "TH sends the AudioStreamAllocate command with values from step 6 except with AudioCodec set to 10(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
         ]
@@ -137,20 +151,31 @@ class TC_AVSM_2_5(MatterBaseTest):
         logger.info(f"Rx'd MicrophoneCapabilities: {aMicrophoneCapabilities}")
 
         self.step(4)
+        asserts.assert_is_not_none(aMicrophoneCapabilities, "MicrophoneCapabilities is Null")
+        asserts.assert_greater(len(aMicrophoneCapabilities.supportedCodecs), 0, "SupportedCodecs list is empty")
+        supportedCodec = aMicrophoneCapabilities.supportedCodecs[0]
+        aBitRate = None
+        if supportedCodec == cluster.Enums.AudioCodecEnum.kOpus:
+            aBitRate = 30000
+        elif supportedCodec == cluster.Enums.AudioCodecEnum.kAacLc:
+            aBitRate = 40000
+        asserts.assert_is_not_none(aBitRate, "SupportedCodec is neither OPUS nor AAC-LC")
+
+        self.step(5)
         aStreamUsagePriorities = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.StreamUsagePriorities
         )
         logger.info(f"Rx'd StreamUsagePriorities : {aStreamUsagePriorities}")
+        asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities list is empty")
 
-        self.step(5)
-        asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
+        self.step(6)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
                 channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
                 sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
-                bitRate=1024,
+                bitRate=aBitRate,
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             audioStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
@@ -162,21 +187,48 @@ class TC_AVSM_2_5(MatterBaseTest):
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(6)
+        self.step(7)
         aAllocatedAudioStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedAudioStreams
         )
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1.")
 
-        self.step(7)
+        self.step(8)
+        try:
+            unsupportedStreamUsage = next(
+                (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
+                Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
+            )
+            adoStreamAllocateCmd = commands.AudioStreamAllocate(
+                streamUsage=unsupportedStreamUsage,
+                audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
+                channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
+                sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
+                bitRate=aBitRate,
+                bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
+            asserts.assert_true(
+                False,
+                "Unexpected success when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities.",
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.InvalidInState,
+                "Unexpected status returned when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities.",
+            )
+            pass
+
+        self.step(9)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
                 channelCount=16,
                 sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
-                bitRate=1024,
+                bitRate=aBitRate,
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
@@ -191,14 +243,14 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(8)
+        self.step(10)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
                 channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
                 sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
-                bitRate=1024,
+                bitRate=aBitRate,
                 bitDepth=48,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
@@ -213,14 +265,14 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(9)
+        self.step(11)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
                 channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
                 sampleRate=0,
-                bitRate=1024,
+                bitRate=aBitRate,
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
@@ -235,7 +287,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(10)
+        self.step(12)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -254,6 +306,28 @@ class TC_AVSM_2_5(MatterBaseTest):
                 e.status,
                 Status.ConstraintError,
                 "Unexpected status returned when expecting CONSTRAINT_ERROR due to BitRate set to 0(outside of valid range)",
+            )
+            pass
+
+        self.step(13)
+        try:
+            adoStreamAllocateCmd = commands.AudioStreamAllocate(
+                streamUsage=aStreamUsagePriorities[0],
+                audioCodec=cluster.Enums.AudioCodecEnum.extend_enum_if_value_doesnt_exist(10),
+                channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
+                sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
+                bitRate=aBitRate,
+                bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
+            asserts.assert_true(
+                False, "Unexpected success when expecting CONSTRAINT_ERROR due to AudioCodec set to 10(outside of valid range)"
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.ConstraintError,
+                "Unexpected status returned when expecting CONSTRAINT_ERROR due to AudioCodec set to 10(outside of valid range)",
             )
             pass
 

--- a/src/python_testing/TC_AVSM_2_6.py
+++ b/src/python_testing/TC_AVSM_2_6.py
@@ -56,12 +56,10 @@ class TC_AVSM_2_6(MatterBaseTest, AVSMTestBase):
     def steps_TC_AVSM_2_6(self) -> list[TestStep]:
         return [
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify ADO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify ADO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -76,7 +74,7 @@ class TC_AVSM_2_6(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 0.",
             ),
         ]

--- a/src/python_testing/TC_AVSM_2_7.py
+++ b/src/python_testing/TC_AVSM_2_7.py
@@ -56,78 +56,116 @@ class TC_AVSM_2_7(MatterBaseTest):
     def steps_TC_AVSM_2_7(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify VDO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify VDO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aStreamUsagePriorities.",
             ),
             TestStep(
                 4,
-                "TH reads RateDistortionTradeOffPoints attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads RateDistortionTradeOffPoints attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aRateDistortionTradeOffPoints.",
             ),
             TestStep(
                 5,
-                "TH reads MinViewport attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MinViewport attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMinViewport.",
             ),
             TestStep(
                 6,
-                "TH reads VideoSensorParams attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads VideoSensorParams attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aVideoSensorParams.",
             ),
             TestStep(
                 7,
-                "TH reads MaxEncodedPixelRate attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MaxEncodedPixelRate attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMaxEncodedPixelRate.",
             ),
             TestStep(
                 8,
-                "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints. TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the MinKeyFrameInterval and MaxKeyFrameInterval = 4000. TH sends the VideoStreamAllocate command with these arguments.",
-                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID.",
+                "If WMARK is supported, TH sets it’s local aWatermark to True, otherwise this is Null",
+                "",
             ),
             TestStep(
                 9,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
-                "Verify the number of allocated video streams in the list is 1.",
+                "If OSD is supported, TH sets its local aOSD to True, otherwise this is Null",
+                "",
             ),
             TestStep(
                 10,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except StreamUsage set to a value not in aStreamUsagePriorities.",
-                "DUT responds with a INVALID IN STATE status code.",
+                "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints. TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the MinKeyFrameInterval and MaxKeyFrameInterval = 4000. TH sets WatermarkEnabled to aWatermark, TH also sets OSDEnabled to aOSD. TH sends the VideoStreamAllocate command with these arguments.",
+                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID. Store this as myStreamID",
             ),
             TestStep(
                 11,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except MinFrameRate set to 0(outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 1.",
             ),
             TestStep(
                 12,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except MinFrameRate > MaxFrameRate.",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH re-sends the VideoStreamAllocate command that was sent in step 8.",
+                "DUT responds with VideoStreamAllocateResponse command with      equal to myStreamID",
             ),
             TestStep(
                 13,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except MinBitRate set to 0(outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify the number of allocated video streams in the list is 1.",
             ),
             TestStep(
                 14,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except MinBitRate > MaxBitRate.",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "If the CameraAVSettingsUserLevelManagement cluster is present, with the DPTZ feature flag set the proceed to step 15, otherwise jump to step 17",
+                "",
             ),
             TestStep(
                 15,
-                "TH sends the VideoStreamAllocate command with the same arguments from step 7 except MinKeyFrameInterval > MaxKeyFrameInterval.",
-                "DUT responds with a CONSTRAINT_ERROR status code.",
+                "TH reads the Viewport attribute from CameraAVStreamManagement Cluster on DUT",
+                "DUT responds with a Viewport Struct, store this in myViewport",
+            ),
+            TestStep(
+                16,
+                "TH reads the DPTZStreams attribute from CameraAVSettingsUserLevelManagement Cluster on DUT.",
+                "DUT responds with a list of DPTZStructs. Verify: * there is an entry with VideoStreamID set to myStreamID * the Viewport for that entry is the same as myViewport",
+            ),
+            TestStep(
+                17,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except StreamUsage set to a value not in aStreamUsagePriorities.",
+                "DUT responds with a INVALID_IN_STATE status code.",
+            ),
+            TestStep(
+                18,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except MinFrameRate set to 0(outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                19,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except MinFrameRate > MaxFrameRate.",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                20,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except MinBitRate set to 0(outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                21,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except MinBitRate > MaxBitRate.",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                22,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except MinKeyFrameInterval > MaxKeyFrameInterval.",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                23,
+                "TH sends the VideoStreamAllocate command with the same arguments from step 8 except VideoCodec set to 10(outside of valid range).",
+                "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
             ),
         ]
 
@@ -149,10 +187,6 @@ class TC_AVSM_2_7(MatterBaseTest):
         vdoSupport = aFeatureMap & cluster.Bitmaps.Feature.kVideo
         asserts.assert_equal(vdoSupport, cluster.Bitmaps.Feature.kVideo, "Video Feature is not supported.")
 
-        # Check for watermark and OSD features
-        watermark = True if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) != 0 else None
-        osd = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
-
         self.step(2)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
@@ -165,12 +199,15 @@ class TC_AVSM_2_7(MatterBaseTest):
             endpoint=endpoint, cluster=cluster, attribute=attr.StreamUsagePriorities
         )
         logger.info(f"Rx'd StreamUsagePriorities: {aStreamUsagePriorities}")
+        asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
 
         self.step(4)
         aRateDistortionTradeOffPoints = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.RateDistortionTradeOffPoints
         )
         logger.info(f"Rx'd RateDistortionTradeOffPoints: {aRateDistortionTradeOffPoints}")
+        asserts.assert_is_not_none(aRateDistortionTradeOffPoints, "RateDistortionTradeOffPoints list is Null")
+        asserts.assert_greater(len(aRateDistortionTradeOffPoints), 0, "RateDistortionTradeOffPoints is empty")
 
         self.step(5)
         aMinViewport = await self.read_single_attribute_check_success(
@@ -183,6 +220,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             endpoint=endpoint, cluster=cluster, attribute=attr.VideoSensorParams
         )
         logger.info(f"Rx'd VideoSensorParams: {aVideoSensorParams}")
+        asserts.assert_is_not_none(aVideoSensorParams, "VideoSensorParams is Null")
 
         self.step(7)
         aMaxEncodedPixelRate = await self.read_single_attribute_check_success(
@@ -191,13 +229,20 @@ class TC_AVSM_2_7(MatterBaseTest):
         logger.info(f"Rx'd MaxEncodedPixelRate: {aMaxEncodedPixelRate}")
 
         self.step(8)
+        aWatermark = True if (aFeatureMap & cluster.Bitmaps.Feature.kWatermark) != 0 else None
+
+        self.step(9)
+        aOSD = True if (aFeatureMap & cluster.Bitmaps.Feature.kOnScreenDisplay) != 0 else None
+
+        self.step(10)
+        myStreamID = None
+        minFrameRate = 30  # An acceptable value for min frame rate
+        keyFrameInterval = 4000
         try:
-            asserts.assert_greater(len(aStreamUsagePriorities), 0, "StreamUsagePriorities is empty")
-            asserts.assert_greater(len(aRateDistortionTradeOffPoints), 0, "RateDistortionTradeOffPoints is empty")
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=minFrameRate,
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -205,37 +250,107 @@ class TC_AVSM_2_7(MatterBaseTest):
                 ),
                 minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
             logger.info(f"Rx'd VideoStreamAllocateResponse: {videoStreamAllocateResponse}")
             asserts.assert_is_not_none(
                 videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID"
             )
+            myStreamID = videoStreamAllocateResponse.videoStreamID
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(9)
+        self.step(11)
         aAllocatedVideoStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
         )
         logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
         asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated video streams in the list is not 1")
 
-        self.step(10)
+        self.step(12)
         try:
-            notSupportedStreamUsage = next(
+            videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
+            logger.info(f"Rx'd VideoStreamAllocateResponse: {videoStreamAllocateResponse}")
+            asserts.assert_equal(myStreamID, videoStreamAllocateResponse.videoStreamID, "VideoStreamID is not equal to myStreamID")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
+            pass
+
+        self.step(13)
+        aAllocatedVideoStreams = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedVideoStreams
+        )
+        logger.info(f"Rx'd AllocatedVideoStreams: {aAllocatedVideoStreams}")
+        asserts.assert_equal(len(aAllocatedVideoStreams), 1, "The number of allocated video streams in the list is not 1")
+
+        self.step(14)
+        # Check if CameraAVSettingsUserLevelManagement cluster is present
+        serverList = await self.read_single_attribute_check_success(
+            endpoint=endpoint, cluster=Clusters.Descriptor, attribute=Clusters.Descriptor.Attributes.ServerList
+        )
+        logger.info(f"Rx'd Descriptor ServerList: {serverList}")
+        AVSUMPresent = Clusters.CameraAvSettingsUserLevelManagement.id in serverList
+        logger.info(f"CameraAvSettingsUserLevelManagement Present: {AVSUMPresent}")
+
+        DPTZSupport = False
+        if AVSUMPresent:
+            AVSUMFeatureMap = await self.read_single_attribute_check_success(
+                endpoint=endpoint,
+                cluster=Clusters.CameraAvSettingsUserLevelManagement,
+                attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.FeatureMap,
+            )
+            logger.info(f"Rx'd CameraAvSettingsUserLevelManagement FeatureMap: {AVSUMFeatureMap}")
+            DPTZSupport = AVSUMFeatureMap & Clusters.CameraAvSettingsUserLevelManagement.Bitmaps.Feature.kDigitalPTZ != 0
+
+        logger.info(f"DigitalPTZ Support: {DPTZSupport}")
+
+        if DPTZSupport:
+            self.step(15)
+            myViewport = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.Viewport)
+            logger.info(f"Rx'd Viewport: {myViewport}")
+            asserts.assert_is_not_none(myViewport, "Viewport is Null")
+
+            self.step(16)
+            DPTZStreams = await self.read_single_attribute_check_success(
+                endpoint=endpoint,
+                cluster=Clusters.CameraAvSettingsUserLevelManagement,
+                attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.DPTZStreams,
+            )
+            logger.info(f"Rx'd DPTZStreams: {DPTZStreams}")
+            asserts.assert_is_not_none(DPTZStreams, "DPTZStreams list is Null")
+
+            def verifyStreamMatches(stream: Clusters.CameraAvSettingsUserLevelManagement.Structs.DPTZStruct) -> bool:
+                return (
+                    stream.videoStreamID == myStreamID
+                    and stream.viewport.x1 == myViewport.x1
+                    and stream.viewport.y1 == myViewport.y1
+                    and stream.viewport.x2 == myViewport.x2
+                    and stream.viewport.y2 == myViewport.y2
+                )
+
+            entryPresent = any(verifyStreamMatches(stream) for stream in DPTZStreams)
+            asserts.assert_true(entryPresent, "Matching DPTZStructs not present in DPTZStreams")
+
+        else:
+            self.skip_step(15)
+            self.skip_step(16)
+
+        self.step(17)
+        try:
+            unsupportedStreamUsage = next(
                 (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
                 Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
             )
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
-                streamUsage=notSupportedStreamUsage,
+                streamUsage=unsupportedStreamUsage,
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=minFrameRate,
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -243,25 +358,24 @@ class TC_AVSM_2_7(MatterBaseTest):
                 ),
                 minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False,
-                "Unexpected success when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities",
+            asserts.fail(
+                "Unexpected success when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities"
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
                 Status.InvalidInState,
-                "Unexpected error returned when expecting InvalidInState due to StreamUsage set to a value not in aStreamUsagePriorities",
+                "Unexpected error returned when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities",
             )
             pass
 
-        self.step(11)
+        self.step(18)
         try:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -274,57 +388,57 @@ class TC_AVSM_2_7(MatterBaseTest):
                 ),
                 minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAIN_ERROR due to MinFrameRate set to 0(outside of valid range)"
+            asserts.fail(
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinFrameRate set to 0(outside of valid range)"
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected error returned when expecting CONSTRAIN_ERROR due to MinFrameRate set to 0(outside of valid range)",
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinFrameRate set to 0(outside of valid range)",
             )
             pass
 
-        self.step(12)
+        self.step(19)
         try:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=16,
-                maxFrameRate=15,
+                minFrameRate=minFrameRate + 1,
+                maxFrameRate=minFrameRate,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
                     width=aVideoSensorParams.sensorWidth, height=aVideoSensorParams.sensorHeight
                 ),
                 minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(False, "Unexpected success when expecting CONSTRAIN_ERROR due to MinFrameRate > MaxFrameRate")
+            asserts.fail("Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinFrameRate > MaxFrameRate")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected error returned when expecting CONSTRAIN_ERROR due to MinFrameRate > MaxFrameRate",
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinFrameRate > MaxFrameRate",
             )
             pass
 
-        self.step(13)
+        self.step(20)
         try:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=minFrameRate,
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -332,29 +446,29 @@ class TC_AVSM_2_7(MatterBaseTest):
                 ),
                 minBitRate=0,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAIN_ERROR due to MinBitRate set to 0(outside of valid range)"
+            asserts.fail(
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinBitRate set to 0(outside of valid range)"
             )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected error returned when expecting CONSTRAIN_ERROR due to MinBitRate set to 0(outside of valid range)",
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinBitRate set to 0(outside of valid range)",
             )
             pass
 
-        self.step(14)
+        self.step(21)
         try:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=minFrameRate,
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
@@ -362,47 +476,78 @@ class TC_AVSM_2_7(MatterBaseTest):
                 ),
                 minBitRate=aRateDistortionTradeOffPoints[0].minBitRate + 1,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(False, "Unexpected success when expecting CONSTRAIN_ERROR due to MinBitRate > MaxBitRate")
+            asserts.fail("Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinBitRate > MaxBitRate")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected error returned when expecting CONSTRAIN_ERROR due to MinBitRate > MaxBitRate",
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinBitRate > MaxBitRate",
             )
             pass
 
-        self.step(15)
+        self.step(22)
         try:
             videoStreamAllocateCmd = commands.VideoStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
                 videoCodec=aRateDistortionTradeOffPoints[0].codec,
-                minFrameRate=30,  # An acceptable value for min frame rate
+                minFrameRate=minFrameRate,
                 maxFrameRate=aVideoSensorParams.maxFPS,
                 minResolution=aMinViewport,
                 maxResolution=cluster.Structs.VideoResolutionStruct(
                     width=aVideoSensorParams.sensorWidth, height=aVideoSensorParams.sensorHeight
                 ),
-                minBitRate=aRateDistortionTradeOffPoints[0].minBitRate + 1,
+                minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
                 maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
-                minKeyFrameInterval=4000 + 1,
-                maxKeyFrameInterval=4000,
-                watermarkEnabled=watermark,
-                OSDEnabled=osd
+                minKeyFrameInterval=keyFrameInterval + 1,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAIN_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval")
+            asserts.fail(
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval"
+            )
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
-                Status.ConstraintError,
-                "Unexpected error returned when expecting CONSTRAIN_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval",
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval",
+            )
+            pass
+
+        self.step(23)
+        try:
+            videoStreamAllocateCmd = commands.VideoStreamAllocate(
+                streamUsage=aStreamUsagePriorities[0],
+                videoCodec=cluster.Enums.VideoCodecEnum.extend_enum_if_value_doesnt_exist(10),
+                minFrameRate=minFrameRate,
+                maxFrameRate=aVideoSensorParams.maxFPS,
+                minResolution=aMinViewport,
+                maxResolution=cluster.Structs.VideoResolutionStruct(
+                    width=aVideoSensorParams.sensorWidth, height=aVideoSensorParams.sensorHeight
+                ),
+                minBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
+                maxBitRate=aRateDistortionTradeOffPoints[0].minBitRate,
+                minKeyFrameInterval=keyFrameInterval,
+                maxKeyFrameInterval=keyFrameInterval,
+                watermarkEnabled=aWatermark,
+                OSDEnabled=aOSD,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
+            asserts.fail(
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due VideoCodec set to 10(outside of valid range)"
+            )
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.DynamicConstraintError,
+                "Unexpected error returned when expecting DYNAMIC_CONSTRAINT_ERROR due VideoCodec set to 10(outside of valid range)",
             )
             pass
 

--- a/src/python_testing/TC_AVSM_2_9.py
+++ b/src/python_testing/TC_AVSM_2_9.py
@@ -58,12 +58,12 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
             TestStep(
                 1,
-                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER",
-                "Verify VDO is supported.",
+                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify VDO is supported. Do not run if not.",
             ),
             TestStep(
                 2,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -78,7 +78,7 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
         ]

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -5,8 +5,6 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
-    - name: TC_AVSM_2_7.py
-      reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py
       reason: It has no CI execution block, it not executed in CI
     - name: TC_CNET_4_1.py

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -5,17 +5,7 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
-    - name: TC_AVSM_2_2.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_5.py
-      reason: Camera App does not support all features required for this TC
     - name: TC_AVSM_2_7.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_8.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_9.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_11.py
       reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py
       reason: It has no CI execution block, it not executed in CI


### PR DESCRIPTION
Updated status code for `SnapshotStreamAllocate` command when unsupported field values are received.
Updated status code for `VideoStreamAllocate` command when unsupported field values are received.

Updated the following Test Cases:
- TC-AVSM-2.1
- TC-AVSM-2.2 (enabled for testing)
- TC-AVSM-2.3
- TC-AVSM-2.4
- TC-AVSM-2.5 (enabled for testing)
- TC-AVSM-2.6
- TC-AVSM-2.7 (enabled for testing)
- TC-AVSM-2.8 (enabled for testing)
- TC-AVSM-2.9 (enabled for testing)
- TC-AVSM-2.10
- TC-AVSM-2.11 (enabled for testing)

### Testing

Build python wheel and activate venv:

```sh
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
```
For example, to run To run tests for TC-AVSM-2.3:

```
./scripts/tests/run_python_test.py --factory-reset --app <chip-camera-app> --app-args "--trace-to json:log" --script src/python_testing/TC_AVSM_2_3.py --script-args "--commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00"
```