### PR TITLE
Increase unit test code coverage of `ble/` by 3.6%

### DIFF
--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -425,4 +425,24 @@ TEST_F(TestBtpEngine, HandleCharacteristicReceivedIncorrectSequence)
     EXPECT_EQ(mBtpEngine.RxState(), BtpEngine::kState_Error);
 }
 
+TEST_F(TestBtpEngine, HandleCharacteristicReceivedUnexpectedStandaloneAck)
+{
+    constexpr uint8_t ackPacketData[] = {
+        to_underlying(BtpEngine::HeaderFlags::kFragmentAck),
+        0x00,
+        0x01,
+    };
+
+    auto ackPacket = System::PacketBufferHandle::NewWithData(ackPacketData, sizeof(ackPacketData));
+    EXPECT_FALSE(ackPacket.IsNull());
+
+    SequenceNumber_t receivedAck;
+    bool didReceiveAck;
+    EXPECT_EQ(mBtpEngine.HandleCharacteristicReceived(std::move(ackPacket), receivedAck, didReceiveAck), BLE_ERROR_INVALID_ACK);
+    EXPECT_TRUE(didReceiveAck);
+    EXPECT_EQ(receivedAck, 0x00);
+    EXPECT_EQ(mBtpEngine.RxState(), BtpEngine::kState_Error);
+}
+
+
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -509,17 +509,23 @@ TEST_F(TestBtpEngine, HandleAckReceivedIncorrectSequence)
 // Test handling a packet that contains more data than the declared payload length (simulating BLE packet padding).
 TEST_F(TestBtpEngine, HandleCharacteristicReceivedWithPadding)
 {
-    // Create a packet buffer with a single message.
+    // Create a packet buffer with a single message and padding bytes.
+    // The payload length in the header is 1 byte, but the actual packet has padding.
     constexpr uint8_t packetData0[] = {
         to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
         0x01, // Sequence number
         0x01, // Payload length (only 1 byte of actual payload)
-        0x00, // Payload length
+        0x00, // Payload length (high byte)
         0xff, // Payload
+        0x00, // Padding bytes (should be ignored by BTP engine)
+        0x00,
+        0x00,
+        0x00,
+        0x00,
     };
 
-    // Create a packet with 10 bytes total, but only 1 byte is actual payload (the rest is padding).
-    auto packet0 = System::PacketBufferHandle::NewWithData(packetData0, 10);
+    // Create a packet with the full data including padding.
+    auto packet0 = System::PacketBufferHandle::NewWithData(packetData0, sizeof(packetData0));
 
     // Handle the received packet and check the state of the BTP engine.
     SequenceNumber_t receivedAck;

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -473,4 +473,23 @@ TEST_F(TestBtpEngine, HandleAckReceivedIncorrectSequence)
     EXPECT_EQ(mBtpEngine.ExpectingAck(), 1);
 }
 
+TEST_F(TestBtpEngine, HandleCharacteristicReceivedWithPadding)
+{
+    constexpr uint8_t packetData[] = {
+        to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage),
+        0x01,
+        0x01,
+        0x00,
+        0xff,
+    };
+
+    auto packet = System::PacketBufferHandle::NewWithData(packetData, 10);
+
+    SequenceNumber_t receivedAck;
+    bool didReceiveAck;
+    EXPECT_EQ(mBtpEngine.HandleCharacteristicReceived(std::move(packet), receivedAck, didReceiveAck), CHIP_NO_ERROR);
+    EXPECT_EQ(mBtpEngine.RxState(), BtpEngine::kState_Complete);
+    EXPECT_EQ(packet->DataLength(), 10);
+}
+
 } // namespace

--- a/src/ble/tests/TestBtpEngine.cpp
+++ b/src/ble/tests/TestBtpEngine.cpp
@@ -311,8 +311,8 @@ TEST_F(TestBtpEngine, EncodeStandAloneAckOnePacket)
     constexpr uint8_t packetData0[] = {
         to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
         0x01, // Sequence number
-        0x01, // Payload length
-        0x00, // Payload length
+        0x01, // Payload length, Least Significant Byte
+        0x00, // Payload length, Most Significant Byte
         0xff, // Payload
     };
     // Create a packet buffer with the data for the message and check that it is created successfully.
@@ -373,9 +373,23 @@ TEST_F(TestBtpEngine, EncodeStandAloneAckInsufficientBuffer)
 TEST_F(TestBtpEngine, EncodeStandAloneAckMultiFragmentMessage)
 {
     // Create packet buffers for a multi-fragment message.
-    constexpr uint8_t packetData0[] = { to_underlying(BtpEngine::HeaderFlags::kStartMessage), 0x01, 0x03, 0x00, 0xfd };
-    constexpr uint8_t packetData1[] = { to_underlying(BtpEngine::HeaderFlags::kContinueMessage), 0x02, 0xfe };
-    constexpr uint8_t packetData2[] = { to_underlying(BtpEngine::HeaderFlags::kEndMessage), 0x03, 0xff };
+    constexpr uint8_t packetData0[] = {
+        to_underlying(BtpEngine::HeaderFlags::kStartMessage), // Header flags
+        0x01,                                                 // Sequence number
+        0x03,                                                 // Payload length, Least Significant Byte
+        0x00,                                                 // Payload length, Most Significant Byte
+        0xfd,                                                 // Payload
+    };
+    constexpr uint8_t packetData1[] = {
+        to_underlying(BtpEngine::HeaderFlags::kContinueMessage), // Header flags
+        0x02,                                                    // Sequence number
+        0xfe,                                                    // Payload
+    };
+    constexpr uint8_t packetData2[] = {
+        to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
+        0x03,                                               // Sequence number
+        0xff,                                               // Payload
+    };
 
     // Create the first packet and check its data length.
     auto packet0 = System::PacketBufferHandle::NewWithData(packetData0, sizeof(packetData0));
@@ -420,8 +434,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicReceivedIncorrectSequence)
     uint8_t packetData0[] = {
         to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
         0x01, // Sequence number
-        0x01, // Payload length
-        0x00, // Payload length
+        0x01, // Payload length, Least Significant Byte
+        0x00, // Payload length, Most Significant Byte
         0xff, // Payload
     };
     auto packet0 = System::PacketBufferHandle::NewWithData(packetData0, sizeof(packetData0));
@@ -437,8 +451,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicReceivedIncorrectSequence)
     uint8_t packetData1[] = {
         to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
         0x02, // Sequence number
-        0x01, // Payload length
-        0x00, // Payload length
+        0x01, // Payload length, Least Significant Byte
+        0x00, // Payload length, Most Significant Byte
         0xff, // Payload
     };
     auto packet1 = System::PacketBufferHandle::NewWithData(packetData1, sizeof(packetData1));
@@ -514,8 +528,8 @@ TEST_F(TestBtpEngine, HandleCharacteristicReceivedWithPadding)
     constexpr uint8_t packetData0[] = {
         to_underlying(BtpEngine::HeaderFlags::kStartMessage) | to_underlying(BtpEngine::HeaderFlags::kEndMessage), // Header flags
         0x01, // Sequence number
-        0x01, // Payload length (only 1 byte of actual payload)
-        0x00, // Payload length (high byte)
+        0x01, // Payload length, Least Significant Byte (only 1 byte of actual payload)
+        0x00, // Payload length, Most Significant Byte
         0xff, // Payload
         0x00, // Padding bytes (should be ignored by BTP engine)
         0x00,


### PR DESCRIPTION
#### Summary

This PR increases `ble` unit test coverage from 67.2% to 70.8% by adding comprehensive unit tests for the `BtpEngine::EncodeStandAloneAck` and `BtpEngine::HandleCharacteristicReceived` methods in `TestBtpEngine`. The new tests validate correct behavior for BLE acknowledgment encoding, message reception, and protocol error handling in edge cases. Specifically, the tests cover:

* Encoding standalone ACK packets:

  * When unacknowledged data exists.
  * When no data is pending acknowledgment.
  * When the packet buffer is too small to hold the header.
  * Correctly assembling multi-fragment messages.

* Handling received characteristic packets:

  * Rejecting new messages if the previous one remains unacknowledged.
  * Detecting and handling unexpected standalone ACK packets.
  * Detecting and handling ACK packets with incorrect sequence numbers.
  * Managing padded payloads where extra bytes exist beyond declared length.
  * Testing sequence number wraparound and ACK validation logic after extended transmissions.

**Testing Notes**

Buffer headroom validation in `EncodeStandAloneAck`: This function checks if there's enough buffer space reserved for lower BLE layers before encoding an ACK packet. However, the configuration value `CHIP_CONFIG_BLE_PKT_RESERVED_SIZE` is currently set to 0, so the validation always passes. While code coverage shows this line as tested, the error path that should trigger when there's insufficient buffer headroom cannot actually be tested with the current configuration.

#### Related issues

Main issue [#37232](https://github.com/project-chip/connectedhomeip/issues/37232)

#### Testing

This PR only adds new unit tests. No changes made to production code.