### PR TITLE
Set initial states for Closure Linux example app

### DIFF
--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -144,14 +144,14 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
 {
     ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
     DataModel::Nullable<GenericDimensionStateStruct> currentState(
-        GenericDimensionStateStruct(MakeOptional(10000), 
-                                    MakeOptional(true), 
+        GenericDimensionStateStruct(MakeOptional(10000),
+                                    MakeOptional(true),
                                     MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
 
     DataModel::Nullable<GenericDimensionStateStruct> targetState(
-        GenericDimensionStateStruct(MakeOptional(DataModel::NullNullable), 
-                                    MakeOptional(DataModel::NullNullable), 
+        GenericDimensionStateStruct(MakeOptional(DataModel::NullNullable),
+                                    MakeOptional(DataModel::NullNullable),
                                     MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetTargetState(targetState));
 

--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -123,19 +123,17 @@ CHIP_ERROR ClosureManager::SetClosureControlInitialState(ClosureControlEndpoint 
     ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetCountdownTimeFromDelegate(NullNullable));
     ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetMainState(MainStateEnum::kStopped));
 
-    DataModel::Nullable<GenericOverallCurrentState> overallState(
-        GenericOverallCurrentState(MakeOptional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)),
-                                   MakeOptional(DataModel::MakeNullable(true)),
-                                   MakeOptional(Globals::ThreeLevelAutoEnum::kAuto),
-                                   MakeOptional(DataModel::MakeNullable(true))));
+    DataModel::Nullable<GenericOverallCurrentState> overallState(GenericOverallCurrentState(
+        MakeOptional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)), MakeOptional(DataModel::MakeNullable(true)),
+        MakeOptional(Globals::ThreeLevelAutoEnum::kAuto), MakeOptional(DataModel::MakeNullable(true))));
     ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetOverallCurrentState(overallState));
     DataModel::Nullable<GenericOverallTargetState> overallTarget(
-        GenericOverallTargetState(MakeOptional(DataModel::NullNullable),
-                                  MakeOptional(DataModel::NullNullable),
+        GenericOverallTargetState(MakeOptional(DataModel::NullNullable), MakeOptional(DataModel::NullNullable),
                                   MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetOverallTargetState(overallTarget));
     BitFlags<ClosureControl::LatchControlModesBitmap> latchControlModes;
-    latchControlModes.Set(ClosureControl::LatchControlModesBitmap::kRemoteLatching).Set(ClosureControl::LatchControlModesBitmap::kRemoteUnlatching);
+    latchControlModes.Set(ClosureControl::LatchControlModesBitmap::kRemoteLatching)
+        .Set(ClosureControl::LatchControlModesBitmap::kRemoteUnlatching);
     ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetLatchControlModes(latchControlModes));
     return CHIP_NO_ERROR;
 }
@@ -144,14 +142,11 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
 {
     ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
     DataModel::Nullable<GenericDimensionStateStruct> currentState(
-        GenericDimensionStateStruct(MakeOptional(10000),
-                                    MakeOptional(true),
-                                    MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+        GenericDimensionStateStruct(MakeOptional(10000), MakeOptional(true), MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
 
     DataModel::Nullable<GenericDimensionStateStruct> targetState(
-        GenericDimensionStateStruct(MakeOptional(DataModel::NullNullable),
-                                    MakeOptional(DataModel::NullNullable),
+        GenericDimensionStateStruct(MakeOptional(DataModel::NullNullable), MakeOptional(DataModel::NullNullable),
                                     MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetTargetState(targetState));
 
@@ -159,17 +154,15 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(1000));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnit(ClosureUnitEnum::kMillimeter));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnitRange(
-        ClosureDimension::Structs::UnitRangeStruct::Type{ .min = static_cast<int16_t>(0),
-                                                          .max = static_cast<int16_t>(10000) }));
+        ClosureDimension::Structs::UnitRangeStruct::Type{ .min = static_cast<int16_t>(0), .max = static_cast<int16_t>(10000) }));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetOverflow(OverflowEnum::kTopInside));
 
-    ClosureDimension::Structs::RangePercent100thsStruct::Type limitRange{
-        .min = static_cast<Percent100ths>(0),
-        .max = static_cast<Percent100ths>(10000)
-    };
+    ClosureDimension::Structs::RangePercent100thsStruct::Type limitRange{ .min = static_cast<Percent100ths>(0),
+                                                                          .max = static_cast<Percent100ths>(10000) };
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetLimitRange(limitRange));
     BitFlags<ClosureDimension::LatchControlModesBitmap> latchControlModes;
-    latchControlModes.Set(ClosureDimension::LatchControlModesBitmap::kRemoteLatching).Set(ClosureDimension::LatchControlModesBitmap::kRemoteUnlatching);
+    latchControlModes.Set(ClosureDimension::LatchControlModesBitmap::kRemoteLatching)
+        .Set(ClosureDimension::LatchControlModesBitmap::kRemoteUnlatching);
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetLatchControlModes(latchControlModes));
 
     return CHIP_NO_ERROR;

--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -142,7 +142,7 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
 {
     ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
     DataModel::Nullable<GenericDimensionStateStruct> currentState(
-        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)), MakeOptional(DataModel::MakeNullable(true)), 
+        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)), MakeOptional(DataModel::MakeNullable(true)),
                                     MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
 

--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -142,7 +142,8 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
 {
     ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
     DataModel::Nullable<GenericDimensionStateStruct> currentState(
-        GenericDimensionStateStruct(MakeOptional(10000), MakeOptional(true), MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)), MakeOptional(DataModel::MakeNullable(true)), 
+                                    MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
 
     DataModel::Nullable<GenericDimensionStateStruct> targetState(

--- a/examples/closure-app/linux/ClosureManager.cpp
+++ b/examples/closure-app/linux/ClosureManager.cpp
@@ -142,8 +142,8 @@ CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint 
 {
     ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
     DataModel::Nullable<GenericDimensionStateStruct> currentState(
-        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)), MakeOptional(DataModel::MakeNullable(true)),
-                                    MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)),
+                                    MakeOptional(DataModel::MakeNullable(true)), MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
     ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
 
     DataModel::Nullable<GenericDimensionStateStruct> targetState(

--- a/examples/closure-app/linux/include/ClosureManager.h
+++ b/examples/closure-app/linux/include/ClosureManager.h
@@ -62,6 +62,28 @@ public:
     chip::Protocols::InteractionModel::Status OnCalibrateCommand();
 
     /**
+     * @brief Sets the initial state for the ClosureControlEndpoint.
+     *
+     * This method initializes the closure control instance with default values and configurations.
+     *
+     * @param closureControlEndpoint The ClosureControlEndpoint to be initialized.
+     * 
+     * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
+     */
+    CHIP_ERROR SetClosureControlInitialState(chip::app::Clusters::ClosureControl::ClosureControlEndpoint & closureControlEndpoint);
+
+    /**
+     * @brief Sets the initial state for the ClosureDimensionEndpoint.
+     *
+     * This method initializes the closure panel instance with default values and configurations.
+     *
+     * @param closurePanelEndpoint The ClosureDimensionEndpoint to be initialized.
+     * 
+     * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
+     */
+    CHIP_ERROR SetClosurePanelInitialState(chip::app::Clusters::ClosureDimension::ClosureDimensionEndpoint & closurePanelEndpoint);
+
+    /**
      * @brief Handles the "MoveTo" command for the closure manager.
      *
      * This method initiates the move to command for the closure system, allowing it to move

--- a/examples/closure-app/linux/include/ClosureManager.h
+++ b/examples/closure-app/linux/include/ClosureManager.h
@@ -67,7 +67,7 @@ public:
      * This method initializes the closure control instance with default values and configurations.
      *
      * @param closureControlEndpoint The ClosureControlEndpoint to be initialized.
-     * 
+     *
      * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
      */
     CHIP_ERROR SetClosureControlInitialState(chip::app::Clusters::ClosureControl::ClosureControlEndpoint & closureControlEndpoint);
@@ -78,7 +78,7 @@ public:
      * This method initializes the closure panel instance with default values and configurations.
      *
      * @param closurePanelEndpoint The ClosureDimensionEndpoint to be initialized.
-     * 
+     *
      * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
      */
     CHIP_ERROR SetClosurePanelInitialState(chip::app::Clusters::ClosureDimension::ClosureDimensionEndpoint & closurePanelEndpoint);


### PR DESCRIPTION
#### Summary

This PR adds the logic to set the initial states of the Closure Control and Closure Panel instances during initialization of the linux app. 

#### Related issues

N/A

#### Testing

Built linux app and read the attributes to reflect the state-set during initialization

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
