### PR TITLE
[Linux] Add indication confirmation support for BlueZ >= 5.80

### DIFF
--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -171,29 +171,30 @@ const char * BluezConnection::GetPeerAddress() const
 
 gboolean BluezConnection::WriteHandlerCallback(GIOChannel * aChannel, GIOCondition aCond, BluezConnection * apConn)
 {
+    VerifyOrReturnValue(!(aCond & G_IO_HUP), G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "INFO: socket disconnected in %s", __func__));
+    VerifyOrReturnValue(!(aCond & (G_IO_ERR | G_IO_NVAL)), G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "INFO: socket error in %s", __func__));
+    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE, ChipLogError(DeviceLayer, "FAIL: error in %s", __func__));
+
     uint8_t buf[512 /* characteristic max size per BLE specification */];
-    bool isSuccess = false;
-    GVariant * newVal;
     ssize_t len;
 
-    VerifyOrExit(!(aCond & G_IO_HUP), ChipLogError(DeviceLayer, "INFO: socket disconnected in %s", __func__));
-    VerifyOrExit(!(aCond & (G_IO_ERR | G_IO_NVAL)), ChipLogError(DeviceLayer, "INFO: socket error in %s", __func__));
-    VerifyOrExit(aCond == G_IO_IN, ChipLogError(DeviceLayer, "FAIL: error in %s", __func__));
-
-    ChipLogDetail(DeviceLayer, "C1 %s MTU: %d", __func__, apConn->GetMTU());
-
     len = read(g_io_channel_unix_get_fd(aChannel), buf, sizeof(buf));
-    VerifyOrExit(len > 0, ChipLogError(DeviceLayer, "FAIL: short read in %s (%zd)", __func__, len));
+    if (len <= 0)
+    {
+        ChipLogError(DeviceLayer, "FAIL: short read in %s: %zd", __func__, len);
+    }
+    else
+    {
+        ChipLogDetail(DeviceLayer, "C1 %s received %zd bytes", __func__, len);
+        // Casting len to size_t is safe, since we ensured that it's not negative.
+        bluez_gatt_characteristic1_set_value(
+            apConn->mC1.get(), g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, buf, static_cast<size_t>(len), sizeof(uint8_t)));
+        BLEManagerImpl::HandleRXCharWrite(apConn, buf, static_cast<size_t>(len));
+    }
 
-    // Casting len to size_t is safe, since we ensured that it's not negative.
-    newVal = g_variant_new_fixed_array(G_VARIANT_TYPE_BYTE, buf, static_cast<size_t>(len), sizeof(uint8_t));
-
-    bluez_gatt_characteristic1_set_value(apConn->mC1.get(), newVal);
-    BLEManagerImpl::HandleRXCharWrite(apConn, buf, static_cast<size_t>(len));
-    isSuccess = true;
-
-exit:
-    return isSuccess ? G_SOURCE_CONTINUE : G_SOURCE_REMOVE;
+    return G_SOURCE_CONTINUE;
 }
 
 void BluezConnection::SetupWriteHandler(int aSocketFd)
@@ -203,7 +204,7 @@ void BluezConnection::SetupWriteHandler(int aSocketFd)
     g_io_channel_set_close_on_unref(channel, TRUE);
     g_io_channel_set_buffered(channel, FALSE);
 
-    auto watchSource = g_io_create_watch(channel, static_cast<GIOCondition>(G_IO_HUP | G_IO_IN | G_IO_ERR | G_IO_NVAL));
+    auto watchSource = g_io_create_watch(channel, static_cast<GIOCondition>(G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL));
     g_source_set_callback(watchSource, G_SOURCE_FUNC(WriteHandlerCallback), this, nullptr);
 
     mC1Channel.mChannel.reset(channel);
@@ -212,9 +213,33 @@ void BluezConnection::SetupWriteHandler(int aSocketFd)
     PlatformMgrImpl().GLibMatterContextAttachSource(watchSource);
 }
 
-gboolean BluezConnection::NotifyHandlerCallback(GIOChannel *, GIOCondition, BluezConnection *)
+gboolean BluezConnection::NotifyHandlerCallback(GIOChannel * aChannel, GIOCondition aCond, BluezConnection * apConn)
 {
-    return G_SOURCE_REMOVE;
+    VerifyOrReturnValue(!(aCond & G_IO_HUP), G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "INFO: socket disconnected in %s", __func__));
+    VerifyOrReturnValue(!(aCond & (G_IO_ERR | G_IO_NVAL)), G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "INFO: socket error in %s", __func__));
+    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE, ChipLogError(DeviceLayer, "FAIL: error in %s", __func__));
+
+    uint8_t value = 0;
+    ssize_t len;
+
+    // NOTE: For BlueZ version <= 5.73 the confirmation was delivered via the D-Bus "Confirm"
+    //       method call. However, for BlueZ >= 5.80 the confirmation is sent via the socket
+    //       opened in the "AcquireNotify" method. For versions in between, the confirmation
+    //       might not work correctly at all!
+    len = read(g_io_channel_unix_get_fd(aChannel), &value, sizeof(value));
+    if (value != 1)
+    {
+        ChipLogError(DeviceLayer, "FAIL: Invalid indication confirmation: len=%zd value=%u", len, value);
+    }
+    else
+    {
+        ChipLogDetail(DeviceLayer, "Indication confirmation: conn=%p", apConn);
+        BLEManagerImpl::HandleTXComplete(apConn);
+    }
+
+    return G_SOURCE_CONTINUE;
 }
 
 void BluezConnection::SetupNotifyHandler(int aSocketFd, bool aAdditionalAdvertising)
@@ -224,7 +249,7 @@ void BluezConnection::SetupNotifyHandler(int aSocketFd, bool aAdditionalAdvertis
     g_io_channel_set_close_on_unref(channel, TRUE);
     g_io_channel_set_buffered(channel, FALSE);
 
-    auto watchSource = g_io_create_watch(channel, static_cast<GIOCondition>(G_IO_HUP | G_IO_ERR | G_IO_NVAL));
+    auto watchSource = g_io_create_watch(channel, static_cast<GIOCondition>(G_IO_IN | G_IO_HUP | G_IO_ERR | G_IO_NVAL));
     g_source_set_callback(watchSource, G_SOURCE_FUNC(NotifyHandlerCallback), this, nullptr);
 
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING

--- a/src/platform/Linux/bluez/BluezConnection.cpp
+++ b/src/platform/Linux/bluez/BluezConnection.cpp
@@ -173,9 +173,8 @@ gboolean BluezConnection::WriteHandlerCallback(GIOChannel * aChannel, GIOConditi
 {
     VerifyOrReturnValue(!(aCond & G_IO_HUP), G_SOURCE_REMOVE,
                         ChipLogError(DeviceLayer, "INFO: socket disconnected in %s", __func__));
-    VerifyOrReturnValue(!(aCond & (G_IO_ERR | G_IO_NVAL)), G_SOURCE_REMOVE,
-                        ChipLogError(DeviceLayer, "INFO: socket error in %s", __func__));
-    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE, ChipLogError(DeviceLayer, "FAIL: error in %s", __func__));
+    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "FAIL: socket error in %s: cond=0x%x", __func__, aCond));
 
     uint8_t buf[512 /* characteristic max size per BLE specification */];
     ssize_t len;
@@ -212,9 +211,8 @@ gboolean BluezConnection::NotifyHandlerCallback(GIOChannel * aChannel, GIOCondit
 {
     VerifyOrReturnValue(!(aCond & G_IO_HUP), G_SOURCE_REMOVE,
                         ChipLogError(DeviceLayer, "INFO: socket disconnected in %s", __func__));
-    VerifyOrReturnValue(!(aCond & (G_IO_ERR | G_IO_NVAL)), G_SOURCE_REMOVE,
-                        ChipLogError(DeviceLayer, "INFO: socket error in %s", __func__));
-    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE, ChipLogError(DeviceLayer, "FAIL: error in %s", __func__));
+    VerifyOrReturnValue(aCond == G_IO_IN, G_SOURCE_REMOVE,
+                        ChipLogError(DeviceLayer, "FAIL: socket error in %s: cond=0x%x", __func__, aCond));
 
     uint8_t value = 0;
     ssize_t len;

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -97,10 +97,7 @@ gboolean BluezEndpoint::BluezCharacteristicReadValue(BluezGattCharacteristic1 * 
 gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
                                                         GUnixFDList * aFDList, GVariant * aOptions)
 {
-    int fds[2] = { -1, -1 };
-#if CHIP_ERROR_LOGGING
-    char * errStr;
-#endif // CHIP_ERROR_LOGGING
+    int fds[2]             = { -1, -1 };
     BluezConnection * conn = nullptr;
     uint16_t mtu;
 
@@ -118,10 +115,7 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireWrite(BluezGattCharacteristic1
 
     if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) < 0)
     {
-#if CHIP_ERROR_LOGGING
-        errStr = strerror(errno);
-#endif // CHIP_ERROR_LOGGING
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(errStr), __func__);
+        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
         return FALSE;
     }
@@ -148,10 +142,7 @@ static gboolean BluezCharacteristicAcquireWriteError(BluezGattCharacteristic1 * 
 gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation,
                                                          GUnixFDList * aFDList, GVariant * aOptions)
 {
-    int fds[2] = { -1, -1 };
-#if CHIP_ERROR_LOGGING
-    char * errStr;
-#endif // CHIP_ERROR_LOGGING
+    int fds[2]                   = { -1, -1 };
     BluezConnection * conn       = nullptr;
     bool isAdditionalAdvertising = false;
     uint16_t mtu;
@@ -178,10 +169,7 @@ gboolean BluezEndpoint::BluezCharacteristicAcquireNotify(BluezGattCharacteristic
 
     if (socketpair(AF_UNIX, SOCK_SEQPACKET | SOCK_NONBLOCK | SOCK_CLOEXEC, 0, fds) < 0)
     {
-#if CHIP_ERROR_LOGGING
-        errStr = strerror(errno);
-#endif // CHIP_ERROR_LOGGING
-        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(errStr), __func__);
+        ChipLogError(DeviceLayer, "FAIL: socketpair: %s in %s", StringOrNullMarker(strerror(errno)), __func__);
         g_dbus_method_invocation_return_dbus_error(aInvocation, "org.bluez.Error.Failed", "FD creation failed");
         return FALSE;
     }
@@ -557,8 +545,7 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
-        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -203,10 +203,13 @@ static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 *
     return TRUE;
 }
 
+// TODO: When using with BlueZ >= 5.80, this method can be removed. Also, the GetBluezConnectionViaDevice
+//       method will no longer be needed, since every callback will have the device object path available
+//       in the options parameter.
 gboolean BluezEndpoint::BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)
 {
     BluezConnection * conn = GetBluezConnectionViaDevice();
-    ChipLogDetail(Ble, "Indication confirmation, %p", conn);
+    ChipLogDetail(DeviceLayer, "Indication confirmation: conn=%p", conn);
     bluez_gatt_characteristic1_complete_confirm(aChar, aInvocation);
     BLEManagerImpl::HandleTXComplete(conn);
     return TRUE;

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -203,7 +203,7 @@ static gboolean BluezCharacteristicAcquireNotifyError(BluezGattCharacteristic1 *
     return TRUE;
 }
 
-// TODO: When using with BlueZ >= 5.80, this method can be removed. Also, the GetBluezConnectionViaDevice
+// NOTE: When using with BlueZ >= 5.80, this method can be removed. Also, the GetBluezConnectionViaDevice
 //       method will no longer be needed, since every callback will have the device object path available
 //       in the options parameter.
 gboolean BluezEndpoint::BluezCharacteristicConfirm(BluezGattCharacteristic1 * aChar, GDBusMethodInvocation * aInvocation)

--- a/src/platform/Linux/bluez/BluezEndpoint.cpp
+++ b/src/platform/Linux/bluez/BluezEndpoint.cpp
@@ -555,7 +555,8 @@ CHIP_ERROR BluezEndpoint::Init(BluezAdapter1 * apAdapter, bool aIsCentral)
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to subscribe for notifications: %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = PlatformMgrImpl().GLibMatterContextInvokeSync(+[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
+    err = PlatformMgrImpl().GLibMatterContextInvokeSync(
+        +[](BluezEndpoint * self) { return self->SetupEndpointBindings(); }, this);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err,
                         ChipLogError(DeviceLayer, "Failed to schedule endpoint initialization: %" CHIP_ERROR_FORMAT, err.Format()));
 


### PR DESCRIPTION
#### Summary

Current indication confirmation mechanisms works for BlueZ up to 5.73 (that was tested). Above that version indication confirmation might not work at all... However, starting with BlueZ 5.80, indication confirmation is delivered via opened socket (not via `Confirm` D-Bus call) if notification was started with `AcquireNotify` D-Bus call (https://github.com/bluez/bluez/issues/1081).

#### Testing

Tested locally that device created with matter SDK can be commissioned on host with BlueZ <=  5.73 (old confirmation logic) and with BlueZ >= 5.80 (new confirmation logic). For versions in between it was not possible to either receive confirmation or start BLE advertising - one might assume that for versions in between matter SDK will not work if used as a Matter device.