### PR TITLE
[Silabs] [Closure] Set initial states for closure endpoints in 917 sample app

### DIFF
--- a/examples/closure-app/silabs/include/ClosureManager.h
+++ b/examples/closure-app/silabs/include/ClosureManager.h
@@ -156,6 +156,28 @@ public:
      */
     const Action_t & GetCurrentAction() const { return mCurrentAction; }
 
+    /**
+     * @brief Sets the initial state for the ClosureControlEndpoint.
+     *
+     * This method initializes the closure control instance with default values and configurations.
+     *
+     * @param closureControlEndpoint The ClosureControlEndpoint to be initialized.
+     *
+     * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
+     */
+    CHIP_ERROR SetClosureControlInitialState(chip::app::Clusters::ClosureControl::ClosureControlEndpoint & closureControlEndpoint);
+
+    /**
+     * @brief Sets the initial state for the ClosureDimensionEndpoint.
+     *
+     * This method initializes the closure panel instance with default values and configurations.
+     *
+     * @param closurePanelEndpoint The ClosureDimensionEndpoint to be initialized.
+     *
+     * @return CHIP_ERROR Returns CHIP_NO_ERROR on success, or an error code if initialization fails.
+     */
+    CHIP_ERROR SetClosurePanelInitialState(chip::app::Clusters::ClosureDimension::ClosureDimensionEndpoint & closurePanelEndpoint);
+
 private:
     static ClosureManager sClosureMgr;
 

--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -29,6 +29,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::DataModel;
 using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
 using namespace chip::app::Clusters::ClosureControl;
@@ -105,7 +106,67 @@ void ClosureManager::Init()
     SetTagList(/* endpoint= */ 2, Span<const Clusters::Descriptor::Structs::SemanticTagStruct::Type>(kEndpoint2TagList));
     SetTagList(/* endpoint= */ 3, Span<const Clusters::Descriptor::Structs::SemanticTagStruct::Type>(kEndpoint3TagList));
 
+    // Set Initial state for Closure endpoints
+    VerifyOrDie(SetClosureControlInitialState(mClosureEndpoint1) == CHIP_NO_ERROR);
+    ChipLogProgress(AppServer, "Initial state for Closure Control Endpoint set successfully");
+    VerifyOrDie(SetClosurePanelInitialState(mClosurePanelEndpoint2) == CHIP_NO_ERROR);
+    ChipLogProgress(AppServer, "Initial state for Closure Panel Endpoint 2 set successfully");
+    VerifyOrDie(SetClosurePanelInitialState(mClosurePanelEndpoint3) == CHIP_NO_ERROR);
+    ChipLogProgress(AppServer, "Initial state for Closure Panel Endpoint 3 set successfully");
+
     DeviceLayer::PlatformMgr().UnlockChipStack();
+}
+
+CHIP_ERROR ClosureManager::SetClosureControlInitialState(ClosureControlEndpoint & closureControlEndpoint)
+{
+    ChipLogProgress(AppServer, "ClosureControlEndpoint SetInitialState");
+    ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetCountdownTimeFromDelegate(NullNullable));
+    ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetMainState(MainStateEnum::kStopped));
+
+    DataModel::Nullable<GenericOverallCurrentState> overallState(GenericOverallCurrentState(
+        MakeOptional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)), MakeOptional(DataModel::MakeNullable(true)),
+        MakeOptional(Globals::ThreeLevelAutoEnum::kAuto), MakeOptional(DataModel::MakeNullable(true))));
+    ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetOverallCurrentState(overallState));
+    DataModel::Nullable<GenericOverallTargetState> overallTarget(
+        GenericOverallTargetState(MakeOptional(DataModel::NullNullable), MakeOptional(DataModel::NullNullable),
+                                  MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+    ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetOverallTargetState(overallTarget));
+    BitFlags<ClosureControl::LatchControlModesBitmap> latchControlModes;
+    latchControlModes.Set(ClosureControl::LatchControlModesBitmap::kRemoteLatching)
+        .Set(ClosureControl::LatchControlModesBitmap::kRemoteUnlatching);
+    ReturnErrorOnFailure(closureControlEndpoint.GetLogic().SetLatchControlModes(latchControlModes));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR ClosureManager::SetClosurePanelInitialState(ClosureDimensionEndpoint & closurePanelEndpoint)
+{
+    ChipLogProgress(AppServer, "ClosurePanelEndpoint SetInitialState");
+    DataModel::Nullable<GenericDimensionStateStruct> currentState(
+        GenericDimensionStateStruct(MakeOptional(DataModel::MakeNullable<Percent100ths>(10000)),
+                                    MakeOptional(DataModel::MakeNullable(true)), MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetCurrentState(currentState));
+
+    DataModel::Nullable<GenericDimensionStateStruct> targetState(
+        GenericDimensionStateStruct(MakeOptional(DataModel::NullNullable), MakeOptional(DataModel::NullNullable),
+                                    MakeOptional(Globals::ThreeLevelAutoEnum::kAuto)));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetTargetState(targetState));
+
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetResolution(Percent100ths(100)));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetStepValue(1000));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnit(ClosureUnitEnum::kMillimeter));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetUnitRange(
+        ClosureDimension::Structs::UnitRangeStruct::Type{ .min = static_cast<int16_t>(0), .max = static_cast<int16_t>(10000) }));
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetOverflow(OverflowEnum::kTopInside));
+
+    ClosureDimension::Structs::RangePercent100thsStruct::Type limitRange{ .min = static_cast<Percent100ths>(0),
+                                                                          .max = static_cast<Percent100ths>(10000) };
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetLimitRange(limitRange));
+    BitFlags<ClosureDimension::LatchControlModesBitmap> latchControlModes;
+    latchControlModes.Set(ClosureDimension::LatchControlModesBitmap::kRemoteLatching)
+        .Set(ClosureDimension::LatchControlModesBitmap::kRemoteUnlatching);
+    ReturnErrorOnFailure(closurePanelEndpoint.GetLogic().SetLatchControlModes(latchControlModes));
+
+    return CHIP_NO_ERROR;
 }
 
 void ClosureManager::StartTimer(uint32_t aTimeoutMs)


### PR DESCRIPTION
#### Summary

This PR adds the logic to set the initial states of the Closure Control and Closure Panel instances during initialization of 917 sample app.

#### Related issues

N/A

#### Testing

Built 917 closure app and read the attributes to reflect the state-set during initialization

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
