### PR TITLE
[ESP32]: ensure all matter services are removed

### DIFF
--- a/src/platform/ESP32/ESP32DnssdImpl.cpp
+++ b/src/platform/ESP32/ESP32DnssdImpl.cpp
@@ -214,15 +214,15 @@ CHIP_ERROR EspDnssdRemoveServices()
     /* Calling ‘mdns_service_remove’ once may remove only a single matching service instance */
     while (mdns_service_exists("_matter", "_tcp", nullptr))
     {
-        mdns_service_remove("_matter", "_tcp");
+        ReturnMappedErrorOnFailure(mdns_service_remove("_matter", "_tcp"));
     }
     while (mdns_service_exists("_matterc", "_udp", nullptr))
     {
-        mdns_service_remove("_matterc", "_udp");
+        ReturnMappedErrorOnFailure(mdns_service_remove("_matterc", "_udp"));
     }
     while (mdns_service_exists("_matterd", "_udp", nullptr))
     {
-        mdns_service_remove("_matterd", "_udp");
+        ReturnMappedErrorOnFailure(mdns_service_remove("_matterd", "_udp"));
     }
     return CHIP_NO_ERROR;
 }

--- a/src/platform/ESP32/ESP32DnssdImpl.cpp
+++ b/src/platform/ESP32/ESP32DnssdImpl.cpp
@@ -178,7 +178,7 @@ CHIP_ERROR EspDnssdPublishService(const DnssdService * service, DnssdPublishCall
     }
 
     // Remove service before adding it
-    if (mdns_service_exists(service->mType, GetProtocolString(service->mProtocol), nullptr))
+    if (mdns_service_exists_with_instance(service->mName, service->mType, GetProtocolString(service->mProtocol), nullptr))
     {
         mdns_service_remove_for_host(service->mName, service->mType, GetProtocolString(service->mProtocol), nullptr);
     }
@@ -211,15 +211,16 @@ exit:
 
 CHIP_ERROR EspDnssdRemoveServices()
 {
-    if (mdns_service_exists("_matter", "_tcp", nullptr))
+    /* Calling ‘mdns_service_remove’ once may remove only a single matching service instance */
+    while (mdns_service_exists("_matter", "_tcp", nullptr))
     {
         mdns_service_remove("_matter", "_tcp");
     }
-    if (mdns_service_exists("_matterc", "_udp", nullptr))
+    while (mdns_service_exists("_matterc", "_udp", nullptr))
     {
         mdns_service_remove("_matterc", "_udp");
     }
-    if (mdns_service_exists("_matterd", "_udp", nullptr))
+    while (mdns_service_exists("_matterd", "_udp", nullptr))
     {
         mdns_service_remove("_matterd", "_udp");
     }


### PR DESCRIPTION
#### Summary
When mdns services update, we remove all services and re-add used service. But when using esp platform mdns, calling `mdns_service_remove` once may remove only the first matching service instance, use a loop to remove all registered services.

#### Testing
- Added three fabrics and removed the second fabric, ensure the operational mdns service for the second fabric is removed.