### PR TITLE
[camera] Fix failing to start liveview issue

### DIFF
--- a/examples/camera-controller/device-manager/AVStreamManagement.cpp
+++ b/examples/camera-controller/device-manager/AVStreamManagement.cpp
@@ -72,6 +72,9 @@ CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId end
     mVideoStreamAllocate.minKeyFrameInterval = kMinKeyFrameInterval;
     mVideoStreamAllocate.maxKeyFrameInterval = kMaxKeyFrameInterval;
 
+    mVideoStreamAllocate.watermarkEnabled.SetValue(false);
+    mVideoStreamAllocate.OSDEnabled.SetValue(false);
+
     mEndpointId  = endpointId;
     mCommandType = CommandType::kVideoStreamAllocate;
     return mCommissioner->GetConnectedDevice(nodeId, &mOnConnectedCallback, &mOnConnectionFailureCallback);


### PR DESCRIPTION
#### Summary

liveview failed to start due to Invalid command error. 

With the latest server update, 
1. if Watermark feature is supported, then command should have the isWaterMarkEnabled param. 
2. If OSD feature is supported, then command should have the isOSDEnabled param. 

#### Related issues
N/A


#### Testing

Terminal 1: Start the Camera App (Device)

Launch the chip-camera-app binary. The --camera-deferred-offer flag prepares the camera to stream upon request from the controller.
Clean up any existing configurations (first-time pairing only):

```
sudo rm -rf /tmp/chip_*
./out/linux-x64-camera/chip-camera-app --camera-deferred-offer
```
Terminal 2: Launch and Use the Camera Controller (Client)

Launch the Controller Start the interactive controller shell.
`./out/linux-x64-camera-controller/chip-camera-controller`
Commission the Device At the controller's > prompt, use the pairing command to securely commission the Camera App onto the Matter network.
onnetwork: Specifies pairing over the local IP network.

`pairing onnetwork 1 20202021`
Wait for the command to complete and confirm that commissioning was successful.

Start the Live Stream Still in the controller shell, use the Live View command with the nodeID you assigned during pairing to request a video stream.
`liveview start 1`
Wave your hand in front of the camera to trigger live view; a video window will appear, confirming that the stream is active.
