### PR TITLE
Matter testing framework: Fix bool-arg so it is not lower case'd

### DIFF
--- a/src/python_testing/TestFrameworkArgParsing.py
+++ b/src/python_testing/TestFrameworkArgParsing.py
@@ -1,0 +1,121 @@
+#
+#    Copyright (c) 2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     script-args: >
+#       --hex-arg UPPER.CASE.HEX_ARG_WITH_UPPER_CASE_VAL:01020A
+#       --hex-arg UPPER.CASE.HEX_ARG_WITH_LOWER_CASE_VAL:01020a
+#       --hex-arg lower.case.hex_arg:01020a
+#       --hex-arg MiXed.case.hex_arg:01020a
+#       --string-arg UPPER.CASE.STRING_ARG:TestyTesty
+#       --string-arg lower.case.string_arg:TestyTesty
+#       --string-arg MiXed.case.string_arg:TestyTesty
+#       --int-arg UPPER.CASE.INT_ARG:15
+#       --int-arg lower.case.int_arg:15
+#       --int-arg MiXed.case.int_arg:15
+#       --bool-arg UPPER.CASE.BOOL_ARG_WITH_LOWER_CASE_VAL:true
+#       --bool-arg UPPER.CASE.BOOL_ARG_WITH_UPPER_CASE_VAL:TRUE
+#       --bool-arg UPPER.CASE.BOOL_ARG_WITH_MIXED_CASE_VAL:True
+#       --bool-arg UPPER.CASE.BOOL_ARG_WITH_NUMBER_VAL_1:1
+#       --bool-arg UPPER.CASE.BOOL_ARG_WITH_NUMBER_VAL_0:0
+#       --bool-arg lower.case.bool_arg_with_lower_case_val:true
+#       --bool-arg lower.case.bool_arg_with_upper_case_val:TRUE
+#       --bool-arg lower.case.bool_arg_with_mixed_case_val:True
+#       --bool-arg lower.case.bool_arg_with_number_val_1:1
+#       --bool-arg lower.case.bool_arg_with_number_val_0:0
+#       --bool-arg MiXed.case.bool_arg_with_number_val_0:0
+#       --float-arg UPPER.CASE.FLOAT_ARG:1.57
+#       --float-arg lower.case.float_arg:1.57
+#       --float-arg MiXed.case.float_arg:1.57
+#       --json-arg UPPER.CASE.JSON_ARG:{\"jsontestkey\":\"jsontestval\"}
+#       --json-arg lower.case.json_arg:{\"jsontestkey\":\"jsontestval\"}
+#       --json-arg MiXed.case.json_arg:{\"jsontestkey\":\"jsontestval\"}
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+
+import json
+
+from chip.testing.conversions import bytes_from_hex
+from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
+from typing import Any
+from mobly import asserts
+
+
+class TestFrameworkArgParsing(MatterBaseTest):
+    def check_arg(self, expected_name: str, expected_val: Any) -> None:
+        # Why do we have both? No idea, but folks expect stuff to be in both, so let's check both
+        asserts.assert_in(expected_name, self.matter_test_config.global_test_params.keys(),
+                          f"Expected user parameter {expected_name} not found in global_test_params")
+        asserts.assert_in(expected_name, self.user_params.keys())
+        asserts.assert_in(expected_name, self.matter_test_config.global_test_params.keys(),
+                          f"Expected user parameter {expected_name} not found in user_params")
+        asserts.assert_equal(
+            self.matter_test_config.global_test_params[expected_name], expected_val, f"Unexpected value for {expected_name}")
+        asserts.assert_equal(self.user_params[expected_name],
+                             expected_val, f"Unexpected value for {expected_name}")
+
+    def test_FrameworkArgParsing(self):
+        hex_val = bytes_from_hex('01020A')
+        string_val = 'TestyTesty'
+        int_val = 15
+        float_val = 1.57
+        json_val = json.loads('{\"jsontestkey\":\"jsontestval\"}')
+
+        self.check_arg('UPPER.CASE.HEX_ARG_WITH_UPPER_CASE_VAL', hex_val)
+        self.check_arg('UPPER.CASE.HEX_ARG_WITH_LOWER_CASE_VAL', hex_val)
+        self.check_arg('lower.case.hex_arg', hex_val)
+        self.check_arg('MiXed.case.hex_arg', hex_val)
+
+        self.check_arg('UPPER.CASE.STRING_ARG', string_val)
+        self.check_arg('lower.case.string_arg', string_val)
+        self.check_arg('MiXed.case.string_arg', string_val)
+
+        self.check_arg('UPPER.CASE.INT_ARG', 15)
+        self.check_arg('lower.case.int_arg', 15)
+        self.check_arg('MiXed.case.int_arg', 15)
+
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_LOWER_CASE_VAL', True)
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_UPPER_CASE_VAL', True)
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_MIXED_CASE_VAL', True)
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_MIXED_CASE_VAL', True)
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_NUMBER_VAL_1', True)
+        self.check_arg('UPPER.CASE.BOOL_ARG_WITH_NUMBER_VAL_0', False)
+
+        self.check_arg('lower.case.bool_arg_with_lower_case_val', True)
+        self.check_arg('lower.case.bool_arg_with_upper_case_val', True)
+        self.check_arg('lower.case.bool_arg_with_mixed_case_val', True)
+        self.check_arg('lower.case.bool_arg_with_number_val_1', True)
+        self.check_arg('lower.case.bool_arg_with_number_val_0', False)
+
+        self.check_arg('MiXed.case.bool_arg_with_number_val_0', False)
+
+        self.check_arg('UPPER.CASE.FLOAT_ARG', float_val)
+        self.check_arg('lower.case.float_arg', float_val)
+        self.check_arg('MiXed.case.float_arg', float_val)
+
+        self.check_arg('UPPER.CASE.JSON_ARG', json_val)
+        self.check_arg('lower.case.json_arg', json_val)
+        self.check_arg('MiXed.case.json_arg', json_val)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TestFrameworkArgParsing.py
+++ b/src/python_testing/TestFrameworkArgParsing.py
@@ -89,9 +89,9 @@ class TestFrameworkArgParsing(MatterBaseTest):
         self.check_arg('lower.case.string_arg', string_val)
         self.check_arg('MiXed.case.string_arg', string_val)
 
-        self.check_arg('UPPER.CASE.INT_ARG', 15)
-        self.check_arg('lower.case.int_arg', 15)
-        self.check_arg('MiXed.case.int_arg', 15)
+        self.check_arg('UPPER.CASE.INT_ARG', int_val)
+        self.check_arg('lower.case.int_arg', int_val)
+        self.check_arg('MiXed.case.int_arg', int_val)
 
         self.check_arg('UPPER.CASE.BOOL_ARG_WITH_LOWER_CASE_VAL', True)
         self.check_arg('UPPER.CASE.BOOL_ARG_WITH_UPPER_CASE_VAL', True)

--- a/src/python_testing/TestFrameworkArgParsing.py
+++ b/src/python_testing/TestFrameworkArgParsing.py
@@ -53,10 +53,10 @@
 # === END CI TEST ARGUMENTS ===
 
 import json
+from typing import Any
 
 from chip.testing.conversions import bytes_from_hex
 from chip.testing.matter_testing import MatterBaseTest, default_matter_test_main
-from typing import Any
 from mobly import asserts
 
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1411,8 +1411,8 @@ def json_named_arg(s: str) -> Tuple[str, object]:
 
 
 def bool_named_arg(s: str) -> Tuple[str, bool]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false|True|False|TRUE|FALSE)|(?P<decimal_value>[01]))$"
-    match = re.match(regex, s)
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false)|(?P<decimal_value>[01]))$"
+    match = re.match(regex, s, re.IGNORECASE)
     if not match:
         raise ValueError("Invalid bool argument format, does not match %s" % regex)
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1411,14 +1411,14 @@ def json_named_arg(s: str) -> Tuple[str, object]:
 
 
 def bool_named_arg(s: str) -> Tuple[str, bool]:
-    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false)|(?P<decimal_value>[01]))$"
-    match = re.match(regex, s.lower())
+    regex = r"^(?P<name>[a-zA-Z_0-9.]+):((?P<truth_value>true|false|True|False|TRUE|FALSE)|(?P<decimal_value>[01]))$"
+    match = re.match(regex, s)
     if not match:
         raise ValueError("Invalid bool argument format, does not match %s" % regex)
 
     name = match.group("name")
     if match.group("truth_value"):
-        value = True if match.group("truth_value") == "true" else False
+        value = True if match.group("truth_value").lower() == "true" else False
     else:
         value = int(match.group("decimal_value")) != 0
 


### PR DESCRIPTION

#### Summary
Fixes the argument parsing for boolean arguments in the python matter testing framework. These were all getting converted to lower case.

All the other --x-arg command line arguments respect casing, but the bool one got lower cased because of the regex. Fixing this and adding a test to ensure all the arg types come through properly.

#### Related issues
#39914

#### Testing
Please see attached unit test

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ X] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [X ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ X] PR size is short
-   [ X] Try to avoid "squashing" and "force-update" in commit history
-   [? ] CI time didn't increase - not sure, I guess we'll see. I'm adding a new test. 

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
