### PR TITLE
TC-CLCTRL-4.2/3/4 reset sub_handler at the end of each relevant section

### DIFF
--- a/src/python_testing/TC_CLCTRL_4_2.py
+++ b/src/python_testing/TC_CLCTRL_4_2.py
@@ -233,6 +233,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
 
             self.step("2k")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_latch_matcher(False)], timeout_sec=timeout)
+            sub_handler.reset()
 
         self.step("3a")
         if latch_control_modes != 0:
@@ -269,6 +270,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
             self.step("3e")
             self.wait_for_user_input(prompt_msg="Manually unlatch the device and press enter when done")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_latch_matcher(False)], timeout_sec=timeout)
+            sub_handler.reset()
 
         self.step("4a")
         if latch_control_modes != 1:
@@ -310,6 +312,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
             self.step("4h")
             self.wait_for_user_input(prompt_msg="Manually unlatch the device and press enter when done")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_latch_matcher(False)], timeout_sec=timeout)
+            sub_handler.reset()
 
         self.step("5a")
         if latch_control_modes != 2:
@@ -353,6 +356,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
             self.step("5h")
             sub_handler.await_all_expected_report_matches(expected_matchers=[main_state_matcher(
                 Clusters.ClosureControl.Enums.MainStateEnum.kStopped)], timeout_sec=timeout)
+            sub_handler.reset()
 
         self.step("6a")
         if latch_control_modes != 3:
@@ -404,6 +408,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
             self.step("6k")
             sub_handler.await_all_expected_report_matches(expected_matchers=[main_state_matcher(
                 Clusters.ClosureControl.Enums.MainStateEnum.kStopped)], timeout_sec=timeout)
+            sub_handler.reset()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_CLCTRL_4_3.py
+++ b/src/python_testing/TC_CLCTRL_4_3.py
@@ -274,6 +274,7 @@ class TC_CLCTRL_4_3(MatterBaseTest):
             self.step("4h")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_position_matcher(
                 Clusters.ClosureControl.Enums.CurrentPositionEnum.kFullyOpened)], timeout_sec=timeout)
+            sub_handler.reset()
 
         self.step("5a")
         if not is_latching_supported or is_position_supported:
@@ -378,6 +379,7 @@ class TC_CLCTRL_4_3(MatterBaseTest):
                     logging.info(f"Exception caught for MoveTo with Position = MoveToFullyOpen and Latch = True: {e}")
                     asserts.assert_equal(e.status, Status.InvalidInState,
                                          f"Expected INVALID_IN_STATE for MoveTo with Position = MoveToFullyOpen and Latch = True but got: {e}")
+            sub_handler.reset()
 
         self.step("6a")
         if not is_speed_supported or is_latching_supported:
@@ -437,6 +439,7 @@ class TC_CLCTRL_4_3(MatterBaseTest):
             self.step("6h")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_speed_matcher(
                 Clusters.Globals.Enums.ThreeLevelAutoEnum.kLow)], timeout_sec=timeout)
+            sub_handler.reset()
 
         if is_position_supported:
             self.step("7a")
@@ -542,6 +545,7 @@ class TC_CLCTRL_4_3(MatterBaseTest):
                     logging.error(f"MoveTo command with Latch = False failed: {e}")
                     asserts.assert_equal(e.status, Status.Success,
                                          f"Expected Success status for MoveTo with Latch = False, but got: {e}")
+            sub_handler.reset()
 
         else:
             logging.info("Skipping steps 8b to 8k as Latching feature is not supported")

--- a/src/python_testing/TC_CLCTRL_4_4.py
+++ b/src/python_testing/TC_CLCTRL_4_4.py
@@ -229,6 +229,7 @@ class TC_CLCTRL_4_4(MatterBaseTest):
                 self.step("2m")
                 sub_handler.await_all_expected_report_matches(expected_matchers=[current_latch_matcher(False)], timeout_sec=timeout)
                 logging.info("Latch is now False, proceeding with CountdownTime checks")
+                sub_handler.reset()
 
         # STEP 3: Verify the CountdownTime when no operation is in progress
         self.step(3)
@@ -295,6 +296,7 @@ class TC_CLCTRL_4_4(MatterBaseTest):
             asserts.assert_equal(countdown_time_after_operation, 0,
                                  f"CountdownTime should be 0 after operation completes, got: {countdown_time_after_operation}.")
             logging.info(f"CountdownTime after operation: {countdown_time_after_operation}")
+        sub_handler.reset()
 
         # STEP 5: Verify the CountdownTime behavior when an operation is interrupted
         self.step("5a")
@@ -334,6 +336,7 @@ class TC_CLCTRL_4_4(MatterBaseTest):
             asserts.assert_true(countdown_time_after_interruption == 0,
                                 f"CountdownTime after interruption not 0, but: {countdown_time_after_interruption}.")
             logging.info(f"CountdownTime after interruption not 0, but: {countdown_time_after_interruption}")
+            sub_handler.reset()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Contains updates to the test scripts for the ClosureControl cluster.

Resets the sub_handler at the end of each relevant section in the scripts:
- TC_CLCTRL_4_2.py
- TC_CLCTRL_4_3.py
- TC_CLCTRL_4_4.py

#### Testing
Executing scripts against closure-app:

- TC-CLCTRL-4.2 -> PASS
- TC-CLCTRL-4.3 -> PASS
- TC-CLCTRL-4.4 -> PASS