### PR TITLE
Adding Workflow status badge for Tests.yaml on main readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 
 **Tests**
 
+[![Tests](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/tests.yaml)
 [![Unit / Integration Tests](https://github.com/project-chip/connectedhomeip/workflows/Unit%20/%20Integration%20Tests/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/unit_integration_test.yaml)
 [![Cirque](https://github.com/project-chip/connectedhomeip/workflows/Cirque/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/cirque.yaml)
 [![QEMU](https://github.com/project-chip/connectedhomeip/workflows/QEMU/badge.svg)](https://github.com/project-chip/connectedhomeip/actions/workflows/qemu.yaml)


### PR DESCRIPTION
#### Summary

- we have workflow status badges for many jobs, except Tests which often fails
- its useful to check status there rather than navigating in Actions Tab
-
#### Testing

- Nothing to Test really, we can just observe the markdown in rich diff
