### PR TITLE
[Camera] Update Python WebRTC TCs

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -49,7 +49,7 @@ declare install_pytest_requirements=yes
 declare install_jupyterlab=no
 declare -a extra_packages
 declare -a extra_gn_args
-declare chip_build_controller_dynamic_server=false
+declare chip_build_controller_dynamic_server=true
 
 help() {
 
@@ -194,6 +194,7 @@ if [[ -n $wifi_paf_config ]]; then
 fi
 echo "  enable_ipv4=\"$enable_ipv4\""
 echo "  chip_build_controller_dynamic_server=\"$chip_build_controller_dynamic_server\""
+echo "  chip_support_webrtc_python_bindings=true"
 
 if [[ ${#extra_gn_args[@]} -gt 0 ]]; then
     echo "In addition, the following extra args will added to gn command line: ${extra_gn_args[*]}"
@@ -230,6 +231,7 @@ gn_args=(
     "chip_inet_config_enable_ipv4=$enable_ipv4"
     "chip_crypto=\"openssl\""
     "chip_build_controller_dynamic_server=$chip_build_controller_dynamic_server"
+    "chip_support_webrtc_python_bindings=true"
 )
 if [[ -n "$chip_mdns" ]]; then
     gn_args+=("chip_mdns=\"$chip_mdns\"")

--- a/src/python_testing/TC_WEBRTC_1_1.py
+++ b/src/python_testing/TC_WEBRTC_1_1.py
@@ -168,11 +168,12 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
         self.step(6)
-        if not self.is_pics_sdk_ci_only and aVideoStreamID != NullValue:
-            self.wait_for_user_input("Verify WebRTC session is established")
-        elif not await webrtc_peer.check_for_session_establishment():
+        if not await webrtc_peer.check_for_session_establishment():
             logging.error("Failed to establish webrtc session")
             raise Exception("Failed to establish webrtc session")
+
+        if not self.is_pics_sdk_ci_only and aVideoStreamID != NullValue:
+            self.user_verify_video_stream("Verify WebRTC session by validating if video is received")
 
         self.step(7)
         await self.send_single_cmd(

--- a/src/python_testing/TC_WEBRTC_1_1.py
+++ b/src/python_testing/TC_WEBRTC_1_1.py
@@ -14,6 +14,27 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
 import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability

--- a/src/python_testing/TC_WEBRTC_1_1.py
+++ b/src/python_testing/TC_WEBRTC_1_1.py
@@ -14,8 +14,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import logging
+
 from chip.ChipDeviceCtrl import TransportPayloadCapability
-from chip.clusters import WebRTCTransportProvider
+from chip.clusters import Objects, WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.webrtc import PeerConnection, WebRTCManager
@@ -29,28 +31,54 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
             TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
-            TestStep(1, "TH sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT."),
-            TestStep(2, "DUT sends Answer command to the TH/WEBRTCR."),
-            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
-            TestStep(4, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
-            TestStep(5, "DUT sends ProvideICECandidates command to the TH/WEBRTCR."),
-            TestStep(6, "TH waits for 5 seconds. Verify the WebRTC session has been successfully established."),
+            TestStep(
+                1,
+                description="TH sends the ProvideOffer command with an SDP Offer and null WebRTCSessionID to the DUT.",
+                expectation="DUT responds with ProvideOfferResponse containing allocated WebRTCSessionID. TH saves the WebRTCSessionID to be used in a later step",
+            ),
+            TestStep(
+                2,
+                description="DUT sends Answer command to the TH/WEBRTCR.",
+                expectation="Verify that Answer command contains the same WebRTCSessionID saved in step 1 and contain a non-empty SDP string.",
+            ),
+            TestStep(3, description="TH sends the SUCCESS status code to the DUT."),
+            TestStep(
+                4,
+                description="TH sends the ProvideICECandidates command with a its ICE candidates to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                5,
+                description="DUT sends ICECandidates command to the TH/WEBRTCR.",
+                expectation="Verify that ICECandidates command contains the same WebRTCSessionID saved in step 1 and contain a non-empty ICE candidates.",
+            ),
+            TestStep(
+                6, description="TH waits for 5 seconds", expectation="Verify the WebRTC session has been successfully established."
+            ),
+            TestStep(
+                7,
+                description="TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
         ]
-
         return steps
 
     def desc_TC_WEBRTC_1_1(self) -> str:
-        return "[TC-WEBRTC-1.1] Validate that setting an SDP Offer successfully initiates a new WebRTC session."
+        return "[TC-WEBRTC-1.1] Validate that setting an SDP Offer successfully initiates a new WebRTC session"
 
     def pics_TC_WEBRTC_1_1(self) -> list[str]:
         return ["WEBRTCR", "WEBRTCP"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
 
     @async_test_body
     async def test_TC_WEBRTC_1_1(self):
         self.step("precondition-1")
 
         endpoint = self.get_endpoint(default=1)
-        webrtc_manager = WebRTCManager()
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
         webrtc_peer: PeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
         )
@@ -68,16 +96,15 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
         # Test Invokation
 
         self.step(1)
-
+        webrtc_peer.create_offer()
         offer = webrtc_peer.get_local_offer()
 
-        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await self.send_single_cmd(
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
             cmd=WebRTCTransportProvider.Commands.ProvideOffer(
                 webRTCSessionID=NullValue,
                 sdp=offer,
-                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
                 videoStreamID=aVideoStreamID,
-                audioStreamID=NullValue,
                 originatingEndpointID=1,
             ),
             endpoint=endpoint,
@@ -90,7 +117,7 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
 
         self.step(2)
 
-        answer_sessionId, answer = webrtc_peer.get_remote_answer()
+        answer_sessionId, answer = await webrtc_peer.get_remote_answer()
 
         asserts.assert_equal(session_id, answer_sessionId, "ProvideAnswer invoked with wrong session id")
         asserts.assert_true(len(answer) > 0, "Invalid answer SDP received")
@@ -100,18 +127,20 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
         webrtc_peer.set_remote_answer(answer)
 
         self.step(4)
-        local_candidates = webrtc_peer.get_local_ice_candidates()
-
+        local_candidates = await webrtc_peer.get_local_ice_candidates()
+        local_candidates_struct_list = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+        ]
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
-                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates
+                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
 
         self.step(5)
-        ice_session_id, remote_candidates = webrtc_peer.get_remote_ice_candidates()
+        ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
         asserts.assert_equal(session_id, ice_session_id, "ProvideIceCandidates invoked with wrong session id")
         asserts.assert_true(len(remote_candidates) > 0, "Invalid remote ice candidates received")
 
@@ -120,8 +149,18 @@ class TC_WEBRTC_1_1(MatterBaseTest, WebRTCTestHelper):
         self.step(6)
         if not self.is_pics_sdk_ci_only and aVideoStreamID != NullValue:
             self.wait_for_user_input("Verify WebRTC session is established")
-        else:
-            webrtc_peer.wait_for_session_establishment()
+        elif not await webrtc_peer.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
+
+        self.step(7)
+        await self.send_single_cmd(
+            cmd=WebRTCTransportProvider.Commands.EndSession(
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+            ),
+            endpoint=endpoint,
+            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
+        )
 
         webrtc_manager.close_all()
 

--- a/src/python_testing/TC_WEBRTC_1_2.py
+++ b/src/python_testing/TC_WEBRTC_1_2.py
@@ -171,11 +171,12 @@ class TC_WEBRTC_1_2(MatterBaseTest, WebRTCTestHelper):
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
         self.step(7)
-        if not self.is_pics_sdk_ci_only:
-            self.wait_for_user_input("Verify WebRTC session is established")
-        elif not webrtc_peer.is_session_connected():
+        if not webrtc_peer.is_session_connected():
             logging.error("Failed to establish webrtc session")
             raise Exception("Failed to establish webrtc session")
+
+        if not self.is_pics_sdk_ci_only:
+            self.user_verify_video_stream("Verify WebRTC session by validating if video is received")
 
         self.step(8)
         await self.send_single_cmd(

--- a/src/python_testing/TC_WEBRTC_1_2.py
+++ b/src/python_testing/TC_WEBRTC_1_2.py
@@ -14,68 +14,103 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import logging
+
 from chip.ChipDeviceCtrl import TransportPayloadCapability
-from chip.clusters import WebRTCTransportProvider
+from chip.clusters import Objects, WebRTCTransportProvider
 from chip.clusters.Types import NullValue
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.webrtc import PeerConnection, WebRTCManager
 from mobly import asserts
+from TC_WEBRTC_Utils import WebRTCTestHelper
 from test_plan_support import commission_if_required
 
 
-class TC_WEBRTC_1_2(MatterBaseTest):
+class TC_WEBRTC_1_2(MatterBaseTest, WebRTCTestHelper):
     def steps_TC_WEBRTC_1_2(self) -> list[TestStep]:
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
             TestStep("precondition-2", "Confirm there is an active WebRTC sessions exist in DUT"),
-            TestStep(0, "TH Reads CurrentSessions attribute from WEBRTCP (DUT)"),
-            TestStep(1, "TH sends the ProvideOffer command with an SDP Offer with the WebRTCSessionID saved in step 1 to the DUT."),
-            TestStep(2, "TH waits up to 30 seconds for Answer command from the DUT."),
-            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
-            TestStep(4, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
-            TestStep(5, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
-            TestStep(6, "TH waits for 10 seconds."),
-            TestStep(7, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT."),
+            TestStep(
+                1,
+                description="TH Reads CurrentSessions attribute from WEBRTCP (DUT)",
+                expectation="Verify the number of WebRTCSession in the list is 1 and the WebRTCSessionID of the WebRTCSession also exists in the CurrentSessions attribute of local WEBRTCR. TH saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                2,
+                description="TH sends the ProvideOffer command with an SDP Offer with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with ProvideOfferResponse containing the same WebRTCSessionID.",
+            ),
+            TestStep(
+                3,
+                description="TH waits up to 30 seconds for Answer command from the DUT.",
+                expectation="Verify that Answer command contains the same WebRTCSessionID saved in step 1 and contain a non-empty SDP string.",
+            ),
+            TestStep(4, "TH sends the SUCCESS status code to the DUT."),
+            TestStep(
+                5,
+                description="TH sends the ProvideICECandidates command with a its ICE candidates to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                6,
+                description="TH waits up to 30 seconds for ICECandidates command from the DUT.",
+                expectation="Verify that ICECandidates command contains the same WebRTCSessionID saved in step 1 and contain a non-empty ICE candidates.",
+            ),
+            TestStep(
+                7,
+                description="TH waits for 10 seconds.",
+                expectation="Verify the WebRTC session has been successfully established.",
+            ),
+            TestStep(
+                8,
+                description="TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
         ]
 
         return steps
 
     def desc_TC_WEBRTC_1_2(self) -> str:
-        return "[TC-WEBRTC-1.2] Validate that providing an existing WebRTC session ID with an SDP Offer successfully triggers the re-offer flow."
+        return "[TC-WEBRTC-1.2] Validate that providing an existing WebRTC session ID with an SDP Offer successfully triggers the re-offer flow"
 
     def pics_TC_WEBRTC_1_2(self) -> list[str]:
         return ["WEBRTCR", "WEBRTCP"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
 
     @async_test_body
     async def test_TC_WEBRTC_1_2(self):
         self.step("precondition-1")
 
         endpoint = self.get_endpoint(default=1)
-        webrtc_manager = WebRTCManager()
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
         webrtc_peer: PeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
         )
         # Test Invokation
         self.step("precondition-2")
-        await establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self)
+        if not await establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, self):
+            raise Exception("Failed to create WebRTC session")
 
-        self.step(0)
+        self.step(1)
         current_sessions = await self.read_single_attribute_check_success(
             cluster=WebRTCTransportProvider, attribute=WebRTCTransportProvider.Attributes.CurrentSessions, endpoint=endpoint
         )
         asserts.assert_equal(len(current_sessions), 1, "No Pre-Existing session found")
         prev_sessionid = current_sessions[0].id
 
-        self.step(1)
+        self.step(2)
+        webrtc_peer.create_offer()
         offer = webrtc_peer.get_local_offer()
 
-        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await self.send_single_cmd(
+        provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
             cmd=WebRTCTransportProvider.Commands.ProvideOffer(
                 webRTCSessionID=prev_sessionid,
                 sdp=offer,
-                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
-                videoStreamID=NullValue,
-                audioStreamID=NullValue,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
                 originatingEndpointID=1,
             ),
             endpoint=endpoint,
@@ -86,42 +121,45 @@ class TC_WEBRTC_1_2(MatterBaseTest):
             provide_offer_response.webRTCSessionID, prev_sessionid, "Session id does not match with the previous session"
         )
 
-        self.step(2)
-        answer_sessionId, answer = webrtc_peer.get_remote_answer(timeout=30)
+        self.step(3)
+        answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout=30)
 
         asserts.assert_equal(prev_sessionid, answer_sessionId, "Session id does not match with the previous session")
         asserts.assert_true(len(answer) > 0, "Invalid answer SDP received")
 
-        self.step(3)
+        self.step(4)
         webrtc_peer.set_remote_answer(answer)
 
-        self.step(4)
-        local_candidates = webrtc_peer.get_local_ice_candidates()
-
+        self.step(5)
+        local_candidates = await webrtc_peer.get_local_ice_candidates()
+        local_candidates_struct_list = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+        ]
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
-                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates
+                webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
 
-        self.step(5)
-        ice_session_id, remote_candidates = webrtc_peer.get_remote_ice_candidates()
+        self.step(6)
+        ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
         asserts.assert_equal(prev_sessionid, ice_session_id, "ProvideIceCandidates invoked with wrong session id")
         asserts.assert_true(len(remote_candidates) > 0, "Invalid remote ice candidates received")
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
-        self.step(6)
+        self.step(7)
         if not self.is_pics_sdk_ci_only:
             self.wait_for_user_input("Verify WebRTC session is established")
-        else:
-            webrtc_peer.wait_for_session_establishment()
+        elif not webrtc_peer.is_session_connected():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
 
-        self.step(7)
+        self.step(8)
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=prev_sessionid, reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+                webRTCSessionID=prev_sessionid, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
@@ -131,15 +169,16 @@ class TC_WEBRTC_1_2(MatterBaseTest):
 
 
 async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, ctrl):
+    webrtc_peer.create_offer()
     offer = webrtc_peer.get_local_offer()
-    provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await ctrl.send_single_cmd(
+    aVideoStreamId = await ctrl.allocate_video_stream(endpoint)
+    provide_offer_response: WebRTCTransportProvider.Commands.ProvideOfferResponse = await webrtc_peer.send_command(
         cmd=WebRTCTransportProvider.Commands.ProvideOffer(
             webRTCSessionID=NullValue,
             sdp=offer,
-            streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
-            videoStreamID=NullValue,
-            audioStreamID=NullValue,
+            streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
             originatingEndpointID=1,
+            videoStreamID=aVideoStreamId,
         ),
         endpoint=endpoint,
         payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
@@ -147,20 +186,25 @@ async def establish_webrtc_session(webrtc_manager, webrtc_peer, endpoint, ctrl):
     asserts.assert_true(provide_offer_response.webRTCSessionID >= 0, "Invalid response")
     webrtc_manager.session_id_created(provide_offer_response.webRTCSessionID, ctrl.dut_node_id)
 
-    answer_sessionId, answer = webrtc_peer.get_remote_answer(timeout=30)
+    answer_sessionId, answer = await webrtc_peer.get_remote_answer(timeout=30)
     webrtc_peer.set_remote_answer(answer)
 
-    local_candidates = webrtc_peer.get_local_ice_candidates()
+    local_candidates = await webrtc_peer.get_local_ice_candidates()
+    local_candidates_struct_list = [
+        Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+    ]
     await ctrl.send_single_cmd(
-        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(webRTCSessionID=answer_sessionId, ICECandidates=local_candidates),
+        cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+            webRTCSessionID=answer_sessionId, ICECandidates=local_candidates_struct_list
+        ),
         endpoint=endpoint,
         payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
     )
 
-    ice_session_id, remote_candidates = webrtc_peer.get_remote_ice_candidates()
+    ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates()
     webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
-    return webrtc_peer.wait_for_session_establishment()
+    return await webrtc_peer.check_for_session_establishment()
 
 
 if __name__ == "__main__":

--- a/src/python_testing/TC_WEBRTC_1_2.py
+++ b/src/python_testing/TC_WEBRTC_1_2.py
@@ -14,6 +14,27 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
 import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability

--- a/src/python_testing/TC_WEBRTC_1_3.py
+++ b/src/python_testing/TC_WEBRTC_1_3.py
@@ -13,6 +13,28 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --camera-deferred-offer --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
 import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability

--- a/src/python_testing/TC_WEBRTC_1_3.py
+++ b/src/python_testing/TC_WEBRTC_1_3.py
@@ -13,45 +13,76 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability
-from chip.clusters import WebRTCTransportProvider
-from chip.clusters.Types import NullValue
+from chip.clusters import Objects, WebRTCTransportProvider
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.webrtc import PeerConnection, WebRTCManager
 from mobly import asserts
+from TC_WEBRTC_Utils import WebRTCTestHelper
 from test_plan_support import commission_if_required
 
 
-class TC_WEBRTC_1_3(MatterBaseTest):
+class TC_WEBRTC_1_3(MatterBaseTest, WebRTCTestHelper):
     def steps_TC_WEBRTC_1_3(self) -> list[TestStep]:
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
             TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
-            TestStep(1, "TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT."),
-            TestStep(2, "TH waits up to 30 seconds for Offer command from the DUT."),
-            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
-            TestStep(4, "TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT."),
-            TestStep(5, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
-            TestStep(6, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
-            TestStep(7, "TH waits for 10 seconds."),
-            TestStep(8, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT."),
+            TestStep(
+                1,
+                description="TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT.",
+                expectation="DUT responds with SolicitOfferResponse containing allocated WebRTCSessionID and the DeferredOffer parameter set to TRUE. TH saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                2,
+                description="TH waits up to 30 seconds for Offer command from the DUT.",
+                expectation="Verify that Offer command contains the same WebRTCSessionID saved in step 1 and contain a non-empty SDP string.",
+            ),
+            TestStep(
+                3,
+                description="TH sends the SUCCESS status code to the DUT.",
+            ),
+            TestStep(
+                4,
+                description="TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and with ICE Candidates included in the SDP.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                5,
+                description="TH waits up to 30 seconds for ICECandidates command from the DUT.",
+                expectation="Verify that ICECandidates command contains the same WebRTCSessionID saved in step 1 and contain a non-empty ICE candidates.",
+            ),
+            TestStep(
+                6,
+                description="TH waits for 10 seconds.",
+                expectation="Verify the WebRTC session has been successfully established.",
+            ),
+            TestStep(
+                7,
+                description="TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
         ]
 
         return steps
 
     def desc_TC_WEBRTC_1_3(self) -> str:
-        return "[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode."
+        return "[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode"
 
     def pics_TC_WEBRTC_1_3(self) -> list[str]:
         return ["WEBRTCR", "WEBRTCP"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
 
     @async_test_body
     async def test_TC_WEBRTC_1_3(self):
         self.step("precondition-1")
 
         endpoint = self.get_endpoint(default=1)
-        webrtc_manager = WebRTCManager()
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
         webrtc_peer: PeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
         )
@@ -62,12 +93,15 @@ class TC_WEBRTC_1_3(MatterBaseTest):
         )
         asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
 
+        # Allocate video stream in DUT if possible, to receive actual video stream
+        # This step is not part of test plan
+        aVideoStreamID = await self.allocate_video_stream(endpoint)
+
         self.step(1)
-        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await self.send_single_cmd(
+        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await webrtc_peer.send_command(
             cmd=WebRTCTransportProvider.Commands.SolicitOffer(
-                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
-                videoStreamID=NullValue,
-                audioStreamID=NullValue,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=aVideoStreamID,
                 originatingEndpointID=1,
             ),
             endpoint=endpoint,
@@ -79,7 +113,7 @@ class TC_WEBRTC_1_3(MatterBaseTest):
         webrtc_manager.session_id_created(session_id, self.dut_node_id)
 
         self.step(2)
-        offer_sessionId, remote_offer_sdp = webrtc_peer.get_remote_offer(timeout=30)
+        offer_sessionId, remote_offer_sdp = await webrtc_peer.get_remote_offer(timeout=30)
         asserts.assert_equal(offer_sessionId, session_id, "Invalid session id")
         asserts.assert_true(len(remote_offer_sdp) > 0, "Invalid offer sdp received")
 
@@ -87,6 +121,7 @@ class TC_WEBRTC_1_3(MatterBaseTest):
         webrtc_peer.set_remote_offer(remote_offer_sdp)
 
         self.step(4)
+        await webrtc_peer.wait_for_gathering_complete()
         local_answer = webrtc_peer.get_local_answer()
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.ProvideAnswer(webRTCSessionID=session_id, sdp=local_answer),
@@ -95,29 +130,22 @@ class TC_WEBRTC_1_3(MatterBaseTest):
         )
 
         self.step(5)
-        local_candidates = webrtc_peer.get_local_ice_candidates()
-        await self.send_single_cmd(
-            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(webRTCSessionID=session_id, ICECandidates=local_candidates),
-            endpoint=endpoint,
-            payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
-        )
-
-        self.step(6)
-        ice_session_id, remote_candidates = webrtc_peer.get_remote_ice_candidates(timeout=30)
+        ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates(timeout=30)
         asserts.assert_equal(ice_session_id, session_id, "Invalid session id")
         asserts.assert_true(len(remote_candidates) > 0, "Invalid ice candidates received")
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
-        self.step(7)
+        self.step(6)
         if not self.is_pics_sdk_ci_only:
             self.wait_for_user_input("Verify WebRTC session is established")
-        else:
-            webrtc_peer.wait_for_session_establishment()
+        elif not await webrtc_peer.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
 
-        self.step(8)
+        self.step(7)
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=session_id, reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,

--- a/src/python_testing/TC_WEBRTC_1_3.py
+++ b/src/python_testing/TC_WEBRTC_1_3.py
@@ -158,11 +158,12 @@ class TC_WEBRTC_1_3(MatterBaseTest, WebRTCTestHelper):
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
         self.step(6)
-        if not self.is_pics_sdk_ci_only:
-            self.wait_for_user_input("Verify WebRTC session is established")
-        elif not await webrtc_peer.check_for_session_establishment():
+        if not await webrtc_peer.check_for_session_establishment():
             logging.error("Failed to establish webrtc session")
             raise Exception("Failed to establish webrtc session")
+
+        if not self.is_pics_sdk_ci_only:
+            self.user_verify_video_stream("Verify WebRTC session by validating if video is received")
 
         self.step(7)
         await self.send_single_cmd(

--- a/src/python_testing/TC_WEBRTC_1_4.py
+++ b/src/python_testing/TC_WEBRTC_1_4.py
@@ -14,6 +14,27 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
+
 import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability

--- a/src/python_testing/TC_WEBRTC_1_4.py
+++ b/src/python_testing/TC_WEBRTC_1_4.py
@@ -14,45 +14,78 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import logging
 
 from chip.ChipDeviceCtrl import TransportPayloadCapability
-from chip.clusters import WebRTCTransportProvider
-from chip.clusters.Types import NullValue
+from chip.clusters import Objects, WebRTCTransportProvider
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main
 from chip.webrtc import PeerConnection, WebRTCManager
 from mobly import asserts
+from TC_WEBRTC_Utils import WebRTCTestHelper
 from test_plan_support import commission_if_required
 
 
-class TC_WEBRTC_1_4(MatterBaseTest):
+class TC_WEBRTC_1_4(MatterBaseTest, WebRTCTestHelper):
     def steps_TC_WEBRTC_1_4(self) -> list[TestStep]:
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
             TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
-            TestStep(1, "TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT."),
-            TestStep(2, "DUT sends Offer command to TH/WEBRTCR."),
-            TestStep(3, "TH sends the SUCCESS status code to the DUT."),
-            TestStep(4, "TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT."),
-            TestStep(5, "TH sends the ICECandidates command with a its ICE candidates to the DUT."),
-            TestStep(6, "TH waits up to 30 seconds for ProvideICECandidates command from the DUT."),
-            TestStep(7, "TH waits for 10 seconds."),
-            TestStep(8, "TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT."),
+            TestStep(
+                1,
+                description="TH sends the SolicitOffer command without ICEServers and ICETransportPolicy to the DUT.",
+                expectation="DUT responds with SolicitOfferResponse containing allocated WebRTCSessionID and the DeferredOffer parameter set to FALSE. TH saves the WebRTCSessionID to be used in a later step.",
+            ),
+            TestStep(
+                2,
+                description="DUT sends Offer command to TH/WEBRTCR.",
+                expectation="Verify that Offer command contains the same WebRTCSessionID saved in step 1 and contain a non-empty SDP string.",
+            ),
+            TestStep(3, description="TH sends the SUCCESS status code to the DUT."),
+            TestStep(
+                4,
+                description="TH sends the ProvideAnswer command with the WebRTCSessionID saved in step 1 and a SDP Offer to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                5,
+                description="TH sends the ProvideICECandidates command with a its ICE candidates to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
+            TestStep(
+                6,
+                description="TH waits up to 30 seconds for ICECandidates command from the DUT.",
+                expectation="Verify that ICECandidates command contains the same WebRTCSessionID saved in step 1 and contain a non-empty ICE candidates.",
+            ),
+            TestStep(
+                7,
+                description="TH waits for 10 seconds.",
+                expectation="Verify the WebRTC session has been successfully established.",
+            ),
+            TestStep(
+                8,
+                description="TH sends the EndSession command with the WebRTCSessionID saved in step 1 to the DUT.",
+                expectation="DUT responds with SUCCESS status code.",
+            ),
         ]
 
         return steps
 
     def desc_TC_WEBRTC_1_4(self) -> str:
-        return "[TC-WEBRTC-1.3] Validate Deferred Offer Flow for Battery-Powered Camera in Standby Mode."
+        return "[TC-WEBRTC-1.4] Validate Non-Deferred Offer Flow for Battery-Powered Camera in Standby Mode"
 
     def pics_TC_WEBRTC_1_4(self) -> list[str]:
         return ["WEBRTCR", "WEBRTCP"]
+
+    @property
+    def default_timeout(self) -> int:
+        return 4 * 60  # 4 minutes
 
     @async_test_body
     async def test_TC_WEBRTC_1_4(self):
         self.step("precondition-1")
 
         endpoint = self.get_endpoint(default=1)
-        webrtc_manager = WebRTCManager()
+        webrtc_manager = WebRTCManager(event_loop=self.event_loop)
         webrtc_peer: PeerConnection = webrtc_manager.create_peer(
             node_id=self.dut_node_id, fabric_index=self.default_controller.GetFabricIndexInternal(), endpoint=endpoint
         )
@@ -63,12 +96,15 @@ class TC_WEBRTC_1_4(MatterBaseTest):
         )
         asserts.assert_equal(len(current_sessions), 0, "Found an existing WebRTC session")
 
+        # Allocate video stream in DUT if possible, to receive actual video stream
+        # This step is not part of test plan
+        aVideoStreamID = await self.allocate_video_stream(endpoint)
+
         self.step(1)
-        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await self.send_single_cmd(
+        solicit_offer_response: WebRTCTransportProvider.Commands.SolicitOfferResponse = await webrtc_peer.send_command(
             cmd=WebRTCTransportProvider.Commands.SolicitOffer(
-                streamUsage=WebRTCTransportProvider.Enums.StreamUsageEnum.kLiveView,
-                videoStreamID=NullValue,
-                audioStreamID=NullValue,
+                streamUsage=Objects.Globals.Enums.StreamUsageEnum.kLiveView,
+                videoStreamID=aVideoStreamID,
                 originatingEndpointID=1,
             ),
             endpoint=endpoint,
@@ -82,7 +118,7 @@ class TC_WEBRTC_1_4(MatterBaseTest):
 
         self.step(2)
         # TH should immediately get Offer from DUT
-        offer_sessionId, remote_offer_sdp = webrtc_peer.get_remote_offer(timeout=5)
+        offer_sessionId, remote_offer_sdp = await webrtc_peer.get_remote_offer(timeout=5)
         asserts.assert_equal(offer_sessionId, session_id, "Invalid session id")
         asserts.assert_true(len(remote_offer_sdp) > 0, "Invalid offer sdp received")
 
@@ -98,15 +134,20 @@ class TC_WEBRTC_1_4(MatterBaseTest):
         )
 
         self.step(5)
-        local_candidates = webrtc_peer.get_local_ice_candidates()
+        local_candidates = await webrtc_peer.get_local_ice_candidates()
+        local_candidates_struct_list = [
+            Objects.Globals.Structs.ICECandidateStruct(candidate=cand.candidate) for cand in local_candidates
+        ]
         await self.send_single_cmd(
-            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(webRTCSessionID=session_id, ICECandidates=local_candidates),
+            cmd=WebRTCTransportProvider.Commands.ProvideICECandidates(
+                webRTCSessionID=session_id, ICECandidates=local_candidates_struct_list
+            ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
 
         self.step(6)
-        ice_session_id, remote_candidates = webrtc_peer.get_remote_ice_candidates(timeout=30)
+        ice_session_id, remote_candidates = await webrtc_peer.get_remote_ice_candidates(timeout=30)
         asserts.assert_equal(ice_session_id, session_id, "Invalid session id")
         asserts.assert_true(len(remote_candidates) > 0, "Invalid ice candidates received")
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
@@ -114,13 +155,14 @@ class TC_WEBRTC_1_4(MatterBaseTest):
         self.step(7)
         if not self.is_pics_sdk_ci_only:
             self.wait_for_user_input("Verify WebRTC session is established")
-        else:
-            webrtc_peer.wait_for_session_establishment()
+        elif not await webrtc_peer.check_for_session_establishment():
+            logging.error("Failed to establish webrtc session")
+            raise Exception("Failed to establish webrtc session")
 
         self.step(8)
         await self.send_single_cmd(
             cmd=WebRTCTransportProvider.Commands.EndSession(
-                webRTCSessionID=session_id, reason=WebRTCTransportProvider.Enums.WebRTCEndReasonEnum.kUserHangup
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
             ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,

--- a/src/python_testing/TC_WEBRTC_1_4.py
+++ b/src/python_testing/TC_WEBRTC_1_4.py
@@ -174,11 +174,12 @@ class TC_WEBRTC_1_4(MatterBaseTest, WebRTCTestHelper):
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
         self.step(7)
-        if not self.is_pics_sdk_ci_only:
-            self.wait_for_user_input("Verify WebRTC session is established")
-        elif not await webrtc_peer.check_for_session_establishment():
+        if not await webrtc_peer.check_for_session_establishment():
             logging.error("Failed to establish webrtc session")
             raise Exception("Failed to establish webrtc session")
+
+        if not self.is_pics_sdk_ci_only:
+            self.user_verify_video_stream("Verify WebRTC session by validating if video is received")
 
         self.step(8)
         await self.send_single_cmd(

--- a/src/python_testing/TC_WEBRTC_1_5.py
+++ b/src/python_testing/TC_WEBRTC_1_5.py
@@ -47,7 +47,6 @@ from test_plan_support import commission_if_required
 
 class TC_WEBRTC_1_5(MatterBaseTest):
     def steps_TC_WEBRTC_1_5(self) -> list[TestStep]:
-
         steps = [
             TestStep("precondition-1", commission_if_required(), is_commissioning=True),
             TestStep("precondition-2", "Confirm no active WebRTC sessions exist in DUT"),
@@ -134,7 +133,8 @@ class TC_WEBRTC_1_5(MatterBaseTest):
         ]
         await self.send_single_cmd(
             cmd=WebRTCTransportRequestor.Commands.ICECandidates(
-                webRTCSessionID=session_id, ICECandidates=local_candidates_struct_list),
+                webRTCSessionID=session_id, ICECandidates=local_candidates_struct_list
+            ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )
@@ -146,16 +146,18 @@ class TC_WEBRTC_1_5(MatterBaseTest):
         webrtc_peer.set_remote_ice_candidates(remote_candidates)
 
         self.step(6)
-        if not self.is_pics_sdk_ci_only:
-            self.wait_for_user_input("Verify WebRTC session is established")
-        elif not await webrtc_peer.check_for_session_establishment():
+        if not await webrtc_peer.check_for_session_establishment():
             logging.error("Failed to establish webrtc session")
             raise Exception("Failed to establish webrtc session")
+
+        if not self.is_pics_sdk_ci_only:
+            self.user_verify_video_stream("Verify WebRTC session by validating if video is received")
 
         self.step(7)
         await self.send_single_cmd(
             cmd=WebRTCTransportRequestor.Commands.End(
-                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup),
+                webRTCSessionID=session_id, reason=Objects.Globals.Enums.WebRTCEndReasonEnum.kUserHangup
+            ),
             endpoint=endpoint,
             payloadCapability=TransportPayloadCapability.LARGE_PAYLOAD,
         )

--- a/src/python_testing/TC_WEBRTC_1_5.py
+++ b/src/python_testing/TC_WEBRTC_1_5.py
@@ -14,6 +14,26 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See https://github.com/project-chip/connectedhomeip/blob/master/docs/testing/python.md#defining-the-ci-test-arguments
+# for details about the block below.
+#
+# === BEGIN CI TEST ARGUMENTS ===
+# test-runner-runs:
+#   run1:
+#     app: ${CAMERA_APP}
+#     app-args: --camera-initiated-session --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     script-args: >
+#       --PICS src/app/tests/suites/certification/ci-pics-values
+#       --storage-path admin_storage.json
+#       --commissioning-method on-network
+#       --discriminator 1234
+#       --passcode 20202021
+#       --trace-to json:${TRACE_TEST_JSON}.json
+#       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
+#     factory-reset: true
+#     quiet: true
+# === END CI TEST ARGUMENTS ===
+#
 
 import logging
 

--- a/src/python_testing/TC_WEBRTC_Utils.py
+++ b/src/python_testing/TC_WEBRTC_Utils.py
@@ -17,7 +17,6 @@
 import logging
 
 from chip.clusters import CameraAvStreamManagement
-from chip.clusters.Types import NullValue
 
 
 class WebRTCTestHelper:
@@ -27,6 +26,7 @@ class WebRTCTestHelper:
         )
 
     async def allocate_video_stream(self, endpoint):
+        """Try to allocate a video stream from the camera device. Returns the stream ID if successful, otherwise None."""
         attrs = CameraAvStreamManagement.Attributes
         try:
             # Check for watermark and OSD features
@@ -65,4 +65,4 @@ class WebRTCTestHelper:
 
         except Exception as e:
             logging.error(f"Failed to allocate video stream. {e}")
-            return NullValue
+            return None

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -110,26 +110,10 @@ not_automated:
     - name: TC_AVSUMTestBase.py
       reason:
           Shared code for Camera AV Settings (TC_AVSUM*), not a standalone test.
-    - name: TC_WEBRTC_1_1.py
-      reason:
-          Depends on Python WebRTC bindings. Will be enabled once local tests
-          are fully verified.
-    - name: TC_WEBRTC_1_2.py
-      reason:
-          Depends on Python WebRTC bindings. Will be enabled once local tests
-          are fully verified.
-    - name: TC_WEBRTC_1_3.py
-      reason:
-          Depends on Python WebRTC bindings. Will be enabled once local tests
-          are fully verified.
-    - name: TC_WEBRTC_1_4.py
-      reason:
-          Depends on Python WebRTC bindings. Will be enabled once local tests
-          are fully verified.
     - name: TC_WEBRTC_1_5.py
       reason:
-          Depends on Python WebRTC bindings. Will be enabled once local tests
-          are fully verified.
+          Depends on Python WebRTC bindings and Camera App. Will be enabled once
+          local tests are fully verified.
     - name: TC_WEBRTC_Utils.py
       reason: Helper methods for WebRTC TCs, not a standalone test.
     - name: TC_CHIMETestBase.py


### PR DESCRIPTION
This PR 
- Updates WebRTC Test Scripts with spec changes
- Enables WebRTC TC 1.1, 1.2, 1.3, 1.4 in CI


### Testing
```sh
# 1.1
python3 TC_WEBRTC_1_1.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/

rm -rf /tmp/chip_*
./chip-camera-app 

# 1.2
python3 TC_WEBRTC_1_2.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/

rm -rf /tmp/chip_*
./chip-camera-app 

# 1.3
python3 TC_WEBRTC_1_3.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/

rm -rf /tmp/chip_*
./chip-camera-app --camera-deferred-offer

# 1.4
python3 TC_WEBRTC_1_4.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/

rm -rf /tmp/chip_*
./chip-camera-app 

# 1.5
python3 TC_WEBRTC_1_5.py --discriminator 3840 --passcode 20202021 --commissioning-method on-network --paa-trust-store-path ./paa-root-certs/

rm -rf /tmp/chip_*
./chip-camera-app --camera-initiated-session
```
