### PR TITLE
[Closures] Add secure state field validation check.

### DIFF
--- a/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
+++ b/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
@@ -260,8 +260,28 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
                                 CHIP_ERROR_INVALID_ARGUMENT);
         }
 
-        // TODO: SecureState field Value based on conditions validation will be done after the specification issue #11805
-        // resolution.
+        // SecureState can only be true if the closure meets the required conditions for a secure state, preventing unauthorized or undetectable access.
+        if (!incomingOverallCurrentState.secureState.IsNull() && incomingOverallCurrentState.secureState.Value())
+        {
+            // secure state requires the closure to meet all of the following conditions based on feature support:
+            // If the Positioning feature is supported, then the Position field of OverallCurrentState is FullyClosed.
+            // If the MotionLatching feature is supported, then the Latch field of OverallCurrentState is True.
+    
+            if (mConformance.HasFeature(Feature::kPositioning))
+            {
+                VerifyOrReturnError(!incomingOverallCurrentState.position.HasValue() || incomingOverallCurrentState.position.Value().IsNull(),
+                                    CHIP_ERROR_INVALID_ARGUMENT);
+                VerifyOrReturnError(incomingOverallCurrentState.position.Value().Value() == CurrentPositionEnum::kFullyClosed,
+                                    CHIP_ERROR_INVALID_ARGUMENT);
+            }
+
+            if (mConformance.HasFeature(Feature::kMotionLatching))
+            {
+                VerifyOrReturnError(!incomingOverallCurrentState.latch.HasValue() || incomingOverallCurrentState.latch.Value().IsNull(),
+                                    CHIP_ERROR_INVALID_ARGUMENT);
+                VerifyOrReturnError(incomingOverallCurrentState.latch.Value().Value() == true, CHIP_ERROR_INVALID_ARGUMENT);
+            }
+        }
 
         // SecureStateChanged event SHALL be generated when the SecureState field in the OverallCurrentState attribute changes
         if (!incomingOverallCurrentState.secureState.IsNull())

--- a/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
+++ b/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
@@ -266,7 +266,7 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
             // secure state requires the closure to meet all of the following conditions based on feature support:
             // If the Positioning feature is supported, then the Position field of OverallCurrentState is FullyClosed.
             // If the MotionLatching feature is supported, then the Latch field of OverallCurrentState is True.
-    
+
             if (mConformance.HasFeature(Feature::kPositioning))
             {
                 VerifyOrReturnError(incomingOverallCurrentState.position.HasValue() && !incomingOverallCurrentState.position.Value().IsNull(),

--- a/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
+++ b/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
@@ -260,7 +260,8 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
                                 CHIP_ERROR_INVALID_ARGUMENT);
         }
 
-        // SecureState can only be true if the closure meets the required conditions for a secure state, preventing unauthorized or undetectable access.
+        // SecureState can only be true if the closure meets the required conditions for a secure state, preventing unauthorized or
+        // undetectable access.
         if (!incomingOverallCurrentState.secureState.IsNull() && incomingOverallCurrentState.secureState.Value())
         {
             // secure state requires the closure to meet all of the following conditions based on feature support:
@@ -269,7 +270,8 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
 
             if (mConformance.HasFeature(Feature::kPositioning))
             {
-                VerifyOrReturnError(incomingOverallCurrentState.position.HasValue() && !incomingOverallCurrentState.position.Value().IsNull(),
+                VerifyOrReturnError(incomingOverallCurrentState.position.HasValue() &&
+                                        !incomingOverallCurrentState.position.Value().IsNull(),
                                     CHIP_ERROR_INVALID_ARGUMENT);
                 VerifyOrReturnError(incomingOverallCurrentState.position.Value().Value() == CurrentPositionEnum::kFullyClosed,
                                     CHIP_ERROR_INVALID_ARGUMENT);
@@ -277,7 +279,8 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
 
             if (mConformance.HasFeature(Feature::kMotionLatching))
             {
-                VerifyOrReturnError(incomingOverallCurrentState.latch.HasValue() && !incomingOverallCurrentState.latch.Value().IsNull(),
+                VerifyOrReturnError(incomingOverallCurrentState.latch.HasValue() &&
+                                        !incomingOverallCurrentState.latch.Value().IsNull(),
                                     CHIP_ERROR_INVALID_ARGUMENT);
                 VerifyOrReturnError(incomingOverallCurrentState.latch.Value().Value() == true, CHIP_ERROR_INVALID_ARGUMENT);
             }

--- a/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
+++ b/src/app/clusters/closure-control-server/closure-control-cluster-logic.cpp
@@ -269,7 +269,7 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
     
             if (mConformance.HasFeature(Feature::kPositioning))
             {
-                VerifyOrReturnError(!incomingOverallCurrentState.position.HasValue() || incomingOverallCurrentState.position.Value().IsNull(),
+                VerifyOrReturnError(incomingOverallCurrentState.position.HasValue() && !incomingOverallCurrentState.position.Value().IsNull(),
                                     CHIP_ERROR_INVALID_ARGUMENT);
                 VerifyOrReturnError(incomingOverallCurrentState.position.Value().Value() == CurrentPositionEnum::kFullyClosed,
                                     CHIP_ERROR_INVALID_ARGUMENT);
@@ -277,7 +277,7 @@ CHIP_ERROR ClusterLogic::SetOverallCurrentState(const DataModel::Nullable<Generi
 
             if (mConformance.HasFeature(Feature::kMotionLatching))
             {
-                VerifyOrReturnError(!incomingOverallCurrentState.latch.HasValue() || incomingOverallCurrentState.latch.Value().IsNull(),
+                VerifyOrReturnError(incomingOverallCurrentState.latch.HasValue() && !incomingOverallCurrentState.latch.Value().IsNull(),
                                     CHIP_ERROR_INVALID_ARGUMENT);
                 VerifyOrReturnError(incomingOverallCurrentState.latch.Value().Value() == true, CHIP_ERROR_INVALID_ARGUMENT);
             }

--- a/src/app/tests/TestClosureControlClusterLogic.cpp
+++ b/src/app/tests/TestClosureControlClusterLogic.cpp
@@ -813,7 +813,7 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_InvalidSecureStateWithPos
 
     DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
         GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kPartiallyOpened)), NullOptional,
-                                    NullOptional, DataModel::MakeNullable(true)));
+                                   NullOptional, DataModel::MakeNullable(true)));
     EXPECT_EQ(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
 
     DataModel::Nullable<GenericOverallCurrentState> readValue;
@@ -832,8 +832,7 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_InvalidSecureStateWithMot
     mockContext.ResetReportedAttributeId();
 
     DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
-        GenericOverallCurrentState(NullOptional, Optional(false),
-                                    NullOptional, DataModel::MakeNullable(true)));
+        GenericOverallCurrentState(NullOptional, Optional(false), NullOptional, DataModel::MakeNullable(true)));
     EXPECT_EQ(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
 
     DataModel::Nullable<GenericOverallCurrentState> readValue;
@@ -852,8 +851,8 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithPosit
     mockContext.ResetReportedAttributeId();
 
     DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
-        GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)), NullOptional,
-                                    NullOptional, DataModel::MakeNullable(true)));
+        GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)), NullOptional, NullOptional,
+                                   DataModel::MakeNullable(true)));
     EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
 
     DataModel::Nullable<GenericOverallCurrentState> readValue;
@@ -876,8 +875,7 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithMotio
     mockContext.ResetReportedAttributeId();
 
     DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
-        GenericOverallCurrentState(NullOptional, Optional(true),
-                                    NullOptional, DataModel::MakeNullable(true)));
+        GenericOverallCurrentState(NullOptional, Optional(true), NullOptional, DataModel::MakeNullable(true)));
     EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
 
     DataModel::Nullable<GenericOverallCurrentState> readValue;
@@ -901,7 +899,7 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithPosit
 
     DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
         GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kPartiallyOpened)), Optional(false),
-                                    NullOptional, DataModel::MakeNullable(false)));
+                                   NullOptional, DataModel::MakeNullable(false)));
     EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
 
     DataModel::Nullable<GenericOverallCurrentState> readValue;

--- a/src/app/tests/TestClosureControlClusterLogic.cpp
+++ b/src/app/tests/TestClosureControlClusterLogic.cpp
@@ -803,6 +803,118 @@ TEST_F(TestClosureControlClusterLogic, SetOverallState_InvalidSpeedPositioningAn
     EXPECT_FALSE(mockContext.HasBeenMarkedDirty());
 }
 
+TEST_F(TestClosureControlClusterLogic, SetOverallState_InvalidSecureStateWithPositioningFeature)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning);
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+
+    mockContext.ResetDirtyFlag();
+    mockContext.ResetReportedAttributeId();
+
+    DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
+        GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kPartiallyOpened)), NullOptional,
+                                    NullOptional, DataModel::MakeNullable(true)));
+    EXPECT_EQ(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
+
+    DataModel::Nullable<GenericOverallCurrentState> readValue;
+    EXPECT_EQ(logic->GetOverallCurrentState(readValue), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(readValue.IsNull());
+    EXPECT_FALSE(mockContext.HasBeenMarkedDirty());
+}
+
+TEST_F(TestClosureControlClusterLogic, SetOverallState_InvalidSecureStateWithMotionLatchingFeature)
+{
+    conformance.FeatureMap().Set(Feature::kMotionLatching);
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+
+    mockContext.ResetDirtyFlag();
+    mockContext.ResetReportedAttributeId();
+
+    DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
+        GenericOverallCurrentState(NullOptional, Optional(false),
+                                    NullOptional, DataModel::MakeNullable(true)));
+    EXPECT_EQ(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
+
+    DataModel::Nullable<GenericOverallCurrentState> readValue;
+    EXPECT_EQ(logic->GetOverallCurrentState(readValue), CHIP_NO_ERROR);
+
+    EXPECT_TRUE(readValue.IsNull());
+    EXPECT_FALSE(mockContext.HasBeenMarkedDirty());
+}
+
+TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithPositioningFeature)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning);
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+
+    mockContext.ResetDirtyFlag();
+    mockContext.ResetReportedAttributeId();
+
+    DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
+        GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kFullyClosed)), NullOptional,
+                                    NullOptional, DataModel::MakeNullable(true)));
+    EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
+
+    DataModel::Nullable<GenericOverallCurrentState> readValue;
+    EXPECT_EQ(logic->GetOverallCurrentState(readValue), CHIP_NO_ERROR);
+
+    EXPECT_FALSE(readValue.IsNull());
+    EXPECT_EQ(readValue.Value().position.Value().Value(), CurrentPositionEnum::kFullyClosed);
+    EXPECT_FALSE(readValue.Value().latch.HasValue());
+    EXPECT_FALSE(readValue.Value().speed.HasValue());
+    EXPECT_EQ(readValue.Value().secureState.Value(), true);
+    EXPECT_TRUE(mockContext.HasBeenMarkedDirty());
+}
+
+TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithMotionLatchingFeature)
+{
+    conformance.FeatureMap().Set(Feature::kMotionLatching);
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+
+    mockContext.ResetDirtyFlag();
+    mockContext.ResetReportedAttributeId();
+
+    DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
+        GenericOverallCurrentState(NullOptional, Optional(true),
+                                    NullOptional, DataModel::MakeNullable(true)));
+    EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
+
+    DataModel::Nullable<GenericOverallCurrentState> readValue;
+    EXPECT_EQ(logic->GetOverallCurrentState(readValue), CHIP_NO_ERROR);
+
+    EXPECT_FALSE(readValue.IsNull());
+    EXPECT_FALSE(readValue.Value().position.HasValue());
+    EXPECT_EQ(readValue.Value().latch.Value().Value(), true);
+    EXPECT_FALSE(readValue.Value().speed.HasValue());
+    EXPECT_EQ(readValue.Value().secureState.Value(), true);
+    EXPECT_TRUE(mockContext.HasBeenMarkedDirty());
+}
+
+TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidSecureStateWithPositioningAndMotionLatchingFeature)
+{
+    conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kMotionLatching);
+    EXPECT_EQ(logic->Init(conformance, initParams), CHIP_NO_ERROR);
+
+    mockContext.ResetDirtyFlag();
+    mockContext.ResetReportedAttributeId();
+
+    DataModel::Nullable<GenericOverallCurrentState> overallCurrentState(
+        GenericOverallCurrentState(Optional(DataModel::MakeNullable(CurrentPositionEnum::kPartiallyOpened)), Optional(false),
+                                    NullOptional, DataModel::MakeNullable(false)));
+    EXPECT_NE(logic->SetOverallCurrentState(overallCurrentState), CHIP_ERROR_INVALID_ARGUMENT);
+
+    DataModel::Nullable<GenericOverallCurrentState> readValue;
+    EXPECT_EQ(logic->GetOverallCurrentState(readValue), CHIP_NO_ERROR);
+
+    EXPECT_FALSE(readValue.IsNull());
+    EXPECT_EQ(readValue.Value().position.Value().Value(), CurrentPositionEnum::kPartiallyOpened);
+    EXPECT_EQ(readValue.Value().latch.Value().Value(), false);
+    EXPECT_FALSE(readValue.Value().speed.HasValue());
+    EXPECT_EQ(readValue.Value().secureState.Value(), false);
+    EXPECT_TRUE(mockContext.HasBeenMarkedDirty());
+}
+
 TEST_F(TestClosureControlClusterLogic, SetOverallState_ValidPositioningAndSpeed)
 {
     conformance.FeatureMap().Set(Feature::kPositioning).Set(Feature::kSpeed);


### PR DESCRIPTION
#### Summary
 
 As per latest closure control specification (https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/ClosureControl.adoc#554-securestate-field)

secure state field can only be true , if closure meet the specific conditions.
so adding a validation check to make sure the conditions are fullfilled when secure state is set to true or else return CHIP_ERROR_INVALID_ARGUMENT.

A secure state requires the closure to meet all of the following conditions defined by the OverallCurrentState Struct based on feature support:

If the Positioning feature is supported, then the Position field of OverallCurrentState is FullyClosed.

If the MotionLatching feature is supported, then the Latch field of OverallCurrentState is True.

#### Related issues


#### Testing
        Added unit tests for the same.
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
