### PR TITLE
Fix Build error with ffmpeg7 version.

### DIFF
--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -391,11 +391,11 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
             Stop();
             return -1;
         }
-        mAudioEncoderContext->sample_rate    = mAudioInfo.mSampleRate;
+        mAudioEncoderContext->sample_rate = mAudioInfo.mSampleRate;
         av_channel_layout_default(&mAudioEncoderContext->ch_layout, mAudioInfo.mChannels);
-        mAudioEncoderContext->bit_rate       = mAudioInfo.mBitRate;
-        mAudioEncoderContext->sample_fmt     = audioCodec->sample_fmts[0];
-        mAudioEncoderContext->time_base      = (AVRational){ 1, mAudioInfo.mSampleRate };
+        mAudioEncoderContext->bit_rate              = mAudioInfo.mBitRate;
+        mAudioEncoderContext->sample_fmt            = audioCodec->sample_fmts[0];
+        mAudioEncoderContext->time_base             = (AVRational){ 1, mAudioInfo.mSampleRate };
         mAudioEncoderContext->strict_std_compliance = FF_COMPLIANCE_EXPERIMENTAL;
         AVDictionary * opts                         = NULL;
         av_dict_set(&opts, "strict", "experimental", 0);

--- a/examples/camera-app/linux/src/pushav-clip-recorder.cpp
+++ b/examples/camera-app/linux/src/pushav-clip-recorder.cpp
@@ -392,8 +392,7 @@ int PushAVClipRecorder::AddStreamToOutput(AVMediaType type)
             return -1;
         }
         mAudioEncoderContext->sample_rate    = mAudioInfo.mSampleRate;
-        mAudioEncoderContext->channels       = mAudioInfo.mChannels;
-        mAudioEncoderContext->channel_layout = static_cast<uint64_t>(av_get_default_channel_layout(mAudioEncoderContext->channels));
+        av_channel_layout_default(&mAudioEncoderContext->ch_layout, mAudioInfo.mChannels);
         mAudioEncoderContext->bit_rate       = mAudioInfo.mBitRate;
         mAudioEncoderContext->sample_fmt     = audioCodec->sample_fmts[0];
         mAudioEncoderContext->time_base      = (AVRational){ 1, mAudioInfo.mSampleRate };


### PR DESCRIPTION
#### Summary
* Currently in the matter docker image, Ubuntu 24.04 version is used. In that by default ffmpeg 6.1.1 version is available.
* But due to Test harness and other developers are using ffmpeg7 version in which some deprecated APIs are not available, build break occurs.
* Updating the ffmpeg dependency code to work with both ffmpeg-6.1.1 and ffmpeg7

#### Testing
* Build camera example application on  Linux host with ffmpeg6.1.1
* Build camera example application on  Linux host with ffmpeg7
* Build camera example application on docker image
* CI build
