### PR TITLE
Fix memory leak in function WriteKVSToNV

### DIFF
--- a/src/platform/cc32xx/CC32XXConfig.cpp
+++ b/src/platform/cc32xx/CC32XXConfig.cpp
@@ -516,11 +516,13 @@ CHIP_ERROR CC32XXConfig::WriteKVSToNV()
     if (ret < 0)
     {
         cc32xxLog("could not write in Linked List to NV, error %d", ret);
+        delete[] list;
         return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 
     else
     {
+        delete[] list;
         return CHIP_NO_ERROR;
     }
     // return error


### PR DESCRIPTION
The function `SerializeLinkedList` allocates a memory object [here](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/platform/cc32xx/CC32XXConfig.cpp#L218) and returns it to the caller.
Then the function `WriteKVSToNV` stores the object in `list`, which is not freed before the function returns.
