### PR TITLE
Ignore more `libdatachannel` lossy int conversion warnings to fix Darwin python repl build post-`libdatachannel` inclusion

### DIFF
--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -55,6 +55,9 @@ static_library("chip_webrtc") {
 
   # suppress known `libdatachannel` int conversion issues on darwin builds
   if (host_os == "mac") {
-    cflags = [ "-Wno-implicit-int-conversion", "-Wno-conversion" ]
+    cflags = [
+      "-Wno-implicit-int-conversion",
+      "-Wno-conversion",
+    ]
   }
 }

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -52,7 +52,8 @@ static_library("chip_webrtc") {
     "ssl",
     "crypto",
   ]
-  
+
+  # suppress known `libdatachannel` int conversion issues on darwin builds
   if (host_os == "mac") {
     cflags = [ "-Wno-implicit-int-conversion", "-Wno-conversion" ]
   }

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -54,5 +54,5 @@ static_library("chip_webrtc") {
   ]
 
   # suppress known `libdatachannel` int conversion issues
-  cflags_cc = [ "-Wno-implicit-int-conversion" ]
+  cflags = [ "-Wno-implicit-int-conversion" ]
 }

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -53,11 +53,6 @@ static_library("chip_webrtc") {
     "crypto",
   ]
 
-  # suppress known `libdatachannel` int conversion issues on darwin builds
-  if (host_os == "mac") {
-    cflags = [
-      "-Wno-implicit-int-conversion",
-      "-Wno-conversion",
-    ]
-  }
+  # suppress known `libdatachannel` int conversion issues
+  cflags_cc = [ "-Wno-implicit-int-conversion" ]
 }

--- a/src/controller/webrtc/BUILD.gn
+++ b/src/controller/webrtc/BUILD.gn
@@ -52,4 +52,8 @@ static_library("chip_webrtc") {
     "ssl",
     "crypto",
   ]
+  
+  if (host_os == "mac") {
+    cflags = [ "-Wno-implicit-int-conversion", "-Wno-conversion" ]
+  }
 }

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -44,6 +44,8 @@ config("datachannel_config") {
   ]
 
   cflags_cc = [ "-Wno-shadow" ]
+
+  # suppress known `libdatachannel` int conversion issues on darwin builds
   if (host_os == "mac") {
     cflags_cc += [ "-Wno-implicit-int-conversion" ]
   }

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -45,10 +45,8 @@ config("datachannel_config") {
 
   cflags_cc = [ "-Wno-shadow" ]
 
-  # suppress known `libdatachannel` int conversion issues on darwin builds
-  if (host_os == "mac") {
-    cflags_cc += [ "-Wno-implicit-int-conversion" ]
-  }
+  # suppress known `libdatachannel` int conversion issues
+  cflags_cc += [ "-Wno-implicit-int-conversion" ]
 
   if (is_clang) {
     # We build static libraries and srtp2 depends on openssl

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -46,7 +46,7 @@ config("datachannel_config") {
   cflags_cc = [ "-Wno-shadow" ]
 
   # suppress known `libdatachannel` int conversion issues
-  cflags_cc += [ "-Wno-implicit-int-conversion" ]
+  cflags = [ "-Wno-implicit-int-conversion" ]
 
   if (is_clang) {
     # We build static libraries and srtp2 depends on openssl

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -62,7 +62,7 @@ config("datachannel_config") {
   ]
 }
 
-static_library("libdatachannel") {
+group("libdatachannel") {
   deps = [ ":build_libdatachannel" ]
   public_configs = [ ":datachannel_config" ]
 }

--- a/third_party/libdatachannel/BUILD.gn
+++ b/third_party/libdatachannel/BUILD.gn
@@ -44,6 +44,9 @@ config("datachannel_config") {
   ]
 
   cflags_cc = [ "-Wno-shadow" ]
+  if (host_os == "mac") {
+    cflags_cc += [ "-Wno-implicit-int-conversion" ]
+  }
 
   if (is_clang) {
     # We build static libraries and srtp2 depends on openssl


### PR DESCRIPTION
#### Summary

Fixes #40171 by:

- suppressing lossy int conversion warnings in `libdatachannel`
- suppressing lossy int conversion warnings in `chip_webrtc`
- converting build of `libdatachannel` from `static_library` to `group`
  -  it is built by an external script, so there is no filelist
  - `ar` fails without the filelist on Darwin
  - need confirmation from folks working on `chip_webrtc` that this is the correct solution

This breakage made it past CI because CI is currently skipping Darwin REPL tests altogether due to past flakiness - see #16441.

#### Related issues

Fixes #40171.

Followup to re-enable build-only of Darwin Python REPL: #40176 

#### Testing

- `scripts/build_python.sh -m platform -d true -i python_env`
  - should build successfully before and after included changes on arm64 Linux (manually checked on Raspberry Pi)
  - should fail to build before and build successfully after included changes on arm64 Darwin (manually checked on my Mac)
- CI checks for Linux REPL build and test

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase
