### PR TITLE
[Silabs] Correcting the uart define for EFR32 and 917SoC

### DIFF
--- a/third_party/silabs/SiWx917_sdk.gni
+++ b/third_party/silabs/SiWx917_sdk.gni
@@ -258,7 +258,6 @@ template("siwx917_sdk") {
       "SL_CODE_COMPONENT_FREERTOS_KERNEL=freertos_kernel",
       "SLI_CODE_CLASSIFICATION_DISABLE=1",
       "SL_MATTER_GN_BUILD=1",
-      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
       "SUPPORT_CPLUSPLUS=1",
       "SLI_SI91X_LWIP_HOSTED_NETWORK_STACK=1",
       "__FREERTOS_OS_WISECONNECT=1",
@@ -273,6 +272,12 @@ template("siwx917_sdk") {
       defines += [ "SILABS_LOG_ENABLED=1" ]
     } else {
       defines += [ "SILABS_LOG_ENABLED=0" ]
+    }
+
+    if (sl_uart_log_output) {
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (chip_enable_wifi_ipv4) {

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -500,7 +500,6 @@ template("efr32_sdk") {
       "SL_OPENTHREAD_STACK_FEATURES_CONFIG_FILE=\"sl_openthread_features_config.h\"",
       "SL_CSL_TIMEOUT=${sl_ot_csl_timeout_sec}",
       "CIRCULAR_QUEUE_USE_LOCAL_CONFIG_HEADER=1",
-      "SILABS_LOG_OUT_UART=${sl_uart_log_output}",
       "SL_RAIL_3_API=1",
       "SL_CODE_COMPONENT_OPENTHREAD=openthread",
       "SL_CODE_COMPONENT_INTERRUPT_MANAGER=interrupt_manager",
@@ -510,6 +509,12 @@ template("efr32_sdk") {
       defines += [ "SILABS_LOG_ENABLED=1" ]
     } else {
       defines += [ "SILABS_LOG_ENABLED=0" ]
+    }
+
+    if (sl_uart_log_output) {
+      defines += [ "SILABS_LOG_OUT_UART=1" ]
+    } else {
+      defines += [ "SILABS_LOG_OUT_UART=0" ]
     }
 
     if (use_silabs_thread_lib) {


### PR DESCRIPTION
#### Summary

SILABS_LOG_OUT_UART was based of boolean i.e., true/false which caused 
`#if SILABS_LOG_OUT_UART` is always true in C files since the check is based of the string value independent of the gn argument value.

Added a condition check and then assigning the integer value for this.

#### Testing
Tested with EFR32 and 917SoC
