### PR TITLE
[darwin-framework-tool] Fix a typo when dumping value as string

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -51,7 +51,7 @@ constexpr char kTrustStorePathVariable[] = "PAA_TRUST_STORE_PATH";
 namespace {
 NSString * ToNSString(const chip::Optional<chip::app::DataModel::Nullable<char *>> & string)
 {
-    if (!string.HasValue() && string.Value().IsNull()) {
+    if (!string.HasValue() || string.Value().IsNull()) {
         return nil;
     }
 


### PR DESCRIPTION
#### Summary

Corrects a logic error that used `&&` instead of `||`.

#### Related issues

N/A.

#### Testing

I found that out while running some local tests. It obviously doesn't work without that change...
