### PR TITLE
chip-cert-bins/Dockerfile: Enable NFC-based commissioning by default for chip-tool

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -148,7 +148,7 @@ RUN case ${TARGETPLATFORM} in \
     set -x \
     && source scripts/activate.sh \
     && scripts/build/build_examples.py \
-    --target linux-x64-chip-tool-ipv6only-platform-mdns \
+    --target linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission \
     --target linux-x64-shell-ipv6only-platform-mdns \
     --target linux-x64-chip-cert-ipv6only-platform-mdns \
     --target linux-x64-air-purifier-ipv6only \
@@ -176,7 +176,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-terms-and-conditions-ipv6only \
     --target linux-x64-water-leak-detector-ipv6only \
     build \
-    && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
+    && mv out/linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
     && mv out/linux-x64-chip-cert-ipv6only-platform-mdns/chip-cert out/chip-cert \
     && mv out/linux-x64-air-purifier-ipv6only/chip-air-purifier-app out/chip-air-purifier-app \
@@ -208,7 +208,7 @@ RUN case ${TARGETPLATFORM} in \
     set -x \
     && source scripts/activate.sh \
     && scripts/build/build_examples.py \
-    --target linux-arm64-chip-tool-ipv6only-platform-mdns \
+    --target linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission \
     --target linux-arm64-shell-ipv6only-platform-mdns \
     --target linux-arm64-chip-cert-ipv6only-platform-mdns \
     --target linux-arm64-air-purifier-ipv6only \
@@ -236,7 +236,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-terms-and-conditions-ipv6only \
     --target linux-arm64-water-leak-detector-ipv6only \
     build \
-    && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
+    && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
     && mv out/linux-arm64-chip-cert-ipv6only-platform-mdns/chip-cert out/chip-cert \
     && mv out/linux-arm64-air-purifier-ipv6only/chip-air-purifier-app out/chip-air-purifier-app \


### PR DESCRIPTION
Enable NFC-based commissioning by default for chip-tool app.

#### Testing

CI tests will confirm that compilation is OK. 

On my side, I'm always compiling chip-tool with the following command and it works:
`./scripts/build/build_examples.py --target linux-arm64-chip-tool-ipv6only-clang-nfc-commission build`