### PR TITLE
[Camera] Update TC_AVSM Test Cases for CI

### DIFF
--- a/src/python_testing/TC_AVSM_2_1.py
+++ b/src/python_testing/TC_AVSM_2_1.py
@@ -107,7 +107,7 @@ class TC_AVSM_2_1(MatterBaseTest):
             TestStep(
                 19,
                 "TH reads AllocatedSnapshotStreams attribute.",
-                "Verify that the DUT response contains a list of AudioStreamStruct entries.",
+                "Verify that the DUT response contains a list of SnapshotStreamStruct entries.",
             ),
             TestStep(
                 20,

--- a/src/python_testing/TC_AVSM_2_10.py
+++ b/src/python_testing/TC_AVSM_2_10.py
@@ -64,7 +64,7 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1.",
             ),
             TestStep(
@@ -142,8 +142,10 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         self.step(3)
         try:
             captureSnapshotResponse = await self.send_single_cmd(
-                cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID, requestedResolution=aResolution), endpoint=endpoint,
-                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
+                cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID, requestedResolution=aResolution),
+                endpoint=endpoint,
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
+            )
             logger.info(f"Rx'd CaptureSnapshotResponse: {captureSnapshotResponse}")
             asserts.assert_greater(len(captureSnapshotResponse.data), 0, "Image data returned by CaptureSnapshotResponse is empty")
             asserts.assert_equal(
@@ -165,9 +167,11 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         self.step(4)
         try:
             await self.send_single_cmd(
-                cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID + 1, requestedResolution=aResolution), endpoint=endpoint,
-                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-            asserts.assert_true(False, "Unexpected success when expecting NOT_FOUND due to snapshotStreamID set to aStreamID + 1")
+                cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID + 1, requestedResolution=aResolution),
+                endpoint=endpoint,
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
+            )
+            asserts.fail("Unexpected success when expecting NOT_FOUND due to snapshotStreamID set to aStreamID + 1")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -179,8 +183,10 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         self.step(5)
         try:
             captureSnapshotResponse = await self.send_single_cmd(
-                cmd=commands.CaptureSnapshot(requestedResolution=aResolution), endpoint=endpoint,
-                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
+                cmd=commands.CaptureSnapshot(requestedResolution=aResolution),
+                endpoint=endpoint,
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
+            )
             logger.info(f"Rx'd CaptureSnapshotResponse: {captureSnapshotResponse}")
             asserts.assert_greater(len(captureSnapshotResponse.data), 0, "Image data returned by CaptureSnapshotResponse is empty")
             asserts.assert_equal(
@@ -201,17 +207,18 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
 
         if self.privacySupport:
             self.step(6)
-            result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(True),
-                                                       endpoint_id=endpoint)
+            result = await self.write_single_attribute(attr.SoftLivestreamPrivacyModeEnabled(True), endpoint_id=endpoint)
             asserts.assert_equal(result, Status.Success, "Error when trying to write SoftLivestreamPrivacyModeEnabled")
             logger.info(f"Tx'd : SoftLivestreamPrivacyModeEnabled{True}")
 
             self.step(7)
             try:
                 await self.send_single_cmd(
-                    cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID, requestedResolution=aResolution), endpoint=endpoint,
-                    payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-                asserts.assert_true(False, "Unexpected success when expecting INVALID_IN_STATE due to SoftPrivacy mode set to On")
+                    cmd=commands.CaptureSnapshot(snapshotStreamID=aStreamID, requestedResolution=aResolution),
+                    endpoint=endpoint,
+                    payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
+                )
+                asserts.fail("Unexpected success when expecting INVALID_IN_STATE due to SoftPrivacy mode set to On")
             except InteractionModelError as e:
                 asserts.assert_equal(
                     e.status,
@@ -228,8 +235,7 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=aStreamID))
         except InteractionModelError as e:
-            asserts.fail(
-                f"Expected SnapshotStreamDeallocate to succeed, but it failed with status: {e.status}")
+            asserts.fail(f"Expected SnapshotStreamDeallocate to succeed, but it failed with status: {e.status}")
             pass
 
         self.step(9)
@@ -242,9 +248,11 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
         self.step(10)
         try:
             captureSnapshotResponse = await self.send_single_cmd(
-                cmd=commands.CaptureSnapshot(requestedResolution=aResolution), endpoint=endpoint,
-                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
-            asserts.assert_true(False, "Unexpected success when expecting NOT_FOUND due to 0 allocated snapshot streams")
+                cmd=commands.CaptureSnapshot(requestedResolution=aResolution),
+                endpoint=endpoint,
+                payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD,
+            )
+            asserts.fail("Unexpected success when expecting NOT_FOUND due to 0 allocated snapshot streams")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status, Status.NotFound, "Unexpected error returned when expecting NOT_FOUND due to 0 allocated snapshot streams"

--- a/src/python_testing/TC_AVSM_2_11.py
+++ b/src/python_testing/TC_AVSM_2_11.py
@@ -59,41 +59,46 @@ class TC_AVSM_2_11(MatterBaseTest, AVSMTestBase):
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
             TestStep(
                 1,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1. Store StreamID as aStreamID.",
             ),
             TestStep(
                 2,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 0.",
             ),
             TestStep(
                 4,
-                "TH reads SupportedStreamUsages attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads SupportedStreamUsages attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aSupportedStreamUsages.",
             ),
             TestStep(
                 5,
+                "TH sends the SetStreamPriorities command with StreamPriorities set as a subset of aSupportedStreamUsages.",
+                "DUT responds with a INVALID_IN_STATE status code.",
+            ),
+            TestStep(
+                6,
                 "TH sends the SnapshotStreamDeallocate command with SnapshotStreamID set to aStreamID.",
                 "DUT responds with a SUCCESS status code.",
             ),
             TestStep(
-                6,
+                7,
                 "TH sends the SetStreamPriorities command with StreamPriorities set as a subset of aSupportedStreamUsages.",
                 "DUT responds with a SUCCESS status code.",
             ),
             TestStep(
-                7,
+                8,
                 "TH sends the SetStreamPriorities command with StreamPriorities containing a StreamUsage not in aSupportedStreamUsages.",
                 "DUT responds with a DYNAMIC_CONSTRAINT_ERROR status code.",
             ),
             TestStep(
-                8,
+                9,
                 "TH sends the SetStreamPriorities command with StreamPriorities containing duplicate StreamUsage values from aSupportedStreamUsages.",
                 "DUT responds with a ALREADY_EXISTS status code.",
             ),
@@ -144,12 +149,24 @@ class TC_AVSM_2_11(MatterBaseTest, AVSMTestBase):
 
         self.step(5)
         try:
+            await self.send_single_cmd(endpoint=endpoint, cmd=commands.SetStreamPriorities(streamPriorities=aSupportedStreamUsages))
+            asserts.fail("Unexpected success when expecting INVALID_IN_STATE due to allocated SnapshotStream")
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.InvalidInState,
+                "Unexpected error returned expecting INVALID_IN_STATE due to allocated SnapshotStream",
+            )
+            pass
+
+        self.step(6)
+        try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=aStreamID))
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(6)
+        self.step(7)
         try:
             await self.send_single_cmd(
                 endpoint=endpoint, cmd=commands.SetStreamPriorities(streamPriorities=(aSupportedStreamUsages))
@@ -158,15 +175,14 @@ class TC_AVSM_2_11(MatterBaseTest, AVSMTestBase):
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(7)
+        self.step(8)
         try:
             notSupportedStreamUsage = next((e for e in Globals.Enums.StreamUsageEnum if e not in aSupportedStreamUsages), None)
             await self.send_single_cmd(
                 endpoint=endpoint, cmd=commands.SetStreamPriorities(streamPriorities=([notSupportedStreamUsage]))
             )
-            asserts.assert_true(
-                False,
-                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to StreamPriorities containing a StreamUsage not in aSupportedStreamUsages",
+            asserts.fail(
+                "Unexpected success when expecting DYNAMIC_CONSTRAINT_ERROR due to StreamPriorities containing a StreamUsage not in aSupportedStreamUsages"
             )
         except InteractionModelError as e:
             asserts.assert_equal(
@@ -176,14 +192,13 @@ class TC_AVSM_2_11(MatterBaseTest, AVSMTestBase):
             )
             pass
 
-        self.step(8)
+        self.step(9)
         try:
             await self.send_single_cmd(
                 endpoint=endpoint,
                 cmd=commands.SetStreamPriorities(streamPriorities=(aSupportedStreamUsages + aSupportedStreamUsages)),
             )
-            asserts.assert_true(
-                False,
+            asserts.fail(
                 "Unexpected success when expecting ALREADY_EXISTS due to StreamPriorities containing duplicate StreamUsage values from aSupportedStreamUsages",
             )
         except InteractionModelError as e:

--- a/src/python_testing/TC_AVSM_2_2.py
+++ b/src/python_testing/TC_AVSM_2_2.py
@@ -55,17 +55,15 @@ class TC_AVSM_2_2(MatterBaseTest):
     def steps_TC_AVSM_2_2(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify SNP is supported"
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify SNP is supported"),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads SnapshotCapabilities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads SnapshotCapabilities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aSnapshotCapabilities.",
             ),
             TestStep(
@@ -78,13 +76,12 @@ class TC_AVSM_2_2(MatterBaseTest):
             ),
             TestStep(
                 6,
-                "TH sends the SnapshotStreamAllocate command with valid values of ImageCodec, MaxFrameRate, MinResolution=MaxResolution=Resolution from aSnapshotCapabilities,",
-                "WatermarkEnabled to aWatermark, OSDEnabled to aOSD, and Quality set to 90.",
+                "TH sends the SnapshotStreamAllocate command with valid values of ImageCodec, MaxFrameRate, MinResolution=MaxResolution=Resolution from aSnapshotCapabilities, WatermarkEnabled to aWatermark, OSDEnabled to aOSD, and Quality set to 90.",
                 "DUT responds with SnapshotStreamAllocateResponse command with a valid SnapshotStreamID.",
             ),
             TestStep(
                 7,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1.",
             ),
             TestStep(
@@ -110,7 +107,7 @@ class TC_AVSM_2_2(MatterBaseTest):
             TestStep(
                 12,
                 "TH sends the SnapshotStreamAllocate command with values from step 6 except with MinResolution set to {0,0} (outside of valid range).",
-                "DUT responds with a CONSTRAINT_ERROR status code."
+                "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
                 13,
@@ -167,7 +164,7 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             snpStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
             logger.info(f"Rx'd SnapshotStreamAllocateResponse: {snpStreamAllocateResponse}")
@@ -194,12 +191,10 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MaxFrameRate set to 0(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -217,12 +212,10 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=0,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to Quality set to 0 (below valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to Quality set to 0 (below valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -240,12 +233,10 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=101,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to Quality set to 101 (above valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to Quality set to 101 (above valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -263,12 +254,10 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to ImageCodec set to 10(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -286,11 +275,11 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=aSnapshotCapabilities[0].resolution,
                 quality=90,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinResolution set to {0,0} (outside of valid range)"
+            asserts.fail(
+                "Unexpected success when expecting CONSTRAINT_ERROR due to MinResolution set to {0,0} (outside of valid range)",
             )
         except InteractionModelError as e:
             asserts.assert_equal(
@@ -309,11 +298,11 @@ class TC_AVSM_2_2(MatterBaseTest):
                 maxResolution=Clusters.CameraAvStreamManagement.Structs.VideoResolutionStruct(width=0, height=0),
                 quality=90,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=snpStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MaxResolution set to {0,0} (outside of valid range)"
+            asserts.fail(
+                "Unexpected success when expecting CONSTRAINT_ERROR due to MaxResolution set to {0,0} (outside of valid range)",
             )
         except InteractionModelError as e:
             asserts.assert_equal(

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -58,12 +58,12 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
             TestStep(
                 1,
-                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify SNP & (WMARK|OSD) is supported.",
             ),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1. Store StreamID as aStreamID. If WMARK is supported, store WaterMarkEnabled as aWmark. If OSD is supported, store OSDEnabled as aOSD.",
             ),
             TestStep(
@@ -73,7 +73,7 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 4,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the following: If WMARK is supported, verify WaterMarkEnabled == !aWmark. If OSD is supported, verify OSDEnabled == !aOSD.",
             ),
         ]
@@ -104,7 +104,6 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         logger.info(f"Rx'd snpSupport: {snpSupport}, wmarkSupport: {wmarkSupport}, osdSupport: {osdSupport}")
         asserts.assert_true(
             (snpSupport and (wmarkSupport or osdSupport)),
-            cluster.Bitmaps.Feature.kSnapshot,
             "SNP & (WMARK|OSD) is supported is not supported.",
         )
 

--- a/src/python_testing/TC_AVSM_2_4.py
+++ b/src/python_testing/TC_AVSM_2_4.py
@@ -56,12 +56,10 @@ class TC_AVSM_2_4(MatterBaseTest, AVSMTestBase):
     def steps_TC_AVSM_2_4(self) -> list[TestStep]:
         return [
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify SNP is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify SNP is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -76,7 +74,7 @@ class TC_AVSM_2_4(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated snapshot streams in the list is 0.",
             ),
         ]
@@ -113,9 +111,7 @@ class TC_AVSM_2_4(MatterBaseTest, AVSMTestBase):
             await self.send_single_cmd(
                 endpoint=endpoint, cmd=commands.SnapshotStreamDeallocate(snapshotStreamID=(aStreamIDToDelete + 1))
             )
-            asserts.assert_true(
-                False, "Unexpected success when expecting NOT_FOUND due to snapshotStreamID set to aStreamIDToDelete + 1"
-            )
+            asserts.fail("Unexpected success when expecting NOT_FOUND due to snapshotStreamID set to aStreamIDToDelete + 1")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -56,17 +56,15 @@ class TC_AVSM_2_5(MatterBaseTest):
     def steps_TC_AVSM_2_5(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify ADO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify ADO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads MicrophoneCapabilities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MicrophoneCapabilities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMicrophoneCapabilities.",
             ),
             TestStep(
@@ -76,18 +74,17 @@ class TC_AVSM_2_5(MatterBaseTest):
             ),
             TestStep(
                 5,
-                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aStreamUsagePriorities.",
             ),
             TestStep(
                 6,
-                "TH sends the AudioStreamAllocate command with valid values of AudioCodec, ChannelCount, SampleRate and BitDepth from aMicrophoneCapabilities",
-                "a StreamUsage from aStreamUsagePriorities and aBitRate as set above.",
+                "TH sends the AudioStreamAllocate command with valid values of AudioCodec, ChannelCount, SampleRate and BitDepth from aMicrophoneCapabilities, a StreamUsage from aStreamUsagePriorities and aBitRate as set above.",
                 "DUT responds with AudioStreamAllocateResponse command with a valid AudioStreamID.",
             ),
             TestStep(
                 7,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 1.",
             ),
             TestStep(
@@ -156,7 +153,6 @@ class TC_AVSM_2_5(MatterBaseTest):
         self.step(4)
         aBitRate = 0
         match aMicrophoneCapabilities.supportedCodecs[0]:
-
             case Clusters.CameraAvStreamManagement.Enums.AudioCodecEnum.kOpus:
                 aBitRate = 30000
 
@@ -196,8 +192,10 @@ class TC_AVSM_2_5(MatterBaseTest):
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1.")
 
-        notSupportedStreamUsage = next((e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
-                                       Globals.Enums.StreamUsageEnum.kUnknownEnumValue,)
+        notSupportedStreamUsage = next(
+            (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
+            Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
+        )
 
         self.step(8)
         try:
@@ -210,9 +208,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting INVALID_IN_STATE due to unsupported StreamUsage"
-            )
+            asserts.fail("Unexpected success when expecting INVALID_IN_STATE due to unsupported StreamUsage")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -232,9 +228,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to ChannelCount set to 16(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to ChannelCount set to 16(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -254,9 +248,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=48,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to BitDepth set to 48(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to BitDepth set to 48(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -276,9 +268,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to SampleRate set to 0(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to SampleRate set to 0(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -298,9 +288,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to BitRate set to 0(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to BitRate set to 0(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -320,9 +308,7 @@ class TC_AVSM_2_5(MatterBaseTest):
                 bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to AudioCodec set to 10(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to AudioCodec set to 10(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,

--- a/src/python_testing/TC_AVSM_2_6.py
+++ b/src/python_testing/TC_AVSM_2_6.py
@@ -56,12 +56,10 @@ class TC_AVSM_2_6(MatterBaseTest, AVSMTestBase):
     def steps_TC_AVSM_2_6(self) -> list[TestStep]:
         return [
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify ADO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify ADO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -76,7 +74,7 @@ class TC_AVSM_2_6(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedAudioStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated audio streams in the list is 0.",
             ),
         ]
@@ -111,9 +109,7 @@ class TC_AVSM_2_6(MatterBaseTest, AVSMTestBase):
         self.step(3)
         try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.AudioStreamDeallocate(audioStreamID=(aStreamIDToDelete + 1)))
-            asserts.assert_true(
-                False, "Unexpected success when expecting NOT_FOUND due to audioStreamID set to aStreamIDToDelete + 1"
-            )
+            asserts.fail("Unexpected success when expecting NOT_FOUND due to audioStreamID set to aStreamIDToDelete + 1")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,

--- a/src/python_testing/TC_AVSM_2_7.py
+++ b/src/python_testing/TC_AVSM_2_7.py
@@ -56,37 +56,35 @@ class TC_AVSM_2_7(MatterBaseTest):
     def steps_TC_AVSM_2_7(self) -> list[TestStep]:
         return [
             TestStep("precondition", "Commissioning, already done", is_commissioning=True),
-            TestStep(
-                1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER", "Verify VDO is supported."
-            ),
+            TestStep(1, "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT", "Verify VDO is supported."),
             TestStep(
                 2,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
             TestStep(
                 3,
-                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads StreamUsagePriorities attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aStreamUsagePriorities.",
             ),
             TestStep(
                 4,
-                "TH reads RateDistortionTradeOffPoints attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads RateDistortionTradeOffPoints attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aRateDistortionTradeOffPoints.",
             ),
             TestStep(
                 5,
-                "TH reads MinViewport attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MinViewport attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMinViewport.",
             ),
             TestStep(
                 6,
-                "TH reads VideoSensorParams attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads VideoSensorParams attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aVideoSensorParams.",
             ),
             TestStep(
                 7,
-                "TH reads MaxEncodedPixelRate attribute from CameraAVStreamManagement Cluster on TH_SERVER.",
+                "TH reads MaxEncodedPixelRate attribute from CameraAVStreamManagement Cluster on DUT.",
                 "Store this value in aMaxEncodedPixelRate.",
             ),
             TestStep(
@@ -99,13 +97,12 @@ class TC_AVSM_2_7(MatterBaseTest):
             ),
             TestStep(
                 10,
-                "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints.",
-                "TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the MinKeyFrameInterval and MaxKeyFrameInterval = 4000. TH sets WatermarkEnabled and OSDEnabled.",
-                "TH sends the VideoStreamAllocate command with these arguments.",
+                "TH sets StreamUsage from aStreamUsagePriorities. TH sets VideoCodec, MinResolution, MaxResolution, MinBitRate, MaxBitRate conforming with aRateDistortionTradeOffPoints. TH sets MinFrameRate, MaxFrameRate conforming with aVideoSensorParams. TH sets the MinKeyFrameInterval and MaxKeyFrameInterval = 4000. TH sets WatermarkEnabled to aWatermark, TH also sets OSDEnabled to aOSD. TH sends the VideoStreamAllocate command with these arguments.",
+                "DUT responds with VideoStreamAllocateResponse command with a valid VideoStreamID. Store this as myStreamID",
             ),
             TestStep(
                 11,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 1.",
             ),
             TestStep(
@@ -115,7 +112,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             ),
             TestStep(
                 13,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 1.",
             ),
             TestStep(
@@ -129,8 +126,7 @@ class TC_AVSM_2_7(MatterBaseTest):
             ),
             TestStep(
                 16,
-                "TH reads the `DPTZStreams` attribute from CameraAVSettingsUserLevelManagement Cluster on DUT.",
-                "Verify there is an entry with `VideoStreamID` set to `myStreamID.",
+                "TH reads the `DPTZStreams` attribute from CameraAVSettingsUserLevelManagement Cluster on DUT. Verify there is an entry with `VideoStreamID` set to `myStreamID.",
                 "Verify the `Viewport` for that entry is the same as `myViewport",
             ),
             TestStep(
@@ -251,12 +247,13 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
             logger.info(f"Rx'd VideoStreamAllocateResponse: {videoStreamAllocateResponse}")
             asserts.assert_is_not_none(
-                videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID")
+                videoStreamAllocateResponse.videoStreamID, "VideoStreamAllocateResponse does not contain StreamID"
+            )
             myStreamID = videoStreamAllocateResponse.videoStreamID
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
@@ -285,12 +282,13 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             videoStreamAllocateResponse = await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
             logger.info(f"Rx'd VideoStreamAllocateResponse: {videoStreamAllocateResponse}")
             asserts.assert_equal(
-                videoStreamAllocateResponse.videoStreamID, myStreamID, "VideoStreamAllocateResponse does not reuse the StreamID")
+                videoStreamAllocateResponse.videoStreamID, myStreamID, "VideoStreamAllocateResponse does not reuse the StreamID"
+            )
         except InteractionModelError as e:
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
@@ -305,19 +303,29 @@ class TC_AVSM_2_7(MatterBaseTest):
         # Viewport check
         descriptor = await self.default_controller.ReadAttribute(self.dut_node_id, [(endpoint, Clusters.Descriptor)])
         server_list = descriptor[endpoint][Clusters.Descriptor][Clusters.Descriptor.Attributes.ServerList]
-        has_cameraavsettings = (Clusters.CameraAvSettingsUserLevelManagement.id in server_list)
+        has_cameraavsettings = Clusters.CameraAvSettingsUserLevelManagement.id in server_list
 
         self.step(14)
         if has_cameraavsettings:
-            aFeatureMap = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.CameraAvSettingsUserLevelManagement, attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.FeatureMap)
+            aFeatureMap = await self.read_single_attribute_check_success(
+                endpoint=endpoint,
+                cluster=Clusters.CameraAvSettingsUserLevelManagement,
+                attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.FeatureMap,
+            )
             dptzSupport = (aFeatureMap & Clusters.CameraAvSettingsUserLevelManagement.Bitmaps.Feature.kDigitalPTZ) != 0
 
             if dptzSupport:
                 self.step(15)
-                aViewport = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attr.Viewport)
+                aViewport = await self.read_single_attribute_check_success(
+                    endpoint=endpoint, cluster=cluster, attribute=attr.Viewport
+                )
 
                 self.step(16)
-                aDptzStreams = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=Clusters.CameraAvSettingsUserLevelManagement, attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.DPTZStreams)
+                aDptzStreams = await self.read_single_attribute_check_success(
+                    endpoint=endpoint,
+                    cluster=Clusters.CameraAvSettingsUserLevelManagement,
+                    attribute=Clusters.CameraAvSettingsUserLevelManagement.Attributes.DPTZStreams,
+                )
 
                 dptzWritten = False
                 for dptzStream in aDptzStreams:
@@ -326,7 +334,8 @@ class TC_AVSM_2_7(MatterBaseTest):
                             dptzWritten = True
 
                 asserts.assert_true(
-                    dptzWritten, "DPTZStreams in CameraAvSettingsUserLevelManagement was not updated with the allocated stream id")
+                    dptzWritten, "DPTZStreams in CameraAvSettingsUserLevelManagement was not updated with the allocated stream id"
+                )
             else:
                 self.skip_step(15)
                 self.skip_step(16)
@@ -354,11 +363,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False,
+            asserts.fail(
                 "Unexpected success when expecting INVALID_IN_STATE due to StreamUsage set to a value not in aStreamUsagePriorities",
             )
         except InteractionModelError as e:
@@ -385,12 +393,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinFrameRate set to 0(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MinFrameRate set to 0(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -415,11 +421,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinFrameRate > MaxFrameRate")
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MinFrameRate > MaxFrameRate")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -444,12 +449,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinBitRate set to 0(outside of valid range)"
-            )
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MinBitRate set to 0(outside of valid range)")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -474,10 +477,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinBitRate > MaxBitRate")
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MinBitRate > MaxBitRate")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -502,11 +505,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000 + 1,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval")
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to MinKeyFrameInterval > MaxKeyFrameInterval")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,
@@ -531,11 +533,10 @@ class TC_AVSM_2_7(MatterBaseTest):
                 minKeyFrameInterval=4000,
                 maxKeyFrameInterval=4000,
                 watermarkEnabled=watermark,
-                OSDEnabled=osd
+                OSDEnabled=osd,
             )
             await self.send_single_cmd(endpoint=endpoint, cmd=videoStreamAllocateCmd)
-            asserts.assert_true(
-                False, "Unexpected success when expecting CONSTRAINT_ERROR due to invalid codec")
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to invalid codec")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,

--- a/src/python_testing/TC_AVSM_2_9.py
+++ b/src/python_testing/TC_AVSM_2_9.py
@@ -58,12 +58,12 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
             TestStep("precondition", "DUT commissioned and preconditions", is_commissioning=True),
             TestStep(
                 1,
-                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on TH_SERVER",
-                "Verify VDO is supported.",
+                "TH reads FeatureMap attribute from CameraAVStreamManagement Cluster on DUT",
+                "Verify VDO is supported. Do not run if not.",
             ),
             TestStep(
                 2,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 1. Store StreamID as aStreamIDToDelete.",
             ),
             TestStep(
@@ -78,7 +78,7 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 5,
-                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on TH_SERVER",
+                "TH reads AllocatedVideoStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the number of allocated video streams in the list is 0.",
             ),
         ]
@@ -113,9 +113,7 @@ class TC_AVSM_2_9(MatterBaseTest, AVSMTestBase):
         self.step(3)
         try:
             await self.send_single_cmd(endpoint=endpoint, cmd=commands.VideoStreamDeallocate(videoStreamID=(aStreamIDToDelete + 1)))
-            asserts.assert_true(
-                False, "Unexpected success when expecting NOT_FOUND due to videoStreamID set to aStreamIDToDelete + 1"
-            )
+            asserts.fail("Unexpected success when expecting NOT_FOUND due to videoStreamID set to aStreamIDToDelete + 1")
         except InteractionModelError as e:
             asserts.assert_equal(
                 e.status,

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -5,18 +5,6 @@ not_automated:
       reason: Code/Test not being used or not shared code for any other tests
     - name: TC_AVSMTestBase.py
       reason: Shared code for TC_AVSM, not a standalone test
-    - name: TC_AVSM_2_2.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_5.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_7.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_8.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_9.py
-      reason: Camera App does not support all features required for this TC
-    - name: TC_AVSM_2_11.py
-      reason: Camera App does not support all features required for this TC
     - name: TC_CNET_4_2.py
       reason: It has no CI execution block, it not executed in CI
     - name: TC_CNET_4_1.py


### PR DESCRIPTION
Updated the following Test Cases:
- TC-AVSM-2.1
- TC-AVSM-2.2 (enabled for testing)
- TC-AVSM-2.3
- TC-AVSM-2.4
- TC-AVSM-2.5 (enabled for testing)
- TC-AVSM-2.6
- TC-AVSM-2.7 (enabled for testing)
- TC-AVSM-2.8 (enabled for testing)
- TC-AVSM-2.9 (enabled for testing)
- TC-AVSM-2.10
- TC-AVSM-2.11 (enabled for testing)

### Testing

Build python wheel and activate venv:

```sh
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
```
For example, to run To run tests for TC-AVSM-2.3:

```
./scripts/tests/run_python_test.py --factory-reset --app <chip-camera-app> --app-args "--trace-to json:log" --script src/python_testing/TC_AVSM_2_3.py --script-args "--commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00"
```