### PR TITLE
python: remove unused imports from python_testing and example build scripts

### DIFF
--- a/scripts/build/builders/mbed.py
+++ b/scripts/build/builders/mbed.py
@@ -15,7 +15,6 @@
 import os
 import shlex
 from enum import Enum, auto
-from typing import Optional
 
 from .builder import Builder, BuilderOutput
 

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -16,7 +16,6 @@ import logging
 import os
 import shlex
 from enum import Enum, auto
-from typing import Optional
 
 from .builder import Builder, BuilderOutput
 

--- a/scripts/build/builders/nxp.py
+++ b/scripts/build/builders/nxp.py
@@ -16,7 +16,6 @@ import importlib.util
 import logging
 import os
 from enum import Enum, auto
-from typing import Optional
 
 from .builder import BuilderOutput
 from .gn import GnBuilder

--- a/scripts/build/builders/qpg.py
+++ b/scripts/build/builders/qpg.py
@@ -14,7 +14,6 @@
 
 import os
 from enum import Enum, auto
-from typing import Optional
 
 from .builder import BuilderOutput
 from .gn import GnBuilder

--- a/scripts/build/builders/realtek.py
+++ b/scripts/build/builders/realtek.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import os
 from enum import Enum, auto
 

--- a/scripts/build/builders/telink.py
+++ b/scripts/build/builders/telink.py
@@ -16,7 +16,6 @@ import logging
 import os
 import shlex
 from enum import Enum, auto
-from typing import Optional
 
 from .builder import Builder, BuilderOutput
 

--- a/src/python_testing/TC_ACE_1_2.py
+++ b/src/python_testing/TC_ACE_1_2.py
@@ -35,7 +35,6 @@
 # === END CI TEST ARGUMENTS ===
 
 import chip.clusters as Clusters
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.exceptions import ChipStackError
 from chip.interaction_model import Status
 from chip.testing.event_attribute_reporting import AttributeSubscriptionHandler, EventSubscriptionHandler

--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -41,7 +41,6 @@ from typing import Optional
 
 import chip.clusters as Clusters
 from chip.clusters import Attribute
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Types import NullValue
 from chip.testing import matter_asserts
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, has_attribute

--- a/src/python_testing/TC_FAN_2_1.py
+++ b/src/python_testing/TC_FAN_2_1.py
@@ -38,7 +38,6 @@ import logging
 from typing import Any
 
 import chip.clusters as Clusters
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.interaction_model import Status
 from chip.testing.matter_asserts import is_valid_uint_value
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_FAN_3_1.py
+++ b/src/python_testing/TC_FAN_3_1.py
@@ -41,7 +41,6 @@ from enum import Enum
 from typing import Any
 
 import chip.clusters as Clusters
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.interaction_model import Status
 from chip.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from chip.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main

--- a/src/python_testing/TC_FAN_3_2.py
+++ b/src/python_testing/TC_FAN_3_2.py
@@ -42,7 +42,6 @@ from enum import Enum
 from typing import Any
 
 import chip.clusters as Clusters
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.interaction_model import Status
 from chip.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from chip.testing.matter_asserts import assert_valid_uint8

--- a/src/python_testing/TC_IDM_4_2.py
+++ b/src/python_testing/TC_IDM_4_2.py
@@ -40,7 +40,6 @@ import time
 
 import chip.clusters as Clusters
 from chip.ChipDeviceCtrl import ChipDeviceController
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.clusters.Attribute import AttributePath, TypedAttributePath
 from chip.exceptions import ChipStackError
 from chip.interaction_model import Status

--- a/src/python_testing/TestGroupTableReports.py
+++ b/src/python_testing/TestGroupTableReports.py
@@ -37,7 +37,6 @@
 from typing import List
 
 import chip.clusters as Clusters
-from chip.clusters import ClusterObjects as ClusterObjects
 from chip.interaction_model import Status
 from chip.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main


### PR DESCRIPTION
#### Summary
`flake8` flagged few unused imports, removed them
```
flake8 --select=F401 src/python_testing scripts
```

#### Related issues

#### Testing
- manually verified that they are not really used
- CI should not break as most of the builder script and python tests are used in CI.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
