### PR TITLE
Fix null pointer dereference in function MdnsAvahi::Resolve

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -862,10 +862,10 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
         ChipLogError(Discovery, "Failed to allocate resolve context");
         return CHIP_ERROR_NO_MEMORY;
     }
-    CHIP_ERROR error                = CHIP_NO_ERROR;
-    resolveContext->mInstance       = this;
-    resolveContext->mCallback       = callback;
-    resolveContext->mContext        = context;
+    CHIP_ERROR error          = CHIP_NO_ERROR;
+    resolveContext->mInstance = this;
+    resolveContext->mCallback = callback;
+    resolveContext->mContext  = context;
 
     if (!interface.IsPresent())
     {

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -857,6 +857,11 @@ CHIP_ERROR MdnsAvahi::Resolve(const char * name, const char * type, DnssdService
 {
     AvahiIfIndex avahiInterface     = static_cast<AvahiIfIndex>(interface.GetPlatformInterface());
     ResolveContext * resolveContext = AllocateResolveContext();
+    if (resolveContext == nullptr)
+    {
+        ChipLogError(Discovery, "Failed to allocate resolve context");
+        return CHIP_ERROR_NO_MEMORY;
+    }
     CHIP_ERROR error                = CHIP_NO_ERROR;
     resolveContext->mInstance       = this;
     resolveContext->mCallback       = callback;


### PR DESCRIPTION
#### Summary
The function AllocateResolveContext returns a null pointer if fails to create a new object. The NULL value potentially returned by AllocateResolveContext() is dereferenced without a null check, causing a null pointer dereference bug.

#### Testing
Verified using static analysis and manual review:
* Identified the issue with a static analyzer and confirmed it through code inspection.
* Applied this patch and re-ran the analysis, confirming that the bug report no longer appears.