### PR TITLE
[FIX] Reverting #40017 And Changing Camera App Target Parameter

### DIFF
--- a/examples/camera-app/linux/BUILD.gn
+++ b/examples/camera-app/linux/BUILD.gn
@@ -22,10 +22,7 @@ import("${build_root}/config/linux/pkg_config.gni")
 assert(chip_build_tools)
 
 config("config") {
-  cflags = [
-    "-Wconversion",
-    "-Wno-shadow",
-  ]
+  cflags = [ "-Wno-shadow" ]
 
   if (is_clang) {
     # libdatachannel has a lot of these like:

--- a/examples/camera-controller/BUILD.gn
+++ b/examples/camera-controller/BUILD.gn
@@ -25,10 +25,7 @@ import("${chip_root}/src/lib/core/core.gni")
 assert(chip_build_tools)
 
 config("config") {
-  cflags = [
-    "-Wconversion",
-    "-Wno-shadow",
-  ]
+  cflags = [ "-Wno-shadow" ]
 
   if (is_clang) {
     # libdatachannel has a lot of these like:

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -156,7 +156,7 @@ RUN case ${TARGETPLATFORM} in \
     set -x \
     && source scripts/activate.sh \
     && scripts/build/build_examples.py \
-    --target linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission \
+    --target linux-x64-chip-tool-ipv6only-platform-mdns \
     --target linux-x64-shell-ipv6only-platform-mdns \
     --target linux-x64-chip-cert-ipv6only-platform-mdns \
     --target linux-x64-air-purifier-ipv6only \
@@ -186,7 +186,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-camera-ipv6only \
     --target linux-x64-camera-controller-ipv6only \
     build \
-    && mv out/linux-x64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
+    && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
     && mv out/linux-x64-chip-cert-ipv6only-platform-mdns/chip-cert out/chip-cert \
     && mv out/linux-x64-air-purifier-ipv6only/chip-air-purifier-app out/chip-air-purifier-app \
@@ -220,7 +220,7 @@ RUN case ${TARGETPLATFORM} in \
     set -x \
     && source scripts/activate.sh \
     && scripts/build/build_examples.py \
-    --target linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission \
+    --target linux-arm64-chip-tool-ipv6only-platform-mdns \
     --target linux-arm64-shell-ipv6only-platform-mdns \
     --target linux-arm64-chip-cert-ipv6only-platform-mdns \
     --target linux-arm64-air-purifier-ipv6only \
@@ -250,7 +250,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-camera-clang-ipv6only \
     --target linux-arm64-camera-controller-ipv6only \
     build \
-    && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
+    && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
     && mv out/linux-arm64-chip-cert-ipv6only-platform-mdns/chip-cert out/chip-cert \
     && mv out/linux-arm64-air-purifier-ipv6only/chip-air-purifier-app out/chip-air-purifier-app \

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -247,7 +247,7 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-network-manager-ipv6only \
     --target linux-arm64-terms-and-conditions-ipv6only \
     --target linux-arm64-water-leak-detector-ipv6only \
-    --target linux-arm64-camera-ipv6only \
+    --target linux-arm64-camera-clang-ipv6only \
     --target linux-arm64-camera-controller-ipv6only \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns-nfc-commission/chip-tool out/chip-tool \
@@ -277,7 +277,7 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-network-manager-ipv6only/matter-network-manager-app out/matter-network-manager-app \
     && mv out/linux-arm64-terms-and-conditions-ipv6only/chip-terms-and-conditions-app out/chip-terms-and-conditions-app \
     && mv out/linux-arm64-water-leak-detector-ipv6only/water-leak-detector-app out/water-leak-detector-app \
-    && mv out/linux-arm64-camera-ipv6only/chip-camera-app out/chip-camera-app \
+    && mv out/linux-arm64-camera-clang-ipv6only/chip-camera-app out/chip-camera-app \
     && mv out/linux-arm64-camera-controller-ipv6only/chip-camera-controller out/chip-camera-controller \
     ;; \
     *) ;; \


### PR DESCRIPTION
#### IMPORTANT

This change is **reverting** the following PR [#40017](https://github.com/project-chip/connectedhomeip/pull/40017) since it was causing a failure using the SDK container (Tested with TH v2.14-beta1.1+winter2025 release).

#### Summary

This fix changes the chip-cert-bins Dockerfile to use Clang target for the ARM64 camera app. This is necessary since the build process was failing due a warning result of a conversion (int to char) used by the third party GStreamer lib.
Since GCC wasn't recognizing the avoid warning flags (e.g. `-Wno-implicit-int-conversion`), the solution was to use Clang as the camera app code already had a related "if condition" block when running with that compiler.

#### Testing

Full chip-cert-bins build completed.
