### PR TITLE
Added an assertion to TC_CNET_4_16.py for when LastNetworkID is None

### DIFF
--- a/src/python_testing/TC_CNET_4_16.py
+++ b/src/python_testing/TC_CNET_4_16.py
@@ -55,8 +55,8 @@ class TC_CNET_4_16(MatterBaseTest):
         # Precondition 2: TH can communicate with the DUT on PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET
         networkID = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.LastNetworkID)
 
-        if networkID is None:
-            asserts.fail("Failed to read LastNetworkID attribute. Returned None. Ensure DUT is commissioned to Thread network.")
+        asserts.assert_is_not_none(
+            networkID, "Failed to read LastNetworkID attribute. Returned None. Ensure DUT is commissioned to Thread network.")
 
         logger.info(f" --- NetworkID: {networkID.hex()}")
         asserts.assert_in(networkID.hex(), thread_1st.hex(),

--- a/src/python_testing/TC_CNET_4_16.py
+++ b/src/python_testing/TC_CNET_4_16.py
@@ -54,6 +54,10 @@ class TC_CNET_4_16(MatterBaseTest):
         # Precondition 1: DUT is commissioned on PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET
         # Precondition 2: TH can communicate with the DUT on PIXIT.CNET.THREAD_1ST_OPERATIONALDATASET
         networkID = await self.read_single_attribute_check_success(cluster=cnet, attribute=attr.LastNetworkID)
+
+        if networkID is None:
+            asserts.fail("Failed to read LastNetworkID attribute. Returned None. Ensure DUT is commissioned to Thread network.")
+
         logger.info(f" --- NetworkID: {networkID.hex()}")
         asserts.assert_in(networkID.hex(), thread_1st.hex(),
                           f"NetworkID: {networkID.hex()} not in {thread_1st.hex()}")


### PR DESCRIPTION
#### Testing

This update to TC_CNET_4_16.py fixes [Issue #664](https://github.com/project-chip/certification-tool/issues/664) by adding an assertion to fail with a clear message in case `LastNetworkID` is `None`.
This affected both TC_CNET_4_16.py and TC_CNET_4_10.py

It was not actually a bug but it produced a cryptic error message when trying to commission using `--wifi` option.
Using `./chip-all-clusters-app --wifi` enables NetworkCommissioning for Wi-Fi but does not initialize the NetworkCommissioning cluster in Thread mode, resulting in the attribute `LastNetworkID` being unavailable (returns `None`), which leads to the following exception:
`AttributeError: 'NoneType' object has no attribute 'hex'.`

These tests were validated in a local Thread setup using:
- Raspberry Pi + nRF52840 as Thread Border Router
- EFR32 running chip-all-clusters-app
- Command to run the test:

```python3 src/python_testing/TC_CNET_4_16.py --commissioning-method ble-thread --discriminator 3840 --passcode 20202021 --thread-dataset-hex <THREAD_DATASET_HEX> --endpoint 0```

Both test cases passed successfully under this configuration.