### PR TITLE
Add a method to iterate all attributes in ClusterStateCache.

### DIFF
--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -434,13 +434,13 @@ public:
     template <typename IteratorFunc>
     CHIP_ERROR ForEachAttribute(IteratorFunc func) const
     {
-        for (auto & endpointIter : mCache)
+        for (const auto & [endpointId, endpointState] : mCache)
         {
-            for (auto & clusterIter : endpointIter.second)
+            for (const auto & [clusterId, clusterState] : endpointState)
             {
-                for (auto & attributeIter : clusterIter.second.mAttributes)
+                for (const auto & [attributeId, _] : clusterState.mAttributes)
                 {
-                    const ConcreteAttributePath path(endpointIter.first, clusterIter.first, attributeIter.first);
+                    const ConcreteAttributePath path(endpointId, clusterId, attributeId);
                     ReturnErrorOnFailure(func(path));
                 }
             }

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -438,9 +438,9 @@ public:
         {
             for (const auto & [clusterId, clusterState] : endpointState)
             {
-                for (const auto & [attributeId, _] : clusterState.mAttributes)
+                for (const auto & attributeIter : clusterState.mAttributes)
                 {
-                    const ConcreteAttributePath path(endpointId, clusterId, attributeId);
+                    const ConcreteAttributePath path(endpointId, clusterId, attributeIter.first);
                     ReturnErrorOnFailure(func(path));
                 }
             }

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -420,6 +420,35 @@ public:
     }
 
     /*
+     * Execute an iterator function that is called for every attribute
+     * in the cache.  The function is passed a concrete attribute path
+     * to every attribute in the cache.
+     *
+     * The iterator is expected to have this signature:
+     *      CHIP_ERROR IteratorFunc(const ConcreteAttributePath &path);
+     *
+     * Notable return values:
+     *      - If func returns an error, that will result in termination of any further iteration over attributes
+     *        and that error shall be returned back up to the original call to this function.
+     */
+    template <typename IteratorFunc>
+    CHIP_ERROR ForEachAttribute(IteratorFunc func) const
+    {
+        for (auto & endpointIter : mCache)
+        {
+            for (auto & clusterIter : endpointIter.second)
+            {
+                for (auto & attributeIter : clusterIter.second.mAttributes)
+                {
+                    const ConcreteAttributePath path(endpointIter.first, clusterIter.first, attributeIter.first);
+                    ReturnErrorOnFailure(func(path));
+                }
+            }
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    /*
      * Execute an iterator function that is called for every cluster
      * in a given endpoint and passed a ClusterId for every cluster that
      * matches.


### PR DESCRIPTION
Commissioning API consumers can request extra attributes be read in the "read data from commissionee" step, and they get notified with the resulting ClusterStateCache, but that cache has no way to iterate over all the things that got read.  This PR is adding such a method.

#### Testing

Manual testing (in a separate PR that uses this) for now.  Not quite sure how to best add tests for this to the existing cluster state cache bits, since none of the other For* bits are tested right now.