### PR TITLE
[NXP][examples][cmake] Adding post-build image conversion to binary format for all NXP examples

### DIFF
--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -294,6 +294,6 @@ endif()
 mcux_convert_binary(
     BINARY ${APPLICATION_BINARY_DIR}/app.bin
     TARGET app
-    TOOLCHAINS armgcc
+    TOOLCHAINS ${CONFIG_TOOLCHAIN}
     EXTRA_ARGS "${CONFIG_REMOVE_SECTIONS_FROM_BIN}"
 )

--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -289,3 +289,11 @@ if (CONFIG_CHIP_APP_WIFI_CONNECT)
         ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/wifi_connect/source/WifiConnect.cpp
     )
 endif()
+
+# Use MCUX post-build function to convert the executable to binary format
+mcux_convert_binary(
+    BINARY ${APPLICATION_BINARY_DIR}/app.bin
+    TARGET app
+    TOOLCHAINS armgcc
+    EXTRA_ARGS "${CONFIG_REMOVE_SECTIONS_FROM_BIN}"
+)


### PR DESCRIPTION
#### Summary

The aim of this PR is to use MCUX SDK's post-build function "mcux_convert_binary" to generate the .bin automatically for all NXP examples and all platforms.

#### Testing

This change was tested by manually building the example, and testing the generated the ".bin" by programming it into the board.
Example of build command: 
- west build -d build_matter -b rdrw612bga examples/thermostat/nxp

