### PR TITLE
update NRF for cloudbuild: version 150 works now (and old version does not)

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -38,8 +38,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "ghcr.io/project-chip/chip-build-vscode:140"
-      # TODO: use more recent image once NRF builds are fixed
+    - name: "ghcr.io/project-chip/chip-build-vscode:150"
       # ICD device is currently not supported for ESP32 and NRF targets. New rule to compile only ICD
       # linux binary.
       env:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -44,8 +44,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-    - name: "ghcr.io/project-chip/chip-build-vscode:140"
-      # TODO: use more recent image once NRF builds are fixed
+    - name: "ghcr.io/project-chip/chip-build-vscode:150"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Summary

#39654 updated nrf images but not cloudbuild. This matches up cloudbuild,

#### Testing

Trivial change, cloudbuild will validate.