### PR TITLE
Update chip-build-crosscompile docker to point to the latest version

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-147 : Update docker image to add ffmpeg, curl dev packages
+148 : Update docker image to add ffmpeg, curl dev packages for cross compile

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt
 RUN set -x \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-build-2025.07.10' > ensure_file.txt \
+  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.07.10' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \

--- a/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
+++ b/integrations/docker/images/stage-1/chip-build-crosscompile/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt
 RUN set -x \
   && git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools \
   # TODO: Remove experimental solution to create the sysroot file in cross-compile image
-  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-2025.06.05' > ensure_file.txt \
+  && echo 'experimental/matter/sysroot/ubuntu-24.04-aarch64 version:build-build-2025.07.10' > ensure_file.txt \
   && ./depot_tools/cipd ensure -ensure-file ensure_file.txt -root ./ \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/firmware \
   && rm -rf /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/git-core \


### PR DESCRIPTION
#### Summary

For cross compiling of camera-app, following dev package configs needed:
ffmpeg
libavformat
libavutil
libavcodec
libcurl

In cross‑builds the target(arm64) development packages—headers, .pc files and libs—have to live in the sysroot, not on the host.

We have already update the sysroot to contain ffmpeg, curl dev packages, docker should point to the new version

Referred: https://github.com/project-chip/connectedhomeip/pull/39497

#### Testing
Build new docker.
docker run -it -v ~/connectedhomeip:/var/connectedhomeip ghcr.io/project-chip/chip-build-crosscompile:latest /bin/bash

ls /opt/ubuntu-24.04-aarch64-sysroot/usr/lib/aarch64-linux-gnu/pkgconfig |
grep -Ei "avformat|avcodec|avutil|curl"

