### PR TITLE
Fix imports in the TestConformanceTest.py

### DIFF
--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -21,9 +21,9 @@ from typing import Any
 
 import chip.clusters as Clusters
 from chip.testing.basic_composition import arls_populated
-from chip.testing.problem_notices import (AttributePathLocation, CommandPathLocation, ProblemLocation)
-from chip.testing.runner import default_matter_test_main
 from chip.testing.matter_testing import MatterBaseTest
+from chip.testing.problem_notices import AttributePathLocation, CommandPathLocation, ProblemLocation
+from chip.testing.runner import default_matter_test_main
 from chip.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 from fake_device_builder import create_minimal_cluster, create_minimal_dt
 from mobly import asserts

--- a/src/python_testing/TestConformanceTest.py
+++ b/src/python_testing/TestConformanceTest.py
@@ -21,8 +21,9 @@ from typing import Any
 
 import chip.clusters as Clusters
 from chip.testing.basic_composition import arls_populated
-from chip.testing.matter_testing import (AttributePathLocation, CommandPathLocation, MatterBaseTest, ProblemLocation,
-                                         default_matter_test_main)
+from chip.testing.problem_notices import (AttributePathLocation, CommandPathLocation, ProblemLocation)
+from chip.testing.runner import default_matter_test_main
+from chip.testing.matter_testing import MatterBaseTest
 from chip.testing.spec_parsing import PrebuiltDataModelDirectory, build_xml_clusters, build_xml_device_types
 from fake_device_builder import create_minimal_cluster, create_minimal_dt
 from mobly import asserts


### PR DESCRIPTION
#### Summary

This PR fixes the issue below:

```
Executing in python environment out/venv: python3 src/python_testing/TestConformanceTest.py
Traceback (most recent call last):
  File "/__w/connectedhomeip/connectedhomeip/src/python_testing/TestConformanceTest.py", line 24, in <module>
    from chip.testing.matter_testing import (AttributePathLocation, CommandPathLocation, MatterBaseTest, ProblemLocation,
ImportError: cannot import name 'CommandPathLocation' from 'chip.testing.matter_testing' (/__w/connectedhomeip/connectedhomeip/out/venv/lib/python3.12/site-packages/chip/testing/matter_testing.py)
```

#### Related issues

None

#### Testing

CI checks need to pass
