### PR TITLE
[Camera] Include push_av_server and required dependencies in chip-cert-bins

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -43,6 +43,7 @@ RUN set -x \
     cmake \
     curl \
     flex \
+    ffmpeg \
     g++ \
     gcc \
     git \
@@ -319,6 +320,10 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/data_model python_testing
 
 COPY --from=chip-build-cert-bins /root/connectedhomeip/src/python_testing/requirements.txt /tmp/requirements.txt
 RUN pip install --break-system-packages -r /tmp/requirements.txt && rm /tmp/requirements.txt
+
+# Copy PushAV Server to apps and install dependencies
+COPY --from=chip-build-cert-bins /root/connectedhomeip/src/tools/push_av_server apps/push_av_server
+RUN pip install --break-system-packages -r apps/push_av_server/requirements.txt
 
 # Stage 3.2: Setup the Mock Server
 COPY --from=chip-build-cert-bins /root/connectedhomeip/integrations/mock_server mock_server


### PR DESCRIPTION
### Summary
Integrate `push_av_server` into **chip-cert-bins** docker image to facilitate push av integration test cases on Test Harness.
Need ffmpeg package for `push_av_server` to abe able to produce probe results.
### Testing
Validated by CI