### PR TITLE
[Cameras] Handle WatermarkEnabled and OSDEnabled being optional 

### DIFF
--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1205,7 +1205,7 @@ void CameraDevice::InitializeSnapshotStreams()
                                           90 /* Quality */,
                                           0 /* RefCount */,
                                           false /* EncodedPixels */,
-                                          false /* HardareEncoder */
+                                          false /* HardwareEncoder */
                                       },
                                       false,
                                       nullptr };

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1204,9 +1204,9 @@ void CameraDevice::InitializeSnapshotStreams()
                                         90 /* Quality */,
                                         0 /* RefCount */,
                                         false /* EncodedPixels */,
-                                        false /* HardareEncoder */ 
+                                        false /* HardareEncoder */
                                       },
-                                      false, 
+                                      false,
                                       nullptr };
 
     mSnapshotStreams.push_back(snapshotStream);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1202,8 +1202,11 @@ void CameraDevice::InitializeSnapshotStreams()
                                         { kMinResolutionWidth, kMinResolutionHeight } /* MinResolution*/,
                                         { kMaxResolutionWidth, kMaxResolutionHeight } /* MaxResolution */,
                                         90 /* Quality */,
-                                        0 /* RefCount */ },
-                                      false,
+                                        0 /* RefCount */,
+                                        false /* EncodedPixels */,
+                                        false /* HardareEncoder */ 
+                                      },
+                                      false, 
                                       nullptr };
 
     mSnapshotStreams.push_back(snapshotStream);

--- a/examples/camera-app/linux/src/camera-device.cpp
+++ b/examples/camera-app/linux/src/camera-device.cpp
@@ -1196,15 +1196,16 @@ void CameraDevice::InitializeAudioStreams()
 void CameraDevice::InitializeSnapshotStreams()
 {
     // Create single snapshot stream with typical supported parameters
-    SnapshotStream snapshotStream = { { 1 /* Id */,
-                                        ImageCodecEnum::kJpeg,
-                                        kSnapshotStreamFrameRate /* FrameRate */,
-                                        { kMinResolutionWidth, kMinResolutionHeight } /* MinResolution*/,
-                                        { kMaxResolutionWidth, kMaxResolutionHeight } /* MaxResolution */,
-                                        90 /* Quality */,
-                                        0 /* RefCount */,
-                                        false /* EncodedPixels */,
-                                        false /* HardareEncoder */
+    SnapshotStream snapshotStream = { {
+                                          1 /* Id */,
+                                          ImageCodecEnum::kJpeg,
+                                          kSnapshotStreamFrameRate /* FrameRate */,
+                                          { kMinResolutionWidth, kMinResolutionHeight } /* MinResolution*/,
+                                          { kMaxResolutionWidth, kMaxResolutionHeight } /* MaxResolution */,
+                                          90 /* Quality */,
+                                          0 /* RefCount */,
+                                          false /* EncodedPixels */,
+                                          false /* HardareEncoder */
                                       },
                                       false,
                                       nullptr };

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -278,6 +278,17 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
             {
                 stream.isAllocated = true;
 
+                // Set the optional Watermark and OSD values if provided in the allocation
+                if (allocateArgs.watermarkEnabled.HasValue())
+                {
+                    stream.snapshotStreamParams.watermarkEnabled = allocateArgs.watermarkEnabled;
+                }
+
+                if (allocateArgs.OSDEnabled.HasValue())
+                {
+                    stream.snapshotStreamParams.OSDEnabled = allocateArgs.OSDEnabled;
+                }
+
                 // Start the snapshot stream for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartSnapshotStream(outStreamID);
 

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -278,16 +278,11 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
             {
                 stream.isAllocated = true;
 
-                // Set the optional Watermark and OSD values if provided in the allocation
-                if (allocateArgs.watermarkEnabled.HasValue())
-                {
-                    stream.snapshotStreamParams.watermarkEnabled = allocateArgs.watermarkEnabled;
-                }
-
-                if (allocateArgs.OSDEnabled.HasValue())
-                {
-                    stream.snapshotStreamParams.OSDEnabled = allocateArgs.OSDEnabled;
-                }
+                // Set the optional Watermark and OSD values that may have been provided.  This is the initial 
+                // setting of these values, they may be subsequently modified. If the values have no value that
+                // is ok, the allocated stream will store as such and ignore.
+                stream.snapshotStreamParams.watermarkEnabled = allocateArgs.watermarkEnabled;
+                stream.snapshotStreamParams.OSDEnabled = allocateArgs.OSDEnabled;
 
                 // Start the snapshot stream for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartSnapshotStream(outStreamID);

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -278,7 +278,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
             {
                 stream.isAllocated = true;
 
-                // Set the optional Watermark and OSD values that may have been provided.  This is the initial 
+                // Set the optional Watermark and OSD values that may have been provided.  This is the initial
                 // setting of these values, they may be subsequently modified. If the values have no value that
                 // is ok, the allocated stream will store as such and ignore.
                 stream.snapshotStreamParams.watermarkEnabled = allocateArgs.watermarkEnabled;

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -282,7 +282,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamAllocat
                 // setting of these values, they may be subsequently modified. If the values have no value that
                 // is ok, the allocated stream will store as such and ignore.
                 stream.snapshotStreamParams.watermarkEnabled = allocateArgs.watermarkEnabled;
-                stream.snapshotStreamParams.OSDEnabled = allocateArgs.OSDEnabled;
+                stream.snapshotStreamParams.OSDEnabled       = allocateArgs.OSDEnabled;
 
                 // Start the snapshot stream for serving.
                 mCameraDeviceHAL->GetCameraHALInterface().StartSnapshotStream(outStreamID);

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1941,7 +1941,7 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamAllocate(HandlerContext & ctx
             ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: WatermarkEnabled provided but Watermark Feature not set", mEndpointId);
             ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
         });
-    }   
+    }
 
     // If OSDEnabled is provided then the OSD feature has to be supported
     if (commandData.OSDEnabled.HasValue())
@@ -2019,7 +2019,7 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamModify(HandlerContext & ctx,
     if (commandData.watermarkEnabled.HasValue() || commandData.OSDEnabled.HasValue())
     {
         status = mDelegate.SnapshotStreamModify(snapshotStreamID, isWaterMarkEnabled, isOSDEnabled);
-    }    
+    }
 
     if (status == Status::Success)
     {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -2015,11 +2015,14 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamModify(HandlerContext & ctx,
         });
     }
 
-    // Call the delegate only if there is either a WatermarkEnabled or OSDEnabled value, the spec allows for both to be absent
-    if (commandData.watermarkEnabled.HasValue() || commandData.OSDEnabled.HasValue())
-    {
-        status = mDelegate.SnapshotStreamModify(snapshotStreamID, isWaterMarkEnabled, isOSDEnabled);
-    }
+    // One of WatermarkEnabled or OSDEnabled has to be present
+    VerifyOrReturn(commandData.watermarkEnabled.HasValue() || commandData.OSDEnabled.HasValue(), {
+        ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: One of WatermarkEnabled or OSDEnabled must be provided in SnapshotStreamModify", mEndpointId);
+        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
+    });
+    
+    status = mDelegate.SnapshotStreamModify(snapshotStreamID, isWaterMarkEnabled, isOSDEnabled);
+    
 
     if (status == Status::Success)
     {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -2017,12 +2017,13 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamModify(HandlerContext & ctx,
 
     // One of WatermarkEnabled or OSDEnabled has to be present
     VerifyOrReturn(commandData.watermarkEnabled.HasValue() || commandData.OSDEnabled.HasValue(), {
-        ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: One of WatermarkEnabled or OSDEnabled must be provided in SnapshotStreamModify", mEndpointId);
+        ChipLogError(Zcl,
+                     "CameraAVStreamMgmt[ep=%d]: One of WatermarkEnabled or OSDEnabled must be provided in SnapshotStreamModify",
+                     mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
     });
 
     status = mDelegate.SnapshotStreamModify(snapshotStreamID, isWaterMarkEnabled, isOSDEnabled);
-
 
     if (status == Status::Success)
     {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -2020,9 +2020,9 @@ void CameraAVStreamMgmtServer::HandleSnapshotStreamModify(HandlerContext & ctx,
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: One of WatermarkEnabled or OSDEnabled must be provided in SnapshotStreamModify", mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand);
     });
-    
+
     status = mDelegate.SnapshotStreamModify(snapshotStreamID, isWaterMarkEnabled, isOSDEnabled);
-    
+
 
     if (status == Status::Success)
     {

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -76,6 +76,11 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
                 "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the following: If WMARK is supported, verify WaterMarkEnabled == !aWmark. If OSD is supported, verify OSDEnabled == !aOSD.",
             ),
+            TestStep(
+                5,
+                "TH sends the SnapshotStreamModify command with SnapshotStreamID set to aStreamID. Neither WaterMarkEnabled nor OSDEnabled is provided. Verify Succcess.",
+                "DUT responds with a SUCCESS status code.",
+            ),
         ]
 
     @run_if_endpoint_matches(
@@ -116,6 +121,7 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         aStreamID = aAllocatedSnapshotStreams[0].snapshotStreamID
         aWmark = aAllocatedSnapshotStreams[0].watermarkEnabled
         aOSD = aAllocatedSnapshotStreams[0].OSDEnabled
+        aWmark = aOSD = None
 
         self.step(3)
         try:
@@ -141,6 +147,17 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         if osdSupport:
             asserts.assert_equal(aAllocatedSnapshotStreams[0].OSDEnabled, not aOSD, "OSDEnabled is not equal to !aOSD")
 
+        self.step(5)
+        try:
+            cmd = commands.SnapshotStreamModify(
+                snapshotStreamID=aStreamID,
+                watermarkEnabled=None,
+                OSDEnabled=None,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=cmd)
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
+            pass
 
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -68,18 +68,18 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             ),
             TestStep(
                 3,
+                "TH sends the SnapshotStreamModify command with SnapshotStreamID set to aStreamID. No WaterMarkEnabled or OSDEnabled provided.",
+                "DUT responds with an INVALID_COMMAND status code.",
+            ),
+            TestStep(
+                4,
                 "TH sends the SnapshotStreamModify command with SnapshotStreamID set to aStreamID. If WMARK is supported, set WaterMarkEnabled to !aWmark`and if OSD is supported, set OSDEnabled to `!aOSD in the command.",
                 "DUT responds with a SUCCESS status code.",
             ),
             TestStep(
-                4,
+                5,
                 "TH reads AllocatedSnapshotStreams attribute from CameraAVStreamManagement Cluster on DUT",
                 "Verify the following: If WMARK is supported, verify WaterMarkEnabled == !aWmark. If OSD is supported, verify OSDEnabled == !aOSD.",
-            ),
-            TestStep(
-                5,
-                "TH sends the SnapshotStreamModify command with SnapshotStreamID set to aStreamID. Neither WaterMarkEnabled nor OSDEnabled is provided. Verify Succcess.",
-                "DUT responds with a SUCCESS status code.",
             ),
         ]
 
@@ -109,7 +109,7 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         logger.info(f"Rx'd snpSupport: {snpSupport}, wmarkSupport: {wmarkSupport}, osdSupport: {osdSupport}")
         asserts.assert_true(
             (snpSupport and (wmarkSupport or osdSupport)),
-            "SNP & (WMARK|OSD) is supported is not supported.",
+            "SNP & (WMARK|OSD) is not supported.",
         )
 
         self.step(2)
@@ -126,6 +126,19 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         try:
             cmd = commands.SnapshotStreamModify(
                 snapshotStreamID=aStreamID,
+                watermarkEnabled=None,
+                OSDEnabled=None,
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=cmd)
+            asserts.fail("Unexpected success when expecting INVALID_COMMAND due to absence of WatermarkEnabled and OSDEnabled)")
+        except InteractionModelError as e:
+            asserts.assert_equal(e.status, Status.InvalidCommand, "Unexpected error when expecting INVALID_COMMAND")
+            pass
+
+        self.step(4)
+        try:
+            cmd = commands.SnapshotStreamModify(
+                snapshotStreamID=aStreamID,
                 watermarkEnabled=None if aWmark is None else not aWmark,
                 OSDEnabled=None if aOSD is None else not aOSD,
             )
@@ -134,7 +147,7 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
-        self.step(4)
+        self.step(5)
         aAllocatedSnapshotStreams = await self.read_single_attribute_check_success(
             endpoint=endpoint, cluster=cluster, attribute=attr.AllocatedSnapshotStreams
         )
@@ -145,18 +158,6 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             )
         if osdSupport:
             asserts.assert_equal(aAllocatedSnapshotStreams[0].OSDEnabled, not aOSD, "OSDEnabled is not equal to !aOSD")
-
-        self.step(5)
-        try:
-            cmd = commands.SnapshotStreamModify(
-                snapshotStreamID=aStreamID,
-                watermarkEnabled=None,
-                OSDEnabled=None,
-            )
-            await self.send_single_cmd(endpoint=endpoint, cmd=cmd)
-        except InteractionModelError as e:
-            asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
-            pass
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -159,5 +159,6 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
             asserts.assert_equal(e.status, Status.Success, "Unexpected error returned")
             pass
 
+
 if __name__ == "__main__":
     default_matter_test_main()

--- a/src/python_testing/TC_AVSM_2_3.py
+++ b/src/python_testing/TC_AVSM_2_3.py
@@ -121,7 +121,6 @@ class TC_AVSM_2_3(MatterBaseTest, AVSMTestBase):
         aStreamID = aAllocatedSnapshotStreams[0].snapshotStreamID
         aWmark = aAllocatedSnapshotStreams[0].watermarkEnabled
         aOSD = aAllocatedSnapshotStreams[0].OSDEnabled
-        aWmark = aOSD = None
 
         self.step(3)
         try:


### PR DESCRIPTION
#### Summary

Recent spec change (see: ) makes the presence of WatermarkEnabled and OSDEnabled optional if the feature flags are set for snapshot streams, rather than mandatory.

This PR changes the logic for SnapshotStreamAllocate and SnapshotStreamModify to align with the spec change.  Which now allows a modify with no real actionable data (it's a no-op).  It also adds a test step to AVSM_2_3 to check for a modify with no WatermarkEnabled or OSDEnabled being handled correctly.

#### Testing
Using the Python runner execute AVSM_2_2 and AVSM_2_3 against the camera app
Using ChipTool and an instrumented camera app that doesn't have the Watermark feature, verify that an allocate that includes WatermarkEnabled is correctly rejected.


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
