### PR TITLE
Fix venv created by build_python.sh to include minimal build requirements #1

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -286,6 +286,8 @@ if [ -n "$install_virtual_env" ]; then
     "$ENVIRONMENT_ROOT"/bin/python -m ensurepip --upgrade
     "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade "${WHEEL[@]}"
 
+    "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/setup/requirements.build.txt"
+
     if [ "$install_pytest_requirements" = "yes" ]; then
         echo_blue "Installing python test dependencies ..."
         "$ENVIRONMENT_ROOT"/bin/pip install -r "$CHIP_ROOT/scripts/tests/requirements.txt"


### PR DESCRIPTION
#### Summary

Adding scripts/setup/requirements.build.txt in the python venv created by build_python.sh to be able to run "build_examples.py"



#### Related issues

Without this change, when following the instructions in [running-yaml-tests](https://github.com/project-chip/connectedhomeip/blob/56a0c43c15aaea97959d7c9408009bb47400ae2a/docs/testing/yaml.md#running-yaml-tests), I had python_path module missing from out/python_env because it was not a requirement when this venv is created.

#### Testing

In my installation, the instructions in [running-yaml-tests](https://github.com/project-chip/connectedhomeip/blob/56a0c43c15aaea97959d7c9408009bb47400ae2a/docs/testing/yaml.md#running-yaml-tests) now run fine.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [X ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ X] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [X ] PR size is short
-   [ X] Try to avoid "squashing" and "force-update" in commit history
-   [X ] CI time didn't increase
