### PR TITLE
Implement webrtc multi-client handling

### DIFF
--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -118,9 +118,9 @@ private:
 
     CHIP_ERROR SendICECandidatesCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
 
-    CHIP_ERROR AcquireAudioVideoStreams();
+    CHIP_ERROR AcquireAudioVideoStreams(uint16_t sessionId);
 
-    CHIP_ERROR ReleaseAudioVideoStreams();
+    CHIP_ERROR ReleaseAudioVideoStreams(uint16_t sessionId);
 
     static void OnDeviceConnected(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                   const chip::SessionHandle & sessionHandle);
@@ -134,8 +134,6 @@ private:
     void OnTrack(std::shared_ptr<WebRTCTrack> track);
 
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
-    std::shared_ptr<WebRTCTrack> mVideoTrack;
-    std::shared_ptr<WebRTCTrack> mAudioTrack;
 
     chip::ScopedNodeId mPeerId;
     chip::EndpointId mOriginatingEndpointId;
@@ -155,9 +153,6 @@ private:
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectionFailureCallback;
 
     std::unordered_map<uint16_t, std::unique_ptr<WebrtcTransport>> mWebrtcTransportMap;
-
-    uint16_t mVideoStreamID;
-    uint16_t mAudioStreamID;
 
     MediaController * mMediaController = nullptr;
 

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -93,11 +93,14 @@ private:
 
     void RegisterWebrtcTransport(uint16_t sessionId);
 
-    CHIP_ERROR SendOfferCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
+    CHIP_ERROR SendOfferCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
+                                uint16_t sessionId);
 
-    CHIP_ERROR SendAnswerCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
+    CHIP_ERROR SendAnswerCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
+                                 uint16_t sessionId);
 
-    CHIP_ERROR SendICECandidatesCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle);
+    CHIP_ERROR SendICECandidatesCommand(chip::Messaging::ExchangeManager & exchangeMgr, const chip::SessionHandle & sessionHandle,
+                                        uint16_t sessionId);
 
     CHIP_ERROR AcquireAudioVideoStreams(uint16_t sessionId);
 

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -89,6 +89,8 @@ public:
     // Stops WebRTC peer connection and cleanup
     void Stop();
 
+    void AddTracks();
+
     // Set video track for the transport
     void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);
 

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -50,12 +50,34 @@ public:
     // Set audio track for the transport
     void SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack);
 
+    void SetVideoStreamID(uint16_t videoStreamID);
+
+    void SetAudioStreamID(uint16_t audioStreamID);
+
+    uint16_t GetAudioStreamID() { return mAudioStreamID; }
+
+    uint16_t GetVideoStreamID() { return mVideoStreamID; }
+
+    std::shared_ptr<WebRTCPeerConnection> GetPeerConnection() { return mPeerConnection; }
+
+    std::string GetSdpAnswer() { return mSdpAnswer; }
+
+    void SetSdpAnswer(std::string sdpAnswer) { mSdpAnswer = sdpAnswer; }
+
+    std::vector<std::string> GetCandidates() { return mLocalCandidates; }
+
+    void SetCandidates(std::vector<std::string> candidates) { mLocalCandidates = candidates; }
+
 private:
     uint16_t mSessionID;
+    uint16_t mVideoStreamID;
+    uint16_t mAudioStreamID;
     uint64_t mNodeID;
     uint32_t mAudioSampleTimestamp;
     uint32_t mVideoSampleTimestamp;
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
     std::shared_ptr<WebRTCTrack> mVideoTrack;
     std::shared_ptr<WebRTCTrack> mAudioTrack;
+    std::string mSdpAnswer;
+    std::vector<std::string> mLocalCandidates;
 };

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -20,14 +20,53 @@
 
 #include "transport.h"
 #include "webrtc-abstract.h"
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/ScopedNodeId.h>
+
+using OnTransportLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type, const int16_t sessionId)>;
+using OnTransportConnectionStateCallback  = std::function<void(bool connected, const int16_t sessionId)>;
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
 {
 public:
-    WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<WebRTCPeerConnection> peerConnection);
+    enum class CommandType : uint8_t
+    {
+        kUndefined     = 0,
+        kOffer         = 1,
+        kAnswer        = 2,
+        kICECandidates = 3,
+    };
+
+    enum class State : uint8_t
+    {
+        Idle,                 ///< Default state, no communication initiated yet
+        SendingOffer,         ///< Sending Offer command from camera
+        SendingAnswer,        ///< Sending Answer command from camera
+        SendingICECandidates, ///< Sending ICECandidates command from camera
+    };
+
+    struct RequestArgs
+    {
+        uint16_t sessionId;
+        uint16_t videoStreamId;
+        uint16_t audioStreamId;
+        chip::NodeId peerNodeId;
+        chip::FabricIndex fabricIndex;
+        chip::EndpointId originatingEndpointId;
+        chip::ScopedNodeId peerId;
+    };
+
+    WebrtcTransport();
 
     ~WebrtcTransport();
+
+    void SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription, OnTransportConnectionStateCallback onConnectionState);
+
+    void MoveToState(const State targetState);
+    const char * GetStateStr() const;
+
+    State GetState() { return mState; }
 
     // Send video data for a given stream ID
     void SendVideo(const char * data, size_t size, uint16_t videoStreamID) override;
@@ -44,40 +83,57 @@ public:
     // Indicates that the transport is ready to send audio data
     bool CanSendAudio() override;
 
+    // Takes care of creation WebRTC peer connection and registering the necessary callbacks
+    void Start();
+
+    // Stops WebRTC peer connection and cleanup
+    void Stop();
+
     // Set video track for the transport
     void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);
 
     // Set audio track for the transport
     void SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack);
 
-    void SetVideoStreamID(uint16_t videoStreamID);
-
-    void SetAudioStreamID(uint16_t audioStreamID);
-
-    uint16_t GetAudioStreamID() { return mAudioStreamID; }
-
-    uint16_t GetVideoStreamID() { return mVideoStreamID; }
-
     std::shared_ptr<WebRTCPeerConnection> GetPeerConnection() { return mPeerConnection; }
 
-    std::string GetSdpAnswer() { return mSdpAnswer; }
+    std::string GetLocalDescription() { return mLocalSdp; }
 
-    void SetSdpAnswer(std::string sdpAnswer) { mSdpAnswer = sdpAnswer; }
+    void SetSdpAnswer(std::string localSdp) { mLocalSdp = localSdp; }
 
     std::vector<std::string> GetCandidates() { return mLocalCandidates; }
 
     void SetCandidates(std::vector<std::string> candidates) { mLocalCandidates = candidates; }
 
+    void AddRemoteCandidate(const std::string & candidate, const std::string & mid);
+
+    bool ClosePeerConnection();
+
+    void SetCommandType(const CommandType commandtype);
+
+    CommandType GetCommandType() { return mCommandType; }
+
+    // WebRTC Callbacks
+    void OnLocalDescription(const std::string & sdp, SDPType type);
+    void OnICECandidate(const std::string & candidate);
+    void OnConnectionStateChanged(bool connected);
+    void OnTrack(std::shared_ptr<WebRTCTrack> track);
+
+    void SetRequestArgs(const RequestArgs & args);
+    RequestArgs & GetRequestArgs();
+
 private:
-    uint16_t mSessionID;
-    uint16_t mVideoStreamID;
-    uint16_t mAudioStreamID;
-    uint64_t mNodeID;
-    uint32_t mAudioSampleTimestamp;
-    uint32_t mVideoSampleTimestamp;
+    CommandType mCommandType = CommandType::kUndefined;
+    State mState             = State::Idle;
+
     std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
     std::shared_ptr<WebRTCTrack> mVideoTrack;
     std::shared_ptr<WebRTCTrack> mAudioTrack;
-    std::string mSdpAnswer;
+    std::string mLocalSdp;
+    SDPType mLocalSdpType;
     std::vector<std::string> mLocalCandidates;
+
+    RequestArgs mRequestArgs;
+    OnTransportLocalDescriptionCallback mOnLocalDescription = nullptr;
+    OnTransportConnectionStateCallback mOnConnectionState   = nullptr;
 };

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -40,25 +40,13 @@ void WebRTCProviderManager::SetCameraDevice(CameraDeviceInterface * aCameraDevic
 void WebRTCProviderManager::Init()
 {
     ChipLogProgress(Camera, "Initializing WebRTC PeerConnection");
-    mPeerConnection = CreateWebRTCPeerConnection();
-
-    mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
-                                  [this](const std::string & candidate) { this->OnICECandidate(candidate); },
-                                  [this](bool connected) { this->OnConnectionStateChanged(connected); },
-                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); });
 }
 
 void WebRTCProviderManager::CloseConnection()
 {
     // Clean up all the Webrtc Transports
     mWebrtcTransportMap.clear();
-
-    // Close the peer connection if they exist
-    if (mPeerConnection)
-    {
-        mPeerConnection->Close();
-        mPeerConnection.reset();
-    }
+    mSessionIdMap.clear();
 }
 
 void WebRTCProviderManager::SetMediaController(MediaController * mediaController)
@@ -69,11 +57,6 @@ void WebRTCProviderManager::SetMediaController(MediaController * mediaController
 CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                                      bool & outDeferredOffer)
 {
-    if (mPeerConnection == nullptr)
-    {
-        // Re-initialization of PeerConnection is needed
-        Init();
-    }
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;
     outSession.peerNodeID  = args.peerNodeId;
@@ -120,37 +103,53 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
         outSession.audioStreamID.SetNull();
     }
 
-    mPeerId                = ScopedNodeId(args.peerNodeId, args.fabricIndex);
-    mOriginatingEndpointId = args.originatingEndpointId;
-    mCurrentSessionId      = args.sessionId;
+    // outDeferredOffer = LinuxDeviceOptions::GetInstance().cameraDeferredOffer;
 
-    outDeferredOffer = LinuxDeviceOptions::GetInstance().cameraDeferredOffer;
+    WebrtcTransport * transport = GetTransport(args.sessionId);
+    WebrtcTransport::RequestArgs requestArgs;
+    requestArgs.sessionId             = args.sessionId;
+    requestArgs.fabricIndex           = args.fabricIndex;
+    requestArgs.peerNodeId            = args.peerNodeId;
+    requestArgs.originatingEndpointId = args.originatingEndpointId;
+    requestArgs.videoStreamId         = videoStreamID;
+    requestArgs.audioStreamId         = audioStreamID;
+    requestArgs.peerId                = ScopedNodeId(args.peerNodeId, args.fabricIndex);
 
-    if (mWebrtcTransportMap.find(args.sessionId) == mWebrtcTransportMap.end())
+    if (transport == nullptr)
     {
-        mWebrtcTransportMap[args.sessionId] =
-            std::unique_ptr<WebrtcTransport>(new WebrtcTransport(args.sessionId, mPeerId.GetNodeId(), mPeerConnection));
+        mWebrtcTransportMap[args.sessionId] = std::unique_ptr<WebrtcTransport>(new WebrtcTransport());
+        mSessionIdMap[args.peerNodeId]      = args.sessionId;
+        transport                           = mWebrtcTransportMap[args.sessionId].get();
+        transport->SetCallbacks(
+            [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
+                this->OnLocalDescription(sdp, type, sessionId);
+            },
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
     }
 
-    mWebrtcTransportMap[args.sessionId]->SetVideoStreamID(videoStreamID);
-    mWebrtcTransportMap[args.sessionId]->SetAudioStreamID(audioStreamID);
+    transport->SetRequestArgs(requestArgs);
+    transport->Start();
 
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.
     AcquireAudioVideoStreams(args.sessionId);
 
-    MoveToState(State::SendingOffer);
+    transport->MoveToState(WebrtcTransport::State::SendingOffer);
 
     ChipLogProgress(Camera, "Generate and set the SDP");
-    mWebrtcTransportMap[args.sessionId]->GetPeerConnection()->CreateOffer();
+    if (transport->GetPeerConnection())
+        transport->GetPeerConnection()->CreateOffer();
 
     return CHIP_NO_ERROR;
 }
 
 void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
 {
-    if (mWebrtcTransportMap.find(sessionId) == mWebrtcTransportMap.end())
+
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
+        ChipLogProgress(Camera, "WebRTC Transport is null for sessionId %u. Failed to Register WebRTC Transport", sessionId);
         return;
     }
 
@@ -160,20 +159,20 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
         return;
     }
 
-    mMediaController->RegisterTransport(mWebrtcTransportMap[sessionId].get(), mWebrtcTransportMap[sessionId]->GetVideoStreamID(),
-                                        mWebrtcTransportMap[sessionId]->GetAudioStreamID());
+    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+    mMediaController->RegisterTransport(transport, args.videoStreamId, args.audioStreamId);
 }
 
 CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession)
 {
     ChipLogProgress(Camera, "HandleProvideOffer called");
-
+#if 0
     if (mPeerConnection == nullptr)
     {
         // Re-initialization of PeerConnection is needed
         Init();
     }
-
+#endif
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;
     outSession.peerNodeID  = args.peerNodeId;
@@ -219,26 +218,42 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
     }
 
     // Process the SDP Offer, begin the ICE Candidate gathering phase, create the SDP Answer, and invoke Answer.
-    mPeerId                = ScopedNodeId(args.peerNodeId, args.fabricIndex);
-    mOriginatingEndpointId = args.originatingEndpointId;
-    mCurrentSessionId      = args.sessionId;
+    WebrtcTransport::RequestArgs requestArgs;
+    requestArgs.sessionId             = args.sessionId;
+    requestArgs.fabricIndex           = args.fabricIndex;
+    requestArgs.peerNodeId            = args.peerNodeId;
+    requestArgs.originatingEndpointId = args.originatingEndpointId;
+    requestArgs.videoStreamId         = videoStreamID;
+    requestArgs.audioStreamId         = audioStreamID;
+    requestArgs.peerId                = ScopedNodeId(args.peerNodeId, args.fabricIndex);
 
-    if (mWebrtcTransportMap.find(args.sessionId) == mWebrtcTransportMap.end())
+    WebrtcTransport * transport = GetTransport(args.sessionId);
+    if (transport == nullptr)
     {
-        mWebrtcTransportMap[args.sessionId] =
-            std::unique_ptr<WebrtcTransport>(new WebrtcTransport(args.sessionId, mPeerId.GetNodeId(), mPeerConnection));
+        mWebrtcTransportMap[args.sessionId] = std::unique_ptr<WebrtcTransport>(new WebrtcTransport());
+        mSessionIdMap[args.peerNodeId]      = args.sessionId;
+        transport                           = mWebrtcTransportMap[args.sessionId].get();
+        transport->SetCallbacks(
+            [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
+                this->OnLocalDescription(sdp, type, sessionId);
+            },
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
     }
 
-    mWebrtcTransportMap[args.sessionId]->SetVideoStreamID(videoStreamID);
-    mWebrtcTransportMap[args.sessionId]->SetAudioStreamID(audioStreamID);
+    transport->SetRequestArgs(requestArgs);
+    transport->Start();
 
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.
     AcquireAudioVideoStreams(args.sessionId);
 
-    MoveToState(State::SendingAnswer);
-    mPeerConnection->SetRemoteDescription(args.sdp, SDPType::Offer);
-    mPeerConnection->CreateAnswer();
+    transport->MoveToState(WebrtcTransport::State::SendingAnswer);
+
+    if (transport->GetPeerConnection())
+    {
+        transport->GetPeerConnection()->SetRemoteDescription(args.sdp, SDPType::Offer);
+        transport->GetPeerConnection()->CreateAnswer();
+    }
 
     return CHIP_NO_ERROR;
 }
@@ -248,8 +263,8 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
     ChipLogProgress(Camera, "HandleProvideAnswer called with sessionId: %u", sessionId);
 
     // Check if the provided sessionId matches your current sessions
-    auto it = mWebrtcTransportMap.find(sessionId);
-    if (it == mWebrtcTransportMap.end() || !it->second)
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
         ChipLogError(Camera, "Session ID %u does not match the current sessions", sessionId);
         return CHIP_ERROR_INVALID_ARGUMENT;
@@ -261,23 +276,36 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (!mWebrtcTransportMap[sessionId]->GetPeerConnection())
+    if (!transport->GetPeerConnection())
     {
         ChipLogError(Camera, "Cannot set remote description: mPeerConnection is null for session ID %u", sessionId);
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    if (mWebrtcTransportMap.find(sessionId) == mWebrtcTransportMap.end())
+    WebrtcTransport::RequestArgs requestArgs = {
+        0,
+    };
+    requestArgs.sessionId = sessionId;
+    if (transport == nullptr)
     {
-        mWebrtcTransportMap[sessionId] =
-            std::unique_ptr<WebrtcTransport>(new WebrtcTransport(sessionId, mPeerId.GetNodeId(), mPeerConnection));
+        chip::ScopedNodeId peerId; // CHK
+        mWebrtcTransportMap[sessionId] = std::unique_ptr<WebrtcTransport>(new WebrtcTransport());
+        // mSessionIdMap[peerId]      = sessionId;
+        transport = mWebrtcTransportMap[sessionId].get();
+        transport->SetCallbacks(
+            [this](const std::string & sdp, SDPType type, const uint16_t sessionId) {
+                this->OnLocalDescription(sdp, type, sessionId);
+            },
+            [this](bool connected, const uint16_t sessionId) { this->OnConnectionStateChanged(connected, sessionId); });
     }
+    transport->SetRequestArgs(requestArgs);
+    transport->Start();
     AcquireAudioVideoStreams(sessionId);
 
-    mWebrtcTransportMap[sessionId]->GetPeerConnection()->SetRemoteDescription(sdpAnswer, SDPType::Answer);
+    transport->GetPeerConnection()->SetRemoteDescription(sdpAnswer, SDPType::Answer);
 
-    MoveToState(State::SendingICECandidates);
-    ScheduleICECandidatesSend();
+    transport->MoveToState(WebrtcTransport::State::SendingICECandidates);
+    ScheduleICECandidatesSend(sessionId);
 
     return CHIP_NO_ERROR;
 }
@@ -287,16 +315,16 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId,
     ChipLogProgress(Camera, "HandleProvideICECandidates called with session ID %u", sessionId);
 
     // Check if the provided sessionId matches your current sessions
-    auto it = mWebrtcTransportMap.find(sessionId);
-    if (it == mWebrtcTransportMap.end() || !it->second)
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
         ChipLogError(Camera, "Session ID %u does not match the current sessions", sessionId);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    if (!mWebrtcTransportMap[sessionId]->GetPeerConnection())
+    if (!transport->GetPeerConnection())
     {
-        ChipLogError(Camera, "Cannot process ICE candidates: mPeerConnection is null for session ID %u", sessionId);
+        ChipLogError(Camera, "Cannot process ICE candidates: PeerConnection is null for session ID %u", sessionId);
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -312,12 +340,12 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId,
                         std::string(candidate.candidate.begin(), candidate.candidate.end()).c_str());
         std::string mid =
             candidate.SDPMid.IsNull() ? "" : std::string(candidate.SDPMid.Value().begin(), candidate.SDPMid.Value().end());
-        mPeerConnection->AddRemoteCandidate(std::string(candidate.candidate.begin(), candidate.candidate.end()), mid);
+        transport->AddRemoteCandidate(std::string(candidate.candidate.begin(), candidate.candidate.end()), mid);
     }
 
     // Schedule sending Ice Candidates when remote candidates are received. This keeps the exchange simple
-    MoveToState(State::SendingICECandidates);
-    ScheduleICECandidatesSend();
+    transport->MoveToState(WebrtcTransport::State::SendingICECandidates);
+    ScheduleICECandidatesSend(sessionId);
 
     return CHIP_NO_ERROR;
 }
@@ -326,8 +354,13 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
                                                    DataModel::Nullable<uint16_t> videoStreamID,
                                                    DataModel::Nullable<uint16_t> audioStreamID)
 {
-    auto it = mWebrtcTransportMap.find(sessionId);
-    if (it != mWebrtcTransportMap.end())
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "Session ID %u does not match the current sessions", sessionId);
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+    if (transport != nullptr)
     {
         ChipLogProgress(Camera, "Delete Webrtc Transport for the session: %u", sessionId);
 
@@ -336,24 +369,15 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         // TODO: Lookup the sessionID to get the Video/Audio StreamID
         ReleaseAudioVideoStreams(sessionId);
 
-        mMediaController->UnregisterTransport(it->second.get());
-        mWebrtcTransportMap.erase(it);
+        mMediaController->UnregisterTransport(transport);
+        mWebrtcTransportMap.erase(sessionId);
+        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+        mSessionIdMap.erase(args.peerNodeId);
     }
 
-    if (mPeerConnection)
+    if (transport->ClosePeerConnection())
     {
         ChipLogProgress(Camera, "Closing peer connection: %u", sessionId);
-        mPeerConnection->Close();
-        mPeerConnection.reset();
-    }
-
-    if (mCurrentSessionId == sessionId)
-    {
-        mCurrentSessionId      = 0;
-        mOriginatingEndpointId = 0;
-        mPeerId                = ScopedNodeId();
-        mLocalSdp.clear();
-        mLocalCandidates.clear();
     }
 
     return CHIP_NO_ERROR;
@@ -440,84 +464,82 @@ bool WebRTCProviderManager::HasAllocatedAudioStreams()
     return avsmController.HasAllocatedAudioStreams();
 }
 
-void WebRTCProviderManager::MoveToState(const State targetState)
-{
-    mState = targetState;
-    ChipLogProgress(Camera, "WebRTCProviderManager moving to [ %s ]", GetStateStr());
-}
-
-const char * WebRTCProviderManager::GetStateStr() const
-{
-    switch (mState)
-    {
-    case State::Idle:
-        return "Idle";
-
-    case State::SendingOffer:
-        return "SendingOffer";
-
-    case State::SendingAnswer:
-        return "SendingAnswer";
-
-    case State::SendingICECandidates:
-        return "SendingICECandidates";
-    }
-    return "N/A";
-}
-
-void WebRTCProviderManager::ScheduleOfferSend()
+void WebRTCProviderManager::ScheduleOfferSend(uint16_t sessionId)
 {
     ChipLogProgress(Camera, "ScheduleOfferSend called.");
 
-    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
-        ChipLogProgress(Camera, "Sending Offer command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
+        WebrtcTransport * transport = GetTransport(sessionId);
+        if (transport == nullptr)
+        {
+            return;
+        }
 
-        mCommandType = CommandType::kOffer;
+        WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+        ChipLogProgress(Camera, "Sending Offer command to node " ChipLogFormatX64, ChipLogValueX64(args.peerNodeId));
+
+        transport->SetCommandType(WebrtcTransport::CommandType::kOffer);
 
         // Attempt to find or establish a CASE session to the target PeerId.
         CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
         VerifyOrDie(caseSessionMgr != nullptr);
 
         // WebRTC Answer requires a large payload session establishment.
-        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+        caseSessionMgr->FindOrEstablishSession(args.peerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
 }
 
-void WebRTCProviderManager::ScheduleAnswerSend()
+void WebRTCProviderManager::ScheduleAnswerSend(uint16_t sessionId)
 {
     ChipLogProgress(Camera, "ScheduleAnswerSend called.");
 
-    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
-        ChipLogProgress(Camera, "Sending Answer command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
+        WebrtcTransport * transport = GetTransport(sessionId);
+        if (transport == nullptr)
+        {
+            return;
+        }
 
-        mCommandType = CommandType::kAnswer;
+        WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
+        chip::ScopedNodeId peerId                = requestArgs.peerId;
+        ChipLogProgress(Camera, "Sending Answer command to node " ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
+
+        transport->SetCommandType(WebrtcTransport::CommandType::kAnswer);
 
         // Attempt to find or establish a CASE session to the target PeerId.
         CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
         VerifyOrDie(caseSessionMgr != nullptr);
 
         // WebRTC Answer requires a large payload session establishment.
-        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+        caseSessionMgr->FindOrEstablishSession(peerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
 }
 
-void WebRTCProviderManager::ScheduleICECandidatesSend()
+void WebRTCProviderManager::ScheduleICECandidatesSend(uint16_t sessionId)
 {
     ChipLogProgress(Camera, "ScheduleICECandidatesSend called.");
 
-    DeviceLayer::SystemLayer().ScheduleLambda([this]() {
-        ChipLogProgress(Camera, "Sending ICECandidates command to node " ChipLogFormatX64, ChipLogValueX64(mPeerId.GetNodeId()));
+    DeviceLayer::SystemLayer().ScheduleLambda([this, sessionId]() {
+        WebrtcTransport * transport = GetTransport(sessionId);
+        if (transport == nullptr)
+        {
+            return;
+        }
 
-        mCommandType = CommandType::kICECandidates;
+        WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
+        chip::ScopedNodeId peerId                = requestArgs.peerId;
+        ChipLogProgress(Camera, "Sending ICECandidates command to node " ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
+
+        transport->SetCommandType(WebrtcTransport::CommandType::kICECandidates);
 
         // Attempt to find or establish a CASE session to the target PeerId.
         CASESessionManager * caseSessionMgr = Server::GetInstance().GetCASESessionManager();
         VerifyOrDie(caseSessionMgr != nullptr);
 
         // WebRTC Answer requires a large payload session establishment.
-        caseSessionMgr->FindOrEstablishSession(mPeerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
+        caseSessionMgr->FindOrEstablishSession(peerId, &mOnConnectedCallback, &mOnConnectionFailureCallback,
                                                TransportPayloadCapability::kLargePayload);
     });
 }
@@ -528,26 +550,33 @@ void WebRTCProviderManager::OnDeviceConnected(void * context, Messaging::Exchang
     WebRTCProviderManager * self = reinterpret_cast<WebRTCProviderManager *>(context);
     VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDeviceConnected:: context is null"));
 
-    ChipLogProgress(Camera, "CASE session established, sending command with Command Type: %d...",
-                    static_cast<int>(self->mCommandType));
+    NodeId peerId      = sessionHandle->GetPeer().GetNodeId();
+    uint16_t sessionId = self->mSessionIdMap[peerId];
+
+    WebrtcTransport * transport = self->GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        return;
+    }
+    // ChipLogProgress(Camera, "CASE session established, sending command with Command Type: %d...",
+    //                 static_cast<int>(self->mCommandType));
 
     CHIP_ERROR err = CHIP_NO_ERROR;
 
-    switch (self->mCommandType)
+    switch (transport->GetCommandType())
     {
-    case CommandType::kOffer:
+    case WebrtcTransport::CommandType::kOffer:
         err = self->SendOfferCommand(exchangeMgr, sessionHandle);
-        self->MoveToState(State::Idle);
+        transport->MoveToState(WebrtcTransport::State::Idle);
         break;
 
-    case CommandType::kAnswer:
+    case WebrtcTransport::CommandType::kAnswer:
         err = self->SendAnswerCommand(exchangeMgr, sessionHandle);
-        self->MoveToState(State::Idle);
+        transport->MoveToState(WebrtcTransport::State::Idle);
         break;
-
-    case CommandType::kICECandidates:
+    case WebrtcTransport::CommandType::kICECandidates:
         err = self->SendICECandidatesCommand(exchangeMgr, sessionHandle);
-        self->MoveToState(State::Idle);
+        transport->MoveToState(WebrtcTransport::State::Idle);
         break;
 
     default:
@@ -568,6 +597,17 @@ void WebRTCProviderManager::OnDeviceConnectionFailure(void * context, const Scop
     VerifyOrReturn(self != nullptr, ChipLogError(Camera, "OnDeviceConnectionFailure: context is null"));
 }
 
+WebrtcTransport * WebRTCProviderManager::GetTransport(uint16_t sessionId)
+{
+    WebrtcTransport * transport = nullptr;
+    if (mWebrtcTransportMap.find(sessionId) != mWebrtcTransportMap.end())
+    {
+        transport = mWebrtcTransportMap[sessionId].get();
+    }
+
+    return transport;
+}
+
 CHIP_ERROR WebRTCProviderManager::SendOfferCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
@@ -576,72 +616,68 @@ CHIP_ERROR WebRTCProviderManager::SendOfferCommand(Messaging::ExchangeManager & 
 
     auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "Offer command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
 
-    uint16_t sessionId = mCurrentSessionId;
+    uint16_t sessionId          = mSessionIdMap[sessionHandle->GetPeer().GetNodeId()];
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "SendOfferCommand failed, WebTransport not found for sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
+    }
+
     CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ModifyWebRTCOfferSessionId, sessionId++);
 
     // Build the command
     WebRTCTransportRequestor::Commands::Offer::Type command;
     command.webRTCSessionID = sessionId;
-    command.sdp             = CharSpan::fromCharString(mLocalSdp.c_str());
+    std::string localSdp    = transport->GetLocalDescription();
+    command.sdp             = CharSpan::fromCharString(localSdp.c_str());
 
+    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
     // Now invoke the command using the found session handle
-    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure,
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, args.originatingEndpointId, command, onSuccess, onFailure,
                                             /* timedInvokeTimeoutMs = */ NullOptional, /* responseTimeout = */ NullOptional,
                                             /* outCancelFn = */ nullptr, /*allowLargePayload = */ true);
 }
 
-void WebRTCProviderManager::OnLocalDescription(const std::string & sdp, SDPType type)
+void WebRTCProviderManager::OnLocalDescription(const std::string & sdp, SDPType type, const uint16_t sessionId)
 {
-    if (mState == State::SendingAnswer && type != SDPType::Answer)
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
+        ChipLogError(Camera, "SendOfferCommand failed, WebTransport not found for sessionId: %u", sessionId);
         return;
     }
 
-    mLocalSdp            = sdp;
-    const char * typeStr = (type == SDPType::Offer) ? "offer" : "answer";
-    ChipLogProgress(Camera, "Local Description (%s):", typeStr);
-    ChipLogProgress(Camera, "%s", mLocalSdp.c_str());
-
-    switch (mState)
+    WebrtcTransport::State state = transport->GetState();
+    if (state == WebrtcTransport::State::SendingAnswer && type != SDPType::Answer)
     {
-    case State::SendingOffer:
-        ScheduleOfferSend();
+        return;
+    }
+    // std::string localSdp            = transport->GetLocalDescription();
+    const char * typeStr = (type == SDPType::Offer) ? "offer" : "answer";
+    std::string localSdp = sdp;
+    ChipLogProgress(Camera, "Local Description (%s):", typeStr);
+    ChipLogProgress(Camera, "%s", localSdp.c_str());
+
+    switch (state)
+    {
+    case WebrtcTransport::State::SendingOffer:
+        ScheduleOfferSend(sessionId);
         break;
-    case State::SendingAnswer:
-        ScheduleAnswerSend();
+    case WebrtcTransport::State::SendingAnswer:
+        ScheduleAnswerSend(sessionId);
         break;
     default:
         break;
     }
 }
 
-void WebRTCProviderManager::OnICECandidate(const std::string & candidate)
+void WebRTCProviderManager::OnConnectionStateChanged(bool connected, const uint16_t sessionId)
 {
-    mLocalCandidates.push_back(candidate);
-    ChipLogProgress(Camera, "Local Candidate:");
-    ChipLogProgress(Camera, "%s", candidate.c_str());
-}
-
-void WebRTCProviderManager::OnConnectionStateChanged(bool connected)
-{
+    ChipLogProgress(Camera, "Connection state changed for session %u", sessionId);
     if (connected)
     {
-        RegisterWebrtcTransport(mCurrentSessionId);
-    }
-}
-
-void WebRTCProviderManager::OnTrack(std::shared_ptr<WebRTCTrack> track)
-{
-    ChipLogProgress(Camera, "Remote track received for session %u", mCurrentSessionId);
-    if (track->GetType() == "video")
-    {
-        mWebrtcTransportMap[mCurrentSessionId]->SetVideoTrack(track);
-        ChipLogProgress(Camera, "Video track updated from remote peer");
-    }
-    else if (track->GetType() == "audio")
-    {
-        mWebrtcTransportMap[mCurrentSessionId]->SetAudioTrack(track);
-        ChipLogProgress(Camera, "Audio track updated from remote peer");
+        RegisterWebrtcTransport(sessionId);
     }
 }
 
@@ -653,16 +689,25 @@ CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager &
 
     auto onFailure = [](CHIP_ERROR error) { ChipLogError(Camera, "Answer command failed: %" CHIP_ERROR_FORMAT, error.Format()); };
 
-    uint16_t sessionId = mCurrentSessionId;
+    uint16_t sessionId          = mSessionIdMap[sessionHandle->GetPeer().GetNodeId()];
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "SendOfferCommand failed, WebTransport not found for sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
+    }
+
     CHIP_FAULT_INJECT(chip::FaultInjection::kFault_ModifyWebRTCAnswerSessionId, sessionId++);
 
     // Build the command
     WebRTCTransportRequestor::Commands::Answer::Type command;
-    command.webRTCSessionID = sessionId;
-    command.sdp             = CharSpan::fromCharString(mLocalSdp.c_str());
+    command.webRTCSessionID = mSessionIdMap[sessionHandle->GetPeer().GetNodeId()];
+    std::string localSdp    = transport->GetLocalDescription();
+    command.sdp             = CharSpan::fromCharString(localSdp.c_str());
 
+    WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
     // Now invoke the command using the found session handle
-    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure,
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, requestArgs.originatingEndpointId, command, onSuccess, onFailure,
                                             /* timedInvokeTimeoutMs = */ NullOptional, /* responseTimeout = */ NullOptional,
                                             /* outCancelFn = */ nullptr, /*allowLargePayload = */ true);
 }
@@ -678,52 +723,65 @@ CHIP_ERROR WebRTCProviderManager::SendICECandidatesCommand(Messaging::ExchangeMa
         ChipLogError(Camera, "ICECandidates command failed: %" CHIP_ERROR_FORMAT, error.Format());
     };
 
+    uint16_t sessionId          = mSessionIdMap[sessionHandle->GetPeer().GetNodeId()];
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
+    {
+        ChipLogError(Camera, "WebTransport not found for the sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
+    }
+    std::vector<std::string> localCandidates = transport->GetCandidates();
     // Build the command
     WebRTCTransportRequestor::Commands::ICECandidates::Type command;
 
-    if (mLocalCandidates.empty())
+    if (localCandidates.empty())
     {
         ChipLogError(Camera, "No local ICE candidates to send");
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
     std::vector<ICECandidateStruct> iceCandidateStructList;
-    for (const auto & candidate : mLocalCandidates)
+    for (const auto & candidate : localCandidates)
     {
         ICECandidateStruct iceCandidate = { CharSpan::fromCharString(candidate.c_str()) };
         iceCandidateStructList.push_back(iceCandidate);
     }
 
-    command.webRTCSessionID = mCurrentSessionId;
+    command.webRTCSessionID = sessionId;
     command.ICECandidates = DataModel::List<const ICECandidateStruct>(iceCandidateStructList.data(), iceCandidateStructList.size());
 
+    WebrtcTransport::RequestArgs requestArgs = transport->GetRequestArgs();
     // Now invoke the command using the found session handle
-    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure,
+    return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, requestArgs.originatingEndpointId, command, onSuccess, onFailure,
                                             /* timedInvokeTimeoutMs = */ NullOptional, /* responseTimeout = */ NullOptional,
                                             /* outCancelFn = */ nullptr, /*allowLargePayload = */ true);
 }
 
 CHIP_ERROR WebRTCProviderManager::AcquireAudioVideoStreams(uint16_t sessionId)
 {
-    auto it = mWebrtcTransportMap.find(sessionId);
-    if (it == mWebrtcTransportMap.end() || !it->second)
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        ChipLogError(Camera, "WebTransport not found for the sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
     }
 
-    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(it->second->GetAudioStreamID(),
-                                                                                              it->second->GetVideoStreamID());
+    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
+    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportAcquireAudioVideoStreams(args.audioStreamId,
+                                                                                              args.videoStreamId);
 }
 
 CHIP_ERROR WebRTCProviderManager::ReleaseAudioVideoStreams(uint16_t sessionId)
 {
-    auto it = mWebrtcTransportMap.find(sessionId);
-    if (it == mWebrtcTransportMap.end() || !it->second)
+    WebrtcTransport * transport = GetTransport(sessionId);
+    if (transport == nullptr)
     {
-        return CHIP_ERROR_INVALID_ARGUMENT;
+        ChipLogError(Camera, "WebTransport not found for the sessionId: %u", sessionId);
+        return CHIP_ERROR_INTERNAL;
     }
 
+    WebrtcTransport::RequestArgs args = transport->GetRequestArgs();
     // TODO: Use passed in audio/video stream ids corresponding to a sessionId.
-    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(it->second->GetAudioStreamID(),
-                                                                                              it->second->GetVideoStreamID());
+    return mCameraDevice->GetCameraAVStreamMgmtDelegate().OnTransportReleaseAudioVideoStreams(args.audioStreamId,
+                                                                                              args.videoStreamId);
 }

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
         outSession.audioStreamID.SetNull();
     }
 
-    // outDeferredOffer = LinuxDeviceOptions::GetInstance().cameraDeferredOffer;
+    outDeferredOffer = LinuxDeviceOptions::GetInstance().cameraDeferredOffer;
 
     WebrtcTransport * transport = GetTransport(args.sessionId);
     WebrtcTransport::RequestArgs requestArgs;
@@ -129,6 +129,7 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     transport->SetRequestArgs(requestArgs);
     transport->Start();
+    transport->AddTracks();
 
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.
@@ -166,13 +167,7 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
 CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession)
 {
     ChipLogProgress(Camera, "HandleProvideOffer called");
-#if 0
-    if (mPeerConnection == nullptr)
-    {
-        // Re-initialization of PeerConnection is needed
-        Init();
-    }
-#endif
+
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;
     outSession.peerNodeID  = args.peerNodeId;

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -158,6 +158,21 @@ void WebrtcTransport::Stop()
     }
 }
 
+void WebrtcTransport::AddTracks()
+{
+    if (mPeerConnection != nullptr)
+    {
+        if (mRequestArgs.videoStreamId != 0)
+        {
+            mVideoTrack = mPeerConnection->AddTrack(MediaType::Video);
+        }
+        if (mRequestArgs.audioStreamId != 0)
+        {
+            mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio);
+        }
+    }
+}
+
 // Implementation of SetVideoTrack method
 void WebrtcTransport::SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack)
 {

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -162,14 +162,8 @@ void WebrtcTransport::AddTracks()
 {
     if (mPeerConnection != nullptr)
     {
-        if (mRequestArgs.videoStreamId != 0)
-        {
-            mVideoTrack = mPeerConnection->AddTrack(MediaType::Video);
-        }
-        if (mRequestArgs.audioStreamId != 0)
-        {
-            mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio);
-        }
+        mVideoTrack = mPeerConnection->AddTrack(MediaType::Video);
+        mAudioTrack = mPeerConnection->AddTrack(MediaType::Audio);
     }
 }
 

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -102,10 +102,29 @@ bool WebrtcTransport::CanSendAudio()
     return mAudioTrack != nullptr;
 }
 
+const char * WebrtcTransport::GetStateStr() const
+{
+    switch (mState)
+    {
+    case State::Idle:
+        return "Idle";
+
+    case State::SendingOffer:
+        return "SendingOffer";
+
+    case State::SendingAnswer:
+        return "SendingAnswer";
+
+    case State::SendingICECandidates:
+        return "SendingICECandidates";
+    }
+    return "N/A";
+}
+
 void WebrtcTransport::MoveToState(const State targetState)
 {
     mState = targetState;
-    ChipLogProgress(Camera, "WebRTCProviderManager moving to [ %s ]", GetStateStr());
+    ChipLogProgress(Camera, "WebrtcTransport moving to [ %s ]", GetStateStr());
 }
 
 void WebrtcTransport::SetCommandType(const CommandType commandtype)

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -16,22 +16,55 @@
  *    limitations under the License.
  */
 
+#include "webrtc-abstract.h"
 #include <lib/support/logging/CHIPLogging.h>
+#include <rtc/rtc.hpp>
 #include <webrtc-transport.h>
 
-WebrtcTransport::WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<WebRTCPeerConnection> peerConnection)
+SDPType RtcTypeToSDPType(rtc::Description::Type type)
 {
-    ChipLogProgress(Camera, "WebrtcTransport created for sessionID: %u", sessionID);
-    mSessionID            = sessionID;
-    mNodeID               = nodeID;
-    mPeerConnection       = peerConnection;
-    mVideoSampleTimestamp = 0;
-    mAudioSampleTimestamp = 0;
+    switch (type)
+    {
+    case rtc::Description::Type::Offer:
+        return SDPType::Offer;
+    case rtc::Description::Type::Answer:
+        return SDPType::Answer;
+    case rtc::Description::Type::Pranswer:
+        return SDPType::Pranswer;
+    case rtc::Description::Type::Rollback:
+        return SDPType::Rollback;
+    default:
+        return SDPType::Offer;
+    }
+}
+
+WebrtcTransport::WebrtcTransport()
+{
+    ChipLogProgress(Camera, "WebrtcTransport created");
+    mRequestArgs = { 0, 0, 0, 0, 0, 0 }; // Initialize request arguments to zero
 }
 
 WebrtcTransport::~WebrtcTransport()
 {
-    ChipLogProgress(Camera, "WebrtcTransport destroyed for sessionID: [%u]", mSessionID);
+    ClosePeerConnection();
+    ChipLogProgress(Camera, "WebrtcTransport destroyed for sessionID: [%u]", mRequestArgs.sessionId);
+}
+
+void WebrtcTransport::SetCallbacks(OnTransportLocalDescriptionCallback onLocalDescription,
+                                   OnTransportConnectionStateCallback onConnectionState)
+{
+    mOnLocalDescription = onLocalDescription;
+    mOnConnectionState  = onConnectionState;
+}
+
+void WebrtcTransport::SetRequestArgs(const RequestArgs & args)
+{
+    mRequestArgs = args;
+}
+
+WebrtcTransport::RequestArgs & WebrtcTransport::GetRequestArgs()
+{
+    return mRequestArgs;
 }
 
 void WebrtcTransport::SendVideo(const char * data, size_t size, uint16_t videoStreamID)
@@ -69,26 +102,111 @@ bool WebrtcTransport::CanSendAudio()
     return mAudioTrack != nullptr;
 }
 
+void WebrtcTransport::MoveToState(const State targetState)
+{
+    mState = targetState;
+    ChipLogProgress(Camera, "WebRTCProviderManager moving to [ %s ]", GetStateStr());
+}
+
+void WebrtcTransport::SetCommandType(const CommandType commandtype)
+{
+    mCommandType = commandtype;
+}
+
+void WebrtcTransport::Start()
+{
+    if (mPeerConnection.get())
+    {
+        ChipLogProgress(Camera, "Start, mPeerConnection is already created");
+        return;
+    }
+
+    mPeerConnection = CreateWebRTCPeerConnection();
+
+    mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
+                                  [this](const std::string & candidate) { this->OnICECandidate(candidate); },
+                                  [this](bool connected) { this->OnConnectionStateChanged(connected); },
+                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); });
+}
+
+void WebrtcTransport::Stop()
+{
+    mVideoTrack = nullptr;
+    mAudioTrack = nullptr;
+    if (mPeerConnection != nullptr)
+    {
+        mPeerConnection->Close();
+    }
+}
+
 // Implementation of SetVideoTrack method
 void WebrtcTransport::SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack)
 {
-    ChipLogProgress(Camera, "Setting video track for sessionID: %u", mSessionID);
+    ChipLogProgress(Camera, "Setting video track for sessionID: %u", mRequestArgs.sessionId);
     mVideoTrack = videoTrack;
 }
 
 // Implementation of SetAudioTrack method
 void WebrtcTransport::SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack)
 {
-    ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mSessionID);
+    ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mRequestArgs.sessionId);
     mAudioTrack = audioTrack;
 }
 
-void WebrtcTransport::SetVideoStreamID(uint16_t videoStreamID)
+void WebrtcTransport::AddRemoteCandidate(const std::string & candidate, const std::string & mid)
 {
-    mVideoStreamID = videoStreamID;
+    ChipLogProgress(Camera, "Adding remote candidate for sessionID: %u", mRequestArgs.sessionId);
+    mPeerConnection->AddRemoteCandidate(candidate, mid);
 }
 
-void WebrtcTransport::SetAudioStreamID(uint16_t audioStreamID)
+// WebRTC Callbacks
+void WebrtcTransport::OnLocalDescription(const std::string & sdp, SDPType type)
 {
-    mAudioStreamID = audioStreamID;
+    ChipLogProgress(Camera, "Local description received for sessionID: %u", mRequestArgs.sessionId);
+    mLocalSdp     = sdp;
+    mLocalSdpType = type;
+    if (mOnLocalDescription)
+        mOnLocalDescription(sdp, type, mRequestArgs.sessionId);
+}
+
+bool WebrtcTransport::ClosePeerConnection()
+{
+    if (mPeerConnection == nullptr)
+    {
+        return false;
+    }
+    mPeerConnection->Close();
+    mPeerConnection.reset();
+
+    return true;
+}
+
+void WebrtcTransport::OnICECandidate(const std::string & candidate)
+{
+    ChipLogProgress(Camera, "ICE Candidate received for sessionID: %u", mRequestArgs.sessionId);
+    mLocalCandidates.push_back(candidate);
+    ChipLogProgress(Camera, "Local Candidate:");
+    ChipLogProgress(Camera, "%s", candidate.c_str());
+}
+
+void WebrtcTransport::OnConnectionStateChanged(bool connected)
+{
+    ChipLogProgress(Camera, "Connection state changed for sessionID: %u", mRequestArgs.sessionId);
+    if (mOnConnectionState)
+        mOnConnectionState(connected, mRequestArgs.sessionId);
+}
+
+void WebrtcTransport::OnTrack(std::shared_ptr<WebRTCTrack> track)
+{
+    ChipLogProgress(Camera, "Track received for sessionID: %u, type: %s", mRequestArgs.sessionId, track->GetType().c_str());
+    if (track->GetType() == "video")
+    {
+        ChipLogProgress(Camera, "Video track updated from remote peer");
+        SetVideoTrack(track);
+    }
+    else if (track->GetType() == "audio")
+    {
+        ChipLogProgress(Camera, "audio track updated from remote peer");
+        SetAudioTrack(track);
+    }
 }

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -82,3 +82,13 @@ void WebrtcTransport::SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack)
     ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mSessionID);
     mAudioTrack = audioTrack;
 }
+
+void WebrtcTransport::SetVideoStreamID(uint16_t videoStreamID)
+{
+    mVideoStreamID = videoStreamID;
+}
+
+void WebrtcTransport::SetAudioStreamID(uint16_t audioStreamID)
+{
+    mAudioStreamID = audioStreamID;
+}


### PR DESCRIPTION
#### Summary

This PR handles  webrtc clients management. Simultaneously more than one webrtc client from same controller or different clients can request for streaming.

#### Testing

* Build camera application
* Run camera application
* Run camera controller
* Pair camera app
* Allocate first webrtctransport
* Allocate second webrtctransport
* Both the connections should be successful and camera data must be received
