### PR TITLE
re-enable darwin Python REPL build

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -781,7 +781,7 @@ jobs:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"
 
-        if: github.actor != 'restyled-io[bot]' && false
+        if: github.actor != 'restyled-io[bot]'
         runs-on: macos-13
 
         steps:
@@ -812,6 +812,7 @@ jobs:
                       --copy-artifacts-to objdir-clone \
                    "
             - name: Run Tests
+              if: false # disable darwin test runs for now as they were very flaky in the past
               run: |
                   scripts/run_in_python_env.sh out/venv './scripts/tests/run_python_test.py --app out/darwin-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factory-reset --quiet --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files

--- a/.gitmodules
+++ b/.gitmodules
@@ -344,7 +344,7 @@
 [submodule "third_party/libdatachannel/repo"]
 	path = third_party/libdatachannel/repo
 	url = https://github.com/paullouisageneau/libdatachannel.git
-	platforms = linux
+	platforms = linux,darwin
 	recursive = true
 [submodule "third_party/openthread/ot-realtek"]
 	path = third_party/openthread/ot-realtek


### PR DESCRIPTION
#### Summary

Darwin Python REPL tests were disabled some time ago in #16441 due to flakiness/poor pass rates.
Luckily, they have continued to be buildable until very recently, but let's not count on luck alone.

- [x] Step 1:  Re-enable build
- [x] Step 2:  See if tests handle numerous re-runs and pass (result: tests do not pass, so just enabling build for now and skipping the tests)

If Step 2 doesn't work out, re-enabling the build alone for now will suffice.

#### Related issues

Fixes #40176

#### Testing

- CI (specifically `REPL Tests - Darwin` job)

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
