### PR TITLE
Fix memory leak in function HandleBrowse

### DIFF
--- a/src/app/clusters/closure-dimension-server/closure-dimension-cluster-logic.h
+++ b/src/app/clusters/closure-dimension-server/closure-dimension-cluster-logic.h
@@ -23,6 +23,7 @@
 #include "closure-dimension-cluster-objects.h"
 #include "closure-dimension-delegate.h"
 #include "closure-dimension-matter-context.h"
+#include <app/cluster-building-blocks/QuieterReporting.h>
 
 namespace chip {
 namespace app {
@@ -387,6 +388,11 @@ private:
     ClusterConformance mConformance;
     DelegateBase & mDelegate;
     MatterContext & mMatterContext;
+
+    // At Present, QuieterReportingAttribute doesnt support Structs.
+    // So, this variable will be used for Quietreporting of current state position.
+    // TODO: Refactor CurrentState Atrribute to use QuieterReportingAttribute once Issue#39801 is resolved
+    QuieterReportingAttribute<Percent100ths> quietReportableCurrentStatePosition{ DataModel::NullNullable };
 };
 
 } // namespace ClosureDimension

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -192,6 +192,7 @@ source_set("closure-dimension-test-srcs") {
   ]
   public_deps = [
     "${chip_root}/src/app:interaction-model",
+    "${chip_root}/src/app/cluster-building-blocks:cluster-building-blocks",
     "${chip_root}/src/app/common:cluster-objects",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",

--- a/src/app/tests/TestClosureDimensionCluster.cpp
+++ b/src/app/tests/TestClosureDimensionCluster.cpp
@@ -21,6 +21,7 @@
 #include <app/clusters/closure-dimension-server/closure-dimension-delegate.h>
 #include <app/clusters/closure-dimension-server/closure-dimension-matter-context.h>
 #include <lib/support/CHIPMem.h>
+#include <lib/support/UnitTestUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <pw_unit_test/framework.h>
 #include <system/SystemClock.h>
@@ -1943,6 +1944,414 @@ TEST_F(TestClosureDimensionClusterLogic, TestHandleStepCommandWithLimitation)
                               Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kAuto));
     currentState.SetNonNull(setCurrentStateStruct);
     EXPECT_EQ(logic->SetCurrentState(currentState), CHIP_NO_ERROR);
+}
+
+//=========================================================================================
+// Tests for CurrentState Attribute Quiet Reporting
+//=========================================================================================
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingPositionNonNulltoNull)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set position to 1000
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set position to null
+    testCurrentState.Value().position.Value().SetNull();
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingPositionNulltoNonNull)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(DataModel::NullNullable);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set position as null
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set position to NonNull(1000)
+    testCurrentState.Value().position.SetValue(DataModel::MakeNullable<chip::Percent100ths>(chip::Percent100ths(1000)));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingPositionChangeValueWithoutDelay)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set position as 1000
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set position to 2000
+    testCurrentState.Value().position.SetValue(DataModel::MakeNullable<chip::Percent100ths>(chip::Percent100ths(2000)));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_FALSE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingPositionChangeValueWithDelay)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set position as 1000
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    chip::test_utils::SleepMillis(2000); // Sleep for 2 seconds
+
+    // set position to 2000
+    testCurrentState.Value().position.SetValue(DataModel::MakeNullable<chip::Percent100ths>(chip::Percent100ths(2000)));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_FALSE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+
+    chip::test_utils::SleepMillis(2000); // Sleep for 2 seconds
+
+    // set position to 3000
+    testCurrentState.Value().position.SetValue(DataModel::MakeNullable<chip::Percent100ths>(chip::Percent100ths(3000)));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_FALSE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+
+    chip::test_utils::SleepMillis(2000); // Sleep for 2 seconds
+
+    // set position to 4000
+    testCurrentState.Value().position.SetValue(DataModel::MakeNullable<chip::Percent100ths>(chip::Percent100ths(4000)));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingLatchNulltoValue)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(DataModel::NullNullable);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set latch as null
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set latch to false
+    testCurrentState.Value().latch.SetValue(DataModel::MakeNullable<bool>(false));
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingLatchValuetoNull)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set latch as false
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set latch to null
+    testCurrentState.Value().latch.Value().SetNull();
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingLatchValueChange)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set latch as false
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set latch to true
+    testCurrentState.Value().latch.Value().SetNonNull(true);
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingSpeedNullOptionaltoValue)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = NullOptional;
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set speed as nulloptional
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set speed to low
+    testCurrentState.Value().speed.SetValue(Globals::ThreeLevelAutoEnum::kLow);
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingSpeedValuetoNullOptional)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set speed as low
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set latch to NullOptional
+    testCurrentState.Value().speed.ClearValue();
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
+}
+
+TEST_F(TestClosureDimensionClusterLogic, TestCurrentStateQuietReportingSpeedValueChange)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching).Set(Feature::kSpeed);
+    conformance.OptionalAttributes().Clear(OptionalAttributeEnum::kOverflow);
+
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+    mockContext.ClearDirtyList();
+
+    GenericDimensionStateStruct testCurrentStateStruct;
+    testCurrentStateStruct.position = Optional<DataModel::Nullable<chip::Percent100ths>>(1000);
+    testCurrentStateStruct.latch    = Optional<DataModel::Nullable<bool>>(false);
+    testCurrentStateStruct.speed    = Optional<Globals::ThreeLevelAutoEnum>(Globals::ThreeLevelAutoEnum::kLow);
+
+    DataModel::Nullable<GenericDimensionStateStruct> testCurrentState(testCurrentStateStruct);
+    DataModel::Nullable<GenericDimensionStateStruct> currentState;
+
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, DataModel::NullNullable);
+
+    mockContext.ClearDirtyList();
+
+    // set speed as low
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+
+    mockContext.ClearDirtyList();
+
+    // set speed to medium
+    testCurrentState.Value().speed.SetValue(Globals::ThreeLevelAutoEnum::kMedium);
+    EXPECT_EQ(logic->SetCurrentState(testCurrentState), CHIP_NO_ERROR);
+    EXPECT_EQ(logic->GetCurrentState(currentState), CHIP_NO_ERROR);
+    EXPECT_EQ(currentState, testCurrentState);
+    EXPECT_TRUE(HasAttributeChanges(mockContext.GetDirtyList(), Attributes::CurrentState::Id));
+
+    mockContext.ClearDirtyList();
 }
 
 } // namespace ClosureDimension

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -519,7 +519,6 @@ void HandleBrowse(jobjectArray instanceName, jstring serviceType, jlong callback
     }
 
     dispatch(CHIP_NO_ERROR, services.get(), size);
-    // Memory automatically freed when unique_ptr goes out of scope
 }
 
 } // namespace Dnssd

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -504,21 +504,22 @@ void HandleBrowse(jobjectArray instanceName, jstring serviceType, jlong callback
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     JniUtfString jniServiceType(env, serviceType);
 
-    auto size              = env->GetArrayLength(instanceName);
-    DnssdService * service = new DnssdService[size];
+    auto size = env->GetArrayLength(instanceName);
+    auto services = std::make_unique<DnssdService[]>(size);
+    
     for (decltype(size) i = 0; i < size; i++)
     {
         JniUtfString jniInstanceName(env, (jstring) env->GetObjectArrayElement(instanceName, i));
         VerifyOrReturn(strlen(jniInstanceName.c_str()) <= Operational::kInstanceNameMaxLength,
-                       { delete[] service; dispatch(CHIP_ERROR_INVALID_ARGUMENT); });
+                       dispatch(CHIP_ERROR_INVALID_ARGUMENT));
 
-        CopyString(service[i].mName, jniInstanceName.c_str());
-        VerifyOrReturn(extractProtocol(jniServiceType.c_str(), service[i].mType, service[i].mProtocol) == CHIP_NO_ERROR,
-                       { delete[] service; dispatch(CHIP_ERROR_INVALID_ARGUMENT); });
+        CopyString(services[i].mName, jniInstanceName.c_str());
+        VerifyOrReturn(extractProtocol(jniServiceType.c_str(), services[i].mType, services[i].mProtocol) == CHIP_NO_ERROR,
+                       dispatch(CHIP_ERROR_INVALID_ARGUMENT));
     }
 
-    dispatch(CHIP_NO_ERROR, service, size);
-    delete[] service;
+    dispatch(CHIP_NO_ERROR, services.get(), size);
+    // Memory automatically freed when unique_ptr goes out of scope
 }
 
 } // namespace Dnssd

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -510,11 +510,11 @@ void HandleBrowse(jobjectArray instanceName, jstring serviceType, jlong callback
     {
         JniUtfString jniInstanceName(env, (jstring) env->GetObjectArrayElement(instanceName, i));
         VerifyOrReturn(strlen(jniInstanceName.c_str()) <= Operational::kInstanceNameMaxLength,
-                       dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+                       { delete[] service; dispatch(CHIP_ERROR_INVALID_ARGUMENT); });
 
         CopyString(service[i].mName, jniInstanceName.c_str());
         VerifyOrReturn(extractProtocol(jniServiceType.c_str(), service[i].mType, service[i].mProtocol) == CHIP_NO_ERROR,
-                       dispatch(CHIP_ERROR_INVALID_ARGUMENT));
+                       { delete[] service; dispatch(CHIP_ERROR_INVALID_ARGUMENT); });
     }
 
     dispatch(CHIP_NO_ERROR, service, size);


### PR DESCRIPTION
The function `HandleBrowse` allocates memory with `DnssdService * service = new DnssdService[size];` but doesn't release it in 2 error handling branches.