### PR TITLE
[nrfconnect] Implementation of factory reset test event trigger

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -40,6 +40,7 @@
 #include <static-supported-modes-manager.h>
 #include <static-supported-temperature-levels.h>
 
+#include <platform/nrfconnect/FactoryResetTestEventTriggerHandler.h>
 #ifdef CONFIG_CHIP_WIFI
 #include <platform/nrfconnect/wifi/NrfWiFiDriver.h>
 #endif
@@ -244,8 +245,11 @@ CHIP_ERROR AppTask::Init()
     static CommonCaseDeviceServerInitParams initParams;
     static SimpleTestEventTriggerDelegate sTestEventTriggerDelegate{};
     static OTATestEventTriggerHandler sOtaTestEventTriggerHandler{};
+    static DeviceLayer::FactoryResetTestEventTriggerHandler sFactoryResetEventTriggerHandler{};
     VerifyOrDie(sTestEventTriggerDelegate.Init(ByteSpan(sTestEventTriggerEnableKey)) == CHIP_NO_ERROR);
     VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sOtaTestEventTriggerHandler) == CHIP_NO_ERROR);
+    VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sFactoryResetEventTriggerHandler) == CHIP_NO_ERROR);
+    LOG_INF("Factory Reset Test Event Trigger Handler registered");
 #ifdef CONFIG_CHIP_CRYPTO_PSA
     initParams.operationalKeystore = &sPSAOperationalKeystore;
 #endif

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -41,6 +41,7 @@
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/nrfconnect/FactoryResetTestEventTriggerHandler.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 #include <system/SystemClock.h>
 
@@ -272,8 +273,11 @@ CHIP_ERROR AppTask::Init()
     static CommonCaseDeviceServerInitParams initParams;
     static SimpleTestEventTriggerDelegate sTestEventTriggerDelegate{};
     static OTATestEventTriggerHandler sOtaTestEventTriggerHandler{};
+    static DeviceLayer::FactoryResetTestEventTriggerHandler sFactoryResetEventTriggerHandler{};
     VerifyOrDie(sTestEventTriggerDelegate.Init(ByteSpan(sTestEventTriggerEnableKey)) == CHIP_NO_ERROR);
     VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sOtaTestEventTriggerHandler) == CHIP_NO_ERROR);
+    VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sFactoryResetEventTriggerHandler) == CHIP_NO_ERROR);
+    LOG_INF("Factory Reset Test Event Trigger Handler registered");
 #ifdef CONFIG_CHIP_CRYPTO_PSA
     initParams.operationalKeystore = &sPSAOperationalKeystore;
 #endif

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -37,6 +37,7 @@
 #include <lib/core/ErrorStr.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/nrfconnect/FactoryResetTestEventTriggerHandler.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 #include <system/SystemClock.h>
 
@@ -234,8 +235,11 @@ CHIP_ERROR AppTask::Init()
     static CommonCaseDeviceServerInitParams initParams;
     static SimpleTestEventTriggerDelegate sTestEventTriggerDelegate{};
     static OTATestEventTriggerHandler sOtaTestEventTriggerHandler{};
+    static DeviceLayer::FactoryResetTestEventTriggerHandler sFactoryResetEventTriggerHandler{};
     VerifyOrDie(sTestEventTriggerDelegate.Init(ByteSpan(sTestEventTriggerEnableKey)) == CHIP_NO_ERROR);
     VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sOtaTestEventTriggerHandler) == CHIP_NO_ERROR);
+    VerifyOrDie(sTestEventTriggerDelegate.AddHandler(&sFactoryResetEventTriggerHandler) == CHIP_NO_ERROR);
+    LOG_INF("Factory Reset Test Event Trigger Handler registered");
 #ifdef CONFIG_CHIP_CRYPTO_PSA
     initParams.operationalKeystore = &sPSAOperationalKeystore;
 #endif

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -47,6 +47,8 @@ static_library("nrfconnect") {
     "DiagnosticDataProviderImplNrf.cpp",
     "DiagnosticDataProviderImplNrf.h",
     "ExternalFlashManager.h",
+    "FactoryResetTestEventTriggerHandler.cpp",
+    "FactoryResetTestEventTriggerHandler.h",
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.h",
     "PlatformManagerImpl.h",
@@ -64,6 +66,7 @@ static_library("nrfconnect") {
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
   deps = [
     "${chip_root}/src/app:app_config",
+    "${chip_root}/src/app:test-event-trigger",
     "${chip_root}/src/app/common:ids",
     "${chip_root}/src/platform/logging:headers",
   ]

--- a/src/platform/nrfconnect/FactoryResetTestEventTriggerHandler.cpp
+++ b/src/platform/nrfconnect/FactoryResetTestEventTriggerHandler.cpp
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "FactoryResetTestEventTriggerHandler.h"
+
+#include <app/server/Server.h> // nogncheck
+#include <platform/ConfigurationManager.h>
+#include <platform/PlatformManager.h>
+#include <platform/nrfconnect/Reboot.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+CHIP_ERROR FactoryResetTestEventTriggerHandler::HandleEventTrigger(uint64_t eventTrigger)
+{
+    // Clear the endpoint from the event trigger as per the standard pattern
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+
+    if (eventTrigger == kFactoryResetTrigger)
+    {
+        ChipLogProgress(DeviceLayer, "Factory Reset Test Event Trigger MATCHED - initiating factory reset");
+
+        // Use ScheduleFactoryReset to be sure that all data is cleared
+        chip::Server::GetInstance().ScheduleFactoryReset();
+
+        return CHIP_NO_ERROR;
+    }
+
+    ChipLogProgress(DeviceLayer, "FactoryReset Handler: Trigger NOT matched, returning INVALID_ARGUMENT");
+    // If the trigger is not recognized, return an error to allow other handlers to process it
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/FactoryResetTestEventTriggerHandler.h
+++ b/src/platform/nrfconnect/FactoryResetTestEventTriggerHandler.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/TestEventTriggerDelegate.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+/**
+ * @brief nRF Connect platform-specific test event trigger handler for factory reset operations
+ *
+ * This handler provides a test event trigger that can be used to initiate
+ * a factory reset operation via the TestEventTrigger command in the
+ * General Diagnostics cluster on nRF Connect SDK platforms.
+ */
+class FactoryResetTestEventTriggerHandler : public TestEventTriggerHandler
+{
+public:
+    /**
+     * @brief Test event trigger value for factory reset
+     *
+     * This trigger value follows the standard pattern for test event triggers.
+     * The format is 0x[UniqueID]0000[SubTrigger] where bits 32-47 are always 0x0000
+     * to ensure clearEndpointInEventTrigger() doesn't modify the value.
+     * Format: 0xFFFF000000000001
+     */
+    static constexpr uint64_t kFactoryResetTrigger = 0xFFFF'0000'0000'0001;
+
+    /**
+     * @brief Handle the test event trigger
+     *
+     * @param eventTrigger The event trigger value to handle
+     * @return CHIP_NO_ERROR if the trigger was handled successfully
+     * @return CHIP_ERROR_INVALID_ARGUMENT if the trigger is not recognized
+     */
+    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override;
+};
+
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
### Changes:

Implementation of the test event trigger with command id 0xFFFF000000000001. 
Enabled the test event trigger to nrfconnect platform samples: lock, lighting, all-cluster-app.

### Testing:

Using lighting app on nrfconnect platform I was able to perform factory reset of the devices triggered by Custom Matter Test Event Trigger 