### PR TITLE
[Closure] Fix TC-CLCTRL-6.1 random fails

### DIFF
--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -428,10 +428,10 @@ class TC_CLCTRL_6_1(MatterBaseTest):
 
             # STEP 5b: TH sends command MoveTo with Position = MoveToFullyOpen
             self.step("5b")
-            
+
             event_sub_handler.reset()
             sub_handler.reset()
-            
+
             try:
                 await self.send_single_cmd(cmd=Clusters.ClosureControl.Commands.MoveTo(
                     position=Clusters.ClosureControl.Enums.TargetPositionEnum.kMoveToFullyOpen,
@@ -467,7 +467,7 @@ class TC_CLCTRL_6_1(MatterBaseTest):
 
             logging.info("Waiting for OverallCurrentState.Position to be FullyClosed and the corresponding MovementCompleted event.")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_position_matcher(Clusters.ClosureControl.Enums.CurrentPositionEnum.kFullyClosed)],
-                                                timeout_sec=timeout)
+                                                          timeout_sec=timeout)
             event_sub_handler.wait_for_event_report(Clusters.ClosureControl.Events.MovementCompleted, timeout_sec=timeout)
 
             # STEP 5f: TH reads from the DUT the MainState attribute

--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -25,7 +25,7 @@
 #       --commissioning-method on-network
 #       --discriminator 1234
 #       --passcode 20202021
-#       --timeout 30
+#       --timeout 60
 #       --endpoint 1
 #       --hex-arg enableKey:000102030405060708090a0b0c0d0e0f
 #       --trace-to json:${TRACE_TEST_JSON}.json

--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -428,8 +428,10 @@ class TC_CLCTRL_6_1(MatterBaseTest):
 
             # STEP 5b: TH sends command MoveTo with Position = MoveToFullyOpen
             self.step("5b")
-
+            
+            event_sub_handler.reset()
             sub_handler.reset()
+            
             try:
                 await self.send_single_cmd(cmd=Clusters.ClosureControl.Commands.MoveTo(
                     position=Clusters.ClosureControl.Enums.TargetPositionEnum.kMoveToFullyOpen,
@@ -439,7 +441,7 @@ class TC_CLCTRL_6_1(MatterBaseTest):
                     e.status, Status.Success, f"Failed to send command MoveTo: {e.status}")
                 pass
 
-            # STEP 5c: Wait until TH receives a subscription report with OverallCurrentState.Position = FullyOpened.
+            # STEP 5c: Wait until TH receives a subscription report with OverallCurrentState.Position = FullyOpened and the MovementCompleted event.
             self.step("5c")
 
             logging.info("Waiting for OverallCurrentState.Position to be FullyOpened and the corresponding MovementCompleted event.")
@@ -460,10 +462,12 @@ class TC_CLCTRL_6_1(MatterBaseTest):
                     e.status, Status.Success, f"Failed to send command MoveTo: {e.status}")
                 pass
 
-            # STEP 5e: Verify that the DUT has emitted the MovementCompleted event.
+            # STEP 5e: Wait until TH receives a subscription report with OverallCurrentState.Position = FullyClosed and the MovementCompleted event.
             self.step("5e")
 
-            # Wait for the MovementCompleted event to be emitted
+            logging.info("Waiting for OverallCurrentState.Position to be FullyClosed and the corresponding MovementCompleted event.")
+            sub_handler.await_all_expected_report_matches(expected_matchers=[current_position_matcher(Clusters.ClosureControl.Enums.CurrentPositionEnum.kFullyClosed)],
+                                                timeout_sec=timeout)
             event_sub_handler.wait_for_event_report(Clusters.ClosureControl.Events.MovementCompleted, timeout_sec=timeout)
 
             # STEP 5f: TH reads from the DUT the MainState attribute

--- a/src/python_testing/TC_CLCTRL_6_1.py
+++ b/src/python_testing/TC_CLCTRL_6_1.py
@@ -442,9 +442,10 @@ class TC_CLCTRL_6_1(MatterBaseTest):
             # STEP 5c: Wait until TH receives a subscription report with OverallCurrentState.Position = FullyOpened.
             self.step("5c")
 
-            logging.info("Waiting for OverallCurrentState.Position to be FullyOpened and OverallCurrentState.SecureState to be False")
+            logging.info("Waiting for OverallCurrentState.Position to be FullyOpened and the corresponding MovementCompleted event.")
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_position_matcher(Clusters.ClosureControl.Enums.CurrentPositionEnum.kFullyOpened)],
                                                           timeout_sec=timeout)
+            event_sub_handler.wait_for_event_report(Clusters.ClosureControl.Events.MovementCompleted, timeout_sec=timeout)
 
             # STEP 5d: TH sends command MoveTo with Position = MoveToFullyClosed
             self.step("5d")

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -170,3 +170,4 @@ slow_tests:
     - { name: TC_TIMESYNC_2_7.py, duration: 20 seconds }
     - { name: TC_TIMESYNC_2_8.py, duration: 1.5 minutes }
     - { name: TC_CLCTRL_3_1.py, duration: 45 seconds }
+    - { name: TC_CLCTRL_6_1.py, duration: 45 seconds }


### PR DESCRIPTION
#### Summary

CI had some runs fail due to TC_CLCTRL_6_1.py. 
Recreating the same build as in CI and running locally resulted in the same flakiness:
- `./scripts/build/build_examples.py --target linux-x64-closure-ipv6only-no-ble-no-wifi-tsan-clang-test build`

Testrun can take longer than the previous 30 second timeout, increased it to 60 seconds.

fixes https://github.com/project-chip/connectedhomeip/issues/40132

#### Testing

- Tested locally
- In CI
