### PR TITLE
TC_RVCRUNM_1_2 inherits from ModeBaseClusterChecks

### DIFF
--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -57,14 +57,12 @@ class TC_RVCRUNM_1_2(MatterBaseTest, ModeBaseClusterChecks):
     @async_test_body
     async def test_TC_RVCRUNM_1_2(self):
         self.endpoint = self.get_endpoint()
-
-        # attributes = Clusters.RvcRunMode.Attributes
+        supported_modes = []
 
         self.print_step(1, "Commissioning, already done")
-
         if self.check_pics("RVCRUNM.S.A0000"):
-            self.print_step(2, "Read SupportedModes attribute")
 
+            self.print_step(2, "Read SupportedModes attribute")
             # Verify common checks for Mode Base as described in the TC-RVCRUNM-1.2
             supported_modes = await self.check_supported_modes_and_labels(self.endpoint)
 

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -36,33 +36,20 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-import logging
-
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main
 from mobly import asserts
+from modebase_cluster_check import ModeBaseClusterChecks
+
+cluster_rvcrunm_mode = Clusters.RvcRunMode
 
 
-class TC_RVCRUNM_1_2(MatterBaseTest):
+class TC_RVCRUNM_1_2(MatterBaseTest, ModeBaseClusterChecks):
     def __init__(self, *args):
-        super().__init__(*args)
+        MatterBaseTest.__init__(self, *args)
+        ModeBaseClusterChecks.__init__(self,
+                                       modebase_derived_cluster=cluster_rvcrunm_mode)
         self.endpoint = 0
-        self.commonTags = {0x0: 'Auto',
-                           0x1: 'Quick',
-                           0x2: 'Quiet',
-                           0x3: 'LowNoise',
-                           0x4: 'LowEnergy',
-                           0x5: 'Vacation',
-                           0x6: 'Min',
-                           0x7: 'Max',
-                           0x8: 'Night',
-                           0x9: 'Day'}
-        self.runTags = [tag.value for tag in Clusters.RvcRunMode.Enums.ModeTag]
-        self.supported_modes_dut = []
-
-    async def read_mod_attribute_expect_success(self, endpoint, attribute):
-        cluster = Clusters.Objects.RvcRunMode
-        return await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=attribute)
 
     def pics_TC_RVCRUNM_1_2(self) -> list[str]:
         return ["RVCRUNM.S"]
@@ -71,60 +58,17 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
     async def test_TC_RVCRUNM_1_2(self):
         self.endpoint = self.get_endpoint()
 
-        attributes = Clusters.RvcRunMode.Attributes
+        # attributes = Clusters.RvcRunMode.Attributes
 
         self.print_step(1, "Commissioning, already done")
 
         if self.check_pics("RVCRUNM.S.A0000"):
             self.print_step(2, "Read SupportedModes attribute")
-            supported_modes = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.SupportedModes)
 
-            logging.info("SupportedModes: %s" % (supported_modes))
+            # Verify common checks for Mode Base as described in the TC-RVCRUNM-1.2
+            supported_modes = await self.check_supported_modes_and_labels(self.endpoint)
 
-            # Verify that the list has at least 2 and at most 255 entries
-            asserts.assert_greater_equal(len(supported_modes), 2, "SupportedModes must have at least 2 entries!")
-            asserts.assert_less_equal(len(supported_modes), 255, "SupportedModes must have at most 255 entries!")
-
-            # Verify that each ModeOptionsStruct entry has a unique Mode field value
-            for m in supported_modes:
-                if m.mode in self.supported_modes_dut:
-                    asserts.fail("SupportedModes must have unique mode values!")
-                else:
-                    self.supported_modes_dut.append(m.mode)
-
-            # Verify that each ModeOptionsStruct entry has a unique Label field value
-            labels = []
-            for m in supported_modes:
-                if m.label in labels:
-                    asserts.fail("SupportedModes must have unique mode label values!")
-                else:
-                    labels.append(m.label)
-
-            # Verify that each ModeOptionsStruct entry's ModeTags field has:
-            for m in supported_modes:
-                # * at least one entry
-                if len(m.modeTags) == 0:
-                    asserts.fail("SupportedModes must have at least one mode tag!")
-
-                at_least_one_common_or_run_tag = False
-                for t in m.modeTags:
-                    # * the values of the Value fields that are not larger than 16 bits
-                    if t.value > 0xFFFF or t.value < 0:
-                        asserts.fail("Mode tag values must not be larger than 16 bits!")
-
-                    # * for each Value field: {isCommonOrDerivedOrMfgTagsVal}
-                    is_mfg = (0x8000 <= t.value <= 0xBFFF)
-                    if (t.value not in self.commonTags and
-                            t.value not in self.runTags and
-                            not is_mfg):
-                        asserts.fail("Mode tag value is not a common tag, run tag or vendor tag!")
-
-                    # * for at least one Value field: {isCommonOrDerivedTagsVal}
-                    if not is_mfg:
-                        at_least_one_common_or_run_tag = True
-
-                if not at_least_one_common_or_run_tag:
-                    asserts.fail("At least one mode tag must be a common tag or run tag!")
+            self.check_tags_in_lists(supported_modes)
 
             # Verify that at least one ModeOptionsStruct entry includes the Idle(0x4000)
             # mode tag in the ModeTags field
@@ -159,10 +103,8 @@ class TC_RVCRUNM_1_2(MatterBaseTest):
 
         if self.check_pics("RVCRUNM.S.A0001"):
             self.print_step(3, "Read CurrentMode attribute")
-            current_mode = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentMode)
-
-            logging.info("CurrentMode: %s" % (current_mode))
-            asserts.assert_true(current_mode in self.supported_modes_dut, "CurrentMode is not a supported mode!")
+            mode = self.cluster.Attributes.CurrentMode
+            await self.read_and_check_mode(endpoint=self.endpoint, mode=mode, supported_modes=supported_modes)
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_RVCRUNM_1_2.py
+++ b/src/python_testing/TC_RVCRUNM_1_2.py
@@ -49,7 +49,6 @@ class TC_RVCRUNM_1_2(MatterBaseTest, ModeBaseClusterChecks):
         MatterBaseTest.__init__(self, *args)
         ModeBaseClusterChecks.__init__(self,
                                        modebase_derived_cluster=cluster_rvcrunm_mode)
-        self.endpoint = 0
 
     def pics_TC_RVCRUNM_1_2(self) -> list[str]:
         return ["RVCRUNM.S"]

--- a/src/python_testing/modebase_cluster_check.py
+++ b/src/python_testing/modebase_cluster_check.py
@@ -119,7 +119,7 @@ class ModeBaseClusterChecks:
                 # Check if is tag is common, derived or mfg.
                 is_mfg = (START_MFGTAGS_RANGE <= tag.value <= END_MFGTAGS_RANGE)
                 if not (is_mfg or tag.value in self.mode_tags):
-                    asserts.fail("Mode tag value is not a common, derived or vendor tag.")
+                    asserts.fail(f"Mode tag value: {hex(tag.value)} is not a common tag, run tag or vendor tag")
 
                 # Confirm if tag is common or derived.
                 if not is_mfg:

--- a/src/python_testing/modebase_cluster_check.py
+++ b/src/python_testing/modebase_cluster_check.py
@@ -119,7 +119,7 @@ class ModeBaseClusterChecks:
                 # Check if is tag is common, derived or mfg.
                 is_mfg = (START_MFGTAGS_RANGE <= tag.value <= END_MFGTAGS_RANGE)
                 if not (is_mfg or tag.value in self.mode_tags):
-                    asserts.fail(f"Mode tag value: {hex(tag.value)} is not a common tag, run tag or vendor tag")
+                    asserts.fail(f"Mode tag value: {hex(tag.value)} is not a common tag, derived tag or vendor tag")
 
                 # Confirm if tag is common or derived.
                 if not is_mfg:

--- a/src/python_testing/modebase_cluster_check.py
+++ b/src/python_testing/modebase_cluster_check.py
@@ -118,8 +118,9 @@ class ModeBaseClusterChecks:
 
                 # Check if is tag is common, derived or mfg.
                 is_mfg = (START_MFGTAGS_RANGE <= tag.value <= END_MFGTAGS_RANGE)
+                value = hex(tag.value)
                 if not (is_mfg or tag.value in self.mode_tags):
-                    asserts.fail(f"Mode tag value: {hex(tag.value)} is not a common tag, derived tag or vendor tag")
+                    asserts.fail(f"Mode tag value: {value} is not a common tag, derived tag or vendor tag")
 
                 # Confirm if tag is common or derived.
                 if not is_mfg:


### PR DESCRIPTION
This PR fixes [#607](https://github.com/project-chip/matter-test-scripts/issues/607)

In this case some code in `TC_RVCRUNM_1_2.py` is replicated in `ModeBaseClusterChecks` class, so their methods were replaced in the test case.

### Updates

- `TC_RVCRUNM_1_2` inherits from `ModeBaseClusterChecks`
- Initialized supported_modes variable because in test step 3 it can be undefined if PICS requirements are not met
- Test step 2 uses `check_supported_modes_and_labels()` and `check_tags_in_lists()` methods
- Test step 3 uses `read_and_check_mode()` method
- Removed `self.commonTags` (in `TC_RVCRUNM_1_2.py`) because they are included in `self.mode_tags` (`ModeBaseClustersChecks`)

### Testing

In the first terminal:
- Clear commissioning data:
  ``` bash
  rm /tmp/chip_*
  ```
- Build cvc app:
  ``` bash
  ./scripts/build/build_examples.py –-target darwin-arm64-rvc build
  ```
- Run:
  ``` bash
  ./out/darwin-arm64-rvc/chip-rvc-app
  ```

In the second terminal:
- Activate Python environment
- Test:
  ``` bash
  python3 src/python_testing/TC_RVCRUNM_1_2.py --commissioning-method on-network --qr-code MT:-24J042C00KA0648G00 --endpoint 1 --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values
  ```