### PR TITLE
[Camera] Support camera session re-establishment without peforming reset

### DIFF
--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -352,6 +352,7 @@ CHIP_ERROR WebRTCProviderManager::HandleEndSession(uint16_t sessionId, WebRTCEnd
         mOriginatingEndpointId = 0;
         mPeerId                = ScopedNodeId();
         mLocalSdp.clear();
+        mLocalCandidates.clear();
     }
 
     return CHIP_NO_ERROR;

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -69,7 +69,7 @@ void WebRTCProviderManager::SetMediaController(MediaController * mediaController
 CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                                      bool & outDeferredOffer)
 {
-    if (!mPeerConnection)
+    if (mPeerConnection == nullptr)
     {
         // Re-initialization of PeerConnection is needed
         Init();
@@ -172,7 +172,7 @@ CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestAr
 {
     ChipLogProgress(Camera, "HandleProvideOffer called");
 
-    if (!mPeerConnection)
+    if (mPeerConnection == nullptr)
     {
         // Re-initialization of PeerConnection is needed
         Init();

--- a/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/webrtc-provider/webrtc-provider-manager.cpp
@@ -39,6 +39,7 @@ void WebRTCProviderManager::SetCameraDevice(CameraDeviceInterface * aCameraDevic
 
 void WebRTCProviderManager::Init()
 {
+    ChipLogProgress(Camera, "Initializing WebRTC PeerConnection");
     mPeerConnection = CreateWebRTCPeerConnection();
 
     mPeerConnection->SetCallbacks([this](const std::string & sdp, SDPType type) { this->OnLocalDescription(sdp, type); },
@@ -68,6 +69,11 @@ void WebRTCProviderManager::SetMediaController(MediaController * mediaController
 CHIP_ERROR WebRTCProviderManager::HandleSolicitOffer(const OfferRequestArgs & args, WebRTCSessionStruct & outSession,
                                                      bool & outDeferredOffer)
 {
+    if (!mPeerConnection)
+    {
+        // Re-initialization of PeerConnection is needed
+        Init();
+    }
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;
     outSession.peerNodeID  = args.peerNodeId;
@@ -165,6 +171,12 @@ void WebRTCProviderManager::RegisterWebrtcTransport(uint16_t sessionId)
 CHIP_ERROR WebRTCProviderManager::HandleProvideOffer(const ProvideOfferRequestArgs & args, WebRTCSessionStruct & outSession)
 {
     ChipLogProgress(Camera, "HandleProvideOffer called");
+
+    if (!mPeerConnection)
+    {
+        // Re-initialization of PeerConnection is needed
+        Init();
+    }
 
     // Initialize a new WebRTC session from the SolicitOfferRequestArgs
     outSession.id          = args.sessionId;

--- a/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
+++ b/examples/camera-app/linux/src/webrtc-libdatachannel.cpp
@@ -108,9 +108,13 @@ public:
 
     void SendData(const char * data, size_t size) override
     {
-        if (mTrack)
+        if (mTrack && mTrack->isOpen())
         {
             mTrack->send(reinterpret_cast<const std::byte *>(data), size);
+        }
+        else
+        {
+            ChipLogError(Camera, "Track is closed");
         }
     }
 


### PR DESCRIPTION
This PR,
* Fixed https://github.com/project-chip/connectedhomeip/issues/40212
* Supports for multiple session re-establishment without necessary to reset camera-app
* Fixes stability issues when runing multiple WEBRTC_1_X tests together in TH
### Testing
Running multiple TC_WEBRTC_1_X tests together from Test Harness.