### PR TITLE
[ICD] Update get function to return max value between the IdleModeDuration …

### DIFF
--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -70,7 +70,7 @@ jobs:
                      "clang") GN_ARGS='is_clang=true chip_build_all_platform_tests=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls" chip_build_all_platform_tests=true';;
                      "rotating_device_id") GN_ARGS='chip_crypto="boringssl" chip_enable_rotating_device_id=true chip_build_all_platform_tests=true';;
-                     "icd") GN_ARGS='chip_enable_icd_server=true chip_enable_icd_lit=true chip_build_all_platform_tests=true chip_icd_report_on_active_mode=true';;
+                     "icd") GN_ARGS='chip_enable_icd_server=true chip_enable_icd_lit=true chip_build_all_platform_tests=true';;
                      *) ;;
                   esac
 

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -70,7 +70,7 @@ jobs:
                      "clang") GN_ARGS='is_clang=true chip_build_all_platform_tests=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls" chip_build_all_platform_tests=true';;
                      "rotating_device_id") GN_ARGS='chip_crypto="boringssl" chip_enable_rotating_device_id=true chip_build_all_platform_tests=true';;
-                     "icd") GN_ARGS='chip_enable_icd_server=true chip_enable_icd_lit=true chip_build_all_platform_tests=true';;
+                     "icd") GN_ARGS='chip_enable_icd_server=true chip_enable_icd_lit=true chip_build_all_platform_tests=true chip_icd_report_on_active_mode=true';;
                      *) ;;
                   esac
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -52,7 +52,8 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this), mManagementCallback(apCallback)
+    mExchangeCtx(*this),
+    mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -42,6 +42,7 @@ using Status = Protocols::InteractionModel::Status;
 uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
+    // We don't need to check for precision loss since the max value of the IdleModeDuration can fit inside a uint16_t
     const auto idleModeDuration =
         std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
     return std::max(idleModeDuration, kSubscriptionMaxIntervalPublisherLimit);
@@ -52,8 +53,7 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this),
-    mManagementCallback(apCallback)
+    mExchangeCtx(*this), mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 
@@ -780,8 +780,7 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     // If the next interval is greater than the MaxIntervalCeiling, use the MaxIntervalCeiling.
     // Otherwise, use IdleModeDuration as MaxInterval
 
-    // GetPublisherSelectedIntervalLimit() returns the IdleModeDuration if the device is an ICD
-    uint32_t decidedMaxInterval = GetPublisherSelectedIntervalLimit();
+    uint32_t decidedMaxInterval = ICDConfigurationData::GetInstance().GetIdleModeDuration().count();
 
     // Check if the PublisherSelectedIntervalLimit is 0. If so, set decidedMaxInterval to MaxIntervalCeiling
     if (decidedMaxInterval == 0)

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -51,7 +51,8 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this), mManagementCallback(apCallback)
+    mExchangeCtx(*this),
+    mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -53,7 +53,8 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this), mManagementCallback(apCallback)
+    mExchangeCtx(*this),
+    mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -42,8 +42,9 @@ using Status = Protocols::InteractionModel::Status;
 uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    return std::max(static_cast<uint16_t>(ICDConfigurationData::GetInstance().GetIdleModeDuration().count()),
-                    kSubscriptionMaxIntervalPublisherLimit);
+    const auto idleModeDuration =
+        std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
+    return std::max(idleModeDuration, kSubscriptionMaxIntervalPublisherLimit);
 #else
     return kSubscriptionMaxIntervalPublisherLimit;
 #endif
@@ -51,8 +52,7 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this),
-    mManagementCallback(apCallback)
+    mExchangeCtx(*this), mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -42,7 +42,8 @@ using Status = Protocols::InteractionModel::Status;
 uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 {
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
-    return std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
+    return std::max(static_cast<uint16_t>(ICDConfigurationData::GetInstance().GetIdleModeDuration().count()),
+                    kSubscriptionMaxIntervalPublisherLimit);
 #else
     return kSubscriptionMaxIntervalPublisherLimit;
 #endif
@@ -50,8 +51,7 @@ uint16_t ReadHandler::GetPublisherSelectedIntervalLimit()
 
 ReadHandler::ReadHandler(ManagementCallback & apCallback, Messaging::ExchangeContext * apExchangeContext,
                          InteractionType aInteractionType, Observer * observer) :
-    mExchangeCtx(*this),
-    mManagementCallback(apCallback)
+    mExchangeCtx(*this), mManagementCallback(apCallback)
 {
     VerifyOrDie(apExchangeContext != nullptr);
 

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -300,6 +300,7 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/data-model-provider/tests:encode-decode",
     "${chip_root}/src/app/icd/client:handler",
     "${chip_root}/src/app/icd/client:manager",
+    "${chip_root}/src/app/icd/server:configuration-data",
     "${chip_root}/src/app/server",
     "${chip_root}/src/app/server:terms_and_conditions",
     "${chip_root}/src/app/tests:helpers",

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -24,6 +24,7 @@
 #include <app/InteractionModelHelper.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/EventDataIB.h>
+#include <app/icd/server/ICDConfigurationData.h>
 #include <app/icd/server/ICDServerConfig.h>
 #include <app/reporting/tests/MockReportScheduler.h>
 #include <app/tests/AppTestContext.h>
@@ -182,8 +183,7 @@ class AttributeCaptureAssertion
 public:
     constexpr AttributeCaptureAssertion(chip::EndpointId ep, chip::ClusterId cl, chip::AttributeId at,
                                         std::optional<unsigned> listSize = std::nullopt) :
-        mEndpoint(ep),
-        mCluster(cl), mAttribute(at), mListSize(listSize)
+        mEndpoint(ep), mCluster(cl), mAttribute(at), mListSize(listSize)
     {}
 
     chip::app::ConcreteAttributePath Path() const { return chip::app::ConcreteAttributePath(mEndpoint, mCluster, mAttribute); }
@@ -843,7 +843,8 @@ void TestReadInteraction::TestReadHandlerSetMaxReportingInterval()
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
         // When an ICD build, the default behavior is to select the IdleModeDuration as MaxInterval
-        kMaxIntervalCeiling = readHandler.GetPublisherSelectedIntervalLimit();
+        kMaxIntervalCeiling =
+            std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
 #endif
         // Try to change the MaxInterval while ReadHandler is active
         EXPECT_EQ(readHandler.SetMaxReportingInterval(340), CHIP_ERROR_INCORRECT_STATE);
@@ -1615,8 +1616,7 @@ void TestReadInteraction::TestSetDirtyBetweenChunks()
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths),
-                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 
@@ -1880,7 +1880,8 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMaxIntervalCeiling()
 
         EXPECT_EQ(readHandler.ProcessSubscribeRequest(std::move(subscribeRequestbuf)), CHIP_NO_ERROR);
 
-        uint16_t idleModeDuration = readHandler.GetPublisherSelectedIntervalLimit();
+        uint16_t idleModeDuration =
+            std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -1949,7 +1950,8 @@ void TestReadInteraction::TestICDProcessSubscribeRequestInfMaxIntervalCeiling()
 
         EXPECT_EQ(readHandler.ProcessSubscribeRequest(std::move(subscribeRequestbuf)), CHIP_NO_ERROR);
 
-        uint16_t idleModeDuration = readHandler.GetPublisherSelectedIntervalLimit();
+        uint16_t idleModeDuration =
+            std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -2018,7 +2020,8 @@ void TestReadInteraction::TestICDProcessSubscribeRequestSupMinInterval()
 
         EXPECT_EQ(readHandler.ProcessSubscribeRequest(std::move(subscribeRequestbuf)), CHIP_NO_ERROR);
 
-        uint16_t idleModeDuration = readHandler.GetPublisherSelectedIntervalLimit();
+        uint16_t idleModeDuration =
+            std::chrono::duration_cast<System::Clock::Seconds16>(ICDConfigurationData::GetInstance().GetIdleModeDuration()).count();
 
         uint16_t minInterval;
         uint16_t maxInterval;
@@ -2102,7 +2105,7 @@ void TestReadInteraction::TestICDProcessSubscribeRequestMaxMinInterval()
 
 /**
  * @brief Test validates that an ICD will choose the MaxIntervalCeiling as MaxInterval if the next multiple after the MinInterval
- *        is greater than the IdleModeDuration and MaxIntervalCeiling
+ *        is greater than the publisher selected max interval limit and the MaxIntervalCeiling
  */
 TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteraction, TestICDProcessSubscribeRequestInvalidIdleModeDuration)
 TEST_F_FROM_FIXTURE_NO_BODY(TestReadInteractionSync, TestICDProcessSubscribeRequestInvalidIdleModeDuration)
@@ -2114,8 +2117,10 @@ void TestReadInteraction::TestICDProcessSubscribeRequestInvalidIdleModeDuration(
     auto * engine = chip::app::InteractionModelEngine::GetInstance();
     EXPECT_EQ(engine->Init(&GetExchangeManager(), &GetFabricTable(), gReportScheduler), CHIP_NO_ERROR);
 
-    uint16_t kMinInterval        = 400;
-    uint16_t kMaxIntervalCeiling = 400;
+    // Since the default IdleModeDuration is 300s for unit test,
+    // we need to set both values higher than 3600s which is the publisher selected max interval limit in this situation.
+    uint16_t kMinInterval        = 3610;
+    uint16_t kMaxIntervalCeiling = 3610;
 
     Messaging::ExchangeContext * exchangeCtx = NewExchangeToAlice(nullptr, false);
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -183,7 +183,8 @@ class AttributeCaptureAssertion
 public:
     constexpr AttributeCaptureAssertion(chip::EndpointId ep, chip::ClusterId cl, chip::AttributeId at,
                                         std::optional<unsigned> listSize = std::nullopt) :
-        mEndpoint(ep), mCluster(cl), mAttribute(at), mListSize(listSize)
+        mEndpoint(ep),
+        mCluster(cl), mAttribute(at), mListSize(listSize)
     {}
 
     chip::app::ConcreteAttributePath Path() const { return chip::app::ConcreteAttributePath(mEndpoint, mCluster, mAttribute); }
@@ -1616,7 +1617,8 @@ void TestReadInteraction::TestSetDirtyBetweenChunks()
         public:
             DirtyingMockDelegate(AttributePathParams (&aReadPaths)[2], int & aNumAttributeResponsesWhenSetDirty,
                                  int & aNumArrayItemsWhenSetDirty) :
-                mReadPaths(aReadPaths), mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
+                mReadPaths(aReadPaths),
+                mNumAttributeResponsesWhenSetDirty(aNumAttributeResponsesWhenSetDirty),
                 mNumArrayItemsWhenSetDirty(aNumArrayItemsWhenSetDirty)
             {}
 


### PR DESCRIPTION
…and the SubscriptionMaxIntervalPublisherLimit

#### Summary
PR updates the GetPublisherSelectedIntervalLimit, when the device is an ICD, to return the maximum value between the IdleModeDuration and SubscriptionMaxIntervalPublisherLimit

All the changes outisde of the `GetPublisherSelectedIntervalLimit` function update are due to the fact that the code assumed that the `GetPublisherSelectedIntervalLimit` returned the IdleModeDuration wen the device was an ICD.
With the current changes, the assumption is not true anymore so PR udpates the function usages to get the IdleModeDuration directly to keep the existing behavior.


#### Related issues

Spec defined behavior was updated but the SDK was not updated to implement the new specification requirement.
I noticed this during the ballot review for 0.9

```
If the publisher is an ICD, this SHALL be set to the IdleModeDuration or 60 minutes, whichever is greater. 
If not,  Otherwise,  this SHALL be set to 60 minutes.
```

#### Testing

CI - ICD unit and integration tests should still pass

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)