### PR TITLE
 [Backport-1.4]: Pass discovery timeout to Matter server initialization

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -322,7 +322,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     else
     {
 #if CHIP_DEVICE_CONFIG_ENABLE_PAIRING_AUTOSTART
-        SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow());
+        SuccessOrExit(err = mCommissioningWindowManager.OpenBasicCommissioningWindow(initParams.discoveryTimeout));
 #endif
     }
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -133,6 +133,8 @@ struct ServerInitParams
 
     // Application delegate to handle some commissioning lifecycle events
     AppDelegate * appDelegate = nullptr;
+    // device discovery timeout
+    System::Clock::Seconds32 discoveryTimeout = System::Clock::Seconds32(CHIP_DEVICE_CONFIG_DISCOVERY_TIMEOUT_SECS);
     // Port to use for Matter commissioning/operational traffic
     uint16_t operationalServicePort = CHIP_PORT;
     // Port to use for UDC if supported


### PR DESCRIPTION
### Changes: 
This change allows applications to configure the device discovery timeout during Matter server initialization by passing the value in ServerInitParams.

Backported from: [#38940](https://github.com/project-chip/connectedhomeip/pull/38940)

### Testing:

- Built example app with customized discoveryTimeout value
- Verified that the commissioning window stayed open for the configured duration via manual commissioning