### PR TITLE
[E2E][JF] Implemented JF Datastore attributes and commands

### DIFF
--- a/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
+++ b/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
@@ -48,11 +48,20 @@ public:
     void MarkNodeListChanged() override;
 
 private:
+    CHIP_ERROR ReadAnchorRootCA(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadAnchorNodeId(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadAnchorVendorId(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadFriendlyName(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadGroupKeySetList(AttributeValueEncoder & aEncoder);
-    CHIP_ERROR ReadAdminList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadGroupList(AttributeValueEncoder & aEncoder);
     CHIP_ERROR ReadNodeList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadAdminList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadStatus(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadEndpointGroupIDList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadEndpointBindingList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadNodeKeySetList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadNodeACLList(AttributeValueEncoder & aEncoder);
+    CHIP_ERROR ReadNodeEndpointList(AttributeValueEncoder & aEncoder);
 };
 
 JointFabricDatastoreAttrAccess gJointFabricDatastoreAttrAccess;
@@ -63,26 +72,59 @@ CHIP_ERROR JointFabricDatastoreAttrAccess::Read(const ConcreteReadAttributePath 
 
     switch (aPath.mAttributeId)
     {
+    case JointFabricDatastoreCluster::Attributes::AnchorRootCA::Id: {
+        return ReadAnchorRootCA(aEncoder);
+    }
     case JointFabricDatastoreCluster::Attributes::AnchorNodeID::Id: {
         return ReadAnchorNodeId(aEncoder);
     }
     case JointFabricDatastoreCluster::Attributes::AnchorVendorID::Id: {
         return ReadAnchorVendorId(aEncoder);
     }
+    case JointFabricDatastoreCluster::Attributes::FriendlyName::Id: {
+        return ReadFriendlyName(aEncoder);
+    }
     case JointFabricDatastoreCluster::Attributes::GroupKeySetList::Id: {
         return ReadGroupKeySetList(aEncoder);
     }
-    case JointFabricDatastoreCluster::Attributes::AdminList::Id: {
-        return ReadAdminList(aEncoder);
+    case JointFabricDatastoreCluster::Attributes::GroupList::Id: {
+        return ReadGroupList(aEncoder);
     }
     case JointFabricDatastoreCluster::Attributes::NodeList::Id: {
         return ReadNodeList(aEncoder);
     }
-    // TODO: Others
+    case JointFabricDatastoreCluster::Attributes::AdminList::Id: {
+        return ReadAdminList(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::Status::Id: {
+        return ReadStatus(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::EndpointGroupIDList::Id: {
+        return ReadEndpointGroupIDList(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::EndpointBindingList::Id: {
+        return ReadEndpointBindingList(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::NodeKeySetList::Id: {
+        return ReadNodeKeySetList(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::NodeACLList::Id: {
+        return ReadNodeACLList(aEncoder);
+    }
+    case JointFabricDatastoreCluster::Attributes::NodeEndpointList::Id: {
+        return ReadNodeEndpointList(aEncoder);
+    }
     default:
         break;
     }
 
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadAnchorRootCA(AttributeValueEncoder & aEncoder)
+{
+    ByteSpan anchorRootCA = Server::GetInstance().GetJointFabricDatastore().GetAnchorRootCA();
+    ReturnErrorOnFailure(aEncoder.Encode(anchorRootCA));
     return CHIP_NO_ERROR;
 }
 
@@ -100,6 +142,13 @@ CHIP_ERROR JointFabricDatastoreAttrAccess::ReadAnchorVendorId(AttributeValueEnco
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadFriendlyName(AttributeValueEncoder & aEncoder)
+{
+    CharSpan friendlyName = Server::GetInstance().GetJointFabricDatastore().GetFriendlyName();
+    ReturnErrorOnFailure(aEncoder.Encode(friendlyName));
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR JointFabricDatastoreAttrAccess::ReadGroupKeySetList(AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
@@ -113,10 +162,10 @@ CHIP_ERROR JointFabricDatastoreAttrAccess::ReadGroupKeySetList(AttributeValueEnc
     });
 }
 
-CHIP_ERROR JointFabricDatastoreAttrAccess::ReadAdminList(AttributeValueEncoder & aEncoder)
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadGroupList(AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
-        auto entries = Server::GetInstance().GetJointFabricDatastore().GetAdminEntries();
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetGroupEntries();
 
         for (auto & entry : entries)
         {
@@ -139,10 +188,240 @@ CHIP_ERROR JointFabricDatastoreAttrAccess::ReadNodeList(AttributeValueEncoder & 
     });
 }
 
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadAdminList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetAdminEntries();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadStatus(AttributeValueEncoder & aEncoder)
+{
+    auto status = Server::GetInstance().GetJointFabricDatastore().GetStatus();
+    return aEncoder.Encode(status);
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadEndpointGroupIDList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetEndpointGroupIDList();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadEndpointBindingList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetEndpointBindingList();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadNodeKeySetList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetNodeKeySetList();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadNodeACLList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetNodeACLList();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
+CHIP_ERROR JointFabricDatastoreAttrAccess::ReadNodeEndpointList(AttributeValueEncoder & aEncoder)
+{
+    return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
+        auto entries = Server::GetInstance().GetJointFabricDatastore().GetNodeEndpointList();
+
+        for (auto & entry : entries)
+        {
+            ReturnErrorOnFailure(encoder.Encode(entry));
+        }
+        return CHIP_NO_ERROR;
+    });
+}
+
 void JointFabricDatastoreAttrAccess::MarkNodeListChanged()
 {
     MatterReportingAttributeChangeCallback(kRootEndpointId, JointFabricDatastoreCluster::Id,
                                            JointFabricDatastoreCluster::Attributes::NodeList::Id);
+}
+
+bool emberAfJointFabricDatastoreClusterAddKeySetCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::AddKeySet::DecodableType & commandData)
+{
+    CHIP_ERROR err                                                                              = CHIP_NO_ERROR;
+    JointFabricDatastoreCluster::Structs::DatastoreGroupKeySetStruct::DecodableType groupKeySet = commandData.groupKeySet;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    VerifyOrExit(jointFabricDatastore.IsGroupKeySetEntryPresent(groupKeySet.groupKeySetID) == false,
+                 // TODO: make sure this maps to Protocols::InteractionModel::ClusterStatusCode::ConstraintError
+                 err = CHIP_ERROR_INVALID_ARGUMENT);
+    SuccessOrExit(err = jointFabricDatastore.AddGroupKeySetEntry(groupKeySet));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterUpdateKeySetCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::UpdateKeySet::DecodableType & commandData)
+{
+    CHIP_ERROR err                                                                              = CHIP_NO_ERROR;
+    JointFabricDatastoreCluster::Structs::DatastoreGroupKeySetStruct::DecodableType groupKeySet = commandData.groupKeySet;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    VerifyOrExit(jointFabricDatastore.IsGroupKeySetEntryPresent(groupKeySet.groupKeySetID), err = CHIP_ERROR_NOT_FOUND);
+    SuccessOrExit(err = jointFabricDatastore.UpdateGroupKeySetEntry(groupKeySet));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterRemoveKeySetCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::RemoveKeySet::DecodableType & commandData)
+{
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    uint16_t groupKeySetId                           = commandData.groupKeySetID;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    VerifyOrExit(jointFabricDatastore.IsGroupKeySetEntryPresent(groupKeySetId), err = CHIP_ERROR_NOT_FOUND);
+    SuccessOrExit(err = jointFabricDatastore.RemoveGroupKeySetEntry(groupKeySetId));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterAddGroupCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::AddGroup::DecodableType & commandData)
+{
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    SuccessOrExit(err = jointFabricDatastore.AddGroup(commandData));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterUpdateGroupCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::UpdateGroup::DecodableType & commandData)
+{
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    SuccessOrExit(err = jointFabricDatastore.UpdateGroup(commandData));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterRemoveGroupCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::RemoveGroup::DecodableType & commandData)
+{
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    SuccessOrExit(err = jointFabricDatastore.RemoveGroup(commandData));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
 }
 
 bool emberAfJointFabricDatastoreClusterAddAdminCallback(
@@ -177,93 +456,17 @@ exit:
     return true;
 }
 
-// TODO
-bool emberAfJointFabricDatastoreClusterAddGroupCallback(
+bool emberAfJointFabricDatastoreClusterUpdateAdminCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::AddGroup::DecodableType & commandData)
+    const JointFabricDatastoreCluster::Commands::UpdateAdmin::DecodableType & commandData)
 {
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterAddKeySetCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::AddKeySet::DecodableType & commandData)
-{
-    CHIP_ERROR err                                                                              = CHIP_NO_ERROR;
-    JointFabricDatastoreCluster::Structs::DatastoreGroupKeySetStruct::DecodableType groupKeySet = commandData.groupKeySet;
+    CHIP_ERROR err                                   = CHIP_NO_ERROR;
+    auto nodeId                                      = commandData.nodeID.Value();
+    auto friendlyName                                = commandData.friendlyName.Value();
+    auto icac                                        = commandData.icac.Value();
     app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
 
-    VerifyOrExit(jointFabricDatastore.IsGroupKeySetEntryPresent(groupKeySet.groupKeySetID) == false,
-                 err = CHIP_ERROR_INVALID_ARGUMENT);
-    SuccessOrExit(err = jointFabricDatastore.AddGroupKeySetEntry(groupKeySet));
-
-exit:
-    if (err == CHIP_NO_ERROR)
-    {
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-    }
-    else
-    {
-        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
-    }
-
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterRemoveNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RemoveNode::DecodableType & commandData)
-{
-    NodeId nodeId = commandData.nodeID;
-
-    CHIP_ERROR err = Server::GetInstance().GetJointFabricDatastore().RemoveNode(nodeId);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-    }
-    else
-    {
-        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
-    }
-
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterUpdateNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::UpdateNode::DecodableType & commandData)
-{
-    NodeId nodeId                 = commandData.nodeID;
-    const CharSpan & friendlyName = commandData.friendlyName;
-
-    CHIP_ERROR err = Server::GetInstance().GetJointFabricDatastore().UpdateNode(nodeId, friendlyName);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-    }
-    else
-    {
-        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
-    }
-
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterRefreshNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RefreshNode::DecodableType & commandData)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    NodeId nodeId  = commandData.nodeID;
-
-    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
-
-    SuccessOrExit(err = jointFabricDatastore.RefreshNode(nodeId));
+    SuccessOrExit(err = jointFabricDatastore.UpdateAdmin(nodeId, friendlyName, icac));
 
 exit:
     if (err == CHIP_NO_ERROR)
@@ -303,96 +506,63 @@ exit:
     return true;
 }
 
-// TODO
-bool emberAfJointFabricDatastoreClusterRemoveGroupCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RemoveGroup::DecodableType & commandData)
-{
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterUpdateAdminCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::UpdateAdmin::DecodableType & commandData)
-{
-    CHIP_ERROR err                                   = CHIP_NO_ERROR;
-    auto nodeId                                      = commandData.nodeID.Value();
-    auto friendlyName                                = commandData.friendlyName.Value();
-    auto icac                                        = commandData.icac.Value();
-    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
-
-    SuccessOrExit(err = jointFabricDatastore.UpdateAdmin(nodeId, friendlyName, icac));
-
-exit:
-    if (err == CHIP_NO_ERROR)
-    {
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-    }
-    else
-    {
-        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
-    }
-
-    return true;
-}
-
-// TODO
-bool emberAfJointFabricDatastoreClusterUpdateGroupCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::UpdateGroup::DecodableType & commandData)
-{
-    return true;
-}
-
-// TODO
-bool emberAfJointFabricDatastoreClusterAddACLToNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::AddACLToNode::DecodableType & commandData)
-{
-    return true;
-}
-
-bool emberAfJointFabricDatastoreClusterRemoveKeySetCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RemoveKeySet::DecodableType & commandData)
-{
-    CHIP_ERROR err                                   = CHIP_NO_ERROR;
-    uint16_t groupKeySetId                           = commandData.groupKeySetID;
-    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
-
-    SuccessOrExit(err = jointFabricDatastore.RemoveGroupKeySetEntry(groupKeySetId));
-
-exit:
-    if (err == CHIP_NO_ERROR)
-    {
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
-    }
-    else
-    {
-        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
-        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
-    }
-
-    return true;
-}
-
-// TODO
-bool emberAfJointFabricDatastoreClusterUpdateKeySetCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::UpdateKeySet::DecodableType & commandData)
-{
-    return true;
-}
-
 bool emberAfJointFabricDatastoreClusterAddPendingNodeCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
     const JointFabricDatastoreCluster::Commands::AddPendingNode::DecodableType & commandData)
 {
+    CHIP_ERROR err                = CHIP_NO_ERROR;
     NodeId nodeId                 = commandData.nodeID;
     const CharSpan & friendlyName = commandData.friendlyName;
 
-    CHIP_ERROR err = Server::GetInstance().GetJointFabricDatastore().AddPendingNode(nodeId, friendlyName);
+    SuccessOrExit(err = Server::GetInstance().GetJointFabricDatastore().AddPendingNode(nodeId, friendlyName));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterRefreshNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::RefreshNode::DecodableType & commandData)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    NodeId nodeId  = commandData.nodeID;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    SuccessOrExit(err = jointFabricDatastore.RefreshNode(nodeId));
+
+exit:
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterUpdateNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::UpdateNode::DecodableType & commandData)
+{
+    NodeId nodeId                 = commandData.nodeID;
+    const CharSpan & friendlyName = commandData.friendlyName;
+
+    CHIP_ERROR err = Server::GetInstance().GetJointFabricDatastore().UpdateNode(nodeId, friendlyName);
 
     if (err == CHIP_NO_ERROR)
     {
@@ -407,51 +577,204 @@ bool emberAfJointFabricDatastoreClusterAddPendingNodeCallback(
     return true;
 }
 
-// TODO
-bool emberAfJointFabricDatastoreClusterRemoveACLFromNodeCallback(
+bool emberAfJointFabricDatastoreClusterRemoveNodeCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RemoveACLFromNode::DecodableType & commandData)
+    const JointFabricDatastoreCluster::Commands::RemoveNode::DecodableType & commandData)
 {
+    NodeId nodeId = commandData.nodeID;
+
+    CHIP_ERROR err = Server::GetInstance().GetJointFabricDatastore().RemoveNode(nodeId);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
     return true;
 }
 
-// TODO
 bool emberAfJointFabricDatastoreClusterUpdateEndpointForNodeCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
     const JointFabricDatastoreCluster::Commands::UpdateEndpointForNode::DecodableType & commandData)
 {
+    CHIP_ERROR err                = CHIP_NO_ERROR;
+    NodeId nodeId                 = commandData.nodeID;
+    EndpointId endpointId         = commandData.endpointID;
+    const CharSpan & friendlyName = commandData.friendlyName;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.UpdateEndpointForNode(nodeId, endpointId, friendlyName);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
     return true;
 }
 
-// TODO
-bool emberAfJointFabricDatastoreClusterAddBindingToEndpointForNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::AddBindingToEndpointForNode::DecodableType & commandData)
-{
-    return true;
-}
-
-// TODO
 bool emberAfJointFabricDatastoreClusterAddGroupIDToEndpointForNodeCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
     const JointFabricDatastoreCluster::Commands::AddGroupIDToEndpointForNode::DecodableType & commandData)
 {
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    NodeId nodeId         = commandData.nodeID;
+    EndpointId endpointId = commandData.endpointID;
+    GroupId groupID       = commandData.groupID;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.AddGroupIDToEndpointForNode(nodeId, endpointId, groupID);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
     return true;
 }
 
-// TODO
-bool emberAfJointFabricDatastoreClusterRemoveBindingFromEndpointForNodeCallback(
-    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-    const JointFabricDatastoreCluster::Commands::RemoveBindingFromEndpointForNode::DecodableType & commandData)
-{
-    return true;
-}
-
-// TODO
 bool emberAfJointFabricDatastoreClusterRemoveGroupIDFromEndpointForNodeCallback(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
     const JointFabricDatastoreCluster::Commands::RemoveGroupIDFromEndpointForNode::DecodableType & commandData)
 {
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    NodeId nodeId         = commandData.nodeID;
+    EndpointId endpointId = commandData.endpointID;
+    GroupId groupID       = commandData.groupID;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.RemoveGroupIDFromEndpointForNode(nodeId, endpointId, groupID);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterAddBindingToEndpointForNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::AddBindingToEndpointForNode::DecodableType & commandData)
+{
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    NodeId nodeId         = commandData.nodeID;
+    EndpointId endpointId = commandData.endpointID;
+    auto & binding        = commandData.binding;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.AddBindingToEndpointForNode(nodeId, endpointId, binding);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterRemoveBindingFromEndpointForNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::RemoveBindingFromEndpointForNode::DecodableType & commandData)
+{
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    uint16_t listId       = commandData.listID;
+    NodeId nodeId         = commandData.nodeID;
+    EndpointId endpointId = commandData.endpointID;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.RemoveBindingFromEndpointForNode(listId, nodeId, endpointId);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterAddACLToNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::AddACLToNode::DecodableType & commandData)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    NodeId nodeId   = commandData.nodeID;
+    auto & aclEntry = commandData.ACLEntry;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.AddACLToNode(nodeId, aclEntry);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
+    return true;
+}
+
+bool emberAfJointFabricDatastoreClusterRemoveACLFromNodeCallback(
+    CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
+    const JointFabricDatastoreCluster::Commands::RemoveACLFromNode::DecodableType & commandData)
+{
+    CHIP_ERROR err  = CHIP_NO_ERROR;
+    uint16_t listId = commandData.listID;
+    NodeId nodeId   = commandData.nodeID;
+
+    app::JointFabricDatastore & jointFabricDatastore = Server::GetInstance().GetJointFabricDatastore();
+
+    err = jointFabricDatastore.RemoveACLFromNode(listId, nodeId);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
+    }
+    else
+    {
+        ChipLogError(DataManagement, "JointFabricDatastoreCluster: failed with error: %" CHIP_ERROR_FORMAT, err.Format());
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::ClusterStatusCode(err));
+    }
+
     return true;
 }
 

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -51,6 +51,7 @@ source_set("joint_fabric") {
   ]
 
   public_deps = [
+    "${chip_root}/src/credentials",
     "${chip_root}/src/lib/core",
     "${chip_root}/zzz_generated/app-common/clusters/JointFabricAdministrator",
     "${chip_root}/zzz_generated/app-common/clusters/JointFabricDatastore",

--- a/src/app/server/JointFabricDatastore.cpp
+++ b/src/app/server/JointFabricDatastore.cpp
@@ -20,6 +20,8 @@
 namespace chip {
 namespace app {
 
+#define CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR CHIP_CORE_ERROR(0x87)
+
 void JointFabricDatastore::AddListener(Listener & listener)
 {
     if (mListeners == nullptr)
@@ -97,7 +99,7 @@ CHIP_ERROR JointFabricDatastore::UpdateNode(NodeId nodeId, const CharSpan & frie
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR JointFabricDatastore::RemoveNode(NodeId nodeId)
@@ -117,7 +119,7 @@ CHIP_ERROR JointFabricDatastore::RemoveNode(NodeId nodeId)
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR JointFabricDatastore::RefreshNode(NodeId nodeId)
@@ -161,7 +163,7 @@ CHIP_ERROR JointFabricDatastore::IsNodeIDInDatastore(NodeId nodeId, size_t & ind
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR
@@ -199,7 +201,7 @@ CHIP_ERROR JointFabricDatastore::RemoveGroupKeySetEntry(uint16_t groupKeySetId)
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR
@@ -212,13 +214,13 @@ JointFabricDatastore::UpdateGroupKeySetEntry(
         {
             entry = groupKeySet;
 
-            // TODO: RefreshNodes
+            ReturnErrorOnFailure(UpdateNodeKeySetList(entry));
 
             return CHIP_NO_ERROR;
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR
@@ -258,7 +260,7 @@ CHIP_ERROR JointFabricDatastore::UpdateAdmin(NodeId nodeId, CharSpan friendlyNam
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 CHIP_ERROR JointFabricDatastore::RemoveAdmin(NodeId nodeId)
@@ -272,7 +274,366 @@ CHIP_ERROR JointFabricDatastore::RemoveAdmin(NodeId nodeId)
         }
     }
 
-    return CHIP_ERROR_KEY_NOT_FOUND;
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR
+JointFabricDatastore::UpdateNodeKeySetList(Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type & groupKeySet)
+{
+    for (auto & entry : mNodeKeySetEntries)
+    {
+        if (entry.groupKeySetID == groupKeySet.groupKeySetID)
+        {
+            // TODO: update device
+            entry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::RemoveKeySet(uint16_t groupKeySetId)
+{
+    for (auto it = mNodeKeySetEntries.begin(); it != mNodeKeySetEntries.end(); ++it)
+    {
+        if (it->groupKeySetID == groupKeySetId)
+        {
+            if (it->statusEntry.state != Clusters::JointFabricDatastore::DatastoreStateEnum::kDeletePending)
+            {
+                return CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR; // Cannot remove a key set that is not pending
+            }
+
+            ReturnErrorOnFailure(RemoveGroupKeySetEntry(groupKeySetId));
+
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::AddGroup(const Clusters::JointFabricDatastore::Commands::AddGroup::DecodableType & commandData)
+{
+    size_t index = 0;
+    // Check if the group ID already exists in the datastore
+    VerifyOrReturnError(IsGroupIDInDatastore(commandData.groupID, index) == CHIP_ERROR_NOT_FOUND,
+                        CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR);
+
+    // TODO: Add AdminCAT and AnchorCAT checks from spec
+
+    Clusters::JointFabricDatastore::Structs::DatastoreGroupInformationEntryStruct::Type groupEntry;
+    groupEntry.groupID         = commandData.groupID;
+    groupEntry.friendlyName    = commandData.friendlyName;
+    groupEntry.groupKeySetID   = commandData.groupKeySetID;
+    groupEntry.groupCAT        = commandData.groupCAT;
+    groupEntry.groupCATVersion = commandData.groupCATVersion;
+    groupEntry.groupPermission = commandData.groupPermission;
+
+    // Add the group entry to the datastore
+    mGroupInformationEntries.push_back(groupEntry);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+JointFabricDatastore::UpdateGroup(const Clusters::JointFabricDatastore::Commands::UpdateGroup::DecodableType & commandData)
+{
+    size_t index = 0;
+    // Check if the group ID exists in the datastore
+    VerifyOrReturnError(IsGroupIDInDatastore(commandData.groupID, index) == CHIP_NO_ERROR,
+                        CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR);
+
+    // TODO: Add AdminCAT and AnchorCAT checks from spec
+
+    // Update the group entry with the new data
+    if (commandData.friendlyName.IsNull() == false)
+    {
+        mGroupInformationEntries[index].friendlyName = commandData.friendlyName.Value();
+    }
+    if (commandData.groupKeySetID.IsNull() == false)
+    {
+        mGroupInformationEntries[index].groupKeySetID = commandData.groupKeySetID.Value();
+    }
+    if (commandData.groupCAT.IsNull() == false)
+    {
+        mGroupInformationEntries[index].groupCAT = commandData.groupCAT.Value();
+    }
+    if (commandData.groupCATVersion.IsNull() == false)
+    {
+        mGroupInformationEntries[index].groupCATVersion = commandData.groupCATVersion.Value();
+    }
+    if (commandData.groupPermission != Clusters::JointFabricDatastore::DatastoreAccessControlEntryPrivilegeEnum::kUnknownEnumValue)
+    {
+        // If the groupPermission is not set to kUnknownEnumValue, update it
+        mGroupInformationEntries[index].groupPermission = commandData.groupPermission;
+    }
+
+    // TODO: iterate through each Node Information Entry to check for membership, and when found, set to pending, update device, set
+    // to committed, etc.
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+JointFabricDatastore::RemoveGroup(const Clusters::JointFabricDatastore::Commands::RemoveGroup::DecodableType & commandData)
+{
+    size_t index = 0;
+    // Check if the group ID exists in the datastore
+    VerifyOrReturnError(IsGroupIDInDatastore(commandData.groupID, index) == CHIP_NO_ERROR,
+                        CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR);
+
+    // TODO: Add AdminCAT and AnchorCAT checks from spec
+
+    // Remove the group entry from the datastore
+    auto it = mGroupInformationEntries.begin();
+    std::advance(it, index);
+    mGroupInformationEntries.erase(it);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR JointFabricDatastore::IsGroupIDInDatastore(chip::GroupId groupId, size_t & index)
+{
+    for (auto & entry : mGroupInformationEntries)
+    {
+        if (entry.groupID == groupId)
+        {
+            index = static_cast<size_t>(&entry - &mGroupInformationEntries[0]);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::IsNodeIdInNodeInformationEntries(NodeId nodeId, size_t & index)
+{
+    for (auto & entry : mNodeInformationEntries)
+    {
+        if (entry.nodeID == nodeId)
+        {
+            index = static_cast<size_t>(&entry - &mNodeInformationEntries[0]);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::UpdateEndpointForNode(NodeId nodeId, chip::EndpointId endpointId, CharSpan friendlyName)
+{
+    for (auto & entry : mEndpointEntries)
+    {
+        if (entry.nodeID == nodeId && entry.endpointID == endpointId)
+        {
+            entry.friendlyName = friendlyName;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::IsNodeIdAndEndpointInEndpointInformationEntries(NodeId nodeId, EndpointId endpointId,
+                                                                                 size_t & index)
+{
+    for (auto & entry : mEndpointEntries)
+    {
+        if (entry.nodeID == nodeId && entry.endpointID == endpointId)
+        {
+            index = static_cast<size_t>(&entry - &mEndpointEntries[0]);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::AddGroupIDToEndpointForNode(NodeId nodeId, chip::EndpointId endpointId, chip::GroupId groupId)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdAndEndpointInEndpointInformationEntries(nodeId, endpointId, index));
+
+    VerifyOrReturnError(IsGroupIDInDatastore(groupId, index) == CHIP_ERROR_NOT_FOUND, CHIP_ERROR_IM_STATUS_CODE_CONSTRAINT_ERROR);
+
+    // TODO: make sure NodeKeySetList contains an entry for this keyset and node, else add one and update device
+
+    // Check if the group ID already exists for the endpoint
+    for (auto & entry : mEndpointGroupIDEntries)
+    {
+        if (entry.nodeID == nodeId && entry.endpointID == endpointId && entry.groupID == groupId)
+        {
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    VerifyOrReturnError(mEndpointGroupIDEntries.size() < kMaxGroups, CHIP_ERROR_NO_MEMORY);
+
+    // Create a new endpoint group ID entry
+    Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type newGroupEntry;
+    newGroupEntry.nodeID            = nodeId;
+    newGroupEntry.endpointID        = endpointId;
+    newGroupEntry.groupID           = groupId;
+    newGroupEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+
+    // Add the new ACL entry to the datastore
+    mEndpointGroupIDEntries.push_back(newGroupEntry);
+
+    // TODO: set to pending, update device, set to committed
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR JointFabricDatastore::RemoveGroupIDFromEndpointForNode(NodeId nodeId, chip::EndpointId endpointId, chip::GroupId groupId)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdAndEndpointInEndpointInformationEntries(nodeId, endpointId, index));
+
+    // TODO: 3
+
+    for (auto it = mEndpointGroupIDEntries.begin(); it != mEndpointGroupIDEntries.end(); ++it)
+    {
+        if (it->nodeID == nodeId && it->endpointID == endpointId && it->groupID == groupId)
+        {
+            // TODO: set to delete_pending, update device, then erase
+            mEndpointGroupIDEntries.erase(it);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR
+JointFabricDatastore::AddBindingToEndpointForNode(
+    NodeId nodeId, chip::EndpointId endpointId,
+    const Clusters::JointFabricDatastore::Structs::DatastoreBindingTargetStruct::Type & binding)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdAndEndpointInEndpointInformationEntries(nodeId, endpointId, index));
+
+    // Check if the group ID already exists for the endpoint
+    for (auto & entry : mEndpointBindingEntries)
+    {
+        if (entry.nodeID == nodeId && entry.endpointID == endpointId)
+        {
+            // TODO: mark as pending, update device, then mark as committed
+            entry.binding = binding;
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    VerifyOrReturnError(mEndpointBindingEntries.size() < kMaxGroups, CHIP_ERROR_NO_MEMORY);
+
+    // Create a new binding entry
+    Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type newBindingEntry;
+    newBindingEntry.nodeID            = nodeId;
+    newBindingEntry.endpointID        = endpointId;
+    newBindingEntry.binding           = binding;
+    newBindingEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+
+    // Add the new binding entry to the datastore
+    mEndpointBindingEntries.push_back(newBindingEntry);
+
+    // TODO: mark as pending, update device, then mark as committed
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+JointFabricDatastore::RemoveBindingFromEndpointForNode(uint16_t listId, NodeId nodeId, chip::EndpointId endpointId)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdAndEndpointInEndpointInformationEntries(nodeId, endpointId, index));
+
+    for (auto it = mEndpointBindingEntries.begin(); it != mEndpointBindingEntries.end(); ++it)
+    {
+        if (it->nodeID == nodeId && it->endpointID == endpointId)
+        {
+            // TODO: mark as delete pending, update device, then erase
+            mEndpointBindingEntries.erase(it);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
+}
+
+CHIP_ERROR JointFabricDatastore::UpdateACLEntry(
+    Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type & entryToUpdate,
+    const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType & aclEntry)
+{
+    // Update the ACL entry with the new data
+    if (aclEntry.privilege != Clusters::JointFabricDatastore::DatastoreAccessControlEntryPrivilegeEnum::kUnknownEnumValue)
+    {
+        entryToUpdate.ACLEntry.privilege = aclEntry.privilege;
+    }
+    if (aclEntry.authMode != Clusters::JointFabricDatastore::DatastoreAccessControlEntryAuthModeEnum::kUnknownEnumValue)
+    {
+        entryToUpdate.ACLEntry.authMode = aclEntry.authMode;
+    }
+    if (aclEntry.subjects.IsNull() == false)
+    {
+        // TODO: Handle subjects
+    }
+    if (aclEntry.targets.IsNull() == false)
+    {
+        // TODO: Handle targets
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR
+JointFabricDatastore::AddACLToNode(
+    NodeId nodeId, const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType & aclEntry)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdInNodeInformationEntries(nodeId, index));
+
+    // Check if the ACL entry already exists for the node
+    for (auto & entry : mACLEntries)
+    {
+        if (entry.nodeID == nodeId)
+        {
+            // TODO: mark as pending, update device, mark as committed
+            ReturnErrorOnFailure(UpdateACLEntry(entry, aclEntry));
+            return CHIP_NO_ERROR;
+        }
+    }
+    VerifyOrReturnError(mACLEntries.size() < kMaxACLs, CHIP_ERROR_NO_MEMORY);
+    // Create a new ACL entry
+    Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type newACLEntry;
+    newACLEntry.nodeID             = nodeId;
+    newACLEntry.ACLEntry.privilege = aclEntry.privilege;
+    newACLEntry.ACLEntry.authMode  = aclEntry.authMode;
+    // TODO: Handle subjects and targets
+    newACLEntry.statusEntry.state = Clusters::JointFabricDatastore::DatastoreStateEnum::kCommitted;
+
+    // TODO: mark as pending, update device, mark as committed
+    // Add the new ACL entry to the datastore
+    mACLEntries.push_back(newACLEntry);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR JointFabricDatastore::RemoveACLFromNode(uint16_t listId, NodeId nodeId)
+{
+    size_t index = 0;
+    ReturnErrorOnFailure(IsNodeIdInNodeInformationEntries(nodeId, index));
+
+    for (auto it = mACLEntries.begin(); it != mACLEntries.end(); ++it)
+    {
+        if (it->nodeID == nodeId)
+        {
+            // TODO: mark as delete pending, update device, erase
+            mACLEntries.erase(it);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 } // namespace app


### PR DESCRIPTION
#### Summary
Implement JF Datastore attributes and commands as per the spec

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/38949.

#### Testing
Verified using the below instructions.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```