### PR TITLE
Backport the fan-control circular callback changes to v1.3-branch.

### DIFF
--- a/src/app/clusters/fan-control-server/fan-control-server.cpp
+++ b/src/app/clusters/fan-control-server/fan-control-server.cpp
@@ -92,6 +92,7 @@ bool gWriteFromClusterLogic = false;
 // Avoid circular callback calls when adjusting SpeedSetting and PercentSetting together.
 ScopedChangeOnly gSpeedWriteInProgress(false);
 ScopedChangeOnly gPercentWriteInProgress(false);
+ScopedChangeOnly gFanModeWriteInProgress(false);
 
 Status SetFanModeToOff(EndpointId endpointId)
 {
@@ -163,12 +164,16 @@ MatterFanControlClusterServerPreAttributeChangedCallback(const ConcreteAttribute
     switch (attributePath.mAttributeId)
     {
     case FanMode::Id: {
+        if (gFanModeWriteInProgress)
+        {
+            return Status::WriteIgnored;
+        }
         if (*value == to_underlying(FanModeEnum::kOn))
         {
             FanMode::Set(attributePath.mEndpointId, FanModeEnum::kHigh);
-            res = Status::WriteIgnored;
+            return Status::WriteIgnored;
         }
-        else if (*value == to_underlying(FanModeEnum::kSmart))
+        if (*value == to_underlying(FanModeEnum::kSmart))
         {
             FanModeSequenceEnum fanModeSequence;
             Status status = FanModeSequence::Get(attributePath.mEndpointId, &fanModeSequence);
@@ -330,6 +335,9 @@ void MatterFanControlClusterServerAttributeChangedCallback(const app::ConcreteAt
         FanModeEnum mode;
         Status status = FanMode::Get(attributePath.mEndpointId, &mode);
         VerifyOrReturn(Status::Success == status);
+
+        // Avoid circular callback calls
+        ScopedChange FanModeWriteInProgress(gFanModeWriteInProgress, true);
 
         // Setting the FanMode value to Off SHALL set the values of PercentSetting, PercentCurrent,
         // SpeedSetting, SpeedCurrent attributes to 0 (zero).


### PR DESCRIPTION
#### Summary
- Backport https://github.com/project-chip/connectedhomeip/pull/36489 and https://github.com/project-chip/connectedhomeip/pull/36515 to v1.3-branch.

#### Testing
- Tested the air-purifier app linux by writing and reading percentsetting and fanmode attribute and verified the behaviour as done in #36489 and #36515.
