### PR TITLE
Removing unneeded get_test_info call

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
@@ -328,12 +328,6 @@ def run_tests_no_exit(
     CommissionDeviceTest.event_loop = event_loop
     test_class.event_loop = event_loop
 
-    # If the test class is not CommissionDeviceTest, retrieve its information.
-    # CommissionDeviceTest does not implement the methods expected by get_test_info
-    # and this information is not required for its execution.
-    if test_class is not CommissionDeviceTest:
-        get_test_info(test_class, matter_test_config)
-
     # Load test config file.
     test_config = generate_mobly_test_config(matter_test_config)
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
@@ -331,7 +331,7 @@ def run_tests_no_exit(
     # If the test class is not CommissionDeviceTest, retrieve its information.
     # CommissionDeviceTest does not implement the methods expected by get_test_info
     # and this information is not required for its execution.
-    if test_class != CommissionDeviceTest:
+    if test_class is not CommissionDeviceTest:
         get_test_info(test_class, matter_test_config)
 
     # Load test config file.

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/runner.py
@@ -328,7 +328,11 @@ def run_tests_no_exit(
     CommissionDeviceTest.event_loop = event_loop
     test_class.event_loop = event_loop
 
-    get_test_info(test_class, matter_test_config)
+    # If the test class is not CommissionDeviceTest, retrieve its information.
+    # CommissionDeviceTest does not implement the methods expected by get_test_info
+    # and this information is not required for its execution.
+    if test_class != CommissionDeviceTest:
+        get_test_info(test_class, matter_test_config)
 
     # Load test config file.
     test_config = generate_mobly_test_config(matter_test_config)


### PR DESCRIPTION
#### Summary
This PR removes the call `get_test_info(test_class, matter_test_config)` since it doesn't seem to be doing anything in this context.

#### Related issues
https://github.com/project-chip/certification-tool/issues/652

#### Testing

- Running the following command successfully:
python3 /root/python_testing/scripts/sdk/TC_CADMIN_1_11.py --commissioning-method on-network --trace-to json:log  --discriminator 3840 --passcode 20202021

- Running using TH client successfully (Commissioning):
python3 /root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py commission --trace-to json:log --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage_path /root/python_testing/admin_storage2.json

- Running using TH client successfully (Test Execution):
python3 /root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py sdk/TC_ACE_1_3 TC_ACE_1_3 --tests test_TC_ACE_1_3 --trace-to json:log --in-test-commissioning-method on-network --discriminator 3840 --passcode 20202021