### PR TITLE
OpenThread: clear srp host and services during DisconnectFromNetwork

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -342,6 +342,11 @@ CHIP_ERROR GenericThreadDriver::DisconnectFromNetwork()
 {
     if (ThreadStackMgrImpl().IsThreadProvisioned())
     {
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+        // ClearAllSrpHostAndServices may cause temporary blocking, with a maximum duration of 2 seconds.
+        // However, only limited data traffic is expected during the network disconnection period.
+        ThreadStackMgrImpl().ClearAllSrpHostAndServices();
+#endif
         Thread::OperationalDataset emptyNetwork = {};
         // Attach to an empty network will disconnect the driver.
         ReturnErrorOnFailure(ThreadStackMgrImpl().AttachToThreadNetwork(emptyNetwork, nullptr));


### PR DESCRIPTION
#### Problem
Ref to [network commissioning cluster](https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/service_device_management/NetworkCommissioningCluster.adoc#78-connectnetwork-command), "Before connecting to the new network, the Node SHALL disconnect the operational network connections managed by any other Network Commissioning cluster instances, where those connections are not represented by an entry in the Networks attribute of the corresponding cluster instance". 

For Thread network, if we don't remove the srp host and services before disconnecting it, the stale srp services will still be discoverable, similar to the description in problem #21101

#### Summary
- Clear all srp host and services before disconnecting the Thread driver

#### Testing
Tested on ESP32C6 platform
1. commissioning device to Thread network
2. use RemoveNetwork to remove Thread network config
3. use AddOrUpdateWiFiNetwork to add Wi-Fi network config
4. use ConnectNetwork to connect Wi-Fi network, check that srp host and services are removed before disconnecting Thread network.
