### PR TITLE
Make sure that we nil-check after strongifying in MTRDevice_Concrete.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -924,7 +924,7 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
             MTR_LOG_ERROR("%@ _setUTCTime failed on endpoint %@, with parameters %@, error: %@", self, endpoint, params, error);
         }
 #ifdef DEBUG
-        {
+        if (self) {
             std::lock_guard lock(self->_lock);
             [self _callDelegatesWithBlock:^(id testDelegate) {
                 if ([testDelegate respondsToSelector:@selector(unitTestSetUTCTimeInvokedForDevice:error:)]) {
@@ -4077,7 +4077,7 @@ static BOOL AttributeHasChangesOmittedQuality(MTRAttributePath * attributePath)
                             queue:queue
                        completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
                            mtr_strongify(self);
-                           {
+                           if (self) {
                                std::lock_guard lock(self->_lock);
                                self.diagnosticLogTransferInProgress = NO;
                                [self _notifyDelegateOfPrivateInternalPropertiesChanges];


### PR DESCRIPTION
In a few places we were missing nil-checks, which could have led to crashes if the object were in fact gone.

#### Testing

Code inspection only for now.  Triggering these situations is rather difficult.