### PR TITLE
Switch cloudbuild to use docker image 140 for nrf builds

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -38,7 +38,8 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:150"
+    - name: "ghcr.io/project-chip/chip-build-vscode:140"
+      # TODO: use more recent image once NRF builds are fixed
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -44,7 +44,8 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:150"
+    - name: "ghcr.io/project-chip/chip-build-vscode:140"
+      # TODO: use more recent image once NRF builds are fixed
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Summary

NR images are being held back to 140. Do the same for cloudbuild to ensure compilation works

#### Testing

Cloudbuild will validate compilation. Compile is red currently, so this should not make things worse.