### PR TITLE
Fix software-fault-listener include in air-quality-sensor-app

### DIFF
--- a/examples/air-quality-sensor-app/linux/BUILD.gn
+++ b/examples/air-quality-sensor-app/linux/BUILD.gn
@@ -41,6 +41,7 @@ executable("air-quality-sensor-app") {
   deps = [
     "${chip_root}/examples/air-quality-sensor-app/air-quality-sensor-common",
     "${chip_root}/examples/platform/linux:app-main",
+    "${chip_root}/src/app/clusters/software-diagnostics-server:software-fault-listener",
     "${chip_root}/src/lib",
     "${chip_root}/third_party/jsoncpp",
   ]


### PR DESCRIPTION
#### Summary
Fix the air-quality-sensor-app Linux example by adding the software-fault-listener header as dependency just like in other examples. This got missed in #38914.

#### Related issues

#### Testing
Build test the example.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
