### PR TITLE
Check the return value of snprintf before using it as a buffer index

### DIFF
--- a/src/lib/dnssd/ServiceNaming.cpp
+++ b/src/lib/dnssd/ServiceNaming.cpp
@@ -135,6 +135,10 @@ CHIP_ERROR MakeServiceSubtype(char * buffer, size_t bufferLen, DiscoveryFilter s
         break;
     case DiscoveryFilterType::kCompressedFabricId:
         requiredSize = snprintf(buffer, bufferLen, "_I");
+        if (requiredSize < 0)
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
         return Encoding::Uint64ToHex(subtype.code, &buffer[requiredSize], bufferLen - static_cast<size_t>(requiredSize),
                                      Encoding::HexFlags::kUppercaseAndNullTerminate);
         break;


### PR DESCRIPTION
The function snprintf may return -1 in error cases. It would be better to check the return value before using it as a buffer index.