### PR TITLE
[Camera] Add WebRTC Provider Server In python controller for Camera Initiated session flow.

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -210,4 +210,5 @@ ALLOW: Dict[str, Set[str]] = {
     'src/controller/webrtc/WebRTC.h': {'string'},
     'src/controller/webrtc/WebRTCClient.h': {'map', 'string'},
     'src/controller/webrtc/WebRTCTransportRequestorManager.cpp': {'string', 'vector'},
+    'src/controller/webrtc/WebRTCTransportProviderManager.cpp': {'string', 'vector'},
 }

--- a/src/app/dynamic_server/AccessControl.cpp
+++ b/src/app/dynamic_server/AccessControl.cpp
@@ -53,7 +53,8 @@ class AccessControlDelegate : public Access::AccessControl::Delegate
 
         // Check for WebRTC Transport Requestor endpoint
         bool isWebRtcEndpoint =
-            (requestPath.endpoint == kWebRTCRequesterDynamicEndpointId && requestPath.cluster == WebRTCTransportRequestor::Id);
+            ((requestPath.endpoint == kWebRTCRequesterDynamicEndpointId && requestPath.cluster == WebRTCTransportRequestor::Id) ||
+             (requestPath.endpoint == kWebRTCProviderDynamicEndpointId && requestPath.cluster == WebRTCTransportProvider::Id));
 
         // Only allow these specific endpoints
         if (!isOtaEndpoint && !isWebRtcEndpoint)

--- a/src/app/dynamic_server/AccessControl.h
+++ b/src/app/dynamic_server/AccessControl.h
@@ -19,6 +19,7 @@
 
 constexpr chip::EndpointId kOtaProviderDynamicEndpointId     = 0;
 constexpr chip::EndpointId kWebRTCRequesterDynamicEndpointId = 1;
+constexpr chip::EndpointId kWebRTCProviderDynamicEndpointId  = 1;
 
 namespace chip {
 namespace app {

--- a/src/controller/python/chip/webrtc/RTCClient.cpp
+++ b/src/controller/python/chip/webrtc/RTCClient.cpp
@@ -88,7 +88,7 @@ void pychip_webrtc_client_set_state_change_callback(WebRTCClientHandle handle, O
     chip::webrtc::webrtc_client_set_state_change_callback(handle, cb);
 }
 
-void pychip_webrtc_provider_client_init(WebRTCClientHandle handle, uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
+void pychip_webrtc_provider_client_init(WebRTCClientHandle handle, uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
 {
     chip::webrtc::webrtc_provider_client_init(handle, nodeId, fabricIndex, endpoint);
 }

--- a/src/controller/python/chip/webrtc/WebRTC.cpp
+++ b/src/controller/python/chip/webrtc/WebRTC.cpp
@@ -167,7 +167,7 @@ void webrtc_client_set_state_change_callback(WebRTCClientHandle handle, OnStateC
     }
 }
 
-void webrtc_provider_client_init(WebRTCClientHandle handle, uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
+void webrtc_provider_client_init(WebRTCClientHandle handle, uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
 {
     std::lock_guard<std::mutex> lock(g_mutex);
     auto it = g_clients.find(handle);

--- a/src/controller/python/chip/webrtc/WebRTC.h
+++ b/src/controller/python/chip/webrtc/WebRTC.h
@@ -176,7 +176,7 @@ void webrtc_client_set_state_change_callback(WebRTCClientHandle handle, OnStateC
  *
  * @note This function assumes that the handle is valid and exists in the global clients map.
  */
-void webrtc_provider_client_init(WebRTCClientHandle handle, uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
+void webrtc_provider_client_init(WebRTCClientHandle handle, uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
 
 /**
  * @brief Initializes the WebRTC client handle with webrtc provider client command sender callbacks.

--- a/src/controller/python/chip/webrtc/WebRTCTransportCluster.cpp
+++ b/src/controller/python/chip/webrtc/WebRTCTransportCluster.cpp
@@ -15,7 +15,9 @@
  *    limitations under the License.
  */
 
+#include <controller/webrtc/WebRTCTransportProviderManager.h>
 #include <controller/webrtc/WebRTCTransportRequestorManager.h>
+
 // These methods are expected to be called from Python.
 extern "C" {
 // WebRTC Requestor functions
@@ -31,5 +33,19 @@ void pychip_WebRTCTransportRequestor_InitCallbacks(OnOfferCallback onOnOfferCall
                                                               onEndCallback);
 }
 
-// WebRTC Provider client functions
+// WebRTC Provider functions
+void pychip_WebRTCTransportProvider_Init()
+{
+    WebRTCTransportProviderManager::Instance().Init();
+}
+
+void pychip_WebRTCTransportProvider_InitCallbacks(ProvideOfferCallback provideOfferCallback,
+                                                  ProvideAnswerCallback provideAnswerCallback,
+                                                  ProvideICECandidatesCallback provideICECandidatesCallback,
+                                                  ProvideEndCallback provideEndCallback,
+                                                  SessionIdCreatedCallback sessionIdCreatedCallback)
+{
+    WebRTCTransportProviderManager::Instance().InitCallbacks(
+        provideOfferCallback, provideAnswerCallback, provideICECandidatesCallback, provideEndCallback, sessionIdCreatedCallback);
+}
 }

--- a/src/controller/python/chip/webrtc/library_handle.py
+++ b/src/controller/python/chip/webrtc/library_handle.py
@@ -21,7 +21,8 @@ from ..clusters.Command import (_OnCommandSenderDoneCallbackFunct, _OnCommandSen
                                 _OnCommandSenderResponseCallbackFunct)
 from ..native import GetLibraryHandle, HandleFlags, PyChipError
 from .types import (GatheringCompleteCallbackType, IceCandidateCallbackType, LocalDescriptionCallbackType, OnAnswerCallbackFunct,
-                    OnEndCallbackFunct, OnICECandidatesCallbackFunct, OnOfferCallbackFunct, StateChangeCallback, WebRTCClientHandle)
+                    OnEndCallbackFunct, OnICECandidatesCallbackFunct, OnOfferCallbackFunct, SessionIdCreatedCallbackFunct,
+                    StateChangeCallback, WebRTCClientHandle)
 
 
 def _GetWebRTCLibraryHandle() -> CDLL:
@@ -85,7 +86,7 @@ def _GetWebRTCLibraryHandle() -> CDLL:
     return lib
 
 
-def get_webrtc_requestor_handle() -> CDLL:
+def get_webrtc_cluster_handle() -> CDLL:
     lib = GetLibraryHandle()
 
     if not lib.pychip_WebRTCTransportRequestor_InitCallbacks.argtypes:
@@ -96,10 +97,18 @@ def get_webrtc_requestor_handle() -> CDLL:
             OnICECandidatesCallbackFunct,
             OnEndCallbackFunct,
         ]
+        lib.pychip_WebRTCTransportProvider_Init.argtypes = []
+        lib.pychip_WebRTCTransportProvider_InitCallbacks.argtypes = [
+            OnOfferCallbackFunct,
+            OnAnswerCallbackFunct,
+            OnICECandidatesCallbackFunct,
+            OnEndCallbackFunct,
+            SessionIdCreatedCallbackFunct,
+        ]
     return lib
 
 
-class WebRTCRequestorNativeBindings:
+class WebRTCTransportNativeBindings:
     """This class is intended to be used only by WebRTCManager.
 
     Exposes python methods for accessing native APIs. Also holds
@@ -111,13 +120,28 @@ class WebRTCRequestorNativeBindings:
         self.handle_answer_cb = OnAnswerCallbackFunct(self.handle_answer)
         self.handle_ice_candidates_cb = OnICECandidatesCallbackFunct(self.handle_ice_candidates)
         self.handle_end_cb = OnEndCallbackFunct(self.handle_end)
+        self.sessionid_created_cb = SessionIdCreatedCallbackFunct(self.session_id_created)
 
     def init_webrtc_requestor_server(self):
-        handle = get_webrtc_requestor_handle()
+        handle = get_webrtc_cluster_handle()
         handle.pychip_WebRTCTransportRequestor_Init()
 
     def set_webrtc_requestor_delegate_callbacks(self):
-        handle = get_webrtc_requestor_handle()
+        handle = get_webrtc_cluster_handle()
         handle.pychip_WebRTCTransportRequestor_InitCallbacks(
             self.handle_offer_cb, self.handle_answer_cb, self.handle_ice_candidates_cb, self.handle_end_cb
+        )
+
+    def init_webrtc_provider_server(self):
+        handle = get_webrtc_cluster_handle()
+        handle.pychip_WebRTCTransportProvider_Init()
+
+    def set_webrtc_provider_delegate_callbacks(self):
+        handle = get_webrtc_cluster_handle()
+        handle.pychip_WebRTCTransportProvider_InitCallbacks(
+            self.handle_offer_cb,
+            self.handle_answer_cb,
+            self.handle_ice_candidates_cb,
+            self.handle_end_cb,
+            self.sessionid_created_cb,
         )

--- a/src/controller/python/chip/webrtc/library_handle.py
+++ b/src/controller/python/chip/webrtc/library_handle.py
@@ -15,7 +15,7 @@
 #  limitations under the License.
 #
 
-from ctypes import CDLL, c_char_p, c_int, c_size_t, c_uint8, c_uint16, c_uint32, c_void_p, py_object
+from ctypes import CDLL, c_char_p, c_int, c_size_t, c_uint8, c_uint16, c_uint32, c_uint64, c_void_p, py_object
 
 from ..clusters.Command import (_OnCommandSenderDoneCallbackFunct, _OnCommandSenderErrorCallbackFunct,
                                 _OnCommandSenderResponseCallbackFunct)
@@ -65,7 +65,7 @@ def _GetWebRTCLibraryHandle() -> CDLL:
         lib.pychip_webrtc_client_set_gathering_complete_callback.argtypes = [WebRTCClientHandle, GatheringCompleteCallbackType]
         lib.pychip_webrtc_client_set_state_change_callback.argtypes = [WebRTCClientHandle, StateChangeCallback]
 
-        lib.pychip_webrtc_provider_client_init.argtypes = [WebRTCClientHandle, c_uint32, c_uint8, c_uint16]
+        lib.pychip_webrtc_provider_client_init.argtypes = [WebRTCClientHandle, c_uint64, c_uint8, c_uint16]
         lib.pychip_webrtc_provider_client_init_commandsender_callbacks.argtypes = [
             WebRTCClientHandle,
             _OnCommandSenderResponseCallbackFunct,

--- a/src/controller/python/chip/webrtc/types.py
+++ b/src/controller/python/chip/webrtc/types.py
@@ -25,10 +25,10 @@ GatheringCompleteCallbackType = CFUNCTYPE(None)
 StateChangeCallback = CFUNCTYPE(None, c_int)
 
 # Callback types for WebRTCRequestor server
-OnOfferCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_char_p)
-OnAnswerCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_char_p)
-OnICECandidatesCallbackFunct = CFUNCTYPE(c_int, c_uint64, POINTER(c_char_p), c_int)
-OnEndCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_uint8)
+OnOfferCallbackFunct = CFUNCTYPE(c_int, c_uint16, c_char_p)
+OnAnswerCallbackFunct = CFUNCTYPE(c_int, c_uint16, c_char_p)
+OnICECandidatesCallbackFunct = CFUNCTYPE(c_int, c_uint16, POINTER(c_char_p), c_int)
+OnEndCallbackFunct = CFUNCTYPE(c_int, c_uint16, c_uint8)
 SessionIdCreatedCallbackFunct = CFUNCTYPE(None, c_uint16, c_uint64)
 
 

--- a/src/controller/python/chip/webrtc/types.py
+++ b/src/controller/python/chip/webrtc/types.py
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from ctypes import CFUNCTYPE, POINTER, c_char_p, c_int, c_uint8, c_uint64, c_void_p
+from ctypes import CFUNCTYPE, POINTER, c_char_p, c_int, c_uint8, c_uint16, c_uint64, c_void_p
 from dataclasses import dataclass, field
 from enum import Enum, auto
 
@@ -29,6 +29,7 @@ OnOfferCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_char_p)
 OnAnswerCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_char_p)
 OnICECandidatesCallbackFunct = CFUNCTYPE(c_int, c_uint64, POINTER(c_char_p), c_int)
 OnEndCallbackFunct = CFUNCTYPE(c_int, c_uint64, c_uint8)
+SessionIdCreatedCallbackFunct = CFUNCTYPE(None, c_uint16, c_uint64)
 
 
 class PeerConnectionState(Enum):

--- a/src/controller/python/chip/webrtc/webrtc_manager.py
+++ b/src/controller/python/chip/webrtc/webrtc_manager.py
@@ -3,11 +3,11 @@ import logging
 import threading
 from collections import defaultdict
 
-from .library_handle import WebRTCRequestorNativeBindings
+from .library_handle import WebRTCTransportNativeBindings
 from .peer_connection import PeerConnection
 
 
-class WebRTCManager(WebRTCRequestorNativeBindings):
+class WebRTCManager(WebRTCTransportNativeBindings):
     """Manages WebRTC peer connections and handles various WebRTC-related events and operations.
     Maintains mappings between session IDs <-> node IDs <-> peer connections.
 
@@ -23,8 +23,15 @@ class WebRTCManager(WebRTCRequestorNativeBindings):
 
     def __init__(self, event_loop: asyncio.AbstractEventLoop | None = None):
         super().__init__()
+
+        # Initialize WebRTC requestor server and set up delegate callbacks.
         self.init_webrtc_requestor_server()
         self.set_webrtc_requestor_delegate_callbacks()
+
+        # Initialize WebRTC provider server and set up delegate callbacks.
+        self.init_webrtc_provider_server()
+        self.set_webrtc_provider_delegate_callbacks()
+
         self.event_loop = event_loop or asyncio.get_running_loop()
 
     def create_peer(self, node_id: int, fabric_index: int, endpoint: int) -> PeerConnection:

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -23,6 +23,8 @@ import("${chip_root}/build/chip/buildconfig_header.gni")
 
 static_library("chip_webrtc") {
   sources = [
+    "${chip_root}/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.cpp",
+    "${chip_root}/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h",
     "${chip_root}/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.cpp",
     "${chip_root}/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-server.h",
     "${chip_root}/src/controller/python/chip/native/PyChipError.h",
@@ -30,6 +32,8 @@ static_library("chip_webrtc") {
     "WebRTCClient.h",
     "WebRTCTransportProviderClient.cpp",
     "WebRTCTransportProviderClient.h",
+    "WebRTCTransportProviderManager.cpp",
+    "WebRTCTransportProviderManager.h",
     "WebRTCTransportRequestorManager.cpp",
     "WebRTCTransportRequestorManager.h",
   ]

--- a/src/controller/webrtc/WebRTCClient.cpp
+++ b/src/controller/webrtc/WebRTCClient.cpp
@@ -245,7 +245,7 @@ void WebRTCClient::OnStateChange(std::function<void(int)> callback)
     mStateChangeCallback = callback;
 }
 
-void WebRTCClient::WebRTCProviderClientInit(uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
+void WebRTCClient::WebRTCProviderClientInit(uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
 {
     mTransportProviderClient->Init(nodeId, fabricIndex, endpoint);
 }

--- a/src/controller/webrtc/WebRTCClient.h
+++ b/src/controller/webrtc/WebRTCClient.h
@@ -46,7 +46,7 @@ public:
     int GetPeerConnectionState();
     void Disconnect();
 
-    void WebRTCProviderClientInit(uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
+    void WebRTCProviderClientInit(uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
     PyChipError SendCommand(void * appContext, uint16_t endpointId, uint32_t clusterId, uint32_t commandId, const uint8_t * payload,
                             size_t length);
     void WebRTCProviderClientInitCallbacks(OnCommandSenderResponseCallback onCommandSenderResponseCallback,

--- a/src/controller/webrtc/WebRTCTransportProviderClient.cpp
+++ b/src/controller/webrtc/WebRTCTransportProviderClient.cpp
@@ -30,7 +30,7 @@ using namespace chip::app;
 using WebRTCSessionStruct                              = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
 static constexpr ClusterStatus kUndefinedClusterStatus = 0xFF;
 
-void WebRTCTransportProviderClient::Init(uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
+void WebRTCTransportProviderClient::Init(uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint)
 {
     mPeerId     = ScopedNodeId(nodeId, fabricIndex);
     mEndpointId = static_cast<EndpointId>(endpoint);

--- a/src/controller/webrtc/WebRTCTransportProviderClient.h
+++ b/src/controller/webrtc/WebRTCTransportProviderClient.h
@@ -47,7 +47,7 @@ public:
     ~WebRTCTransportProviderClient() = default;
 
     // methods to be called from python
-    void Init(uint32_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
+    void Init(uint64_t nodeId, uint8_t fabricIndex, uint16_t endpoint);
 
     PyChipError SendCommand(void * appContext, uint16_t endpointId, uint32_t clusterId, uint32_t commandId, const uint8_t * payload,
                             size_t length);

--- a/src/controller/webrtc/WebRTCTransportProviderManager.cpp
+++ b/src/controller/webrtc/WebRTCTransportProviderManager.cpp
@@ -1,0 +1,191 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "WebRTCTransportProviderManager.h"
+#include <string>
+#include <vector>
+
+namespace chip {
+namespace python {
+
+// The callback methods provided by python.
+ProvideOfferCallback gProvideOfferCallback                 = nullptr;
+ProvideAnswerCallback gProvideAnswerCallback               = nullptr;
+ProvideICECandidatesCallback gProvideICECandidatesCallback = nullptr;
+ProvideEndCallback gEndSessionCallback                     = nullptr;
+SessionIdCreatedCallback gSessionIdCreatedCallback         = nullptr;
+} // namespace python
+} // namespace chip
+
+using namespace chip::python;
+
+void WebRTCTransportProviderManager::Init()
+{
+#if CHIP_DEVICE_CONFIG_DYNAMIC_SERVER
+    chip::app::dynamic_server::InitAccessControl();
+#endif
+    mWebRTCProviderServer.Init();
+}
+
+void WebRTCTransportProviderManager::InitCallbacks(ProvideOfferCallback provideOfferCallback,
+                                                   ProvideAnswerCallback provideAnswerCallback,
+                                                   ProvideICECandidatesCallback provideICECandidatesCallback,
+                                                   ProvideEndCallback provideEndCallback,
+                                                   SessionIdCreatedCallback sessionIdCreatedCallback)
+{
+    gProvideOfferCallback         = provideOfferCallback;
+    gProvideAnswerCallback        = provideAnswerCallback;
+    gProvideICECandidatesCallback = provideICECandidatesCallback;
+    gEndSessionCallback           = provideEndCallback;
+    gSessionIdCreatedCallback     = sessionIdCreatedCallback;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
+                                                              bool & outDeferredOffer)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::HandleProvideOffer(const ProvideOfferRequestArgs & args,
+                                                              WebRTCSessionStruct & outSession)
+{
+    ChipLogProgress(Camera, "HandleProvideOffer called");
+    if (gSessionIdCreatedCallback)
+        gSessionIdCreatedCallback(args.sessionId, args.peerNodeId);
+
+    // Initialize a new WebRTC session from the SolicitOfferRequestArgs
+    outSession.id          = args.sessionId;
+    outSession.peerNodeID  = args.peerNodeId;
+    outSession.streamUsage = args.streamUsage;
+    outSession.fabricIndex = args.fabricIndex;
+
+    // Resolve or allocate a VIDEO stream
+    if (args.videoStreamId.HasValue())
+    {
+        if (args.videoStreamId.Value().IsNull())
+        {
+            // Automatic stream selection behavior is ambiguous for controller role. Do nothing for now.
+        }
+        else
+        {
+            outSession.videoStreamID = args.videoStreamId.Value();
+        }
+    }
+    else
+    {
+        outSession.videoStreamID.SetNull();
+    }
+
+    // Resolve or allocate an AUDIO stream
+    if (args.audioStreamId.HasValue())
+    {
+        if (args.audioStreamId.Value().IsNull())
+        {
+            // Automatic stream selection behavior is ambiguous for controller role. Do nothing for now.
+        }
+        else
+        {
+            outSession.audioStreamID = args.audioStreamId.Value();
+        }
+    }
+    else
+    {
+        outSession.audioStreamID.SetNull();
+    }
+
+    std::string offer = args.sdp;
+    int err           = gProvideOfferCallback(args.sessionId, offer.c_str());
+    return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::HandleProvideAnswer(uint16_t sessionId, const std::string & sdpAnswer)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::HandleProvideICECandidates(uint16_t sessionId,
+                                                                      const std::vector<ICECandidateStruct> & candidates)
+{
+    std::vector<std::string> remoteCandidates;
+    remoteCandidates.clear();
+    std::vector<const char *> cStrings;
+    cStrings.clear();
+
+    if (candidates.empty())
+    {
+        ChipLogError(Camera, "Candidate list is empty. At least one candidate is expected.");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    for (const auto & candidate : candidates)
+    {
+        remoteCandidates.push_back(std::string(candidate.candidate.begin(), candidate.candidate.end()));
+    }
+
+    for (const std::string & candidate : remoteCandidates)
+    {
+        cStrings.push_back(candidate.c_str());
+    }
+
+    int err = gProvideICECandidatesCallback(sessionId, cStrings.data(), static_cast<int>(cStrings.size()));
+    return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode,
+                                                            chip::app::DataModel::Nullable<uint16_t> videoStreamID,
+                                                            chip::app::DataModel::Nullable<uint16_t> audioStreamID)
+{
+    int err = gEndSessionCallback(sessionId, static_cast<uint8_t>(reasonCode));
+    return err == 0 ? CHIP_NO_ERROR : CHIP_ERROR_INCORRECT_STATE;
+}
+
+// Below Delegate Calls are still ambiguous with their role with controller. Returning default positive values for now.
+// TODO Implement delegate methods
+
+CHIP_ERROR
+WebRTCTransportProviderManager::ValidateStreamUsage(StreamUsageEnum streamUsage,
+                                                    const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & videoStreamId,
+                                                    const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & audioStreamId)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::ValidateVideoStreamID(uint16_t videoStreamId)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::ValidateAudioStreamID(uint16_t audioStreamId)
+{
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WebRTCTransportProviderManager::IsPrivacyModeActive(bool & isActive)
+{
+    isActive = false;
+    return CHIP_NO_ERROR;
+}
+
+bool WebRTCTransportProviderManager::HasAllocatedVideoStreams()
+{
+    return true;
+}
+
+bool WebRTCTransportProviderManager::HasAllocatedAudioStreams()
+{
+    return true;
+}

--- a/src/controller/webrtc/WebRTCTransportProviderManager.cpp
+++ b/src/controller/webrtc/WebRTCTransportProviderManager.cpp
@@ -121,9 +121,9 @@ CHIP_ERROR WebRTCTransportProviderManager::HandleProvideICECandidates(uint16_t s
                                                                       const std::vector<ICECandidateStruct> & candidates)
 {
     std::vector<std::string> remoteCandidates;
-    remoteCandidates.clear();
+    remoteCandidates.reserve(candidates.size());
     std::vector<const char *> cStrings;
-    cStrings.clear();
+    cStrings.reserve(candidates.size());
 
     if (candidates.empty())
     {

--- a/src/controller/webrtc/WebRTCTransportProviderManager.h
+++ b/src/controller/webrtc/WebRTCTransportProviderManager.h
@@ -1,0 +1,94 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app-common/zap-generated/cluster-enums.h>
+#include <app/CASESessionManager.h>
+#include <app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h>
+#include <rtc/rtc.hpp>
+
+#if CHIP_DEVICE_CONFIG_DYNAMIC_SERVER
+#include <app/dynamic_server/AccessControl.h>
+#endif
+
+// The Python callbacks to call when certain events happen in WebRTCTransportProvider.
+using ProvideOfferCallback         = int (*)(uint16_t, const char *);
+using ProvideAnswerCallback        = int (*)(uint16_t, const char *);
+using ProvideICECandidatesCallback = int (*)(uint16_t, const char **, const int);
+using ProvideEndCallback           = int (*)(uint16_t, uint8_t);
+using SessionIdCreatedCallback     = void (*)(uint16_t, uint64_t);
+
+using ICEServerDecodableStruct = chip::app::Clusters::Globals::Structs::ICEServerStruct::DecodableType;
+using WebRTCSessionStruct      = chip::app::Clusters::Globals::Structs::WebRTCSessionStruct::Type;
+using ICECandidateStruct       = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;
+using StreamUsageEnum          = chip::app::Clusters::Globals::StreamUsageEnum;
+using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEnum;
+
+class WebRTCTransportProviderManager : public chip::app::Clusters::WebRTCTransportProvider::Delegate
+{
+public:
+    static WebRTCTransportProviderManager & Instance()
+    {
+        static WebRTCTransportProviderManager instance;
+        return instance;
+    }
+    void Init();
+
+    void InitCallbacks(ProvideOfferCallback provideOfferCallback, ProvideAnswerCallback provideAnswerCallback,
+                       ProvideICECandidatesCallback provideICECandidatesCallback, ProvideEndCallback provideEndCallback,
+                       SessionIdCreatedCallback sessionIdCreatedCallback);
+
+    CHIP_ERROR HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
+                                  bool & outDeferredOffer) override;
+
+    CHIP_ERROR
+    HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession) override;
+
+    CHIP_ERROR HandleProvideAnswer(uint16_t sessionId, const std::string & sdpAnswer) override;
+
+    CHIP_ERROR HandleProvideICECandidates(uint16_t sessionId, const std::vector<ICECandidateStruct> & candidates) override;
+
+    CHIP_ERROR HandleEndSession(uint16_t sessionId, WebRTCEndReasonEnum reasonCode,
+                                chip::app::DataModel::Nullable<uint16_t> videoStreamID,
+                                chip::app::DataModel::Nullable<uint16_t> audioStreamID) override;
+
+    CHIP_ERROR ValidateStreamUsage(StreamUsageEnum streamUsage,
+                                   const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & videoStreamId,
+                                   const chip::Optional<chip::app::DataModel::Nullable<uint16_t>> & audioStreamId) override;
+
+    CHIP_ERROR ValidateVideoStreamID(uint16_t videoStreamId) override;
+
+    CHIP_ERROR ValidateAudioStreamID(uint16_t audioStreamId) override;
+
+    CHIP_ERROR IsPrivacyModeActive(bool & isActive) override;
+
+    bool HasAllocatedVideoStreams() override;
+
+    bool HasAllocatedAudioStreams() override;
+
+private:
+#if CHIP_DEVICE_CONFIG_DYNAMIC_SERVER
+    int webRTCProviderDynamicEndpointId = kWebRTCProviderDynamicEndpointId;
+#else
+    int webRTCProviderDynamicEndpointId = 1;
+#endif
+
+    WebRTCTransportProviderManager() : mWebRTCProviderServer(*this, webRTCProviderDynamicEndpointId) {};
+    ~WebRTCTransportProviderManager() = default;
+
+    chip::app::Clusters::WebRTCTransportProvider::WebRTCTransportProviderServer mWebRTCProviderServer;
+};

--- a/src/controller/webrtc/WebRTCTransportProviderManager.h
+++ b/src/controller/webrtc/WebRTCTransportProviderManager.h
@@ -87,7 +87,7 @@ private:
     int webRTCProviderDynamicEndpointId = 1;
 #endif
 
-    WebRTCTransportProviderManager() : mWebRTCProviderServer(*this, webRTCProviderDynamicEndpointId) {};
+    WebRTCTransportProviderManager() : mWebRTCProviderServer(*this, webRTCProviderDynamicEndpointId){};
     ~WebRTCTransportProviderManager() = default;
 
     chip::app::Clusters::WebRTCTransportProvider::WebRTCTransportProviderServer mWebRTCProviderServer;


### PR DESCRIPTION
WebRTC Provider Server and WebRTC Requestor Client is needed in controller for Camera Initiated Flow. https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/webrtc.adoc#33-camera-initiated-flow
This PR 
- Adds WebRTC Provider Server endpoint definitions in dynamic_server/DynamicDispatcher.cpp
- Implements provider delegates required for MVP
- Enables WEBRTC TC 1.5
- Allows camera to start the webrtc session establishment

### Testing

```
python3 TC_WEBRTC_1_5.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/
```
```
 rm -rf /tmp/chip_*
./chip-camera-app --camera-initiated-session
```
