### PR TITLE
TC-SC-3.4: Add commissioning marker for the test harness

### DIFF
--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -59,7 +59,7 @@ class TC_SC_3_4(MatterBaseTest):
     def steps_TC_SC_3_4(self) -> list[TestStep]:
         steps = [
 
-            TestStep("precondition", "DUT is commissioned and TH has an open CASE Session with DUT"),
+            TestStep("precondition", "DUT is commissioned and TH has an open CASE Session with DUT", is_commissioning=True),
 
             TestStep(1, "TH constructs and sends a Sigma1 message with a resumptionID and NO initiatorResumeMIC to DUT",
                      "DUT sends a status report to the TH with a FAILURE general code , Protocol ID of SECURE_CHANNEL (0x0000), and Protocol Code of INVALID_PARAMETER (0X0002). DUT MUST perform no further processing after sending the status report."),


### PR DESCRIPTION
#### Summary

Adds a commissioning marker for this test so the TH knows the device needs to be commissioned for the test to run. It is clear that this mechanism is not ideal, but it is what we have right now.

#### Related issues

https://github.com/project-chip/matter-test-scripts/issues/664

#### Testing

Ran locally, test also runs in the CI.
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
