### PR TITLE
Removed missing on-network-ip missing. Removed attributes related to ip_addr.

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/commissioning.py
@@ -57,9 +57,6 @@ class CommissioningInfo:
     Represents the information required for commissioning a device.
 
     Attributes:
-        commissionee_ip_address_just_for_testing (Optional[str]):
-            The IP address of the commissionee used only for testing purposes.
-
         commissioning_method (Optional[str]):
             The method by which the device is being commissioned.
 
@@ -79,7 +76,6 @@ class CommissioningInfo:
         tc_user_response_to_simulate (Optional[int]):
             The user response to simulate for the Terms and Conditions, if applicable.
     """
-    commissionee_ip_address_just_for_testing: Optional[str] = None
     commissioning_method: Optional[str] = None
     thread_operational_dataset: Optional[bytes] = None
     wifi_passphrase: Optional[str] = None
@@ -288,7 +284,6 @@ class CommissionDeviceTest(base_test.BaseTestClass):
         meta_config = test_config.user_params['meta_config']
         self.dut_node_ids: List[int] = meta_config['dut_node_ids']
         self.commissioning_info: CommissioningInfo = CommissioningInfo(
-            commissionee_ip_address_just_for_testing=meta_config['commissionee_ip_address_just_for_testing'],
             commissioning_method=meta_config['commissioning_method'],
             thread_operational_dataset=meta_config['thread_operational_dataset'],
             wifi_passphrase=meta_config['wifi_passphrase'],

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -201,7 +201,6 @@ class MatterTestConfig:
     in_test_commissioning_method: Optional[str] = None
     discriminators: List[int] = field(default_factory=list)
     setup_passcodes: List[int] = field(default_factory=list)
-    commissionee_ip_address_just_for_testing: Optional[str] = None
     # By default, we start with maximized cert chains, as required for RR-1.1.
     # This allows cert tests to be run without re-commissioning for RR-1.1.
     maximize_cert_chains: bool = True
@@ -737,7 +736,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         dut_node_ids: List[int] = self.matter_test_config.dut_node_ids
         setup_payloads: List[SetupPayloadInfo] = self.get_setup_payload_info()
         commissioning_info: CommissioningInfo = CommissioningInfo(
-            commissionee_ip_address_just_for_testing=self.matter_test_config.commissionee_ip_address_just_for_testing,
+
             commissioning_method=self.matter_test_config.commissioning_method,
             thread_operational_dataset=self.matter_test_config.thread_operational_dataset,
             wifi_passphrase=self.matter_test_config.wifi_passphrase,
@@ -1542,11 +1541,6 @@ def populate_commissioning_args(args: argparse.Namespace, config: MatterTestConf
             print("error: missing --thread-dataset-hex <DATASET_HEX> for --commissioning-method ble-thread!")
             return False
         config.thread_operational_dataset = args.thread_dataset_hex
-    elif config.commissioning_method == "on-network-ip":
-        if args.ip_addr is None:
-            print("error: missing --ip-addr <IP_ADDRESS> for --commissioning-method on-network-ip")
-            return False
-        config.commissionee_ip_address_just_for_testing = args.ip_addr
 
     if args.case_admin_subject is None:
         # Use controller node ID as CASE admin subject during commissioning if nothing provided


### PR DESCRIPTION
#### Summary

Removed missing on-network-ip argument.
Removed attribute commission_ip_address_just_for_testing commissioning classes.
This cleanup will just left with CommissionIP from chipdevicectrl.


#### Related issues
Fixes: https://github.com/project-chip/matter-test-scripts/issues/535

https://github.com/project-chip/matter-test-scripts/issues/532
https://github.com/project-chip/matter-test-scripts/issues/535

#### Testing

CI Checks completed.
No issues con commissioning


