### PR TITLE
Update clusters to use attribute list builder

### DIFF
--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
@@ -17,6 +17,7 @@
 
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/clusters/general-diagnostics-server/general-diagnostics-cluster.h>
+#include <app/server-cluster/AttributeListBuilder.h>
 #include <app/server-cluster/DefaultServerCluster.h>
 #include <app/server/Server.h>
 #include <clusters/GeneralDiagnostics/ClusterId.h>
@@ -213,6 +214,14 @@ HandlePayloadTestRequest(CommandHandler & handler, const ConcreteCommandPath & c
 namespace chip {
 namespace app {
 namespace Clusters {
+namespace {
+    constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
+        GeneralDiagnostics::Attributes::NetworkInterfaces::kMetadataEntry,
+        GeneralDiagnostics::Attributes::RebootCount::kMetadataEntry,
+        GeneralDiagnostics::Attributes::UpTime::kMetadataEntry,
+        GeneralDiagnostics::Attributes::TestEventTriggersEnabled::kMetadataEntry,
+    };
+}
 
 CHIP_ERROR GeneralDiagnosticsCluster::Startup(ServerClusterContext & context)
 {
@@ -316,45 +325,17 @@ std::optional<DataModel::ActionReturnStatus> GeneralDiagnosticsCluster::InvokeCo
 CHIP_ERROR GeneralDiagnosticsCluster::Attributes(const ConcreteClusterPath & path,
                                                  ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
-    using namespace GeneralDiagnostics::Attributes;
+    AttributeListBuilder listBuilder(builder);
 
-    // Ensure we have space for all possible attributes (there will be 5 optional at most, 4 mandatory)
-    ReturnErrorOnFailure(builder.EnsureAppendCapacity(9 + DefaultServerCluster::GlobalAttributes().size()));
+    constexpr AttributeListBuilder::OptionalAttributeEntry optionalAttributeEntries[] = {
+        { mEnabledAttributes.enableTotalOperationalHours, GeneralDiagnostics::Attributes::TotalOperationalHours::kMetadataEntry },
+        { mEnabledAttributes.enableBootReason, GeneralDiagnostics::Attributes::BootReason::kMetadataEntry },
+        { mEnabledAttributes.enableActiveHardwareFaults, GeneralDiagnostics::Attributes::ActiveHardwareFaults::kMetadataEntry },
+        { mEnabledAttributes.enableActiveRadioFaults, GeneralDiagnostics::Attributes::ActiveRadioFaults::kMetadataEntry },
+        { mEnabledAttributes.enableActiveNetworkFaults, GeneralDiagnostics::Attributes::ActiveNetworkFaults::kMetadataEntry },
+    };
 
-    // Mandatory attributes
-    ReturnErrorOnFailure(builder.AppendElements({
-        NetworkInterfaces::kMetadataEntry,
-        RebootCount::kMetadataEntry,
-        UpTime::kMetadataEntry,
-        TestEventTriggersEnabled::kMetadataEntry,
-    }));
-
-    if (mEnabledAttributes.enableTotalOperationalHours)
-    {
-        ReturnErrorOnFailure(builder.Append(TotalOperationalHours::kMetadataEntry));
-    }
-
-    if (mEnabledAttributes.enableBootReason)
-    {
-        ReturnErrorOnFailure(builder.Append(BootReason::kMetadataEntry));
-    }
-
-    if (mEnabledAttributes.enableActiveHardwareFaults)
-    {
-        ReturnErrorOnFailure(builder.Append(ActiveHardwareFaults::kMetadataEntry));
-    }
-
-    if (mEnabledAttributes.enableActiveRadioFaults)
-    {
-        ReturnErrorOnFailure(builder.Append(ActiveRadioFaults::kMetadataEntry));
-    }
-
-    if (mEnabledAttributes.enableActiveNetworkFaults)
-    {
-        ReturnErrorOnFailure(builder.Append(ActiveNetworkFaults::kMetadataEntry));
-    }
-
-    return builder.AppendElements(DefaultServerCluster::GlobalAttributes());
+    return listBuilder.Append(Span(kMandatoryAttributes), Span(optionalAttributeEntries));
 }
 
 CHIP_ERROR GeneralDiagnosticsCluster::AcceptedCommands(const ConcreteClusterPath & path,

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
@@ -327,7 +327,7 @@ CHIP_ERROR GeneralDiagnosticsCluster::Attributes(const ConcreteClusterPath & pat
 {
     AttributeListBuilder listBuilder(builder);
 
-    constexpr AttributeListBuilder::OptionalAttributeEntry optionalAttributeEntries[] = {
+    const AttributeListBuilder::OptionalAttributeEntry optionalAttributeEntries[] = {
         { mEnabledAttributes.enableTotalOperationalHours, GeneralDiagnostics::Attributes::TotalOperationalHours::kMetadataEntry },
         { mEnabledAttributes.enableBootReason, GeneralDiagnostics::Attributes::BootReason::kMetadataEntry },
         { mEnabledAttributes.enableActiveHardwareFaults, GeneralDiagnostics::Attributes::ActiveHardwareFaults::kMetadataEntry },

--- a/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
+++ b/src/app/clusters/general-diagnostics-server/general-diagnostics-cluster.cpp
@@ -215,12 +215,12 @@ namespace chip {
 namespace app {
 namespace Clusters {
 namespace {
-    constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
-        GeneralDiagnostics::Attributes::NetworkInterfaces::kMetadataEntry,
-        GeneralDiagnostics::Attributes::RebootCount::kMetadataEntry,
-        GeneralDiagnostics::Attributes::UpTime::kMetadataEntry,
-        GeneralDiagnostics::Attributes::TestEventTriggersEnabled::kMetadataEntry,
-    };
+constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
+    GeneralDiagnostics::Attributes::NetworkInterfaces::kMetadataEntry,
+    GeneralDiagnostics::Attributes::RebootCount::kMetadataEntry,
+    GeneralDiagnostics::Attributes::UpTime::kMetadataEntry,
+    GeneralDiagnostics::Attributes::TestEventTriggersEnabled::kMetadataEntry,
+};
 }
 
 CHIP_ERROR GeneralDiagnosticsCluster::Startup(ServerClusterContext & context)

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
@@ -24,8 +24,8 @@
 #include <app/InteractionModelEngine.h>
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h>
 #include <app/reporting/reporting.h>
-#include <app/util/util.h>
 #include <app/server-cluster/AttributeListBuilder.h>
+#include <app/util/util.h>
 #include <clusters/PushAvStreamTransport/Commands.h>
 #include <clusters/PushAvStreamTransport/Ids.h>
 #include <clusters/PushAvStreamTransport/Metadata.h>

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
@@ -25,6 +25,7 @@
 #include <app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.h>
 #include <app/reporting/reporting.h>
 #include <app/util/util.h>
+#include <app/server-cluster/AttributeListBuilder.h>
 #include <clusters/PushAvStreamTransport/Commands.h>
 #include <clusters/PushAvStreamTransport/Ids.h>
 #include <clusters/PushAvStreamTransport/Metadata.h>
@@ -50,7 +51,7 @@ constexpr CommandId kGeneratedCommands[] = {
     FindTransportResponse::Id,
 };
 
-constexpr DataModel::AttributeEntry kAttributes[] = {
+constexpr DataModel::AttributeEntry kMandatoryAttributes[] = {
     PushAvStreamTransport::Attributes::SupportedFormats::kMetadataEntry,
     PushAvStreamTransport::Attributes::CurrentConnections::kMetadataEntry,
 };
@@ -63,8 +64,8 @@ using namespace PushAvStreamTransport::Commands;
 CHIP_ERROR PushAvStreamTransportServer::Attributes(const ConcreteClusterPath & path,
                                                    ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder)
 {
-    ReturnErrorOnFailure(builder.ReferenceExisting(kAttributes));
-    return builder.AppendElements(DefaultServerCluster::GlobalAttributes());
+    AttributeListBuilder listBuilder(builder);
+    return listBuilder.Append(Span(kMandatoryAttributes), {});
 }
 
 CHIP_ERROR PushAvStreamTransportServer::ReadAndEncodeSupportedFormats(const AttributeValueEncoder::ListEncodeHelper & encoder)


### PR DESCRIPTION
#### Summary

This PR updates the code driven clusters to use the recently added ```AtributeListBuilder``` class for its ```Attributes``` functions. This allows optional, mandatory, and global attributes to be added in a consistent manner (and to properly check append capacity as well).

#### Testing

- CI should still pass

