### PR TITLE
Increase unit test code coverage of `access/` by 1.7%

### DIFF
--- a/src/access/tests/BUILD.gn
+++ b/src/access/tests/BUILD.gn
@@ -29,6 +29,9 @@ chip_test_suite("tests") {
   cflags = [ "-Wconversion" ]
   public_deps = [
     "${chip_root}/src/access",
+    "${chip_root}/src/access:provider-impl",
+    "${chip_root}/src/app/data-model-provider:data-model-provider",
+    "${chip_root}/src/app/data-model-provider:metadata",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support:test_utils",
     "${dir_pw_unit_test}",

--- a/src/access/tests/BUILD.gn
+++ b/src/access/tests/BUILD.gn
@@ -21,7 +21,10 @@ import("${chip_root}/build/chip/chip_test_suite.gni")
 
 chip_test_suite("tests") {
   output_name = "libaccesstest"
-  test_sources = [ "TestAccessControl.cpp" ]
+  test_sources = [
+    "TestAccessControl.cpp",
+    "TestProviderDeviceTypeResolver.cpp",
+  ]
 
   cflags = [ "-Wconversion" ]
   public_deps = [

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -1,0 +1,119 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "access/ProviderDeviceTypeResolver.h"
+#include <pw_unit_test/framework.h>
+
+#include <app/data-model-provider/Provider.h>
+#include <app/data-model-provider/MetadataTypes.h>
+#include <lib/support/ReadOnlyBuffer.h>
+#include <lib/support/CHIPMem.h> 
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::DataModel;
+
+namespace {
+
+class FakeProvider final : public Provider
+{
+public:
+    // Devices are represented by endpoints, and each endpoint can have multiple device types.
+    CHIP_ERROR DeviceTypes(EndpointId endpointId, ReadOnlyBufferBuilder<DeviceTypeEntry> & builder) override
+    {
+        if (endpointId == 1)
+        {
+            // Hardcoded device types for endpoint 1
+            constexpr DeviceTypeEntry types[] = {
+                { .deviceTypeId = 0x0000'0001, .deviceTypeRevision = 1 },
+                { .deviceTypeId = 0x0000'0002, .deviceTypeRevision = 1 },
+            };
+            return builder.AppendElements(chip::Span<const DeviceTypeEntry>(types, sizeof(types)/sizeof(types[0])));
+        }
+        if (endpointId == 2)
+        {
+            // Hardcoded device types for endpoint 2
+            constexpr DeviceTypeEntry types[] = {
+                { .deviceTypeId = 0x0000'0003, .deviceTypeRevision = 1 },
+            };
+            return builder.AppendElements(chip::Span<const DeviceTypeEntry>(types, sizeof(types)/sizeof(types[0])));
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    // The following methods are not used in this test, but must be implemented as they are pure virtual in the Provider interface.
+    CHIP_ERROR SemanticTags(EndpointId, ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR ClientClusters(EndpointId, ReadOnlyBufferBuilder<ClusterId> &)                                            override { return CHIP_NO_ERROR; }
+    CHIP_ERROR ServerClusters(EndpointId, ReadOnlyBufferBuilder<ServerClusterEntry> &)                                   override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Endpoints(ReadOnlyBufferBuilder<EndpointEntry> &)                                                         override { return CHIP_NO_ERROR; }
+    CHIP_ERROR EventInfo(const ConcreteEventPath &, EventEntry &)                                                        override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Attributes(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AttributeEntry> &)                          override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<CommandId> &)                        override { return CHIP_NO_ERROR; }
+    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AcceptedCommandEntry> &)              override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Shutdown()                                                                                                override { return CHIP_NO_ERROR; }
+    void Temporary_ReportAttributeChanged(const AttributePathParams &)                        override {}
+    ActionReturnStatus ReadAttribute(const ReadAttributeRequest &, AttributeValueEncoder &)   override { return Protocols::InteractionModel::Status::Success; }
+    ActionReturnStatus WriteAttribute(const WriteAttributeRequest &, AttributeValueDecoder &) override { return Protocols::InteractionModel::Status::Success; }
+    void ListAttributeWriteNotification(const ConcreteAttributePath &, ListWriteOperation)    override {}
+    std::optional<ActionReturnStatus> InvokeCommand(const InvokeRequest &, TLV::TLVReader &, CommandHandler *) override { return Protocols::InteractionModel::Status::Success; }
+};
+
+// Hook required by DynamicProviderDeviceTypeResolver
+FakeProvider gFakeProvider;
+Provider * GetFakeProvider() { return &gFakeProvider; }
+
+} // unnamed namespace
+
+namespace chip::Access {
+
+class TestDeviceTypeResolver : public ::testing::Test
+{
+public:
+    // In a smart home context, the physical device that can act as a resolver is typically
+    // a gateway or hub, e.g. a controller that can communicate with various devices.
+    DynamicProviderDeviceTypeResolver resolver{ &GetFakeProvider };
+
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
+    }
+    static void TearDownTestSuite()
+    {
+        chip::Platform::MemoryShutdown();
+    }
+};
+
+// Checks that the system can correctly identify when a specific device type (like a smart bulb or sensor) 
+// is actually present on a given endpoint (for example, a particular room or appliance port).
+TEST_F(TestDeviceTypeResolver, PositiveMatches)
+{
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 1));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0002, 1));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0003, 2));
+}
+
+// Checks that the system does not mistakenly identify a device type as present on an endpoint where it 
+// doesn’t actually exist (for example, asking if a light switch is in the kitchen when it isn't).
+TEST_F(TestDeviceTypeResolver, NegativeMatches)
+{
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0004, 1));  // wrong device type
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 2));  // wrong endpoint
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 99)); // unknown endpoint
+}
+
+} // namespace chip::Access

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -16,7 +16,7 @@
  *    limitations under the License.
  */
 
-#include "access/ProviderDeviceTypeResolver.h"
+#include <access/ProviderDeviceTypeResolver.h>
 #include <pw_unit_test/framework.h>
 
 #include <app/data-model-provider/MetadataTypes.h>
@@ -30,13 +30,16 @@ using namespace chip::app::DataModel;
 
 namespace {
 
+constexpr EndpointId kTestEndpointRoot  = 1; // Example: could represent the main/root device
+constexpr EndpointId kTestEndpointLight = 2; // Example: could represent a lighting device
+
 class FakeProvider final : public Provider
 {
 public:
     // Devices are represented by endpoints, and each endpoint can have multiple device types.
     CHIP_ERROR DeviceTypes(EndpointId endpointId, ReadOnlyBufferBuilder<DeviceTypeEntry> & builder) override
     {
-        if (endpointId == 1)
+        if (endpointId == kTestEndpointRoot)
         {
             // Hardcoded device types for endpoint 1
             constexpr DeviceTypeEntry types[] = {
@@ -45,7 +48,7 @@ public:
             };
             return builder.AppendElements(chip::Span(types));
         }
-        if (endpointId == 2)
+        if (endpointId == kTestEndpointLight)
         {
             // Hardcoded device types for endpoint 2
             constexpr DeviceTypeEntry types[] = {
@@ -114,17 +117,17 @@ public:
 // is actually present on a given endpoint (for example, a particular room or appliance port).
 TEST_F(TestDeviceTypeResolver, PositiveMatches)
 {
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 1));
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0002, 1));
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0003, 2));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, kTestEndpointRoot));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0002, kTestEndpointRoot));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0003, kTestEndpointLight));
 }
 
 // Checks that the system does not mistakenly identify a device type as present on an endpoint where it
 // doesn’t actually exist (for example, asking if a light switch is in the kitchen when it isn't).
 TEST_F(TestDeviceTypeResolver, NegativeMatches)
 {
-    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0004, 1));  // wrong device type
-    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 2));  // wrong endpoint
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0004, kTestEndpointRoot));  // wrong device type
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, kTestEndpointLight)); // wrong endpoint
     EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 99)); // unknown endpoint
 }
 

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -19,10 +19,10 @@
 #include "access/ProviderDeviceTypeResolver.h"
 #include <pw_unit_test/framework.h>
 
-#include <app/data-model-provider/Provider.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/data-model-provider/Provider.h>
+#include <lib/support/CHIPMem.h>
 #include <lib/support/ReadOnlyBuffer.h>
-#include <lib/support/CHIPMem.h> 
 
 using namespace chip;
 using namespace chip::app;
@@ -57,25 +57,43 @@ public:
     }
 
     // The following methods are not used in this test, but must be implemented as they are pure virtual in the Provider interface.
-    CHIP_ERROR SemanticTags(EndpointId, ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> &) override { return CHIP_NO_ERROR; }
-    CHIP_ERROR ClientClusters(EndpointId, ReadOnlyBufferBuilder<ClusterId> &)                                            override { return CHIP_NO_ERROR; }
-    CHIP_ERROR ServerClusters(EndpointId, ReadOnlyBufferBuilder<ServerClusterEntry> &)                                   override { return CHIP_NO_ERROR; }
-    CHIP_ERROR Endpoints(ReadOnlyBufferBuilder<EndpointEntry> &)                                                         override { return CHIP_NO_ERROR; }
-    CHIP_ERROR EventInfo(const ConcreteEventPath &, EventEntry &)                                                        override { return CHIP_NO_ERROR; }
-    CHIP_ERROR Attributes(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AttributeEntry> &)                          override { return CHIP_NO_ERROR; }
-    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<CommandId> &)                        override { return CHIP_NO_ERROR; }
-    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AcceptedCommandEntry> &)              override { return CHIP_NO_ERROR; }
-    CHIP_ERROR Shutdown()                                                                                                override { return CHIP_NO_ERROR; }
-    void Temporary_ReportAttributeChanged(const AttributePathParams &)                        override {}
-    ActionReturnStatus ReadAttribute(const ReadAttributeRequest &, AttributeValueEncoder &)   override { return Protocols::InteractionModel::Status::Success; }
-    ActionReturnStatus WriteAttribute(const WriteAttributeRequest &, AttributeValueDecoder &) override { return Protocols::InteractionModel::Status::Success; }
-    void ListAttributeWriteNotification(const ConcreteAttributePath &, ListWriteOperation)    override {}
-    std::optional<ActionReturnStatus> InvokeCommand(const InvokeRequest &, TLV::TLVReader &, CommandHandler *) override { return Protocols::InteractionModel::Status::Success; }
+    CHIP_ERROR SemanticTags(EndpointId, ReadOnlyBufferBuilder<Clusters::Descriptor::Structs::SemanticTagStruct::Type> &) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR ClientClusters(EndpointId, ReadOnlyBufferBuilder<ClusterId> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR ServerClusters(EndpointId, ReadOnlyBufferBuilder<ServerClusterEntry> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Endpoints(ReadOnlyBufferBuilder<EndpointEntry> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR EventInfo(const ConcreteEventPath &, EventEntry &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR Attributes(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AttributeEntry> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR GeneratedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<CommandId> &) override { return CHIP_NO_ERROR; }
+    CHIP_ERROR AcceptedCommands(const ConcreteClusterPath &, ReadOnlyBufferBuilder<AcceptedCommandEntry> &) override
+    {
+        return CHIP_NO_ERROR;
+    }
+    CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; }
+    void Temporary_ReportAttributeChanged(const AttributePathParams &) override {}
+    ActionReturnStatus ReadAttribute(const ReadAttributeRequest &, AttributeValueEncoder &) override
+    {
+        return Protocols::InteractionModel::Status::Success;
+    }
+    ActionReturnStatus WriteAttribute(const WriteAttributeRequest &, AttributeValueDecoder &) override
+    {
+        return Protocols::InteractionModel::Status::Success;
+    }
+    void ListAttributeWriteNotification(const ConcreteAttributePath &, ListWriteOperation) override {}
+    std::optional<ActionReturnStatus> InvokeCommand(const InvokeRequest &, TLV::TLVReader &, CommandHandler *) override
+    {
+        return Protocols::InteractionModel::Status::Success;
+    }
 };
 
 // Hook required by DynamicProviderDeviceTypeResolver
 FakeProvider gFakeProvider;
-Provider * GetFakeProvider() { return &gFakeProvider; }
+Provider * GetFakeProvider()
+{
+    return &gFakeProvider;
+}
 
 } // unnamed namespace
 
@@ -88,17 +106,11 @@ public:
     // a gateway or hub, e.g. a controller that can communicate with various devices.
     DynamicProviderDeviceTypeResolver resolver{ &GetFakeProvider };
 
-    static void SetUpTestSuite()
-    {
-        ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR);
-    }
-    static void TearDownTestSuite()
-    {
-        chip::Platform::MemoryShutdown();
-    }
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 };
 
-// Checks that the system can correctly identify when a specific device type (like a smart bulb or sensor) 
+// Checks that the system can correctly identify when a specific device type (like a smart bulb or sensor)
 // is actually present on a given endpoint (for example, a particular room or appliance port).
 TEST_F(TestDeviceTypeResolver, PositiveMatches)
 {
@@ -107,7 +119,7 @@ TEST_F(TestDeviceTypeResolver, PositiveMatches)
     EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0003, 2));
 }
 
-// Checks that the system does not mistakenly identify a device type as present on an endpoint where it 
+// Checks that the system does not mistakenly identify a device type as present on an endpoint where it
 // doesn’t actually exist (for example, asking if a light switch is in the kitchen when it isn't).
 TEST_F(TestDeviceTypeResolver, NegativeMatches)
 {

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -43,7 +43,7 @@ public:
                 { .deviceTypeId = 0x0000'0001, .deviceTypeRevision = 1 },
                 { .deviceTypeId = 0x0000'0002, .deviceTypeRevision = 1 },
             };
-            return builder.AppendElements(chip::Span<const DeviceTypeEntry>(types, sizeof(types)/sizeof(types[0])));
+            return builder.AppendElements(chip::Span(types));
         }
         if (endpointId == 2)
         {
@@ -51,7 +51,7 @@ public:
             constexpr DeviceTypeEntry types[] = {
                 { .deviceTypeId = 0x0000'0003, .deviceTypeRevision = 1 },
             };
-            return builder.AppendElements(chip::Span<const DeviceTypeEntry>(types, sizeof(types)/sizeof(types[0])));
+            return builder.AppendElements(chip::Span(types));
         }
         return CHIP_NO_ERROR;
     }

--- a/src/access/tests/TestProviderDeviceTypeResolver.cpp
+++ b/src/access/tests/TestProviderDeviceTypeResolver.cpp
@@ -33,6 +33,13 @@ namespace {
 constexpr EndpointId kTestEndpointRoot  = 1; // Example: could represent the main/root device
 constexpr EndpointId kTestEndpointLight = 2; // Example: could represent a lighting device
 
+// In real applications, DeviceTypeId could represent specific
+// device types like "Smart Bulb", "Thermostat", etc.
+constexpr DeviceTypeId kDeviceTypeId1 = 0x0000'0001;
+constexpr DeviceTypeId kDeviceTypeId2 = 0x0000'0002;
+constexpr DeviceTypeId kDeviceTypeId3 = 0x0000'0003;
+constexpr DeviceTypeId kDeviceTypeId4 = 0x0000'0004;
+
 class FakeProvider final : public Provider
 {
 public:
@@ -43,8 +50,8 @@ public:
         {
             // Hardcoded device types for endpoint 1
             constexpr DeviceTypeEntry types[] = {
-                { .deviceTypeId = 0x0000'0001, .deviceTypeRevision = 1 },
-                { .deviceTypeId = 0x0000'0002, .deviceTypeRevision = 1 },
+                { .deviceTypeId = kDeviceTypeId1, .deviceTypeRevision = 1 },
+                { .deviceTypeId = kDeviceTypeId2, .deviceTypeRevision = 1 },
             };
             return builder.AppendElements(chip::Span(types));
         }
@@ -52,7 +59,7 @@ public:
         {
             // Hardcoded device types for endpoint 2
             constexpr DeviceTypeEntry types[] = {
-                { .deviceTypeId = 0x0000'0003, .deviceTypeRevision = 1 },
+                { .deviceTypeId = kDeviceTypeId3, .deviceTypeRevision = 1 },
             };
             return builder.AppendElements(chip::Span(types));
         }
@@ -117,18 +124,18 @@ public:
 // is actually present on a given endpoint (for example, a particular room or appliance port).
 TEST_F(TestDeviceTypeResolver, PositiveMatches)
 {
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, kTestEndpointRoot));
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0002, kTestEndpointRoot));
-    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(0x0000'0003, kTestEndpointLight));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId1, kTestEndpointRoot));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId2, kTestEndpointRoot));
+    EXPECT_TRUE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId3, kTestEndpointLight));
 }
 
 // Checks that the system does not mistakenly identify a device type as present on an endpoint where it
 // doesn’t actually exist (for example, asking if a light switch is in the kitchen when it isn't).
 TEST_F(TestDeviceTypeResolver, NegativeMatches)
 {
-    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0004, kTestEndpointRoot));  // wrong device type
-    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, kTestEndpointLight)); // wrong endpoint
-    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(0x0000'0001, 99)); // unknown endpoint
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId4, kTestEndpointRoot));  // wrong device type
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId1, kTestEndpointLight)); // wrong endpoint
+    EXPECT_FALSE(resolver.IsDeviceTypeOnEndpoint(kDeviceTypeId1, 99));                 // unknown endpoint
 }
 
 } // namespace chip::Access

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -41,7 +41,7 @@ namespace DataModel {
 ///   - class is allowed to attempt to cache indexes/locations for faster
 ///     lookups of things (e.g during iterations)
 class Provider : public ProviderMetadataTree
-{ 
+{
 public:
     virtual ~Provider() = default;
 

--- a/src/app/data-model-provider/Provider.h
+++ b/src/app/data-model-provider/Provider.h
@@ -41,7 +41,7 @@ namespace DataModel {
 ///   - class is allowed to attempt to cache indexes/locations for faster
 ///     lookups of things (e.g during iterations)
 class Provider : public ProviderMetadataTree
-{
+{ 
 public:
     virtual ~Provider() = default;
 


### PR DESCRIPTION
#### Summary

This PR adds new unit tests for `DynamicProviderDeviceTypeResolver::IsDeviceTypeOnEndpoint()` to improve line and branch coverage for device type resolution in the access control module. The tests verify that the resolver correctly identifies whether a specific device type exists on a given endpoint, both for positive (device present) and negative (device absent or endpoint unknown) cases.

`PositiveMatches()` checks that known device types are correctly found on their associated endpoints (e.g., confirming a smart bulb is registered in the living room).

`NegativeMatches()` checks that the resolver correctly returns false for device types not present on a given endpoint or when the endpoint is unrecognized.

#### Related issues

Main issue: [37218](https://github.com/project-chip/connectedhomeip/issues/37218)

#### Testing

This PR only adds new unit tests. No changes made to production code.

#### Local (MacOS*) Coverage Impact of `/access`

| Metric   | Before | After | Delta   |
|----------|--------|-------|---------|
| Line     | 71.9%  | 73.6% | +1.7%  |
| Function | 65.4%  | 66.2% | +0.8%   |

*) MacOS coverage numbers differ slightly from Linux coverage numbers