### PR TITLE
[Camera] Re-enable WebRTC Requester tests

### DIFF
--- a/examples/camera-controller/commands/webrtc/Commands.h
+++ b/examples/camera-controller/commands/webrtc/Commands.h
@@ -29,6 +29,7 @@ void registerCommandsWebRTC(Commands & commands, CredentialIssuerCommands * cred
         make_unique<webrtc::ConnectCommand>(credsIssuerConfig),
         make_unique<webrtc::ProvideOfferCommand>(credsIssuerConfig),
         make_unique<webrtc::SolicitOfferCommand>(credsIssuerConfig),
+        make_unique<webrtc::EstablishSessionCommand>(credsIssuerConfig),
     };
 
     commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for WebRTC.");

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
@@ -19,6 +19,7 @@
 #include "WebRTCProviderCommands.h"
 #include <commands/common/RemoteDataModelLogger.h>
 #include <commands/interactive/InteractiveCommands.h>
+#include <device-manager/DeviceManager.h>
 #include <thread>
 #include <unistd.h>
 #include <webrtc-manager/WebRTCManager.h>
@@ -51,10 +52,29 @@ CHIP_ERROR ProvideOfferCommand::RunCommand()
     // Convert the stream usage into its enum type:
     auto streamUsage = static_cast<StreamUsageEnum>(mStreamUsage);
 
-    return WebRTCManager::Instance().ProvideOffer(webrtcSessionId, streamUsage,
-                                                  NullOptional, // "Empty" for video
-                                                  NullOptional  // "Empty" for audio
-    );
+    chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamIdOptional;
+    if (mVideoStreamId.HasValue())
+    {
+        auto videoStreamIdNullable = app::DataModel::MakeNullable(mVideoStreamId.Value());
+        videoStreamIdOptional      = MakeOptional(videoStreamIdNullable);
+    }
+    else
+    {
+        videoStreamIdOptional = NullOptional;
+    }
+
+    chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamIdOptional;
+    if (mAudioStreamId.HasValue())
+    {
+        auto audioStreamIdNullable = app::DataModel::MakeNullable(mAudioStreamId.Value());
+        audioStreamIdOptional      = MakeOptional(audioStreamIdNullable);
+    }
+    else
+    {
+        audioStreamIdOptional = NullOptional;
+    }
+
+    return WebRTCManager::Instance().ProvideOffer(webrtcSessionId, streamUsage, videoStreamIdOptional, audioStreamIdOptional);
 }
 
 CHIP_ERROR SolicitOfferCommand::RunCommand()
@@ -64,7 +84,51 @@ CHIP_ERROR SolicitOfferCommand::RunCommand()
     // Convert the stream usage into its enum type:
     auto streamUsage = static_cast<StreamUsageEnum>(mStreamUsage);
 
-    return WebRTCManager::Instance().SolicitOffer(streamUsage);
+    chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamIdOptional;
+    if (mVideoStreamId.HasValue())
+    {
+        auto videoStreamIdNullable = app::DataModel::MakeNullable(mVideoStreamId.Value());
+        videoStreamIdOptional      = MakeOptional(videoStreamIdNullable);
+    }
+    else
+    {
+        videoStreamIdOptional = NullOptional;
+    }
+
+    chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamIdOptional;
+    if (mAudioStreamId.HasValue())
+    {
+        auto audioStreamIdNullable = app::DataModel::MakeNullable(mAudioStreamId.Value());
+        audioStreamIdOptional      = MakeOptional(audioStreamIdNullable);
+    }
+    else
+    {
+        audioStreamIdOptional = NullOptional;
+    }
+
+    return WebRTCManager::Instance().SolicitOffer(streamUsage, videoStreamIdOptional, audioStreamIdOptional);
+}
+
+CHIP_ERROR EstablishSessionCommand::RunCommand()
+{
+    ChipLogProgress(Camera, "Run EstablishSessionCommand");
+
+    if (mPeerNodeId == chip::kUndefinedNodeId)
+    {
+        ChipLogError(Camera, "Missing --node-id");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    uint8_t streamUsage = static_cast<uint8_t>(StreamUsageEnum::kRecording);
+
+    // Use provided offer type or default to ProvideOffer
+    camera::WebRTCOfferType offerType = camera::WebRTCOfferType::kProvideOffer;
+    if (mOfferType.HasValue())
+    {
+        offerType = mOfferType.Value() == 0 ? camera::WebRTCOfferType::kProvideOffer : camera::WebRTCOfferType::kSolicitOffer;
+    }
+
+    return camera::DeviceManager::Instance().AllocateVideoStream(mPeerNodeId, streamUsage, offerType);
 }
 
 } // namespace webrtc

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.cpp
@@ -125,7 +125,7 @@ CHIP_ERROR EstablishSessionCommand::RunCommand()
     camera::WebRTCOfferType offerType = camera::WebRTCOfferType::kProvideOffer;
     if (mOfferType.HasValue())
     {
-        offerType = mOfferType.Value() == 0 ? camera::WebRTCOfferType::kProvideOffer : camera::WebRTCOfferType::kSolicitOffer;
+        offerType = static_cast<camera::WebRTCOfferType>(mOfferType.Value());
     }
 
     return camera::DeviceManager::Instance().AllocateVideoStream(mPeerNodeId, streamUsage, offerType);

--- a/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.h
+++ b/examples/camera-controller/commands/webrtc/WebRTCProviderCommands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <commands/common/CHIPCommand.h>
+#include <device-manager/DeviceManager.h>
 
 namespace webrtc {
 
@@ -46,8 +47,10 @@ class ProvideOfferCommand : public CHIPCommand
 public:
     ProvideOfferCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("provide-offer", credIssuerCommands)
     {
-        AddArgument("webrtc-session-id", 0, UINT16_MAX, &mWebRTCSessionId);
         AddArgument("stream-usage", 0, UINT8_MAX, &mStreamUsage);
+        AddArgument("webrtc-session-id", 0, UINT16_MAX, &mWebRTCSessionId);
+        AddArgument("video-stream-id", 0, UINT16_MAX, &mVideoStreamId);
+        AddArgument("audio-stream-id", 0, UINT16_MAX, &mAudioStreamId);
     }
 
     /////////// CHIPCommand Interface /////////
@@ -57,7 +60,9 @@ public:
 
 private:
     uint8_t mStreamUsage = 0;
-    chip::Optional<uint8_t> mWebRTCSessionId;
+    chip::Optional<uint16_t> mWebRTCSessionId;
+    chip::Optional<uint16_t> mVideoStreamId;
+    chip::Optional<uint16_t> mAudioStreamId;
 };
 
 class SolicitOfferCommand : public CHIPCommand
@@ -66,6 +71,8 @@ public:
     SolicitOfferCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("solicit-offer", credIssuerCommands)
     {
         AddArgument("stream-usage", 0, UINT8_MAX, &mStreamUsage);
+        AddArgument("video-stream-id", 0, UINT16_MAX, &mVideoStreamId);
+        AddArgument("audio-stream-id", 0, UINT16_MAX, &mAudioStreamId);
     }
 
     /////////// CHIPCommand Interface /////////
@@ -75,6 +82,27 @@ public:
 
 private:
     uint8_t mStreamUsage = 0;
+    chip::Optional<uint16_t> mVideoStreamId;
+    chip::Optional<uint16_t> mAudioStreamId;
+};
+
+class EstablishSessionCommand : public CHIPCommand
+{
+public:
+    EstablishSessionCommand(CredentialIssuerCommands * credIssuerCommands) : CHIPCommand("establish-session", credIssuerCommands)
+    {
+        AddArgument("node-id", 0, UINT64_MAX, &mPeerNodeId);
+        AddArgument("offer-type", 0, 1, &mOfferType, "WebRTC offer type: 0=ProvideOffer (default), 1=SolicitOffer");
+    }
+
+    /////////// CHIPCommand Interface /////////
+    CHIP_ERROR RunCommand() override;
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(5); }
+
+private:
+    chip::NodeId mPeerNodeId = chip::kUndefinedNodeId;
+    chip::Optional<uint8_t> mOfferType;
 };
 
 } // namespace webrtc

--- a/examples/camera-controller/device-manager/DeviceManager.cpp
+++ b/examples/camera-controller/device-manager/DeviceManager.cpp
@@ -85,7 +85,7 @@ void DeviceManager::Shutdown()
     WebRTCManager::Instance().Disconnect();
 }
 
-CHIP_ERROR DeviceManager::AllocateVideoStream(NodeId nodeId, uint8_t streamUsage)
+CHIP_ERROR DeviceManager::AllocateVideoStream(NodeId nodeId, uint8_t streamUsage, WebRTCOfferType offerType)
 {
     ChipLogProgress(Camera, "Allocate a video stream on the camera device.");
 
@@ -102,6 +102,7 @@ CHIP_ERROR DeviceManager::AllocateVideoStream(NodeId nodeId, uint8_t streamUsage
     {
         mNodeId      = nodeId;
         mStreamUsage = streamUsage;
+        mOfferType   = offerType;
     }
 
     return error;
@@ -170,8 +171,11 @@ void DeviceManager::HandleVideoStreamAllocateResponse(TLV::TLVReader & data)
     ChipLogProgress(Camera, "DecodableType fields:");
     ChipLogProgress(Camera, "  videoStreamId: %u", value.videoStreamID);
 
-    // Store the stream ID we're setting up
-    mPendingVideoStreamId = value.videoStreamID;
+    // Store the stream ID we're setting up only for LiveView streams
+    if (mStreamUsage == static_cast<uint8_t>(StreamUsageEnum::kLiveView))
+    {
+        mPendingVideoStreamId = value.videoStreamID;
+    }
 
     InitiateWebRTCSession(value.videoStreamID);
 }
@@ -192,15 +196,26 @@ void DeviceManager::InitiateWebRTCSession(uint16_t videoStreamId)
     auto videoStreamIdOptional = MakeOptional(videoStreamIdNullable);
     auto streamUsage           = static_cast<StreamUsageEnum>(mStreamUsage);
 
-    // Provide the offer to establish the WebRTC session
-    err = WebRTCManager::Instance().ProvideOffer(app::DataModel::NullNullable, // session ID (null)
-                                                 streamUsage,                  // stream‑usage field
-                                                 videoStreamIdOptional,        // videoStreamId you just built
-                                                 NullOptional);                // audioStreamID (empty)
+    // Choose between ProvideOffer and SolicitOffer based on the configured offer type
+    if (mOfferType == WebRTCOfferType::kProvideOffer)
+    {
+        ChipLogProgress(Camera, "Using ProvideOffer for WebRTC session establishment");
+        err = WebRTCManager::Instance().ProvideOffer(app::DataModel::NullNullable, // session ID (null)
+                                                     streamUsage,                  // stream‑usage field
+                                                     videoStreamIdOptional,        // videoStreamId you just built
+                                                     NullOptional);                // audioStreamID (empty)
+    }
+    else // WebRTCOfferType::kSolicitOffer
+    {
+        ChipLogProgress(Camera, "Using SolicitOffer for WebRTC session establishment");
+        err = WebRTCManager::Instance().SolicitOffer(streamUsage,           // stream‑usage field
+                                                     videoStreamIdOptional, // videoStreamId you just built
+                                                     NullOptional);         // audioStreamID (empty)
+    }
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Camera, "Failed to provide an offer. Error: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Camera, "Failed to initiate WebRTC offer. Error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -208,11 +223,15 @@ void DeviceManager::OnWebRTCSessionEstablished(uint16_t streamId)
 {
     ChipLogProgress(Camera, "WebRTC session established for stream ID: %u", streamId);
 
-    // Verify this matches our pending stream
-    if (streamId == mPendingVideoStreamId)
+    // Only start video stream process for LiveView streams
+    if (mStreamUsage == static_cast<uint8_t>(StreamUsageEnum::kLiveView))
     {
-        StartVideoStreamProcess(streamId);
-        mPendingVideoStreamId = 0;
+        // Verify this matches our pending stream
+        if (streamId == mPendingVideoStreamId)
+        {
+            StartVideoStreamProcess(streamId);
+            mPendingVideoStreamId = 0;
+        }
     }
 }
 

--- a/examples/camera-controller/device-manager/DeviceManager.h
+++ b/examples/camera-controller/device-manager/DeviceManager.h
@@ -24,6 +24,12 @@
 
 namespace camera {
 
+enum class WebRTCOfferType : uint8_t
+{
+    kProvideOffer = 0,
+    kSolicitOffer = 1
+};
+
 class DeviceManager
 {
 public:
@@ -46,9 +52,11 @@ public:
      *
      * @param nodeId      The node ID of the remote camera device.
      * @param streamUsage The usage of the stream(Recording, LiveView, etc) that this allocation is for.
+     * @param offerType   The type of WebRTC offer to use (ProvideOffer or SolicitOffer).
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or an appropriate error code on failure.
      */
-    CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, uint8_t streamUsage);
+    CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, uint8_t streamUsage,
+                                   WebRTCOfferType offerType = WebRTCOfferType::kProvideOffer);
 
     /**
      * @brief Sends a VideoStreamDeallocate command to the device.
@@ -78,6 +86,7 @@ private:
     chip::Controller::DeviceCommissioner * mCommissioner = nullptr;
     chip::NodeId mNodeId                                 = chip::kUndefinedNodeId;
     uint8_t mStreamUsage                                 = 0;
+    WebRTCOfferType mOfferType                           = WebRTCOfferType::kProvideOffer;
     std::map<uint16_t, pid_t> mVideoStreamProcesses; // Stream ID -> Process ID mapping
     uint16_t mPendingVideoStreamId = 0;              // Track the stream ID we're setting up
 

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.cpp
@@ -343,6 +343,13 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId, 
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+    // At least one of Video Stream ID and Audio Stream ID has to be present
+    if (!videoStreamId.HasValue() && !audioStreamId.HasValue())
+    {
+        ChipLogError(Zcl, "One of VideoStreamID or AudioStreamID must be present");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     // Store the stream ID for the callback
     if (videoStreamId.HasValue() && !videoStreamId.Value().IsNull())
     {
@@ -361,14 +368,20 @@ CHIP_ERROR WebRTCManager::ProvideOffer(DataModel::Nullable<uint16_t> sessionId, 
     return err;
 }
 
-CHIP_ERROR WebRTCManager::SolicitOffer(StreamUsageEnum streamUsage)
+CHIP_ERROR WebRTCManager::SolicitOffer(StreamUsageEnum streamUsage, Optional<app::DataModel::Nullable<uint16_t>> videoStreamId,
+                                       Optional<app::DataModel::Nullable<uint16_t>> audioStreamId)
 {
     ChipLogProgress(Camera, "Sending SolicitOffer command to the peer device");
 
-    CHIP_ERROR err = mWebRTCProviderClient.SolicitOffer(streamUsage, kWebRTCRequesterDynamicEndpointId,
-                                                        MakeOptional(DataModel::NullNullable), // "Null" for video
-                                                        MakeOptional(DataModel::NullNullable)  // "Null" for audio
-    );
+    // At least one of Video Stream ID and Audio Stream ID has to be present
+    if (!videoStreamId.HasValue() && !audioStreamId.HasValue())
+    {
+        ChipLogError(Zcl, "One of VideoStreamID or AudioStreamID must be present");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    CHIP_ERROR err =
+        mWebRTCProviderClient.SolicitOffer(streamUsage, kWebRTCRequesterDynamicEndpointId, videoStreamId, audioStreamId);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/camera-controller/webrtc-manager/WebRTCManager.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCManager.h
@@ -59,8 +59,8 @@ public:
                             chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
                             chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId);
 
-    CHIP_ERROR SolicitOffer(StreamUsageEnum streamUsage);
-
+    CHIP_ERROR SolicitOffer(StreamUsageEnum streamUsage, chip::Optional<chip::app::DataModel::Nullable<uint16_t>> videoStreamId,
+                            chip::Optional<chip::app::DataModel::Nullable<uint16_t>> audioStreamId);
     CHIP_ERROR ProvideAnswer(uint16_t sessionId, const std::string & sdp);
 
     CHIP_ERROR ProvideICECandidates(uint16_t sessionId);

--- a/src/python_testing/TC_WEBRTCR_2_1.py
+++ b/src/python_testing/TC_WEBRTCR_2_1.py
@@ -97,9 +97,8 @@ class TC_WebRTCRequestor_2_1(MatterBaseTest):
             TestStep(1, "Commission the {TH_Server} from TH"),
             TestStep(2, "Open the Commissioning Window of the {TH_Server}"),
             TestStep(3, "Commission the {TH_Server} from DUT"),
-            TestStep(4, "Connect the {TH_Server} from DUT"),
-            TestStep(5, "Activate the fault injection to modify the session ID of the WebRTC Offer command from {TH_Server}"),
-            TestStep(6, "Send SolicitOffer command to the {TH_Server} from DUT"),
+            TestStep(4, "Activate the fault injection to modify the session ID of the WebRTC Offer command from {TH_Server}"),
+            TestStep(5, "Send SolicitOffer command to the {TH_Server} from DUT"),
         ]
         return steps
 
@@ -156,19 +155,6 @@ class TC_WebRTCRequestor_2_1(MatterBaseTest):
         )
 
         self.step(4)
-        # Prompt user with instructions
-        prompt_msg = (
-            "\nPlease connect the server app from DUT:\n"
-            "  webrtc connect 1 1\n"
-        )
-
-        if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            pass
-        else:
-            self.wait_for_user_input(prompt_msg)
-
-        self.step(5)
         logging.info("Injecting kFault_ModifyWebRTCAnswerSessionId on TH_SERVER")
 
         # --- Fault‑Injection cluster (mfg‑specific 0xFFF1_FC06) ---
@@ -193,11 +179,11 @@ class TC_WebRTCRequestor_2_1(MatterBaseTest):
         )
         sleep(1)
 
-        self.step(6)
+        self.step(5)
         # Prompt user with instructions
         prompt_msg = (
             "\nSend 'SolicitOffer' command to the server app from DUT:\n"
-            "  webrtc solicit-offer 3\n"
+            "  webrtc establish-session 1 --offer-type 1\n"
             "Input 'Y' if WebRTC session is failed with error 'NOT_FOUND'\n"
             "Input 'N' if WebRTC session is successfully established\n"
         )

--- a/src/python_testing/TC_WEBRTCR_2_2.py
+++ b/src/python_testing/TC_WEBRTCR_2_2.py
@@ -97,9 +97,8 @@ class TC_WebRTCRequestor_2_2(MatterBaseTest):
             TestStep(1, "Commission the {TH_Server} from TH"),
             TestStep(2, "Open the Commissioning Window of the {TH_Server}"),
             TestStep(3, "Commission the {TH_Server} from DUT"),
-            TestStep(4, "Connect the {TH_Server} from DUT"),
-            TestStep(5, "Activate the Fault injection to modify the session ID of the WebRTC Answer command from {TH_Server}"),
-            TestStep(6, "Send ProvideOffer command to the {TH_Server} from DUT"),
+            TestStep(4, "Activate the Fault injection to modify the session ID of the WebRTC Answer command from {TH_Server}"),
+            TestStep(5, "Send ProvideOffer command to the {TH_Server} from DUT"),
         ]
         return steps
 
@@ -156,19 +155,6 @@ class TC_WebRTCRequestor_2_2(MatterBaseTest):
         )
 
         self.step(4)
-        # Prompt user with instructions
-        prompt_msg = (
-            "\nPlease connect the server app from DUT:\n"
-            "  webrtc connect 1 1\n"
-        )
-
-        if self.is_pics_sdk_ci_only:
-            # TODO: send command to DUT via websocket
-            pass
-        else:
-            self.wait_for_user_input(prompt_msg)
-
-        self.step(5)
         logging.info("Injecting kFault_ModifyWebRTCAnswerSessionId on TH_SERVER")
 
         # --- Fault‑Injection cluster (mfg‑specific 0xFFF1_FC06) ---
@@ -193,11 +179,11 @@ class TC_WebRTCRequestor_2_2(MatterBaseTest):
         )
         sleep(1)
 
-        self.step(6)
+        self.step(5)
         # Prompt user with instructions
         prompt_msg = (
             "\nSend 'ProvideOffer' command to the server app from DUT:\n"
-            "  webrtc provide-offer 3\n"
+            "  webrtc establish-session 1\n"
             "Input 'Y' if WebRTC session is failed with error 'NOT_FOUND'\n"
             "Input 'N' if WebRTC session is successfully established\n"
         )

--- a/src/python_testing/TC_WEBRTCR_2_3.py
+++ b/src/python_testing/TC_WEBRTCR_2_3.py
@@ -98,8 +98,7 @@ class TC_WebRTCRequestor_2_3(MatterBaseTest):
         """
         steps = [
             TestStep(1, "Commission the {TH_Server} from DUT"),
-            TestStep(2, "Connect the {TH_Server} from DUT"),
-            TestStep(3, "Send SolicitOffer command to the {TH_Server}"),
+            TestStep(2, "Send SolicitOffer command to the {TH_Server}"),
         ]
         return steps
 
@@ -157,21 +156,8 @@ class TC_WebRTCRequestor_2_3(MatterBaseTest):
         await asyncio.sleep(1)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease connect the server app from DUT:\n"
-            "  webrtc connect 1 1\n"
-        )
-
-        if self.is_pics_sdk_ci_only:
-            await self.send_command("webrtc connect 1 1")
-        else:
-            self.wait_for_user_input(prompt_msg)
-
-        self.step(3)
-        await asyncio.sleep(1)
-        # Prompt user with instructions
-        prompt_msg = (
             "\nSend 'SolicitOffer' command to the server app from DUT:\n"
-            "  webrtc solicit-offer 3\n"
+            "  webrtc establish-session 1 --offer-type 1\n"
             "Input 'Y' if WebRTC session is successfully established\n"
             "Input 'N' if WebRTC session is not established\n"
         )
@@ -181,7 +167,7 @@ class TC_WebRTCRequestor_2_3(MatterBaseTest):
             self.th_server.event.clear()
 
             try:
-                await self.send_command("webrtc solicit-offer 3")
+                await self.send_command("webrtc establish-session 1 --offer-type 1")
                 # Wait up to 90s until the provider logs that the data‑channel opened
                 if not self.th_server.event.wait(90):
                     raise TimeoutError("PeerConnection is not connected within 90s")

--- a/src/python_testing/TC_WEBRTCR_2_4.py
+++ b/src/python_testing/TC_WEBRTCR_2_4.py
@@ -98,8 +98,7 @@ class TC_WebRTCRequestor_2_4(MatterBaseTest):
         """
         steps = [
             TestStep(1, "Commission the {TH_Server} from DUT"),
-            TestStep(2, "Connect the {TH_Server} from DUT"),
-            TestStep(3, "Send ProvideOffer command to the {TH_Server}"),
+            TestStep(2, "Send ProvideOffer command to the {TH_Server}"),
         ]
         return steps
 
@@ -156,21 +155,8 @@ class TC_WebRTCRequestor_2_4(MatterBaseTest):
         await asyncio.sleep(1)
         # Prompt user with instructions
         prompt_msg = (
-            "\nPlease connect the server app from DUT:\n"
-            "  webrtc connect 1 1\n"
-        )
-
-        if self.is_pics_sdk_ci_only:
-            await self.send_command("webrtc connect 1 1")
-        else:
-            self.wait_for_user_input(prompt_msg)
-
-        self.step(3)
-        await asyncio.sleep(1)
-        # Prompt user with instructions
-        prompt_msg = (
             "\nSend 'ProvideOffer' command to the server app from DUT:\n"
-            "  webrtc provide-offer 3\n"
+            "  webrtc establish-session 1\n"
             "Input 'Y' if WebRTC session is successfully established\n"
             "Input 'N' if WebRTC session is not established\n"
         )
@@ -180,7 +166,7 @@ class TC_WebRTCRequestor_2_4(MatterBaseTest):
             self.th_server.event.clear()
 
             try:
-                await self.send_command("webrtc provide-offer 3")
+                await self.send_command("webrtc establish-session 1")
                 # Wait up to 90s until the provider logs that the data‑channel opened
                 if not self.th_server.event.wait(90):
                     raise TimeoutError("PeerConnection is not connected within 90s")

--- a/src/python_testing/test_metadata.yaml
+++ b/src/python_testing/test_metadata.yaml
@@ -119,10 +119,6 @@ not_automated:
     - name: TC_WEBRTCPTestBase.py
       reason:
           Shared code for the WebRTC Provider Cluster, not a standalone test.
-    - name: TC_WEBRTCR_2_3.py
-      reason: Camera Controller App does not support stream allocation requests
-    - name: TC_WEBRTCR_2_4.py
-      reason: Camera Controller App does not support stream allocation requests
     - name: TC_PAVST_2_1.py
       reason:
           Depends on PushAV cluster. Will be enabled once local tests are fully


### PR DESCRIPTION
#### Summary

WebRTC Requester tests has been temperately disabled due to the camera-controller could not allocate video stream before establishing WebRTC session.

1. Allocate video stream before trigger WebRTC session establishment process
2. Re-enable WebRTC Requester tests

#### Related issues

Fixes: #39840 

#### Testing

Update the WebRTCR python tests and validate the change by CI
