### PR TITLE
[Darwin] Move diagnostic log transfer state to internal for now

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -77,11 +77,6 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 @property (readonly) BOOL deviceCachePrimed MTR_AVAILABLE(ios(17.6), macos(14.6), watchos(10.6), tvos(17.6));
 
 /**
- * Returns true if a diagnostic log transfer is ongoing.
- */
-@property (readonly) BOOL diagnosticLogTransferInProgress MTR_PROVISIONALLY_AVAILABLE;
-
-/**
  * The estimated device system start time.
  *
  * A device can report its events with either calendar time or time since system start time. When events are reported with time

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -183,6 +183,11 @@ MTR_DIRECT_MEMBERS
 
 - (void)_forgetAttributeWaiter:(MTRAttributeValueWaiter *)attributeValueWaiter;
 
+/**
+ * Returns true if a diagnostic log transfer is ongoing.
+ */
+@property (readonly) BOOL diagnosticLogTransferInProgress;
+
 @end
 
 @interface MTRDevice (MatterPrivateForInternalDragonsDoNotFeed)


### PR DESCRIPTION
#### Summary

`MTR_ENABLE_PROVISIONAL` was not the right annotation; move to Internal until it's ready.

#### Testing

CI should suffice.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase
