### PR TITLE
TC-SC-7.1: Add PICS per CCB 4232

### DIFF
--- a/src/python_testing/TC_SC_7_1.py
+++ b/src/python_testing/TC_SC_7_1.py
@@ -76,7 +76,11 @@ class TC_SC_7_1(MatterBaseTest):
                 _trusted_root_test_step(2),
                 TestStep(3, "TH compares the discriminators from the provided setup codes", "Discriminators do not match")]
 
-    # TODO: Need a pics or something to limit this to devices that have a factory-provided matter setup code (as opposed to a field upgradable device / device with a custom commissioning where this test won't apply)
+    def pics_TC_SC_7_1(self):
+        # Testers can use either the QR or manual code, but this test is gated on manual because the manual pairing code is required
+        # per 5.7.6. Onboarding Payload Inclusion (Manual Pairing Code, QR Code, NFC Tag), so devices that have a QR code will always
+        # have a manual code, and thus be required to run this test.
+        return ['MCORE.DD.MANUAL_PC']
 
     @async_test_body
     async def test_TC_SC_7_1(self):


### PR DESCRIPTION
#### Summary

As the CCB points out, this test is currently required for all commissionable devices, but is actually only applicable for devices that include a pairing code since the test requires it. This is MOST of the commissionable devices, but doesn't apply to devices that are field-upgrading to Matter.
The correct PICS as discussed in the TSG is the MANUAL PC PICS. Devices may opt to provide the QR code, but the test is gated on the manual PICS since all devices with a QR code will have a manual code (mandatory), but the QR code is technically optional.

#### Related issues
CCB: https://zigbeecertifiedproducts.knack.com/zigbee-alliance-ccb-tool#home/ccbs4/ccb-details16/6879819f3a994802cce434eb/
test plan: https://github.com/CHIP-Specifications/chip-test-plans/pull/5389

#### Testing
Test is run in the CI REPL test

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
