### PR TITLE
Add push_av_server in tests workflow to support pushav integration TCs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -676,6 +676,11 @@ jobs:
                   build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test"
 
+            - name: Copy push_av_server and install dependencies
+              run: >-
+                  cp -r ./src/tools/push_av_server objdir-clone/
+                  && pip install --break-system-packages -r objdir-clone/push_av_server/requirements.txt
+
             - name: Generate an argument environment file
               run: |
                   echo -n "" >/tmp/test_env.yaml
@@ -700,6 +705,7 @@ jobs:
                   echo "JF_CONTROL_APP: objdir-clone/linux-x64-jf-control-app/jfc-app" >> /tmp/test_env.yaml
                   echo "JF_ADMIN_APP: objdir-clone/linux-x64-jf-admin-app/jfa-app" >> /tmp/test_env.yaml
                   echo "CLOSURE_APP: objdir-clone/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test/closure-app" >> /tmp/test_env.yaml
+                  echo "PUSH_AV_SERVER: objdir-clone/push_av_server/server.py" >> /tmp/test_env.yaml
 
                   # Generic trace setups after applications
                   echo "TRACE_TEST_JSON: out/trace_data/test-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml


### PR DESCRIPTION
### Summary
Integrate **push_av_server** in tests.yml workflow to support push av integration tests in CI.
This PR requires #39830 to be merged first as the server has a dependency on ffmpeg.

### Testing
Validated by CI