### PR TITLE
Unify CHIP_ERROR formatting throughout SDK

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/static-supported-temperature-levels.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/static-supported-temperature-levels.cpp
@@ -56,7 +56,7 @@ CHIP_ERROR AppSupportedTemperatureLevelsDelegate::Next(MutableCharSpan & item)
                 CHIP_ERROR err = CopyCharSpanToMutableCharSpan(endpointPair.mTemperatureLevels[mIndex], item);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(Zcl, "Error copying char span to mutable char span %s", ErrorStr(err));
+                    ChipLogError(Zcl, "Error copying char span to mutable char span: %" CHIP_ERROR_FORMAT, err.Format());
                     return err;
                 }
                 mIndex++;

--- a/examples/energy-management-app/energy-management-common/device-energy-management/src/DEMTestEventTriggers.cpp
+++ b/examples/energy-management-app/energy-management-common/device-energy-management/src/DEMTestEventTriggers.cpp
@@ -146,7 +146,7 @@ void SetTestEventTrigger_PowerAdjustment()
     CHIP_ERROR err = GetDEMDelegate()->SetPowerAdjustmentCapability(sPowerAdjustmentCapability);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Support, "SetTestEventTrigger_PowerAdjustment failed %s", chip::ErrorStr(err));
+        ChipLogError(Support, "SetTestEventTrigger_PowerAdjustment failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -168,7 +168,7 @@ void SetTestEventTrigger_ClearForecast()
     CHIP_ERROR err = GetDEMDelegate()->SetPowerAdjustmentCapability(powerAdjustmentCapabilityStruct);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Support, "SetTestEventTrigger_PowerAdjustment failed %s", chip::ErrorStr(err));
+        ChipLogError(Support, "SetTestEventTrigger_PowerAdjustment failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseTargetsStore.cpp
+++ b/examples/energy-management-app/energy-management-common/energy-evse/src/EnergyEvseTargetsStore.cpp
@@ -187,7 +187,7 @@ CHIP_ERROR EvseTargetsDelegate::LoadTargets()
         err = mChargingTargets.AllocAndCopy();
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "SetTargets: Failed to allocate memory during LoadTargets %s", chip::ErrorStr(err));
+            ChipLogError(AppServer, "SetTargets: Failed to allocate memory during LoadTargets: %" CHIP_ERROR_FORMAT, err.Format());
             return err;
         }
 
@@ -307,7 +307,8 @@ CHIP_ERROR EvseTargetsDelegate::SetTargets(
                 CHIP_ERROR err = updatedChargingTargets.AllocAndCopy(newChargingTargetSchedule.chargingTargets);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets %s", chip::ErrorStr(err));
+                    ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets: %" CHIP_ERROR_FORMAT,
+                                 err.Format());
                     return err;
                 }
 
@@ -322,7 +323,8 @@ CHIP_ERROR EvseTargetsDelegate::SetTargets(
                 CHIP_ERROR err = updatedChargingTargets.AllocAndCopy(currentChargingTargetSchedule.chargingTargets);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets %s", chip::ErrorStr(err));
+                    ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets: %" CHIP_ERROR_FORMAT,
+                                 err.Format());
                     return err;
                 }
             }
@@ -348,7 +350,7 @@ CHIP_ERROR EvseTargetsDelegate::SetTargets(
             CHIP_ERROR err = updatedChargingTargets.AllocAndCopy(newChargingTargetSchedule.chargingTargets);
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets %s", chip::ErrorStr(err));
+                ChipLogError(AppServer, "SetTargets: Failed to copy the new chargingTargets: %" CHIP_ERROR_FORMAT, err.Format());
                 return err;
             }
 
@@ -374,7 +376,7 @@ CHIP_ERROR EvseTargetsDelegate::SetTargets(
         CHIP_ERROR err = SaveTargets(updatedChargingTargetSchedulesList);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "SetTargets: Failed to save Target to persistent storage %s", chip::ErrorStr(err));
+            ChipLogError(AppServer, "SetTargets: Failed to save Target to persistent storage: %" CHIP_ERROR_FORMAT, err.Format());
             return err;
         }
 
@@ -382,7 +384,7 @@ CHIP_ERROR EvseTargetsDelegate::SetTargets(
         err = LoadTargets();
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "SetTargets: Failed to load Target from persistent storage %s", chip::ErrorStr(err));
+            ChipLogError(AppServer, "SetTargets: Failed to load Target from persistent storage: %" CHIP_ERROR_FORMAT, err.Format());
             return err;
         }
     }

--- a/examples/energy-management-app/energy-management-common/water-heater/src/WhmMain.cpp
+++ b/examples/energy-management-app/energy-management-common/water-heater/src/WhmMain.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR WhmInit(EndpointId endpointId)
     err = gWhmInstance->Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "gWhmInstance->Init failed %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "gWhmInstance->Init failed: %" CHIP_ERROR_FORMAT, err.Format());
         gWhmInstance.reset();
         gWhmDelegate.reset();
         return err;

--- a/examples/light-switch-app/qpg/src/AppTask.cpp
+++ b/examples/light-switch-app/qpg/src/AppTask.cpp
@@ -144,7 +144,7 @@ bool AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
 
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(NotSpecified, "StartTimer failed %s: ", chip::ErrorStr(err));
+                ChipLogError(NotSpecified, "StartTimer failed: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
         else
@@ -160,7 +160,7 @@ bool AppTask::ButtonEventHandler(uint8_t btnIdx, bool btnPressed)
 
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(NotSpecified, "StartTimer failed %s: ", chip::ErrorStr(err));
+                ChipLogError(NotSpecified, "StartTimer failed: %" CHIP_ERROR_FORMAT, err.Format());
             }
 
             // if we have active multipress window we need to send extra event

--- a/examples/lighting-app/silabs/zephyr/src/AppTask.cpp
+++ b/examples/lighting-app/silabs/zephyr/src/AppTask.cpp
@@ -40,7 +40,7 @@ void AppTask::PostInitMatterStack()
     err = InitBindingHandlers();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "InitBindingHandlers failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "InitBindingHandlers failed: %" CHIP_ERROR_FORMAT, err.Format());
         goto exit;
     }
 #endif

--- a/examples/refrigerator-app/refrigerator-common/src/static-supported-temperature-levels.cpp
+++ b/examples/refrigerator-app/refrigerator-common/src/static-supported-temperature-levels.cpp
@@ -60,7 +60,7 @@ CHIP_ERROR AppSupportedTemperatureLevelsDelegate::Next(MutableCharSpan & item)
                 CHIP_ERROR err = CopyCharSpanToMutableCharSpan(endpointPair.mTemperatureLevels[mIndex], item);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(Zcl, "Error copying char span to mutable char span %s", ErrorStr(err));
+                    ChipLogError(Zcl, "Error copying char span to mutable char span: %" CHIP_ERROR_FORMAT, err.Format());
                     return err;
                 }
                 mIndex++;

--- a/examples/tv-app/tv-common/src/AppTv.cpp
+++ b/examples/tv-app/tv-common/src/AppTv.cpp
@@ -175,7 +175,7 @@ class MyPostCommissioningListener : public PostCommissioningListener
             cluster.ReadAttribute<Binding::Attributes::Binding::TypeInfo>(this, OnReadSuccessResponse, OnReadFailureResponse);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "Failed in reading binding. Error %s", ErrorStr(err));
+            ChipLogError(Controller, "Failed in reading binding: %" CHIP_ERROR_FORMAT, err.Format());
             clearContext();
         }
     }

--- a/src/app/app-platform/ContentApp.cpp
+++ b/src/app/app-platform/ContentApp.cpp
@@ -159,7 +159,7 @@ CHIP_ERROR ContentAppClientCommandSender::SendMessage(chip::Messaging::ExchangeM
     CHIP_ERROR err       = cluster.InvokeCommand(request, nullptr, OnCommandResponse, OnCommandFailure);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogDetail(Controller, "ContentAppClientCommandSender SendMessage error err %s", ErrorStr(err));
+        ChipLogDetail(Controller, "ContentAppClientCommandSender SendMessage error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     mIsBusy = false;
@@ -170,7 +170,7 @@ CHIP_ERROR ContentAppClientCommandSender::SendMessage(chip::Messaging::ExchangeM
 
 void ContentAppClientCommandSender::OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR err)
 {
-    ChipLogProgress(Controller, "ContentAppClientCommandSender::OnDeviceConnectedFn error err %s", ErrorStr(err));
+    ChipLogProgress(Controller, "ContentAppClientCommandSender::OnDeviceConnectedFn error: %" CHIP_ERROR_FORMAT, err.Format());
 
     ContentAppClientCommandSender * sender = reinterpret_cast<ContentAppClientCommandSender *>(context);
     VerifyOrReturn(sender != nullptr, ChipLogError(chipTool, "OnDeviceConnectionFailureFn: context is null"));
@@ -191,7 +191,7 @@ void ContentAppClientCommandSender::OnCommandResponse(void * context, const Cont
 
 void ContentAppClientCommandSender::OnCommandFailure(void * context, CHIP_ERROR error)
 {
-    ChipLogProgress(Controller, "ContentAppClientCommandSender::OnCommandFailure error err %s", ErrorStr(error));
+    ChipLogProgress(Controller, "ContentAppClientCommandSender::OnCommandFailure error: %" CHIP_ERROR_FORMAT, error.Format());
 }
 
 } // namespace AppPlatform

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -615,8 +615,8 @@ CHIP_ERROR ContentAppPlatform::GetACLEntryIndex(size_t * foundIndex, FabricIndex
             CHIP_ERROR err = Access::GetAccessControl().ReadEntry(fabricIndex, --index, entry);
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogDetail(DeviceLayer, "ContentAppPlatform::GetACLEntryIndex error reading entry %d err %s",
-                              static_cast<int>(index), ErrorStr(err));
+                ChipLogDetail(DeviceLayer, "ContentAppPlatform::GetACLEntryIndex error reading entry %d: %" CHIP_ERROR_FORMAT,
+                              static_cast<int>(index), err.Format());
             }
             else
             {
@@ -624,9 +624,10 @@ CHIP_ERROR ContentAppPlatform::GetACLEntryIndex(size_t * foundIndex, FabricIndex
                 err = entry.GetSubjectCount(count);
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogDetail(DeviceLayer,
-                                  "ContentAppPlatform::GetACLEntryIndex error reading subject count for entry %d err %s",
-                                  static_cast<int>(index), ErrorStr(err));
+                    ChipLogDetail(
+                        DeviceLayer,
+                        "ContentAppPlatform::GetACLEntryIndex error reading subject count for entry %d: %" CHIP_ERROR_FORMAT,
+                        static_cast<int>(index), err.Format());
                     continue;
                 }
                 if (count)
@@ -638,9 +639,10 @@ CHIP_ERROR ContentAppPlatform::GetACLEntryIndex(size_t * foundIndex, FabricIndex
                         err = entry.GetSubject(i, subject);
                         if (err != CHIP_NO_ERROR)
                         {
-                            ChipLogDetail(DeviceLayer,
-                                          "ContentAppPlatform::GetACLEntryIndex error reading subject %i for entry %d err %s",
-                                          static_cast<int>(i), static_cast<int>(index), ErrorStr(err));
+                            ChipLogDetail(
+                                DeviceLayer,
+                                "ContentAppPlatform::GetACLEntryIndex error reading subject %i for entry %d: %" CHIP_ERROR_FORMAT,
+                                static_cast<int>(i), static_cast<int>(index), err.Format());
                             continue;
                         }
                         if (subject == subjectNodeId)
@@ -684,8 +686,8 @@ CHIP_ERROR ContentAppPlatform::ManageClientAccess(Messaging::ExchangeManager & e
             err = Access::GetAccessControl().DeleteEntry(nullptr, fabricIndex, index);
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogDetail(DeviceLayer, "ContentAppPlatform::ManageClientAccess error entry %d err %s", static_cast<int>(index),
-                              ErrorStr(err));
+                ChipLogDetail(DeviceLayer, "ContentAppPlatform::ManageClientAccess error entry %d: %" CHIP_ERROR_FORMAT,
+                              static_cast<int>(index), err.Format());
             }
         }
     }

--- a/src/app/server/EchoHandler.cpp
+++ b/src/app/server/EchoHandler.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR InitEchoHandler(chip::Messaging::ExchangeManager * exchangeMgr)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "EchoServer failed, err:%s\n", chip::ErrorStr(err));
+        ChipLogError(AppServer, "EchoServer failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -513,7 +513,7 @@ CommissioningStage AutoCommissioner::GetNextCommissioningStageInternal(Commissio
 // No specific actions to take when an error happens since this command can fail and commissioning can still succeed.
 static void OnFailsafeFailureForCASE(void * context, CHIP_ERROR error)
 {
-    ChipLogProgress(Controller, "ExtendFailsafe received failure response %s\n", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "ExtendFailsafe received failure response: %" CHIP_ERROR_FORMAT, error.Format());
 }
 
 // No specific actions to take upon success.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1182,7 +1182,7 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
     CHIP_ERROR err = device->SetConnected(session);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed in setting up secure channel: err %s", ErrorStr(err));
+        ChipLogError(Controller, "Failed in setting up secure channel: %" CHIP_ERROR_FORMAT, err.Format());
         OnSessionEstablishmentError(err);
         return;
     }
@@ -1220,7 +1220,8 @@ CHIP_ERROR DeviceCommissioner::SendCertificateChainRequestCommand(DeviceProxy * 
 void DeviceCommissioner::OnCertificateChainFailureResponse(void * context, CHIP_ERROR error)
 {
     MATTER_TRACE_SCOPE("OnCertificateChainFailureResponse", "DeviceCommissioner");
-    ChipLogProgress(Controller, "Device failed to receive the Certificate Chain request Response: %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Device failed to receive the Certificate Chain request Response: %" CHIP_ERROR_FORMAT,
+                    error.Format());
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(error);
 }
@@ -1257,7 +1258,8 @@ CHIP_ERROR DeviceCommissioner::SendAttestationRequestCommand(DeviceProxy * devic
 void DeviceCommissioner::OnAttestationFailureResponse(void * context, CHIP_ERROR error)
 {
     MATTER_TRACE_SCOPE("OnAttestationFailureResponse", "DeviceCommissioner");
-    ChipLogProgress(Controller, "Device failed to receive the Attestation Information Response: %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Device failed to receive the Attestation Information Response: %" CHIP_ERROR_FORMAT,
+                    error.Format());
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(error);
 }
@@ -1393,7 +1395,8 @@ void DeviceCommissioner::HandleDeviceAttestationCompleted()
 
 void DeviceCommissioner::OnFailedToExtendedArmFailSafeDeviceAttestation(void * context, CHIP_ERROR error)
 {
-    ChipLogProgress(Controller, "Failed to extend fail-safe timer to handle attestation failure %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Failed to extend fail-safe timer to handle attestation failure: %" CHIP_ERROR_FORMAT,
+                    error.Format());
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     CommissioningDelegate::CommissioningReport report;
@@ -1573,7 +1576,7 @@ CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(D
 void DeviceCommissioner::OnCSRFailureResponse(void * context, CHIP_ERROR error)
 {
     MATTER_TRACE_SCOPE("OnCSRFailureResponse", "DeviceCommissioner");
-    ChipLogProgress(Controller, "Device failed to receive the CSR request Response: %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Device failed to receive the CSR request Response: %" CHIP_ERROR_FORMAT, error.Format());
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(error);
 }
@@ -1606,14 +1609,16 @@ void DeviceCommissioner::OnDeviceNOCChainGeneration(void * context, CHIP_ERROR s
         status = CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    ChipLogProgress(Controller, "Received callback from the CA for NOC Chain generation. Status %s", ErrorStr(status));
+    ChipLogProgress(Controller, "Received callback from the CA for NOC Chain generation. Status: %" CHIP_ERROR_FORMAT,
+                    status.Format());
     if (status == CHIP_NO_ERROR && commissioner->mState != State::Initialized)
     {
         status = CHIP_ERROR_INCORRECT_STATE;
     }
     if (status != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed in generating device's operational credentials. Error %s", ErrorStr(status));
+        ChipLogError(Controller, "Failed in generating device's operational credentials. Error: %" CHIP_ERROR_FORMAT,
+                     status.Format());
     }
 
     // TODO - Verify that the generated root cert matches with commissioner's root cert
@@ -1731,7 +1736,8 @@ CHIP_ERROR DeviceCommissioner::ConvertFromOperationalCertStatus(OperationalCrede
 void DeviceCommissioner::OnAddNOCFailureResponse(void * context, CHIP_ERROR error)
 {
     MATTER_TRACE_SCOPE("OnAddNOCFailureResponse", "DeviceCommissioner");
-    ChipLogProgress(Controller, "Device failed to receive the operational certificate Response: %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Device failed to receive the operational certificate Response: %" CHIP_ERROR_FORMAT,
+                    error.Format());
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(error);
 }
@@ -1757,7 +1763,7 @@ void DeviceCommissioner::OnOperationalCertificateAddResponse(
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogProgress(Controller, "Add NOC failed with error %s", ErrorStr(err));
+        ChipLogProgress(Controller, "Add NOC failed with error: %" CHIP_ERROR_FORMAT, err.Format());
         commissioner->CommissioningStageComplete(err);
     }
 }
@@ -1791,7 +1797,7 @@ void DeviceCommissioner::OnRootCertSuccessResponse(void * context, const chip::a
 void DeviceCommissioner::OnRootCertFailureResponse(void * context, CHIP_ERROR error)
 {
     MATTER_TRACE_SCOPE("OnRootCertFailureResponse", "DeviceCommissioner");
-    ChipLogProgress(Controller, "Device failed to receive the root certificate Response: %s", chip::ErrorStr(error));
+    ChipLogProgress(Controller, "Device failed to receive the root certificate Response: %" CHIP_ERROR_FORMAT, error.Format());
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(error);
 }

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -180,7 +180,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIssuerKeypairStorage, ErrorStr(err));
+        ChipLogProgress(Controller, "Couldn't get %s from storage: %" CHIP_ERROR_FORMAT,
+                        kOperationalCredentialsIssuerKeypairStorage, err.Format());
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mRootIssuer.Initialize(Crypto::ECPKeyTarget::ECDSA));
         ReturnErrorOnFailure(mRootIssuer.Serialize(serializedKey));
@@ -206,8 +207,8 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDele
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogProgress(Controller, "Couldn't get %s from storage: %s", kOperationalCredentialsIntermediateIssuerKeypairStorage,
-                        ErrorStr(err));
+        ChipLogProgress(Controller, "Couldn't get %s from storage: %" CHIP_ERROR_FORMAT,
+                        kOperationalCredentialsIntermediateIssuerKeypairStorage, err.Format());
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
         ReturnErrorOnFailure(mIntermediateIssuer.Initialize(Crypto::ECPKeyTarget::ECDSA));
         ReturnErrorOnFailure(mIntermediateIssuer.Serialize(serializedKey));

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -310,8 +310,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     }
 
     VerifyOrReturn(aStatus.IsSuccess(),
-                   ChipLogError(Controller, "Receive bad status %" CHIP_ERROR_FORMAT, aStatus.ToChipError().Format()));
-    aPath.LogPath();
+                   ChipLogError(Controller, "Receive bad status %" CHIP_ERROR_FORMAT, aStatus.ToChipError().Format());
+                   aPath.LogPath());
     VerifyOrReturn(apData != nullptr, ChipLogError(Controller, "Receive empty apData"); aPath.LogPath());
 
     TLV::TLVReader readerForJavaTLV;
@@ -332,8 +332,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     }
 
     VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Fail to decode attribute with error %" CHIP_ERROR_FORMAT, err.Format()));
-    aPath.LogPath();
+                   ChipLogError(Controller, "Fail to decode attribute with error %" CHIP_ERROR_FORMAT, err.Format());
+                   aPath.LogPath());
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 #else
     value = DecodeGeneralTLVValue(env, readerForJavaObject, err);
@@ -491,8 +491,8 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
         err   = CHIP_NO_ERROR;
     }
     VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Fail to decode event with error %" CHIP_ERROR_FORMAT, err.Format()));
-    aEventHeader.LogPath();
+                   ChipLogError(Controller, "Fail to decode event with error %" CHIP_ERROR_FORMAT, err.Format());
+                   aEventHeader.LogPath());
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 #else
     value = DecodeGeneralTLVValue(env, readerForJavaObject, err);

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -119,11 +119,11 @@ void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context,
     jthrowable exception;
     err = AndroidConnectionFailureExceptions::GetInstance().CreateAndroidConnectionFailureException(
         env, failureInfo.error.Format(), failureInfo.error.AsInteger(), failureInfo.sessionStage, exception);
-    VerifyOrReturn(
-        err == CHIP_NO_ERROR,
-        ChipLogError(Controller,
-                     "Unable to create AndroidControllerException on GetConnectedDeviceCallback::OnDeviceConnectionFailureFn: %s",
-                     ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller,
+                                "Unable to create AndroidControllerException on "
+                                "GetConnectedDeviceCallback::OnDeviceConnectionFailureFn: %" CHIP_ERROR_FORMAT,
+                                err.Format()));
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(javaCallback, failureMethod, failureInfo.peerId.GetNodeId(), exception);
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
@@ -309,8 +309,9 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
         VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
     }
 
-    VerifyOrReturn(aStatus.IsSuccess(), ChipLogError(Controller, "Receive bad status %s", ErrorStr(aStatus.ToChipError()));
-                   aPath.LogPath());
+    VerifyOrReturn(aStatus.IsSuccess(),
+                   ChipLogError(Controller, "Receive bad status %" CHIP_ERROR_FORMAT, aStatus.ToChipError().Format()));
+    aPath.LogPath();
     VerifyOrReturn(apData != nullptr, ChipLogError(Controller, "Receive empty apData"); aPath.LogPath());
 
     TLV::TLVReader readerForJavaTLV;
@@ -330,8 +331,9 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
         err   = CHIP_NO_ERROR;
     }
 
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Fail to decode attribute with error %s", ErrorStr(err));
-                   aPath.LogPath());
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Fail to decode attribute with error %" CHIP_ERROR_FORMAT, err.Format()));
+    aPath.LogPath();
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 #else
     value = DecodeGeneralTLVValue(env, readerForJavaObject, err);
@@ -347,7 +349,8 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     TLV::TLVWriter writer;
     writer.Init(buffer.get(), bufferLen);
     err = writer.CopyElement(TLV::AnonymousTag(), readerForJavaTLV);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Fail to copy tlv element with error %s", ErrorStr(err));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Fail to copy tlv element with error %" CHIP_ERROR_FORMAT, err.Format());
                    aPath.LogPath());
     size = writer.GetLengthWritten();
     chip::ByteArray jniByteArray(env, reinterpret_cast<jbyte *>(buffer.get()), static_cast<jint>(size));
@@ -356,7 +359,7 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     std::string json;
     err = ConvertReportTlvToJson(static_cast<uint32_t>(aPath.mAttributeId), *apData, json);
     VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Fail to convert report tlv to json with error %s", ErrorStr(err));
+                   ChipLogError(Controller, "Fail to convert report tlv to json with error %" CHIP_ERROR_FORMAT, err.Format());
                    aPath.LogPath());
     UtfString jsonString(env, json.c_str());
 
@@ -365,7 +368,7 @@ void ReportCallback::OnAttributeData(const app::ConcreteDataAttributePath & aPat
     err = JniReferences::GetInstance().FindMethod(env, nodeState, "addAttribute", "(IJJLjava/lang/Object;[BLjava/lang/String;)V",
                                                   &addAttributeMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Could not find addAttribute method with error %s", ErrorStr(err)));
+                   ChipLogError(Controller, "Could not find addAttribute method with error %" CHIP_ERROR_FORMAT, err.Format()));
     env->CallVoidMethod(nodeState, addAttributeMethod, static_cast<jint>(aPath.mEndpointId), static_cast<jlong>(aPath.mClusterId),
                         static_cast<jlong>(aPath.mAttributeId), value, jniByteArray.jniValue(), jsonString.jniValue());
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
@@ -487,8 +490,9 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
         value = DecodeGeneralTLVValue(env, readerForGeneralValueObject, err);
         err   = CHIP_NO_ERROR;
     }
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Fail to decode event with error %s", ErrorStr(err));
-                   aEventHeader.LogPath());
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Fail to decode event with error %" CHIP_ERROR_FORMAT, err.Format()));
+    aEventHeader.LogPath();
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 #else
     value = DecodeGeneralTLVValue(env, readerForJavaObject, err);
@@ -505,7 +509,8 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     writer.Init(buffer.get(), bufferLen);
     err = writer.CopyElement(TLV::AnonymousTag(), readerForJavaTLV);
 
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Fail to copy element with error %s", ErrorStr(err));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Fail to copy element with error %" CHIP_ERROR_FORMAT, err.Format());
                    aEventHeader.LogPath());
     size = writer.GetLengthWritten();
     chip::ByteArray jniByteArray(env, reinterpret_cast<jbyte *>(buffer.get()), static_cast<jint>(size));
@@ -514,14 +519,15 @@ void ReportCallback::OnEventData(const app::EventHeader & aEventHeader, TLV::TLV
     std::string json;
     err = ConvertReportTlvToJson(static_cast<uint32_t>(aEventHeader.mPath.mEventId), *apData, json);
     VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller, "Fail to convert report tlv to Json with error %s", ErrorStr(err));
+                   ChipLogError(Controller, "Fail to convert report tlv to Json with error %" CHIP_ERROR_FORMAT, err.Format());
                    aEventHeader.LogPath());
     UtfString jsonString(env, json.c_str());
 
     jmethodID addEventMethod;
     err = JniReferences::GetInstance().FindMethod(env, nodeState, "addEvent", "(IJJJIIJLjava/lang/Object;[BLjava/lang/String;)V",
                                                   &addEventMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find addEvent method with error %s", ErrorStr(err));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Could not find addEvent method with error %" CHIP_ERROR_FORMAT, err.Format());
                    aEventHeader.LogPath());
     env->CallVoidMethod(nodeState, addEventMethod, static_cast<jint>(aEventHeader.mPath.mEndpointId),
                         static_cast<jlong>(aEventHeader.mPath.mClusterId), static_cast<jlong>(aEventHeader.mPath.mEventId),
@@ -620,13 +626,15 @@ void ReportCallback::ReportError(const app::ConcreteAttributePath * attributePat
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
     jthrowable exception;
     err = AndroidControllerExceptions::GetInstance().CreateAndroidControllerException(env, message, errorCode, exception);
-    VerifyOrReturn(
-        err == CHIP_NO_ERROR,
-        ChipLogError(Controller, "Unable to create AndroidControllerException on ReportCallback::ReportError: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller,
+                                "Unable to create AndroidControllerException on ReportCallback::ReportError: %" CHIP_ERROR_FORMAT,
+                                err.Format()));
     jmethodID onErrorMethod;
     err = JniReferences::GetInstance().FindMethod(env, wrapperCallback, "onError", "(ZIJJZIJJLjava/lang/Exception;)V",
                                                   &onErrorMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Unable to find onError method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     DeviceLayer::StackUnlock unlock;
 
@@ -687,7 +695,8 @@ void WriteAttributesCallback::OnResponse(const app::WriteClient * apWriteClient,
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
     err = JniReferences::GetInstance().FindMethod(env, wrapperCallback, "onResponse", "(IJJILjava/lang/Integer;)V",
                                                   &onResponseMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Unable to find onError method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     jobject jClusterState = nullptr;
     if (aStatus.mClusterStatus.has_value())
@@ -751,16 +760,18 @@ void WriteAttributesCallback::ReportError(const app::ConcreteAttributePath * att
     ChipLogError(Controller, "WriteAttributesCallback::ReportError is called with %u", errorCode);
     jthrowable exception;
     err = AndroidControllerExceptions::GetInstance().CreateAndroidControllerException(env, message, errorCode, exception);
-    VerifyOrReturn(err == CHIP_NO_ERROR,
-                   ChipLogError(Controller,
-                                "Unable to create AndroidControllerException on WriteAttributesCallback::ReportError: %s",
-                                ErrorStr(err)));
+    VerifyOrReturn(
+        err == CHIP_NO_ERROR,
+        ChipLogError(Controller,
+                     "Unable to create AndroidControllerException on WriteAttributesCallback::ReportError: %" CHIP_ERROR_FORMAT,
+                     err.Format()));
     jmethodID onErrorMethod;
     VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(),
                    ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
     err = JniReferences::GetInstance().FindMethod(env, wrapperCallback, "onError", "(ZIJJLjava/lang/Exception;)V", &onErrorMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Unable to find onError method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     jboolean isAttributePath = JNI_FALSE;
     jint attributeEndpointId = static_cast<jint>(kInvalidEndpointId);
@@ -809,7 +820,8 @@ void InvokeCallback::OnResponse(app::CommandSender * apCommandSender, const app:
     jobject wrapperCallbackRef = mWrapperCallbackRef.ObjectRef();
     err = JniReferences::GetInstance().FindMethod(env, wrapperCallbackRef, "onResponse", "(IJJ[BLjava/lang/String;J)V",
                                                   &onResponseMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onResponse method: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Unable to find onResponse method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     DeviceLayer::StackUnlock unlock;
 
@@ -904,16 +916,18 @@ void InvokeCallback::ReportError(const char * message, ChipError::StorageType er
     ChipLogError(Controller, "InvokeCallback::ReportError is called with %u", errorCode);
     jthrowable exception;
     err = AndroidControllerExceptions::GetInstance().CreateAndroidControllerException(env, message, errorCode, exception);
-    VerifyOrReturn(
-        err == CHIP_NO_ERROR,
-        ChipLogError(Controller, "Unable to create AndroidControllerException: %s on InvokeCallback::ReportError", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller,
+                                "Unable to create AndroidControllerException on InvokeCallback::ReportError: %" CHIP_ERROR_FORMAT,
+                                err.Format()));
 
     jmethodID onErrorMethod;
     VerifyOrReturn(mWrapperCallbackRef.HasValidObjectRef(),
                    ChipLogError(Controller, "mWrapperCallbackRef is not valid in %s", __func__));
     jobject wrapperCallback = mWrapperCallbackRef.ObjectRef();
     err = JniReferences::GetInstance().FindMethod(env, wrapperCallback, "onError", "(Ljava/lang/Exception;)V", &onErrorMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onError method: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Unable to find onError method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(wrapperCallback, onErrorMethod, exception);
@@ -1093,7 +1107,8 @@ void ExtendableInvokeCallback::OnResponse(app::CommandSender * apCommandSender,
 
         err = JniReferences::GetInstance().FindMethod(env, wrapperCallbackRef, "onResponse",
                                                       "(IJJLjava/lang/Integer;[BLjava/lang/String;)V", &onResponseMethod);
-        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onResponse method: %s", ErrorStr(err)));
+        VerifyOrReturn(err == CHIP_NO_ERROR,
+                       ChipLogError(Controller, "Unable to find onResponse method: %" CHIP_ERROR_FORMAT, err.Format()));
 
         env->CallVoidMethod(wrapperCallbackRef, onResponseMethod, static_cast<jint>(aResponseData.path.mEndpointId),
                             static_cast<jlong>(aResponseData.path.mClusterId), static_cast<jlong>(aResponseData.path.mCommandId),
@@ -1103,7 +1118,8 @@ void ExtendableInvokeCallback::OnResponse(app::CommandSender * apCommandSender,
     {
         err = JniReferences::GetInstance().FindMethod(env, wrapperCallbackRef, "onResponse",
                                                       "(IJJLjava/lang/Integer;ILjava/lang/Integer;)V", &onResponseMethod);
-        VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Unable to find onResponse method: %s", ErrorStr(err)));
+        VerifyOrReturn(err == CHIP_NO_ERROR,
+                       ChipLogError(Controller, "Unable to find onResponse method: %" CHIP_ERROR_FORMAT, err.Format()));
 
         jobject jClusterState = nullptr;
         if (aResponseData.statusIB.mClusterStatus.has_value())

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -858,7 +858,8 @@ void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
     err = JniReferences::GetInstance().FindMethod(
         env, mJavaObjectRef.ObjectRef(), "onScanNetworksSuccess",
         "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V", &javaMethod);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error invoking Java callback: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(Controller, "Error invoking Java callback: %" CHIP_ERROR_FORMAT, err.Format()));
 
     jobject NetworkingStatus;
     std::string NetworkingStatusClassName     = "java/lang/Integer";

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1366,7 +1366,7 @@ JNI_METHOD(jlong, getDeviceBeingCommissionedPointer)(JNIEnv * env, jobject self,
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to get commissionee device: %s", ErrorStr(err));
+        ChipLogError(Controller, "Failed to get commissionee device: %" CHIP_ERROR_FORMAT, err.Format());
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
         return 0;
     }
@@ -1418,7 +1418,7 @@ JNI_METHOD(jlong, getGroupDevicePointer)(JNIEnv * env, jobject self, jlong handl
     if (device == nullptr)
     {
         CHIP_ERROR err = CHIP_ERROR_NO_MEMORY;
-        ChipLogError(Controller, "GroupDeviceProxy handle is nullptr: %s", ErrorStr(err));
+        ChipLogError(Controller, "GroupDeviceProxy handle is nullptr: %" CHIP_ERROR_FORMAT, err.Format());
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
         return 0;
     }

--- a/src/controller/python/chip/internal/CommissionerImpl.cpp
+++ b/src/controller/python/chip/internal/CommissionerImpl.cpp
@@ -163,7 +163,7 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
         err = gOperationalCredentialsIssuer.Initialize(gServerStorage);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Controller, "Operational credentials issuer initialization failed: %s", chip::ErrorStr(err));
+            ChipLogError(Controller, "Operational credentials issuer initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -205,12 +205,12 @@ extern "C" chip::Controller::DeviceCommissioner * pychip_internal_Commissioner_N
                                                                         compressedFabricIdSpan));
         }
     exit:
-        ChipLogProgress(Controller, "Commissioner initialization status: %s", chip::ErrorStr(err));
+        ChipLogProgress(Controller, "Commissioner initialization status: %" CHIP_ERROR_FORMAT, err.Format());
     });
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Commissioner initialization failed: %s", chip::ErrorStr(err));
+        ChipLogError(Controller, "Commissioner initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
         return nullptr;
     }
 

--- a/src/controller/webrtc/WebRTCTransportProviderClient.cpp
+++ b/src/controller/webrtc/WebRTCTransportProviderClient.cpp
@@ -81,7 +81,7 @@ void WebRTCTransportProviderClient::OnResponse(chip::app::CommandSender * client
     CHIP_ERROR error = status.ToChipError();
     if (CHIP_NO_ERROR != error)
     {
-        ChipLogError(Camera, "Response Failure: %s", ErrorStr(error));
+        ChipLogError(Camera, "Response Failure: %" CHIP_ERROR_FORMAT, error.Format());
         this->OnError(client, error);
         return;
     }

--- a/src/messaging/tests/echo/echo_responder.cpp
+++ b/src/messaging/tests/echo/echo_responder.cpp
@@ -141,7 +141,7 @@ int main(int argc, char * argv[])
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        printf("EchoServer failed, err:%s\n", chip::ErrorStr(err));
+        printf("EchoServer failed, err: %s\n", chip::ErrorStr(err));
         exit(EXIT_FAILURE);
     }
 

--- a/src/platform/ASR/ASROTAImageProcessor.cpp
+++ b/src/platform/ASR/ASROTAImageProcessor.cpp
@@ -184,7 +184,7 @@ void ASROTAImageProcessor::HandleProcessBlock(intptr_t context)
 
     if (chip_error != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(chip_error));
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, chip_error.Format());
         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
         return;
     }

--- a/src/platform/ASR/BLEManagerImpl.cpp
+++ b/src/platform/ASR/BLEManagerImpl.cpp
@@ -400,7 +400,7 @@ void BLEManagerImpl::DriveBLEState(void)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -499,7 +499,7 @@ void BLEManagerImpl::SetAdvStartFlag(void)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "SetAdvStartFlag to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "SetAdvStartFlag to error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -516,7 +516,7 @@ void BLEManagerImpl::SetAdvEndFlag(void)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "SetAdvEndFlag to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "SetAdvEndFlag to error: %" CHIP_ERROR_FORMAT, err.Format());
     }
     if (mFlags.Has(Flags::kFlag_AdvertisingRestarted))
     {
@@ -552,7 +552,7 @@ bool BLEManagerImpl::HandleRXCharWrite(uint8_t connection_id, uint16_t length, u
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
     else
@@ -600,7 +600,7 @@ bool BLEManagerImpl::HandleTXCharCCCDWrite(uint8_t connection_id, uint16_t lengt
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
     else

--- a/src/platform/ASR/ConfigurationManagerImpl.cpp
+++ b/src/platform/ASR/ConfigurationManagerImpl.cpp
@@ -214,7 +214,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = ASRConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/ASR/ConnectivityManagerImpl.cpp
+++ b/src/platform/ASR/ConnectivityManagerImpl.cpp
@@ -305,7 +305,7 @@ void ConnectivityManagerImpl::DriveStationState()
             err = Internal::ASRUtils::asr_wifi_disconnect();
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "asr_wifi_disconnect() failed: %s", chip::ErrorStr(err));
+                ChipLogError(DeviceLayer, "asr_wifi_disconnect() failed: %" CHIP_ERROR_FORMAT, err.Format());
             }
             SuccessOrExit(err);
 
@@ -351,7 +351,7 @@ void ConnectivityManagerImpl::DriveStationState()
                     err = Internal::ASRUtils::asr_wifi_connect();
                     if (err != CHIP_NO_ERROR)
                     {
-                        ChipLogError(DeviceLayer, "asr_wifi_connect() failed: %s", chip::ErrorStr(err));
+                        ChipLogError(DeviceLayer, "asr_wifi_connect() failed: %" CHIP_ERROR_FORMAT, err.Format());
                     }
                     SuccessOrExit(err);
                     ChangeWiFiStationState(kWiFiStationState_Connecting);

--- a/src/platform/ASR/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/ASR/NetworkCommissioningWiFiDriver.cpp
@@ -179,7 +179,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/Ameba/BLEManagerImpl.cpp
+++ b/src/platform/Ameba/BLEManagerImpl.cpp
@@ -221,7 +221,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(int conn_id, int indicationsEnabled, 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return;
@@ -538,7 +538,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 #endif
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Close connection failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Close connection failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     mFlags.Set(Flags::kRestartAdvertising);
@@ -626,7 +626,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData()
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -761,7 +761,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -892,7 +892,7 @@ CHIP_ERROR BLEManagerImpl::matter_blemgr_gap_connect_cb(uint8_t conn_id)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 
@@ -909,7 +909,7 @@ CHIP_ERROR BLEManagerImpl::matter_blemgr_gap_disconnect_cb(uint8_t conn_id, uint
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 
@@ -1073,7 +1073,7 @@ CHIP_ERROR BLEManagerImpl::ble_svr_gap_msg_event(void * param, T_IO_MSG * p_gap_
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -279,7 +279,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = AmebaConfig::ClearNamespace();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ClearNamespace() failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "ClearNamespace() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -542,7 +542,7 @@ void ConnectivityManagerImpl::DriveStationState()
                 err = Internal::AmebaUtils::WiFiConnectProvisionedNetwork();
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(DeviceLayer, "WiFiConnectProvisionedNetwork() failed: %s", chip::ErrorStr(err));
+                    ChipLogError(DeviceLayer, "WiFiConnectProvisionedNetwork() failed: %" CHIP_ERROR_FORMAT, err.Format());
                 }
                 SuccessOrExit(err);
             }

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -191,7 +191,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/Beken/BLEManagerImpl.cpp
+++ b/src/platform/Beken/BLEManagerImpl.cpp
@@ -277,7 +277,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(int conn_id, int notificationsEnabled
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return;
@@ -575,7 +575,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     err = MapBLEError(ret);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "bk_ble_disconnect() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "bk_ble_disconnect() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -724,7 +724,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         err              = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -864,7 +864,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -999,7 +999,7 @@ void BLEManagerImpl::HandleRXCharWrite(uint8_t * p_value, uint16_t len, uint8_t 
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/Beken/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Beken/NetworkCommissioningWiFiDriver.cpp
@@ -194,7 +194,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         // chip::DeviceLayer::PlatformMgr().LockChipStack();
         callback->OnResult(networkingStatus, CharSpan(), 0);

--- a/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
+++ b/src/platform/Darwin/inet/UDPEndPointImplNetworkFrameworkDebug.mm
@@ -169,7 +169,7 @@ namespace Inet {
 
             if (error) {
                 CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+                ChipLogDetail(Inet, "%s - Error: %" CHIP_ERROR_FORMAT, str, err.Format());
             } else {
                 ChipLogDetail(Inet, "%s", str);
             }
@@ -202,7 +202,7 @@ namespace Inet {
             const char * interfaceName = nw_interface_get_name(interface);
             if (error) {
                 CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                ChipLogDetail(Inet, "%s (%s) - Error: %s", str, interfaceName, chip::ErrorStr(err));
+                ChipLogDetail(Inet, "%s (%s) - Error: %" CHIP_ERROR_FORMAT, str, interfaceName, err.Format());
             } else {
                 ChipLogDetail(Inet, "%s (%s)", str, interfaceName);
             }
@@ -237,7 +237,7 @@ namespace Inet {
 
             if (error) {
                 CHIP_ERROR err = CHIP_ERROR_POSIX(nw_error_get_error_code(error));
-                ChipLogDetail(Inet, "%s - Error: %s", str, chip::ErrorStr(err));
+                ChipLogDetail(Inet, "%s - Error: %" CHIP_ERROR_FORMAT, str, err.Format());
             } else {
                 ChipLogDetail(Inet, "%s", str);
             }

--- a/src/platform/DeviceControlServer.cpp
+++ b/src/platform/DeviceControlServer.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR DeviceControlServer::PostCommissioningCompleteEvent(NodeId peerNodeId
 
 CHIP_ERROR DeviceControlServer::SetRegulatoryConfig(uint8_t location, const CharSpan & countryCode)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err;
 
     err = ConfigurationMgr().StoreRegulatoryLocation(location);
     SuccessOrExit(err);
@@ -58,7 +58,7 @@ CHIP_ERROR DeviceControlServer::SetRegulatoryConfig(uint8_t location, const Char
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "SetRegulatoryConfig failed with error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "SetRegulatoryConfig failed with error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -480,14 +480,14 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = ESP32Config::ClearNamespace(ESP32Config::kConfigNamespace_ChipConfig);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Erase all values in the chip-counters NVS namespace.
     err = ESP32Config::ClearNamespace(ESP32Config::kConfigNamespace_ChipCounters);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ClearNamespace(ChipCounters) failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "ClearNamespace(ChipCounters) failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restore WiFi persistent settings to default values.

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -108,7 +108,7 @@ void ConnectivityManagerImpl::_ClearWiFiStationProvision(void)
         CHIP_ERROR error = chip::DeviceLayer::Internal::ESP32Utils::ClearWiFiStationProvision();
         if (error != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %s", chip::ErrorStr(error));
+            ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %" CHIP_ERROR_FORMAT, error.Format());
             return;
         }
         DeviceLayer::SystemLayer().ScheduleWork(DriveStationState, NULL);

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -238,7 +238,7 @@ CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
         CHIP_ERROR error = chip::DeviceLayer::Internal::ESP32Utils::ClearWiFiStationProvision();
         if (error != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %s", chip::ErrorStr(error));
+            ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %" CHIP_ERROR_FORMAT, error.Format());
             return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
         }
     }
@@ -300,7 +300,7 @@ void ESPWiFiDriver::OnConnectWiFiNetworkFailed(chip::System::Layer * aLayer, voi
     CHIP_ERROR error = chip::DeviceLayer::Internal::ESP32Utils::ClearWiFiStationProvision();
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %s", chip::ErrorStr(error));
+        ChipLogError(DeviceLayer, "ClearWiFiStationProvision failed: %" CHIP_ERROR_FORMAT, error.Format());
     }
     ESPWiFiDriver::GetInstance().OnConnectWiFiNetworkFailed();
 }
@@ -341,7 +341,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -430,7 +430,7 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -683,7 +683,7 @@ void BLEManagerImpl::gattc_profile_event_handler(esp_gattc_cb_event_t event, esp
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 
@@ -823,7 +823,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     err = MapBLEError(esp_ble_gatts_close(mAppIf, conId));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_close() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_close() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Release the associated connection state record.
@@ -865,7 +865,7 @@ CHIP_ERROR BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const Chi
                                                   data->Start(), true /* need_confirm */));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_indicate() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_indicate() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -965,7 +965,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_app_register(CHIPoBLEAppId));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_app_register() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_app_register() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -980,7 +980,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_create_attr_tab(CHIPoBLEGATTAttrs, mAppIf, CHIPoBLEGATTAttrCount, 0));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_create_attr_tab() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_create_attr_tab() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -995,7 +995,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_start_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_start_service() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_start_service() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -1040,7 +1040,7 @@ void BLEManagerImpl::DriveBLEState(void)
             err = MapBLEError(esp_ble_gap_stop_advertising());
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "esp_ble_gap_stop_advertising() failed: %s", ErrorStr(err));
+                ChipLogError(DeviceLayer, "esp_ble_gap_stop_advertising() failed: %" CHIP_ERROR_FORMAT, err.Format());
                 ExitNow();
             }
 
@@ -1058,7 +1058,7 @@ void BLEManagerImpl::DriveBLEState(void)
         err = MapBLEError(esp_ble_gatts_stop_service(mServiceAttrHandle));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gatts_stop_service() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gatts_stop_service() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -1071,7 +1071,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -1089,7 +1089,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_mem_release() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_mem_release() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
 
@@ -1098,7 +1098,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err                               = MapBLEError(esp_bt_controller_init(&bt_cfg));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_init() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_init() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -1109,7 +1109,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bt_controller_enable(ESP_BT_MODE_BLE));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bt_controller_enable() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bt_controller_enable() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -1120,7 +1120,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bluedroid_init());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bluedroid_init() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bluedroid_init() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -1131,7 +1131,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
         err = MapBLEError(esp_bluedroid_enable());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_bluedroid_enable() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_bluedroid_enable() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
     }
@@ -1140,7 +1140,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gatts_register_callback(HandleGATTEvent));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_register_callback() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_register_callback() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1148,7 +1148,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gap_register_callback(HandleGAPEvent));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_register_callback() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_register_callback() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1156,7 +1156,7 @@ CHIP_ERROR BLEManagerImpl::InitESPBleLayer(void)
     err = MapBLEError(esp_ble_gatt_set_local_mtu(CHIP_MAX_MTU_SIZE));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatt_set_local_mtu() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatt_set_local_mtu() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -1204,7 +1204,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = MapBLEError(esp_ble_gap_set_device_name(mDeviceName));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_set_device_name() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1242,7 +1242,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1254,7 +1254,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     err = MapBLEError(esp_ble_gap_config_adv_data_raw(advData, sizeof(advData)));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_config_adv_data_raw(<raw_data>) failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1323,7 +1323,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
     err = MapBLEError(esp_ble_gap_start_advertising(&advertParams));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gap_start_advertising() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gap_start_advertising() failed: %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -1427,7 +1427,7 @@ void BLEManagerImpl::HandleGATTControlEvent(esp_gatts_cb_event_t event, esp_gatt
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
     if (controlOpComplete)
@@ -1557,7 +1557,7 @@ void BLEManagerImpl::HandleRXCharWrite(esp_ble_gatts_cb_param_t * param)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         if (needResp)
         {
             esp_ble_gatts_send_response(mAppIf, param->write.conn_id, param->write.trans_id, ESP_GATT_INTERNAL_ERROR, NULL);
@@ -1579,7 +1579,7 @@ void BLEManagerImpl::HandleTXCharRead(esp_ble_gatts_cb_param_t * param)
     err = MapBLEError(esp_ble_gatts_send_response(mAppIf, param->read.conn_id, param->read.trans_id, ESP_GATT_OK, &rsp));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -1606,7 +1606,7 @@ void BLEManagerImpl::HandleTXCharCCCDRead(esp_ble_gatts_cb_param_t * param)
                                                   (conState != NULL) ? ESP_GATT_OK : ESP_GATT_INTERNAL_ERROR, &rsp));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "esp_ble_gatts_send_response() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -1651,7 +1651,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(esp_ble_gatts_cb_param_t * param)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         if (needResp)
         {
             esp_ble_gatts_send_response(mAppIf, param->write.conn_id, param->write.trans_id, ESP_GATT_INTERNAL_ERROR, NULL);
@@ -1763,7 +1763,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
         err = MapBLEError(esp_ble_gattc_register_callback(esp_gattc_cb));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gattc_register_callback() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gattc_register_callback() failed: %" CHIP_ERROR_FORMAT, err.Format());
             ExitNow();
         }
         ChipLogProgress(Ble, "Before initialising (PROFILE\n");
@@ -1771,7 +1771,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
         int rc = esp_ble_gattc_app_register(PROFILE_A_APP_ID);
         if (rc != 0)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gattc_app_register() failed %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gattc_app_register() failed: %s", ErrorStr(err));
             ExitNow();
         }
     }
@@ -1846,7 +1846,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     if (err != CHIP_NO_ERROR)
     {
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
-        ChipLogError(Ble, "Failed to initialize device scanner: %s", ErrorStr(err));
+        ChipLogError(Ble, "Failed to initialize device scanner: %" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
 
@@ -1856,7 +1856,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-        ChipLogError(Ble, "Failed to start a BLE scan: %s", chip::ErrorStr(err));
+        ChipLogError(Ble, "Failed to start a BLE scan: %" CHIP_ERROR_FORMAT, err.Format());
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
         return;
     }
@@ -2138,7 +2138,7 @@ void BLEManagerImpl::HandleGAPEvent(esp_gap_ble_cb_event_t event, esp_ble_gap_cb
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
     PlatformMgr().ScheduleWork(DriveBLEState, 0);

--- a/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/bluedroid/BLEManagerImpl.cpp
@@ -1771,7 +1771,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
         int rc = esp_ble_gattc_app_register(PROFILE_A_APP_ID);
         if (rc != 0)
         {
-            ChipLogError(DeviceLayer, "esp_ble_gattc_app_register() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "esp_ble_gattc_app_register() failed: %d", rc);
             ExitNow();
         }
     }

--- a/src/platform/Infineon/CYW30739/BLEManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/BLEManagerImpl.cpp
@@ -359,7 +359,7 @@ void BLEManagerImpl::DriveBLEState(void)
     // exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }

--- a/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/ConfigurationManagerImpl.cpp
@@ -191,7 +191,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = CYW30739Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.cpp
@@ -96,7 +96,8 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
 
     size_t byte_count;
     err = CYW30739Config::ReadConfigValueBin(entry->GetValueConfigKey(), value, value_size, byte_count);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "%s ReadConfigValueBin %s", __func__, ErrorStr(err));
+    VerifyOrExit(err == CHIP_NO_ERROR,
+                 ChipLogError(DeviceLayer, "%s ReadConfigValueBin %" CHIP_ERROR_FORMAT, __func__, err.Format());
                  err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
 
     if (read_bytes_size != nullptr)

--- a/src/platform/Infineon/PSOC6/BLEManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/BLEManagerImpl.cpp
@@ -416,7 +416,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -924,7 +924,7 @@ void BLEManagerImpl::SetAdvertisingData(void)
     wiced_bt_ble_set_raw_scan_response_data(num_elem, adv_elem);
 
 exit:
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SetAdvertisingData err:%s", ErrorStr(err));
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::SetAdvertisingData err: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 BLEManagerImpl::CHIPoBLEConState * BLEManagerImpl::AllocConnectionState(uint16_t conId)

--- a/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConfigurationManagerImpl.cpp
@@ -230,7 +230,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = PSOC6Config::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
@@ -453,7 +453,8 @@ void ConnectivityManagerImpl::DriveAPState()
                 SystemLayer().ScheduleLambda([apTimeout, this] {
                     CHIP_ERROR ret = CHIP_NO_ERROR;
                     ret            = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, this);
-                    VerifyOrReturn(ret == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartTimer failed: %" CHIP_ERROR_FORMAT, ret.Format()));
+                    VerifyOrReturn(ret == CHIP_NO_ERROR,
+                                   ChipLogError(DeviceLayer, "StartTimer failed: %" CHIP_ERROR_FORMAT, ret.Format()));
                 });
             }
             else

--- a/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
+++ b/src/platform/Infineon/PSOC6/ConnectivityManagerImpl.cpp
@@ -384,7 +384,7 @@ CHIP_ERROR ConnectivityManagerImpl::ConfigureWiFiAP()
     err = Internal::PSOC6Utils::p6_start_ap();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "p6_start_ap failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "p6_start_ap failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -453,7 +453,7 @@ void ConnectivityManagerImpl::DriveAPState()
                 SystemLayer().ScheduleLambda([apTimeout, this] {
                     CHIP_ERROR ret = CHIP_NO_ERROR;
                     ret            = DeviceLayer::SystemLayer().StartTimer(apTimeout, DriveAPState, this);
-                    VerifyOrReturn(ret == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartTimer failed %s: ", chip::ErrorStr(ret)));
+                    VerifyOrReturn(ret == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartTimer failed: %" CHIP_ERROR_FORMAT, ret.Format()));
                 });
             }
             else
@@ -555,7 +555,7 @@ void ConnectivityManagerImpl::DriveStationState()
             err = Internal::PSOC6Utils::p6_wifi_disconnect();
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "p6_wifi_disconnect() failed: %s", chip::ErrorStr(err));
+                ChipLogError(DeviceLayer, "p6_wifi_disconnect() failed: %" CHIP_ERROR_FORMAT, err.Format());
             }
             SuccessOrExit(err);
 
@@ -599,7 +599,7 @@ void ConnectivityManagerImpl::DriveStationState()
                 err = Internal::PSOC6Utils::p6_wifi_connect();
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(DeviceLayer, "p6_wifi_connect() failed: %s", chip::ErrorStr(err));
+                    ChipLogError(DeviceLayer, "p6_wifi_connect() failed: %" CHIP_ERROR_FORMAT, err.Format());
                 }
                 SuccessOrExit(err);
             }
@@ -613,7 +613,8 @@ void ConnectivityManagerImpl::DriveStationState()
                 SystemLayer().ScheduleLambda([timeToNextConnect, this] {
                     CHIP_ERROR ret = CHIP_NO_ERROR;
                     ret            = DeviceLayer::SystemLayer().StartTimer(timeToNextConnect, DriveStationState, this);
-                    VerifyOrReturn(ret == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartTimer failed %s: ", chip::ErrorStr(ret)));
+                    VerifyOrReturn(ret == CHIP_NO_ERROR,
+                                   ChipLogError(DeviceLayer, "StartTimer failed: %" CHIP_ERROR_FORMAT, ret.Format()));
                 });
             }
         }

--- a/src/platform/Infineon/PSOC6/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Infineon/PSOC6/NetworkCommissioningWiFiDriver.cpp
@@ -184,7 +184,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
+++ b/src/platform/Infineon/PSOC6/PSOC6Utils.cpp
@@ -137,7 +137,7 @@ CHIP_ERROR PSOC6Utils::StartWiFiLayer(void)
         if (result != CY_RSLT_SUCCESS)
         {
             err = CHIP_ERROR_INTERNAL;
-            ChipLogError(DeviceLayer, "StartWiFiLayer() PSOC6 Wi-Fi Started Failed: %s", chip::ErrorStr(err));
+            ChipLogError(DeviceLayer, "StartWiFiLayer() PSOC6 Wi-Fi Started Failed: %" CHIP_ERROR_FORMAT, err.Format());
             SuccessOrExit(err);
         }
         wcm_init_done = true;

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -286,13 +286,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = PosixConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     err = PosixConfig::FactoryResetCounters();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset counters: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset counters: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -528,7 +528,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
         CHIP_ERROR errInner = StopAutoScan();
         if (errInner != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %s", ErrorStr(errInner));
+            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %" CHIP_ERROR_FORMAT, errInner.Format());
         }
     });
 }
@@ -947,7 +947,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         SetWiFiAPMode(kWiFiAPMode_Disabled);
-        ChipLogError(DeviceLayer, "Drive AP state failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Drive AP state failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/Linux/PosixConfig.cpp
+++ b/src/platform/Linux/PosixConfig.cpp
@@ -517,14 +517,14 @@ CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -549,14 +549,14 @@ CHIP_ERROR PosixConfig::FactoryResetConfig()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -581,14 +581,14 @@ CHIP_ERROR PosixConfig::FactoryResetCounters()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:

--- a/src/platform/NuttX/BLEManagerImpl.cpp
+++ b/src/platform/NuttX/BLEManagerImpl.cpp
@@ -321,7 +321,7 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
         DeviceLayer::SystemLayer().CancelTimer(HandleAdvertisingTimer, this);
         sInstance.mFlags.Clear(Flags::kControlOpInProgress);
@@ -477,7 +477,7 @@ void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
 
 exit:
     if (err != CHIP_NO_ERROR)
-        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
@@ -502,7 +502,7 @@ void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -627,7 +627,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         DeviceLayer::SystemLayer().CancelTimer(HandleAdvertisingTimer, this);
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
@@ -730,7 +730,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-        ChipLogError(Ble, "Failed to start a BLE can: %s", chip::ErrorStr(err));
+        ChipLogError(Ble, "Failed to start a BLE can: %" CHIP_ERROR_FORMAT, err.Format());
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
         return;
     }

--- a/src/platform/NuttX/ConfigurationManagerImpl.cpp
+++ b/src/platform/NuttX/ConfigurationManagerImpl.cpp
@@ -279,13 +279,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = PosixConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     err = PosixConfig::FactoryResetCounters();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset counters: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset counters: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/NuttX/ConnectivityManagerImpl.cpp
+++ b/src/platform/NuttX/ConnectivityManagerImpl.cpp
@@ -525,7 +525,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * sourceObject, 
         CHIP_ERROR errInner = StopAutoScan();
         if (errInner != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %s", ErrorStr(errInner));
+            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %" CHIP_ERROR_FORMAT, errInner.Format());
         }
     });
 }
@@ -909,7 +909,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         SetWiFiAPMode(kWiFiAPMode_Disabled);
-        ChipLogError(DeviceLayer, "Drive AP state failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Drive AP state failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/NuttX/PosixConfig.cpp
+++ b/src/platform/NuttX/PosixConfig.cpp
@@ -499,14 +499,14 @@ CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -531,14 +531,14 @@ CHIP_ERROR PosixConfig::FactoryResetConfig()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -563,14 +563,14 @@ CHIP_ERROR PosixConfig::FactoryResetCounters()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1005,7 +1005,7 @@ exit:
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetAndLogThreadTopologyFull failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetAndLogThreadTopologyFull failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 #endif // CHIP_PROGRESS_LOGGING
     return err;

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp
@@ -202,8 +202,8 @@ void GenericThreadStackManagerImpl_OpenThread_LwIP<ImplClass>::UpdateThreadInter
                         }
                         else if (lwipErr != ERR_OK)
                         {
-                            ChipLogProgress(DeviceLayer, "netif_add_ip6_address) failed: %s",
-                                            ErrorStr(chip::System::MapErrorLwIP(lwipErr)));
+                            ChipLogProgress(DeviceLayer, "netif_add_ip6_address) failed: %" CHIP_ERROR_FORMAT,
+                                            chip::System::MapErrorLwIP(lwipErr).Format());
                         }
                     }
 

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -49,7 +49,6 @@
 #include <ble/Ble.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPSafeCasts.h>
-#include <lib/core/ErrorStr.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/SafeInt.h>

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -20,7 +20,6 @@
 #include <limits>
 
 #include <lib/core/CHIPError.h>
-#include <lib/core/ErrorStr.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/Span.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -154,7 +153,7 @@ exit:
 
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }
 }

--- a/src/platform/Zephyr/wifi/WiFiManager.cpp
+++ b/src/platform/Zephyr/wifi/WiFiManager.cpp
@@ -535,7 +535,7 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data, size_t lengt
             CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
             if (error != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Cannot post event [error: %s]", ErrorStr(error));
+                ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
             }
 
             WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();

--- a/src/platform/android/AndroidChipPlatform-JNI.cpp
+++ b/src/platform/android/AndroidChipPlatform-JNI.cpp
@@ -130,7 +130,8 @@ JNI_METHOD(void, initChipStack)(JNIEnv * env, jobject self)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().InitChipStack();
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "Error initializing CHIP stack: %s", ErrorStr(err)));
+    VerifyOrReturn(err == CHIP_NO_ERROR,
+                   ChipLogError(DeviceLayer, "Error initializing CHIP stack: %" CHIP_ERROR_FORMAT, err.Format()));
 }
 
 // for NFCCommissioningManager
@@ -446,7 +447,7 @@ JNI_METHOD(jboolean, updateCommissionableDataProviderData)
                                                                 spake2pIterationCount, setupPasscode, discriminator);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to update commissionable data provider data: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to update commissionable data provider data: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
 

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.cpp
@@ -207,7 +207,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL616/NetworkCommissioningDriver.cpp
@@ -194,7 +194,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL702/NetworkCommissioningDriver.cpp
@@ -200,7 +200,7 @@ exit:
     }
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/bouffalolab/common/BLEManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/BLEManagerImpl.cpp
@@ -208,7 +208,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }

--- a/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/common/ConfigurationManagerImpl.cpp
@@ -214,7 +214,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = BLConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/bouffalolab/common/OTAImageProcessorImpl.cpp
+++ b/src/platform/bouffalolab/common/OTAImageProcessorImpl.cpp
@@ -230,7 +230,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         }
         else if (CHIP_NO_ERROR != error)
         {
-            ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(error));
+            ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, error.Format());
             imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
             imageProcessor->mHeaderParser.Clear();
             return;

--- a/src/platform/bouffalolab/common/OTAImageProcessorImpl_bflb.cpp
+++ b/src/platform/bouffalolab/common/OTAImageProcessorImpl_bflb.cpp
@@ -257,7 +257,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         }
         else if (CHIP_NO_ERROR != error)
         {
-            ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(error));
+            ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, error.Format());
             imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
             imageProcessor->mHeaderParser.Clear();
             return;

--- a/src/platform/cc32xx/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.cpp
@@ -181,7 +181,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = CC32XXConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/mbed/BLEManagerImpl.cpp
+++ b/src/platform/mbed/BLEManagerImpl.cpp
@@ -235,7 +235,7 @@ class GapEventHandler : private mbed::NonCopyable<GapEventHandler>, public ble::
             CHIP_ERROR err = sConnectionInfo.setStatus(event.getConnectionHandle(), BLE_GATT_MTU_SIZE_DEFAULT);
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Unable to store connection status, error: %s ", ErrorStr(err));
+                ChipLogError(DeviceLayer, "Unable to store connection status, error: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
         else
@@ -285,7 +285,7 @@ class GapEventHandler : private mbed::NonCopyable<GapEventHandler>, public ble::
         CHIP_ERROR err = sConnectionInfo.clearStatus(event.getConnectionHandle());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "Unable to clear connection status, error: %s ", ErrorStr(err));
+            ChipLogError(DeviceLayer, "Unable to clear connection status, error: %" CHIP_ERROR_FORMAT, err.Format());
         }
 
         ChipDeviceEvent chip_event;
@@ -410,7 +410,7 @@ struct CHIPService : public ble::GattServer::EventHandler
         CHIP_ERROR err = sConnectionInfo.setStatus(connectionHandle, attMtuSize);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "Unable to store connection status, error: %s ", ErrorStr(err));
+            ChipLogError(DeviceLayer, "Unable to store connection status, error: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
 
@@ -640,7 +640,7 @@ void BLEManagerImpl::HandleInitComplete(bool no_error)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "BLEManager init error: %s ", ErrorStr(err));
+        ChipLogError(DeviceLayer, "BLEManager init error: %" CHIP_ERROR_FORMAT, err.Format());
         ChipLogError(DeviceLayer, "Disabling CHIPoBLE service.");
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
         mInitialized = false;
@@ -692,7 +692,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -227,7 +227,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     const CHIP_ERROR err = MbedConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/mbed/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/mbed/ConnectivityManagerImpl_WiFi.cpp
@@ -58,7 +58,7 @@ CHIP_ERROR ConnectivityManagerImpl::InitWiFi()
 #else
     err = NetworkCommissioning::WiFiDriverImpl::GetInstance().Init(nullptr);
 #endif
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "WiFi driver init failed: %s", chip::ErrorStr(err)));
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "WiFi driver init failed: %" CHIP_ERROR_FORMAT, err.Format()));
 
     mWiFiStationMode = kWiFiStationMode_Enabled;
     networks         = NetworkCommissioning::WiFiDriverImpl::GetInstance().GetNetworks();

--- a/src/platform/mt793x/BLEManagerImpl.cpp
+++ b/src/platform/mt793x/BLEManagerImpl.cpp
@@ -318,7 +318,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "bt_gap_le_disconnect() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "bt_gap_le_disconnect() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -392,7 +392,7 @@ void BLEManagerImpl::HandleRXCharWrite(uint16_t handle, void * data, uint16_t si
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -439,7 +439,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(uint16_t handle, void * data, uint16_
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -775,7 +775,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }

--- a/src/platform/mt793x/ConfigurationManagerImpl.cpp
+++ b/src/platform/mt793x/ConfigurationManagerImpl.cpp
@@ -228,7 +228,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = MT793XConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/mt793x/NetworkCommissioningWiFiDriver.cpp
@@ -209,7 +209,7 @@ void GenioWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 exit:
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -552,7 +552,7 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data, size_t lengt
             CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
             if (error != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Cannot post event [error: %s]", ErrorStr(error));
+                ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
             }
 
             WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -323,7 +323,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = NXPConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/nxp/common/ble/BLEManagerCommon.cpp
+++ b/src/platform/nxp/common/ble/BLEManagerCommon.cpp
@@ -818,7 +818,7 @@ void BLEManagerCommon::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = kCHIPoBLE_Disabled;
     }
 }
@@ -1033,7 +1033,7 @@ void BLEManagerCommon::HandleTXCharCCCDWrite(blekw_msg_t * msg)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -1068,7 +1068,7 @@ void BLEManagerCommon::HandleRXCharWrite(blekw_msg_t * msg)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProvider.cpp
@@ -499,7 +499,7 @@ CHIP_ERROR FactoryDataProvider::GetSoftwareVersionString(char * buf, size_t bufS
     CHIP_ERROR err = ConfigurationMgr().GetSoftwareVersionString(buf, bufSize);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to get software version string from ConfigurationMgr: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to get software version string from ConfigurationMgr: %" CHIP_ERROR_FORMAT, err.Format());
     }
     return err;
 }

--- a/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
+++ b/src/platform/nxp/common/factory_data/legacy/FactoryDataProviderImpl.cpp
@@ -77,7 +77,7 @@ CHIP_ERROR FactoryDataProviderImpl::Init()
 #endif
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Factory data init failed with: %s", ErrorStr(error));
+        ChipLogError(DeviceLayer, "Factory data init failed with: %" CHIP_ERROR_FORMAT, error.Format());
     }
 
 #if !CHIP_USE_PLAIN_DAC_KEY

--- a/src/platform/nxp/common/ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/nxp/common/ota/OTAFactoryDataProcessor.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR OTAFactoryDataProcessor::ApplyAction()
 exit:
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to update factory data. Error: %s", ErrorStr(error));
+        ChipLogError(DeviceLayer, "Failed to update factory data. Error: %" CHIP_ERROR_FORMAT, error.Format());
     }
     else
     {

--- a/src/platform/nxp/common/ota/OTAImageProcessorImpl.cpp
+++ b/src/platform/nxp/common/ota/OTAImageProcessorImpl.cpp
@@ -262,7 +262,7 @@ void OTAImageProcessorImpl::HandleStatus(CHIP_ERROR status)
     }
     else
     {
-        ChipLogError(SoftwareUpdate, "Image update canceled. Failed to process OTA block: %s", ErrorStr(status));
+        ChipLogError(SoftwareUpdate, "Image update canceled. Failed to process OTA block: %" CHIP_ERROR_FORMAT, status.Format());
         GetRequestorInstance()->CancelImageUpdate();
     }
 }

--- a/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mcxw71/ConfigurationManagerImpl.cpp
@@ -265,7 +265,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = NXPConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/openiotsdk/ConfigurationManagerImpl.cpp
+++ b/src/platform/openiotsdk/ConfigurationManagerImpl.cpp
@@ -146,7 +146,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     const CHIP_ERROR err = KVStoreConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Restart the system.

--- a/src/platform/qpg/BLEManagerImpl.cpp
+++ b/src/platform/qpg/BLEManagerImpl.cpp
@@ -273,7 +273,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
     err = MapBLEError(qvCHIP_BleCloseConnection(conId));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "qvCHIP_BleCloseConnection() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "qvCHIP_BleCloseConnection() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -285,7 +285,7 @@ uint16_t BLEManagerImpl::GetMTU(BLE_CONNECTION_OBJECT conId) const
     CHIP_ERROR err  = MapBLEError(qvCHIP_BleGetMTU(conId, &retVal));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "qvCHIP_BleGetMTU() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "qvCHIP_BleGetMTU() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return retVal;
@@ -387,7 +387,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -599,7 +599,7 @@ void BLEManagerImpl::HandleRXCharWrite(uint16_t connId, uint16_t handle, uint8_t
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         // TODO: fail connection???
     }
 }
@@ -647,7 +647,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(qvCHIP_Ble_AttsCccEvt_t * pEvt)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         // TODO: fail connection???
     }
 }

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -261,7 +261,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = QPGConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     qvErr = qvCHIP_KvsErasePartition();

--- a/src/platform/qpg/OTAImageProcessorImpl.cpp
+++ b/src/platform/qpg/OTAImageProcessorImpl.cpp
@@ -205,7 +205,7 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
     CHIP_ERROR err = ProcessHeader(block);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(err));
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, err.Format());
         this->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
         return err;
     }

--- a/src/platform/realtek/BEE/BLEManagerImpl.cpp
+++ b/src/platform/realtek/BEE/BLEManagerImpl.cpp
@@ -189,7 +189,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(int conn_id, int indicationsEnabled)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return;
@@ -497,7 +497,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Close connection failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Close connection failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     mFlags.Set(Flags::kRestartAdvertising);
@@ -576,7 +576,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData()
     err = ConfigurationMgr().GetBLEDeviceIdentificationInfo(deviceIdInfo);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "GetBLEDeviceIdentificationInfo(): %" CHIP_ERROR_FORMAT, err.Format());
         ExitNow();
     }
 
@@ -624,7 +624,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData()
     }
     else
     {
-        ChipLogError(DeviceLayer, "ConfigureAdvertisingData error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "ConfigureAdvertisingData error: %" CHIP_ERROR_FORMAT, err.Format());
     }
 #endif
 
@@ -732,7 +732,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -913,7 +913,7 @@ CHIP_ERROR BLEManagerImpl::HandleGapMsg(T_IO_MSG * p_gap_msg)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         sInstance.mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 

--- a/src/platform/realtek/BEE/ConfigurationManagerImpl.cpp
+++ b/src/platform/realtek/BEE/ConfigurationManagerImpl.cpp
@@ -217,7 +217,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = BeeConfig::ClearNamespace();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "ClearNamespace() failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "ClearNamespace() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/silabs/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/ConfigurationManagerImpl.cpp
@@ -288,7 +288,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     error = SilabsConfig::FactoryResetConfig();
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", chip::ErrorStr(error));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, error.Format());
     }
 
     GetDefaultInstance().ClearThreadStack();
@@ -302,7 +302,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     error = WifiInterface::GetInstance().TriggerDisconnection();
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %s", chip::ErrorStr(error));
+        ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %" CHIP_ERROR_FORMAT, error.Format());
     }
 
     ChipLogProgress(DeviceLayer, "Clearing WiFi provision");

--- a/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/silabs/ConnectivityManagerImpl_WIFI.cpp
@@ -224,7 +224,8 @@ void ConnectivityManagerImpl::DriveStationState()
     {
         // Ensure that the Wifi task is started.
         CHIP_ERROR error = WifiInterface::GetInstance().StartWifiTask();
-        VerifyOrReturn(error == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "StartWifiTask() failed: %s", ErrorStr(error)));
+        VerifyOrReturn(error == CHIP_NO_ERROR,
+                       ChipLogError(DeviceLayer, "StartWifiTask() failed: %" CHIP_ERROR_FORMAT, error.Format()));
 
         // Ensure that station mode is enabled in the WiFi layer.
         WifiInterface::GetInstance().ConfigureStationMode();
@@ -257,7 +258,8 @@ void ConnectivityManagerImpl::DriveStationState()
             ChipLogProgress(DeviceLayer, "Disconnecting WiFi station interface");
 
             CHIP_ERROR error = WifiInterface::GetInstance().TriggerDisconnection();
-            SuccessOrExitAction(error, ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %s", ErrorStr(error)));
+            SuccessOrExitAction(error,
+                                ChipLogError(DeviceLayer, "TriggerDisconnection() failed: %" CHIP_ERROR_FORMAT, error.Format()));
 
             ChangeWiFiStationState(kWiFiStationState_Disconnecting);
         }

--- a/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/silabs/NetworkCommissioningWiFiDriver.cpp
@@ -225,7 +225,7 @@ void SlWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback
 exit:
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         mpConnectCallback = nullptr;
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }
@@ -275,7 +275,7 @@ bool SlWiFiDriver::StartScanWiFiNetworks(ByteSpan ssid)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "StartNetworkScan failed: %s", chip::ErrorStr(err));
+        ChipLogError(DeviceLayer, "StartNetworkScan failed: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
 

--- a/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/SiWx917/OTAImageProcessorImpl.cpp
@@ -270,7 +270,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     if (chip_error != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(chip_error));
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, chip_error.Format());
         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
         return;
     }

--- a/src/platform/silabs/efr32/BLEManagerImpl.cpp
+++ b/src/platform/silabs/efr32/BLEManagerImpl.cpp
@@ -300,7 +300,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "sl_bt_connection_close() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "sl_bt_connection_close() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -395,7 +395,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -471,14 +471,14 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         ret = sl_bt_advertiser_create_set(&advertising_set_handle);
         VerifyOrExit(ret == SL_STATUS_OK, {
             err = MapBLEError(ret);
-            ChipLogError(DeviceLayer, "sl_bt_advertiser_create_set() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "sl_bt_advertiser_create_set() failed: %" CHIP_ERROR_FORMAT, err.Format());
         });
 
         ret =
             sl_bt_advertiser_set_random_address(advertising_set_handle, sl_bt_gap_static_address, randomizedAddr, &randomizedAddr);
         VerifyOrExit(ret == SL_STATUS_OK, {
             err = MapBLEError(ret);
-            ChipLogError(DeviceLayer, "sl_bt_advertiser_set_random_address() failed: %s", ErrorStr(err));
+            ChipLogError(DeviceLayer, "sl_bt_advertiser_set_random_address() failed: %" CHIP_ERROR_FORMAT, err.Format());
         });
         ChipLogDetail(DeviceLayer, "BLE Static Device Address %02X:%02X:%02X:%02X:%02X:%02X", randomizedAddr.addr[5],
                       randomizedAddr.addr[4], randomizedAddr.addr[3], randomizedAddr.addr[2], randomizedAddr.addr[1],
@@ -490,7 +490,8 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     VerifyOrExit(ret == SL_STATUS_OK, {
         err = MapBLEError(ret);
-        ChipLogError(DeviceLayer, "sl_bt_legacy_advertiser_set_data() - Advertising Data failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "sl_bt_legacy_advertiser_set_data() - Advertising Data failed: %" CHIP_ERROR_FORMAT,
+                     err.Format());
     });
 
     index = 0;
@@ -510,7 +511,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
 
     VerifyOrExit(ret == SL_STATUS_OK, {
         err = MapBLEError(ret);
-        ChipLogError(DeviceLayer, "sl_bt_legacy_advertiser_set_data() - Scan Response failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "sl_bt_legacy_advertiser_set_data() - Scan Response failed: %" CHIP_ERROR_FORMAT, err.Format());
     });
 
     err = MapBLEError(ret);
@@ -799,7 +800,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(volatile sl_bt_msg_t * evt)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -829,7 +830,7 @@ void BLEManagerImpl::HandleRXCharWrite(volatile sl_bt_msg_t * evt)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
+++ b/src/platform/silabs/efr32/OTAImageProcessorImpl.cpp
@@ -358,7 +358,7 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 
     if (chip_error != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Matter image header parser error: %s", chip::ErrorStr(chip_error));
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, chip_error.Format());
         imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
         return;
     }

--- a/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
+++ b/src/platform/silabs/multi-ota/OTAFactoryDataProcessor.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR OTAFactoryDataProcessor::ApplyAction()
 exit:
     if (error != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Failed to update factory data. Error: %s", ErrorStr(error));
+        ChipLogError(SoftwareUpdate, "Failed to update factory data. Error: %" CHIP_ERROR_FORMAT, error.Format());
     }
     else
     {

--- a/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
+++ b/src/platform/silabs/multi-ota/OTAMultiImageProcessorImpl.cpp
@@ -262,7 +262,7 @@ void OTAMultiImageProcessorImpl::HandleStatus(CHIP_ERROR status)
     }
     else
     {
-        ChipLogError(SoftwareUpdate, "Image update canceled. Failed to process OTA block: %s", ErrorStr(status));
+        ChipLogError(SoftwareUpdate, "Image update canceled. Failed to process OTA block: %" CHIP_ERROR_FORMAT, status.Format());
         GetRequestorInstance()->CancelImageUpdate();
     }
 }

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -494,7 +494,7 @@ CHIP_ERROR BLEManagerImpl::CloseConnection(BLE_CONNECTION_OBJECT conId)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "sl_bt_connection_close() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "sl_bt_connection_close() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -587,7 +587,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -743,7 +743,7 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 
 exit:
     // TODO: Add MapBLEError to return the correct error code
-    ChipLogError(DeviceLayer, "StartAdvertising() End error: %s", ErrorStr(err));
+    ChipLogError(DeviceLayer, "StartAdvertising() End error: %" CHIP_ERROR_FORMAT, err.Format());
     return err;
 }
 
@@ -925,7 +925,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(const SilabsBleWrapper::sl_wfx_msg_t 
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -955,7 +955,7 @@ void BLEManagerImpl::HandleRXCharWrite(const SilabsBleWrapper::sl_wfx_msg_t & ev
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/stm32/BLEManagerImpl.cpp
+++ b/src/platform/stm32/BLEManagerImpl.cpp
@@ -337,7 +337,7 @@ void BLEManagerImpl::DriveBLEState(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -571,7 +571,7 @@ void BLEManagerImpl::HandleRXCharWrite(BLE_Matter_RX * aMessage)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         // TODO: fail connection???
     }
 }
@@ -619,7 +619,7 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(BLE_Matter_TXCharCCCD * aMessage)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharCCCDWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
         // TODO: fail connection???
     }
 }

--- a/src/platform/stm32/OTAImageProcessorImpl.cpp
+++ b/src/platform/stm32/OTAImageProcessorImpl.cpp
@@ -164,7 +164,7 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
     ChipLogProgress(DeviceLayer, "OTA Process Block");
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(err));
+        ChipLogError(SoftwareUpdate, "Matter image header parser error: %" CHIP_ERROR_FORMAT, err.Format());
         this->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
         return err;
     }

--- a/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
+++ b/src/platform/telink/wifi/3.3.99.0/WiFiManager.cpp
@@ -470,7 +470,7 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data, size_t lengt
             CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
             if (error != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Cannot post event [error: %s]", ErrorStr(error));
+                ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
             }
         }
         // cleanup the provisioning data as it is configured per each connect request

--- a/src/platform/telink/wifi/4.1.0.0/WiFiManager.cpp
+++ b/src/platform/telink/wifi/4.1.0.0/WiFiManager.cpp
@@ -534,7 +534,7 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data, size_t lengt
             CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
             if (error != CHIP_NO_ERROR)
             {
-                ChipLogError(DeviceLayer, "Cannot post event [error: %s]", ErrorStr(error));
+                ChipLogError(DeviceLayer, "Cannot post event: %" CHIP_ERROR_FORMAT, error.Format());
             }
 
             WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();

--- a/src/platform/ti/cc13xx_26xx/ConfigurationManagerImpl.cpp
+++ b/src/platform/ti/cc13xx_26xx/ConfigurationManagerImpl.cpp
@@ -211,7 +211,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = CC13XX_26XXConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "FactoryResetConfig() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -330,7 +330,7 @@ void BLEManagerImpl::HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * apEv
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
         sInstance.mFlags.Clear(Flags::kControlOpInProgress);
     }
@@ -717,7 +717,7 @@ void BLEManagerImpl::HandleTXCharChanged(BLE_CONNECTION_OBJECT conId, const uint
 
 exit:
     if (err != CHIP_NO_ERROR)
-        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleTXCharChanged() failed: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_t * value, size_t len)
@@ -742,7 +742,7 @@ void BLEManagerImpl::HandleRXCharWrite(BLE_CONNECTION_OBJECT conId, const uint8_
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "HandleRXCharWrite() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -780,7 +780,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -822,7 +822,7 @@ void BLEManagerImpl::InitiateScan(BleScanState scanType)
     if (err != CHIP_NO_ERROR)
     {
         mBLEScanConfig.mBleScanState = BleScanState::kNotScanning;
-        ChipLogError(Ble, "Failed to start a BLE can: %s", chip::ErrorStr(err));
+        ChipLogError(Ble, "Failed to start a BLE can: %" CHIP_ERROR_FORMAT, err.Format());
         BleConnectionDelegate::OnConnectionError(mBLEScanConfig.mAppState, err);
         return;
     }

--- a/src/platform/webos/ConfigurationManagerImpl.cpp
+++ b/src/platform/webos/ConfigurationManagerImpl.cpp
@@ -260,13 +260,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     err = PosixConfig::FactoryResetConfig();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset configurations: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     err = PosixConfig::FactoryResetCounters();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Failed to factory reset counters: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Failed to factory reset counters: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -481,7 +481,7 @@ void ConnectivityManagerImpl::_OnWpaInterfaceProxyReady(GObject * source_object,
         CHIP_ERROR errInner = StopAutoScan();
         if (errInner != CHIP_NO_ERROR)
         {
-            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %s", ErrorStr(errInner));
+            ChipLogError(DeviceLayer, "wpa_supplicant: Failed to stop auto scan: %" CHIP_ERROR_FORMAT, errInner.Format());
         }
     });
 
@@ -809,7 +809,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         SetWiFiAPMode(kWiFiAPMode_Disabled);
-        ChipLogError(DeviceLayer, "Drive AP state failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Drive AP state failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
@@ -169,7 +169,7 @@ exit:
 
     if (networkingStatus != Status::kSuccess)
     {
-        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %s", chip::ErrorStr(err));
+        ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network: %" CHIP_ERROR_FORMAT, err.Format());
         callback->OnResult(networkingStatus, CharSpan(), 0);
     }
 }

--- a/src/platform/webos/PosixConfig.cpp
+++ b/src/platform/webos/PosixConfig.cpp
@@ -506,14 +506,14 @@ CHIP_ERROR PosixConfig::ClearNamespace(const char * ns)
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -538,14 +538,14 @@ CHIP_ERROR PosixConfig::FactoryResetConfig()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:
@@ -570,14 +570,14 @@ CHIP_ERROR PosixConfig::FactoryResetCounters()
     err = storage->ClearAll();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage ClearAll failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage ClearAll failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     err = storage->Commit();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Storage Commit failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Storage Commit failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 exit:


### PR DESCRIPTION
#### Summary

Unify `CHIP_ERROR` formatting in `ChipLog*` functions to use `err.Format()` instead of using `ErrorStr()` directly. Unit tests were left as they are.

#### Testing

CI should check for potential build breaks.