### PR TITLE
[Linux] Report public WiFiConnectivityChange events

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -261,8 +261,6 @@ bool ConnectivityManagerImpl::_IsWiFiStationConnected()
 
     if (g_strcmp0(wpa_supplicant_1_interface_get_state(mWpaSupplicant.iface.get()), "completed") == 0)
     {
-        mConnectivityFlag.Set(ConnectivityFlags::kHaveIPv4InternetConnectivity)
-            .Set(ConnectivityFlags::kHaveIPv6InternetConnectivity);
         return true;
     }
 
@@ -740,7 +738,6 @@ void ConnectivityManagerImpl::StartWiFiManagement()
 {
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
 
-    mConnectivityFlag.ClearAll();
     mWpaSupplicant = GDBusWpaSupplicant{};
 
     CHIP_ERROR err = PlatformMgrImpl().GLibMatterContextInvokeSync(

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -607,12 +607,9 @@ void ConnectivityManagerImpl::_OnWpaInterfaceRemoved(WpaSupplicant1 * proxy, con
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
     if (g_strcmp0(mWpaSupplicant.interfacePath.get(), path) == 0)
     {
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: WiFi interface removed: %s", StringOrNullMarker(path));
-
+        ChipLogProgress(DeviceLayer, "WPA supplicant: WiFi interface removed: %s", StringOrNullMarker(path));
         mWpaSupplicant.interfacePath.reset();
         mWpaSupplicant.iface.reset();
-
-        mWpaSupplicant.scanState = GDBusWpaSupplicant::WpaScanningState::IDLE;
     }
 }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1780,7 +1780,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
     VerifyOrReturnError(mWpaSupplicant.iface, CHIP_ERROR_INCORRECT_STATE);
 
     const char * mode = wpa_supplicant_1_interface_get_current_auth_mode(mWpaSupplicant.iface.get());
-    ChipLogProgress(DeviceLayer, "WPA supplicant: Surrent Wi-Fi security type: %s", StringOrNullMarker(mode));
+    ChipLogProgress(DeviceLayer, "WPA supplicant: Current Wi-Fi security type: %s", StringOrNullMarker(mode));
 
     if (strncmp(mode, "WPA-PSK", 7) == 0)
     {

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -503,7 +503,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
     mWpaSupplicant.iface.reset(wpa_supplicant_1_interface_proxy_new_for_bus_finish(res, &err.GetReceiver()));
     if (mWpaSupplicant.iface && err == nullptr)
     {
-        ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to wpa_supplicant interface proxy");
+        ChipLogProgress(DeviceLayer, "WPA supplicant: connected to wpa_supplicant interface proxy");
 
         g_signal_connect(
             mWpaSupplicant.iface.get(), "g-properties-changed",

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -115,7 +115,6 @@ struct GDBusWpaSupplicant
     WpaScanningState scanState = WpaScanningState::IDLE;
     GAutoPtr<WpaSupplicant1> proxy;
     GAutoPtr<WpaSupplicant1Interface> iface;
-    GAutoPtr<WpaSupplicant1BSS> bss;
     GAutoPtr<char> interfacePath;
     GAutoPtr<char> networkPath;
 };
@@ -256,7 +255,6 @@ private:
     void _OnWpaInterfaceScanDone(WpaSupplicant1Interface * iface, gboolean success);
     void _OnWpaInterfaceReady(GObject * sourceObject, GAsyncResult * res);
     void _OnWpaInterfaceProxyReady(GObject * sourceObject, GAsyncResult * res);
-    void _OnWpaBssProxyReady(GObject * sourceObject, GAsyncResult * res);
     CHIP_ERROR StartWiFiManagementSync();
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFIPAF
     OnConnectionCompleteFunct mOnPafSubscribeComplete;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -226,6 +226,7 @@ private:
     void _MaintainOnDemandWiFiAP();
     System::Clock::Timeout _GetWiFiAPIdleTimeout();
     void _SetWiFiAPIdleTimeout(System::Clock::Timeout val);
+    void NotifyWiFiConnectivityChange(ConnectivityChange change);
     void UpdateNetworkStatus();
     CHIP_ERROR StopAutoScan();
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -276,7 +276,6 @@ private:
     CHIP_ERROR _StartWiFiManagement();
 
     bool mAssociationStarted = false;
-    BitFlags<ConnectivityFlags> mConnectivityFlag;
     GDBusWpaSupplicant mWpaSupplicant CHIP_GUARDED_BY(mWpaSupplicantMutex);
     // Access to mWpaSupplicant has to be protected by a mutex because it is accessed from
     // the CHIP event loop thread and dedicated D-Bus thread started by platform manager.

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -94,24 +94,12 @@ namespace DeviceLayer {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 struct GDBusWpaSupplicant
 {
-    enum class WpaState
-    {
-        INIT,
-        CONNECTING,
-        CONNECTED,
-        NOT_CONNECTED,
-        NO_INTERFACE_PATH,
-        GOT_INTERFACE_PATH,
-        INTERFACE_CONNECTED,
-    };
-
     enum class WpaScanningState
     {
         IDLE,
         SCANNING,
     };
 
-    WpaState state             = WpaState::INIT;
     WpaScanningState scanState = WpaScanningState::IDLE;
     GAutoPtr<WpaSupplicant1> proxy;
     GAutoPtr<WpaSupplicant1Interface> iface;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -94,13 +94,6 @@ namespace DeviceLayer {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 struct GDBusWpaSupplicant
 {
-    enum class WpaScanningState
-    {
-        IDLE,
-        SCANNING,
-    };
-
-    WpaScanningState scanState = WpaScanningState::IDLE;
     GAutoPtr<WpaSupplicant1> proxy;
     GAutoPtr<WpaSupplicant1Interface> iface;
     GAutoPtr<char> interfacePath;

--- a/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
+++ b/src/platform/Linux/dbus/wpa/DBusWpaInterface.xml
@@ -116,7 +116,6 @@ the wpa_supplicant integration with the Matter SDK.
         </signal>
         <property name="State" type="s" access="read" />
         <property name="Scanning" type="b" access="read" />
-        <property name="CurrentBSS" type="o" access="read" />
         <property name="CurrentNetwork" type="o" access="read" />
         <property name="CurrentAuthMode" type="s" access="read" />
         <property name="BSSs" type="ao" access="read" />


### PR DESCRIPTION
#### Summary

Public notification events for WiFi connectivity change might be used by the application to update connectivity status.

#### Changes

- Emitting `DeviceEventType::kWiFiConnectivityChange` events
- Remove not used BSS proxy object - it was created with wrong path anyway
- Remove not required `mConnectivityFlag`, `GDBusWpaSupplicant::WpaScanningState` and `GDBusWpaSupplicant::WpaState`
- Improve provisioned network detection (network is provisioned if it is available as a Network in WPA supplicant)

#### Testing

Locally verified BLE-wifi commissioning. Also, as a follow-up PR, this functionality was tested with new "connectivity" window added to the examples/common/imgui_ui/windows which can be used with applications compiled with -with-gui.

```
out/linux-x64-light-with-ui/chip-lighting-app --ble-controller 1 --wifi
```

```
chip-tool pairing ble-wifi 1 MATTER-AP MatterPassword 20202021 3840
```