### PR TITLE
Fix how std::to_underlying is pulled into namespace chip. (v1.4-cherrypick)

### DIFF
--- a/src/lib/support/TypeTraits.h
+++ b/src/lib/support/TypeTraits.h
@@ -34,7 +34,7 @@ namespace chip {
 
 #if __cplusplus >= 202300L
 
-using to_underlying = std::to_underlying;
+using std::to_underlying;
 
 #else
 /**


### PR DESCRIPTION
Cherrypick #38723 to v1.4 branch.
