### PR TITLE
Fix memory leak in function OTAImageProcessorImpl::MemoryTest

### DIFF
--- a/src/platform/mbed/OTAImageProcessorImpl.cpp
+++ b/src/platform/mbed/OTAImageProcessorImpl.cpp
@@ -213,7 +213,7 @@ exit:
 
     if (buffer)
     {
-        delete buffer;
+        delete[] buffer;
     }
     // Deinitialize the block device
     ret = mBlockDevice->deinit();


### PR DESCRIPTION
Buffer is allocated at line 'buffer = new char[buffer_size]' using array allocation but is deallocated at 'delete buffer' using single object deallocation instead of the correct 'delete[] buffer'. This mismatch between allocation and deallocation methods causes a memory leak.