### PR TITLE
[AVSUM] Correct the checking for running in CI

### DIFF
--- a/src/python_testing/TC_AVSUM_2_2.py
+++ b/src/python_testing/TC_AVSUM_2_2.py
@@ -161,7 +161,7 @@ class TC_AVSUM_2_2(MatterBaseTest, AVSUMTestBase):
             if canbemadebusy:
                 self.step(10)
                 # Busy response check
-                if not self.is_ci:
+                if not self.is_pics_sdk_ci_only:
                     self.wait_for_user_input(prompt_msg="Place device into a busy state. Hit ENTER once ready.")
                     await self.send_mptz_set_pan_position_command(endpoint, newPan, expected_status=Status.Busy)
             else:

--- a/src/python_testing/TC_AVSUM_2_3.py
+++ b/src/python_testing/TC_AVSUM_2_3.py
@@ -279,7 +279,7 @@ class TC_AVSUM_2_3(MatterBaseTest, AVSUMTestBase):
         if canbemadebusy:
             self.step(28)
             # Busy response check
-            if not self.is_ci:
+            if not self.is_pics_sdk_ci_only:
                 self.wait_for_user_input(prompt_msg="Place device into a busy state. Hit ENTER once ready.")
                 await self.send_mptz_relative_move_command(endpoint, relativePan, relativeTilt, relativeZoom, expected_status=Status.Busy)
         else:

--- a/src/python_testing/TC_AVSUM_2_4.py
+++ b/src/python_testing/TC_AVSUM_2_4.py
@@ -203,7 +203,7 @@ class TC_AVSUM_2_4(MatterBaseTest, AVSUMTestBase):
             if canbemadebusy:
                 self.step(18)
                 # Busy response check
-                if not self.is_ci:
+                if not self.is_pics_sdk_ci_only:
                     self.wait_for_user_input(prompt_msg="Place device into a busy state. Hit ENTER once ready.")
                     await self.send_move_to_preset_command(endpoint, max_presets_dut, expected_status=Status.Busy)
             else:


### PR DESCRIPTION
#### Summary

AVSUM test scripts were not correctly checking for running in CI.  This was not caught due to a lower layer problem on PIXIT value handling. This PR corrects the checks.


#### Testing

Using the Python runner execute AVSUM_2_2,  AVSUM_2_3, and AVSUM_2_4 providing them with the PIXIT controlling value set to true and false. 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
