### PR TITLE
[Silabs] Fixing discriminator update via matter shell

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -514,7 +514,10 @@ CHIP_ERROR Storage::SetSetupDiscriminator(uint16_t value)
 {
     CHIP_ERROR err = Flash::Set(Parameters::ID::kDiscriminator, value);
 #if ENABLE_CHIP_SHELL
-    err = Storage::Commit();
+    if (err == CHIP_NO_ERROR)
+    {
+        err = Storage::Commit();
+    }
 #endif // ENABLE_CHIP_SHELL
     return err;
 }

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -514,7 +514,7 @@ CHIP_ERROR Storage::SetSetupDiscriminator(uint16_t value)
 {
     CHIP_ERROR err = Flash::Set(Parameters::ID::kDiscriminator, value);
 #if ENABLE_CHIP_SHELL
-    return err == CHIP_NO_ERROR ? Storage::Commit(): err;
+    err = Storage::Commit();
 #endif // ENABLE_CHIP_SHELL
     return err;
 }

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -512,7 +512,11 @@ CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
 
 CHIP_ERROR Storage::SetSetupDiscriminator(uint16_t value)
 {
-    return Flash::Set(Parameters::ID::kDiscriminator, value);
+    CHIP_ERROR err = Flash::Set(Parameters::ID::kDiscriminator, value);
+#if ENABLE_CHIP_SHELL
+    return err == CHIP_NO_ERROR ? Storage::Commit(): err;
+#endif // ENABLE_CHIP_SHELL
+    return err;
 }
 
 CHIP_ERROR Storage::GetSetupDiscriminator(uint16_t & value)


### PR DESCRIPTION
#### Summary
When the discriminator was updated using the Matter shell command via ProvisionStorageFlash.cpp, the changes to the discriminator were set but not committed, resulting in the updated value being lost after a factory reset.

Ensuring when the discriminator is set via the shell it is commit to flash. It shouldn't affect provisioning working as well since `ENABLE_CHIP_SHELL` will not be defined for provisioning app.

#### Testing
Tested with 917 SoC

