### PR TITLE
Update tests workflow to use venv when installing push_av_server dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -676,10 +676,10 @@ jobs:
                   build --copy-artifacts-to objdir-clone
                   && rm -rf out/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test"
 
-            - name: Copy push_av_server and install dependencies
+            - name: Install push_av_server dependencies
               run: >-
-                  cp -r ./src/tools/push_av_server objdir-clone/
-                  && pip install --break-system-packages -r objdir-clone/push_av_server/requirements.txt
+                  ./scripts/run_in_python_env.sh out/venv \
+                  "python3 -m pip install -r src/tools/push_av_server/requirements.txt"
 
             - name: Generate an argument environment file
               run: |
@@ -705,7 +705,7 @@ jobs:
                   echo "JF_CONTROL_APP: objdir-clone/linux-x64-jf-control-app/jfc-app" >> /tmp/test_env.yaml
                   echo "JF_ADMIN_APP: objdir-clone/linux-x64-jf-admin-app/jfa-app" >> /tmp/test_env.yaml
                   echo "CLOSURE_APP: objdir-clone/linux-x64-closure-${BUILD_VARIANT}-tsan-clang-test/closure-app" >> /tmp/test_env.yaml
-                  echo "PUSH_AV_SERVER: objdir-clone/push_av_server/server.py" >> /tmp/test_env.yaml
+                  echo "PUSH_AV_SERVER: src/tools/push_av_server/server.py" >> /tmp/test_env.yaml
 
                   # Generic trace setups after applications
                   echo "TRACE_TEST_JSON: out/trace_data/test-{SCRIPT_BASE_NAME}" >> /tmp/test_env.yaml


### PR DESCRIPTION
This PR updates the tests workflow to use venv instead of breaking system packages for push_av_server dependency installation

### Testing
Validated by CI