### PR TITLE
Fix ZAP CI Failure

### DIFF
--- a/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
+++ b/examples/air-quality-sensor-app/air-quality-sensor-common/icd-lit-air-quality-sensor-app.matter
@@ -799,7 +799,7 @@ cluster OtaSoftwareUpdateRequestor = 42 {
   }
 
   /** Announce the presence of an OTA Provider */
-  command AnnounceOTAProvider(AnnounceOTAProviderRequest): DefaultSuccess = 0;
+  command access(invoke: administer) AnnounceOTAProvider(AnnounceOTAProviderRequest): DefaultSuccess = 0;
 }
 
 /** This cluster is used to manage global aspects of the Commissioning flow. */


### PR DESCRIPTION
#### Summary

- ZAP Templates CI is failing after https://github.com/project-chip/connectedhomeip/pull/40163 got merged.

- Basically the PR https://github.com/project-chip/connectedhomeip/pull/40243 got merged just before it....and this PR updated Access Rights of a command, and the PR that triggered failure did NOT have that Access Right in its Matter IDL (ZAP Regen was made without merging master back intro branch)

- Fix: regenerate ZAP and commit new updated Matter IDL


#### Testing

CI Testing
