### PR TITLE
[TC_EEVSE_2_10] Fixes #40350 test failure observed on a RaspPi test harness

### DIFF
--- a/src/python_testing/TC_EEVSE_2_10.py
+++ b/src/python_testing/TC_EEVSE_2_10.py
@@ -120,7 +120,7 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
                      "Value has to be 0"),
             TestStep("9f", "TH reads from the DUT the MaximumDischargeCurrent",
                      "Value has to be 0"),
-            TestStep("10", "Wait 5 seconds"),
+            TestStep("10", "Wait 10 seconds"),
             TestStep("10a", "TH reads from the DUT the SupplyState",
                      "Value has to be 0x00 (Disabled)"),
             TestStep("10b", "TH reads from the DUT the ChargingEnabledUntil",
@@ -358,9 +358,9 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
         await self.check_evse_attribute("MaximumDischargeCurrent", 0)
 
         self.step("10")
-        # Wait 5 seconds
-        logger.info("Waiting for 5 seconds for charging timer to expire")
-        time.sleep(5)
+        # Wait 10 seconds
+        logger.info("Waiting for 10 seconds for charging timer to expire")
+        time.sleep(10)
 
         self.step("10a")
         # TH reads from the DUT the SupplyState

--- a/src/python_testing/TC_EEVSE_2_10.py
+++ b/src/python_testing/TC_EEVSE_2_10.py
@@ -85,7 +85,7 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
                      "Verify DUT responds w/ status SUCCESS(0x00) and event EVConnected sent"),
             TestStep("4a", "TH reads from the DUT the State",
                      "Value has to be 0x01 (PluggedInNoDemand)"),
-            TestStep("5", "TH sends command EnableCharging with ChargingEnabledUntil=10 seconds in the future, MinimumChargeCurrent=6000, MaximumChargeCurrent=60000. Store the ChargingEnabledUntil into Matter EPOCH in UTC as ChargingEnabledUntilEpochTime, MinimumChargeCurrent as MinimumChargeCurrent and MaximumChargeCurrent as MaximumChargeCurrent",
+            TestStep("5", "TH sends command EnableCharging with ChargingEnabledUntil=15 seconds in the future, MinimumChargeCurrent=6000, MaximumChargeCurrent=60000. Store the ChargingEnabledUntil into Matter EPOCH in UTC as ChargingEnabledUntilEpochTime, MinimumChargeCurrent as MinimumChargeCurrent and MaximumChargeCurrent as MaximumChargeCurrent",
                      "Verify DUT responds w/ status SUCCESS(0x00)"),
             TestStep("6a", "TH reads from the DUT the SupplyState",
                      "Value has to be 0x01 (ChargingEnabled)"),
@@ -222,12 +222,12 @@ class TC_EEVSE_2_10(MatterBaseTest, EEVSEBaseTestHelper):
 
         self.step("5")
 
-        # TH sends command EnableCharging with ChargingEnabledUntil=10 seconds in the future,
+        # TH sends command EnableCharging with ChargingEnabledUntil=15 seconds in the future,
         # MinimumChargeCurrent=6000, MaximumChargeCurrent=60000.
         # Store the ChargingEnabledUntil into Matter EPOCH in UTC as ChargingEnabledUntilEpochTime,
         # MinimumChargeCurrent as MinimumChargeCurrent and MaximumChargeCurrent as MaximumChargeCurrent
         # Verify DUT responds w/ status SUCCESS(0x00)
-        charging_duration = 10  # seconds
+        charging_duration = 15  # seconds
         min_charge_current = 6000
         max_charge_current = 60000
         utc_time_charging_end = datetime.now(


### PR DESCRIPTION
#### Summary

 During Matter 1.5 TE1 TC_EEVSE_2.10 was observed to fail due to a timing race condition.

##### Root cause:
 - Step 5 (we enable charging with 10s timeout)
 - Step 7 (we enable discharging with 5s timeout)
    - we do multiple reads here which consume some of the time
 - Step 9 we wait 7s (discharging should no longer be enabled, but charging should still be)
 - Step 9b we read ChargingEnabledUntil (expecting it still to be enabled, but more than 10s from step 5 has elapsed now)
    - Step 9b returns 0 which indicates charging is no longer enabled and we fail the test.

This was not seen when testing against a PC, but when testing with ESP32 and RaspPi 4 Test Harness, the relatively slower performance results in a consistent test failure.

##### Solution:
 In Step 5 we increase the charging timeout to 15s

#### Related issues

 Fixes #40350 
 New Test Plan PR to match: https://github.com/CHIP-Specifications/chip-test-plans/pull/5406

#### Testing

Patched the RaspPi test script by overwriting '/home/ubuntu/certification-tool/backend/test_collections/matter/sdk_tests/sdk_checkout/python_testing/scripts/sdk/TC_EEVSE_2_10.py' with updated version here. Test now passes.

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] CI time will increase by 10s

