### PR TITLE
[ESP32]: Added support for opencores ethernet for QEMU in ethernet network driver.

### DIFF
--- a/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver_Ethernet.cpp
@@ -49,15 +49,21 @@ CHIP_ERROR ESPEthernetDriver::Init(NetworkStatusChangeCallback * networkStatusCh
     esp_netif_t * eth_netif = esp_netif_new(&cfg);
 
     // Init MAC and PHY configs to default
-    eth_mac_config_t mac_config               = ETH_MAC_DEFAULT_CONFIG();
-    eth_phy_config_t phy_config               = ETH_PHY_DEFAULT_CONFIG();
-    phy_config.phy_addr                       = CONFIG_ETH_PHY_ADDR;
-    phy_config.reset_gpio_num                 = CONFIG_ETH_PHY_RST_GPIO;
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.phy_addr         = CONFIG_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num   = CONFIG_ETH_PHY_RST_GPIO;
+
+#if CONFIG_ETH_USE_OPENETH
+    esp_eth_mac_t * mac = esp_eth_mac_new_openeth(&mac_config);
+    esp_eth_phy_t * phy = esp_eth_phy_new_dp83848(&phy_config);
+#else // Default ethernet board configuration
     eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
     esp32_emac_config.smi_mdc_gpio_num        = CONFIG_ETH_MDC_GPIO;
     esp32_emac_config.smi_mdio_gpio_num       = CONFIG_ETH_MDIO_GPIO;
     esp_eth_mac_t * mac                       = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
     esp_eth_phy_t * phy                       = esp_eth_phy_new_ip101(&phy_config);
+#endif
 
     esp_eth_config_t config     = ETH_DEFAULT_CONFIG(mac, phy);
     esp_eth_handle_t eth_handle = NULL;


### PR DESCRIPTION
#### Summary
- This PR adds support for opencores ethernet which is used in case of flashing an esp32 example with the help of qemu.
- Added the openeth config option as a check in case of qemu else  default to the default ethernet board configuration.

#### Testing
- Tested the lighting-app esp32 with CONFIG_ETH_USE_OPENETH enabled.
- Tested the app with below steps:
i) idf.py set-target esp32c3
ii) idf.py menuconfig 
```
CONFIG_BT_ENABLED=n
CONFIG_WIFI_STATION=n
CONFIG_ETH_USE_OPENETH=y
CONFIG_ENABLE_ETHERNET_TELEMETRY=y
```
iii)`idf.py qemu monitor"
