### PR TITLE
[NXP][MCXW71] Fix UART console issue

### DIFF
--- a/examples/lock-app/nxp/mcxw71/args.gni
+++ b/examples/lock-app/nxp/mcxw71/args.gni
@@ -39,7 +39,6 @@ is_debug = false
 chip_crypto = "platform"
 chip_openthread_ftd = false
 nxp_enable_ot_cli = false
-nxp_enable_matter_cli = true
 
 chip_with_diag_logs_demo = true
 nxp_use_low_power = false

--- a/third_party/openthread/platforms/nxp/mcxw71/BUILD.gn
+++ b/third_party/openthread/platforms/nxp/mcxw71/BUILD.gn
@@ -56,6 +56,12 @@ config("openthread_mcxw71_config") {
     defines += [ "CONFIG_SETTINGS_RUNTIME=1" ]
   }
 
+  # When CLI is enabled, device log is being moved over to UART0 (auxiliary
+  # serial port) so that the CLI can be available on the default UART1
+  if (nxp_enable_matter_cli) {
+    defines += [ "OT_APP_UART_INSTANCE=0" ]
+  }
+
   cflags = [
     "-Wno-shadow",
     "-Wno-sign-compare",


### PR DESCRIPTION
#### Summary

Matter CLI always uses the default UART port (UART1) hence, when it is enabled, the device logs will have to be relocated to UART0 in order to have both features operational.

#### Testing

Manually tested.
