### PR TITLE
[Closures] [Silabs] Add Timer to simulate unlatch action in 917 and EFR

### DIFF
--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -224,7 +224,7 @@ void ClosureManager::InitiateAction(AppEvent * event)
         ChipLogDetail(AppServer, "Initiating unlatch action");
         // Unlatch action check is a prerequisite for the move to action.
         // In a real application, this would be replaced with actual unlatch logic.
-        PlatformMgr().ScheduleWork([](intptr_t) { ClosureManager::GetInstance().HandleClosureUnlatchAction(); });
+        instance.StartTimer(kMotionCountdownTimeMs); 
         break;
     case Action_t::SET_TARGET_ACTION:
         ChipLogDetail(AppServer, "Initiating set target action");
@@ -293,6 +293,9 @@ void ClosureManager::HandleClosureActionCompleteEvent(AppEvent * event)
         break;
     case Action_t::MOVE_TO_ACTION:
         PlatformMgr().ScheduleWork([](intptr_t) { ClosureManager::GetInstance().HandleClosureMotionAction(); });
+        break;
+    case Action_t::UNLATCH_ACTION:
+        PlatformMgr().ScheduleWork([](intptr_t) { ClosureManager::GetInstance().HandleClosureUnlatchAction(); });
         break;
     case Action_t::SET_TARGET_ACTION:
         PlatformMgr().ScheduleWork([](intptr_t) {

--- a/examples/closure-app/silabs/src/ClosureManager.cpp
+++ b/examples/closure-app/silabs/src/ClosureManager.cpp
@@ -224,7 +224,7 @@ void ClosureManager::InitiateAction(AppEvent * event)
         ChipLogDetail(AppServer, "Initiating unlatch action");
         // Unlatch action check is a prerequisite for the move to action.
         // In a real application, this would be replaced with actual unlatch logic.
-        instance.StartTimer(kMotionCountdownTimeMs); 
+        instance.StartTimer(kMotionCountdownTimeMs);
         break;
     case Action_t::SET_TARGET_ACTION:
         ChipLogDetail(AppServer, "Initiating set target action");


### PR DESCRIPTION
#### Summary

This PR introduces 1 second timer for unlatch action in 917 and EFR.
At present the unlatch action is instatenous, which make stop command not available for unlatch action.
so added a 1 second timer to emulate the unlatch action, similar to other actions

#### Related issues


#### Testing

Validated the unlatch and stop command manually on DUT, latch value should not change with unlatch and stopcommand backtoback.
Also validated the same with TH across the closure control test scripts.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
