### PR TITLE
Check the return value of function cy_network_get_nw_interface before dereference

### DIFF
--- a/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
+++ b/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
@@ -729,21 +729,24 @@ CHIP_ERROR PSOC6Utils::ping_init(void)
     CHIP_ERROR err               = CHIP_NO_ERROR;
     struct netif * net_interface = NULL;
     net_interface                = (netif *) cy_network_get_nw_interface(CY_NETWORK_WIFI_STA_INTERFACE, 0);
-    ping_target                  = &net_interface->gw;
+    if (net_interface)
+    {
+        ping_target                  = &net_interface->gw;
 
-    /* Ping to Gateway address */
-    if (ping_target)
-    {
+        /* Ping to Gateway address */
+        if (ping_target)
+        {
 #if PING_USE_SOCKETS
-        ping_socket();
+            ping_socket();
 #else
-        ping_raw();
+            ping_raw();
 #endif
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "ping_thread failed: Invalid IP address for Ping");
-        err = CHIP_ERROR_INTERNAL;
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "ping_thread failed: Invalid IP address for Ping");
+            err = CHIP_ERROR_INTERNAL;
+        }
     }
     return err;
 }


### PR DESCRIPTION
In function `ping_init`, the return value of `cy_network_get_nw_interface` is dereferenced without any null-check. However, in all other call sites of `cy_network_get_nw_interface`, the return value is checked first before dereference. [Example1](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp#L645), [Example2](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/platform/Infineon/PSOC6/DiagnosticDataProviderImpl.cpp#L161)

So we add a check in the function ping_init to prevent the potential crash.