### PR TITLE
[Tizen] Fix resourced crash when running tests on QEMU

### DIFF
--- a/third_party/tizen/tizen_qemu.py
+++ b/third_party/tizen/tizen_qemu.py
@@ -140,6 +140,9 @@ qemu_args += [
 ]
 
 kernel_args = "console=ttyAMA0 earlyprintk earlycon root=/dev/vda"
+# For some reason memory cgroup is not enabled by default in Tizen kernel,
+# but it is required by resourced system service on Tizen >= 9.0.
+kernel_args += " cgroup_enable=memory"
 if args.interactive:
     # Run root shell instead of the runner script.
     kernel_args += " rootshell"


### PR DESCRIPTION
#### Summary

The resourced system service is a crucial component on Tizen. Instability of that service might affect application installation which causes frequent CI failures after upgrade to Tizen 9.0.

E.g.:
https://github.com/project-chip/connectedhomeip/actions/runs/16513335128/job/46699443582?pr=39856

#### Testing

Locally verified that `resourced` does not crash anymore.