### PR TITLE
Fix memory leak in function OnScanWiFiNetworkDone

### DIFF
--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -230,6 +230,10 @@ void BLWiFiDriver::OnScanWiFiNetworkDone()
 
         if (NULL == pScanList || 0 == wifi_mgmr_sta_scanlist_dump(pScanList, nums))
         {
+            if (pScanList)
+            {
+                MemoryFree(pScanList);
+            }
             mpScanCallback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
             mpScanCallback = nullptr;
         }


### PR DESCRIPTION
When pScanList!=NULL and wifi_mgmr_sta_scanlist_dump(pScanList, nums)=0, the function doesn't free the memory allocated for pScanList.