### PR TITLE
[Linux] Fix BLE connection removal race between BLE layer and device layer

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -234,7 +234,6 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEvent)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    ChipLogDetail(DeviceLayer, "HandlePlatformSpecificBLEEvent %d", apEvent->Type);
     switch (apEvent->Type)
     {
     case DeviceEventType::kPlatformLinuxBLEAdapterAdded:

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -469,7 +469,7 @@ void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
     System::PacketBufferHandle buf(System::PacketBufferHandle::NewWithData(value, len));
     VerifyOrReturn(!buf.IsNull(), ChipLogError(DeviceLayer, "Failed to allocate packet buffer in %s", __func__));
 
-    ChipLogDetail(DeviceLayer, "Indication received, conn = %p", conId);
+    ChipLogDetail(DeviceLayer, "Indication received: conn=%p", conId);
 
     ChipDeviceEvent event{ .Type     = DeviceEventType::kPlatformLinuxBLEIndicationReceived,
                            .Platform = {
@@ -483,7 +483,7 @@ void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_
     System::PacketBufferHandle buf(System::PacketBufferHandle::NewWithData(value, len));
     VerifyOrReturn(!buf.IsNull(), ChipLogError(DeviceLayer, "Failed to allocate packet buffer in %s", __func__));
 
-    ChipLogProgress(Ble, "Write request received, conn = %p", conId);
+    ChipLogProgress(Ble, "Write request received: conn=%p", conId);
 
     // Post an event to the Chip queue to deliver the data into the Chip stack.
     ChipDeviceEvent event{ .Type                  = DeviceEventType::kCHIPoBLEWriteReceived,

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -77,7 +77,8 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn),
+    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -77,8 +77,7 @@ BluezConnection::IOChannel::~IOChannel()
 
 BluezConnection::ConnectionDataBundle::ConnectionDataBundle(const BluezConnection & aConn,
                                                             const chip::System::PacketBufferHandle & aBuf) :
-    mConn(aConn),
-    mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
+    mConn(aConn), mData(g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, aBuf->Start(), aBuf->DataLength(), sizeof(uint8_t)))
 {}
 
 CHIP_ERROR BluezConnection::Init(const BluezEndpoint & aEndpoint)

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -102,7 +102,6 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1
     char * errStr;
 #endif // CHIP_ERROR_LOGGING
     BluezConnection * conn = nullptr;
-    GAutoPtr<GVariant> option_mtu;
     uint16_t mtu;
 
     conn = GetBluezConnectionViaDevice();
@@ -155,7 +154,6 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
 #endif // CHIP_ERROR_LOGGING
     BluezConnection * conn       = nullptr;
     bool isAdditionalAdvertising = false;
-    GAutoPtr<GVariant> option_mtu;
     uint16_t mtu;
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -311,7 +311,7 @@ void BluezEndpoint::UpdateConnectionTable(BluezDevice1 & aDevice)
         // immediately, because the BLE layer might still use it. Instead, we will also
         // schedule the deletion of the connection object, so it will happen after the
         // BLE layer has processed the disconnection event.
-        DeviceLayer::SystemLayer().ScheduleLambda([this, conn] {
+        DeviceLayer::SystemLayer().ScheduleLambda([conn] {
             ChipLogDetail(DeviceLayer, "Freeing BLE connection: conn=%p", conn);
             chip::Platform::Delete(conn);
         });

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -305,15 +305,20 @@ void BluezEndpoint::UpdateConnectionTable(BluezDevice1 & aDevice)
     if (conn != nullptr && !bluez_device1_get_connected(&aDevice))
     {
         ChipLogDetail(DeviceLayer, "BLE connection closed: conn=%p", conn);
+        // Notify the BLE layer that the connection was closed.
         BLEManagerImpl::HandleConnectionClosed(conn);
         mConnMap.erase(objectPath);
-        // TODO: the connection object should be released after BLEManagerImpl finishes cleaning up its resources
-        // after the disconnection. Releasing it here doesn't cause any issues, but it's error-prone.
-        chip::Platform::Delete(conn);
-        return;
+        // The BLE layer notification above is done asynchronously (it will be processed
+        // in the next event loop iteration). So, we can not delete the connection object
+        // immediately, because the BLE layer might still use it. Instead, we will also
+        // schedule the deletion of the connection object, so it will happen after the
+        // BLE layer has processed the disconnection event.
+        DeviceLayer::SystemLayer().ScheduleLambda([this, conn] {
+            ChipLogDetail(DeviceLayer, "Freeing BLE connection: conn=%p", conn);
+            chip::Platform::Delete(conn);
+        });
     }
-
-    if (conn == nullptr)
+    else if (conn == nullptr)
     {
         HandleNewDevice(aDevice);
     }


### PR DESCRIPTION
#### Summary

When device layer receives a signal that BLE has been disconnected it notifies the BLE layer about it and removes the connection object. However, the BLE layer notification is done in async manner, so it might happen that device layer frees the BLE connection object while it is still used by the BLE layer. This can lead to a scenario where BLE layer passes invalid (freed) connection object back to the device layer which results in segmentation fault. To mitigate that we need to make sure that BLE layer cleanup and device layer cleanup are synchronized properly.

#### Changes

- Sync BLE layer and device layer by processing both cleanups on matter event loop
- Remove misleading log message form HandlePlatformSpecificBLEEvent (it receives not only BLE-specific events)

#### Related issues

Fixes https://github.com/project-chip/connectedhomeip/issues/38746

#### Testing

Tested locally to verify that when BLE connection is dropped in the middle of the commissioning process, the `chip::Platform::Delete(conn)` will always happen after the BLE layer clears BLE connection handle `mConnObj = BLE_CONNECTION_UNINITIALIZED`.