### PR TITLE
[QPG] Fix for memory leak in DiagnosticDataProviderImpl

### DIFF
--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -58,7 +58,7 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
     uint8_t Ipv6AddressesBuffer[kMaxIPv6AddrCount][kMaxIPv6AddrSize];
     chip::ByteSpan Ipv4AddressSpans[kMaxIPv4AddrCount];
     chip::ByteSpan Ipv6AddressSpans[kMaxIPv6AddrCount];
-    NetworkInterface * Next; /* Pointer to the next structure.  */
+    NetworkInterface * Next = nullptr; /* Pointer to the next structure.  */
 };
 
 class DiagnosticDataProviderImpl;

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -287,5 +287,15 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     return CHIP_NO_ERROR;
 }
 
+void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * netifp)
+{
+    while (netifp)
+    {
+        NetworkInterface * del = netifp;
+        netifp                 = netifp->Next;
+        delete del;
+    }
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/DiagnosticDataProviderImpl.h
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.h
@@ -56,7 +56,6 @@ public:
     CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
-
 };
 
 /**

--- a/src/platform/qpg/DiagnosticDataProviderImpl.h
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.h
@@ -55,6 +55,8 @@ public:
     CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;
     CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
+    void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
+
 };
 
 /**


### PR DESCRIPTION
#### Summary
- Fix for memory leak in DiagnosticDataProviderImpl

#### Related issues
- N/A
#### Testing
- Verify no memory leak occurs in our internal regression tests 

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
