### PR TITLE
[Closure test-scripts] Test step skips fix

### DIFF
--- a/src/python_testing/TC_CLCTRL_4_1.py
+++ b/src/python_testing/TC_CLCTRL_4_1.py
@@ -439,10 +439,10 @@ class TC_CLCTRL_4_1(MatterBaseTest):
             sub_handler.await_all_expected_report_matches(expected_matchers=[current_latch_matcher(False)],
                                                           timeout_sec=timeout)
         else:
-            logging.info("Motion Latching feature not supported, skipping steps 3k to 5e")
+            logging.info("Motion Latching feature not supported, skipping steps 3f to 5e")
 
-            # Skipping steps 3k to 5e
-            self.mark_step_range_skipped("3k", "5e")
+            # Skipping steps 3f to 5e
+            self.mark_step_range_skipped("3f", "5e")
 
         # STEP 6a: If the SP feature is not supported on the cluster, skip steps 6b to 6e
         self.step("6a")

--- a/src/python_testing/TC_CLCTRL_4_2.py
+++ b/src/python_testing/TC_CLCTRL_4_2.py
@@ -177,7 +177,7 @@ class TC_CLCTRL_4_2(MatterBaseTest):
         self.step("2b")
         if not is_latching_supported:
             logging.info("Latching feature is not supported, skipping remaining steps.")
-            self.skip_all_remaining_steps()
+            self.mark_all_remaining_steps_skipped("2c")
             return
         else:
             logging.info("Latching feature is supported, proceeding with the test.")

--- a/src/python_testing/TC_CLCTRL_4_4.py
+++ b/src/python_testing/TC_CLCTRL_4_4.py
@@ -154,7 +154,7 @@ class TC_CLCTRL_4_4(MatterBaseTest):
 
         if not is_countdown_time_supported:
             logging.info("CountdownTime attribute not supported, skipping test")
-            self.skip_all_remaining_steps()
+            self.mark_all_remaining_steps_skipped("2c")
             return
 
         self.step("2c")

--- a/src/python_testing/TC_CLDIM_3_1.py
+++ b/src/python_testing/TC_CLDIM_3_1.py
@@ -163,7 +163,7 @@ class TC_CLDIM_3_1(MatterBaseTest):
         self.step("2b")
         if not is_positioning_supported:
             logging.info("Positioning Feature is not supported. Skipping remaining steps.")
-            self.skip_all_remaining_steps("2c")
+            self.mark_all_remaining_steps_skipped("2c")
             return
 
         # STEP 2c: Read LimitRange attribute if supported

--- a/src/python_testing/TC_CLDIM_3_2.py
+++ b/src/python_testing/TC_CLDIM_3_2.py
@@ -126,7 +126,7 @@ class TC_CLDIM_3_2(MatterBaseTest):
         self.step("2b")
         if not is_latching_supported:
             logging.info("MotionLatching Feature is not supported. Skipping remaining steps.")
-            self.skip_all_remaining_steps("2c")
+            self.mark_all_remaining_steps_skipped("2c")
             return
 
         # STEP 2c: Read LimitRange attribute if supported

--- a/src/python_testing/TC_CLDIM_4_1.py
+++ b/src/python_testing/TC_CLDIM_4_1.py
@@ -161,7 +161,7 @@ class TC_CLDIM_4_1(MatterBaseTest):
         self.step("2b")
         if not is_positioning_supported:
             logging.info("Positioning feature is not supported. Skipping remaining steps.")
-            self.skip_all_remaining_steps("2c")
+            self.mark_all_remaining_steps_skipped("2c")
             return
 
         # STEP 2c: Read StepValue attribute

--- a/src/python_testing/TC_CLDIM_4_2.py
+++ b/src/python_testing/TC_CLDIM_4_2.py
@@ -116,7 +116,7 @@ class TC_CLDIM_4_2(MatterBaseTest):
         self.step("2b")
         if not is_positioning_supported:
             logging.info("Positioning feature is not supported. Skipping remaining steps.")
-            self.skip_all_remaining_steps("2c")
+            self.mark_all_remaining_steps_skipped("2c")
             return
 
         # STEP 2c: Establish wildcard subscription to all attributes"


### PR DESCRIPTION
#### Summary
- TC_CLCTRL_4_1.py: had wrong steps skipped, is now according to TP
- All other files in PR copied a non-existent skip function from other scripts, replaced with: mark_all_remaining_steps_skipped()

#### Testing
- local execution



#### to discuss

skip_all_remaining_steps() is also present in other scripts outside of Closure - should we also fix it in this PR?