### PR TITLE
Replace some MTR_NEWLY_AVAILABLE annotations with correct availability.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -111,7 +111,8 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
      * Something was requested that could not be located.
      */
     MTRErrorCodeNotFound MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4)) = 19,
-};
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
+
 #define MTRMaxErrorCode MTRErrorCodeNotFound
 
 /**
@@ -145,7 +146,7 @@ typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode){
     MTRInteractionErrorCodeDataVersionMismatch                                                                = 0x92,
     MTRInteractionErrorCodeTimeout                                                                            = 0x94,
     MTRInteractionErrorCodeBusy                                                                               = 0x9c,
-    MTRInteractionErrorCodeAccessRestricted MTR_NEWLY_AVAILABLE                                               = 0x9d,
+    MTRInteractionErrorCodeAccessRestricted MTR_AVAILABLE(ios(26.0), macos(26.0), watchos(26.0), tvos(26.0))  = 0x9d,
     MTRInteractionErrorCodeUnsupportedCluster                                                                 = 0xc3,
     MTRInteractionErrorCodeNoUpstreamSubscription                                                             = 0xc5,
     MTRInteractionErrorCodeNeedsTimedInteraction                                                              = 0xc6,
@@ -155,8 +156,8 @@ typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode){
     MTRInteractionErrorCodeFailsafeRequired                                                                   = 0xca,
     MTRInteractionErrorCodeInvalidInState MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6))    = 0xcb,
     MTRInteractionErrorCodeNoCommandResponse MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6)) = 0xcc,
-    MTRDynamicConstraintError MTR_NEWLY_AVAILABLE                                                             = 0xcf,
-    MTRInteractionErrorCodeInvalidTransportType MTR_NEWLY_AVAILABLE                                           = 0xd1,
-};
+    MTRDynamicConstraintError MTR_PROVISIONALLY_AVAILABLE                                                     = 0xcf,
+    MTRInteractionErrorCodeInvalidTransportType MTR_PROVISIONALLY_AVAILABLE                                   = 0xd1,
+} MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1));
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -27,7 +27,7 @@ typedef NS_OPTIONS(NSUInteger, MTRDiscoveryCapabilities) {
     MTRDiscoveryCapabilitiesSoftAP = 1 << 0, // Device supports WiFi softAP
     MTRDiscoveryCapabilitiesBLE = 1 << 1, // Device supports BLE
     MTRDiscoveryCapabilitiesOnNetwork = 1 << 2, // Device supports On Network setup
-    MTRDiscoveryCapabilitiesNFC MTR_NEWLY_AVAILABLE = 1 << 4, // Device supports NFC-based commissioning
+    MTRDiscoveryCapabilitiesNFC MTR_PROVISIONALLY_AVAILABLE = 1 << 4, // Device supports NFC-based commissioning
 
     // Note: New values added here need to be included in MTRDiscoveryCapabilitiesAsString()
 


### PR DESCRIPTION
* ARL has been shipped as public API, so the corresponding error code should be exposed in next-release.
* DynamicConstraintError and InvalidTransportType are not finalized in the spec yet, so they should be provisionally available for now.
* NFC-based commissioning is not finalized yet, so provisionally available for now.

Also adds previously missing availability annotations to the two NS_ERROR_ENUM declarations. These just match the availability of the corresponding NSErrorDomain declarations.

#### Testing

Availability annotation changes only affect compile-time behavior.