### PR TITLE
[Darwin] Switch from StartTimerWithBlock to the regular StartTimer/Ca…

### DIFF
--- a/src/platform/Darwin/dnssd/DnssdHostNameRegistrar.h
+++ b/src/platform/Darwin/dnssd/DnssdHostNameRegistrar.h
@@ -67,6 +67,8 @@ namespace Dnssd {
         std::string mHostname;
 
         static void OnRegisterRecord(DNSServiceRef sdRef, DNSRecordRef recordRef, DNSServiceFlags flags, DNSServiceErrorType err, void * context);
+        static void OnRegisterRecordTimeout(System::Layer * layer, void * appState);
+        static void RunOnRegisterRecordCallback(void * context, DNSServiceErrorType error);
         OnRegisterRecordCallback mOnRegisterRecordCallback = nullptr;
     };
 


### PR DESCRIPTION
…ncelTimer pattern

#### Summary

Since #39560 has been reverted as it was causing an other kind of crash, this patch is a new attempt at fixing it without introducing a new crash. The main difference with #39560 is that we are now relying on `StartTimer`/`CancelTimer` instead of `StartTimerWithBlock` but keeps the changes in `SystemLayerImplDispatch.mm` since this is better to use `dispatch_source_set_cancel_handler` and have a single source of trust for deleting the context.

#### Related issues

See #39560

#### Testing

Enable the Network.framework  then run:
```
$  xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx -only-testing "MatterTests/MTRPerControllerStorageTests" GCC_PREPROCESSOR_DEFINITIONS='${inherited} ENABLE_LEAK_DETECTION=1'
```

Before this patch: the above test crashes due to accessing a dead object.
After applying this patch: the test completes successfully with no crashes.