### PR TITLE
[Closures] Fix EP1 Partslist attribute

### DIFF
--- a/examples/closure-app/closure-common/closure-app.zap
+++ b/examples/closure-app/closure-common/closure-app.zap
@@ -6139,7 +6139,7 @@
       "profileId": 259,
       "endpointId": 2,
       "networkId": 0,
-      "parentEndpointIdentifier": null
+      "parentEndpointIdentifier": 1
     },
     {
       "endpointTypeName": "Anonymous Endpoint Type",
@@ -6147,7 +6147,7 @@
       "profileId": 259,
       "endpointId": 3,
       "networkId": 0,
-      "parentEndpointIdentifier": null
+      "parentEndpointIdentifier": 1
     }
   ]
 }


### PR DESCRIPTION
#### Summary
At Present EP1 has a empty parts list.  By spec  it actually contain EP2 and EP3.

Updated the .zap file using zaptool to reflect EP1 as parentendpoint for EP2 and EP3.

#### Testing

tested manaully using chiptool command 
chip-tool descriptor read parts-list <comissionerId> 1

[1753195272.757] [384957:384959] [TOO] Endpoint: 1 Cluster: 0x0000_001D Attribute 0x0000_0003 DataVersion: 2439923301
[1753195272.757] [384957:384959] [TOO]   PartsList: 2 entries
[1753195272.757] [384957:384959] [TOO]     [1]: 2
[1753195272.757] [384957:384959] [TOO]     [2]: 3


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
