### PR TITLE
[app] Fix crash when session is replaced before priming reports are sent

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -309,6 +309,11 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
     VerifyOrDie(!IsAwaitingReportResponse()); // Should not be reportable!
     if (IsPriming() || IsChunkedReport())
     {
+        // It might occur that the session on which Subscribe Request was received is replaced with
+        // a new one before all priming reports have been sent. When this happens, the read handler
+        // is switched to the new session but the exchange context is not, as it uses the
+        // kStayAtOldSession policy. Hence, we need to check the session handle before use.
+        VerifyOrReturnLogError(mExchangeCtx->HasSessionHandle(), CHIP_ERROR_INCORRECT_STATE);
         mSessionHandle.Grab(mExchangeCtx->GetSessionHandle());
     }
     else


### PR DESCRIPTION
#### Summary

When session is replaced with a new one after Subscribe Request but before all priming reports have been sent, the exchange context's session is not switched to the new session because of its kStayAtOldSession policy.

The Read Handler code was not expecting that and tried to dereference a released session handle.

#### Related issues

Fixes #40190

#### Testing

Performed the reproduction steps added to #40190.
Noticed the following log in the console instead of the crash:
```
[00:01:01.095,123] <dbg> chip: LogV: [DMG]<RE> Sending report (payload has 44 bytes)...
[00:01:01.095,245] <err> chip: [-]mExchangeCtx->HasSessionHandle():320 false: 3
[00:01:01.095,336] <err> chip: [DMG]<RE> Error sending out report data with 3!
[00:01:01.095,520] <inf> chip: [DMG]Subscription id 0x9fed224b from node <000000000001B669, 1> torn down
[00:01:01.095,611] <dbg> chip: LogV: [DMG]IM RH moving to [AwaitingDestruction]
```


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/pull_request_guidelines.html)
