### PR TITLE
[Camera] Update TC_AVSM_2_10.py with snapshot image verification step

### DIFF
--- a/src/python_testing/TC_AVSM_2_10.py
+++ b/src/python_testing/TC_AVSM_2_10.py
@@ -159,6 +159,8 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
             asserts.assert_greater(
                 captureSnapshotResponse.resolution.height, 0, "Image height returned by CaptureSnapshotResponse is <= 0"
             )
+            if not self.is_pics_sdk_ci_only:
+                self.user_verify_snap_shot("Validate the snapshot image", captureSnapshotResponse.data)
         except InteractionModelError as e:
             # TODO: Fail the test if this is reached, once the test infrastructure supports snapshot capture
             logger.error(f"Snapshot capture is not supported: {e}")
@@ -200,6 +202,8 @@ class TC_AVSM_2_10(MatterBaseTest, AVSMTestBase):
             asserts.assert_greater(
                 captureSnapshotResponse.resolution.height, 0, "Image height returned by CaptureSnapshotResponse is <= 0"
             )
+            if not self.is_pics_sdk_ci_only:
+                self.user_verify_snap_shot("Validate the snapshot image", captureSnapshotResponse.data)
         except InteractionModelError as e:
             # TODO: Fail the test if this is reached, once the test infrastructure supports snapshot capture
             logger.error(f"Snapshot capture is not supported: {e}")

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -87,6 +87,11 @@ _DEFAULT_DUT_NODE_ID = 0x12344321
 _DEFAULT_TRUST_ROOT_INDEX = 1
 
 
+class TestError(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+
 def default_paa_rootstore_from_root(root_path: pathlib.Path) -> Optional[pathlib.Path]:
     """Attempt to find a PAA trust store following SDK convention at `root_path`
 
@@ -1133,8 +1138,9 @@ class MatterBaseTest(base_test.BaseTestClass):
 
     def user_verify_snap_shot(self,
                               prompt_msg: str,
-                              image: bytes) -> Optional[str]:
+                              image: bytes) -> None:
         """Show Image Verification Prompt and wait for user validation.
+           This method will be executed only when TC is running in TH.
 
         Args:
             prompt_msg (str): Message for TH UI prompt and input function.
@@ -1142,47 +1148,58 @@ class MatterBaseTest(base_test.BaseTestClass):
             image (bytes): Image data as bytes.
 
         Returns:
-            str: User input or none if input is closed.
-        """
+            Returns nothing indicating success so the test can go on.
 
-        # Convert bytes to comma separated hex string
-        hex_string = ', '.join(f'{byte:02x}' for byte in image)
-        if self.runner_hook:
+        Raises:
+            TestError: Indicating image validation step failed.
+        """
+        # Only run when TC is being executed in TH
+        if self.runner_hook and hasattr(self.runner_hook, 'show_image_prompt'):
+            # Convert bytes to comma separated hex string
+            hex_string = ', '.join(f'{byte:02x}' for byte in image)
             self.runner_hook.show_image_prompt(
                 msg=prompt_msg,
                 img_hex_str=hex_string
             )
 
-        logging.info("========= USER PROMPT for Image Verification =========")
-        logging.info(f">>> {prompt_msg.rstrip()} (press enter to confirm)")
-        try:
-            return input()
-        except EOFError:
-            logging.info("========= EOF on STDIN =========")
-            return None
+            logging.info("========= USER PROMPT for Image Validation =========")
+
+            try:
+                result = input()
+                if result != '1':  # User did not select 'PASS'
+                    raise TestError("Image validation failed")
+            except EOFError:
+                logging.info("========= EOF on STDIN =========")
+                return None
 
     def user_verify_video_stream(self,
-                                 prompt_msg: str) -> Optional[str]:
+                                 prompt_msg: str) -> None:
         """Show Video Verification Prompt and wait for user validation.
+           This method will be executed only when TC is running in TH.
 
         Args:
             prompt_msg (str): Message for TH UI prompt and input function.
             Indicates what is expected from the user.
 
         Returns:
-            str: User input or none if input is closed.
-        """
+            Returns nothing indicating success so the test can go on.
 
-        if self.runner_hook:
+        Raises:
+            TestError: Indicating video validation step failed.
+        """
+        # Only run when TC is being executed in TH
+        if self.runner_hook and hasattr(self.runner_hook, 'show_video_prompt'):
             self.runner_hook.show_video_prompt(msg=prompt_msg)
 
-        logging.info("========= USER PROMPT for Video Stream Verification =========")
-        logging.info(f">>> {prompt_msg.rstrip()} (press enter to confirm)")
-        try:
-            return input()
-        except EOFError:
-            logging.info("========= EOF on STDIN =========")
-            return None
+            logging.info("========= USER PROMPT for Video Stream Validation =========")
+
+            try:
+                result = input()
+                if result != '1':  # User did not select 'PASS'
+                    raise TestError("Video stream validation failed")
+            except EOFError:
+                logging.info("========= EOF on STDIN =========")
+                return None
 
 
 def _find_test_class():

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -88,8 +88,7 @@ _DEFAULT_TRUST_ROOT_INDEX = 1
 
 
 class TestError(Exception):
-    def __init__(self, msg):
-        self.msg = msg
+    pass
 
 
 def default_paa_rootstore_from_root(root_path: pathlib.Path) -> Optional[pathlib.Path]:


### PR DESCRIPTION
This PR enables snapshot verification pop up in TC-AVSM-2.10.py to allow tester to validate snapshot image visually when the TC is executed in Test Harness.

### Testing

Build python wheel and activate venv:

```sh
. ./scripts/activate.sh
./scripts/build_python.sh -i out/python_env
source out/python_env/bin/activate
```

To run tests for TC-AVSM-2.10:

```sh
./scripts/tests/run_python_test.py --factory-reset --app <chip-camera-app> --app-args "--trace-to json:log" --script src/python_testing/TC_AVSM_2_10.py --script-args "--commissioning-method on-network --qr-code MT:-24J0AFN00KA0648G00 --endpoint 1"
```