### PR TITLE
Add a check on the memory allocation operation to prevent potential crash

### DIFF
--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -381,7 +381,11 @@ bool BLEManagerImpl::gattMonitorCharateristicsCb(LSHandle * sh, LSMessage * mess
             pbnjson::JValue value = jvalue["changed"]["value"];
 
             uint8_t * values = (uint8_t *) malloc(sizeof(uint8_t) * value["bytes"].arraySize());
-
+            if (values == nullptr)
+            {
+                ChipLogError(DeviceLayer, "Failed to allocate memory for values");
+                return false;
+            }
             for (int i = 0; i < value["bytes"].arraySize(); i++)
             {
                 values[i] = value["bytes"][i].asNumber<int32_t>();


### PR DESCRIPTION
If the malloc operation fails, `value` will be null and will later be dereferenced, leading to a potential null pointer dereference. This change adds a check to prevent that.

#### Testing

compile-only: change is trivial