### PR TITLE
Factor out delegate storage into a helper in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDelegateManager.h
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.h
@@ -74,7 +74,6 @@ MTR_TESTABLE
 #ifdef DEBUG
 
 // Returns number of still-alive delegates, without removing entries.
-// ones.
 - (NSUInteger)unitTestNonnullDelegateCount;
 
 // Calls the first delegate synchronously with the provided block.

--- a/src/darwin/Framework/CHIP/MTRDelegateManager.h
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.h
@@ -52,6 +52,7 @@ MTR_TESTABLE
 MTR_TESTABLE
 @interface MTRDelegateManager<DelegateType, DelegateInfoType : MTRDelegateInfo *> : NSObject
 
+// Owner is used for logging only, and held weakly.
 - (instancetype)initWithOwner:(id)owner;
 
 - (void)addDelegateInfo:(DelegateInfoType)delegateInfo;

--- a/src/darwin/Framework/CHIP/MTRDelegateManager.h
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.h
@@ -1,0 +1,90 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "Foundation/Foundation.h"
+
+#import "MTRDefines_Internal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * MTRDelegateInfo can be subclassed to store additional information, in
+ * addition to the delegate and queue.
+ */
+MTR_TESTABLE
+@interface MTRDelegateInfo<__covariant DelegateType> : NSObject
+- (instancetype)initWithDelegate:(DelegateType)delegate queue:(dispatch_queue_t)queue;
+
+@property (nonatomic, weak, readonly) DelegateType delegate;
+@property (nonatomic, readonly) dispatch_queue_t queue;
+
+// Pointer value for logging purpose only
+@property (readonly) void * delegatePointerValue;
+
+// Queues an async call to the provided block on the delegate's queue if the
+// delegate still exists.  Returns whether the delegate exists.
+- (BOOL)callDelegateWithBlock:(void (^)(id delegate))block;
+
+@end
+
+/**
+ * A delegate manager that handles automatic removal of delegates that have gone
+ * away and provides helpers for working with delegates.  This interface does
+ * not do any synchronization; access to an MTRDelegateManager should be
+ * synchronized by its consumer as needed.
+ *
+ * It sure would be nice if the type bound on our second type parameter could be
+ * MTRDelegateInfo<DelegateType>, but that does not seem to be supported.
+ */
+MTR_TESTABLE
+@interface MTRDelegateManager<DelegateType, DelegateInfoType : MTRDelegateInfo *> : NSObject
+
+- (instancetype)initWithOwner:(id)owner;
+
+- (void)addDelegateInfo:(DelegateInfoType)delegateInfo;
+- (void)removeDelegate:(DelegateType)delegate;
+- (void)removeAllDelegates;
+
+// Iterates the delegates, and removes delegate info if the delegate object has dealloc'ed.
+// Returns the number of delegates remaining at the end of the iteration.
+//
+// The passed-in block must not attempt to add or remove delegates during the
+// iteration.  The block is called synchronously during the iteration.
+- (NSUInteger)iterateDelegatesWithBlock:(void(NS_NOESCAPE ^ _Nullable)(DelegateInfoType delegateInfo))block;
+
+// Calls the delegates, asynchronously, with the provided block, on the
+// appropriate queue for each delegate.  Returns whether any asynchronous
+// delegate calls were queued up.
+- (BOOL)callDelegatesWithBlock:(void (^_Nullable)(DelegateType delegate))block;
+- (BOOL)callDelegatesWithBlock:(void (^_Nullable)(DelegateType delegate))block logString:(const char *)logString;
+
+#ifdef DEBUG
+
+// Returns number of still-alive delegates, without removing entries.
+// ones.
+- (NSUInteger)unitTestNonnullDelegateCount;
+
+// Calls the first delegate synchronously with the provided block.
+// Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously
+- (void)callFirstDelegateSynchronouslyWithBlock:(void(NS_NOESCAPE ^)(DelegateType delegate))block;
+
+// Returns the first non-nil delegate, if any.
+- (DelegateType _Nullable)firstDelegate;
+
+#endif // DEBUG
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDelegateManager.mm
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.mm
@@ -1,0 +1,266 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRDelegateManager.h"
+#import "MTRLogging_Internal.h"
+
+@interface MTRDelegateInfo ()
+
+#ifdef DEBUG
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id delegate))block;
+#endif // DEBUG
+
+@end
+
+@implementation MTRDelegateInfo
+- (instancetype)initWithDelegate:(id)delegate queue:(dispatch_queue_t)queue
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _delegate = delegate;
+    _queue = queue;
+    _delegatePointerValue = (__bridge void *) delegate;
+
+    return self;
+}
+
+- (BOOL)callDelegateWithBlock:(void (^)(id))block
+{
+    id strongDelegate = _delegate;
+    if (strongDelegate == nil) {
+        return NO;
+    }
+    dispatch_async(_queue, ^{
+        block(strongDelegate);
+    });
+
+    return YES;
+}
+
+#ifdef DEBUG
+- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id delegate))block
+{
+    id strongDelegate = _delegate;
+    if (strongDelegate == nil) {
+        return NO;
+    }
+
+    block(strongDelegate);
+
+    return YES;
+}
+#endif // DEBUG
+@end
+
+@interface MTRDelegateManager () {
+    NSMutableSet<MTRDelegateInfo *> * _delegates;
+    __weak id _owner;
+}
+@end
+
+@implementation MTRDelegateManager
+
+- (instancetype)initWithOwner:(id)owner
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _delegates = [NSMutableSet set];
+    _owner = owner;
+    return self;
+}
+
+- (void)addDelegateInfo:(MTRDelegateInfo *)delegateInfo
+{
+    id strongOwner = _owner;
+
+    // Replace delegate info with the same delegate object, and opportunistically remove defunct delegate references
+    NSMutableSet<MTRDelegateInfo *> * delegatesToRemove = [NSMutableSet set];
+    for (MTRDelegateInfo * existingInfo in _delegates) {
+        id strongDelegate = existingInfo.delegate;
+        if (!strongDelegate) {
+            [delegatesToRemove addObject:existingInfo];
+            MTR_LOG("%@ removing delegate info for nil delegate %p", strongOwner, existingInfo.delegatePointerValue);
+        } else if (strongDelegate == delegateInfo.delegate) {
+            [delegatesToRemove addObject:existingInfo];
+            MTR_LOG("%@ replacing delegate info for %p", strongOwner, delegateInfo.delegate);
+        }
+    }
+    if (delegatesToRemove.count) {
+        NSUInteger oldDelegatesCount = _delegates.count;
+        [_delegates minusSet:delegatesToRemove];
+        MTR_LOG("%@ addDelegate: removed %lu", strongOwner, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
+    }
+
+    [_delegates addObject:delegateInfo];
+    MTR_LOG("%@ added delegate %p total %lu", strongOwner, delegateInfo.delegatePointerValue, static_cast<unsigned long>(_delegates.count));
+}
+
+- (void)removeDelegate:(id)delegate
+{
+    id strongOwner = _owner;
+
+    MTR_LOG("%@ removeDelegate %p", strongOwner, delegate);
+
+    // Note: _iterateDelegatesWithBlock already removes delegate infos for dead
+    // delegates.
+    __block MTRDelegateInfo * delegateInfoToRemove = nil;
+    [self iterateDelegatesWithBlock:^(MTRDelegateInfo * delegateInfo) {
+        if (delegateInfo.delegate == delegate) {
+            delegateInfoToRemove = delegateInfo;
+        }
+    }];
+
+    if (delegateInfoToRemove) {
+        [_delegates removeObject:delegateInfoToRemove];
+        MTR_LOG("%@ removed %p remaining %lu", strongOwner, delegate, static_cast<unsigned long>(_delegates.count));
+    } else {
+        MTR_LOG("%@ delegate %p not found in %lu", strongOwner, delegate, static_cast<unsigned long>(_delegates.count));
+    }
+}
+
+- (void)removeAllDelegates
+{
+    [_delegates removeAllObjects];
+}
+
+// The compiler complains that that the type-erased version of this method has
+// conflicting parameter types with the header-declared version.  Which sort of
+// makes sense: the headers says you can only pass in
+// MTRDelegateInfo<DelegateType> but the implementation says you can pass in any
+// MTRDelegateInfo (and the same warning happens if this implementation is
+// changed to allow passing any id).
+//
+// In practice, we only have delegate infos of the right type, so this is not a
+// problem.  Just suppress the relevant warning.
+//
+// Why does the compiler not complain about callDelegateWithBlock?  Looks like
+// because of the type bound on DelegateInfoType.  Removing that makes this
+// problem go away.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-parameter-types"
+- (NSUInteger)iterateDelegatesWithBlock:(void(NS_NOESCAPE ^ _Nullable)(id delegateInfo))block
+#pragma clang diagnostic pop
+{
+    id strongOwner = _owner;
+
+    if (!_delegates.count) {
+        MTR_LOG_DEBUG("%@ no delegates to iterate", strongOwner);
+        return 0;
+    }
+
+    // Opportunistically remove defunct delegate references on every iteration
+    NSMutableSet<MTRDelegateInfo *> * delegatesToRemove = nil;
+    for (MTRDelegateInfo * delegateInfo in _delegates) {
+        id strongDelegate = delegateInfo.delegate;
+        if (strongDelegate) {
+            if (block) {
+                @autoreleasepool {
+                    block(delegateInfo);
+                }
+            }
+            (void) strongDelegate; // ensure it stays alive
+        } else {
+            if (!delegatesToRemove) {
+                delegatesToRemove = [NSMutableSet set];
+            }
+            [delegatesToRemove addObject:delegateInfo];
+        }
+    }
+
+    if (delegatesToRemove.count) {
+        [_delegates minusSet:delegatesToRemove];
+        MTR_LOG("%@ iterateDelegatesWithBlock: removed %lu remaining %lu", strongOwner, static_cast<unsigned long>(delegatesToRemove.count), (unsigned long) static_cast<unsigned long>(_delegates.count));
+    }
+
+    return _delegates.count;
+}
+
+- (BOOL)callDelegatesWithBlock:(void (^_Nullable)(id delegate))block
+{
+    return [self _callDelegatesWithBlock:block logString:nullptr];
+}
+
+- (BOOL)callDelegatesWithBlock:(void (^_Nullable)(id delegate))block logString:(const char *)logString
+{
+    return [self _callDelegatesWithBlock:block logString:logString];
+}
+
+- (BOOL)_callDelegatesWithBlock:(void (^_Nullable)(id delegate))block logString:(const char * _Nullable)logString
+{
+    id strongOwner = _owner;
+
+    __block NSUInteger delegatesCalled = 0;
+    [self iterateDelegatesWithBlock:^(MTRDelegateInfo * delegateInfo) {
+        if ([delegateInfo callDelegateWithBlock:block]) {
+            ++delegatesCalled;
+        }
+    }];
+
+    if (logString != nullptr) {
+        MTR_LOG("%@ %lu delegates called for %s", strongOwner, static_cast<unsigned long>(delegatesCalled), logString);
+    }
+
+    return delegatesCalled;
+}
+
+#ifdef DEBUG
+
+- (NSUInteger)unitTestNonnullDelegateCount
+{
+    NSUInteger nonnullDelegateCount = 0;
+    for (MTRDelegateInfo * delegateInfo in _delegates) {
+        if (delegateInfo.delegate) {
+            nonnullDelegateCount++;
+        }
+    }
+
+    return nonnullDelegateCount;
+}
+
+- (void)callFirstDelegateSynchronouslyWithBlock:(void(NS_NOESCAPE ^)(id delegate))block
+{
+    // It's a bit weird to implement a "call first" API on top of NSMutableSet,
+    // but that's what MTRDevice used to do, and in any case in the cases when
+    // this is used there's only one delegate around.
+    id strongOwner = _owner;
+
+    for (MTRDelegateInfo * delegateInfo in _delegates) {
+        if ([delegateInfo callDelegateSynchronouslyWithBlock:block]) {
+            MTR_LOG("%@ callFirstDelegateSynchronouslyWithBlock: successfully called %@", strongOwner, delegateInfo);
+            return;
+        }
+    }
+}
+
+- (id _Nullable)firstDelegate
+{
+    for (MTRDelegateInfo * delegateInfo in _delegates) {
+        id strongDelegate = delegateInfo.delegate;
+        if (strongDelegate != nil) {
+            return strongDelegate;
+        }
+    }
+
+    return nil;
+}
+
+#endif // DEBUG
+
+@end

--- a/src/darwin/Framework/CHIP/MTRDelegateManager.mm
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.mm
@@ -105,7 +105,7 @@
     if (delegatesToRemove.count) {
         NSUInteger oldDelegatesCount = _delegates.count;
         [_delegates minusSet:delegatesToRemove];
-        MTR_LOG("%@ addDelegate: removed %lu", strongOwner, static_cast<unsigned long>(_delegates.count - oldDelegatesCount));
+        MTR_LOG("%@ addDelegate: removed %lu", strongOwner, static_cast<unsigned long>(oldDelegatesCount - _delegates.count));
     }
 
     [_delegates addObject:delegateInfo];
@@ -186,7 +186,7 @@
 
     if (delegatesToRemove.count) {
         [_delegates minusSet:delegatesToRemove];
-        MTR_LOG("%@ iterateDelegatesWithBlock: removed %lu remaining %lu", strongOwner, static_cast<unsigned long>(delegatesToRemove.count), (unsigned long) static_cast<unsigned long>(_delegates.count));
+        MTR_LOG("%@ iterateDelegatesWithBlock: removed %lu remaining %lu", strongOwner, static_cast<unsigned long>(delegatesToRemove.count), static_cast<unsigned long>(_delegates.count));
     }
 
     return _delegates.count;

--- a/src/darwin/Framework/CHIP/MTRDelegateManager.mm
+++ b/src/darwin/Framework/CHIP/MTRDelegateManager.mm
@@ -217,7 +217,7 @@
         MTR_LOG("%@ %lu delegates called for %s", strongOwner, static_cast<unsigned long>(delegatesCalled), logString);
     }
 
-    return delegatesCalled;
+    return delegatesCalled > 0;
 }
 
 #ifdef DEBUG

--- a/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice_Concrete.mm
@@ -566,12 +566,9 @@ typedef NS_ENUM(NSUInteger, MTRDeviceWorkItemDuplicateTypeID) {
     __block id testDelegate = nil;
 #ifdef DEBUG
     // Save the first delegate for testing
-    for (MTRDeviceDelegateInfo * delegateInfo in _delegates) {
-        testDelegate = delegateInfo.delegate;
-        break;
-    }
+    testDelegate = [_delegateManager firstDelegate];
 #endif
-    [_delegates removeAllObjects];
+    [_delegateManager removeAllDelegates];
 
     // Delete subscription callback object to tear down ReadClient
     MTRDeviceMatterCPPObjectsHolder * matterCPPObjectsHolder = self.matterCPPObjectsHolder;

--- a/src/darwin/Framework/CHIP/MTRDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDevice_Internal.h
@@ -22,6 +22,7 @@
 
 #import "MTRAsyncWorkQueue.h"
 #import "MTRDefines_Internal.h"
+#import "MTRDelegateManager.h"
 #import "MTRDeviceStorageBehaviorConfiguration_Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -58,12 +59,7 @@ typedef NS_ENUM(NSUInteger, MTRInternalDeviceState) {
  * paths for attribute reports.
  */
 MTR_DIRECT_MEMBERS
-@interface MTRDeviceDelegateInfo : NSObject {
-@private
-    void * _delegatePointerValue;
-    __weak id _delegate;
-    dispatch_queue_t _queue;
-}
+@interface MTRDeviceDelegateInfo : MTRDelegateInfo <id <MTRDeviceDelegate>>
 
 // Array of interested cluster paths, attribute paths, or endpointID, for attribute report filtering.
 @property (readonly, nullable) NSArray * interestedPathsForAttributes;
@@ -71,21 +67,7 @@ MTR_DIRECT_MEMBERS
 // Array of interested cluster paths, attribute paths, or endpointID, for event report filtering.
 @property (readonly, nullable) NSArray * interestedPathsForEvents;
 
-// Expose delegate
-@property (readonly) id delegate;
-
-// Pointer value for logging purpose only
-@property (readonly) void * delegatePointerValue;
-
 - (instancetype)initWithDelegate:(id<MTRDeviceDelegate>)delegate queue:(dispatch_queue_t)queue interestedPathsForAttributes:(NSArray * _Nullable)interestedPathsForAttributes interestedPathsForEvents:(NSArray * _Nullable)interestedPathsForEvents;
-
-// Returns YES if delegate and queue are both non-null, and the block is scheduled to run.
-- (BOOL)callDelegateWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
-
-#ifdef DEBUG
-// Only used for unit test purposes - normal delegate should not expect or handle being called back synchronously.
-- (BOOL)callDelegateSynchronouslyWithBlock:(void (^)(id<MTRDeviceDelegate>))block;
-#endif
 @end
 
 #pragma mark - MTRDevice internal extensions
@@ -95,7 +77,7 @@ MTR_DIRECT_MEMBERS
 @protected
     // Lock that protects overall device state, including delegate storage.
     os_unfair_lock _lock;
-    NSMutableSet<MTRDeviceDelegateInfo *> * _delegates;
+    MTRDelegateManager<id<MTRDeviceDelegate>, MTRDeviceDelegateInfo *> * _delegateManager;
 
     // Our node ID, with the ivar declared explicitly so it's accessible to
     // subclasses.

--- a/src/darwin/Framework/CHIPTests/MTRDelegateManagerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDelegateManagerTests.m
@@ -1,0 +1,205 @@
+/**
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Matter/Matter.h>
+#import <XCTest/XCTest.h>
+
+#import "MTRDelegateManager.h"
+
+@protocol MTRDelegateManagerTestsDelegate <NSObject>
+@end
+
+@interface MTRDelegateManagerTestsDelegateImpl : NSObject <MTRDelegateManagerTestsDelegate>
+@end
+
+@implementation MTRDelegateManagerTestsDelegateImpl
+@end
+
+@interface MTRDelegateManagerTestsDelegateInfo : MTRDelegateInfo <id <MTRDelegateManagerTestsDelegate>>
+@end
+
+@implementation MTRDelegateManagerTestsDelegateInfo
+@end
+
+@interface MTRDelegateManagerTests : XCTestCase
+@end
+
+@implementation MTRDelegateManagerTests
+
+- (void)testBasicAddRemove
+{
+    MTRDelegateManager<MTRDelegateManagerTestsDelegateImpl *, MTRDelegateManagerTestsDelegateInfo *> * manager = [[MTRDelegateManager alloc] initWithOwner:self];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 0);
+
+    __auto_type * delegate = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate queue:dispatch_get_main_queue()];
+
+    [manager addDelegateInfo:info];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 1);
+
+    [manager removeDelegate:delegate];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 0);
+}
+
+- (void)testRemoveAll
+{
+    MTRDelegateManager<MTRDelegateManagerTestsDelegateImpl *, MTRDelegateManagerTestsDelegateInfo *> * manager = [[MTRDelegateManager alloc] initWithOwner:self];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 0);
+
+    __auto_type * delegate1 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info1 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate1 queue:dispatch_get_main_queue()];
+
+    __auto_type * delegate2 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info2 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate2 queue:dispatch_get_main_queue()];
+
+    __auto_type * delegate3 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info3 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate3 queue:dispatch_get_main_queue()];
+
+    [manager addDelegateInfo:info1];
+    [manager addDelegateInfo:info2];
+    [manager addDelegateInfo:info3];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 3);
+
+    [manager removeAllDelegates];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 0);
+}
+
+- (void)testReplacingAdd
+{
+    MTRDelegateManager<MTRDelegateManagerTestsDelegateImpl *, MTRDelegateManagerTestsDelegateInfo *> * manager = [[MTRDelegateManager alloc] initWithOwner:self];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 0);
+
+    __auto_type * delegate1 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info1 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate1 queue:dispatch_get_main_queue()];
+    __auto_type * info2 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate1 queue:dispatch_get_main_queue()];
+
+    __auto_type * delegate2 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info3 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate2 queue:dispatch_get_main_queue()];
+
+    [manager addDelegateInfo:info1];
+    [manager addDelegateInfo:info2];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 1);
+
+    [manager addDelegateInfo:info3];
+    XCTAssertEqual([manager unitTestNonnullDelegateCount], 2);
+}
+
+- (void)testIterate
+{
+    MTRDelegateManager<MTRDelegateManagerTestsDelegateImpl *, MTRDelegateManagerTestsDelegateInfo *> * manager = [[MTRDelegateManager alloc] initWithOwner:self];
+
+    __block NSMutableSet<MTRDelegateManagerTestsDelegateInfo *> * infoSet = [NSMutableSet set];
+    __auto_type addBlock = ^(MTRDelegateManagerTestsDelegateInfo * info) {
+        [infoSet addObject:info];
+    };
+
+    [manager iterateDelegatesWithBlock:addBlock];
+    XCTAssertEqualObjects(infoSet, [NSSet set]);
+
+    __auto_type * delegate1 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info1 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate1 queue:dispatch_get_main_queue()];
+
+    __auto_type * delegate3 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info3 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate3 queue:dispatch_get_main_queue()];
+
+    MTRDelegateManagerTestsDelegateInfo * info2;
+    @autoreleasepool {
+        __auto_type * delegate2 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+        info2 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate2 queue:dispatch_get_main_queue()];
+
+        [manager addDelegateInfo:info1];
+        [manager addDelegateInfo:info2];
+        [manager addDelegateInfo:info3];
+
+        infoSet = [NSMutableSet set];
+        [manager iterateDelegatesWithBlock:addBlock];
+
+        __auto_type * expectedSet = [NSSet setWithArray:@[ info1, info2, info3 ]];
+        XCTAssertEqualObjects(infoSet, expectedSet);
+    }
+
+    // Now delegate2 should go away.
+    infoSet = [NSMutableSet set];
+    [manager iterateDelegatesWithBlock:addBlock];
+
+    __auto_type * expectedSet = [NSSet setWithArray:@[ info1, info3 ]];
+    XCTAssertEqualObjects(infoSet, expectedSet);
+}
+
+- (void)testCall
+{
+    MTRDelegateManager<MTRDelegateManagerTestsDelegateImpl *, MTRDelegateManagerTestsDelegateInfo *> * manager = [[MTRDelegateManager alloc] initWithOwner:self];
+
+    __auto_type * delegate2 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    __auto_type * info2 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate2 queue:dispatch_get_main_queue()];
+
+    __auto_type * delegate3 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+    dispatch_queue_t queue3 = dispatch_queue_create("MTRDelegateManagerTests", DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL);
+    __auto_type * info3 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate3 queue:queue3];
+
+    MTRDelegateManagerTestsDelegateInfo * info1;
+    @autoreleasepool {
+        __auto_type * delegate1 = [[MTRDelegateManagerTestsDelegateImpl alloc] init];
+        info1 = [[MTRDelegateManagerTestsDelegateInfo alloc] initWithDelegate:delegate1 queue:dispatch_get_main_queue()];
+
+        [manager addDelegateInfo:info1];
+        [manager addDelegateInfo:info2];
+        [manager addDelegateInfo:info3];
+
+        __auto_type * expectation1 = [self expectationWithDescription:@"Delegate 1"];
+        __auto_type * expectation2 = [self expectationWithDescription:@"Delegate 2"];
+        __auto_type * expectation3 = [self expectationWithDescription:@"Delegate 3"];
+        [manager callDelegatesWithBlock:^(MTRDelegateManagerTestsDelegateImpl * delegate) {
+            if (delegate == delegate1) {
+                dispatch_assert_queue(dispatch_get_main_queue());
+                [expectation1 fulfill];
+            } else if (delegate == delegate2) {
+                dispatch_assert_queue(dispatch_get_main_queue());
+                [expectation2 fulfill];
+            } else if (delegate == delegate3) {
+                dispatch_assert_queue(queue3);
+                [expectation3 fulfill];
+            } else {
+                XCTFail("Unexpected delegate %@:", delegate);
+            }
+        }];
+
+        [self waitForExpectations:@[ expectation1, expectation3, expectation2 ]]; // NOTE: No particular ordering required
+    }
+
+    // Now delegate1 should go away.
+
+    __auto_type * expectation1 = [self expectationWithDescription:@"Delegate 1 again"];
+    __auto_type * expectation2 = [self expectationWithDescription:@"Delegate 2 again"];
+    __auto_type * expectation3 = [self expectationWithDescription:@"Delegate 3 again"];
+    expectation1.inverted = YES;
+    [manager callDelegatesWithBlock:^(MTRDelegateManagerTestsDelegateImpl * delegate) {
+        if (delegate == delegate2) {
+            dispatch_assert_queue(dispatch_get_main_queue());
+            [expectation2 fulfill];
+        } else if (delegate == delegate3) {
+            dispatch_assert_queue(queue3);
+            [expectation3 fulfill];
+        } else {
+            dispatch_assert_queue(dispatch_get_main_queue());
+            [expectation1 fulfill];
+        }
+    }];
+
+    [self waitForExpectations:@[ expectation3, expectation2, expectation1 ] timeout:3]; // NOTE: No particular ordering required
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -151,6 +151,8 @@
 		510A07492A685D3900A9241C /* Matter.apinotes in Headers */ = {isa = PBXBuildFile; fileRef = 510A07482A685D3900A9241C /* Matter.apinotes */; settings = {ATTRIBUTES = (Public, ); }; };
 		510B18F22E315731000F9181 /* MTRSecureCodingTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 510B18F12E315731000F9181 /* MTRSecureCodingTestHelpers.m */; };
 		510B18F42E3275D6000F9181 /* MTRCommissioningParameters_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 510B18F32E3275D6000F9181 /* MTRCommissioningParameters_Internal.h */; };
+		510B18F72E385DCD000F9181 /* MTRDelegateManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = 510B18F62E385DCD000F9181 /* MTRDelegateManager.mm */; };
+		510B18F82E385DCD000F9181 /* MTRDelegateManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 510B18F52E385DCD000F9181 /* MTRDelegateManager.h */; };
 		510CECA8297F72970064E0B3 /* MTROperationalCertificateIssuerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 510CECA6297F72470064E0B3 /* MTROperationalCertificateIssuerTests.m */; };
 		5117DD3829A931AE00FFA1AA /* MTROperationalBrowser.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5117DD3629A931AD00FFA1AA /* MTROperationalBrowser.mm */; };
 		5117DD3929A931AE00FFA1AA /* MTROperationalBrowser.h in Headers */ = {isa = PBXBuildFile; fileRef = 5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */; };
@@ -256,6 +258,7 @@
 		51E95DFB2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */; };
 		51E95DFC2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */; };
 		51EF279F2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h in Headers */ = {isa = PBXBuildFile; fileRef = 51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51F152812E397829007A7E05 /* MTRDelegateManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F152802E397829007A7E05 /* MTRDelegateManagerTests.m */; };
 		51F522682AE70734000C4050 /* MTRDeviceTypeMetadata.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51F522672AE70734000C4050 /* MTRDeviceTypeMetadata.mm */; };
 		51F5226A2AE70761000C4050 /* MTRDeviceTypeMetadata.h in Headers */ = {isa = PBXBuildFile; fileRef = 51F522692AE70761000C4050 /* MTRDeviceTypeMetadata.h */; };
 		51F9F9D52BF7A9EE00FEA0E2 /* MTRTestCase+ServerAppRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F9F9D42BF7A9EE00FEA0E2 /* MTRTestCase+ServerAppRunner.m */; };
@@ -760,6 +763,8 @@
 		510B18F02E315731000F9181 /* MTRSecureCodingTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRSecureCodingTestHelpers.h; sourceTree = "<group>"; };
 		510B18F12E315731000F9181 /* MTRSecureCodingTestHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRSecureCodingTestHelpers.m; sourceTree = "<group>"; };
 		510B18F32E3275D6000F9181 /* MTRCommissioningParameters_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRCommissioningParameters_Internal.h; sourceTree = "<group>"; };
+		510B18F52E385DCD000F9181 /* MTRDelegateManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRDelegateManager.h; sourceTree = "<group>"; };
+		510B18F62E385DCD000F9181 /* MTRDelegateManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDelegateManager.mm; sourceTree = "<group>"; };
 		510CECA6297F72470064E0B3 /* MTROperationalCertificateIssuerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTROperationalCertificateIssuerTests.m; sourceTree = "<group>"; };
 		5117DD3629A931AD00FFA1AA /* MTROperationalBrowser.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROperationalBrowser.mm; sourceTree = "<group>"; };
 		5117DD3729A931AE00FFA1AA /* MTROperationalBrowser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTROperationalBrowser.h; sourceTree = "<group>"; };
@@ -869,6 +874,7 @@
 		51E95DF92A78443C00A434F0 /* MTRSessionResumptionStorageBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRSessionResumptionStorageBridge.h; sourceTree = "<group>"; };
 		51E95DFA2A78443C00A434F0 /* MTRSessionResumptionStorageBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRSessionResumptionStorageBridge.mm; sourceTree = "<group>"; };
 		51EF279E2A2A3EB100E33F75 /* MTRBackwardsCompatShims.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBackwardsCompatShims.h; sourceTree = "<group>"; };
+		51F152802E397829007A7E05 /* MTRDelegateManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDelegateManagerTests.m; sourceTree = "<group>"; };
 		51F522662AE7071E000C4050 /* MTRDeviceTypeMetadata-src.zapt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MTRDeviceTypeMetadata-src.zapt"; sourceTree = "<group>"; };
 		51F522672AE70734000C4050 /* MTRDeviceTypeMetadata.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceTypeMetadata.mm; sourceTree = "<group>"; };
 		51F522692AE70761000C4050 /* MTRDeviceTypeMetadata.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceTypeMetadata.h; sourceTree = "<group>"; };
@@ -1761,6 +1767,8 @@
 				3CF134A8289D8D800017A19E /* MTRCSRInfo.mm */,
 				3DECCB732934C21B00585AEC /* MTRDefines.h */,
 				3DFCB32A2966827F00332B35 /* MTRDefines_Internal.h */,
+				510B18F52E385DCD000F9181 /* MTRDelegateManager.h */,
+				510B18F62E385DCD000F9181 /* MTRDelegateManager.mm */,
 				7596A84A287636C1004DAE0E /* MTRDevice_Internal.h */,
 				7596A84228762729004DAE0E /* MTRDevice.h */,
 				7596A84328762729004DAE0E /* MTRDevice.mm */,
@@ -1907,6 +1915,7 @@
 				518D3F842AA14006008E0007 /* MTRControllerAdvertisingTests.m */,
 				99C65E0F267282F1003402F6 /* MTRControllerTests.m */,
 				51A2F1312A00402A00F03298 /* MTRDataValueParserTests.m */,
+				51F152802E397829007A7E05 /* MTRDelegateManagerTests.m */,
 				5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */,
 				75B326A12BCF12E900E17C4E /* MTRDeviceConnectivityMonitorTests.m */,
 				5109E9B62CB8B83D0006884B /* MTRDeviceTypeTests.m */,
@@ -2174,6 +2183,7 @@
 				9B0484F52C701154006C2D5F /* MTRDeviceController_Concrete.h in Headers */,
 				5ACDDD7A27CD129700EFD68A /* MTRClusterStateCacheContainer.h in Headers */,
 				5A6FEC9227B5669C00F25F42 /* MTRDeviceControllerOverXPC.h in Headers */,
+				510B18F82E385DCD000F9181 /* MTRDelegateManager.h in Headers */,
 				D444F9AA2C6E9A08007761E5 /* MTRXPCClientProtocol.h in Headers */,
 				7567A2112DA5ABCF00D91529 /* ServerClusterInterface.h in Headers */,
 				5117DD3929A931AE00FFA1AA /* MTROperationalBrowser.h in Headers */,
@@ -2607,6 +2617,7 @@
 				2CB7163C252E8A7C0026E2BB /* MTRDeviceControllerDelegateBridge.mm in Sources */,
 				997DED162695343400975E97 /* MTRThreadOperationalDataset.mm in Sources */,
 				515C1C6F284F9FFB00A48F0C /* MTRFramework.mm in Sources */,
+				510B18F72E385DCD000F9181 /* MTRDelegateManager.mm in Sources */,
 				51029DF6293AA6100087AFB0 /* MTROperationalCertificateIssuer.mm in Sources */,
 				CF3B63D22CA31E71003C1C87 /* MTROTAUnsolicitedBDXMessageHandler.mm in Sources */,
 				27A53C1827FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm in Sources */,
@@ -2731,6 +2742,7 @@
 				51578AE92D0B9B1D001716FF /* MTRErrorMappingTests.m in Sources */,
 				99C65E10267282F1003402F6 /* MTRControllerTests.m in Sources */,
 				8874C1322B69C7060084BEFD /* MTRMetricsTests.m in Sources */,
+				51F152812E397829007A7E05 /* MTRDelegateManagerTests.m in Sources */,
 				1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* MTRXPCProtocolTests.m in Sources */,
 				3DB9DAE52D67EE5A00704FAB /* MTRBleTests.m in Sources */,


### PR DESCRIPTION
We had similar delegate storage implementations in MTRDevice and MTRDeviceController.  This factors out all that kinda-repeated code into a helper, which can also be used in other situations.

#### Testing

Existing CI and new unit tests.