### PR TITLE
Create super-class OperationalDatasetView out of OperationalDataset

### DIFF
--- a/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
+++ b/src/app/clusters/thread-network-directory-server/thread-network-directory-server.cpp
@@ -180,7 +180,7 @@ void ThreadNetworkDirectoryServer::InvokeCommand(HandlerContext & ctx)
 void ThreadNetworkDirectoryServer::HandleAddNetworkRequest(HandlerContext & ctx,
                                                            const ThreadNetworkDirectory::Commands::AddNetwork::DecodableType & req)
 {
-    OperationalDataset dataset;
+    OperationalDatasetView dataset;
     ByteSpan extendedPanIdSpan;
     uint64_t activeTimestamp;
     union
@@ -200,7 +200,6 @@ void ThreadNetworkDirectoryServer::HandleAddNetworkRequest(HandlerContext & ctx,
     CHIP_ERROR err;
     auto status          = IMStatus::ConstraintError;
     const char * context = nullptr;
-    // TODO: An immutable OperationalDatasetView on top of a ByteSpan (without copying) would be useful here.
     SuccessOrExitAction(err = dataset.Init(req.operationalDataset), context = "OperationalDataset");
     SuccessOrExitAction(err = dataset.GetExtendedPanIdAsByteSpan(extendedPanIdSpan), context = "ExtendedPanID");
     SuccessOrExitAction(err = dataset.GetActiveTimestamp(activeTimestamp), context = "ActiveTimestamp");

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -38,11 +38,11 @@ namespace Thread {
  */
 class ThreadTLV final
 {
+public:
     static constexpr uint8_t kLengthEscape = 0xff; ///< This length value indicates the actual length is of two-bytes length, which
                                                    ///< is not allowed in Thread Operational Dataset TLVs.
-
-public:
-    static constexpr uint8_t kMaxLength = kLengthEscape - 1;
+    static constexpr uint8_t kHeaderSize = 2;      ///< Size of the TLV header (Type + Length).
+    static constexpr uint8_t kMaxLength  = kSizeOperationalDataset - kHeaderSize;
 
     enum : uint8_t
     {
@@ -59,80 +59,77 @@ public:
         kChannelMask     = 53,
     };
 
-    uint8_t GetSize() const { return static_cast<uint8_t>(sizeof(*this) + GetLength()); }
+    size_t GetSize() const
+    {
+        static_assert(sizeof(*this) == kHeaderSize, "Wrong size for ThreadTLV header");
+        return sizeof(*this) + GetLength();
+    }
 
     uint8_t GetType() const { return mType; }
 
     void SetType(uint8_t aType) { mType = aType; }
 
-    uint8_t GetLength() const
-    {
-        assert(mLength != kLengthEscape);
-        return mLength;
-    }
+    uint8_t GetLength() const { return mLength; }
 
-    void SetLength(uint8_t aLength)
+    void SetLength(size_t aLength)
     {
-        assert(aLength != kLengthEscape);
-        mLength = aLength;
+        assert(aLength < kLengthEscape);
+        mLength = static_cast<uint8_t>(aLength);
     }
 
     const uint8_t * GetValue() const
     {
         assert(mLength != kLengthEscape);
-
-        static_assert(sizeof(*this) == sizeof(ThreadTLV::mType) + sizeof(ThreadTLV::mLength), "Wrong size for ThreadTLV header");
-
         return reinterpret_cast<const uint8_t *>(this) + sizeof(*this);
     }
 
     uint8_t * GetValue() { return const_cast<uint8_t *>(const_cast<const ThreadTLV *>(this)->GetValue()); }
 
-    ByteSpan GetValueAsSpan() const { return ByteSpan(static_cast<const uint8_t *>(GetValue()), GetLength()); }
+    ByteSpan GetValueAsSpan() const { return ByteSpan(GetValue(), GetLength()); }
 
     void Get64(uint64_t & aValue) const
     {
-        assert(GetLength() >= sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         aValue = Encoding::BigEndian::Get64(GetValue());
     }
 
     void Get32(uint32_t & aValue) const
     {
-        assert(GetLength() >= sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         aValue = Encoding::BigEndian::Get32(GetValue());
     }
 
     void Get16(uint16_t & aValue) const
     {
-        assert(GetLength() >= sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         aValue = Encoding::BigEndian::Get16(GetValue());
     }
 
     void Set64(uint64_t aValue)
     {
-        SetLength(sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         Encoding::BigEndian::Put64(GetValue(), aValue);
     }
 
     void Set32(uint32_t aValue)
     {
-        SetLength(sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         Encoding::BigEndian::Put32(GetValue(), aValue);
     }
 
     void Set16(uint16_t aValue)
     {
-        SetLength(sizeof(aValue));
+        assert(GetLength() == sizeof(aValue));
         Encoding::BigEndian::Put16(GetValue(), aValue);
     }
 
-    void SetValue(const void * aValue, uint8_t aLength)
+    void SetValue(const void * aValue, size_t aLength)
     {
-        SetLength(aLength);
+        assert(GetLength() == aLength);
         memcpy(GetValue(), aValue, aLength);
     }
 
-    void SetValue(const ByteSpan & aValue) { SetValue(aValue.data(), static_cast<uint8_t>(aValue.size())); }
+    void SetValue(const ByteSpan & aValue) { SetValue(aValue.data(), aValue.size()); }
 
     const ThreadTLV * GetNext() const
     {
@@ -142,58 +139,56 @@ public:
 
     ThreadTLV * GetNext() { return reinterpret_cast<ThreadTLV *>(static_cast<uint8_t *>(GetValue()) + GetLength()); }
 
-    static bool IsValid(ByteSpan aData)
-    {
-        const uint8_t * const end = aData.data() + aData.size();
-        const uint8_t * curr      = aData.data();
-
-        while (curr + sizeof(ThreadTLV) < end)
-        {
-            const ThreadTLV * tlv = reinterpret_cast<const ThreadTLV *>(curr);
-
-            if (tlv->GetLength() == kLengthEscape)
-            {
-                break;
-            }
-
-            curr = reinterpret_cast<const uint8_t *>(tlv->GetNext());
-        }
-
-        return curr == end;
-    }
-
 private:
     uint8_t mType;
     uint8_t mLength;
 };
 
-bool OperationalDataset::IsValid(ByteSpan aData)
+/// OperationalDatasetView
+
+bool OperationalDatasetView::IsValid(ByteSpan aData)
 {
-    return ThreadTLV::IsValid(aData);
+    VerifyOrReturnValue(aData.size() <= kSizeOperationalDataset, false);
+
+    const ThreadTLV * tlv = reinterpret_cast<const ThreadTLV *>(aData.begin());
+    const ThreadTLV * end = reinterpret_cast<const ThreadTLV *>(aData.end());
+    while (tlv != end)
+    {
+        VerifyOrReturnValue(tlv->GetLength() != ThreadTLV::kLengthEscape, false); // not allowed in a dataset TLV
+        tlv = tlv->GetNext();
+        VerifyOrReturnValue(tlv <= end, false); // out of bounds
+    }
+    return true;
 }
 
-CHIP_ERROR OperationalDataset::Init(ByteSpan aData)
+CHIP_ERROR OperationalDatasetView::Init(ByteSpan aData)
 {
-    if (aData.size() > sizeof(mData))
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
-    if (aData.size() > 0)
-    {
-        if (!ThreadTLV::IsValid(aData))
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
-        memcpy(mData, aData.data(), aData.size());
-    }
-
-    mLength = static_cast<uint8_t>(aData.size());
+    VerifyOrReturnError(IsValid(aData), CHIP_ERROR_INVALID_ARGUMENT);
+    mData = aData;
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::GetActiveTimestamp(uint64_t & aActiveTimestamp) const
+const ThreadTLV * OperationalDatasetView::Locate(uint8_t aType) const
+{
+    const ThreadTLV * tlv = reinterpret_cast<const ThreadTLV *>(mData.begin());
+    const ThreadTLV * end = reinterpret_cast<const ThreadTLV *>(mData.end());
+    while (tlv < end)
+    {
+        if (tlv->GetType() == aType)
+        {
+            return tlv;
+        }
+        tlv = tlv->GetNext();
+    }
+    return nullptr;
+}
+
+bool OperationalDatasetView::IsCommissioned() const
+{
+    return Has(ThreadTLV::kPanId) && Has(ThreadTLV::kMasterKey) && Has(ThreadTLV::kExtendedPanId) && Has(ThreadTLV::kChannel);
+}
+
+CHIP_ERROR OperationalDatasetView::GetActiveTimestamp(uint64_t & aActiveTimestamp) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kActiveTimestamp);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -202,19 +197,7 @@ CHIP_ERROR OperationalDataset::GetActiveTimestamp(uint64_t & aActiveTimestamp) c
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetActiveTimestamp(uint64_t aActiveTimestamp)
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kActiveTimestamp, sizeof(*tlv) + sizeof(aActiveTimestamp));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->Set64(aActiveTimestamp);
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetChannel(uint16_t & aChannel) const
+CHIP_ERROR OperationalDatasetView::GetChannel(uint16_t & aChannel) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kChannel);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -225,20 +208,7 @@ CHIP_ERROR OperationalDataset::GetChannel(uint16_t & aChannel) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetChannel(uint16_t aChannel)
-{
-    uint8_t value[] = { 0, static_cast<uint8_t>(aChannel >> 8), static_cast<uint8_t>(aChannel & 0xff) };
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kChannel, sizeof(*tlv) + sizeof(value));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(value, sizeof(value));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeExtendedPanId]) const
+CHIP_ERROR OperationalDatasetView::GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeExtendedPanId]) const
 {
     ByteSpan extPanIdSpan;
     ReturnErrorOnFailure(GetExtendedPanIdAsByteSpan(extPanIdSpan));
@@ -246,7 +216,7 @@ CHIP_ERROR OperationalDataset::GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeE
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::GetExtendedPanId(uint64_t & extendedPanId) const
+CHIP_ERROR OperationalDatasetView::GetExtendedPanId(uint64_t & extendedPanId) const
 {
     ByteSpan extPanIdSpan;
     ReturnErrorOnFailure(GetExtendedPanIdAsByteSpan(extPanIdSpan));
@@ -255,7 +225,7 @@ CHIP_ERROR OperationalDataset::GetExtendedPanId(uint64_t & extendedPanId) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::GetExtendedPanIdAsByteSpan(ByteSpan & span) const
+CHIP_ERROR OperationalDatasetView::GetExtendedPanIdAsByteSpan(ByteSpan & span) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kExtendedPanId);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -264,44 +234,7 @@ CHIP_ERROR OperationalDataset::GetExtendedPanIdAsByteSpan(ByteSpan & span) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId])
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kExtendedPanId, sizeof(*tlv) + sizeof(aExtendedPanId));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(aExtendedPanId, sizeof(aExtendedPanId));
-
-    assert(mLength + tlv->GetSize() <= sizeof(mData));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetMasterKey(uint8_t (&aMasterKey)[kSizeMasterKey]) const
-{
-    const ThreadTLV * tlv = Locate(ThreadTLV::kMasterKey);
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
-    VerifyOrReturnError(tlv->GetLength() == sizeof(aMasterKey), CHIP_ERROR_INVALID_TLV_ELEMENT);
-    memcpy(aMasterKey, tlv->GetValue(), sizeof(aMasterKey));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::SetMasterKey(const uint8_t (&aMasterKey)[kSizeMasterKey])
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kMasterKey, sizeof(*tlv) + sizeof(aMasterKey));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(aMasterKey, sizeof(aMasterKey));
-
-    assert(mLength + tlv->GetSize() <= sizeof(mData));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetMeshLocalPrefix(uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]) const
+CHIP_ERROR OperationalDatasetView::GetMeshLocalPrefix(uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kMeshLocalPrefix);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -310,19 +243,16 @@ CHIP_ERROR OperationalDataset::GetMeshLocalPrefix(uint8_t (&aMeshLocalPrefix)[kS
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetMeshLocalPrefix(const uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix])
+CHIP_ERROR OperationalDatasetView::GetMasterKey(uint8_t (&aMasterKey)[kSizeMasterKey]) const
 {
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kMeshLocalPrefix, sizeof(*tlv) + sizeof(aMeshLocalPrefix));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(aMeshLocalPrefix, sizeof(aMeshLocalPrefix));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
+    const ThreadTLV * tlv = Locate(ThreadTLV::kMasterKey);
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
+    VerifyOrReturnError(tlv->GetLength() == sizeof(aMasterKey), CHIP_ERROR_INVALID_TLV_ELEMENT);
+    memcpy(aMasterKey, tlv->GetValue(), sizeof(aMasterKey));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::GetNetworkName(char (&aNetworkName)[kSizeNetworkName + 1]) const
+CHIP_ERROR OperationalDatasetView::GetNetworkName(char (&aNetworkName)[kSizeNetworkName + 1]) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kNetworkName);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -332,23 +262,7 @@ CHIP_ERROR OperationalDataset::GetNetworkName(char (&aNetworkName)[kSizeNetworkN
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetNetworkName(const char * aNetworkName)
-{
-    VerifyOrReturnError(aNetworkName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    size_t len = strlen(aNetworkName);
-    VerifyOrReturnError(0 < len && len <= kSizeNetworkName, CHIP_ERROR_INVALID_STRING_LENGTH);
-
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kNetworkName, sizeof(*tlv) + len);
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(aNetworkName, static_cast<uint8_t>(len));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetPanId(uint16_t & aPanId) const
+CHIP_ERROR OperationalDatasetView::GetPanId(uint16_t & aPanId) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kPanId);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -357,19 +271,7 @@ CHIP_ERROR OperationalDataset::GetPanId(uint16_t & aPanId) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetPanId(uint16_t aPanId)
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kPanId, sizeof(*tlv) + sizeof(aPanId));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->Set16(aPanId);
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetPSKc(uint8_t (&aPSKc)[kSizePSKc]) const
+CHIP_ERROR OperationalDatasetView::GetPSKc(uint8_t (&aPSKc)[kSizePSKc]) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kPSKc);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -378,19 +280,7 @@ CHIP_ERROR OperationalDataset::GetPSKc(uint8_t (&aPSKc)[kSizePSKc]) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetPSKc(const uint8_t (&aPSKc)[kSizePSKc])
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kPSKc, sizeof(*tlv) + sizeof(aPSKc));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    tlv->SetValue(aPSKc, sizeof(aPSKc));
-
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetChannelMask(ByteSpan & aChannelMask) const
+CHIP_ERROR OperationalDatasetView::GetChannelMask(ByteSpan & aChannelMask) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kChannelMask);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -399,17 +289,7 @@ CHIP_ERROR OperationalDataset::GetChannelMask(ByteSpan & aChannelMask) const
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetChannelMask(ByteSpan aChannelMask)
-{
-    VerifyOrReturnError(0 < aChannelMask.size() && aChannelMask.size() < ThreadTLV::kMaxLength, CHIP_ERROR_INVALID_ARGUMENT);
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kChannelMask, sizeof(*tlv) + aChannelMask.size());
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-    tlv->SetValue(aChannelMask);
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetSecurityPolicy(uint32_t & aSecurityPolicy) const
+CHIP_ERROR OperationalDatasetView::GetSecurityPolicy(uint32_t & aSecurityPolicy) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kSecurityPolicy);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -418,16 +298,7 @@ CHIP_ERROR OperationalDataset::GetSecurityPolicy(uint32_t & aSecurityPolicy) con
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR OperationalDataset::SetSecurityPolicy(uint32_t aSecurityPolicy)
-{
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kSecurityPolicy, sizeof(*tlv) + sizeof(aSecurityPolicy));
-    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
-    tlv->Set32(aSecurityPolicy);
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OperationalDataset::GetDelayTimer(uint32_t & aDelayMillis) const
+CHIP_ERROR OperationalDatasetView::GetDelayTimer(uint32_t & aDelayMillis) const
 {
     const ThreadTLV * tlv = Locate(ThreadTLV::kDelayTimer);
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_TLV_TAG_NOT_FOUND);
@@ -436,12 +307,162 @@ CHIP_ERROR OperationalDataset::GetDelayTimer(uint32_t & aDelayMillis) const
     return CHIP_NO_ERROR;
 }
 
+/// OperationalDataset
+
+CHIP_ERROR OperationalDataset::Init(ByteSpan aData)
+{
+    VerifyOrReturnError(IsValid(aData), CHIP_ERROR_INVALID_ARGUMENT);
+    // Use memmove because aData could be a sub-span of AsByteSpan()
+    memmove(mBuffer, aData.data(), aData.size());
+    mData = ByteSpan(mBuffer, aData.size());
+    return CHIP_NO_ERROR;
+}
+
+void OperationalDataset::CopyIfNecessary()
+{
+    // It's possible that mData points into an external buffer if someone has
+    // called OperationalDatasetView::Init() instead of our copying version.
+    if (mData.data() != mBuffer)
+    {
+        memmove(mBuffer, mData.data(), mData.size());
+        mData = ByteSpan(mBuffer, mData.size());
+    }
+}
+
+void OperationalDataset::Remove(ThreadTLV * tlv)
+{
+    size_t size      = tlv->GetSize();
+    ThreadTLV * next = tlv->GetNext();
+    memmove(tlv, next, static_cast<size_t>(mData.end() - reinterpret_cast<uint8_t *>(next)));
+    mData = ByteSpan(mData.data(), mData.size() - size);
+}
+
+void OperationalDataset::Remove(uint8_t aType)
+{
+    CopyIfNecessary();
+    ThreadTLV * tlv = const_cast<ThreadTLV *>(Locate(aType));
+    if (tlv != nullptr)
+    {
+        Remove(tlv);
+    }
+}
+
+// Inserts a TLV of the specified type and length into the dataset, replacing an existing TLV
+// of the same type if one exists. Returns nullptr if there is not enough space.
+ThreadTLV * OperationalDataset::InsertOrReplace(uint8_t aType, size_t aValueSize)
+{
+    CopyIfNecessary();
+    ThreadTLV * tlv = const_cast<ThreadTLV *>(Locate(aType));
+    if (tlv != nullptr)
+    {
+        size_t tlvLength = tlv->GetLength();
+        VerifyOrReturnValue(aValueSize != tlvLength, tlv); // re-use in place if same size
+        VerifyOrReturnValue(aValueSize < tlvLength || mData.size() + aValueSize - tlvLength <= sizeof(mBuffer), nullptr);
+        Remove(tlv); // we could grow or shrink in place instead, but this is simpler
+    }
+    else
+    {
+        VerifyOrReturnValue(mData.size() + sizeof(ThreadTLV) + aValueSize <= sizeof(mBuffer), nullptr);
+    }
+
+    tlv = reinterpret_cast<ThreadTLV *>(mBuffer + mData.size());
+    tlv->SetType(aType);
+    tlv->SetLength(static_cast<uint8_t>(aValueSize));
+    mData = ByteSpan(mBuffer, mData.size() + tlv->GetSize());
+    return tlv;
+}
+
+CHIP_ERROR OperationalDataset::SetActiveTimestamp(uint64_t aActiveTimestamp)
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kActiveTimestamp, sizeof(aActiveTimestamp));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->Set64(aActiveTimestamp);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetChannel(uint16_t aChannel)
+{
+    uint8_t value[] = { 0, static_cast<uint8_t>(aChannel >> 8), static_cast<uint8_t>(aChannel & 0xff) };
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kChannel, sizeof(value));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(value, sizeof(value));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId])
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kExtendedPanId, sizeof(aExtendedPanId));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aExtendedPanId, sizeof(aExtendedPanId));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetMasterKey(const uint8_t (&aMasterKey)[kSizeMasterKey])
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kMasterKey, sizeof(aMasterKey));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aMasterKey, sizeof(aMasterKey));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetMeshLocalPrefix(const uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix])
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kMeshLocalPrefix, sizeof(aMeshLocalPrefix));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aMeshLocalPrefix, sizeof(aMeshLocalPrefix));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetNetworkName(const char * aNetworkName)
+{
+    VerifyOrReturnError(aNetworkName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    size_t len = strlen(aNetworkName);
+    VerifyOrReturnError(0 < len && len <= kSizeNetworkName, CHIP_ERROR_INVALID_STRING_LENGTH);
+
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kNetworkName, len);
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aNetworkName, len);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetPanId(uint16_t aPanId)
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kPanId, sizeof(aPanId));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->Set16(aPanId);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetPSKc(const uint8_t (&aPSKc)[kSizePSKc])
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kPSKc, sizeof(aPSKc));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aPSKc, sizeof(aPSKc));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetChannelMask(ByteSpan aChannelMask)
+{
+    VerifyOrReturnError(0 < aChannelMask.size() && aChannelMask.size() <= ThreadTLV::kMaxLength, CHIP_ERROR_INVALID_ARGUMENT);
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kChannelMask, aChannelMask.size());
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->SetValue(aChannelMask);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OperationalDataset::SetSecurityPolicy(uint32_t aSecurityPolicy)
+{
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kSecurityPolicy, sizeof(aSecurityPolicy));
+    VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
+    tlv->Set32(aSecurityPolicy);
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR OperationalDataset::SetDelayTimer(uint32_t aDelayMillis)
 {
-    ThreadTLV * tlv = MakeRoom(ThreadTLV::kDelayTimer, sizeof(*tlv) + sizeof(aDelayMillis));
+    ThreadTLV * tlv = InsertOrReplace(ThreadTLV::kDelayTimer, sizeof(aDelayMillis));
     VerifyOrReturnError(tlv != nullptr, CHIP_ERROR_NO_MEMORY);
     tlv->Set32(aDelayMillis);
-    mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
     return CHIP_NO_ERROR;
 }
 
@@ -453,74 +474,6 @@ void OperationalDataset::UnsetMasterKey()
 void OperationalDataset::UnsetPSKc()
 {
     Remove(ThreadTLV::kPSKc);
-}
-
-bool OperationalDataset::IsCommissioned() const
-{
-    return Has(ThreadTLV::kPanId) && Has(ThreadTLV::kMasterKey) && Has(ThreadTLV::kExtendedPanId) && Has(ThreadTLV::kChannel);
-}
-
-const ThreadTLV * OperationalDataset::Locate(uint8_t aType) const
-{
-    const ThreadTLV * tlv = &Begin();
-    const ThreadTLV * end = &End();
-
-    while (tlv < end)
-    {
-        if (tlv->GetType() == aType)
-            break;
-        tlv = tlv->GetNext();
-    }
-
-    assert(tlv < reinterpret_cast<const ThreadTLV *>(&mData[sizeof(mData)]));
-
-    return tlv != end ? tlv : nullptr;
-}
-
-void OperationalDataset::Remove(ThreadTLV & aThreadTLV)
-{
-    uint8_t offset = static_cast<uint8_t>(reinterpret_cast<uint8_t *>(&aThreadTLV) - mData);
-
-    if (offset < mLength && mLength >= (offset + aThreadTLV.GetSize()))
-    {
-        mLength = static_cast<uint8_t>(mLength - aThreadTLV.GetSize());
-        memmove(&aThreadTLV, aThreadTLV.GetNext(), mLength - offset);
-    }
-}
-
-void OperationalDataset::Remove(uint8_t aType)
-{
-    ThreadTLV * tlv = Locate(aType);
-
-    if (tlv != nullptr)
-    {
-        Remove(*tlv);
-    }
-}
-
-ThreadTLV * OperationalDataset::MakeRoom(uint8_t aType, size_t aSize)
-{
-    ThreadTLV * tlv = Locate(aType);
-
-    size_t freeSpace = sizeof(mData) - mLength;
-
-    if (tlv != nullptr)
-    {
-        if (freeSpace + tlv->GetSize() < aSize)
-        {
-            return nullptr;
-        }
-
-        Remove(*tlv);
-    }
-    else if (freeSpace < aSize)
-    {
-        return nullptr;
-    }
-
-    End().SetType(aType);
-
-    return &End();
 }
 
 } // namespace Thread

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -154,9 +154,9 @@ bool OperationalDatasetView::IsValid(ByteSpan aData)
     const ThreadTLV * end = reinterpret_cast<const ThreadTLV *>(aData.end());
     while (tlv != end)
     {
+        VerifyOrReturnValue(tlv + 1 <= end, false);                               // out of bounds
         VerifyOrReturnValue(tlv->GetLength() != ThreadTLV::kLengthEscape, false); // not allowed in a dataset TLV
         tlv = tlv->GetNext();
-        VerifyOrReturnValue(tlv <= end, false); // out of bounds
     }
     return true;
 }

--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -318,15 +318,20 @@ CHIP_ERROR OperationalDataset::Init(ByteSpan aData)
     return CHIP_NO_ERROR;
 }
 
-void OperationalDataset::CopyIfNecessary()
+void OperationalDataset::CopyDataIfNecessary()
 {
     // It's possible that mData points into an external buffer if someone has
     // called OperationalDatasetView::Init() instead of our copying version.
     if (mData.data() != mBuffer)
     {
-        memmove(mBuffer, mData.data(), mData.size());
-        mData = ByteSpan(mBuffer, mData.size());
+        CopyData();
     }
+}
+
+void OperationalDataset::CopyData()
+{
+    memmove(mBuffer, mData.data(), mData.size());
+    mData = ByteSpan(mBuffer, mData.size());
 }
 
 void OperationalDataset::Remove(ThreadTLV * tlv)
@@ -339,7 +344,7 @@ void OperationalDataset::Remove(ThreadTLV * tlv)
 
 void OperationalDataset::Remove(uint8_t aType)
 {
-    CopyIfNecessary();
+    CopyDataIfNecessary();
     ThreadTLV * tlv = const_cast<ThreadTLV *>(Locate(aType));
     if (tlv != nullptr)
     {
@@ -351,7 +356,7 @@ void OperationalDataset::Remove(uint8_t aType)
 // of the same type if one exists. Returns nullptr if there is not enough space.
 ThreadTLV * OperationalDataset::InsertOrReplace(uint8_t aType, size_t aValueSize)
 {
-    CopyIfNecessary();
+    CopyDataIfNecessary();
     ThreadTLV * tlv = const_cast<ThreadTLV *>(Locate(aType));
     if (tlv != nullptr)
     {

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -32,6 +32,7 @@ class ThreadTLV;
 inline constexpr size_t kChannel_NotSpecified = UINT8_MAX;
 inline constexpr size_t kPANId_NotSpecified   = UINT16_MAX;
 
+/// The maximum size of a Thread operational dataset.
 inline constexpr size_t kSizeOperationalDataset = 254;
 
 inline constexpr size_t kSizeNetworkName     = 16;
@@ -40,22 +41,30 @@ inline constexpr size_t kSizeMasterKey       = 16;
 inline constexpr size_t kSizeMeshLocalPrefix = 8;
 inline constexpr size_t kSizePSKc            = 16;
 
+class OperationalDataset;
+
 /**
- * This class provides methods to manipulate Thread operational dataset.
- *
+ * This class provides a read-only view of a Thread operational dataset.
+ * The underlying data is not owned by this class, and must remain valid for the lifetime of the view.
  */
-class OperationalDataset
+class OperationalDatasetView
 {
 public:
     /**
-     * This method initializes the dataset with the given dataset.
+     * This method initializes the dataset view with the given data.
+     * The data itself is not copied, so it must remain valid for the lifetime of the view.
      *
-     * @param[in]   aData       Thread Operational dataset in octects.
+     * @param[in]   aData       The data to interpret as a Thread operational dataset.
      *
      * @retval CHIP_NO_ERROR                Successfully initialized the dataset.
      * @retval CHIP_ERROR_INVALID_ARGUMENT  The dataset length @p aLength is too long or @p data is corrupted.
      */
     CHIP_ERROR Init(ByteSpan aData);
+
+    /**
+     * Returns the ByteSpan underlying this view.
+     */
+    ByteSpan AsByteSpan() const { return mData; }
 
     /**
      * This method retrieves Thread active timestamp from the dataset.
@@ -69,16 +78,6 @@ public:
     CHIP_ERROR GetActiveTimestamp(uint64_t & aActiveTimestamp) const;
 
     /**
-     * This method sets Thread active timestamp to the dataset.
-     *
-     * @param[in]   aActiveTimestamp    The Thread active timestamp.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the active timestamp.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread active timestamp.
-     */
-    CHIP_ERROR SetActiveTimestamp(uint64_t aActiveTimestamp);
-
-    /**
      * This method retrieves Thread channel from the dataset.
      *
      * @param[out]  aChannel    A reference to receive the channel.
@@ -88,16 +87,6 @@ public:
      * @retval CHIP_ERROR_INVALID_TLV_ELEMENT   If the TLV element is invalid.
      */
     CHIP_ERROR GetChannel(uint16_t & aChannel) const;
-
-    /**
-     * This method sets Thread channel to the dataset.
-     *
-     * @param[in]   aChannel    The Thread channel.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the channel.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread channel.
-     */
-    CHIP_ERROR SetChannel(uint16_t aChannel);
 
     /**
      * This method retrieves Thread extended PAN ID from the dataset.
@@ -133,16 +122,6 @@ public:
     CHIP_ERROR GetExtendedPanIdAsByteSpan(ByteSpan & span) const;
 
     /**
-     * This method sets Thread extended PAN ID to the dataset.
-     *
-     * @param[in]   aExtendedPanId  The Thread extended PAN ID.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the extended PAN ID.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread extended PAN ID.
-     */
-    CHIP_ERROR SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId]);
-
-    /**
      * This method retrieves Thread master key from the dataset.
      *
      * @param[out]  aMasterKey  A reference to receive the master key.
@@ -152,21 +131,6 @@ public:
      * @retval CHIP_ERROR_INVALID_TLV_ELEMENT   If the TLV element is invalid.
      */
     CHIP_ERROR GetMasterKey(uint8_t (&aMasterKey)[kSizeMasterKey]) const;
-
-    /**
-     * This method sets Thread master key to the dataset.
-     *
-     * @param[in]   aMasterKey         The Thread master key.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the master key.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread master key.
-     */
-    CHIP_ERROR SetMasterKey(const uint8_t (&aMasterKey)[kSizeMasterKey]);
-
-    /**
-     * This method unsets Thread master key to the dataset.
-     */
-    void UnsetMasterKey(void);
 
     /**
      * This method retrieves Thread mesh local prefix from the dataset.
@@ -180,16 +144,6 @@ public:
     CHIP_ERROR GetMeshLocalPrefix(uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]) const;
 
     /**
-     * This method sets Thread mesh local prefix to the dataset.
-     *
-     * @param[in]   aMeshLocalPrefix   The Thread mesh local prefix.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the Thread mesh local prefix.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread mesh local prefix.
-     */
-    CHIP_ERROR SetMeshLocalPrefix(const uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]);
-
-    /**
      * This method retrieves Thread network name from the dataset.
      *
      * @param[out]  aNetworkName    A reference to receive the Thread network name.
@@ -199,16 +153,6 @@ public:
      * @retval CHIP_ERROR_INVALID_TLV_ELEMENT   If the TLV element is invalid.
      */
     CHIP_ERROR GetNetworkName(char (&aNetworkName)[kSizeNetworkName + 1]) const;
-
-    /**
-     * This method sets Thread network name to the dataset.
-     *
-     * @param[in]   aNetworkName    The Thread network name.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the network name.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread network name.
-     */
-    CHIP_ERROR SetNetworkName(const char * aNetworkName);
 
     /**
      * This method retrieves Thread PAN ID from the dataset.
@@ -222,16 +166,6 @@ public:
     CHIP_ERROR GetPanId(uint16_t & aPanId) const;
 
     /**
-     * This method sets Thread PAN ID to the dataset.
-     *
-     * @param[in]   aPanId  The Thread PAN ID.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the PAN ID.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread PAN ID.
-     */
-    CHIP_ERROR SetPanId(uint16_t aPanId);
-
-    /**
      * This method retrieves Thread PSKc from the dataset.
      *
      * @param[out]  aPSKc   A reference to receive the PSKc.
@@ -241,21 +175,6 @@ public:
      * @retval CHIP_ERROR_INVALID_TLV_ELEMENT   If the TLV element is invalid.
      */
     CHIP_ERROR GetPSKc(uint8_t (&aPSKc)[kSizePSKc]) const;
-
-    /**
-     * This method sets Thread PSKc to the dataset.
-     *
-     * @param[in]   aPSKc   The Thread PSKc.
-     *
-     * @retval CHIP_NO_ERROR           Successfully set the PSKc.
-     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread PSKc.
-     */
-    CHIP_ERROR SetPSKc(const uint8_t (&aPSKc)[kSizePSKc]);
-
-    /**
-     * This method unsets Thread PSKc to the dataset.
-     */
-    void UnsetPSKc(void);
 
     /**
      * Returns ByteSpan pointing to the channel mask within the dataset.
@@ -270,14 +189,6 @@ public:
     CHIP_ERROR GetChannelMask(ByteSpan & aChannelMask) const;
 
     /**
-     * This method sets the channel mask within the dataset.
-     *
-     * @retval CHIP_NO_ERROR on success.
-     * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
-     */
-    CHIP_ERROR SetChannelMask(ByteSpan aChannelMask);
-
-    /**
      * Retrieves the security policy from the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
@@ -287,14 +198,6 @@ public:
     CHIP_ERROR GetSecurityPolicy(uint32_t & aSecurityPolicy) const;
 
     /**
-     * This method sets the security policy within the dataset.
-     *
-     * @retval CHIP_NO_ERROR on success.
-     * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
-     */
-    CHIP_ERROR SetSecurityPolicy(uint32_t aSecurityPolicy);
-
-    /**
      * Retrieves the delay timer from the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
@@ -302,6 +205,156 @@ public:
      * @retval CHIP_ERROR_INVALID_TLV_ELEMENT if the TLV element is invalid.
      */
     CHIP_ERROR GetDelayTimer(uint32_t & aDelayMillis) const;
+
+    /**
+     * Returns true if the dataset contains the required TLV elements for creating a Thread network.
+     * The required elements are: PAN ID, Extended PAN ID, Channel, and Master Key.
+     */
+    bool IsCommissioned() const;
+
+    /**
+     * This method checks if the dataset is empty.
+     */
+    bool IsEmpty() const { return mData.empty(); }
+
+    /**
+     * This method checks whether @p aData contains a valid sequence of Thread TLV elements.
+     *
+     * @note This method only verifies the overall TLV format, not the correctness of individual TLV elements.
+     */
+    static bool IsValid(ByteSpan aData);
+
+private:
+    friend class OperationalDataset;
+
+    ByteSpan mData;
+
+    const ThreadTLV * Locate(uint8_t aType) const;
+    bool Has(uint8_t aType) const { return Locate(aType) != nullptr; }
+};
+
+/**
+ * This class provides methods to manipulate a Thread operational dataset.
+ * It maintains an internal buffer sized to accommodate the maximum possible dataset size.
+ */
+class OperationalDataset : public OperationalDatasetView
+{
+public:
+    /**
+     * Initializes the dataset by copying the provided data into an internal buffer.
+     *
+     * @param[in]   aData       The data to interpret as a Thread operational dataset.
+     *
+     * @retval CHIP_NO_ERROR                Successfully initialized the dataset.
+     * @retval CHIP_ERROR_INVALID_ARGUMENT  The dataset length @p aLength is too long or @p data is corrupted.
+     */
+    CHIP_ERROR Init(ByteSpan aData);
+
+    /**
+     * This method sets Thread active timestamp to the dataset.
+     *
+     * @param[in]   aActiveTimestamp    The Thread active timestamp.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the active timestamp.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread active timestamp.
+     */
+    CHIP_ERROR SetActiveTimestamp(uint64_t aActiveTimestamp);
+
+    /**
+     * This method sets Thread channel to the dataset.
+     *
+     * @param[in]   aChannel    The Thread channel.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the channel.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread channel.
+     */
+    CHIP_ERROR SetChannel(uint16_t aChannel);
+
+    /**
+     * This method sets Thread extended PAN ID to the dataset.
+     *
+     * @param[in]   aExtendedPanId  The Thread extended PAN ID.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the extended PAN ID.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread extended PAN ID.
+     */
+    CHIP_ERROR SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId]);
+
+    /**
+     * This method sets Thread master key to the dataset.
+     *
+     * @param[in]   aMasterKey         The Thread master key.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the master key.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread master key.
+     */
+    CHIP_ERROR SetMasterKey(const uint8_t (&aMasterKey)[kSizeMasterKey]);
+
+    /**
+     * This method unsets Thread master key to the dataset.
+     */
+    void UnsetMasterKey();
+
+    /**
+     * This method sets Thread mesh local prefix to the dataset.
+     *
+     * @param[in]   aMeshLocalPrefix   The Thread mesh local prefix.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the Thread mesh local prefix.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread mesh local prefix.
+     */
+    CHIP_ERROR SetMeshLocalPrefix(const uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]);
+
+    /**
+     * This method sets Thread network name to the dataset.
+     *
+     * @param[in]   aNetworkName    The Thread network name.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the network name.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread network name.
+     */
+    CHIP_ERROR SetNetworkName(const char * aNetworkName);
+
+    /**
+     * This method sets Thread PAN ID to the dataset.
+     *
+     * @param[in]   aPanId  The Thread PAN ID.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the PAN ID.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread PAN ID.
+     */
+    CHIP_ERROR SetPanId(uint16_t aPanId);
+
+    /**
+     * This method sets Thread PSKc to the dataset.
+     *
+     * @param[in]   aPSKc   The Thread PSKc.
+     *
+     * @retval CHIP_NO_ERROR           Successfully set the PSKc.
+     * @retval CHIP_ERROR_NO_MEMORY    Insufficient memory in the dataset for setting Thread PSKc.
+     */
+    CHIP_ERROR SetPSKc(const uint8_t (&aPSKc)[kSizePSKc]);
+
+    /**
+     * This method unsets Thread PSKc to the dataset.
+     */
+    void UnsetPSKc();
+
+    /**
+     * This method sets the channel mask within the dataset.
+     *
+     * @retval CHIP_NO_ERROR on success.
+     * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
+     */
+    CHIP_ERROR SetChannelMask(ByteSpan aChannelMask);
+
+    /**
+     * This method sets the security policy within the dataset.
+     *
+     * @retval CHIP_NO_ERROR on success.
+     * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
+     */
+    CHIP_ERROR SetSecurityPolicy(uint32_t aSecurityPolicy);
 
     /**
      * This method sets the delay timer within the dataset.
@@ -314,44 +367,21 @@ public:
     /**
      * This method clears all data stored in the dataset.
      */
-    void Clear(void) { mLength = 0; }
+    void Clear() { mData = ByteSpan(); }
 
     /**
-     * This method checks if the dataset is ready for creating Thread network.
+     * Returns a ByteSpan view of the current state of the dataset.
+     * The byte span is only valid as long the OperationalDataset object is alive and not modified.
      */
-    bool IsCommissioned(void) const;
-
-    /**
-     * This method checks if the dataset is empty.
-     */
-    bool IsEmpty() const { return mLength == 0; }
-
-    /**
-     * This method checks whether @p aData is formatted as ThreadTLVs.
-     *
-     * @note This method doesn't verify ThreadTLV values are valid.
-     */
-    static bool IsValid(ByteSpan aData);
-
-    ByteSpan AsByteSpan(void) const { return ByteSpan(mData, mLength); }
+    ByteSpan AsByteSpan() const { return this->OperationalDatasetView::AsByteSpan(); }
 
 private:
-    ThreadTLV * Locate(uint8_t aType)
-    {
-        return const_cast<ThreadTLV *>(const_cast<const OperationalDataset *>(this)->Locate(aType));
-    }
-    const ThreadTLV * Locate(uint8_t aType) const;
-    const ThreadTLV & Begin(void) const { return *reinterpret_cast<const ThreadTLV *>(&mData[0]); };
-    ThreadTLV & Begin(void) { return const_cast<ThreadTLV &>(const_cast<const OperationalDataset *>(this)->Begin()); }
-    const ThreadTLV & End(void) const { return *reinterpret_cast<const ThreadTLV *>(&mData[mLength]); };
-    ThreadTLV & End(void) { return const_cast<ThreadTLV &>(const_cast<const OperationalDataset *>(this)->End()); }
-    void Remove(uint8_t aType);
-    void Remove(ThreadTLV & aTlv);
-    ThreadTLV * MakeRoom(uint8_t aType, size_t aSize);
-    bool Has(uint8_t aType) const { return Locate(aType) != nullptr; }
+    uint8_t mBuffer[kSizeOperationalDataset];
 
-    uint8_t mData[kSizeOperationalDataset];
-    uint8_t mLength = 0;
+    void CopyIfNecessary();
+    void Remove(uint8_t aType);
+    void Remove(ThreadTLV * aTlv);
+    ThreadTLV * InsertOrReplace(uint8_t aType, size_t aValueSize);
 };
 
 } // namespace Thread

--- a/src/lib/support/ThreadOperationalDataset.h
+++ b/src/lib/support/ThreadOperationalDataset.h
@@ -53,7 +53,7 @@ public:
     OperationalDatasetView() = default;
 
     /**
-     * This method initializes the dataset view with the given data.
+     * Initializes the dataset view with the given data.
      * The data itself is not copied, so it must remain valid for the lifetime of the view.
      *
      * @param[in]   aData       The data to interpret as a Thread operational dataset.
@@ -69,7 +69,7 @@ public:
     ByteSpan AsByteSpan() const { return mData; }
 
     /**
-     * This method retrieves Thread active timestamp from the dataset.
+     * Retrieves the Active Timestamp from the dataset.
      *
      * @param[out]  aActiveTimestamp    A reference to receive the active timestamp.
      *
@@ -80,7 +80,11 @@ public:
     CHIP_ERROR GetActiveTimestamp(uint64_t & aActiveTimestamp) const;
 
     /**
-     * This method retrieves Thread channel from the dataset.
+     * Retrieves the channel number from the dataset.
+     *
+     * Note that the underlying TLV consists of a 1 byte Channel Page, and a 2 byte Channel Number.
+     * The Channel Page is not returned, as zero is currently the only valid value.
+     * A non-zero Channel Page is treated as a CHIP_ERROR_INVALID_TLV_ELEMENT error
      *
      * @param[out]  aChannel    A reference to receive the channel.
      *
@@ -91,7 +95,7 @@ public:
     CHIP_ERROR GetChannel(uint16_t & aChannel) const;
 
     /**
-     * This method retrieves Thread extended PAN ID from the dataset.
+     * Retrieves the Extended PAN ID from the dataset.
      *
      * @param[out]  aExtendedPanId  A reference to receive the extended PAN ID.
      *
@@ -102,18 +106,17 @@ public:
     CHIP_ERROR GetExtendedPanId(uint8_t (&aExtendedPanId)[kSizeExtendedPanId]) const;
 
     /**
-     * This method retrieves the Thread extended PAN ID from the dataset, interpreted as a big endian number.
+     * Retrieves the Extended PAN ID from the dataset, interpreted as a big endian number.
      * @retval CHIP_NO_ERROR                    Successfully retrieved the extended PAN ID.
      * @retval CHIP_ERROR_TLV_TAG_NOT_FOUND     Thread extended PAN ID is not present in the dataset.
      */
     CHIP_ERROR GetExtendedPanId(uint64_t & extendedPanId) const;
 
     /**
-     * This method returns a const ByteSpan to the extended PAN ID in the dataset.
+     * Retrieves a ByteSpan pointing to the Extended PAN ID within the dataset.
      * This can be used to pass the extended PAN ID to a cluster command without the use of external memory.
      *
-     * Note: The returned span points into storage managed by this class,
-     * and must not be dereferenced beyond the lifetime of this object.
+     * Note: The returned span points must not be dereferenced beyond the lifetime of this object.
      *
      * @param[out]  span  A reference to receive the location of the extended PAN ID.
      *
@@ -124,7 +127,7 @@ public:
     CHIP_ERROR GetExtendedPanIdAsByteSpan(ByteSpan & span) const;
 
     /**
-     * This method retrieves Thread master key from the dataset.
+     * Retrieves the Master Key from the dataset.
      *
      * @param[out]  aMasterKey  A reference to receive the master key.
      *
@@ -135,7 +138,7 @@ public:
     CHIP_ERROR GetMasterKey(uint8_t (&aMasterKey)[kSizeMasterKey]) const;
 
     /**
-     * This method retrieves Thread mesh local prefix from the dataset.
+     * Retrieves the Mesh Local Prefix from the dataset.
      *
      * @param[out]  aMeshLocalPrefix    A reference to receive the mesh local prefix.
      *
@@ -146,7 +149,7 @@ public:
     CHIP_ERROR GetMeshLocalPrefix(uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]) const;
 
     /**
-     * This method retrieves Thread network name from the dataset.
+     * Retrieves the Network Name from the dataset.
      *
      * @param[out]  aNetworkName    A reference to receive the Thread network name.
      *
@@ -157,7 +160,7 @@ public:
     CHIP_ERROR GetNetworkName(char (&aNetworkName)[kSizeNetworkName + 1]) const;
 
     /**
-     * This method retrieves Thread PAN ID from the dataset.
+     * Retrieves the PAN ID from the dataset.
      *
      * @param[out]  aPanId  A reference to receive the PAN ID.
      *
@@ -168,7 +171,7 @@ public:
     CHIP_ERROR GetPanId(uint16_t & aPanId) const;
 
     /**
-     * This method retrieves Thread PSKc from the dataset.
+     * Retrieves the Pre-Shared Key for the Commissioner (PSKc) from the dataset.
      *
      * @param[out]  aPSKc   A reference to receive the PSKc.
      *
@@ -179,10 +182,9 @@ public:
     CHIP_ERROR GetPSKc(uint8_t (&aPSKc)[kSizePSKc]) const;
 
     /**
-     * Returns ByteSpan pointing to the channel mask within the dataset.
+     * Retrieves a ByteSpan pointing to the Channel Mask within the dataset.
      *
-     * Note: The returned span points into storage managed by this class,
-     * and must not be dereferenced beyond the lifetime of this object.
+     * Note: The returned span must not be dereferenced beyond the lifetime of this object.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_TLV_TAG_NOT_FOUND if the channel mask is not present in the dataset.
@@ -191,7 +193,7 @@ public:
     CHIP_ERROR GetChannelMask(ByteSpan & aChannelMask) const;
 
     /**
-     * Retrieves the security policy from the dataset.
+     * Retrieves the Security Policy from the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_TLV_TAG_NOT_FOUND if no security policy is present in the dataset.
@@ -200,7 +202,7 @@ public:
     CHIP_ERROR GetSecurityPolicy(uint32_t & aSecurityPolicy) const;
 
     /**
-     * Retrieves the delay timer from the dataset.
+     * Retrieves the Delay Timer from the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_TLV_TAG_NOT_FOUND if no security policy is present in the dataset.
@@ -272,7 +274,7 @@ public:
     CHIP_ERROR Init(ByteSpan aData);
 
     /**
-     * This method sets Thread active timestamp to the dataset.
+     * Sets the Active Timestamp in the dataset.
      *
      * @param[in]   aActiveTimestamp    The Thread active timestamp.
      *
@@ -282,7 +284,10 @@ public:
     CHIP_ERROR SetActiveTimestamp(uint64_t aActiveTimestamp);
 
     /**
-     * This method sets Thread channel to the dataset.
+     * Sets the Channel Number in the dataset.
+     *
+     * Note that the underlying TLV consists of a 1 byte Channel Page, and a 2 byte Channel Number.
+     * The Channel Page is always set to zero, as it is currently the only valid value.
      *
      * @param[in]   aChannel    The Thread channel.
      *
@@ -292,7 +297,7 @@ public:
     CHIP_ERROR SetChannel(uint16_t aChannel);
 
     /**
-     * This method sets Thread extended PAN ID to the dataset.
+     * Sets the Extended PAN ID in the dataset.
      *
      * @param[in]   aExtendedPanId  The Thread extended PAN ID.
      *
@@ -302,7 +307,7 @@ public:
     CHIP_ERROR SetExtendedPanId(const uint8_t (&aExtendedPanId)[kSizeExtendedPanId]);
 
     /**
-     * This method sets Thread master key to the dataset.
+     * Sets the Master Key in the dataset.
      *
      * @param[in]   aMasterKey         The Thread master key.
      *
@@ -312,12 +317,12 @@ public:
     CHIP_ERROR SetMasterKey(const uint8_t (&aMasterKey)[kSizeMasterKey]);
 
     /**
-     * This method unsets Thread master key to the dataset.
+     * Removes the Master Key from the dataset.
      */
     void UnsetMasterKey();
 
     /**
-     * This method sets Thread mesh local prefix to the dataset.
+     * Sets the Mesh Local Prefix in the dataset.
      *
      * @param[in]   aMeshLocalPrefix   The Thread mesh local prefix.
      *
@@ -327,7 +332,8 @@ public:
     CHIP_ERROR SetMeshLocalPrefix(const uint8_t (&aMeshLocalPrefix)[kSizeMeshLocalPrefix]);
 
     /**
-     * This method sets Thread network name to the dataset.
+     * Sets the Network Name in the dataset. The name must be a non-empty string
+     * with a maximum length of 16 characters (kSizeNetworkName).
      *
      * @param[in]   aNetworkName    The Thread network name.
      *
@@ -337,7 +343,7 @@ public:
     CHIP_ERROR SetNetworkName(const char * aNetworkName);
 
     /**
-     * This method sets Thread PAN ID to the dataset.
+     * Sets the PAN ID in the dataset.
      *
      * @param[in]   aPanId  The Thread PAN ID.
      *
@@ -347,7 +353,7 @@ public:
     CHIP_ERROR SetPanId(uint16_t aPanId);
 
     /**
-     * This method sets Thread PSKc to the dataset.
+     * Sets the Pre-Shared Key for the Commissioner (PSKc) in the dataset.
      *
      * @param[in]   aPSKc   The Thread PSKc.
      *
@@ -357,12 +363,12 @@ public:
     CHIP_ERROR SetPSKc(const uint8_t (&aPSKc)[kSizePSKc]);
 
     /**
-     * This method unsets Thread PSKc to the dataset.
+     * Removes the Pre-Shared Key for the Commissioner (PSKc) from the dataset.
      */
     void UnsetPSKc();
 
     /**
-     * This method sets the channel mask within the dataset.
+     * Sets the Channel Mask in the dataset. This value is a non-empty sequence of sub-TLVs as defined in the Thread specification.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
@@ -370,7 +376,7 @@ public:
     CHIP_ERROR SetChannelMask(ByteSpan aChannelMask);
 
     /**
-     * This method sets the security policy within the dataset.
+     * Sets the Security Policy in the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
@@ -378,7 +384,7 @@ public:
     CHIP_ERROR SetSecurityPolicy(uint32_t aSecurityPolicy);
 
     /**
-     * This method sets the delay timer within the dataset.
+     * Sets the Delay Timer value in the dataset.
      *
      * @retval CHIP_NO_ERROR on success.
      * @retval CHIP_ERROR_NO_MEMORY if there is insufficient space within the dataset.
@@ -388,7 +394,7 @@ public:
     /**
      * This method clears all data stored in the dataset.
      */
-    void Clear() { mData = ByteSpan(); }
+    void Clear() { mData = ByteSpan(mBuffer, 0); }
 
     /**
      * Returns a ByteSpan view of the current state of the dataset.

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -266,7 +266,7 @@ static void TestExampleDatasetTemplate()
 
     char networkName[Thread::kSizeNetworkName + 1];
     EXPECT_EQ(dataset.GetNetworkName(networkName), CHIP_NO_ERROR);
-    EXPECT_EQ(strncmp(networkName, "OpenThread-5938", sizeof(networkName)), 0);
+    EXPECT_STREQ(networkName, "OpenThread-5938");
 
     uint16_t panId;
     EXPECT_EQ(dataset.GetPanId(panId), CHIP_NO_ERROR);
@@ -389,13 +389,13 @@ TEST_F(TestThreadOperationalDataset, TestGrowAndShrinkValue)
     EXPECT_EQ(dataset.GetPanId(panId), CHIP_NO_ERROR);
     EXPECT_EQ(panId, 0x4321u);
     EXPECT_EQ(dataset.GetNetworkName(networkName), CHIP_NO_ERROR);
-    EXPECT_EQ(strncmp(networkName, "BB", sizeof(networkName)), 0);
+    EXPECT_STREQ(networkName, "BB");
     EXPECT_EQ(dataset.SetNetworkName("C"), CHIP_NO_ERROR); // 1 byte shorter
     EXPECT_EQ(dataset.AsByteSpan().size(), 7u);
     EXPECT_EQ(dataset.GetPanId(panId), CHIP_NO_ERROR);
     EXPECT_EQ(panId, 0x4321u);
     EXPECT_EQ(dataset.GetNetworkName(networkName), CHIP_NO_ERROR);
-    EXPECT_EQ(strncmp(networkName, "C", sizeof(networkName)), 0);
+    EXPECT_STREQ(networkName, "C");
 }
 
 TEST_F(TestThreadOperationalDataset, TestInitWithViewInitAndModify)

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -25,7 +25,8 @@ namespace {
 
 using namespace chip;
 
-// Don't warn/error on self assignments in these tests.
+// Don't warn/error on self assignments in these tests, since
+// we're explicitly testing that self-assignments behave correctly.
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
 #endif

--- a/src/lib/support/tests/TestThreadOperationalDataset.cpp
+++ b/src/lib/support/tests/TestThreadOperationalDataset.cpp
@@ -25,8 +25,10 @@ namespace {
 
 using namespace chip;
 
-// Don't warn/fail on self assignments in these tests.
+// Don't warn/error on self assignments in these tests.
+#ifdef __clang__
 #pragma clang diagnostic ignored "-Wself-assign-overloaded"
+#endif
 
 class TestThreadOperationalDataset : public ::testing::Test
 {


### PR DESCRIPTION
#### Summary

OperationalDatasetView does not copy or hold a buffer for the underlying dataset, and provides all the read-only methods that were present on OperationalDataset.  OperationalDataset has its own buffer and copies the dataset as before.

Also simplify some of the mechanics of updating values in the dataset, by replacing MakeRoom with InsertOrReplace that directly takes the required size of the value and handles updating both the tag and length of the TLV item as well as of the overall dataset, so the caller only has to fill in the value.

#### Testing

Existing TestOperationalDataset tests still pass, plus some new tests for both OperationalDatasetView and OperationalDataset.
