### PR TITLE
[Nordic] Adding pw_numeric as a source in CMakeLists

### DIFF
--- a/src/test_driver/nrfconnect/CMakeLists.txt
+++ b/src/test_driver/nrfconnect/CMakeLists.txt
@@ -63,6 +63,7 @@ target_include_directories(app PUBLIC
   ${PIGWEED_ROOT}/pw_assert_zephyr/public
   ${PIGWEED_ROOT}/pw_assert_zephyr/public_overrides
   ${PIGWEED_ROOT}/pw_bytes/public
+  ${PIGWEED_ROOT}/pw_numeric/public
   ${PIGWEED_ROOT}/pw_preprocessor/public
   ${PIGWEED_ROOT}/pw_polyfill/public
   ${PIGWEED_ROOT}/pw_polyfill/standard_library_public


### PR DESCRIPTION
#### Summary

- Submodule update for pigweed is failing in nrf Unit Tests
- This happens because newer pigweed versions `#include "pw_numeric"` and it isnt there in CMakeLists for Nordic

- Pigweed code that includes pw_numeric here: https://github.com/google/pigweed/blob/1baea6bc0ee4afe955a834d17177d7be5418900a/pw_bytes/public/pw_bytes/alignment.h#L22

- Failure happening in https://github.com/project-chip/connectedhomeip/actions/runs/16341839683/job/46166076400?pr=40156
#### Related issues

- similar issue happened here: #39261


#### Testing

- CI Unit Testing
