### PR TITLE
[Silabs] Fix 917 init sequence 

### DIFF
--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -275,6 +275,9 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #if CHIP_ENABLE_OPENTHREAD
     ReturnErrorOnFailure(InitOpenThread());
 #endif
+#ifdef SL_WIFI
+    sWifiNetworkDriver.Init();
+#endif
 
     // Stop Matter event handling while setting up resources
     chip::DeviceLayer::PlatformMgr().LockChipStack();
@@ -341,7 +344,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #ifdef SL_WIFI
 CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
 {
-    sWifiNetworkDriver.Init();
     return WifiInterface::GetInstance().InitWiFiStack();
 }
 #endif // SL_WIFI

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -276,7 +276,7 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     ReturnErrorOnFailure(InitOpenThread());
 #endif
 #ifdef SL_WIFI
-    sWifiNetworkDriver.Init();
+    ReturnErrorOnFailure(sWifiNetworkDriver.Init());
 #endif
 
     // Stop Matter event handling while setting up resources

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -226,13 +226,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 {
     using namespace chip::DeviceLayer::Silabs;
 
-    CHIP_ERROR err;
-#ifdef SL_WIFI
-    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
-    // and set the allocation functions inside sl_ot_create_instance, which is called by sl_system_init in the OpenThread stack
-    // initialization.
-    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
-#endif
     ChipLogProgress(DeviceLayer, "==================================================");
     ChipLogProgress(DeviceLayer, "%s starting", appName);
     ChipLogProgress(DeviceLayer, "==================================================");
@@ -252,9 +245,11 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 
 #ifdef SL_WIFI
     // Init Chip memory management before the stack
-    // See comment above about OpenThread memory allocation as to why this is WIFI only here.
+    // Because OpenThread needs to use memory allocation during its Key operations, we initialize the memory management for thread
+    // and set the allocation functions inside sl_ot_create_instance, which is called earlier by sl_system_init.
+    mbedtls_platform_set_calloc_free(CHIPPlatformMemoryCalloc, CHIPPlatformMemoryFree);
     ReturnErrorOnFailure(chip::Platform::MemoryInit());
-    ReturnErrorOnFailure(InitWiFi());
+    ReturnErrorOnFailure(WifiInterface::GetInstance().InitWiFiStack());
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     ReturnErrorOnFailure(WifiSleepManager::GetInstance().Init(&WifiInterface::GetInstance(), &WifiInterface::GetInstance()));
@@ -272,19 +267,28 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
     SetCommissionableDataProvider(&provision.GetStorage());
     ChipLogProgress(DeviceLayer, "Provision mode %s", provision.IsProvisionRequired() ? "ENABLED" : "disabled");
 
+    // Create initParams with SDK example defaults here
+    // TODO: replace with our own init param to avoid double allocation in examples
+    static chip::CommonCaseDeviceServerInitParams initParams;
+
 #if CHIP_ENABLE_OPENTHREAD
     ReturnErrorOnFailure(InitOpenThread());
+
+    // Set up OpenThread configuration when OpenThread is included
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = LockOpenThreadTask;
+    nativeParams.unlockCb              = UnlockOpenThreadTask;
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
 #endif
 #ifdef SL_WIFI
+    // This must be initialized after InitWiFiStack and InitChipStack which enable communication between the TA an M4
+    // This is required for TA nvm access used by the sWifiNetworkDriver.
     ReturnErrorOnFailure(sWifiNetworkDriver.Init());
 #endif
 
     // Stop Matter event handling while setting up resources
     chip::DeviceLayer::PlatformMgr().LockChipStack();
-
-    // Create initParams with SDK example defaults here
-    // TODO: replace with our own init param to avoid double allocation in examples
-    static chip::CommonCaseDeviceServerInitParams initParams;
 
     // Report scheduler and timer delegate instance
     static DefaultTimerDelegate sTimerDelegate;
@@ -311,21 +315,11 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 #endif
 
     // Initialize the remaining (not overridden) providers to the SDK example defaults
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    ReturnErrorOnFailure(initParams.InitializeStaticResourcesBeforeServerInit());
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
-
-#if CHIP_ENABLE_OPENTHREAD
-    // Set up OpenThread configuration when OpenThread is included
-    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
-    nativeParams.lockCb                = LockOpenThreadTask;
-    nativeParams.unlockCb              = UnlockOpenThreadTask;
-    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
-    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
-#endif
-
-    initParams.appDelegate = &BaseApplication::sAppDelegate;
+    initParams.appDelegate       = &BaseApplication::sAppDelegate;
     // Init Matter Server and Start Event Loop
-    err = chip::Server::GetInstance().Init(initParams);
+    CHIP_ERROR err = chip::Server::GetInstance().Init(initParams);
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
@@ -340,13 +334,6 @@ CHIP_ERROR SilabsMatterConfig::InitMatter(const char * appName)
 
     return CHIP_NO_ERROR;
 }
-
-#ifdef SL_WIFI
-CHIP_ERROR SilabsMatterConfig::InitWiFi(void)
-{
-    return WifiInterface::GetInstance().InitWiFiStack();
-}
-#endif // SL_WIFI
 
 // ================================================================================
 // FreeRTOS Callbacks

--- a/examples/platform/silabs/MatterConfig.h
+++ b/examples/platform/silabs/MatterConfig.h
@@ -31,5 +31,4 @@ public:
 
 private:
     static CHIP_ERROR InitOpenThread(void);
-    static CHIP_ERROR InitWiFi(void);
 };


### PR DESCRIPTION
#### Summary
Issue Summary:
PR #39461 introduced a regression in the 917 initialization sequence, causing the device to fail to automatically reattach to its Wi-Fi network after a power cycle.

Root Cause:
The Wi-Fi Network driver for the 917 was initialized too early, attempting to retrieve previously stored network credentials before the non-volatile memory was fully accessible.

Solution:
Delay the initialization of sWifiNetworkDriver until after the 917 Wi-Fi stack and interface are fully operational.

#### Related issues
N/A

#### Testing
- Commission any 917 platform sample application— In my case, the Lighting App on the BRD4338A board.
- Once commissioning is complete, power cycle the device.
- Confirm that the Wi-Fi credentials are successfully retrieved from non-volatile memory during the standard initialization sequence, and that the 917 automatically reattaches to the Wi-Fi network.

