### PR TITLE
Implement an abstraction layer for WebRTC stack

### DIFF
--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -72,6 +72,7 @@ executable("chip-camera-app") {
     "${chip_root}/examples/camera-app/linux/src/clusters/chime/chime-manager.cpp",
     "${chip_root}/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp",
     "${chip_root}/examples/camera-app/linux/src/media-controller/default-media-controller.cpp",
+    "${chip_root}/examples/camera-app/linux/src/webrtc-libdatachannel.cpp",
     "${chip_root}/examples/camera-app/linux/src/webrtc-transport.cpp",
     "include/CHIPProjectAppConfig.h",
     "main.cpp",

--- a/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
+++ b/examples/camera-app/linux/include/clusters/webrtc-provider/webrtc-provider-manager.h
@@ -19,11 +19,11 @@
 #pragma once
 
 #include "camera-device-interface.h"
+#include "webrtc-abstract.h"
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/CASESessionManager.h>
 #include <app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h>
 #include <media-controller.h>
-#include <rtc/rtc.hpp>
 #include <webrtc-transport.h>
 
 #include <unordered_map>
@@ -127,9 +127,15 @@ private:
 
     static void OnDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
-    std::shared_ptr<rtc::PeerConnection> mPeerConnection;
-    std::shared_ptr<rtc::Track> mVideoTrack;
-    std::shared_ptr<rtc::Track> mAudioTrack;
+    // WebRTC Callbacks
+    void OnLocalDescription(const std::string & sdp, SDPType type);
+    void OnICECandidate(const std::string & candidate);
+    void OnConnectionStateChanged(bool connected);
+    void OnTrack(std::shared_ptr<WebRTCTrack> track);
+
+    std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
+    std::shared_ptr<WebRTCTrack> mVideoTrack;
+    std::shared_ptr<WebRTCTrack> mAudioTrack;
 
     chip::ScopedNodeId mPeerId;
     chip::EndpointId mOriginatingEndpointId;

--- a/examples/camera-app/linux/include/media-controller/default-media-controller.h
+++ b/examples/camera-app/linux/include/media-controller/default-media-controller.h
@@ -41,6 +41,6 @@ public:
     void DistributeAudio(const char * data, size_t size, uint16_t audioStreamID) override;
 
 private:
-    std::vector<Connection> connections;
-    std::mutex connectionsMutex;
+    std::vector<Connection> mConnections;
+    std::mutex mConnectionsMutex;
 };

--- a/examples/camera-app/linux/include/webrtc-abstract.h
+++ b/examples/camera-app/linux/include/webrtc-abstract.h
@@ -1,0 +1,76 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+// Forward declarations
+class WebRTCPeerConnection;
+class WebRTCTrack;
+
+enum class SDPType : uint8_t
+{
+    Offer,
+    Answer,
+    Pranswer,
+    Rollback
+};
+
+enum class MediaType : uint8_t
+{
+    Audio,
+    Video,
+};
+
+using OnLocalDescriptionCallback = std::function<void(const std::string & sdp, SDPType type)>;
+using OnICECandidateCallback     = std::function<void(const std::string & candidate)>;
+using OnConnectionStateCallback  = std::function<void(bool connected)>;
+using OnTrackCallback            = std::function<void(std::shared_ptr<WebRTCTrack> track)>;
+
+// Abstract track interface
+class WebRTCTrack
+{
+public:
+    virtual ~WebRTCTrack() = default;
+
+    virtual void SendData(const char * data, size_t size) = 0;
+    virtual bool IsReady()                                = 0;
+    virtual std::string GetType()                         = 0; // "video" or "audio"
+};
+
+// Abstract peer connection interface
+class WebRTCPeerConnection
+{
+public:
+    virtual ~WebRTCPeerConnection() = default;
+
+    virtual void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
+                              OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack) = 0;
+    virtual void Close()                                                                            = 0;
+    virtual void CreateOffer()                                                                      = 0;
+    virtual void CreateAnswer()                                                                     = 0;
+    virtual void SetRemoteDescription(const std::string & sdp, SDPType type)                        = 0;
+    virtual void AddRemoteCandidate(const std::string & candidate, const std::string & mid)         = 0;
+    virtual std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType)                              = 0;
+};
+
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection();

--- a/examples/camera-app/linux/include/webrtc-transport.h
+++ b/examples/camera-app/linux/include/webrtc-transport.h
@@ -19,13 +19,13 @@
 #pragma once
 
 #include "transport.h"
-#include <rtc/rtc.hpp>
+#include "webrtc-abstract.h"
 
 // Derived class for WebRTC transport
 class WebrtcTransport : public Transport
 {
 public:
-    WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<rtc::PeerConnection> mPeerConnection);
+    WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<WebRTCPeerConnection> peerConnection);
 
     ~WebrtcTransport();
 
@@ -45,17 +45,17 @@ public:
     bool CanSendAudio() override;
 
     // Set video track for the transport
-    void SetVideoTrack(std::shared_ptr<rtc::Track> videoTrack);
+    void SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack);
 
     // Set audio track for the transport
-    void SetAudioTrack(std::shared_ptr<rtc::Track> audioTrack);
+    void SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack);
 
 private:
     uint16_t mSessionID;
     uint64_t mNodeID;
     uint32_t mAudioSampleTimestamp;
     uint32_t mVideoSampleTimestamp;
-    std::shared_ptr<rtc::PeerConnection> mPeerConnection;
-    std::shared_ptr<rtc::Track> mVideoTrack;
-    std::shared_ptr<rtc::Track> mAudioTrack;
+    std::shared_ptr<WebRTCPeerConnection> mPeerConnection;
+    std::shared_ptr<WebRTCTrack> mVideoTrack;
+    std::shared_ptr<WebRTCTrack> mAudioTrack;
 };

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -32,55 +32,6 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::WebRTCTransportProvider;
 
-namespace {
-
-// Constants
-constexpr int kVideoH264PayloadType = 96; // 96 is just the first value in the dynamic RTP payload‑type range (96‑127).
-constexpr int kVideoBitRate         = 3000;
-
-const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
-{
-    switch (state)
-    {
-    case rtc::PeerConnection::State::New:
-        return "New";
-
-    case rtc::PeerConnection::State::Connecting:
-        return "Connecting";
-
-    case rtc::PeerConnection::State::Connected:
-        return "Connected";
-
-    case rtc::PeerConnection::State::Disconnected:
-        return "Disconnected";
-
-    case rtc::PeerConnection::State::Failed:
-        return "Failed";
-
-    case rtc::PeerConnection::State::Closed:
-        return "Closed";
-    }
-    return "N/A";
-}
-
-const char * GetGatheringStateStr(rtc::PeerConnection::GatheringState state)
-{
-    switch (state)
-    {
-    case rtc::PeerConnection::GatheringState::New:
-        return "New";
-
-    case rtc::PeerConnection::GatheringState::InProgress:
-        return "InProgress";
-
-    case rtc::PeerConnection::GatheringState::Complete:
-        return "Complete";
-    }
-    return "N/A";
-}
-
-} // namespace
-
 void WebRTCProviderManager::SetCameraDevice(CameraDeviceInterface * aCameraDevice)
 {
     mCameraDevice = aCameraDevice;
@@ -88,53 +39,12 @@ void WebRTCProviderManager::SetCameraDevice(CameraDeviceInterface * aCameraDevic
 
 void WebRTCProviderManager::Init()
 {
-    rtc::Configuration config;
-    // config.iceServers.emplace_back("stun.l.google.com:19302");
+    mPeerConnection = CreateWebRTCPeerConnection();
 
-    mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
-
-    mPeerConnection->onLocalDescription([this](rtc::Description desc) {
-        if (mState == State::SendingAnswer && desc.type() != rtc::Description::Type::Answer)
-        {
-            return;
-        }
-
-        mLocalSdp = std::string(desc);
-        ChipLogProgress(Camera, "Local Description:");
-        ChipLogProgress(Camera, "%s", mLocalSdp.c_str());
-
-        switch (mState)
-        {
-        case State::SendingOffer:
-            ScheduleOfferSend();
-            break;
-        case State::SendingAnswer:
-            ScheduleAnswerSend();
-            break;
-        default:
-            break;
-        }
-    });
-
-    mPeerConnection->onLocalCandidate([this](rtc::Candidate candidate) {
-        std::string candidateStr = std::string(candidate);
-        mLocalCandidates.push_back(candidateStr);
-        ChipLogProgress(Camera, "Local Candidate:");
-        ChipLogProgress(Camera, "%s", candidateStr.c_str());
-    });
-
-    mPeerConnection->onStateChange([this](rtc::PeerConnection::State state) {
-        // Convert the enum to an integer or string as needed
-        ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
-        if (state == rtc::PeerConnection::State::Connected)
-        {
-            RegisterWebrtcTransport(mCurrentSessionId);
-        }
-    });
-
-    mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
-        ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
-    });
+    mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
+                                  [this](const std::string & candidate) { this->OnICECandidate(candidate); },
+                                  [this](bool connected) { this->OnConnectionStateChanged(connected); },
+                                  [this](std::shared_ptr<WebRTCTrack> track) { this->OnTrack(track); });
 }
 
 void WebRTCProviderManager::CloseConnection()
@@ -145,7 +55,7 @@ void WebRTCProviderManager::CloseConnection()
     // Close the peer connection if they exist
     if (mPeerConnection)
     {
-        mPeerConnection->close();
+        mPeerConnection->Close();
         mPeerConnection.reset();
     }
 }
@@ -216,13 +126,10 @@ CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & ar
 
     MoveToState(State::SendingOffer);
 
-    rtc::Description::Video media("video", rtc::Description::Direction::SendOnly);
-    media.addH264Codec(kVideoH264PayloadType);
-    media.setBitrate(kVideoBitRate);
-    mVideoTrack = mPeerConnection->addTrack(media);
+    mVideoTrack = mPeerConnection->AddTrack(MediaType::Video);
 
     ChipLogProgress(Camera, "Generate and set the SDP");
-    mPeerConnection->setLocalDescription();
+    mPeerConnection->CreateOffer();
 
     return CHIP_NO_ERROR;
 }
@@ -316,32 +223,13 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
             std::unique_ptr<WebrtcTransport>(new WebrtcTransport(args.sessionId, mPeerId.GetNodeId(), mPeerConnection));
     }
 
-    // Only set up onTrack callback if you expect to RECEIVE tracks (answerer role)
-    mPeerConnection->onTrack([this, sessionId = args.sessionId](std::shared_ptr<rtc::Track> track) {
-        ChipLogProgress(Camera, "Remote track received for session %u", sessionId);
-
-        // Check if this is a video track based on the media description
-        auto description = track->description();
-        if (description.type() == "video")
-        {
-            mVideoTrack = track;
-            ChipLogProgress(Camera, "Video track updated from remote peer");
-        }
-        else if (description.type() == "audio")
-        {
-            mAudioTrack = track;
-            ChipLogProgress(Camera, "Audio track updated from remote peer");
-        }
-    });
-
     // Acquire the Video and Audio Streams from the CameraAVStreamManagement
     // cluster and update the reference counts.
     AcquireAudioVideoStreams();
 
     MoveToState(State::SendingAnswer);
-    rtc::Description remoteOffer(args.sdp, rtc::Description::Type::Offer);
-    mPeerConnection->setRemoteDescription(remoteOffer);
-    mPeerConnection->createAnswer();
+    mPeerConnection->SetRemoteDescription(args.sdp, SDPType::Offer);
+    mPeerConnection->CreateAnswer();
 
     return CHIP_NO_ERROR;
 }
@@ -376,7 +264,8 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideAnswer(uint16_t sessionId, const 
     }
     AcquireAudioVideoStreams();
 
-    mPeerConnection->setRemoteDescription(sdpAnswer);
+    mPeerConnection->SetRemoteDescription(sdpAnswer, SDPType::Answer);
+
     MoveToState(State::SendingICECandidates);
     ScheduleICECandidatesSend();
 
@@ -410,17 +299,9 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideICECandidates(uint16_t sessionId,
     {
         ChipLogProgress(Camera, "Applying candidate: %s",
                         std::string(candidate.candidate.begin(), candidate.candidate.end()).c_str());
-        if (candidate.SDPMid.IsNull())
-        {
-            mPeerConnection->addRemoteCandidate(
-                rtc::Candidate(std::string(candidate.candidate.begin(), candidate.candidate.end())));
-        }
-        else
-        {
-            mPeerConnection->addRemoteCandidate(
-                rtc::Candidate(std::string(candidate.candidate.begin(), candidate.candidate.end()),
-                               std::string(candidate.SDPMid.Value().begin(), candidate.SDPMid.Value().end())));
-        }
+        std::string mid =
+            candidate.SDPMid.IsNull() ? "" : std::string(candidate.SDPMid.Value().begin(), candidate.SDPMid.Value().end());
+        mPeerConnection->AddRemoteCandidate(std::string(candidate.candidate.begin(), candidate.candidate.end()), mid);
     }
 
     // Schedule sending Ice Candidates when remote candidates are received. This keeps the exchange simple
@@ -451,7 +332,7 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
     if (mPeerConnection)
     {
         ChipLogProgress(Camera, "Closing peer connection: %u", sessionId);
-        mPeerConnection->close();
+        mPeerConnection->Close();
         mPeerConnection.reset();
     }
 
@@ -693,6 +574,61 @@ CHIP_ERROR WebRTCProviderManager::SendOfferCommand(Messaging::ExchangeManager & 
 
     // Now invoke the command using the found session handle
     return Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, mOriginatingEndpointId, command, onSuccess, onFailure);
+}
+
+void WebRTCProviderManager::OnLocalDescription(const std::string & sdp, SDPType type)
+{
+    if (mState == State::SendingAnswer && type != SDPType::Answer)
+    {
+        return;
+    }
+
+    mLocalSdp            = sdp;
+    const char * typeStr = (type == SDPType::Offer) ? "offer" : "answer";
+    ChipLogProgress(Camera, "Local Description (%s):", typeStr);
+    ChipLogProgress(Camera, "%s", mLocalSdp.c_str());
+
+    switch (mState)
+    {
+    case State::SendingOffer:
+        ScheduleOfferSend();
+        break;
+    case State::SendingAnswer:
+        ScheduleAnswerSend();
+        break;
+    default:
+        break;
+    }
+}
+
+void WebRTCProviderManager::OnICECandidate(const std::string & candidate)
+{
+    mLocalCandidates.push_back(candidate);
+    ChipLogProgress(Camera, "Local Candidate:");
+    ChipLogProgress(Camera, "%s", candidate.c_str());
+}
+
+void WebRTCProviderManager::OnConnectionStateChanged(bool connected)
+{
+    if (connected)
+    {
+        RegisterWebrtcTransport(mCurrentSessionId);
+    }
+}
+
+void WebRTCProviderManager::OnTrack(std::shared_ptr<WebRTCTrack> track)
+{
+    ChipLogProgress(Camera, "Remote track received for session %u", mCurrentSessionId);
+    if (track->GetType() == "video")
+    {
+        mVideoTrack = track;
+        ChipLogProgress(Camera, "Video track updated from remote peer");
+    }
+    else if (track->GetType() == "audio")
+    {
+        mAudioTrack = track;
+        ChipLogProgress(Camera, "Audio track updated from remote peer");
+    }
 }
 
 CHIP_ERROR WebRTCProviderManager::SendAnswerCommand(Messaging::ExchangeManager & exchangeMgr, const SessionHandle & sessionHandle)

--- a/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
+++ b/examples/camera-app/linux/src/media-controller/default-media-controller.cpp
@@ -23,24 +23,24 @@ void DefaultMediaController::RegisterTransport(Transport * transport, uint16_t v
 {
     ChipLogProgress(Camera, "Registering transport: videoStreamID=%u, audioStreamID=%u", videoStreamID, audioStreamID);
 
-    std::lock_guard<std::mutex> lock(connectionsMutex);
-    connections.push_back({ transport, videoStreamID, audioStreamID });
+    std::lock_guard<std::mutex> lock(mConnectionsMutex);
+    mConnections.push_back({ transport, videoStreamID, audioStreamID });
 
-    ChipLogProgress(Camera, "Transport registered successfully. Total connections: %u", (unsigned) connections.size());
+    ChipLogProgress(Camera, "Transport registered successfully. Total connections: %u", (unsigned) mConnections.size());
 }
 
 void DefaultMediaController::UnregisterTransport(Transport * transport)
 {
-    std::lock_guard<std::mutex> lock(connectionsMutex);
-    connections.erase(std::remove_if(connections.begin(), connections.end(),
-                                     [transport](const Connection & c) { return c.transport == transport; }),
-                      connections.end());
+    std::lock_guard<std::mutex> lock(mConnectionsMutex);
+    mConnections.erase(std::remove_if(mConnections.begin(), mConnections.end(),
+                                      [transport](const Connection & c) { return c.transport == transport; }),
+                       mConnections.end());
 }
 
 void DefaultMediaController::DistributeVideo(const char * data, size_t size, uint16_t videoStreamID)
 {
-    std::lock_guard<std::mutex> lock(connectionsMutex);
-    for (const Connection & connection : connections)
+    std::lock_guard<std::mutex> lock(mConnectionsMutex);
+    for (const Connection & connection : mConnections)
     {
         if (connection.videoStreamID == videoStreamID && connection.transport && connection.transport->CanSendVideo())
         {
@@ -51,8 +51,8 @@ void DefaultMediaController::DistributeVideo(const char * data, size_t size, uin
 
 void DefaultMediaController::DistributeAudio(const char * data, size_t size, uint16_t audioStreamID)
 {
-    std::lock_guard<std::mutex> lock(connectionsMutex);
-    for (const Connection & connection : connections)
+    std::lock_guard<std::mutex> lock(mConnectionsMutex);
+    for (const Connection & connection : mConnections)
     {
         if (connection.audioStreamID == audioStreamID && connection.transport && connection.transport->CanSendAudio())
         {

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -154,11 +154,6 @@ public:
             {
                 onConnectionState(true);
             }
-            else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed ||
-                     state == rtc::PeerConnection::State::Disconnected)
-            {
-                onConnectionState(false);
-            }
         });
 
         mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
@@ -211,6 +206,7 @@ public:
         }
 
         // TODO: Add audio track support
+        ChipLogProgress(Camera, "Audio track support is not yet implemented");
         return nullptr;
     }
 

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -1,0 +1,226 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "webrtc-abstract.h"
+#include <lib/support/logging/CHIPLogging.h>
+#include <rtc/rtc.hpp>
+
+namespace {
+
+// Constants
+constexpr int kVideoH264PayloadType = 96;
+constexpr int kVideoBitRate         = 3000;
+
+rtc::Description::Type SDPTypeToRtcType(SDPType type)
+{
+    switch (type)
+    {
+    case SDPType::Offer:
+        return rtc::Description::Type::Offer;
+    case SDPType::Answer:
+        return rtc::Description::Type::Answer;
+    case SDPType::Pranswer:
+        return rtc::Description::Type::Pranswer;
+    case SDPType::Rollback:
+        return rtc::Description::Type::Rollback;
+    default:
+        return rtc::Description::Type::Offer;
+    }
+}
+
+SDPType RtcTypeToSDPType(rtc::Description::Type type)
+{
+    switch (type)
+    {
+    case rtc::Description::Type::Offer:
+        return SDPType::Offer;
+    case rtc::Description::Type::Answer:
+        return SDPType::Answer;
+    case rtc::Description::Type::Pranswer:
+        return SDPType::Pranswer;
+    case rtc::Description::Type::Rollback:
+        return SDPType::Rollback;
+    default:
+        return SDPType::Offer;
+    }
+}
+
+const char * GetPeerConnectionStateStr(rtc::PeerConnection::State state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::State::New:
+        return "New";
+
+    case rtc::PeerConnection::State::Connecting:
+        return "Connecting";
+
+    case rtc::PeerConnection::State::Connected:
+        return "Connected";
+
+    case rtc::PeerConnection::State::Disconnected:
+        return "Disconnected";
+
+    case rtc::PeerConnection::State::Failed:
+        return "Failed";
+
+    case rtc::PeerConnection::State::Closed:
+        return "Closed";
+    }
+    return "N/A";
+}
+
+const char * GetGatheringStateStr(rtc::PeerConnection::GatheringState state)
+{
+    switch (state)
+    {
+    case rtc::PeerConnection::GatheringState::New:
+        return "New";
+
+    case rtc::PeerConnection::GatheringState::InProgress:
+        return "InProgress";
+
+    case rtc::PeerConnection::GatheringState::Complete:
+        return "Complete";
+    }
+    return "N/A";
+}
+
+class LibDataChannelTrack : public WebRTCTrack
+{
+public:
+    LibDataChannelTrack(std::shared_ptr<rtc::Track> track) : mTrack(track) {}
+
+    void SendData(const char * data, size_t size) override
+    {
+        if (mTrack)
+        {
+            mTrack->send(reinterpret_cast<const std::byte *>(data), size);
+        }
+    }
+
+    bool IsReady() override { return mTrack != nullptr && mTrack->isOpen(); }
+
+    std::string GetType() override
+    {
+        if (mTrack)
+        {
+            auto description = mTrack->description();
+            return std::string(description.type());
+        }
+        return "";
+    }
+
+private:
+    std::shared_ptr<rtc::Track> mTrack;
+};
+
+class LibDataChannelPeerConnection : public WebRTCPeerConnection
+{
+public:
+    LibDataChannelPeerConnection()
+    {
+        rtc::Configuration config;
+        // config.iceServers.emplace_back("stun.l.google.com:19302");
+        mPeerConnection = std::make_shared<rtc::PeerConnection>(config);
+    }
+
+    void SetCallbacks(OnLocalDescriptionCallback onLocalDescription, OnICECandidateCallback onICECandidate,
+                      OnConnectionStateCallback onConnectionState, OnTrackCallback onTrack) override
+    {
+        mPeerConnection->onLocalDescription(
+            [onLocalDescription](rtc::Description desc) { onLocalDescription(std::string(desc), RtcTypeToSDPType(desc.type())); });
+
+        mPeerConnection->onLocalCandidate([onICECandidate](rtc::Candidate candidate) { onICECandidate(std::string(candidate)); });
+
+        mPeerConnection->onStateChange([onConnectionState](rtc::PeerConnection::State state) {
+            ChipLogProgress(Camera, "[PeerConnection State: %s]", GetPeerConnectionStateStr(state));
+            if (state == rtc::PeerConnection::State::Connected)
+            {
+                onConnectionState(true);
+            }
+            else if (state == rtc::PeerConnection::State::Failed || state == rtc::PeerConnection::State::Closed ||
+                     state == rtc::PeerConnection::State::Disconnected)
+            {
+                onConnectionState(false);
+            }
+        });
+
+        mPeerConnection->onGatheringStateChange([](rtc::PeerConnection::GatheringState state) {
+            ChipLogProgress(Camera, "[PeerConnection Gathering State: %s]", GetGatheringStateStr(state));
+        });
+
+        mPeerConnection->onTrack(
+            [onTrack](std::shared_ptr<rtc::Track> track) { onTrack(std::make_shared<LibDataChannelTrack>(track)); });
+    }
+
+    void Close() override
+    {
+        if (mPeerConnection)
+        {
+            mPeerConnection->close();
+        }
+    }
+
+    void CreateOffer() override { mPeerConnection->setLocalDescription(); }
+
+    void CreateAnswer() override { mPeerConnection->createAnswer(); }
+
+    void SetRemoteDescription(const std::string & sdp, SDPType type) override
+    {
+        rtc::Description::Type rtcType = SDPTypeToRtcType(type);
+        mPeerConnection->setRemoteDescription(rtc::Description(sdp, rtcType));
+    }
+
+    void AddRemoteCandidate(const std::string & candidate, const std::string & mid) override
+    {
+        if (mid.empty())
+        {
+            mPeerConnection->addRemoteCandidate(rtc::Candidate(candidate));
+        }
+        else
+        {
+            mPeerConnection->addRemoteCandidate(rtc::Candidate(candidate, mid));
+        }
+    }
+
+    std::shared_ptr<WebRTCTrack> AddTrack(MediaType mediaType) override
+    {
+        if (mediaType == MediaType::Video)
+        {
+            rtc::Description::Video media("video", rtc::Description::Direction::SendOnly);
+            media.addH264Codec(kVideoH264PayloadType);
+            media.setBitrate(kVideoBitRate);
+            auto track = mPeerConnection->addTrack(media);
+            return std::make_shared<LibDataChannelTrack>(track);
+        }
+
+        // TODO: Add audio track support
+        return nullptr;
+    }
+
+private:
+    std::shared_ptr<rtc::PeerConnection> mPeerConnection;
+};
+
+} // namespace
+
+std::shared_ptr<WebRTCPeerConnection> CreateWebRTCPeerConnection()
+{
+    return std::make_shared<LibDataChannelPeerConnection>();
+}

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -19,7 +19,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <webrtc-transport.h>
 
-WebrtcTransport::WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<rtc::PeerConnection> peerConnection)
+WebrtcTransport::WebrtcTransport(uint16_t sessionID, uint64_t nodeID, std::shared_ptr<WebRTCPeerConnection> peerConnection)
 {
     ChipLogProgress(Camera, "WebrtcTransport created for sessionID: %u", sessionID);
     mSessionID            = sessionID;
@@ -36,13 +36,19 @@ WebrtcTransport::~WebrtcTransport()
 
 void WebrtcTransport::SendVideo(const char * data, size_t size, uint16_t videoStreamID)
 {
-    mVideoTrack->send(reinterpret_cast<const std::byte *>(data), size);
+    if (mVideoTrack)
+    {
+        mVideoTrack->SendData(data, size);
+    }
 }
 
 // Implementation of SendAudio method
 void WebrtcTransport::SendAudio(const char * data, size_t size, uint16_t audioStreamID)
 {
-    mAudioTrack->send(reinterpret_cast<const std::byte *>(data), size);
+    if (mAudioTrack)
+    {
+        mAudioTrack->SendData(data, size);
+    }
 }
 
 // Implementation of SendAudioVideo method
@@ -54,24 +60,24 @@ void WebrtcTransport::SendAudioVideo(const char * data, size_t size, uint16_t vi
 // Implementation of CanSendVideo method
 bool WebrtcTransport::CanSendVideo()
 {
-    return mVideoTrack != nullptr && mPeerConnection != nullptr;
+    return mVideoTrack && mPeerConnection;
 }
 
 // Implementation of CanSendAudio method
 bool WebrtcTransport::CanSendAudio()
 {
-    return mAudioTrack != nullptr && mPeerConnection != nullptr;
+    return mAudioTrack && mPeerConnection;
 }
 
 // Implementation of SetVideoTrack method
-void WebrtcTransport::SetVideoTrack(std::shared_ptr<rtc::Track> videoTrack)
+void WebrtcTransport::SetVideoTrack(std::shared_ptr<WebRTCTrack> videoTrack)
 {
     ChipLogProgress(Camera, "Setting video track for sessionID: %u", mSessionID);
     mVideoTrack = videoTrack;
 }
 
 // Implementation of SetAudioTrack method
-void WebrtcTransport::SetAudioTrack(std::shared_ptr<rtc::Track> audioTrack)
+void WebrtcTransport::SetAudioTrack(std::shared_ptr<WebRTCTrack> audioTrack)
 {
     ChipLogProgress(Camera, "Setting audio track for sessionID: %u", mSessionID);
     mAudioTrack = audioTrack;

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -60,13 +60,13 @@ void WebrtcTransport::SendAudioVideo(const char * data, size_t size, uint16_t vi
 // Implementation of CanSendVideo method
 bool WebrtcTransport::CanSendVideo()
 {
-    return mVideoTrack && mPeerConnection;
+    return mVideoTrack;
 }
 
 // Implementation of CanSendAudio method
 bool WebrtcTransport::CanSendAudio()
 {
-    return mAudioTrack && mPeerConnection;
+    return mAudioTrack;
 }
 
 // Implementation of SetVideoTrack method

--- a/examples/camera-app/linux/src/webrtc-transport.cpp
+++ b/examples/camera-app/linux/src/webrtc-transport.cpp
@@ -60,13 +60,13 @@ void WebrtcTransport::SendAudioVideo(const char * data, size_t size, uint16_t vi
 // Implementation of CanSendVideo method
 bool WebrtcTransport::CanSendVideo()
 {
-    return mVideoTrack;
+    return mVideoTrack != nullptr;
 }
 
 // Implementation of CanSendAudio method
 bool WebrtcTransport::CanSendAudio()
 {
-    return mAudioTrack;
+    return mAudioTrack != nullptr;
 }
 
 // Implementation of SetVideoTrack method


### PR DESCRIPTION
#### Summary

The current WebRTC implementation is tightly coupled with the libdatachannel library. This means that rtc:: types (like rtc::PeerConnection and rtc::Track) are used directly throughout the WebRTC provider manager and transport classes.

If the system were to integrate a different WebRTC stack, it would require significant effort. This is because:

- All existing rtc:: types would need to be replaced.
- The WebRTC session management logic, which is currently spread across multiple classes, would need to be refactored.
- The transport layer has a direct dependency on libdatachannel specifics, which would also need to be addressed.

To mitigate this tight coupling, we need to introduce an abstraction layer for WebRTC APIs. 

#### Related issues

N/A

#### Testing

Validated by the CI

