### PR TITLE
Add a template deduction guide for constructing Span from std::array.

### DIFF
--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -54,8 +54,9 @@ public:
         VerifyOrDie(databuf != nullptr || datalen == 0); // not constexpr on some platforms
     }
 
-    // A Span can only point to null if it is empty (size == 0). The default constructor
-    // should be used to construct empty Spans. All other cases involving null are invalid.
+    // The only valid length for a span pointing to null is 0 (i.e. it's an empty span).  Disallow
+    // construction of spans from compile-time-known null.  The default constructor should be used
+    // to construct empty Spans. All other cases involving null are invalid.
     Span(std::nullptr_t null, size_t size) = delete;
 
     // Creates a Span view of a plain array.
@@ -210,6 +211,8 @@ template <class T>
 Span(T * data, size_t size) -> Span<T>;
 template <class T, size_t N>
 Span(T (&databuf)[N]) -> Span<T>;
+template <class T, size_t N>
+Span(const std::array<T, N> & data) -> Span<T>;
 
 inline namespace literals {
 

--- a/src/lib/support/Span.h
+++ b/src/lib/support/Span.h
@@ -212,7 +212,9 @@ Span(T * data, size_t size) -> Span<T>;
 template <class T, size_t N>
 Span(T (&databuf)[N]) -> Span<T>;
 template <class T, size_t N>
-Span(const std::array<T, N> & data) -> Span<T>;
+Span(std::array<T, N> & data) -> Span<T>;
+template <class T, size_t N>
+Span(const std::array<T, N> & data) -> Span<const T>;
 
 inline namespace literals {
 

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -366,16 +366,26 @@ void PassSpanArg(const Span<T> &)
 
 TEST(TestSpan, TestConstructorTypeDeduction)
 {
-    const uint8_t nums[]      = { 1, 2 };
-    const uint8_t otherNums[] = { 1, 2, 3 };
+    const uint8_t nums[]                              = { 1, 2 };
+    const uint8_t otherNums[]                         = { 1, 2, 3 };
+    std::array<uint8_t, 2> numsArray                  = { 1, 2 };
+    const std::array<const uint8_t, 2> constNumsArray = { 1, 2 };
 
     // These will fail to compile if type deduction is not working correctly.
     PassSpanArg(Span(nums));
     PassSpanArg(Span(nums, 1));
+    PassSpanArg(Span(numsArray));
+    PassSpanArg(Span(constNumsArray));
 
     Span a(nums);
     EXPECT_TRUE(a.data_equal(Span<const uint8_t>(otherNums, 2)));
 
     Span b(nums, 1);
     EXPECT_TRUE(b.data_equal(Span<const uint8_t>(otherNums, 1)));
+
+    Span c(numsArray);
+    EXPECT_TRUE(c.data_equal(Span<const uint8_t>(otherNums, 2)));
+
+    Span d(constNumsArray);
+    EXPECT_TRUE(c.data_equal(Span<const uint8_t>(otherNums, 2)));
 }

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <array>
+#include <type_traits>
 
 #include <pw_unit_test/framework.h>
 
@@ -367,6 +368,7 @@ void PassSpanArg(const Span<T> &)
 TEST(TestSpan, TestConstructorTypeDeduction)
 {
     const uint8_t nums[]                                   = { 1, 2 };
+    uint8_t nonConstNums[]                                 = { 1, 2 };
     const uint8_t otherNums[]                              = { 1, 2, 3 };
     std::array<uint8_t, 2> numsArray                       = { 1, 2 };
     const std::array<uint8_t, 2> numsConstArray            = { 1, 2 };
@@ -377,23 +379,34 @@ TEST(TestSpan, TestConstructorTypeDeduction)
     PassSpanArg(Span(nums));
     PassSpanArg(Span(nums, 1));
     PassSpanArg(Span(numsArray));
+    PassSpanArg(Span(numsConstArray));
     PassSpanArg(Span(constNumsArray));
+    PassSpanArg(Span(constNumsConstArray));
 
     Span a(nums);
     EXPECT_TRUE(a.data_equal(Span<const uint8_t>(otherNums, 2)));
+    static_assert(std::is_same_v<decltype(a), Span<const uint8_t>>);
+
+    static_assert(std::is_same_v<decltype(Span(nonConstNums)), Span<uint8_t>>);
 
     Span b(nums, 1);
     EXPECT_TRUE(b.data_equal(Span<const uint8_t>(otherNums, 1)));
 
     Span c(numsArray);
     EXPECT_TRUE(c.data_equal(Span<const uint8_t>(otherNums, 2)));
+    static_assert(std::is_same_v<decltype(c), Span<uint8_t>>);
+    c[0] = 42;
+    EXPECT_EQ(numsArray[0], 42); // Verify the underlying array was modified.
 
     Span d(numsConstArray);
     EXPECT_TRUE(d.data_equal(Span<const uint8_t>(otherNums, 2)));
+    static_assert(std::is_same_v<decltype(d), Span<const uint8_t>>);
 
     Span e(constNumsArray);
     EXPECT_TRUE(e.data_equal(Span<const uint8_t>(otherNums, 2)));
+    static_assert(std::is_same_v<decltype(e), Span<const uint8_t>>);
 
     Span f(constNumsConstArray);
     EXPECT_TRUE(f.data_equal(Span<const uint8_t>(otherNums, 2)));
+    static_assert(std::is_same_v<decltype(f), Span<const uint8_t>>);
 }

--- a/src/lib/support/tests/TestSpan.cpp
+++ b/src/lib/support/tests/TestSpan.cpp
@@ -366,10 +366,12 @@ void PassSpanArg(const Span<T> &)
 
 TEST(TestSpan, TestConstructorTypeDeduction)
 {
-    const uint8_t nums[]                              = { 1, 2 };
-    const uint8_t otherNums[]                         = { 1, 2, 3 };
-    std::array<uint8_t, 2> numsArray                  = { 1, 2 };
-    const std::array<const uint8_t, 2> constNumsArray = { 1, 2 };
+    const uint8_t nums[]                                   = { 1, 2 };
+    const uint8_t otherNums[]                              = { 1, 2, 3 };
+    std::array<uint8_t, 2> numsArray                       = { 1, 2 };
+    const std::array<uint8_t, 2> numsConstArray            = { 1, 2 };
+    std::array<const uint8_t, 2> constNumsArray            = { 1, 2 };
+    const std::array<const uint8_t, 2> constNumsConstArray = { 1, 2 };
 
     // These will fail to compile if type deduction is not working correctly.
     PassSpanArg(Span(nums));
@@ -386,6 +388,12 @@ TEST(TestSpan, TestConstructorTypeDeduction)
     Span c(numsArray);
     EXPECT_TRUE(c.data_equal(Span<const uint8_t>(otherNums, 2)));
 
-    Span d(constNumsArray);
-    EXPECT_TRUE(c.data_equal(Span<const uint8_t>(otherNums, 2)));
+    Span d(numsConstArray);
+    EXPECT_TRUE(d.data_equal(Span<const uint8_t>(otherNums, 2)));
+
+    Span e(constNumsArray);
+    EXPECT_TRUE(e.data_equal(Span<const uint8_t>(otherNums, 2)));
+
+    Span f(constNumsConstArray);
+    EXPECT_TRUE(f.data_equal(Span<const uint8_t>(otherNums, 2)));
 }


### PR DESCRIPTION
This allows doing:

    Span something(someStdArray);

without specifying the type of the entries explicitly.

Also fixes confusing comment that sounded like 0-length spans are only allowed to point to a null buffer (which is just not true).

#### Testing

Unit tests added.