### PR TITLE
Define a new commissioning API for Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioneeInfo.h
@@ -55,7 +55,7 @@ MTR_AVAILABLE(ios(18.4), macos(15.4), watchos(11.4), tvos(18.4))
  * 1) The attributes in extraAttributesToRead on MTRCommissioningParameters.
  * 2) The FeatureMap attributes of all Network Commissioning clusters on the commissionee.
  */
-@property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_UNSTABLE_API;
+@property (nonatomic, copy, readonly, nullable) NSDictionary<MTRAttributePath *, NSDictionary<NSString *, id> *> * attributes MTR_PROVISIONALLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -24,6 +24,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, MTRCommissioningStage) {
+    // Possible stages that can be reached during commissioning.  The order of
+    // these stages is not guaranteed to be anything in particular, or to match
+    // the numeric order of this enum.  There are no guarantees that any
+    // particular stage will in fact be reached, unless documented otherwise.
+
+    // The commissionee has received network credentials.  This will never be reached
+    // during on-network commissioning.
+    MTRCommissioningStageProvisionedNetworkCredentials = 1,
+
+    // The commissioning operation is about to ask the commissionee to do a Wi-Fi network scan.
+    MTRCommissioningStageWiFiScanStart = 2,
+
+    // The commissioning operation is about to ask the commissionee to do a Thread network scan.
+    MTRCommissioningStageThreadScanStart = 3,
+} MTR_PROVISIONALLY_AVAILABLE;
+
 MTR_PROVISIONALLY_AVAILABLE
 @protocol MTRCommissioningDelegate <NSObject>
 @optional
@@ -83,12 +100,9 @@ MTR_PROVISIONALLY_AVAILABLE
                completion:(void (^)(NSData * operationalDataset))completion;
 
 /**
- * Notification that network credentials have been successfully communicated
- * to the commissionee and it's going to try to join that network.  Note that
- * for commissionees that are already on-network this notification will not
- * happen.
+ * Notification that a particular comissioning stage has been reached.
  */
-- (void)commissioningProvisionedNetworkCredentials:(MTRCommissioningOperation *)commissioning;
+- (void)commissioning:(MTRCommissioningOperation *)commissioning reachedCommissioningStage:(MTRCommissioningStage)stage;
 
 /**
  * Notification that commissioning has failed.
@@ -104,9 +118,6 @@ MTR_PROVISIONALLY_AVAILABLE
     succeededForNodeID:(NSNumber *)nodeID
                metrics:(MTRMetrics *)metrics;
 
-// TODO: Need some kind of progress marker or more notifications, if we want to
-// support HAPAccessoryServerPairingProgressStateNetworkScanStart notifications
-// in our client?
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -100,7 +100,7 @@ MTR_PROVISIONALLY_AVAILABLE
                completion:(void (^)(NSData * operationalDataset))completion;
 
 /**
- * Notification that a particular comissioning stage has been reached.
+ * Notification that a particular commissioning stage has been reached.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning reachedCommissioningStage:(MTRCommissioningStage)stage;
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -20,7 +20,7 @@
 #import <Matter/MTRMetrics.h>
 #import <Matter/MTRStructsObjc.h>
 
-@class MTRCommissioningOperation; // Can't be imported, since it needs to reference us.
+@class MTRCommissioningOperation;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -76,12 +76,14 @@ MTR_PROVISIONALLY_AVAILABLE
  * commissionee should use, or until commissioning is stopped.  The provided
  * credentials are allowed to be nil for an open Wi-Fi network.
  *
- * Exactly one of networks and error will be non-nil.
+ * * error will be non-nil if a scan was attempted and failed.
+ * * networks will be non-nil if a scan was attempted and succeeded.
+ * * Both error and networks will be nil if no scan was performed.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
-    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
-                  error:(nullable NSError *)error
-             completion:(void (^)(NSData * ssid, NSData * _Nullable credentials))completion;
+    needsWiFiNetworkSelectionWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                                       error:(nullable NSError *)error
+                                  completion:(void (^)(NSData * ssid, NSData * _Nullable credentials))completion;
 
 /**
  * Callback that gets called for a commissionee that supports Thread if Thread
@@ -92,12 +94,14 @@ MTR_PROVISIONALLY_AVAILABLE
  * until the completion is invoked with the operational dataset the commissionee
  * should use, or until commissioning is stopped.
  *
- * Exactly one of networks and error will be non-nil.
+ * * error will be non-nil if a scan was attempted and failed.
+ * * networks will be non-nil if a scan was attempted and succeeded.
+ * * Both error and networks will be nil if no scan was performed.
  */
 - (void)commissioning:(MTRCommissioningOperation *)commissioning
-    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
-                    error:(nullable NSError *)error
-               completion:(void (^)(NSData * operationalDataset))completion;
+    needsThreadNetworkSelectionWithScanResults:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                                         error:(nullable NSError *)error
+                                    completion:(void (^)(NSData * operationalDataset))completion;
 
 /**
  * Notification that a particular commissioning stage has been reached.

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -24,7 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_UNSTABLE_API
+MTR_PROVISIONALLY_AVAILABLE
 @protocol MTRCommissioningDelegate <NSObject>
 @optional
 /**

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate.h
@@ -1,0 +1,112 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRCommissioneeInfo.h>
+#import <Matter/MTRDeviceAttestationDelegate.h> // For MTRDeviceAttestationDeviceInfo
+#import <Matter/MTRMetrics.h>
+#import <Matter/MTRStructsObjc.h>
+
+@class MTRCommissioningOperation; // Can't be imported, since it needs to reference us.
+
+NS_ASSUME_NONNULL_BEGIN
+
+MTR_UNSTABLE_API
+@protocol MTRCommissioningDelegate <NSObject>
+@optional
+/**
+ * Callback that gets called after various information (product identity,
+ * optionally endpoint structure information, optionally other attributes that
+ * were requested) has been read from the commissionee.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    readCommissioneeInfo:(MTRCommissioneeInfo *)info;
+
+@required
+/**
+ * Notification that device attestation has completed.
+ *
+ * Commissioning will pause, regardless of whether attestation succeeded or
+ * failed, until the completion is invoked (indicating that commissioning should
+ * proceed, even if attestation failed), or commissioning is stopped.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    completedDeviceAttestation:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                         error:(nullable NSError *)error
+                    completion:(dispatch_block_t)completion;
+
+@optional
+/**
+ * Callback that gets called for a commissionee that supports Wi-Fi if
+ * Wi-Fi network commissioning is required and Wi-Fi credentials were not
+ * provided in MTRCommissioningParameters.
+ *
+ * Commissioning will pause, including in cases when the network scan failed,
+ * until the completion is invoked with the network and credentials the
+ * commissionee should use, or until commissioning is stopped.  The provided
+ * credentials are allowed to be nil for an open Wi-Fi network.
+ *
+ * Exactly one of networks and error will be non-nil.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                  error:(nullable NSError *)error
+             completion:(void (^)(NSData * ssid, NSData * _Nullable credentials))completion;
+
+/**
+ * Callback that gets called for a commissionee that supports Thread if Thread
+ * network commissioning is required and an operational dataset was not provided
+ * in MTRCommissioningParameters.
+ *
+ * Commissioning will pause, including in cases when the network scan failed,
+ * until the completion is invoked with the operational dataset the commissionee
+ * should use, or until commissioning is stopped.
+ *
+ * Exactly one of networks and error will be non-nil.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                    error:(nullable NSError *)error
+               completion:(void (^)(NSData * operationalDataset))completion;
+
+/**
+ * Notification that network credentials have been successfully communicated
+ * to the commissionee and it's going to try to join that network.  Note that
+ * for commissionees that are already on-network this notification will not
+ * happen.
+ */
+- (void)commissioningProvisionedNetworkCredentials:(MTRCommissioningOperation *)commissioning;
+
+/**
+ * Notification that commissioning has failed.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+      failedWithError:(NSError *)error
+              metrics:(MTRMetrics *)metrics;
+
+/**
+ * Notification that commissioning has succeeded.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    succeededForNodeID:(NSNumber *)nodeID
+               metrics:(MTRMetrics *)metrics;
+
+// TODO: Need some kind of progress marker or more notifications, if we want to
+// support HAPAccessoryServerPairingProgressStateNetworkScanStart notifications
+// in our client?
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate_Internal.h
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <Matter/MTRCommissioningDelegate.h>
 #import <Matter/MTRCommissioningOperation.h>
 #import <Matter/MTRCommissioningParameters.h>
 #import <Matter/MTRDeviceController.h>
@@ -22,7 +23,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol MTRCommissioningDelegate_Internal <NSObject>
+@protocol MTRCommissioningDelegate_Internal <MTRCommissioningDelegate>
 @required
 
 /**

--- a/src/darwin/Framework/CHIP/MTRCommissioningDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningDelegate_Internal.h
@@ -1,0 +1,65 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRCommissioningOperation.h>
+#import <Matter/MTRCommissioningParameters.h>
+#import <Matter/MTRDeviceController.h>
+#import <Matter/MTRDeviceControllerDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MTRCommissioningDelegate_Internal <NSObject>
+@required
+
+/**
+ * Internal-only callback that gets called on PASE session establishment
+ * completion.  If this is implemented, then it's the delegate's job to keep
+ * commissioning as needed.  Otherwise, if PASE was established succcessfully,
+ * MTRCommissioningProcess will kick off the actual commissioning.
+ *
+ * NOTE: If we ever expose this as public API, we will want to re-work it to
+ * take a completion block that takes an MTRCommissioningParameters as an
+ * argument, or something along those lines.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    paseSessionEstablishmentComplete:(NSError * _Nullable)error;
+
+/**
+ * Callback that allows implementation of the controller:statusUpdate:
+ * notification.
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+         statusUpdate:(MTRCommissioningStatus)status;
+
+/**
+ * Callback that allows piping the nodeID through to
+ * commissioneeHasReceivedNetworkCredentials
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning provisionedNetworkCredentialsForDeviceID:(NSNumber *)deviceID;
+
+/**
+ * Callback that allows piping the nodeID through to
+ * commissioningComplete
+ */
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+      failedWithError:(NSError *)error
+          forDeviceID:(NSNumber *)deviceID
+              metrics:(MTRMetrics *)metrics;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -1,0 +1,65 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRCommissioningDelegate.h>
+#import <Matter/MTRCommissioningParameters.h>
+#import <Matter/MTRDeviceController.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+MTR_UNSTABLE_API
+@interface MTRCommissioningOperation : NSObject
+/**
+ * Initialized via initWithParameters:setupPayload:delegate:queue:
+ */
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+/**
+ * Prepare to do a new commissioning of a device with the given parameters and
+ * the given setup payload (QR code, manual pairing code, etc).  Returns nil if
+ * the payload is not valid.
+ *
+ * The deviceAttestationDelegate property of MTRCommissioningParameters will be
+ * ignored. Device attestation notifications will be delivered to the
+ * MTRCommissioningDelegate instead.  The failSafeTimeout property of
+ * MTRCommissioningParameters will be respected.
+ *
+ * The provided delegate will be notified about various things as commissioning
+ * proceeds.  The calls into the delegate will happen on the provided queue.
+ */
+- (nullable instancetype)initWithParameters:(MTRCommissioningParameters *)parameters
+                               setupPayload:(NSString *)payload
+                                   delegate:(id<MTRCommissioningDelegate>)delegate
+                                      queue:(dispatch_queue_t)queue;
+
+/**
+ * Start commissioning with the given controller (which identifies the fabric
+ * the commissionee should be commissioned into).  The delegate will be notified
+ * if there are any failures.
+ */
+- (void)startWithController:(MTRDeviceController *)controller;
+
+/**
+ * Stop commissioning.  This will typically result in
+ * commissioning:failedWithError: callbacks to delegates.
+ */
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -63,6 +63,9 @@ MTR_UNSTABLE_API
  *
  * Returns YES if this commissioning was still in-progress and has now been
  * stopped; returns NO if this commissioning wasn't in-progress.
+ *
+ * Note that this can return NO while there are still pending async calls to
+ * delegate callbacks for the end of the commissioning.
  */
 - (BOOL)stop;
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -30,9 +30,9 @@ MTR_PROVISIONALLY_AVAILABLE
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Prepare to do a new commissioning of a device with the given parameters and
- * the given setup payload (QR code, manual pairing code, etc).  Returns nil if
- * the payload is not valid.
+ * Prepare to commission a device with the given parameters and the given setup
+ * payload (QR code, manual pairing code, etc).  Returns nil if the payload is
+ * not valid.
  *
  * The deviceAttestationDelegate property of MTRCommissioningParameters will be
  * ignored. Device attestation notifications will be delivered to the

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -41,6 +41,9 @@ MTR_UNSTABLE_API
  *
  * The provided delegate will be notified about various things as commissioning
  * proceeds.  The calls into the delegate will happen on the provided queue.
+ *
+ * Modifying the parameters after this call will have no effect on the behavior
+ * of the MTRCommissioningOperation.
  */
 - (nullable instancetype)initWithParameters:(MTRCommissioningParameters *)parameters
                                setupPayload:(NSString *)payload
@@ -57,8 +60,11 @@ MTR_UNSTABLE_API
 /**
  * Stop commissioning.  This will typically result in
  * commissioning:failedWithError: callbacks to delegates.
+ *
+ * Returns YES if this commissioning was still in-progress and has now been
+ * stopped; returns NO if this commissioning wasn't in-progress.
  */
-- (void)stop;
+- (BOOL)stop;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.h
@@ -21,7 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-MTR_UNSTABLE_API
+MTR_PROVISIONALLY_AVAILABLE
 @interface MTRCommissioningOperation : NSObject
 /**
  * Initialized via initWithParameters:setupPayload:delegate:queue:

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -168,15 +168,15 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     }
 }
 
-- (void)stop
+- (BOOL)stop
 {
     MTRDeviceController_Concrete * strongController = _controller;
     if (!strongController) {
         // Nothing to do; controller is gone, so we are stopped no matter what.
-        return;
+        return NO;
     }
 
-    [strongController stopCommissioning:self forCommissioningID:_commissioningID];
+    return [strongController stopCommissioning:self forCommissioningID:_commissioningID];
 }
 
 - (void)_earlyFailCommissioning:(CHIP_ERROR)error

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -342,11 +342,16 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     dispatch_async(_delegateQueue, ^{
         if ([strongInternalDelegate respondsToSelector:@selector(commissioning:provisionedNetworkCredentialsForDeviceID:)]) {
             [strongInternalDelegate commissioning:self provisionedNetworkCredentialsForDeviceID:nodeID];
-        } else if ([strongDelegate respondsToSelector:@selector(commissioningProvisionedNetworkCredentials:)]) {
-            [strongDelegate commissioningProvisionedNetworkCredentials:self];
+        } else if ([strongDelegate respondsToSelector:@selector(commissioning:reachedCommissioningStage:)]) {
+            [strongDelegate commissioning:self reachedCommissioningStage:MTRCommissioningStageProvisionedNetworkCredentials];
         }
     });
 }
+
+// TODO: There is currently no way to know when a commissioning stage _starts_, so we
+// don't have a good way to create MTRCommissioningStageWiFiScanStart and
+// MTRCommissioningStageThreadScanStart notifications.  This will need changes
+// to the C++ DevicePairingDelegate.
 
 #pragma mark - MTRDeviceControllerDelegate_Internal implementatation
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -298,7 +298,7 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     MTRDeviceController_Concrete * strongController = _controller;
 
     // Null out the delegate, so we don't notify based on any internal cleanups
-    // we happend to do.
+    // we happened to do.
     _delegate = nil;
 
     dispatch_async(_delegateQueue, ^{

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -216,6 +216,14 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     // we happen to do.
     _delegate = nil;
 
+    // No matter what, notify our controller that we are done. Do this before
+    // we dispath our notifications, so that in cases when the controller is not
+    // our delegate its state has been updated before our delegate tries to
+    // start a new commissioning, which it might want to do from the failure
+    // callback. If the controller _is_ our delegate, it will ignore this call
+    // until it gets the delegate callbacks.
+    [strongController commissioningDone:self];
+
     dispatch_async(_delegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(commissioning:failedWithError:forDeviceID:metrics:)]) {
             [strongDelegate commissioning:self failedWithError:error forDeviceID:commissioningID metrics:metrics];
@@ -223,9 +231,6 @@ static inline void emitMetricForSetupPayload(NSString * payload)
             [strongDelegate commissioning:self failedWithError:error metrics:metrics];
         }
     });
-
-    // No matter what, notify our controller that we are done.
-    [strongController commissioningDone:self];
 }
 
 - (id<MTRCommissioningDelegate_Internal>)_internalDelegate
@@ -299,14 +304,19 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     // we happened to do.
     _delegate = nil;
 
+    // No matter what, notify our controller that we are done. Do this before
+    // we dispath our notifications, so that in cases when the controller is not
+    // our delegate its state has been updated before our delegate tries to
+    // start a new commissioning, which it might want to do from the success
+    // callback. If the controller _is_ our delegate, it will ignore this call
+    // until it gets the delegate callbacks.
+    [strongController commissioningDone:self];
+
     dispatch_async(_delegateQueue, ^{
         if ([strongDelegate respondsToSelector:@selector(commissioning:succeededForNodeID:metrics:)]) {
             [strongDelegate commissioning:self succeededForNodeID:nodeID metrics:metrics];
         }
     });
-
-    // No matter what, notify our controller that we are done.
-    [strongController commissioningDone:self];
 }
 
 // No need to implement deprecated or less-information versions of

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -1,0 +1,484 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDeviceAttestationDelegate.h>
+
+#import "MTRCommissioningDelegate_Internal.h"
+#import "MTRCommissioningOperation.h"
+#import "MTRCommissioningOperation_Internal.h"
+#import "MTRDefines_Internal.h"
+#import "MTRDeviceControllerDelegate_Internal.h"
+#import "MTRDeviceController_Concrete.h"
+#import "MTRError_Internal.h"
+#import "MTRLogging_Internal.h"
+#import "MTRMetricKeys.h"
+#import "MTRMetricsCollector.h"
+#import "MTRMetrics_Internal.h"
+
+#include <controller/ExampleOperationalCredentialsIssuer.h>
+#include <lib/core/CHIPError.h>
+#include <setup_payload/SetupPayload.h>
+
+using namespace chip;
+using namespace chip::Tracing::DarwinFramework;
+
+@interface MTRCommissioningOperationDeviceAttestationDelegate : NSObject <MTRDeviceAttestationDelegate>
+@property (nonatomic, readwrite, weak) MTRCommissioningOperation * commissioningOperation;
+@end
+
+@interface MTRCommissioningOperation () <MTRDeviceControllerDelegate_Internal>
+@end
+
+@implementation MTRCommissioningOperation {
+    MTRCommissioningParameters * _parameters;
+    NSNumber * _commissioningID;
+    id<MTRCommissioningDelegate> __weak _delegate;
+    dispatch_queue_t _delegateQueue;
+    MTRDeviceController_Concrete * __weak _controller;
+}
+
+- (instancetype)initWithParameters:(MTRCommissioningParameters *)parameters
+                      setupPayload:(NSString *)payload
+                          delegate:(id<MTRCommissioningDelegate>)delegate
+                             queue:(dispatch_queue_t)queue
+{
+    using namespace chip::Controller;
+
+    uint64_t commissioningID;
+    CHIP_ERROR err = ExampleOperationalCredentialsIssuer::GetRandomOperationalNodeId(&commissioningID);
+    if (err != CHIP_NO_ERROR) {
+        // Should basically never happen, so no good reason to propagate err out.
+        // Not logging "self" because we have not done super init yet.
+        MTR_LOG_ERROR("Unable to generate a commissioning identifier: %" CHIP_ERROR_FORMAT, err.Format());
+        return nil;
+    }
+
+    return [self initWithParameters:parameters
+                       setupPayload:payload
+                    commissioningID:@(commissioningID)
+                isInternallyCreated:NO
+                           delegate:delegate
+                              queue:queue];
+}
+
+- (instancetype)initWithParameters:(MTRCommissioningParameters *)parameters
+                      setupPayload:(NSString *)payload
+                   commissioningID:(NSNumber *)commissioningID
+               isInternallyCreated:(BOOL)isInternallyCreated
+                          delegate:(id<MTRCommissioningDelegate>)delegate
+                             queue:(dispatch_queue_t)queue
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    if (!parameters || !payload || !commissioningID || !queue) {
+        MTR_LOG_ERROR("%@ Invalid nil argument to initWithParameters", self);
+        return nil;
+    }
+
+    _parameters = [parameters copy];
+    _setupPayload = payload;
+    _commissioningID = commissioningID;
+    _isInternallyCreated = isInternallyCreated;
+    _delegate = delegate;
+    _delegateQueue = queue;
+
+    // Set an attestation delegate on the parameters, but avoid a reference
+    // loop, so don't set ourselves directly.
+    auto * attestationDelegate = [[MTRCommissioningOperationDeviceAttestationDelegate alloc] init];
+    attestationDelegate.commissioningOperation = self;
+    _parameters.deviceAttestationDelegate = attestationDelegate;
+
+    return self;
+}
+
+static inline void emitMetricForSetupPayload(NSString * payload)
+{
+    std::vector<SetupPayload> payloads;
+    CHIP_ERROR err = SetupPayload::FromStringRepresentation(payload.UTF8String, payloads);
+    if (err != CHIP_NO_ERROR) {
+        // Not much we can do here; can't get a VID/PID from an invalid payload.
+        MTR_LOG_ERROR("Unable to parse setup payload to extract VID/PID");
+        return;
+    }
+
+    if (payloads.empty()) {
+        // Pretty odd that the parse succeeded!
+        MTR_LOG_ERROR("Setup payload parsing succeeded but somehow did not create any payloads we can get a VID/PID from");
+        return;
+    }
+
+    // Just log the first VID/PID we have; that's the best we can do.
+    MATTER_LOG_METRIC(kMetricDeviceVendorID, payloads[0].vendorID);
+    MATTER_LOG_METRIC(kMetricDeviceProductID, payloads[0].productID);
+}
+
+- (void)startWithController:(MTRDeviceController *)controller
+{
+    auto * concreteController = MTR_SAFE_CAST(controller, MTRDeviceController_Concrete);
+    if (!concreteController) {
+        MTR_LOG_ERROR("%@ Cannot start commissioning with a non-concrete controller: %@", self, controller);
+        [self _earlyFailCommissioning:CHIP_ERROR_INVALID_ARGUMENT];
+        return;
+    }
+
+    _controller = concreteController;
+
+    if (controller.suspended) {
+        MTR_LOG_ERROR("%@ suspended: can't start commissioning %@", controller, self);
+        [self _earlyFailCommissioning:CHIP_ERROR_INCORRECT_STATE];
+        return;
+    }
+
+    if (concreteController.currentCommissioning) {
+        MTR_LOG_ERROR("%@ Cannot start commissioning because commissioning %@ already in progress", self, concreteController.currentCommissioning);
+        [self _earlyFailCommissioning:CHIP_ERROR_BUSY];
+        return;
+    }
+
+    MTR_LOG("%@ starting commissioning with controller %@", self, _controller);
+
+    if (!_isInternallyCreated) {
+        [[MTRMetricsCollector sharedInstance] resetMetrics];
+
+        // Track overall commissioning
+        MATTER_LOG_METRIC_BEGIN(kMetricDeviceCommissioning);
+        emitMetricForSetupPayload(_setupPayload);
+    }
+
+    CHIP_ERROR err = [concreteController startCommissioning:self withCommissioningID:_commissioningID];
+    if (err != CHIP_NO_ERROR) {
+        MTR_LOG_ERROR("%@ failed to start commissioning with controller %@", self, _controller);
+        [self _dispatchCommissioningCHIPError:err];
+    }
+}
+
+- (void)stop
+{
+    MTRDeviceController_Concrete * strongController = _controller;
+    if (!strongController) {
+        // Nothing to do; controller is gone, so we are stopped no matter what.
+        return;
+    }
+
+    [strongController stopCommissioning:self forCommissioningID:_commissioningID];
+}
+
+- (void)_earlyFailCommissioning:(CHIP_ERROR)error
+{
+    // This handles failures before we have cleared the way for doing a commissioning at all, and in
+    // particular we might have an existing commissioning when we land here.  Don't mess with the
+    // "normal" metrics here, because we might stomp on the metrics for that ongoing commissioning.
+    auto * emptyMetrics = [[MTRMetrics alloc] initWithCapacity:0];
+    [self _dispatchCommissioningError:[MTRError errorForCHIPErrorCode:error] withMetrics:emptyMetrics];
+}
+
+- (void)_dispatchCommissioningCHIPError:(CHIP_ERROR)error
+{
+    MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, error);
+    MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshotForCommissioning:YES];
+    [self _dispatchCommissioningError:[MTRError errorForCHIPErrorCode:error] withMetrics:metrics];
+}
+
+- (void)_dispatchCommissioningError:(NSError *)error
+{
+    MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, [MTRError errorToCHIPErrorCode:error]);
+    MTRMetrics * metrics = [[MTRMetricsCollector sharedInstance] metricSnapshotForCommissioning:YES];
+    [self _dispatchCommissioningError:error withMetrics:metrics];
+}
+
+- (void)_dispatchCommissioningError:(NSError *)error withMetrics:(MTRMetrics *)metrics
+{
+    [self _dispatchCommissioningError:error forCommissioningID:_commissioningID withMetrics:metrics];
+}
+
+- (void)_dispatchCommissioningError:(NSError *)error forCommissioningID:(NSNumber *)commissioningID withMetrics:(MTRMetrics *)metrics
+{
+    MTRDeviceController_Concrete * strongController = _controller;
+
+    MTR_LOG("%@ Device commissioning failed with controller %@ metrics %@", self, strongController, metrics);
+
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    id<MTRCommissioningDelegate_Internal> strongInternalDelegate = [self _internalDelegate];
+
+    // Null out the delegate, so we don't notify based on any internal cleanups
+    // we happen to do.
+    _delegate = nil;
+
+    dispatch_async(_delegateQueue, ^{
+        if ([strongInternalDelegate respondsToSelector:@selector(commissioning:failedWithError:forDeviceID:metrics:)]) {
+            [strongInternalDelegate commissioning:self failedWithError:error forDeviceID:commissioningID metrics:metrics];
+        } else if ([strongDelegate respondsToSelector:@selector(commissioning:failedWithError:metrics:)]) {
+            [strongDelegate commissioning:self failedWithError:error metrics:metrics];
+        }
+
+        // No matter what, notify our controller that we are done.  This is not
+        // ideal, because if the delegate queue is suspended we will never clear
+        // our state on the MTRDeviceController.  But we want this part to come
+        // after the delegate notification when the delegate is the controller
+        // itself.  Try to figure out a better way to do this.
+        [strongController commissioningDone:self];
+    });
+}
+
+- (id<MTRCommissioningDelegate_Internal>)_internalDelegate
+{
+    return static_cast<id<MTRCommissioningDelegate_Internal>>(_delegate);
+}
+
+#pragma mark - MTRDeviceControllerDelegate implementation
+
+- (void)controller:(MTRDeviceController *)controller statusUpdate:(MTRCommissioningStatus)status
+{
+    id<MTRCommissioningDelegate_Internal> strongDelegate = [self _internalDelegate];
+    dispatch_async(_delegateQueue, ^{
+        if ([strongDelegate respondsToSelector:@selector(commissioning:statusUpdate:)]) {
+            [strongDelegate commissioning:self statusUpdate:status];
+        }
+    });
+}
+
+- (void)controller:(MTRDeviceController *)controller commissioningSessionEstablishmentDone:(NSError * _Nullable)error
+{
+    id<MTRCommissioningDelegate_Internal> strongDelegate = [self _internalDelegate];
+    // NOTE: Doing respondsToSelector check before dispatch, so we can kick off
+    // commissioning ourselves if not.
+    if ([strongDelegate respondsToSelector:@selector(commissioning:paseSessionEstablishmentComplete:)]) {
+        dispatch_async(_delegateQueue, ^{
+            [strongDelegate commissioning:self paseSessionEstablishmentComplete:error];
+        });
+
+        return;
+    }
+
+    MTRDeviceController_Concrete * strongController = _controller;
+    if (!strongController) {
+        // Nothing to do; controller is gone, so no point trying to go on.
+        return;
+    }
+
+    NSError * commissionError;
+    BOOL ok = [strongController commission:self withCommissioningID:_commissioningID commissioningParams:_parameters error:&commissionError];
+    if (!ok) {
+        MTR_LOG_ERROR("%@ attempt to start commissioning with controller %@ and parameters %@ failed: %@", self, strongController, _parameters, commissionError);
+        // _dispatchCommissioningError first, so we don't trigger any
+        // notifications from "stop".
+        [self _dispatchCommissioningError:commissionError];
+        [self stop];
+    }
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    commissioningComplete:(NSError * _Nullable)error
+                   nodeID:(NSNumber * _Nullable)nodeID
+                  metrics:(MTRMetrics *)metrics
+{
+    if (error) {
+        [self _dispatchCommissioningError:error forCommissioningID:nodeID withMetrics:metrics];
+        return;
+    }
+
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    MTRDeviceController_Concrete * strongController = _controller;
+
+    // Null out the delegate, so we don't notify based on any internal cleanups
+    // we happend to do.
+    _delegate = nil;
+
+    dispatch_async(_delegateQueue, ^{
+        if ([strongDelegate respondsToSelector:@selector(commissioning:succeededForNodeID:metrics:)]) {
+            [strongDelegate commissioning:self succeededForNodeID:nodeID metrics:metrics];
+        }
+
+        // No matter what, notify our controller that we are done.  This is not
+        // ideal, because if the delegate queue is suspended we will never clear
+        // our state on the MTRDeviceController.  But we want this part to come
+        // after the delegate notification when the delegate is the controller
+        // itself.  Try to figure out a better way to do this.
+        [strongController commissioningDone:self];
+    });
+}
+
+// No need to implement deprecated or less-information versions of
+// commissioningComplete: if we implement the one we do.
+
+- (void)controller:(MTRDeviceController *)controller
+    readCommissioneeInfo:(MTRCommissioneeInfo *)info
+{
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    dispatch_async(_delegateQueue, ^{
+        if ([strongDelegate respondsToSelector:@selector(commissioning:readCommissioneeInfo:)]) {
+            [strongDelegate commissioning:self readCommissioneeInfo:info];
+        }
+    });
+}
+
+// No need to implement controller:readCommissioningInfo: if we implement controller:readCommissioneeInfo:
+
+// No need to implement controller:suspendedChangedTo: for commissioning purposes.
+
+// No need to implement controller:devicesChangedForController: for commissioning purposes.
+
+- (void)controller:(MTRDeviceController *)controller commissioneeHasReceivedNetworkCredentials:(NSNumber *)nodeID
+{
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    id<MTRCommissioningDelegate_Internal> strongInternalDelegate = [self _internalDelegate];
+    dispatch_async(_delegateQueue, ^{
+        if ([strongInternalDelegate respondsToSelector:@selector(commissioning:provisionedNetworkCredentialsForDeviceID:)]) {
+            [strongInternalDelegate commissioning:self provisionedNetworkCredentialsForDeviceID:nodeID];
+        } else if ([strongDelegate respondsToSelector:@selector(commissioningProvisionedNetworkCredentials:)]) {
+            [strongDelegate commissioningProvisionedNetworkCredentials:self];
+        }
+    });
+}
+
+#pragma mark - MTRDeviceControllerDelegate_Internal implementatation
+
+- (void)controller:(MTRDeviceController *)controller
+    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                  error:(nullable NSError *)error
+{
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    dispatch_async(_delegateQueue, ^{
+        mtr_weakify(self);
+        [strongDelegate commissioning:self scannedWiFiNetworks:networks error:error completion:^(NSData * ssid, NSData * _Nullable credentials) {
+            mtr_strongify(self);
+
+            if (!self) {
+                MTR_LOG_ERROR("MTRCommissioningOperation deallocated while waiting to continue after Wi-Fi network scan");
+                return;
+            }
+
+            MTRDeviceController_Concrete * strongController = self->_controller;
+            if (!strongController) {
+                // Controller is gone, nothing to do here.
+                return;
+            }
+
+            NSError * continueError;
+            BOOL ok = [strongController continueCommissioning:self
+                                                 withWiFiSSID:ssid
+                                                  credentials:credentials
+                                                        error:&continueError];
+
+            if (!ok) {
+                MTR_LOG_ERROR("%@ attempt to continue commissioning with Wi-Fi credentials with controller %@ failed: %@", self, strongController, continueError);
+                // _dispatchCommissioningError first, so we don't trigger any
+                // notifications from "stop".
+                [self _dispatchCommissioningError:continueError];
+                [self stop];
+            }
+        }];
+    });
+}
+
+- (void)controller:(MTRDeviceController *)controller
+    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                    error:(nullable NSError *)error
+{
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    dispatch_async(_delegateQueue, ^{
+        mtr_weakify(self);
+        [strongDelegate commissioning:self scannedThreadNetworks:networks error:error completion:^(NSData * operationalDataset) {
+            mtr_strongify(self);
+
+            if (!self) {
+                MTR_LOG_ERROR("MTRCommissioningOperation deallocated while waiting to continue after Thread network scan");
+                return;
+            }
+
+            MTRDeviceController_Concrete * strongController = self->_controller;
+            if (!strongController) {
+                // Controller is gone, nothing to do here.
+                return;
+            }
+
+            NSError * continueError;
+            BOOL ok = [strongController continueCommissioning:self withOperationalDataset:operationalDataset error:&continueError];
+
+            if (!ok) {
+                MTR_LOG_ERROR("%@ attempt to continue commissioning with Thread credentials with controller %@ failed: %@", self, strongController, continueError);
+                // _dispatchCommissioningError first, so we don't trigger any
+                // notifications from "stop".
+                [self _dispatchCommissioningError:continueError];
+                [self stop];
+            }
+        }];
+    });
+}
+
+#pragma mark - MTRDeviceAttestationDelegate implementation
+
+- (void)deviceAttestationCompletedForController:(MTRDeviceController *)controller
+                             opaqueDeviceHandle:(void *)opaqueDeviceHandle
+                          attestationDeviceInfo:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                                          error:(NSError * _Nullable)error
+{
+    id<MTRCommissioningDelegate> strongDelegate = _delegate;
+    dispatch_async(_delegateQueue, ^{
+        mtr_weakify(self);
+        [strongDelegate commissioning:self completedDeviceAttestation:attestationDeviceInfo error:error completion:^{
+            mtr_strongify(self);
+
+            if (!self) {
+                MTR_LOG_ERROR("MTRCommissioningOperation deallocated while waiting to continue after device attestation");
+                return;
+            }
+
+            MTRDeviceController_Concrete * strongController = self->_controller;
+            if (!strongController) {
+                // Controller is gone, nothing to do here.
+                return;
+            }
+
+            NSError * continueError;
+            BOOL ok = [strongController continueCommissioningAfterAttestation:self forOpaqueHandle:opaqueDeviceHandle error:&continueError];
+
+            if (!ok) {
+                MTR_LOG_ERROR("%@ attempt to continue commissioning after device attestation with controller %@ failed: %@", self, strongController, continueError);
+                // _dispatchCommissioningError first, so we don't trigger any
+                // notifications from "stop".
+                [self _dispatchCommissioningError:continueError];
+                [self stop];
+            }
+        }];
+    });
+}
+
+@end
+
+@implementation MTRCommissioningOperationDeviceAttestationDelegate
+
+- (void)deviceAttestationCompletedForController:(MTRDeviceController *)controller
+                             opaqueDeviceHandle:(void *)opaqueDeviceHandle
+                          attestationDeviceInfo:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                                          error:(NSError * _Nullable)error
+{
+    MTRCommissioningOperation * strongOperation = self.commissioningOperation;
+    if (!strongOperation) {
+        // We are gone, nothing to do.
+        return;
+    }
+
+    [strongOperation deviceAttestationCompletedForController:controller
+                                          opaqueDeviceHandle:opaqueDeviceHandle
+                                       attestationDeviceInfo:attestationDeviceInfo
+                                                       error:error];
+}
+
+@end

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation.mm
@@ -260,6 +260,7 @@ static inline void emitMetricForSetupPayload(NSString * payload)
     // commissioning ourselves if not.
     if ([strongDelegate respondsToSelector:@selector(commissioning:paseSessionEstablishmentComplete:)]) {
         dispatch_async(_delegateQueue, ^{
+            self.isWaitingAfterPASEEstablished = YES;
             [strongDelegate commissioning:self paseSessionEstablishmentComplete:error];
         });
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation_Internal.h
@@ -37,6 +37,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, assign) BOOL isInternallyCreated;
 
+// True if the commissioning is waiting to resume after PASE has been
+// established and the delegate chose to be notified about that.
+//
+// This is currently only true if isInternallyCreated, and is readwrite because
+// MTRDeviceController_Concrete helps maintain this state.
+//
+// This property should generally be written on client queues only, not on the
+// Matter queue.
+@property (nonatomic, readwrite, assign) BOOL isWaitingAfterPASEEstablished;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningOperation_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningOperation_Internal.h
@@ -1,0 +1,42 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRCommissioningOperation.h>
+#import <Matter/MTRDeviceControllerDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRCommissioningOperation () <MTRDeviceControllerDelegate>
+
+/*
+ * If isInternallyCreated is YES, that also means that commissioning metrics
+ * initial setup has already happened.
+ */
+- (instancetype)initWithParameters:(MTRCommissioningParameters *)parameters
+                      setupPayload:(NSString *)payload
+                   commissioningID:(NSNumber *)commissioningID
+               isInternallyCreated:(BOOL)isInternallyCreated
+                          delegate:(id<MTRCommissioningDelegate>)delegate
+                             queue:(dispatch_queue_t)queue;
+
+@property (nonatomic, readonly, copy) NSString * setupPayload;
+
+@property (nonatomic, readonly, assign) BOOL isInternallyCreated;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -122,7 +122,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
  * The FeatureMap attribute of all Network Commissioning clusters on the commissionee
  * will always be read and does not need to be included in this list.
  */
-@property (nonatomic, copy, nullable) NSArray<MTRAttributeRequestPath *> * extraAttributesToRead MTR_UNSTABLE_API;
+@property (nonatomic, copy, nullable) NSArray<MTRAttributeRequestPath *> * extraAttributesToRead MTR_PROVISIONALLY_AVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.mm
@@ -16,6 +16,7 @@
  */
 
 #import "MTRCommissioningParameters.h"
+#import "MTRCommissioningParameters_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
     other.acceptedTermsAndConditions = self.acceptedTermsAndConditions;
     other.acceptedTermsAndConditionsVersion = self.acceptedTermsAndConditionsVersion;
     other.extraAttributesToRead = self.extraAttributesToRead;
+    other.preventNetworkScans = self.preventNetworkScans;
+
     return other;
 }
 
@@ -66,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<MTRCommissioningParameters: %p, has ssid: %d, has thread dataset: %d>, accepted terms: %@, accepted terms version: %@", self,
+    return [NSString stringWithFormat:@"<MTRCommissioningParameters: %p, has ssid: %d, has thread dataset: %d>, accepted terms: %@, accepted terms version: %@>", self,
                      self.wifiSSID != nil, self.threadOperationalDataset != nil,
                      self.acceptedTermsAndConditions, self.acceptedTermsAndConditionsVersion];
 }

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters_Internal.h
@@ -19,4 +19,17 @@
  * as public API yet.
  */
 @interface MTRCommissioningParameters () <NSCopying>
+
+/**
+ * Whether to prevent network scans, even in cases when we do not have network
+ * credentials.
+ *
+ * This is needed to support the old commissioning API, which does not have a
+ * way to respond to those network scans and continue commissioning once they
+ * complete.
+ *
+ * Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL preventNetworkScans;
+
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.h
@@ -17,9 +17,12 @@
 
 #import "MTRCommissioningParameters.h"
 #import "MTRDeviceControllerDelegate.h"
+#import "MTRDeviceControllerDelegate_Internal.h"
 
+#include <clusters/NetworkCommissioning/Enums.h>
 #include <controller/CHIPDeviceController.h>
 #include <controller/CommissioningDelegate.h>
+#include <lib/support/BitMask.h>
 #include <platform/CHIPDeviceConfig.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -33,6 +36,7 @@ public:
 
     void setDelegate(MTRDeviceController * controller, id<MTRDeviceControllerDelegate> delegate, dispatch_queue_t queue);
 
+    // DevicePairingDelegate implementation
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
 
     void OnPairingComplete(CHIP_ERROR error) override;
@@ -44,19 +48,37 @@ public:
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
     void OnCommissioningStatusUpdate(chip::PeerId peerId, chip::Controller::CommissioningStage stageCompleted, CHIP_ERROR error) override;
 
+    void
+    OnScanNetworksSuccess(const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse) override;
+    void OnScanNetworksFailure(CHIP_ERROR error) override;
+
+    // Other helper methods
     void SetDeviceNodeID(chip::NodeId deviceNodeId);
 
     void SetCommissioningParameters(MTRCommissioningParameters * commissioningParameters);
 
 private:
     MTRDeviceController * __weak mController;
-    _Nullable id<MTRDeviceControllerDelegate> mDelegate;
+    _Nullable id<MTRDeviceControllerDelegate> __weak mDelegate;
     _Nullable dispatch_queue_t mQueue;
     chip::NodeId mDeviceNodeId;
+
+    // TODO: Once the C++ SDK is fixed to correctly handle multiple network
+    // commissioning endpoints, we will know which scan is which, but for now
+    // just assume (since that's what the SDK does) that the scan, if any, is
+    // always on endpoint 0.
+    //
+    // See https://github.com/project-chip/connectedhomeip/issues/40755
+    chip::BitMask<chip::app::Clusters::NetworkCommissioning::Feature> mRootEndpointNetworkCommissioningFeatureMap;
 
     MTRCommissioningParameters * mCommissioningParameters;
 
     MTRCommissioningStatus MapStatus(chip::Controller::DevicePairingDelegate::Status status);
+
+    id<MTRDeviceControllerDelegate_Internal> GetInternalDelegate() const
+    {
+        return static_cast<id<MTRDeviceControllerDelegate_Internal>>(mDelegate);
+    }
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegateBridge.mm
@@ -16,6 +16,8 @@
 
 #import "MTRDeviceControllerDelegateBridge.h"
 
+#import <Matter/MTRClusterConstants.h>
+
 #import "MTRCommissioneeInfo_Internal.h"
 #import "MTRDeviceController.h"
 #import "MTRDeviceController_Internal.h"
@@ -26,6 +28,9 @@
 #import "MTRMetricsCollector.h"
 #import "MTRProductIdentity.h"
 #import "MTRUtilities.h"
+#import "zap-generated/MTRCommandPayloads_Internal.h"
+
+#include <lib/core/DataModelTypes.h>
 
 using namespace chip::Tracing::DarwinFramework;
 
@@ -145,6 +150,17 @@ void MTRDeviceControllerDelegateBridge::OnReadCommissioningInfo(const chip::Cont
         });
     }
 
+    mRootEndpointNetworkCommissioningFeatureMap.ClearAll();
+    if (info.attributes) {
+        using TypeInfo = chip::app::Clusters::NetworkCommissioning::Attributes::FeatureMap::TypeInfo;
+        chip::app::ConcreteAttributePath path(chip::kRootEndpointId, MTRClusterIDTypeNetworkCommissioningID,
+            MTRAttributeIDTypeGlobalAttributeFeatureMapID);
+        TypeInfo::DecodableType value;
+        if (info.attributes->Get<TypeInfo>(path, value) == CHIP_NO_ERROR) {
+            mRootEndpointNetworkCommissioningFeatureMap.SetRaw(value);
+        }
+    }
+
     // Don't hold on to the commissioning parameters now that we don't need them anymore.
     mCommissioningParameters = nil;
 }
@@ -210,6 +226,81 @@ void MTRDeviceControllerDelegateBridge::OnCommissioningStatusUpdate(chip::PeerId
                 [strongDelegate controller:strongController commissioneeHasReceivedNetworkCredentials:nodeID];
             });
         }
+    }
+}
+
+void MTRDeviceControllerDelegateBridge::OnScanNetworksSuccess(const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse)
+{
+    MTRDeviceController * strongController = mController;
+    id<MTRDeviceControllerDelegate_Internal> strongDelegate = GetInternalDelegate();
+    // The methods on MTRDeviceControllerDelegate_Internal are required, but
+    // we don't know whether our delegate actually implements the protocol,
+    // so still need to do the respondsToSelector checks.
+
+    MTR_LOG("%@ DeviceControllerDelegate network scan for nodeID 0x%016llx complete", strongController, mDeviceNodeId);
+
+    if (!strongController || !mQueue || !strongDelegate) {
+        MTR_LOG_ERROR("Unable to handle ScanNetworks success: missing required data: %@ %@ %@", strongController, mQueue, strongDelegate);
+        return;
+    }
+
+    auto * response = [[MTRNetworkCommissioningClusterScanNetworksResponseParams alloc] initWithDecodableStruct:dataResponse];
+    if (response == nil) {
+        // The TLV in the arrays was invalid.  Just treat this as a failure.
+        return OnScanNetworksFailure(CHIP_ERROR_SCHEMA_MISMATCH);
+    }
+
+    if (response.wiFiScanResults) {
+        if ([strongDelegate respondsToSelector:@selector(controller:scannedWiFiNetworks:error:)]) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate controller:strongController scannedWiFiNetworks:response.wiFiScanResults error:nil];
+            });
+        }
+    } else if (response.threadScanResults) {
+        if ([strongDelegate respondsToSelector:@selector(controller:scannedThreadNetworks:error:)]) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate controller:strongController scannedThreadNetworks:response.threadScanResults error:nil];
+            });
+        }
+    } else {
+        MTR_LOG_ERROR("Scan succeeded but for unknown network type: %lu", static_cast<unsigned long>(mRootEndpointNetworkCommissioningFeatureMap.Raw()));
+    }
+}
+
+void MTRDeviceControllerDelegateBridge::OnScanNetworksFailure(CHIP_ERROR error)
+{
+    MTRDeviceController * strongController = mController;
+    id<MTRDeviceControllerDelegate_Internal> strongDelegate = GetInternalDelegate();
+    // The methods on MTRDeviceControllerDelegate_Internal are required, but
+    // we don't know whether our delegate actually implements the protocol,
+    // so still need to do the respondsToSelector checks.
+
+    MTR_LOG("%@ DeviceControllerDelegate network scan for nodeID 0x%016llx failed: %" CHIP_ERROR_FORMAT,
+        strongController, mDeviceNodeId, error.Format());
+
+    if (!strongController || !mQueue || !strongDelegate) {
+        MTR_LOG_ERROR("Unable to handle ScanNetworks failure: missing required data: %@ %@ %@", strongController, mQueue, strongDelegate);
+        return;
+    }
+
+    // We don't know which type of scan this was (see
+    // https://github.com/project-chip/connectedhomeip/issues/40755), so decide
+    // based on mRootEndpointNetworkCommissioningFeatureMap.
+    using Feature = chip::app::Clusters::NetworkCommissioning::Feature;
+    if (mRootEndpointNetworkCommissioningFeatureMap.Has(Feature::kWiFiNetworkInterface)) {
+        if ([strongDelegate respondsToSelector:@selector(controller:scannedWiFiNetworks:error:)]) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate controller:strongController scannedWiFiNetworks:nil error:[MTRError errorForCHIPErrorCode:error]];
+            });
+        }
+    } else if (mRootEndpointNetworkCommissioningFeatureMap.Has(Feature::kThreadNetworkInterface)) {
+        if ([strongDelegate respondsToSelector:@selector(controller:scannedThreadNetworks:error:)]) {
+            dispatch_async(mQueue, ^{
+                [strongDelegate controller:strongController scannedThreadNetworks:nil error:[MTRError errorForCHIPErrorCode:error]];
+            });
+        }
+    } else {
+        MTR_LOG_ERROR("Scan failed for unknown network type: %lu", static_cast<unsigned long>(mRootEndpointNetworkCommissioningFeatureMap.Raw()));
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerDelegate_Internal.h
@@ -1,0 +1,32 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/MTRDeviceController.h>
+#import <Matter/MTRStructsObjc.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol MTRDeviceControllerDelegate_Internal <NSObject>
+@required
+- (void)controller:(MTRDeviceController *)controller
+    scannedWiFiNetworks:(nullable NSArray<MTRNetworkCommissioningClusterWiFiInterfaceScanResultStruct *> *)networks
+                  error:(nullable NSError *)error;
+- (void)controller:(MTRDeviceController *)controller
+    scannedThreadNetworks:(nullable NSArray<MTRNetworkCommissioningClusterThreadInterfaceScanResultStruct *> *)networks
+                    error:(nullable NSError *)error;
+@end
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -248,7 +248,7 @@ MTR_AVAILABLE(ios(16.1), macos(13.0), watchos(9.1), tvos(16.1))
 
 /**
  * The certificate issuer delegate to use for issuing operational certificates
- * when commmissioning devices.  Allowed to be nil if this controller either
+ * when commissioning devices.  Allowed to be nil if this controller either
  * does not issue operational certificates at all or internally generates the
  * certificates to be issued.  In the latter case, nocSigner must not be nil.
  */

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -238,8 +238,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Stop commissioning for the given MTRCommissioningOperation.
+ *
+ * Returns NO if this is not the current commissioning or if we can't
+ * sync-dispatch things to the Matter queue to talk to the C++ code.
  */
-- (void)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID;
+- (BOOL)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID;
 
 /**
  * Notification that a commissioning operation is done.

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Note: This is atomic because it might get read/set from both the Matter queue
  * and whatever queues our API clients are running on.
  */
-@property (atomic, readonly, nullable) MTRCommissioningOperation * currentCommissioning;
+@property (atomic, readonly, nullable, weak) MTRCommissioningOperation * currentCommissioning;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.h
@@ -19,6 +19,8 @@
 
 #import <Matter/MTRAccessGrant.h>
 #import <Matter/MTRBaseDevice.h>
+#import <Matter/MTRCommissioningDelegate.h>
+#import <Matter/MTRCommissioningOperation.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDeviceController.h>
 #import <Matter/MTRDeviceControllerFactory.h>
@@ -27,6 +29,7 @@
 #import <Matter/MTROTAProviderDelegate.h>
 
 #import "MTRAsyncWorkQueue.h"
+#import "MTRCommissioningDelegate_Internal.h"
 #import "MTRDeviceConnectionBridge.h"
 #import "MTRDeviceControllerDataStore.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
@@ -36,7 +39,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRDeviceController_Concrete : MTRDeviceController
+@interface MTRDeviceController_Concrete : MTRDeviceController <MTRCommissioningDelegate, MTRCommissioningDelegate_Internal>
 
 /**
  * Init a newly created controller.
@@ -229,6 +232,51 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)definitelyUsesThreadForDevice:(chip::NodeId)nodeID;
 
 /**
+ * Start commissioning for the given MTRCommissioningOperation.
+ */
+- (CHIP_ERROR)startCommissioning:(MTRCommissioningOperation *)commissioning withCommissioningID:(NSNumber *)commissioningID;
+
+/**
+ * Stop commissioning for the given MTRCommissioningOperation.
+ */
+- (void)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID;
+
+/**
+ * Notification that a commissioning operation is done.
+ */
+- (void)commissioningDone:(MTRCommissioningOperation *)commissioning;
+
+/**
+ * Continue commissioning after device attestation.
+ */
+- (BOOL)continueCommissioningAfterAttestation:(MTRCommissioningOperation *)commissioning
+                              forOpaqueHandle:(void *)handle
+                                        error:(NSError * __autoreleasing *)error;
+
+/**
+ * Go ahead with the post-PASE part of commissioning.
+ */
+- (BOOL)commission:(MTRCommissioningOperation *)commissioning
+    withCommissioningID:(NSNumber *)commissioningID
+    commissioningParams:(MTRCommissioningParameters *)commissioningParams
+                  error:(NSError * __autoreleasing *)error;
+
+/**
+ * Continue commissioning with the given credentials after a Wi-Fi scan.
+ */
+- (BOOL)continueCommissioning:(MTRCommissioningOperation *)commissioning
+                 withWiFiSSID:(NSData *)ssid
+                  credentials:(nullable NSData *)credentials
+                        error:(NSError * __autoreleasing *)error;
+
+/**
+ * Continue commissioning with the given credentials after a Thread scan.
+ */
+- (BOOL)continueCommissioning:(MTRCommissioningOperation *)commissioning
+       withOperationalDataset:(NSData *)operationalDataset
+                        error:(NSError * __autoreleasing *)error;
+
+/**
  * Will return chip::kUndefinedFabricIndex if we do not have a fabric index.
  */
 @property (readonly) chip::FabricIndex fabricIndex;
@@ -243,6 +291,19 @@ NS_ASSUME_NONNULL_BEGIN
  * The per-controller data store this controller was initialized with, if any.
  */
 @property (nonatomic, readonly, nullable) MTRDeviceControllerDataStore * controllerDataStore;
+
+/**
+ * The current commissioning this controller is doing, if there is one.
+ *
+ * Ideally we could support multiple commissionings in parallel, but right now
+ * the C++ SDK can't.  And automatically serializing them is not great because
+ * it can cause things to fail when commissioning windows close; better to let
+ * applications handle that for now.
+ *
+ * Note: This is atomic because it might get read/set from both the Matter queue
+ * and whatever queues our API clients are running on.
+ */
+@property (atomic, readonly, nullable) MTRCommissioningOperation * currentCommissioning;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1074,7 +1074,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 {
     auto * currentCommissioning = self.currentCommissioning;
     if (commissioning != currentCommissioning) {
-        MTR_LOG_ERROR("%@ trying to start comissioning %@ but current commmissioning is %@", self, commissioning, currentCommissioning);
+        MTR_LOG_ERROR("%@ trying to start commissioning %@ but current commissioning is %@", self, commissioning, currentCommissioning);
         if (error) {
             *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
         }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -879,6 +879,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 
     // MTRCommissioningOperation already checks whether we have an existing
     // currentCommissioning.
+    MTR_LOG("%@ starting new commissioning %@", self, commissioning);
     self.currentCommissioning = commissioning;
 
     // Capture in a block variable to avoid losing granularity for metrics,
@@ -916,6 +917,7 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 - (void)commissioningDone:(MTRCommissioningOperation *)commissioning
 {
     if (self.currentCommissioning == commissioning) {
+        MTR_LOG("%@ stopping commissioning %@", self, commissioning);
         self.currentCommissioning = nil;
 
         // Reset ourselves as the device controller delegate, so we can
@@ -1281,7 +1283,8 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 {
     auto * currentCommissioning = self.currentCommissioning;
     if (currentCommissioning && !currentCommissioning.isInternallyCreated) {
-        MTR_LOG_ERROR("Trying to cancelCommissioningForNodeID: when using MTRCommissioningOperation; call ignored");
+        MTR_LOG_ERROR("Trying to cancelCommissioningForNodeID 0x%016llX (%@) when using MTRCommissioningOperation; call ignored",
+                      nodeID.unsignedLongLongValue, nodeID);
         if (error) {
             *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
         }

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -1291,15 +1291,15 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return [self _cancelCommissioningForNodeID:nodeID error:error];
 }
 
-- (void)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID
+- (BOOL)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID
 {
     auto * currentCommissioning = self.currentCommissioning;
     if (commissioning != currentCommissioning) {
         MTR_LOG_ERROR("%@ commissioning %@ has already stopped and been replaced by %@", self, commissioning, currentCommissioning);
-        return;
+        return NO;
     }
 
-    [self _cancelCommissioningForNodeID:commissioningID error:nil];
+    return [self _cancelCommissioningForNodeID:commissioningID error:nil];
 }
 
 - (BOOL)_cancelCommissioningForNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Concrete.mm
@@ -23,6 +23,7 @@
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCommissionableBrowser.h"
 #import "MTRCommissionableBrowserResult_Internal.h"
+#import "MTRCommissioningOperation_Internal.h"
 #import "MTRCommissioningParameters.h"
 #import "MTRCommissioningParameters_Internal.h"
 #import "MTRConversion.h"
@@ -50,6 +51,7 @@
 #import "MTRUtilities.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
+
 #import <setup_payload/ManualSetupPayloadGenerator.h>
 #import <setup_payload/SetupPayload.h>
 #import <zap-generated/MTRBaseClusters.h>
@@ -112,7 +114,11 @@ using namespace chip::Tracing::DarwinFramework;
 // Whether we should be advertising our operational identity when we are not suspended.
 @property (nonatomic, readonly) BOOL shouldAdvertiseOperational;
 
+@property (atomic, readwrite, nullable) MTRCommissioningOperation * currentCommissioning;
+
 @end
+
+typedef void (^CommissionDeviceBlock)(MTRCommissioningParameters *);
 
 @implementation MTRDeviceController_Concrete {
     std::atomic<chip::FabricIndex> _storedFabricIndex;
@@ -126,6 +132,11 @@ using namespace chip::Tracing::DarwinFramework;
     NSUInteger _keepRunningAssertionCounter;
     BOOL _shutdownPending;
     os_unfair_lock _assertionLock;
+
+    // Queue for our commissioning bits, so our MTRCommissioningOperation can
+    // run on a queue that's not the Matter queue, and safely use APIs that
+    // involve sync dispatch to the Matter queue.
+    dispatch_queue_t _commissioningQueue;
 }
 
 // TODO: Figure out whether the work queue storage lives here or in the superclass
@@ -182,6 +193,8 @@ using namespace chip::Tracing::DarwinFramework;
         _keepRunningAssertionCounter = 0;
         _shutdownPending = NO;
         _assertionLock = OS_UNFAIR_LOCK_INIT;
+        _currentCommissioning = nil;
+        _commissioningQueue = dispatch_queue_create("org.csa-iot.matter.framework.commissioning.workqueue", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
 
         if (storageDelegate != nil) {
             if (storageDelegateQueue == nil) {
@@ -752,8 +765,7 @@ using namespace chip::Tracing::DarwinFramework;
         commissionerInitialized = YES;
 
         // Set self as delegate, which fans out delegate callbacks to all added delegates
-        id<MTRDeviceControllerDelegate> selfDelegate = static_cast<id<MTRDeviceControllerDelegate>>(self);
-        self->_deviceControllerDelegateBridge->setDelegate(self, selfDelegate, _chipWorkQueue);
+        self->_deviceControllerDelegateBridge->setDelegate(self, self, _chipWorkQueue);
 
         MTR_LOG("%@ startup succeeded for nodeID 0x%016llX", self, self->_cppCommissioner->GetNodeId());
     });
@@ -832,6 +844,43 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     MATTER_LOG_METRIC_BEGIN(kMetricDeviceCommissioning);
     emitMetricForSetupPayload(payload);
 
+    // Try to get a QR code if possible (because it has a better
+    // discriminator, etc), then fall back to manual code if that fails.
+    NSString * pairingCode = [payload qrCodeString:nil];
+    if (pairingCode == nil) {
+        pairingCode = [payload manualEntryCode];
+    }
+    if (pairingCode == nil) {
+        CHIP_ERROR errorCode = CHIP_ERROR_INVALID_ARGUMENT;
+        MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, errorCode);
+        return ![MTRDeviceController_Concrete checkForError:errorCode logMsg:kDeviceControllerErrorSetupCodeGen error:error];
+    }
+
+    // We can just use dummy parameters for now; when commissionWithNodeID is
+    // called we can update the MTRCommissioningOperation with the real
+    // parameters.
+    auto * parameters = [[MTRCommissioningParameters alloc] init];
+    auto * commissioning = [[MTRCommissioningOperation alloc] initWithParameters:parameters
+                                                                    setupPayload:pairingCode
+                                                                 commissioningID:newNodeID
+                                                             isInternallyCreated:YES
+                                                                        delegate:self
+                                                                           queue:_commissioningQueue];
+
+    // startWithController will manage our currentCommissioning state as needed.
+    [commissioning startWithController:self];
+
+    return YES;
+}
+
+- (CHIP_ERROR)startCommissioning:(MTRCommissioningOperation *)commissioning withCommissioningID:(NSNumber *)commissioningID
+{
+    // TODO: This can probably stop being sync and just notify failures async.
+
+    // MTRCommissioningOperation already checks whether we have an existing
+    // currentCommissioning.
+    self.currentCommissioning = commissioning;
+
     // Capture in a block variable to avoid losing granularity for metrics,
     // when translating CHIP_ERROR to NSError
     __block CHIP_ERROR errorCode = CHIP_NO_ERROR;
@@ -840,36 +889,47 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         // Track work until end of scope
         MATTER_LOG_METRIC_SCOPE(kMetricSetupWithPayload, errorCode);
 
-        // Try to get a QR code if possible (because it has a better
-        // discriminator, etc), then fall back to manual code if that fails.
-        NSString * pairingCode = [payload qrCodeString:nil];
-        if (pairingCode == nil) {
-            pairingCode = [payload manualEntryCode];
-        }
-        if (pairingCode == nil) {
-            errorCode = CHIP_ERROR_INVALID_ARGUMENT;
-            return ![MTRDeviceController_Concrete checkForError:errorCode logMsg:kDeviceControllerErrorSetupCodeGen error:error];
-        }
-
-        chip::NodeId nodeId = [newNodeID unsignedLongLongValue];
-        self->_operationalCredentialsDelegate->SetDeviceID(nodeId);
+        unsigned long long deviceID = [commissioningID unsignedLongLongValue];
+        self->_operationalCredentialsDelegate->SetDeviceID(deviceID);
 
         MATTER_LOG_METRIC_BEGIN(kMetricSetupPASESession);
-        errorCode = self->_cppCommissioner->EstablishPASEConnection(nodeId, [pairingCode UTF8String]);
+        errorCode = self->_cppCommissioner->EstablishPASEConnection(deviceID, commissioning.setupPayload.UTF8String);
         if (CHIP_NO_ERROR == errorCode) {
-            self->_deviceControllerDelegateBridge->SetDeviceNodeID(nodeId);
+            self->_deviceControllerDelegateBridge->SetDeviceNodeID(commissioningID.unsignedLongLongValue);
+            self->_deviceControllerDelegateBridge->setDelegate(self, commissioning, self->_commissioningQueue);
         } else {
             MATTER_LOG_METRIC_END(kMetricSetupPASESession, errorCode);
         }
 
-        return ![MTRDeviceController_Concrete checkForError:errorCode logMsg:kDeviceControllerErrorPairDevice error:error];
+        NSError * error;
+        return ![MTRDeviceController_Concrete checkForError:errorCode logMsg:kDeviceControllerErrorPairDevice error:&error];
     };
 
-    auto success = [self syncRunOnWorkQueueWithBoolReturnValue:block error:error];
-    if (!success) {
-        MATTER_LOG_METRIC_END(kMetricDeviceCommissioning, errorCode);
+    NSError * error;
+    BOOL success = [self syncRunOnWorkQueueWithBoolReturnValue:block error:&error];
+    if (!success && errorCode == CHIP_NO_ERROR) {
+        errorCode = [MTRError errorToCHIPErrorCode:error];
     }
-    return success;
+    return errorCode;
+}
+
+- (void)commissioningDone:(MTRCommissioningOperation *)commissioning
+{
+    if (self.currentCommissioning == commissioning) {
+        self.currentCommissioning = nil;
+
+        // Reset ourselves as the device controller delegate, so we can
+        // correctly handle the commissioning codepaths that don't use
+        // MTRCommissioningOperation yet.
+        auto block = ^{
+            self->_deviceControllerDelegateBridge->setDelegate(self, self, self->_chipWorkQueue);
+        };
+
+        // We don't care whether this fails.  If it fails, we are shut down
+        // already, and then we don't need to worry about the device controller
+        // delegate.
+        [self syncRunOnWorkQueue:block error:nil];
+    }
 }
 
 - (BOOL)setupCommissioningSessionWithDiscoveredDevice:(MTRCommissionableBrowserResult *)discoveredDevice
@@ -877,6 +937,19 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
                                             newNodeID:(NSNumber *)newNodeID
                                                 error:(NSError * __autoreleasing *)error
 {
+    auto * existingCommissioning = self.currentCommissioning;
+    if (existingCommissioning) {
+        MTR_LOG_ERROR("%@ Can't set up commissioning session with discovered device: commissioning %@ in progress",
+            self, existingCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    // TODO: should we set up a fake self.currentCommissioning here, even though
+    // we are not using MTRCommissioningOperation to implement this?
+
     MTR_LOG("%@ Setting up commissioning session for already-discovered device %@ and device ID 0x%016llX with setup payload %@", self, discoveredDevice, newNodeID.unsignedLongLongValue, payload);
 
     [[MTRMetricsCollector sharedInstance] resetMetrics];
@@ -953,6 +1026,47 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
          commissioningParams:(MTRCommissioningParameters *)commissioningParams
                        error:(NSError * __autoreleasing *)error
 {
+    auto * currentCommissioning = self.currentCommissioning;
+    if (currentCommissioning && !currentCommissioning.isInternallyCreated) {
+        MTR_LOG_ERROR("Trying to commissionNodeWithID: when using MTRCommissioningOperation; call ignored");
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    MTRCommissioningParameters * params = [commissioningParams copy];
+
+    // Backwards compat: this API did not do any network scanning, and should
+    // keep behaving that way.
+    params.preventNetworkScans = YES;
+
+    return [self _commissionNodeWithID:(NSNumber *) nodeID
+                   commissioningParams:params
+                                 error:error];
+}
+
+- (BOOL)commission:(MTRCommissioningOperation *)commissioning
+    withCommissioningID:(NSNumber *)commissioningID
+    commissioningParams:(MTRCommissioningParameters *)commissioningParams
+                  error:(NSError * __autoreleasing *)error
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("%@ trying to start comissioning %@ but current commmissioning is %@", self, commissioning, currentCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    return [self _commissionNodeWithID:commissioningID commissioningParams:commissioningParams error:error];
+}
+
+- (BOOL)_commissionNodeWithID:(NSNumber *)nodeID
+          commissioningParams:(MTRCommissioningParameters *)commissioningParams
+                        error:(NSError * __autoreleasing *)error
+{
     MTR_LOG("%@ trying to commission node with ID 0x%016llX parameters %@", self, nodeID.unsignedLongLongValue, commissioningParams);
 
     if (self.suspended) {
@@ -990,17 +1104,23 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
         }
         if (commissioningParams.threadOperationalDataset) {
             params.SetThreadOperationalDataset(AsByteSpan(commissioningParams.threadOperationalDataset));
+        } else if (!commissioningParams.preventNetworkScans) {
+            params.SetAttemptThreadNetworkScan(true);
         }
         if (commissioningParams.acceptedTermsAndConditions && commissioningParams.acceptedTermsAndConditionsVersion) {
             if (!chip::CanCastTo<uint16_t>([commissioningParams.acceptedTermsAndConditions unsignedIntValue])) {
                 MTR_LOG_ERROR("%@ Error: acceptedTermsAndConditions value should be between 0 and 65535", self);
-                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+                if (error) {
+                    *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+                }
                 return NO;
             }
 
             if (!chip::CanCastTo<uint16_t>([commissioningParams.acceptedTermsAndConditionsVersion unsignedIntValue])) {
                 MTR_LOG_ERROR("%@ Error: acceptedTermsAndConditionsVersion value should be between 0 and 65535", self);
-                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+                if (error) {
+                    *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+                }
                 return NO;
             }
 
@@ -1019,7 +1139,10 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
             }
             chip::Controller::WiFiCredentials wifiCreds(ssid, credentials);
             params.SetWiFiCredentials(wifiCreds);
+        } else if (!commissioningParams.preventNetworkScans) {
+            params.SetAttemptWiFiNetworkScan(true);
         }
+
         if (commissioningParams.deviceAttestationDelegate) {
             [self clearDeviceAttestationDelegateBridge];
 
@@ -1104,6 +1227,40 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
            ignoreAttestationFailure:(BOOL)ignoreAttestationFailure
                               error:(NSError * __autoreleasing *)error
 {
+    auto * currentCommissioning = self.currentCommissioning;
+    if (currentCommissioning && !currentCommissioning.isInternallyCreated) {
+        MTR_LOG_ERROR("Trying to continueCommissioningDevice: when using MTRCommissioningOperation; call ignored");
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    return [self _continueCommissioningDevice:device
+                     ignoreAttestationFailure:ignoreAttestationFailure
+                                        error:error];
+}
+
+- (BOOL)continueCommissioningAfterAttestation:(MTRCommissioningOperation *)commissioning
+                              forOpaqueHandle:(void *)handle
+                                        error:(NSError * __autoreleasing *)error
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("%@ commissioning %@ has already stopped and been replaced by %@", self, commissioning, currentCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    return [self _continueCommissioningDevice:handle ignoreAttestationFailure:YES error:error];
+}
+
+- (BOOL)_continueCommissioningDevice:(void *)device
+            ignoreAttestationFailure:(BOOL)ignoreAttestationFailure
+                               error:(NSError * __autoreleasing *)error
+{
     auto block = ^BOOL {
         auto lastAttestationResult = self->_deviceAttestationDelegateBridge
             ? self->_deviceAttestationDelegateBridge->attestationVerificationResult()
@@ -1121,6 +1278,31 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
 }
 
 - (BOOL)cancelCommissioningForNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (currentCommissioning && !currentCommissioning.isInternallyCreated) {
+        MTR_LOG_ERROR("Trying to cancelCommissioningForNodeID: when using MTRCommissioningOperation; call ignored");
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    return [self _cancelCommissioningForNodeID:nodeID error:error];
+}
+
+- (void)stopCommissioning:(MTRCommissioningOperation *)commissioning forCommissioningID:(NSNumber *)commissioningID
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("%@ commissioning %@ has already stopped and been replaced by %@", self, commissioning, currentCommissioning);
+        return;
+    }
+
+    [self _cancelCommissioningForNodeID:commissioningID error:nil];
+}
+
+- (BOOL)_cancelCommissioningForNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
 {
     auto block = ^BOOL {
         self->_operationalCredentialsDelegate->ResetDeviceID();
@@ -1781,6 +1963,189 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
     return self.controllerDataStore.nodesWithStoredData;
 }
 
+- (BOOL)continueCommissioning:(MTRCommissioningOperation *)commissioning
+                 withWiFiSSID:(NSData *)ssid
+                  credentials:(nullable NSData *)credentials
+                        error:(NSError * __autoreleasing *)error;
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("%@ commissioning %@ has already stopped and been replaced by %@", self, commissioning, currentCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    auto block = ^BOOL {
+        auto optionalParams = self->_cppCommissioner->GetCommissioningParameters();
+        if (!optionalParams.HasValue()) {
+            MTR_LOG_ERROR("%@ Has no commissioning parameters", self);
+            if (error) {
+                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+            }
+            return NO;
+        }
+
+        chip::Controller::CommissioningParameters params = optionalParams.Value();
+        chip::ByteSpan ssidSpan = AsByteSpan(ssid);
+        chip::ByteSpan credentialsSpan;
+        if (credentials != nil) {
+            credentialsSpan = AsByteSpan(credentials);
+        }
+        chip::Controller::WiFiCredentials wifiCreds(ssidSpan, credentialsSpan);
+        params.SetWiFiCredentials(wifiCreds);
+
+        CHIP_ERROR err = self->_cppCommissioner->UpdateCommissioningParameters(params);
+        if (err == CHIP_NO_ERROR) {
+            err = self->_cppCommissioner->NetworkCredentialsReady();
+        }
+        return ![MTRDeviceController_Concrete checkForError:err logMsg:kDeviceControllerErrorUpdateNetworkCredentials error:error];
+    };
+
+    return [self syncRunOnWorkQueueWithBoolReturnValue:block error:error];
+}
+
+- (BOOL)continueCommissioning:(MTRCommissioningOperation *)commissioning
+       withOperationalDataset:(NSData *)operationalDataset
+                        error:(NSError * __autoreleasing *)error
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("%@ commissioning %@ has already stopped and been replaced by %@", self, commissioning, currentCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    auto block = ^BOOL {
+        auto optionalParams = self->_cppCommissioner->GetCommissioningParameters();
+        if (!optionalParams.HasValue()) {
+            MTR_LOG_ERROR("%@ Has no commissioning parameters", self);
+            if (error) {
+                *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+            }
+            return NO;
+        }
+
+        chip::Controller::CommissioningParameters params = optionalParams.Value();
+        params.SetThreadOperationalDataset(AsByteSpan(operationalDataset));
+
+        CHIP_ERROR err = self->_cppCommissioner->UpdateCommissioningParameters(params);
+        if (err == CHIP_NO_ERROR) {
+            err = self->_cppCommissioner->NetworkCredentialsReady();
+        }
+        return ![MTRDeviceController_Concrete checkForError:err logMsg:kDeviceControllerErrorUpdateNetworkCredentials error:error];
+    };
+
+    return [self syncRunOnWorkQueueWithBoolReturnValue:block error:error];
+}
+
+#pragma mark - MTRCommissioningDelegate implementation
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    readCommissioneeInfo:(MTRCommissioneeInfo *)info
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("readCommissioneeInfo: notification for %@ but current commissioning is %@",
+            commissioning, currentCommissioning);
+        return;
+    }
+
+    [self controller:self readCommissioneeInfo:info];
+}
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    completedDeviceAttestation:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                         error:(nullable NSError *)error
+                    completion:(dispatch_block_t)completion
+{
+    // This is never called, because we only set up ourselves as the delegate on
+    // internal MTRCommissioningOperation instances, but in that case the
+    // MTRCommissioningParameters we use does not have the
+    // MTRCommissioningOperation as the attestation delegate.
+    MTR_ABSTRACT_METHOD();
+}
+
+// We never trigger network scans for commissioning that comes through the old
+// APIs, so don't need scannedWiFiNetworks:/scannedThreadNetworks: bits.
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    succeededForNodeID:(NSNumber *)nodeID
+               metrics:(MTRMetrics *)metrics
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("commissioning:succeededForNodeID: notification for %@ but current commissioning is %@",
+            commissioning, currentCommissioning);
+        return;
+    }
+
+    [self controller:self commissioningComplete:nil nodeID:nodeID metrics:metrics];
+}
+
+#pragma mark - MTRCommissioningDelegate_Internal implementation
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+    paseSessionEstablishmentComplete:(NSError * _Nullable)error
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("commissioning:paseSessionEstablishmentComplete: notification for %@ but current commissioning is %@",
+            commissioning, currentCommissioning);
+        return;
+    }
+
+    [self controller:self commissioningSessionEstablishmentDone:error];
+
+    // Just wait for commissionNodeWithID: to be called on us.
+}
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+         statusUpdate:(MTRCommissioningStatus)status
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("commissioning:statusUpdate: notification for %@ but current commissioning is %@",
+            commissioning, currentCommissioning);
+        return;
+    }
+
+    [self controller:self statusUpdate:status];
+}
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning provisionedNetworkCredentialsForDeviceID:(NSNumber *)deviceID
+{
+    auto * currentCommissioning = self.currentCommissioning;
+    if (commissioning != currentCommissioning) {
+        MTR_LOG_ERROR("commissioningProvisionedNetworkCredentials: notification for %@ but current commissioning is %@",
+            commissioning, currentCommissioning);
+        return;
+    }
+
+    [self controller:self commissioneeHasReceivedNetworkCredentials:deviceID];
+}
+
+- (void)commissioning:(MTRCommissioningOperation *)commissioning
+      failedWithError:(NSError *)error
+          forDeviceID:(NSNumber *)deviceID
+              metrics:(MTRMetrics *)metrics
+{
+    // Don't check whether commissioning matches self.currentCommissioning.
+    //
+    // That's because we can land here if someone tries to start a new
+    // commissioning (e.g. via setupPayloadWithOnboardingPayload) while we have
+    // an ongoing commissioning.  That will create a new
+    // MTRCommissioningOperation with us as the delegate, and then immediately
+    // trigger an error on it when it tries to start.  Just propagate the error
+    // on through.  The node ID will let API consumers who happen do call
+    // setupPayloadWithOnboardingPayload twice disambiguate which one failed, if
+    // they care to do that.
+    [self controller:self commissioningComplete:error nodeID:deviceID metrics:metrics];
+}
+
 @end
 
 /**
@@ -1850,6 +2215,19 @@ static inline void emitMetricForSetupPayload(MTRSetupPayload * payload)
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error
 {
+    auto * existingCommissioning = self.currentCommissioning;
+    if (existingCommissioning) {
+        MTR_LOG_ERROR("%@ Can't set up commissioning session with address/port: commissioning %@ in progress",
+            self, existingCommissioning);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
+        return NO;
+    }
+
+    // TODO: should we set up a fake self.currentCommissioning here, even though
+    // we are not using MTRCommissioningOperation to implement this?
+
     [[MTRMetricsCollector sharedInstance] resetMetrics];
 
     // Track overall commissioning

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -46,7 +46,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRDeviceController ()
+@interface MTRDeviceController () <MTRDeviceControllerDelegate>
 
 @property (nonatomic, readonly) NSMapTable<NSNumber *, MTRDevice *> * nodeIDToDeviceMap;
 @property (readonly, assign) os_unfair_lock_t deviceMapLock;
@@ -147,5 +147,6 @@ static NSString * const kDeviceControllerErrorCSRValidation = @"Extracting publi
 static NSString * const kDeviceControllerErrorGetCommissionee = @"Failure obtaining device being commissioned";
 static NSString * const kDeviceControllerErrorGetAttestationChallenge = @"Failure getting attestation challenge";
 static NSString * const kDeviceControllerErrorCDCertStoreInit = @"Init failure while initializing Certificate Declaration Signing Keys store";
+static NSString * const kDeviceControllerErrorUpdateNetworkCredentials = @"Failure while trying to update network credentials during commissioning";
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -38,6 +38,8 @@
 #import <Matter/MTRCommissionableBrowserDelegate.h>
 #import <Matter/MTRCommissionableBrowserResult.h>
 #import <Matter/MTRCommissioneeInfo.h>
+#import <Matter/MTRCommissioningDelegate.h>
+#import <Matter/MTRCommissioningOperation.h>
 #import <Matter/MTRCommissioningParameters.h>
 #import <Matter/MTRDefines.h>
 #import <Matter/MTRDevice.h>

--- a/src/darwin/Framework/CHIPTests/MTRPairingTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRPairingTests.m
@@ -177,17 +177,17 @@ typedef void (^AttestationHandler)(dispatch_block_t);
 
 @end
 
-typedef void (^PASEEstalishedHandler)(MTRCommissioningOperation * commissioning, NSError * _Nullable error);
+typedef void (^PASEEstablishedHandler)(MTRCommissioningOperation * commissioning, NSError * _Nullable error);
 
 @interface MTRPairingTestsCommissioningDelegateWithPASEHandler : MTRPairingTestsCommissioningDelegate
 - (instancetype)initWithExpectation:(XCTestExpectation *)expectation
-                            handler:(PASEEstalishedHandler)handler;
-@property (nonatomic, readonly) PASEEstalishedHandler paseEstablishedHandler;
+                            handler:(PASEEstablishedHandler)handler;
+@property (nonatomic, readonly) PASEEstablishedHandler paseEstablishedHandler;
 @end
 
 @implementation MTRPairingTestsCommissioningDelegateWithPASEHandler
 - (instancetype)initWithExpectation:(XCTestExpectation *)expectation
-                            handler:(PASEEstalishedHandler)handler
+                            handler:(PASEEstablishedHandler)handler
 {
     if (!(self = [super initWithExpectation:expectation])) {
         return nil;
@@ -1029,7 +1029,7 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
 
     // An attempt to start another commissioning now should fail, since we are
     // in the middle of a commissioning already.
-    XCTestExpectation * expectation2 = [self expectationWithDescription:@"Commissioning 2 compelete"];
+    XCTestExpectation * expectation2 = [self expectationWithDescription:@"Commissioning 2 complete"];
     __auto_type * controllerDelegate2 = [[MTRPairingTestControllerDelegate alloc] initWithExpectation:expectation2
                                                                                   attestationDelegate:attestationDelegate
                                                                                     failSafeExtension:nil];
@@ -1061,7 +1061,7 @@ typedef BOOL (^CommissioningSessionHandler)(NSError * _Nullable error);
     // Should have failed first commissioning (we canceled it).
     XCTAssertNotNil(controllerDelegate1.commissioningCompleteError);
 
-    XCTestExpectation * expectation3 = [self expectationWithDescription:@"Commissioning 3 compelete"];
+    XCTestExpectation * expectation3 = [self expectationWithDescription:@"Commissioning 3 complete"];
     __auto_type * controllerDelegate3 = [[MTRPairingTestControllerDelegate alloc] initWithExpectation:expectation3
                                                                                   attestationDelegate:attestationDelegate
                                                                                     failSafeExtension:nil];

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -181,6 +181,12 @@
 		5143851E2A65885500EDC8E6 /* MTRSwiftPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5143851D2A65885500EDC8E6 /* MTRSwiftPairingTests.swift */; };
 		51445F6A2E5E4281003C7C98 /* SingleEndpointServerClusterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F811B3312F29417E8456E37F /* SingleEndpointServerClusterRegistry.cpp */; };
 		51445F6C2E5E4299003C7C98 /* MTRPairingBackwardsCompatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51445F6B2E5E4299003C7C98 /* MTRPairingBackwardsCompatTests.m */; };
+		51445F732E5E565F003C7C98 /* MTRCommissioningOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51445F712E5E565F003C7C98 /* MTRCommissioningOperation.mm */; };
+		51445F742E5E565F003C7C98 /* MTRCommissioningOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 51445F702E5E565F003C7C98 /* MTRCommissioningOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51445F752E5E565F003C7C98 /* MTRCommissioningOperation_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51445F722E5E565F003C7C98 /* MTRCommissioningOperation_Internal.h */; };
+		51445F762E5E565F003C7C98 /* MTRCommissioningDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51445F6F2E5E565F003C7C98 /* MTRCommissioningDelegate_Internal.h */; };
+		51445F772E5E565F003C7C98 /* MTRCommissioningDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 51445F6E2E5E565F003C7C98 /* MTRCommissioningDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51445F792E5F70AF003C7C98 /* MTRDeviceControllerDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51445F782E5F70AF003C7C98 /* MTRDeviceControllerDelegate_Internal.h */; };
 		514654492A72F9DF00904E61 /* MTRDemuxingStorage.mm in Sources */ = {isa = PBXBuildFile; fileRef = 514654482A72F9DF00904E61 /* MTRDemuxingStorage.mm */; };
 		5146544B2A72F9F500904E61 /* MTRDemuxingStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 5146544A2A72F9F500904E61 /* MTRDemuxingStorage.h */; };
 		514A98AF2CD98C5E000EF4FD /* MTRAttributeValueWaiter.h in Headers */ = {isa = PBXBuildFile; fileRef = 514A98AC2CD98C5E000EF4FD /* MTRAttributeValueWaiter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -799,6 +805,12 @@
 		5143851C2A65885400EDC8E6 /* MatterTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MatterTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5143851D2A65885500EDC8E6 /* MTRSwiftPairingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MTRSwiftPairingTests.swift; sourceTree = "<group>"; };
 		51445F6B2E5E4299003C7C98 /* MTRPairingBackwardsCompatTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRPairingBackwardsCompatTests.m; sourceTree = "<group>"; };
+		51445F6E2E5E565F003C7C98 /* MTRCommissioningDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningDelegate.h; sourceTree = "<group>"; };
+		51445F6F2E5E565F003C7C98 /* MTRCommissioningDelegate_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningDelegate_Internal.h; sourceTree = "<group>"; };
+		51445F702E5E565F003C7C98 /* MTRCommissioningOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningOperation.h; sourceTree = "<group>"; };
+		51445F712E5E565F003C7C98 /* MTRCommissioningOperation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCommissioningOperation.mm; sourceTree = "<group>"; };
+		51445F722E5E565F003C7C98 /* MTRCommissioningOperation_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningOperation_Internal.h; sourceTree = "<group>"; };
+		51445F782E5F70AF003C7C98 /* MTRDeviceControllerDelegate_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerDelegate_Internal.h; sourceTree = "<group>"; };
 		514654482A72F9DF00904E61 /* MTRDemuxingStorage.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDemuxingStorage.mm; sourceTree = "<group>"; };
 		5146544A2A72F9F500904E61 /* MTRDemuxingStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDemuxingStorage.h; sourceTree = "<group>"; };
 		514A98AC2CD98C5E000EF4FD /* MTRAttributeValueWaiter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRAttributeValueWaiter.h; sourceTree = "<group>"; };
@@ -1767,6 +1779,11 @@
 				3D010DCD2D408FA300CFFA02 /* MTRCommissioneeInfo.h */,
 				3D010DD12D4091C800CFFA02 /* MTRCommissioneeInfo_Internal.h */,
 				3D010DCE2D408FA300CFFA02 /* MTRCommissioneeInfo.mm */,
+				51445F6E2E5E565F003C7C98 /* MTRCommissioningDelegate.h */,
+				51445F6F2E5E565F003C7C98 /* MTRCommissioningDelegate_Internal.h */,
+				51445F702E5E565F003C7C98 /* MTRCommissioningOperation.h */,
+				51445F722E5E565F003C7C98 /* MTRCommissioningOperation_Internal.h */,
+				51445F712E5E565F003C7C98 /* MTRCommissioningOperation.mm */,
 				99D466E02798936D0089A18F /* MTRCommissioningParameters.h */,
 				510B18F32E3275D6000F9181 /* MTRCommissioningParameters_Internal.h */,
 				99AECC7F2798A57E00B6355B /* MTRCommissioningParameters.mm */,
@@ -1808,6 +1825,7 @@
 				5A7947E227C0101200434CF2 /* MTRDeviceController+XPC.h */,
 				5A7947E327C0129500434CF2 /* MTRDeviceController+XPC.mm */,
 				2CB7163E252F731E0026E2BB /* MTRDeviceControllerDelegate.h */,
+				51445F782E5F70AF003C7C98 /* MTRDeviceControllerDelegate_Internal.h */,
 				51565CAF2A7AD77600469F18 /* MTRDeviceControllerDataStore.h */,
 				51565CB02A7AD77600469F18 /* MTRDeviceControllerDataStore.mm */,
 				2CB71638252E8A7B0026E2BB /* MTRDeviceControllerDelegateBridge.h */,
@@ -2260,6 +2278,10 @@
 				3DFCB32C29678C9500332B35 /* MTRConversion.h in Headers */,
 				5A60370827EA1FF60020DB79 /* MTRClusterStateCacheContainer+XPC.h in Headers */,
 				7567A20E2DA5ABCF00D91529 /* DefaultServerCluster.h in Headers */,
+				51445F742E5E565F003C7C98 /* MTRCommissioningOperation.h in Headers */,
+				51445F752E5E565F003C7C98 /* MTRCommissioningOperation_Internal.h in Headers */,
+				51445F762E5E565F003C7C98 /* MTRCommissioningDelegate_Internal.h in Headers */,
+				51445F772E5E565F003C7C98 /* MTRCommissioningDelegate.h in Headers */,
 				3D9F2FC92D1105BA003CA2BB /* MTREndpointInfo_Internal.h in Headers */,
 				5ACDDD7E27CD3F3A00EFD68A /* MTRClusterStateCacheContainer_Internal.h in Headers */,
 				5136661328067D550025EDAE /* MTRDeviceController_Internal.h in Headers */,
@@ -2282,6 +2304,7 @@
 				3DECCB742934C21B00585AEC /* MTRDefines.h in Headers */,
 				51C659D92BA3787500C54922 /* MTRTimeUtils.h in Headers */,
 				75139A702B7FE68C00E3A919 /* MTRDeviceControllerLocalTestStorage.h in Headers */,
+				51445F792E5F70AF003C7C98 /* MTRDeviceControllerDelegate_Internal.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,
 				51FE72352ACDB40000437032 /* MTRCommandPayloads_Internal.h in Headers */,
@@ -2686,6 +2709,7 @@
 				517BF3F1282B62B800A8B7DB /* MTRCertificates.mm in Sources */,
 				5A6FEC9627B5983000F25F42 /* MTRDeviceControllerXPCConnection.mm in Sources */,
 				511913FB28C100EF009235E9 /* MTRBaseSubscriptionCallback.mm in Sources */,
+				51445F732E5E565F003C7C98 /* MTRCommissioningOperation.mm in Sources */,
 				510470FB2A2F7DF60053EA7E /* MTRBackwardsCompatShims.mm in Sources */,
 				5173A47629C0E2ED00F67F48 /* MTRFabricInfo.mm in Sources */,
 				5109E9BB2CC1F23E0006884B /* MTRDeviceClusterData.mm in Sources */,


### PR DESCRIPTION
#### Summary

A new API that avoids some of the pitfalls of the existing one (for example by avoiding ambient state as much as possible, in favor of explicit state tied to a commissioning instance).

#### Testing

Unit tests to come; for now this is draft API with no implementation.