### PR TITLE
[E2E][JF] Move OJCW into the pairing command set

### DIFF
--- a/docs/guides/joint_fabric_guide.md
+++ b/docs/guides/joint_fabric_guide.md
@@ -262,7 +262,7 @@ On the Ecosystem B Joint Fabric Controller application
 -   Open Joint Commissioning Window on JF Admin App of Ecosystem B
 
 ```
->>> jcm open-joint-commissioning-window 11 1 400 1000 1261
+>>> pairing open-joint-commissioning-window 11 1 400 1000 1261
 ```
 
 Check for the following logs on the jf-admin-app side:

--- a/examples/chip-tool/commands/common/Commands.h
+++ b/examples/chip-tool/commands/common/Commands.h
@@ -45,6 +45,17 @@ public:
     int Run(int argc, char ** argv);
     int RunInteractive(const char * command, const chip::Optional<char *> & storageDirectory, bool advertiseOperational);
 
+    void UpdateCommandSet(const char * commandSetName, commands_list commandsList)
+    {
+        auto it = mCommandSets.find(commandSetName);
+        VerifyOrReturn(it != mCommandSets.end(), ChipLogError(chipTool, "Command set '%s' not found", commandSetName));
+
+        for (auto & command : commandsList)
+        {
+            it->second.commands.push_back(std::move(command));
+        }
+    }
+
 private:
     struct CommandSet
     {

--- a/examples/jf-control-app/main.cpp
+++ b/examples/jf-control-app/main.cpp
@@ -49,13 +49,13 @@ CHIP_ERROR RpcConnect(void)
 
 void registerCommandsJCM(Commands & commands, CredentialIssuerCommands * credsIssuerConfig)
 {
-    const char * clusterName = "JCM";
+    const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
         make_unique<OpenJointCommissioningWindowCommand>(credsIssuerConfig),
     };
 
-    commands.RegisterCommandSet(clusterName, clusterCommands, "Commands for commissioning JF-enabled devices.");
+    commands.UpdateCommandSet(clusterName, clusterCommands);
 }
 
 // ================================================================================


### PR DESCRIPTION
#### Summary
Moved OJCW into the pairing command set

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/39333.

#### Testing
Verified using the below instructions.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```