### PR TITLE
[FIX] Adding missing apps to the chip-cert-bins docker image.

### DIFF
--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -185,6 +185,9 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-water-leak-detector-ipv6only \
     --target linux-x64-camera-ipv6only \
     --target linux-x64-camera-controller-ipv6only \
+    --target linux-x64-closure-ipv6only \
+    --target linux-x64-jf-control-ipv6only \
+    --target linux-x64-jf-admin-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -215,6 +218,9 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-x64-water-leak-detector-ipv6only/water-leak-detector-app out/water-leak-detector-app \
     && mv out/linux-x64-camera-ipv6only/chip-camera-app out/chip-camera-app \
     && mv out/linux-x64-camera-controller-ipv6only/chip-camera-controller out/chip-camera-controller \
+    && mv out/linux-x64-closure-ipv6only/closure-app out/closure-app \
+    && mv out/linux-x64-jf-control-app-ipv6only/jfc-app out/jfc-app \
+    && mv out/linux-x64-jf-admin-app-ipv6only/jfa-app out/jfa-app \
     ;; \
     "linux/arm64")\
     set -x \
@@ -249,6 +255,9 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-arm64-water-leak-detector-ipv6only \
     --target linux-arm64-camera-clang-ipv6only \
     --target linux-arm64-camera-controller-ipv6only \
+    --target linux-arm64-closure-ipv6only \
+    --target linux-arm64-jf-control-app-ipv6only \
+    --target linux-arm64-jf-admin-app-ipv6only \
     build \
     && mv out/linux-arm64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-arm64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \
@@ -279,6 +288,9 @@ RUN case ${TARGETPLATFORM} in \
     && mv out/linux-arm64-water-leak-detector-ipv6only/water-leak-detector-app out/water-leak-detector-app \
     && mv out/linux-arm64-camera-clang-ipv6only/chip-camera-app out/chip-camera-app \
     && mv out/linux-arm64-camera-controller-ipv6only/chip-camera-controller out/chip-camera-controller \
+    && mv out/linux-arm64-closure-ipv6only/closure-app out/closure-app \
+    && mv out/linux-arm64-jf-control-app-ipv6only/jfc-app out/jfc-app \
+    && mv out/linux-arm64-jf-admin-app-ipv6only/jfa-app out/jfa-app \
     ;; \
     *) ;; \
     esac
@@ -324,6 +336,9 @@ COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-terms-and-condit
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/water-leak-detector-app apps/water-leak-detector-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-camera-app apps/chip-camera-app
 COPY --from=chip-build-cert-bins /root/connectedhomeip/out/chip-camera-controller apps/chip-camera-controller
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/closure-app apps/closure-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/jfc-app apps/jfc-app
+COPY --from=chip-build-cert-bins /root/connectedhomeip/out/jfa-app apps/jfa-app
 
 # Create symbolic links for now since this allows users to use existing configurations
 # for running just `app-name` instead of `apps/app-name`

--- a/integrations/docker/images/chip-cert-bins/Dockerfile
+++ b/integrations/docker/images/chip-cert-bins/Dockerfile
@@ -186,8 +186,8 @@ RUN case ${TARGETPLATFORM} in \
     --target linux-x64-camera-ipv6only \
     --target linux-x64-camera-controller-ipv6only \
     --target linux-x64-closure-ipv6only \
-    --target linux-x64-jf-control-ipv6only \
-    --target linux-x64-jf-admin-ipv6only \
+    --target linux-x64-jf-control-app-ipv6only \
+    --target linux-x64-jf-admin-app-ipv6only \
     build \
     && mv out/linux-x64-chip-tool-ipv6only-platform-mdns/chip-tool out/chip-tool \
     && mv out/linux-x64-shell-ipv6only-platform-mdns/chip-shell out/chip-shell \


### PR DESCRIPTION
#### Summary

The apps closure, jf-control and jf-admin are missing from the chip-cert-bins docker image `apps` folder.
This change adds those apps to the Dockerfile for the image build.

#### Related issues

Fixes: https://github.com/project-chip/certification-tool/issues/663

#### Testing

Successful build was achieved, but no test was made with the relevant apps.

