### PR TITLE
[QPG] configure lighting application as Thread FTD device

### DIFF
--- a/examples/lighting-app/qpg/args.gni
+++ b/examples/lighting-app/qpg/args.gni
@@ -20,7 +20,7 @@ import("${chip_root}/examples/platform/qpg/args.gni")
 qpg_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
-chip_openthread_ftd = false
+chip_openthread_ftd = true
 enable_sleepy_device = false
 
 # Disable lock tracking, since our FreeRTOS configuration does not set


### PR DESCRIPTION
#### Summary
- Change QPG Light app as Thread FTD device

#### Related issues
- N/A

#### Testing
- internal regression test on FTD device passes

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
