### PR TITLE
Fix build with `chip_code_pre_generated_directory` set

### DIFF
--- a/build/chip/chip_codegen.gni
+++ b/build/chip/chip_codegen.gni
@@ -334,7 +334,7 @@ template("chip_codegen") {
         "--source-dir",
         _generation_dir,
         "--target-dir",
-        target_gen_dir,
+        rebase_path(target_gen_dir, root_build_dir),
       ]
 
       inputs = []


### PR DESCRIPTION
#### Summary
When setting `chip_code_pre_generated_directory` the build system is expected to copy the pre-generated files using `scripts/copyfiles.py`. It seems that the target directory is passed directly without using `rebase_path()` to convert it to a relative path. With that, the command fails with permission errors as the script attempts to write to `//out/...`.

Use `rebase_path()` to fix builds with `chip_code_pre_generated_directory` set.

#### Related issues

Fixes: #39787 

#### Testing

Tested by running builds with `chip_code_pre_generated_directory` set.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
