### PR TITLE
Fix a potential null pointer dereference in function GetPrimaryMACAddress

### DIFF
--- a/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
@@ -43,7 +43,12 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan & buf)
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    memcpy(buf.data(), deviceInterface_getNetif()->hwaddr, ConfigurationManager::kPrimaryMACAddressLength);
+    struct netif * netif = deviceInterface_getNetif();
+    if (netif == nullptr)
+    {
+        return CHIP_ERROR_NOT_FOUND;
+    }
+    memcpy(buf.data(), netif->hwaddr, ConfigurationManager::kPrimaryMACAddressLength);
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL702/ConfigurationManagerImpl.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryMACAddress(MutableByteSpan & buf)
     if (buf.size() != ConfigurationManager::kPrimaryMACAddressLength)
         return CHIP_ERROR_INVALID_ARGUMENT;
 
-    struct netif * netif = deviceInterface_getNetif();
+    netif * const netif = deviceInterface_getNetif();
     if (netif == nullptr)
     {
         return CHIP_ERROR_NOT_FOUND;


### PR DESCRIPTION
In BL702, the function `deviceInterface_getNetif` can return NULL. See the code [here](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/platform/bouffalolab/BL702/wifi_mgmr_portable.c#L97).
In function `GetPrimaryMACAddress`, the return value of `deviceInterface_getNetif` is not checked before dereference, causing a potential null pointer dereference.