### PR TITLE
Treat examples/darwin-framework-tool as "darwin" code for review policy purposes.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -284,7 +284,7 @@ groups:
     type: required
     conditions:
       - "files.include('src/darwin/*').exclude('src/darwin/Framework/CHIP/zap-generated/*') or \
-        files.include('src/platform/Darwin/*')" or \
+        files.include('src/platform/Darwin/*') or \
         files.include('examples/darwin-framework-tool/*')"
     reviewers:
       teams: [reviewers-apple]

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -284,7 +284,8 @@ groups:
     type: required
     conditions:
       - "files.include('src/darwin/*').exclude('src/darwin/Framework/CHIP/zap-generated/*') or \
-        files.include('src/platform/Darwin/*')"
+        files.include('src/platform/Darwin/*')" or \
+        files.include('examples/darwin-framework-tool/*')"
     reviewers:
       teams: [reviewers-apple]
     reviews:
@@ -308,7 +309,8 @@ groups:
               .exclude('examples/chef/*')\
               .exclude('integrations/cloudbuild/*')\
               .exclude('src/darwin/*')\
-              .exclude('src/platform/Darwin/*') or \
+              .exclude('src/platform/Darwin/*')\
+              .exclude('examples/darwin-framework-tool/*') or \
         files.include('src/darwin/Framework/CHIP/zap-generated/*')"
     requirements:
       - len(groups.approved.include('shared-reviewers-*')) >= 2


### PR DESCRIPTION
#### Summary

Use the same policy for `examples/darwin-framework-tool` as we do for `src/darwin` and `src/platform/Darwin`.

#### Testing

See how PRs merge or not.