### PR TITLE
[Camera] Fix Camera app in Sending IceCandidates, handling EndSession, Re-Offer case

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -443,7 +443,15 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         // TODO: Lookup the sessionID to get the Video/Audio StreamID
         ReleaseAudioVideoStreams();
 
+        mMediaController->UnregisterTransport(mWebrtcTransportMap[sessionId].get());
         mWebrtcTransportMap.erase(sessionId);
+    }
+
+    if (mPeerConnection)
+    {
+        ChipLogProgress(Camera, "Closing peer connection: %u", sessionId);
+        mPeerConnection->close();
+        mPeerConnection.reset();
     }
 
     if (mCurrentSessionId == sessionId)

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -434,7 +434,8 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
                                                    DataModel::Nullable<uint16_t> videoStreamID,
                                                    DataModel::Nullable<uint16_t> audioStreamID)
 {
-    if (mWebrtcTransportMap.find(sessionId) != mWebrtcTransportMap.end())
+    auto it = mWebrtcTransportMap.find(sessionId);
+    if (it != mWebrtcTransportMap.end())
     {
         ChipLogProgress(Camera, "Delete Webrtc Transport for the session: %u", sessionId);
 
@@ -443,8 +444,8 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         // TODO: Lookup the sessionID to get the Video/Audio StreamID
         ReleaseAudioVideoStreams();
 
-        mMediaController->UnregisterTransport(mWebrtcTransportMap[sessionId].get());
-        mWebrtcTransportMap.erase(sessionId);
+        mMediaController->UnregisterTransport(it->second.get());
+        mWebrtcTransportMap.erase(it);
     }
 
     if (mPeerConnection)

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -369,8 +369,14 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    mPeerConnection->setRemoteDescription(sdpAnswer);
+    if (mWebrtcTransportMap.find(sessionId) == mWebrtcTransportMap.end())
+    {
+        mWebrtcTransportMap[sessionId] =
+            std::unique_ptr<WebrtcTransport>(new WebrtcTransport(sessionId, mPeerId.GetNodeId(), mPeerConnection));
+    }
+    AcquireAudioVideoStreams();
 
+    mPeerConnection->setRemoteDescription(sdpAnswer);
     MoveToState(State::SendingICECandidates);
     ScheduleICECandidatesSend();
 

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -423,6 +423,10 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId,
         }
     }
 
+    // Schedule sending Ice Candidates when remote candidates are received. This keeps the exchange simple
+    MoveToState(State::SendingICECandidates);
+    ScheduleICECandidatesSend();
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp
@@ -393,6 +393,9 @@ void WebRTCTransportProviderServer::HandleProvideOffer(HandlerContext & ctx, con
 
     WebRTCSessionStruct outSession;
 
+    // Prepare delegate arguments for the session
+    Delegate::ProvideOfferRequestArgs args;
+
     // Validate the streamUsage field against the allowed enum values.
     if (req.streamUsage == StreamUsageEnum::kUnknownEnumValue)
     {
@@ -414,6 +417,9 @@ void WebRTCTransportProviderServer::HandleProvideOffer(HandlerContext & ctx, con
 
         // Use the existing session for further processing (re-offer case).
         outSession = *existingSession;
+
+        // re-use the same session id for offer processing in delegate
+        args.sessionId = sessionId;
     }
     else
     {
@@ -492,57 +498,56 @@ void WebRTCTransportProviderServer::HandleProvideOffer(HandlerContext & ctx, con
             return;
         }
 
-        // Prepare delegate arguments for new session
-        Delegate::ProvideOfferRequestArgs args;
-        args.sessionId             = GenerateSessionId();
-        args.streamUsage           = req.streamUsage;
-        args.videoStreamId         = videoStreamID;
-        args.audioStreamId         = audioStreamID;
-        args.peerNodeId            = peerNodeId;
-        args.fabricIndex           = peerFabricIndex;
-        args.sdp                   = std::string(req.sdp.data(), req.sdp.size());
-        args.originatingEndpointId = req.originatingEndpointID;
+        // Generate new sessiond id
+        args.sessionId = GenerateSessionId();
+    }
 
-        // Convert ICE servers list from DecodableList to vector.
-        if (req.ICEServers.HasValue())
+    args.streamUsage           = req.streamUsage;
+    args.videoStreamId         = videoStreamID;
+    args.audioStreamId         = audioStreamID;
+    args.peerNodeId            = peerNodeId;
+    args.fabricIndex           = peerFabricIndex;
+    args.sdp                   = std::string(req.sdp.data(), req.sdp.size());
+    args.originatingEndpointId = req.originatingEndpointID;
+
+    // Convert ICE servers list from DecodableList to vector.
+    if (req.ICEServers.HasValue())
+    {
+        std::vector<ICEServerDecodableStruct> localIceServers;
+
+        auto iter = req.ICEServers.Value().begin();
+        while (iter.Next())
         {
-            std::vector<ICEServerDecodableStruct> localIceServers;
-
-            auto iter = req.ICEServers.Value().begin();
-            while (iter.Next())
-            {
-                localIceServers.push_back(std::move(iter.GetValue()));
-            }
-
-            CHIP_ERROR listErr = iter.GetStatus();
-            if (listErr != CHIP_NO_ERROR)
-            {
-                ChipLogError(Zcl, "HandleProvideOffer: ICEServers list error: %" CHIP_ERROR_FORMAT, listErr.Format());
-                ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
-                return;
-            }
-
-            args.iceServers.SetValue(std::move(localIceServers));
+            localIceServers.push_back(std::move(iter.GetValue()));
         }
 
-        // Convert ICETransportPolicy from CharSpan to std::string.
-        if (req.ICETransportPolicy.HasValue())
+        CHIP_ERROR listErr = iter.GetStatus();
+        if (listErr != CHIP_NO_ERROR)
         {
-            args.iceTransportPolicy.SetValue(
-                std::string(req.ICETransportPolicy.Value().data(), req.ICETransportPolicy.Value().size()));
-        }
-
-        // Delegate processing: process the SDP offer, create session, increment reference counts.
-        auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(mDelegate.HandleProvideOffer(args, outSession));
-        if (!delegateStatus.IsSuccess())
-        {
-            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, delegateStatus);
+            ChipLogError(Zcl, "HandleProvideOffer: ICEServers list error: %" CHIP_ERROR_FORMAT, listErr.Format());
+            ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
             return;
         }
 
-        // Store the new WebRTCSessionStruct in CurrentSessions.
-        UpsertSession(outSession);
+        args.iceServers.SetValue(std::move(localIceServers));
     }
+
+    // Convert ICETransportPolicy from CharSpan to std::string.
+    if (req.ICETransportPolicy.HasValue())
+    {
+        args.iceTransportPolicy.SetValue(std::string(req.ICETransportPolicy.Value().data(), req.ICETransportPolicy.Value().size()));
+    }
+
+    // Delegate processing: process the SDP offer, create session, increment reference counts.
+    auto delegateStatus = Protocols::InteractionModel::ClusterStatusCode(mDelegate.HandleProvideOffer(args, outSession));
+    if (!delegateStatus.IsSuccess())
+    {
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, delegateStatus);
+        return;
+    }
+
+    // Update/Insert the WebRTCSessionStruct in CurrentSessions.
+    UpsertSession(outSession);
 
     // Build and send the ProvideOfferResponse.
     Commands::ProvideOfferResponse::Type resp;


### PR DESCRIPTION
This PR fixes linux camera app and aligns it according to WEBRTC TCs 1.1, 1.2, 1.3 and 1.4
#### WebRTC Transport Provider Server Changes
- In re-offer case, In WebRTC Transport Provider Server 
   - Call the `HandleProvideOffer` delegate method with existing session id so re-offer also get processed.

#### Linux Camera App Changes
- Sends Ice candidates on receiving remote candidates
- Creates `WebrtcTransport` for in SolicitOffer flow, i.e when receiving answer to facilitate video streaming
- Unregister `WebrtcTransport` in EndSession so that `connections` in `default-media-controller` does not hold reference to a dangling pointer after deletion.
- Close and reset peerConnection to cleanly end the webrtc session.


### Testing
Manual verification