### PR TITLE
[Darwin] Track last commissioining stage for metrics

### DIFF
--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -25,6 +25,7 @@
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>
 #include <tracing/registry.h>
+#include <controller/CommissioningDelegate.h>
 
 /*
  * Set this to MTR_LOG_DEBUG(__VA_ARGS__) to enable logging noisy debug logging for metrics events processing
@@ -242,7 +243,14 @@ static inline NSString * suffixNameForMetric(const MetricEvent & event)
 
     // Add to the collection only if it does not exist as yet or pick latest value for instant event
     if (![_metricsDataCollection valueForKey:metricsKey] || event.type() == MetricEvent::Type::kInstantEvent) {
-        [_metricsDataCollection setValue:data forKey:metricsKey];
+        static const size_t kStagingStringLength(strlen(chip::Tracing::kMetricDeviceCommissionerCommissionStage));
+
+        // If this is the commissioning staging event, skip the cleanup to track the last stage completed in case of error
+        // For all other events, just capture the value
+        if (strncmp(event.key(), chip::Tracing::kMetricDeviceCommissionerCommissionStage, kStagingStringLength) != 0 ||
+            event.ValueUInt32() != chip::Controller::CommissioningStage::kCleanup) {
+                [_metricsDataCollection setValue:data forKey:metricsKey];
+        }
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -20,12 +20,12 @@
 #import "MTRMetrics.h"
 #import "MTRMetrics_Internal.h"
 #import <MTRUnfairLock.h>
+#include <controller/CommissioningDelegate.h>
 #import <os/lock.h>
 #include <platform/Darwin/Tracing.h>
 #include <system/SystemClock.h>
 #include <tracing/metric_event.h>
 #include <tracing/registry.h>
-#include <controller/CommissioningDelegate.h>
 
 /*
  * Set this to MTR_LOG_DEBUG(__VA_ARGS__) to enable logging noisy debug logging for metrics events processing
@@ -247,9 +247,8 @@ static inline NSString * suffixNameForMetric(const MetricEvent & event)
 
         // If this is the commissioning staging event, skip the cleanup to track the last stage completed in case of error
         // For all other events, just capture the value
-        if (strncmp(event.key(), chip::Tracing::kMetricDeviceCommissionerCommissionStage, kStagingStringLength) != 0 ||
-            event.ValueUInt32() != chip::Controller::CommissioningStage::kCleanup) {
-                [_metricsDataCollection setValue:data forKey:metricsKey];
+        if (strncmp(event.key(), chip::Tracing::kMetricDeviceCommissionerCommissionStage, kStagingStringLength) != 0 || event.ValueUInt32() != chip::Controller::CommissioningStage::kCleanup) {
+            [_metricsDataCollection setValue:data forKey:metricsKey];
         }
     }
 }

--- a/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
+++ b/src/darwin/Framework/CHIP/MTRMetricsCollector.mm
@@ -243,11 +243,9 @@ static inline NSString * suffixNameForMetric(const MetricEvent & event)
 
     // Add to the collection only if it does not exist as yet or pick latest value for instant event
     if (![_metricsDataCollection valueForKey:metricsKey] || event.type() == MetricEvent::Type::kInstantEvent) {
-        static const size_t kStagingStringLength(strlen(chip::Tracing::kMetricDeviceCommissionerCommissionStage));
-
         // If this is the commissioning staging event, skip the cleanup to track the last stage completed in case of error
         // For all other events, just capture the value
-        if (strncmp(event.key(), chip::Tracing::kMetricDeviceCommissionerCommissionStage, kStagingStringLength) != 0 || event.ValueUInt32() != chip::Controller::CommissioningStage::kCleanup) {
+        if (strcmp(event.key(), chip::Tracing::kMetricDeviceCommissionerCommissionStage) != 0 || event.ValueUInt32() != chip::Controller::CommissioningStage::kCleanup) {
             [_metricsDataCollection setValue:data forKey:metricsKey];
         }
     }


### PR DESCRIPTION


#### Summary

<!--
- Since kCleanup is always called during commissioining it ends up being the last stage tracked. This fix is to ignore this stage and track the last stage committed as part of commissioining.


-->

#### Related issues

<!--
Fixes #40009
-->

#### Testing

<!--
Verified by commissioning a device and logging the MTRMetrics collected 
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
