### PR TITLE
[nrfconnect] Fix build examples script for nRFConnect

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -122,11 +122,11 @@ class NrfBoard(Enum):
 
     def GnArgName(self):
         if self == NrfBoard.NRF52840DK:
-            return 'nrf52840dk_nrf52840'
+            return 'nrf52840dk/nrf52840'
         elif self == NrfBoard.NRF52840DONGLE:
-            return 'nrf52840dongle_nrf52840'
+            return 'nrf52840dongle/nrf52840'
         elif self == NrfBoard.NRF5340DK:
-            return 'nrf5340dk_nrf5340_cpuapp'
+            return 'nrf5340dk/nrf5340cpuapp'
         elif self == NrfBoard.NATIVE_SIM:
             return 'native_sim'
         else:
@@ -147,23 +147,44 @@ class NrfConnectBuilder(Builder):
         self.board = board
         self.enable_rpcs = enable_rpcs
 
+    def _check_ncs_version(self):
+        # validate the the ZEPHYR_BASE is up to date (generally the case in docker images)
+        try:
+            self._Execute(
+                ['python3', 'scripts/setup/nrfconnect/update_ncs.py', '--check'])
+        except Exception:
+            logging.exception('Failed to validate ZEPHYR_BASE status')
+            logging.error(
+                'To update $ZEPHYR_BASE run: python3 scripts/setup/nrfconnect/update_ncs.py --update --shallow')
+
+            raise Exception('ZEPHYR_BASE validation failed')
+
+    def _prepare_environment(self):
+        # Source the zephyr-env.sh script to set up the environment
+        # The zephyr-env.sh script changes the python environment, so we need to
+        # source the activate.sh script after zephyr-env.sh to ensure that the
+        # all python packages and dependencies are available.
+        return 'source "$ZEPHYR_BASE/zephyr-env.sh";\nsource scripts/activate.sh;\n'
+
+    def _get_build_flags(self):
+        flags = []
+        if self.enable_rpcs:
+            flags.append("-DOVERLAY_CONFIG=rpc.overlay")
+
+        if self.options.pregen_dir:
+            flags.append(f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")
+
+        build_flags = " -- " + " ".join(flags) if len(flags) > 0 else ""
+
+        return build_flags
+
     def generate(self):
         if not os.path.exists(self.output_dir):
-            zephyr_sdk_dir = None
-
             if not self._runner.dry_run:
-                if 'ZEPHYR_BASE' not in os.environ:
-                    raise Exception("NRF builds require ZEPHYR_BASE to be set")
-
-                # Users are expected to set ZEPHYR_SDK_INSTALL_DIR but additionally cover the Docker
-                # case by inferring ZEPHYR_SDK_INSTALL_DIR from NRF5_TOOLS_ROOT.
-                if not os.environ.get('ZEPHYR_SDK_INSTALL_DIR') and not os.environ.get('NRF5_TOOLS_ROOT'):
-                    raise Exception("NRF buils require ZEPHYR_SDK_INSTALL_DIR to be set")
+                self._check_ncs_version()
 
                 zephyr_base = os.environ['ZEPHYR_BASE']
                 nrfconnect_sdk = os.path.dirname(zephyr_base)
-                zephyr_sdk_dir = os.environ.get('ZEPHYR_SDK_INSTALL_DIR') or os.path.join(
-                    os.environ['NRF5_TOOLS_ROOT'], 'zephyr-sdk-0.16.1')
 
                 # NRF builds will both try to change .west/config in nrfconnect and
                 # overall perform a git fetch on that location
@@ -171,37 +192,14 @@ class NrfConnectBuilder(Builder):
                     raise Exception(
                         "Directory %s not writable. NRFConnect builds require updates to this directory." % nrfconnect_sdk)
 
-                # validate the the ZEPHYR_BASE is up to date (generally the case in docker images)
-                try:
-                    self._Execute(
-                        ['python3', 'scripts/setup/nrfconnect/update_ncs.py', '--check'])
-                except Exception:
-                    logging.exception('Failed to validate ZEPHYR_BASE status')
-                    logging.error(
-                        'To update $ZEPHYR_BASE run: python3 scripts/setup/nrfconnect/update_ncs.py --update --shallow')
+            cmd = self._prepare_environment()
 
-                    raise Exception('ZEPHYR_BASE validation failed')
-
-            flags = []
-            if self.enable_rpcs:
-                flags.append("-DOVERLAY_CONFIG=rpc.overlay")
-
-            if self.options.pregen_dir:
-                flags.append(f"-DCHIP_CODEGEN_PREGEN_DIR={shlex.quote(self.options.pregen_dir)}")
-
-            build_flags = " -- " + " ".join(flags) if len(flags) > 0 else ""
-
-            cmd = 'source "$ZEPHYR_BASE/zephyr-env.sh";\nexport ZEPHYR_TOOLCHAIN_VARIANT=zephyr;'
-
-            if zephyr_sdk_dir:
-                cmd += f'\nexport ZEPHYR_SDK_INSTALL_DIR={zephyr_sdk_dir};'
-
-            cmd += '\nwest build --cmake-only -d {outdir} -b {board} --sysbuild {sourcedir}{build_flags}\n'.format(
+            cmd += 'west build --cmake-only -d {outdir} -b {board} --sysbuild {sourcedir}{build_flags}\n'.format(
                 outdir=shlex.quote(self.output_dir),
                 board=self.board.GnArgName(),
                 sourcedir=shlex.quote(os.path.join(
                     self.root, self.app.AppPath(), 'nrfconnect')),
-                build_flags=build_flags
+                build_flags=self._get_build_flags()
             )
             self._Execute(['bash', '-c', cmd.strip()],
                           title='Generating ' + self.identifier)
@@ -209,12 +207,13 @@ class NrfConnectBuilder(Builder):
     def _build(self):
         logging.info('Compiling NrfConnect at %s', self.output_dir)
 
-        cmd = ['ninja', '-C', self.output_dir]
+        cmd = self._prepare_environment()
+        cmd += f'ninja -C {self.output_dir}'
 
         if self.ninja_jobs is not None:
-            cmd.append('-j' + str(self.ninja_jobs))
+            cmd += '-j' + str(self.ninja_jobs)
 
-        self._Execute(cmd, title='Building ' + self.identifier)
+        self._Execute(['bash', '-c', cmd.strip()], title='Building ' + self.identifier)
 
         if self.app == NrfApp.UNIT_TESTS:
             # Note: running zephyr/zephyr.elf has the same result except it creates

--- a/scripts/build/testdata/dry_run_nrf-nrf52840dk-pump.txt
+++ b/scripts/build/testdata/dry_run_nrf-nrf52840dk-pump.txt
@@ -3,8 +3,10 @@ cd "{root}"
 
 # Generating nrf-nrf52840dk-pump
 bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr;
-west build --cmake-only -d {out}/nrf-nrf52840dk-pump -b nrf52840dk_nrf52840 --sysbuild {root}/examples/pump-app/nrfconnect'
+source scripts/activate.sh;
+west build --cmake-only -d {out}/nrf-nrf52840dk-pump -b nrf52840dk/nrf52840 --sysbuild {root}/examples/pump-app/nrfconnect'
 
 # Building nrf-nrf52840dk-pump
-ninja -C {out}/nrf-nrf52840dk-pump
+bash -c 'source "$ZEPHYR_BASE/zephyr-env.sh";
+source scripts/activate.sh;
+ninja -C {out}/nrf-nrf52840dk-pump'


### PR DESCRIPTION
#### Summary

Some adjustments and fixes in the nrf.py script are required for the newest nRFConnect toolchain.,
Refactored generate and build functions to be ready to work with NCS 3.0.0.

#### Related issues

Fixes: #40133

#### Testing

Checked locally by executing the following command in the newest nRFConnect docker image:

```
./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --enable-flashbundle --target nrf-nrf52840dk-light --target nrf-nrf52840dk-light-rpc --target nrf-nrf52840dk-lock --target nrf-nrf52840dongle-light build"
```