### PR TITLE
Disable Thread Local Storage on NXP Zephyr platform

### DIFF
--- a/src/platform/nxp/zephyr/SystemPlatformConfig.h
+++ b/src/platform/nxp/zephyr/SystemPlatformConfig.h
@@ -26,4 +26,5 @@
 
 #include <platform/Zephyr/SystemPlatformConfig.h>
 
+#define CHIP_SYSTEM_CONFIG_THREAD_LOCAL_STORAGE 0
 #define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS 0


### PR DESCRIPTION
#### Summary

It seems that NXP Zephyr platform does not have support Thread Local Storage (TLS) pointer.

#### Testing

Locally verified that it's possible to build (in `ghcr.io/project-chip/chip-build-nxp-zephyr:latest` docker):

```
scripts/build/build_examples.py --target nxp-rw61x-zephyr-thermostat build
```