### PR TITLE
[TC-RVCOPSTATE-2.5] Adding Missing app-pipe argument required for CI

### DIFF
--- a/src/python_testing/TC_RVCOPSTATE_2_5.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_5.py
@@ -19,7 +19,7 @@
 # test-runner-runs:
 #   run1:
 #     app: ${ALL_CLUSTERS_APP}
-#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json
+#     app-args: --discriminator 1234 --KVS kvs1 --trace-to json:${TRACE_APP}.json --app-pipe /tmp/rvcopstate_2_5_fifo
 #     script-args: >
 #       --storage-path admin_storage.json
 #       --commissioning-method on-network
@@ -28,6 +28,7 @@
 #       --trace-to json:${TRACE_TEST_JSON}.json
 #       --trace-to perfetto:${TRACE_TEST_PERFETTO}.perfetto
 #       --endpoint 1
+#       --app-pipe /tmp/rvcopstate_2_5_fifo
 #       --PICS examples/rvc-app/rvc-common/pics/rvc-app-pics-values
 #       --int-arg runmode_cleanmode:1
 #     factory-reset: true


### PR DESCRIPTION
#### Summary
- Following this PR https://github.com/project-chip/connectedhomeip/pull/39931
- TC-RVCOPSTATE-2.5 is using `write_to_app_pipe()` but missed adding the required CI-argument `--app-pipe`
- Added that in this PR 

#### Testing

- Will Check CI results (since this fix can only be validated by running in CI and can not (?)  be validated manually)
