### PR TITLE
Add metrics for OTA transfers

### DIFF
--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
@@ -157,6 +157,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
 
 - (void)handleBDXTransferSessionEndForNodeID:(NSNumber * _Nonnull)nodeID
                                   controller:(MTRDeviceController * _Nonnull)controller
+                                     metrics:(MTRMetrics * _Nonnull)metrics
                                        error:(NSError * _Nullable)error
 {
     NSLog(@"BDX TransferSession end with error: %@", error);

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -160,7 +160,7 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningComplete(chip::NodeId nod
     if (strongDelegate && mQueue && strongController) {
 
         // Always collect the metrics to avoid unbounded growth of the stats in the collector
-        MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshot:TRUE];
+        MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshotForCommissioning:YES];
         MTR_LOG("%@ Device commissioning complete with metrics %@", strongController, metrics);
 
         if ([strongDelegate respondsToSelector:@selector(controller:commissioningComplete:nodeID:)] ||

--- a/src/darwin/Framework/CHIP/MTRMetricKeys.h
+++ b/src/darwin/Framework/CHIP/MTRMetricKeys.h
@@ -22,6 +22,17 @@ namespace chip {
 namespace Tracing {
 namespace DarwinFramework {
 
+// When metrics were originally added, they were used for logging events during the commissioning of devices. The data was sent at
+// the end of commissioning (in OnCommissioningComplete). This means that if we want to add metrics that are not related to
+// commissioning, that need to be sent outside of the commissioning of the device, we need a way to separate out metrics by a
+// category. The CHIP metrics infrastructure is fairly simple, with just a key and a numeric value. To add categories without
+// changing existing keys we've opted to use a special prefix with double underscores (dwnfw__CATEGORY__) for the keys that are in a
+// category. Any keys that do not contain this special prefix are now assumed to be used for commissioning events.
+
+// Note that these are not used for commissioning metrics, because those predate the encoding of a category.
+#define METRICS_KEY_PREFIX "dwnfw__"
+#define METRICS_KEY(category, key) METRICS_KEY_PREFIX #category "__" #key
+
 // Tracks overall commissioning via one of the setup APIs
 constexpr Tracing::MetricKey kMetricDeviceCommissioning = "dwnfw_device_commissioning";
 
@@ -93,6 +104,23 @@ constexpr Tracing::MetricKey kMetricUnexpectedCQualityUpdate = "dwnpm_bad_c_attr
 
 // Setup from darwin MTRDevice for initial subscription to a device
 constexpr Tracing::MetricKey kMetricMTRDeviceInitialSubscriptionSetup = "dwnpm_dev_initial_subscription_setup";
+
+constexpr Tracing::MetricKey kMetricOTATransfer = METRICS_KEY(ota, transfer);
+
+// Device Vendor ID
+constexpr Tracing::MetricKey kMetricOTADeviceVendorID = METRICS_KEY(ota, device_vendor_id);
+
+// Device Product ID
+constexpr Tracing::MetricKey kMetricOTADeviceProductID = METRICS_KEY(ota, device_product_id);
+
+// Device Uses Thread
+constexpr Tracing::MetricKey kMetricOTADeviceUsesThread = METRICS_KEY(ota, device_uses_thread_bool);
+
+constexpr Tracing::MetricKey kMetricOTATransferLength = METRICS_KEY(ota, transfer_length);
+
+constexpr Tracing::MetricKey kMetricOTATransferOffset = METRICS_KEY(ota, transfer_offset);
+
+constexpr Tracing::MetricKey kMetricOTATNumBytesProcessed = METRICS_KEY(ota, num_bytes_processed);
 
 } // namespace DarwinFramework
 } // namespace Tracing

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.h
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.h
@@ -44,15 +44,26 @@ void ShutdownMetricsCollection();
 + (instancetype)sharedInstance;
 
 /**
- * @brief This method creates a snapshot of the metrics collected until the current point in time
- * and returns an object with the stats.
+ * @brief This method creates a snapshot of the metrics for commissioning collected until the current
+ *        point in time and returns an object with the stats.
  *
  * @param [in] resetCollection Boolean that specifies whether or not to clear the stats collected after
  *                             creating the snapshot.
  *
  * @return MTRMetric object representing the metric data.
  */
-- (MTRMetrics *)metricSnapshot:(BOOL)resetCollection;
+- (MTRMetrics *)metricSnapshotForCommissioning:(BOOL)resetCollection;
+
+/**
+ * @brief This method creates a snapshot of the metrics for a category (other than for commissioning)
+ *        that were collected until the current point in time and returns an object with those stats.
+ *
+ * @param [in] removeMetrics Boolean that specifies whether to clear the stats for the category after
+ *                           creating the snapshot.
+ *
+ * @return MTRMetric object representing the metric data.
+ */
+- (MTRMetrics *)metricSnapshotForCategory:(NSString *)category removeMetrics:(BOOL)removeMetrics;
 
 /**
  * @brief This method clears any metrics collected.

--- a/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
+++ b/src/darwin/Framework/CHIP/MTROTAImageTransferHandler.h
@@ -78,6 +78,8 @@ private:
     bool mIsPeerNodeAKnownThreadDevice = NO;
 
     chip::System::Clock::Milliseconds32 mBDXThrottleIntervalForThreadDevices;
+
+    size_t mNumBytesProcessed = 0;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -21,6 +21,7 @@
 #import <Matter/MTRDefines.h>
 
 @class MTRDeviceController;
+@class MTRMetrics;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -140,7 +141,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)handleBDXTransferSessionEndForNodeID:(NSNumber *)nodeID
                                   controller:(MTRDeviceController *)controller
-                                       error:(NSError * _Nullable)error;
+                                     metrics:(MTRMetrics *)metrics
+                                       error:(NSError * _Nullable)error
+    MTR_AVAILABLE(ios(26.1), macos(26.1), watchos(26.1), tvos(26.1));
+
+- (void)handleBDXTransferSessionEndForNodeID:(NSNumber *)nodeID
+                                  controller:(MTRDeviceController *)controller
+                                       error:(NSError * _Nullable)error
+    MTR_DEPRECATED_WITH_REPLACEMENT("handleBDXTransferSessionEndForNodeID:controller:metrics:error:", ios(16.1, 26.1),
+        macos(13.0, 26.1), watchos(9.1, 26.1), tvos(16.1, 26.1));
 
 /**
  * Notify the delegate when a BDX Query message has been received for some node.

--- a/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestOTAProvider.m
+++ b/src/darwin/Framework/CHIPTests/TestHelpers/MTRTestOTAProvider.m
@@ -50,6 +50,7 @@
 
 - (void)handleBDXTransferSessionEndForNodeID:(NSNumber * _Nonnull)nodeID
                                   controller:(MTRDeviceController * _Nonnull)controller
+                                     metrics:(MTRMetrics * _Nonnull)metrics
                                        error:(NSError * _Nullable)error
 {
 }


### PR DESCRIPTION
#### Summary

This adds metrics for OTA BDX transfers, recording vendor id, product id, whether the device is on a Thread network, the offset and number of bytes processed and the duration of the transfer.

Because the metrics infrastructure was only used for commissioning before, I tried adding support for encoding categories in the existing key/value system. I also think we don't have good support for recording metrics during simultaneous transfers to different devices. That would require a bit of a redesign of the metrics system.

#### Testing

I added a new test that verifies that metrics are recorded. Unfortunately the OTA tests that do an actual transfer are all disabled in automation, because they used to timeout. I did verify locally that the test passes.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
