### PR TITLE
[NXP][platform][common] Add Ethernet network ID support

### DIFF
--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -114,6 +114,18 @@ CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     return CHIP_NO_ERROR;
 }
 
+NetworkIterator * NxpEthDriver::GetNetworks()
+{
+    EthernetNetworkIterator *iterator = new EthernetNetworkIterator();
+
+    uint8_t interface_index = netif_get_index(&netif_app);
+    /* +1 for end char, example of interface name: eth_1*/
+    iterator->interfaceNameLen = std::min(strlen("eth_") + sizeof(interface_index) + 1, sizeof(iterator->interfaceName));
+    snprintf((char*)iterator->interfaceName, iterator->interfaceNameLen, "eth_%d", interface_index);
+
+    return iterator;
+}
+
 } // namespace NetworkCommissioning
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -116,12 +116,12 @@ CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
 
 NetworkIterator * NxpEthDriver::GetNetworks()
 {
-    EthernetNetworkIterator *iterator = new EthernetNetworkIterator();
+    EthernetNetworkIterator * iterator = new EthernetNetworkIterator();
 
     uint8_t interface_index = netif_get_index(&netif_app);
     /* +1 for end char, example of interface name: eth_1*/
     iterator->interfaceNameLen = std::min(strlen("eth_") + sizeof(interface_index) + 1, sizeof(iterator->interfaceName));
-    snprintf((char*)iterator->interfaceName, iterator->interfaceNameLen, "eth_%d", interface_index);
+    snprintf((char *) iterator->interfaceName, iterator->interfaceNameLen, "eth_%d", interface_index);
 
     return iterator;
 }

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -119,9 +119,11 @@ NetworkIterator * NxpEthDriver::GetNetworks()
     EthernetNetworkIterator * iterator = new EthernetNetworkIterator();
 
     uint8_t interface_index = netif_get_index(&netif_app);
-    /* +1 for end char, example of interface name: eth_1*/
-    iterator->interfaceNameLen = std::min(strlen("eth_") + sizeof(interface_index) + 1, sizeof(iterator->interfaceName));
-    snprintf((char *) iterator->interfaceName, iterator->interfaceNameLen, "eth_%d", interface_index);
+    int len = snprintf(reinterpret_cast<char *>(iterator->interfaceName), sizeof(iterator->interfaceName), "eth_%u", interface_index);
+    if (len > 0 && static_cast<size_t>(len) < sizeof(iterator->interfaceName))
+    {
+        iterator->interfaceNameLen = static_cast<uint8_t>(len);
+    }
 
     return iterator;
 }

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -116,6 +116,7 @@ CHIP_ERROR NxpEthDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
 
 NetworkIterator * NxpEthDriver::GetNetworks()
 {
+    /* Caller is responsible for deleting this object to prevent a memory leak */
     EthernetNetworkIterator * iterator = new EthernetNetworkIterator();
 
     uint8_t interface_index = netif_get_index(&netif_app);

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.cpp
@@ -119,7 +119,8 @@ NetworkIterator * NxpEthDriver::GetNetworks()
     EthernetNetworkIterator * iterator = new EthernetNetworkIterator();
 
     uint8_t interface_index = netif_get_index(&netif_app);
-    int len = snprintf(reinterpret_cast<char *>(iterator->interfaceName), sizeof(iterator->interfaceName), "eth_%u", interface_index);
+    int len =
+        snprintf(reinterpret_cast<char *>(iterator->interfaceName), sizeof(iterator->interfaceName), "eth_%u", interface_index);
     if (len > 0 && static_cast<size_t>(len) < sizeof(iterator->interfaceName))
     {
         iterator->interfaceNameLen = static_cast<uint8_t>(len);

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.h
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.h
@@ -60,6 +60,7 @@ public:
     netif * GetEthInetIf() { return &netif_app; };
 
     // BaseDriver
+    /* current network ID is a concatenation of the prefix "eth_" and the ethernet interface number */
     NetworkIterator * GetNetworks() override;
     uint8_t GetMaxNetworks() { return 1; }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;

--- a/src/platform/nxp/common/Ethernet/NxpEthDriver.h
+++ b/src/platform/nxp/common/Ethernet/NxpEthDriver.h
@@ -32,7 +32,7 @@ public:
     class EthernetNetworkIterator final : public NetworkIterator
     {
     public:
-        EthernetNetworkIterator(NxpEthDriver * aDriver) : mDriver(aDriver) {}
+        EthernetNetworkIterator() = default;
         size_t Count() { return 1; }
         bool Next(Network & item) override
         {
@@ -60,7 +60,7 @@ public:
     netif * GetEthInetIf() { return &netif_app; };
 
     // BaseDriver
-    NetworkIterator * GetNetworks() override { return new EthernetNetworkIterator(this); };
+    NetworkIterator * GetNetworks() override;
     uint8_t GetMaxNetworks() { return 1; }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
     void Shutdown()


### PR DESCRIPTION
#### Summary

Test TC-CNET-4.3 failed at reading network id step when using ethernet, the network ID is empty:

Chip tool command: ./chip-tool networkcommissioning read networks 2 0
DUT response:
Endpoint: 0 Cluster: 0x0000_0031 Attribute 0x0000_0001 DataVersion: 1681188019
     Networks: 1 entries
     [1]:

{        NetworkID:        Connected: TRUE       }

#### Testing
board: frdm rw61x
example: thermostat

- chip-tool pairing DUT using chip-tool pairing onnetwork: ./chip-tool pairing onnetwork-long 1 20202021 3840

- chip-tool read networks attribute by ./chip-tool networkcommissioning read networks 1 0

[1751881350.315] [2668641:2668676] [TOO] Endpoint: 0 Cluster: 0x0000_0031 Attribute 0x0000_0001 DataVersion: 4015475376
[1751881350.315] [2668641:2668676] [TOO]   Networks: 1 entries
[1751881350.315] [2668641:2668676] [TOO]     [1]: {
[1751881350.315] [2668641:2668676] [TOO]       NetworkID: 6574685F3200
[1751881350.315] [2668641:2668676] [TOO]       Connected: TRUE
[1751881350.315] [2668641:2668676] [TOO]      }

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
