### PR TITLE
[E2E][JF] Added OJCW command to CommissioningWindowManager

### DIFF
--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -88,6 +88,12 @@ public:
                                                Crypto::Spake2pVerifier & verifier, uint32_t iterations, chip::ByteSpan salt,
                                                FabricIndex fabricIndex, VendorId vendorId);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    CHIP_ERROR OpenJointCommissioningWindow(System::Clock::Seconds32 commissioningTimeout, uint16_t discriminator,
+                                            Crypto::Spake2pVerifier & verifier, uint32_t iterations, ByteSpan salt,
+                                            FabricIndex fabricIndex, VendorId vendorId);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+
     void CloseCommissioningWindow();
 
     app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum CommissioningWindowStatusForCluster() const;
@@ -190,6 +196,11 @@ private:
         app::Clusters::AdministratorCommissioning::CommissioningWindowStatusEnum::kWindowNotOpen;
 
     bool mIsBLE = true;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
+    // Boolean that tracks whether we are currently in a Joint Commissioning Mode.
+    bool mJCM = false;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_JOINT_FABRIC
 
     PASESession mPairingSession;
 

--- a/src/lib/dnssd/Advertiser.h
+++ b/src/lib/dnssd/Advertiser.h
@@ -44,9 +44,10 @@ enum class CommssionAdvertiseMode : uint8_t
 
 enum class CommissioningMode
 {
-    kDisabled,       // Commissioning Mode is disabled, CM=0 in DNS-SD key/value pairs
-    kEnabledBasic,   // Basic Commissioning Mode, CM=1 in DNS-SD key/value pairs
-    kEnabledEnhanced // Enhanced Commissioning Mode, CM=2 in DNS-SD key/value pairs
+    kDisabled,           // Commissioning Mode is disabled, CM=0 in DNS-SD key/value pairs
+    kEnabledBasic,       // Basic Commissioning Mode, CM=1 in DNS-SD key/value pairs
+    kEnabledEnhanced,    // Enhanced Commissioning Mode, CM=2 in DNS-SD key/value pairs
+    kEnabledJointFabric, // Joint Fabric Commissioning Mode, CM=3 in DNS-SD key/value pairs
 };
 
 enum class ICDModeAdvertise : uint8_t


### PR DESCRIPTION
#### Summary
Add OJCW command to CommissioningWindowManager (OJCW implementation will be provided in a separate PR).

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/39664.

#### Testing
Verified using the below instructions. OJCW functionality will be tested in a follow-up PR that implements it.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```