### PR TITLE
Fix a potential null pointer dereference in function GetNetworkInterfaces

### DIFF
--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -231,7 +231,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetActiveNetworkFaults(GeneralFaults<kMax
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** netifpp)
 {
-    NetworkInterface * ifp = new NetworkInterface();
+    auto ifp = std::make_unique<NetworkInterface>();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     const char * threadNetworkName = otThreadGetNetworkName(ThreadStackMgrImpl().OTInstance());
@@ -280,8 +280,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     }
     ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6AddressSpans, addr_count);
 #endif
-
-    *netifpp = ifp;
+    
+    *netifpp = ifp.release();
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -248,6 +248,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     struct netif * netif = deviceInterface_getNetif();
     if (netif == nullptr)
     {
+        delete ifp;
+        *netifpp = nullptr;
         return CHIP_ERROR_NOT_FOUND;
     }
 

--- a/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/common/DiagnosticDataProviderImpl.cpp
@@ -246,6 +246,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
 #else
 
     struct netif * netif = deviceInterface_getNetif();
+    if (netif == nullptr)
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
 
     Platform::CopyString(ifp->Name, netif->name);
     ifp->name          = CharSpan::fromCharString(ifp->Name);


### PR DESCRIPTION
In BL702, the function deviceInterface_getNetif can return NULL. See the code [here](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/platform/bouffalolab/BL702/wifi_mgmr_portable.c#L97)
In function GetNetworkInterfaces, the return value of deviceInterface_getNetif is not checked before dereference, causing a potential null pointer dereference.

