### PR TITLE
[dnssd] Fixed buffer sizes for dns names

### DIFF
--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -45,9 +45,10 @@ namespace Dnssd {
 static constexpr size_t kDnssdProtocolTextMaxSize = std::max(sizeof(kOperationalProtocol), sizeof(kCommissionProtocol)) - 1;
 static constexpr size_t kDnssdTypeMaxSize =
     std::max({ sizeof(kCommissionableServiceName), sizeof(kOperationalServiceName), sizeof(kCommissionerServiceName) }) - 1;
-static constexpr uint8_t kDnssdTypeAndProtocolMaxSize     = kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1; // <type>.<protocol>
-static constexpr uint16_t kDnssdTextMaxSize               = 64;
-static constexpr uint8_t kDnssdFullTypeAndProtocolMaxSize = Common::kSubTypeMaxLength + /* '.' */ 1 + kDnssdTypeAndProtocolMaxSize;
+static constexpr uint8_t kDnssdTypeAndProtocolMaxSize = kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1; // <type>.<protocol>
+static constexpr uint16_t kDnssdTextMaxSize           = 64;
+static constexpr uint8_t kDnssdFullTypeAndProtocolMaxSize =
+    Common::kSubTypeMaxLength + /* '.' */ 1 + sizeof(kSubtypeServiceNamePart) + kDnssdTypeAndProtocolMaxSize;
 
 enum class DnssdServiceProtocol : uint8_t
 {

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1881,7 +1881,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnDnsBrowseResult(otEr
 {
     CHIP_ERROR error;
     // type buffer size is kDnssdTypeAndProtocolMaxSize + . + kMaxDomainNameSize + . + termination character
-    char type[Dnssd::kDnssdTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
+    char type[Dnssd::kDnssdFullTypeAndProtocolMaxSize + SrpClient::kMaxDomainNameSize + 3];
     // hostname buffer size is kHostNameMaxLength + . + kMaxDomainNameSize + . + termination character
     char hostname[Dnssd::kHostNameMaxLength + SrpClient::kMaxDomainNameSize + 3];
     // secure space for the raw TXT data in the worst-case scenario relevant for Matter:


### PR DESCRIPTION
#### Summary
The DNS browse for vendor id subtype does not work, as full name does not fit in the provided buffer.

By the way of investigating this issue couple of other issues were found:

* Started to use full service name including subtypes for dns browse results handling in Thread implementation
* Fixed max commissionable and commissioner service name sizes that didn't include . character
* Fixed kDnssdFullTypeAndProtocolMaxSize that did not include _sub phrase

#### Testing
Tested manually using dns browse command from the dns shell for the _V and _L subtypes.
