### PR TITLE
[EVSE] HwSetVehicleID could mark already null vehicleID as dirty unneccesarily

### DIFF
--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -730,8 +730,9 @@ Status EnergyEvseDelegate::HwSetRFID(ByteSpan uid)
 Status EnergyEvseDelegate::HwSetVehicleID(const CharSpan & newValue)
 {
 
-    if (!mVehicleID.IsNull() && newValue.data_equal(mVehicleID.Value()))
+    if (!mVehicleID.IsNull() && newValue.data_equal(mVehicleID.Value()) || (mVehicleID.IsNull() && newValue.empty()))
     {
+        // No change in VehicleID, nothing to do
         return Status::Success;
     }
 

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -730,7 +730,7 @@ Status EnergyEvseDelegate::HwSetRFID(ByteSpan uid)
 Status EnergyEvseDelegate::HwSetVehicleID(const CharSpan & newValue)
 {
 
-    if (!mVehicleID.IsNull() && newValue.data_equal(mVehicleID.Value()) || (mVehicleID.IsNull() && newValue.empty()))
+    if ((!mVehicleID.IsNull() && newValue.data_equal(mVehicleID.Value())) || (mVehicleID.IsNull() && newValue.empty()))
     {
         // No change in VehicleID, nothing to do
         return Status::Success;

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp
@@ -773,6 +773,12 @@ CHIP_ERROR EnergyEvseDelegate::HwGetVehicleID(DataModel::Nullable<MutableCharSpa
         return CHIP_NO_ERROR;
     }
 
+    if (outValue.IsNull())
+    {
+        // Defensive: outValue must be non-null to copy into it
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     return CopyCharSpanToMutableCharSpan(mVehicleID.Value(), outValue.Value());
 }
 


### PR DESCRIPTION
#### Summary
 - During post merge check on #39641 it seems that I missed a scenario where both mVehicleID is already null, and an empty string is passed in. The code would fall through to lines 742 and then mark the potentially already null mVehicleID as dirty, even though it was already null.
 - See discussion: https://github.com/project-chip/connectedhomeip/pull/39641#discussion_r2211520266

#### Related issues

N/A

#### Testing

Manually tested by adding code into Init()

```
    char vehicleIdBuffer[64];
    MutableCharSpan mutableSpan(vehicleIdBuffer, sizeof(vehicleIdBuffer));
    DataModel::Nullable<MutableCharSpan> outVehicleId = MakeNullable(mutableSpan);

    CHIP_ERROR err = dg->HwGetVehicleID(outVehicleId);
    ChipLogProgress(AppServer, "HwGetVehicleID result: %" CHIP_ERROR_FORMAT ", vehicleId is Null: %d", err.Format(),
                    outVehicleId.IsNull());

    dg->HwSetVehicleID(CharSpan::fromCharString(""));

    // Reset buffer for clean test
    memset(vehicleIdBuffer, 0, sizeof(vehicleIdBuffer));
    mutableSpan  = MutableCharSpan(vehicleIdBuffer, sizeof(vehicleIdBuffer));
    outVehicleId = MakeNullable(mutableSpan);

    err = dg->HwGetVehicleID(outVehicleId);
    ChipLogProgress(AppServer, "HwGetVehicleID result: %" CHIP_ERROR_FORMAT ", vehicleId is Null: %d", err.Format(),
                    outVehicleId.IsNull());

    dg->HwSetVehicleID(CharSpan::fromCharString("TEST_"));

    // Reset buffer for clean test
    memset(vehicleIdBuffer, 0, sizeof(vehicleIdBuffer));
    mutableSpan  = MutableCharSpan(vehicleIdBuffer, sizeof(vehicleIdBuffer));
    outVehicleId = MakeNullable(mutableSpan);

    err = dg->HwGetVehicleID(outVehicleId);
    ChipLogProgress(AppServer, "HwGetVehicleID result: %" CHIP_ERROR_FORMAT ", vehicleId is Null: %d", err.Format(),
                    outVehicleId.IsNull());
```
Observe that it should print out it is already Null, then no message printed about attribute being marked dirty,
 then another check it is still null. 
```
[1752747563.561] [464449:464449] [SVR] HwGetVehicleID result: examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp:773: Success, vehicleId is Null: 1
[1752747563.561] [464449:464449] [SVR] HwGetVehicleID result: examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseDelegateImpl.cpp:773: Success, vehicleId is Null: 1
```
Then prove that setting it to non null results in it being marked dirty.

```
[1752747563.561] [464449:464449] [SVR] VehicleID updated TEST_
[1752747563.561] [464449:464449] [DMG] Endpoint 1, Cluster 0x0000_0099 update version to a6c34b74
[1752747563.561] [464449:464449] [SVR] HwGetVehicleID result: src/lib/support/Span.h:399: Success, vehicleId is Null: 0
```

