### PR TITLE
Address post-review comments from AdministratorCommissioning cluster code migration

### DIFF
--- a/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.cpp
+++ b/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.cpp
@@ -62,7 +62,7 @@ DataModel::ActionReturnStatus AdministratorCommissioningCluster::ReadAttribute(c
     case WindowStatus::Id:
         return encoder.Encode(mLogic.GetWindowStatus());
     case AdminFabricIndex::Id:
-        return encoder.Encode(mLogic.GetOpenerFabricIndex());
+        return encoder.Encode(mLogic.GetAdminFabricIndex());
     case AdminVendorId::Id:
         return encoder.Encode(mLogic.GetAdminVendorId());
     default:

--- a/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningLogic.h
+++ b/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningLogic.h
@@ -31,7 +31,7 @@ public:
         return Server::GetInstance().GetCommissioningWindowManager().CommissioningWindowStatusForCluster();
     }
 
-    const app::DataModel::Nullable<FabricIndex> & GetOpenerFabricIndex()
+    const app::DataModel::Nullable<FabricIndex> & GetAdminFabricIndex()
     {
         return Server::GetInstance().GetCommissioningWindowManager().GetOpenerFabricIndex();
     }

--- a/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
@@ -29,7 +29,7 @@ using chip::Protocols::InteractionModel::Status;
 
 namespace {
 
-// AdministraotrCommissioningCluster implementation is specifically implemented
+// AdministratorCommissioningCluster implementation is specifically implemented
 // only for the root endpoint (endpoint 0)
 // So either:
 //   - we have a fixed config and it is endpoint 0 OR


### PR DESCRIPTION
#### Summary

Address post-merge comments from #39470.  The `.Raw()` usage was already addressed, so fixed the typo and adjusted one naming.

#### Testing

No functional changes in this PR. Compile/existing tests should be sufficient.

