### PR TITLE
Fix memory leak in function ReadKVSFromNV

### DIFF
--- a/src/platform/cc32xx/CC32XXConfig.cpp
+++ b/src/platform/cc32xx/CC32XXConfig.cpp
@@ -537,12 +537,14 @@ CHIP_ERROR CC32XXConfig::ReadKVSFromNV()
     {
         bufferLength = rc;
         pList->CreateLinkedListFromNV(list, bufferLength);
+        delete[] list;
         cc32xxLog("read in KVS Linked List from NV");
         return CHIP_NO_ERROR;
     }
     else
     {
         cc32xxLog("could not read in Linked List from NV, error %d", rc);
+        delete[] list;
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 }


### PR DESCRIPTION
In function ReadKVSFromNV, list is allocated with `uint8_t * list = new uint8_t[NV_BUFFER_SIZE];` but is not freed.