### PR TITLE
script for TC-BRBINFO-3.2: align text in script to match test plan text updates (no code changes)

### DIFF
--- a/src/python_testing/TC_BRBINFO_3_2.py
+++ b/src/python_testing/TC_BRBINFO_3_2.py
@@ -83,7 +83,7 @@ class TC_BRBINFO_3_2(MatterBaseTest):
             self.write_to_app_pipe(command_dict)
         else:
             self.wait_for_user_input(
-                prompt_msg="Change the configuration version in a way which results in functionality to be added or removed, then continue")
+                prompt_msg="On the corresponding bridged device, change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode), then continue")
 
         self.step(3)
         newConfigurationVersion = await self.read_brbinfo_attribute_expect_success(endpoint=endpoint, attribute=attributes.ConfigurationVersion)

--- a/src/python_testing/TC_BRBINFO_3_2.py
+++ b/src/python_testing/TC_BRBINFO_3_2.py
@@ -50,10 +50,10 @@ class TC_BRBINFO_3_2(MatterBaseTest):
 
     def steps_TC_BRBINFO_3_2(self) -> list[TestStep]:
         steps = [
-            TestStep(1, "TH reads ConfigurationVersion from the DUT and stores the value as initialConfigurationVersion",
+            TestStep(1, "TH reads ConfigurationVersion and stores the value as initialConfigurationVersion",
                      "Verify that the value is in the inclusive range of 1 to 4294967295"),
-            TestStep(2, "Change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
-            TestStep(3, "TH reads ConfigurationVersion from the DUT",
+            TestStep(2, " On the corresponding bridged device, change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
+            TestStep(3, "TH reads ConfigurationVersion from the DUT (same endpoint as in step 1)",
                      "Verify that the value is higher than the value of initialConfigurationVersion"),
         ]
         return steps

--- a/src/python_testing/TC_BRBINFO_3_2.py
+++ b/src/python_testing/TC_BRBINFO_3_2.py
@@ -52,7 +52,7 @@ class TC_BRBINFO_3_2(MatterBaseTest):
         steps = [
             TestStep(1, "TH reads ConfigurationVersion and stores the value as initialConfigurationVersion",
                      "Verify that the value is in the inclusive range of 1 to 4294967295"),
-            TestStep(2, " On the corresponding bridged device, change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
+            TestStep(2, "On the corresponding bridged device, change the configuration version in a way which results in functionality to be added or removed (e.g. rewire thermostat to support a new mode)"),
             TestStep(3, "TH reads ConfigurationVersion from the DUT (same endpoint as in step 1)",
                      "Verify that the value is higher than the value of initialConfigurationVersion"),
         ]


### PR DESCRIPTION
#### Summary

For feature "Node reconfiguration", the attribute ConfigurationVersion was introducted in 1.4.2 spec.
(Provisional in 1.4.2 due to lack of tests executed during SVE/MVE;
for 1.5 release , this is due to become certifiable with tests)

One of the tests for this attribute, TC-BRBINFO-3.2, had confusing language and seems to have been written for a DUT being a device, not being a bridge.
Test plan [PR 5228](https://github.com/CHIP-Specifications/chip-test-plans/pull/5228) updates the text.
This PR makes the corresponding updates to the text in the script for this test.

NOTE: no change to logic or code - just text strings (test operator instructions) got changed.

This PR updates the text to make the configuration change on the bridged device

#### Related issues

Test plan [PR 5228](https://github.com/CHIP-Specifications/chip-test-plans/pull/5228) 

#### Testing

no SDK testing needed, just text changes in a test script

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase
