### PR TITLE
Software diagnostic should not return not enabled attributes

### DIFF
--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-cluster.h
@@ -80,21 +80,33 @@ public:
         switch (request.path.mAttributeId)
         {
         case SoftwareDiagnostics::Attributes::CurrentHeapFree::Id: {
+            VerifyOrReturnError(mLogic.GetEnabledAttributes().enableCurrentHeapFree,
+                                Protocols::InteractionModel::Status::UnsupportedAttribute);
+
             uint64_t value;
             CHIP_ERROR err = mLogic.GetCurrentHeapFree(value);
             return EncodeValue(value, err, encoder);
         }
         case SoftwareDiagnostics::Attributes::CurrentHeapUsed::Id: {
+            VerifyOrReturnError(mLogic.GetEnabledAttributes().enableCurrentHeapUsed,
+                                Protocols::InteractionModel::Status::UnsupportedAttribute);
+
             uint64_t value;
             CHIP_ERROR err = mLogic.GetCurrentHeapUsed(value);
             return EncodeValue(value, err, encoder);
         }
         case SoftwareDiagnostics::Attributes::CurrentHeapHighWatermark::Id: {
+            VerifyOrReturnError(mLogic.GetEnabledAttributes().enableCurrentWatermarks,
+                                Protocols::InteractionModel::Status::UnsupportedAttribute);
+
             uint64_t value;
             CHIP_ERROR err = mLogic.GetCurrentHighWatermark(value);
             return EncodeValue(value, err, encoder);
         }
         case SoftwareDiagnostics::Attributes::ThreadMetrics::Id:
+            VerifyOrReturnError(mLogic.GetEnabledAttributes().enableThreadMetrics,
+                                Protocols::InteractionModel::Status::UnsupportedAttribute);
+
             return mLogic.ReadThreadMetrics(encoder);
         case Globals::Attributes::FeatureMap::Id:
             return encoder.Encode(mLogic.GetFeatureMap());

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-logic.h
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-logic.h
@@ -71,6 +71,9 @@ public:
     /// Determines what commands are supported
     CHIP_ERROR AcceptedCommands(ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder);
 
+    /// Returns the enabled attributes for the SoftwareDiagnostics cluster.
+    SoftwareDiagnosticsEnabledAttributes GetEnabledAttributes() const { return mEnabledAttributes; }
+
 private:
     const SoftwareDiagnosticsEnabledAttributes mEnabledAttributes;
 };


### PR DESCRIPTION
#### Summary
If the attribute is not enabled, it should not be sent to the controller. Instead, it should send UnsupportedAttribute.

#### Testing

Added unit test coverage to the TestSoftwareDiagnosticCluster to verify whether the proper attributes are reported or not.
