### PR TITLE
Fix potential null pointer dereference in HandleTransportConnectionInitiated.

### DIFF
--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -342,7 +342,7 @@ CHIP_ERROR WiFiPAFLayer::HandleTransportConnectionInitiated(WiFiPAF::WiFiPAFSess
 
     ChipLogProgress(WiFiPAF, "Creating WiFiPAFEndPoint");
     err                                  = NewEndPoint(&newEndPoint, SessionInfo, SessionInfo.role);
-    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE);
+    ReturnErrorOnFailure(err);
     newEndPoint->mOnPafSubscribeComplete = OnSubscribeDoneFunc;
     newEndPoint->mOnPafSubscribeError    = OnSubscribeErrFunc;
     newEndPoint->mAppState               = appState;

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -342,6 +342,7 @@ CHIP_ERROR WiFiPAFLayer::HandleTransportConnectionInitiated(WiFiPAF::WiFiPAFSess
 
     ChipLogProgress(WiFiPAF, "Creating WiFiPAFEndPoint");
     err                                  = NewEndPoint(&newEndPoint, SessionInfo, SessionInfo.role);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_ERROR_INCORRECT_STATE);
     newEndPoint->mOnPafSubscribeComplete = OnSubscribeDoneFunc;
     newEndPoint->mOnPafSubscribeError    = OnSubscribeErrFunc;
     newEndPoint->mAppState               = appState;

--- a/src/wifipaf/WiFiPAFLayer.cpp
+++ b/src/wifipaf/WiFiPAFLayer.cpp
@@ -341,8 +341,7 @@ CHIP_ERROR WiFiPAFLayer::HandleTransportConnectionInitiated(WiFiPAF::WiFiPAFSess
     WiFiPAFEndPoint * newEndPoint = nullptr;
 
     ChipLogProgress(WiFiPAF, "Creating WiFiPAFEndPoint");
-    err                                  = NewEndPoint(&newEndPoint, SessionInfo, SessionInfo.role);
-    ReturnErrorOnFailure(err);
+    ReturnErrorOnFailure(NewEndPoint(&newEndPoint, SessionInfo, SessionInfo.role));
     newEndPoint->mOnPafSubscribeComplete = OnSubscribeDoneFunc;
     newEndPoint->mOnPafSubscribeError    = OnSubscribeErrFunc;
     newEndPoint->mAppState               = appState;


### PR DESCRIPTION
#### Summary
The GetFree function may return a null pointer. See the code [here](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/wifipaf/WiFiPAFLayer.cpp#L109)
In NewEndPoint, if `GetFree` returns null, the function returns the error code CHIP_ERROR_ENDPOINT_POOL_FULL. See the code [here](https://github.com/project-chip/connectedhomeip/blob/2f277fca74d88f4a8a79035ba9e43cba128b117a/src/wifipaf/WiFiPAFLayer.cpp#L329)
However, in HandleTransportConnectionInitiated, the error code returned by NewEndPoint is not checked, and the newEndPoint pointer (which could be null) is dereferenced directly.

#### Testing
Verified using static analysis and manual review:

Identified the issue with a static analyzer and confirmed it through code inspection.
Applied this patch and re-ran the analysis, confirming that the bug report no longer appears.