### PR TITLE
[Chef] Initialise identify cluster instance at app init

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -4,6 +4,7 @@
 #include <app/data-model/Nullable.h>
 #include <app/util/attribute-storage.h>
 #include <app/util/config.h>
+#include <app/util/endpoint-config-api.h>
 #include <lib/core/DataModelTypes.h>
 
 using chip::app::DataModel::Nullable;
@@ -46,6 +47,40 @@ using namespace chip::app::Clusters;
 #endif // MATTER_DM_PLUGIN_ON_OFF_SERVER
 #endif // MATTER_DM_PLUGIN_PUMP_CONFIGURATION_AND_CONTROL_SERVER
 
+#if MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+#include <app/clusters/identify-server/identify-server.h>
+
+namespace {
+// TODO: Move this to a standalone cluster cpp file.
+
+constexpr size_t kIdentifyTableSize = MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT;
+static_assert(kIdentifyTableSize <= kEmberInvalidEndpointIndex, "Identify table size error");
+std::unique_ptr<struct Identify> gIdentifyInstanceTable[kIdentifyTableSize];
+
+void InitIdentifyCluster()
+{
+    const uint16_t endpointCount = emberAfEndpointCount();
+
+    for (uint16_t endpointIndex = 0; endpointIndex < endpointCount; endpointIndex++)
+    {
+        chip::EndpointId endpointId = emberAfEndpointFromIndex(endpointIndex);
+        if (endpointId == kInvalidEndpointId)
+        {
+            continue;
+        }
+
+        // Check if endpoint has Identify cluster enabled
+        uint16_t epIndex = emberAfGetClusterServerEndpointIndex(endpointId, chip::app::Clusters::Identify::Id,
+                                                                MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT);
+        if (epIndex >= kIdentifyTableSize)
+            continue;
+
+        gIdentifyInstanceTable[epIndex] =
+            std::make_unique<struct Identify>(endpointId, nullptr, nullptr, chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
+    }
+}
+#endif // MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT
+}
 namespace {
 
 // Please refer to https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces
@@ -541,6 +576,10 @@ void ApplicationInit()
     ChipLogProgress(NotSpecified, "Initializing MicrowaveOvenControl cluster.");
     InitChefMicrowaveOvenControlCluster();
 #endif // MATTER_DM_PLUGIN_MICROWAVE_OVEN_CONTROL_SERVER
+
+#if MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT > 0
+    InitIdentifyCluster();
+#endif // MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT
 }
 
 void ApplicationShutdown()

--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -79,8 +79,8 @@ void InitIdentifyCluster()
             std::make_unique<struct Identify>(endpointId, nullptr, nullptr, chip::app::Clusters::Identify::IdentifyTypeEnum::kNone);
     }
 }
+} // namespace
 #endif // MATTER_DM_IDENTIFY_CLUSTER_SERVER_ENDPOINT_COUNT
-}
 namespace {
 
 // Please refer to https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/namespaces


### PR DESCRIPTION
#### Summary

[Identify struct](https://github.com/project-chip/connectedhomeip/blob/252a32ba39f8497bf9406aab810bb4d8a77fd75c/src/app/clusters/identify-server/identify-server.h#L23) is not currently initialised in the chef app.

Unable to run TriggerEffect command `./chip-tool identify command-by-id 0x40 '{"0": 0, "1": 0}' 0x20 1`

```
[1753078444.549] [1:1] [EM] Handling via exchange: 31463r, Delegate: 0x562d43984128
[1753078444.549] [1:1] [DMG] InvokeRequestMessage =
[1753078444.549] [1:1] [DMG] {
[1753078444.549] [1:1] [DMG] 	suppressResponse = false, 
[1753078444.549] [1:1] [DMG] 	timedRequest = false, 
[1753078444.549] [1:1] [DMG] 	InvokeRequests =
[1753078444.549] [1:1] [DMG] 	[
[1753078444.549] [1:1] [DMG] 		CommandDataIB =
[1753078444.549] [1:1] [DMG] 		{
[1753078444.549] [1:1] [DMG] 			CommandPathIB =
[1753078444.549] [1:1] [DMG] 			{
[1753078444.549] [1:1] [DMG] 				EndpointId = 0x1,
[1753078444.549] [1:1] [DMG] 				ClusterId = 0x3,
[1753078444.549] [1:1] [DMG] 				CommandId = 0x40,
[1753078444.549] [1:1] [DMG] 			},
[1753078444.549] [1:1] [DMG] 			
[1753078444.549] [1:1] [DMG] 			CommandFields = 
[1753078444.549] [1:1] [DMG] 			{
[1753078444.549] [1:1] [DMG] 				0x0 = 0 (unsigned), 
[1753078444.549] [1:1] [DMG] 				0x1 = 0 (unsigned), 
[1753078444.549] [1:1] [DMG] 			},
[1753078444.549] [1:1] [DMG] 		},
[1753078444.549] [1:1] [DMG] 		
[1753078444.549] [1:1] [DMG] 	],
[1753078444.549] [1:1] [DMG] 	
[1753078444.549] [1:1] [DMG] 	InteractionModelRevision = 12
[1753078444.549] [1:1] [DMG] },
[1753078444.549] [1:1] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0003 e=1 p=o r=i
[1753078444.549] [1:1] [DMG] AccessControl: allowed
[1753078444.549] [1:1] [DMG] AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0x0000_0003 e=1 p=m r=i
[1753078444.549] [1:1] [DMG] AccessControl: allowed
[1753078444.549] [1:1] [DMG] Received command for Endpoint=1 Cluster=0x0000_0003 Command=0x0000_0040
[1753078444.549] [1:1] [ZCL] RX identify:trigger effect identifier 0x0 variant 0x0
[1753078444.549] [1:1] [ZCL] Failed to dispatch command, TLVError=zzz_generated/app-common/clusters/Identify/Commands.ipp:77: Success
[1753078444.549] [1:1] [DMG] Endpoint=1 Cluster=0x0000_0003 Command=0x0000_0040 status 0x85 (INVALID_COMMAND) (no additional context)
```



#### Testing

Verified TriggerEffect command `./chip-tool identify command-by-id 0x40 '{"0": 0, "1": 0}' 0x20 1` is successful on `rootnode_fan_7N2TobIlOX` chef device -

chip tool response -
```
[1753078861.494] [212901:212903] [DMG] Received Command Response Status for Endpoint=1 Cluster=0x0000_0003 Command=0x0000_0040 Status=0x0

```

