### PR TITLE
[Silabs] Matter Shell fixing for the Silabs devices

### DIFF
--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -28,6 +28,7 @@ constexpr uint8_t kRefEndpointId = 1;
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace Clusters::RefrigeratorAlarm;
 using namespace Clusters::TemperatureControl;
 using Shell::Engine;
@@ -113,7 +114,7 @@ CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
     int value = std::stoi(argv[0]); // Safe to use now, as we validated the input earlier
 
     RefrigeratorAlarmEventData * data = Platform::New<RefrigeratorAlarmEventData>();
-    data->eventId                     = Events::Notify::Id;
+    data->eventId                     = RefrigeratorAlarm::Events::Notify::Id;
     data->doorState                   = static_cast<AlarmBitmap>(value);
 
     DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -163,7 +164,7 @@ void EventWorkerFunction(intptr_t context)
 
     switch (data->eventId)
     {
-    case Events::Notify::Id: {
+    case RefrigeratorAlarm::Events::Notify::Id: {
         RefrigeratorAlarmEventData * alarmData = reinterpret_cast<RefrigeratorAlarmEventData *>(context);
         RefrigeratorAlarmServer::Instance().SetStateValue(kRefEndpointId, alarmData->doorState);
         break;

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -29,8 +29,6 @@ constexpr uint8_t kRefEndpointId = 1;
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters;
-using namespace Clusters::RefrigeratorAlarm;
-using namespace Clusters::TemperatureControl;
 using Shell::Engine;
 using Shell::shell_command_t;
 using Shell::streamer_get;

--- a/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
+++ b/src/platform/silabs/SiWx917/SiWxPlatformInterface.h
@@ -20,9 +20,9 @@
 #include <app/icd/server/ICDServerConfig.h>
 
 namespace {
-#ifdef ENABLE_CHIP_SHELL
+#if defined(ENABLE_CHIP_SHELL) && CHIP_CONFIG_ENABLE_ICD_SERVER
 bool ps_requirement_added = false;
-#endif // ENABLE_CHIP_SHELL
+#endif // ENABLE_CHIP_SHELL && CHIP_CONFIG_ENABLE_ICD_SERVER
 } // namespace
 
 #ifdef __cplusplus


### PR DESCRIPTION
#### Summary
Matter Shell build was failing for the Refrigerator App and there was an unused parameter only when matter shell was enabled for 917SoC.

Fixing the build for the Matter Shell for EFR32 and 917SoC

#### Testing
Local builds with matter shell enabled.

