### PR TITLE
[Android] Remove redundant <uses-sdk> declaration from AndroidManifest.xml

### DIFF
--- a/examples/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/examples/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.chip.chiptool">
 
-    <uses-sdk android:minSdkVersion="28" />
-
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />


### PR DESCRIPTION
The minSdkVersion is already defined in build.gradle's defaultConfig

#### Summary

This PR removes the redundant <uses-sdk> declaration from AndroidManifest.xml.

The minimum SDK version is already defined in build.gradle under defaultConfig, which takes precedence during build configuration.

Keeping both can be confusing and is unnecessary. 
Removing the duplicate declaration helps avoid ambiguity and follows best practices in modern Android development.