### PR TITLE
[Silabs] UART RAM usage reduction

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -336,6 +336,7 @@ cstdint
 csu
 csv
 ctl
+CTS
 ctrl
 ctypes
 CurrentHue
@@ -1276,6 +1277,7 @@ rtd
 RTL
 rtld
 RTOS
+RTS
 RTT
 RTX
 runArgs

--- a/examples/air-quality-sensor-app/silabs/README.md
+++ b/examples/air-quality-sensor-app/silabs/README.md
@@ -11,6 +11,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
         -   [Mac OS X](#mac-os-x)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
             -   [On Border Router:](#on-border-router)
@@ -169,6 +171,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -214,6 +218,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/dishwasher-app/silabs/README.md
+++ b/examples/dishwasher-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of Matter on the Silicon Labs EFR32 MG24 boards.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Commissioning](#commissioning)
 
@@ -126,6 +128,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -167,6 +171,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/energy-management-app/silabs/README.md
+++ b/examples/energy-management-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG12 and MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Running RPC console](#running-rpc-console)
@@ -163,6 +165,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -208,6 +212,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/light-switch-app/silabs/README.md
+++ b/examples/light-switch-app/silabs/README.md
@@ -11,6 +11,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
         -   [Mac OS X](#mac-os-x)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
             -   [On Border Router:](#on-border-router)
@@ -169,6 +171,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -212,6 +216,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/lighting-app/silabs/README.md
+++ b/examples/lighting-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt-recommended)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Running RPC console](#running-rpc-console)
@@ -159,6 +161,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT (recommended)
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -202,6 +206,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/lit-icd-app/silabs/README.md
+++ b/examples/lit-icd-app/silabs/README.md
@@ -11,6 +11,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
         -   [Mac OS X](#mac-os-x)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
             -   [On Border Router:](#on-border-router)
@@ -154,6 +156,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -197,6 +201,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/lock-app/silabs/README.md
+++ b/examples/lock-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Memory settings](#memory-settings)
@@ -176,6 +178,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -225,6 +229,25 @@ combination with JLinkRTTClient as follows:
           ```
           $ JLinkRTTClient
           ```
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/platform/silabs/MatterConfig.cpp
+++ b/examples/platform/silabs/MatterConfig.cpp
@@ -174,7 +174,7 @@ constexpr osThreadAttr_t kMainTaskAttr = { .name       = "main",
 #ifdef SLI_SI91X_MCU_INTERFACE
                                            .priority = osPriorityRealtime4
 #else
-                                           .priority = osPriorityRealtime7
+                                           .priority = osPriorityRealtime5 // Must be above BLE Link Layer priority
 #endif // SLI_SI91X_MCU_INTERFACE
 };
 osThreadId_t sMainTaskHandle;

--- a/examples/platform/silabs/matter-platform.slcp
+++ b/examples/platform/silabs/matter-platform.slcp
@@ -94,6 +94,9 @@ configuration:
   value: 0
 - {name: SL_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED, value: '0'}
 - {name: SL_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED, value: '1'}
+- condition: [uartdrv_eusart]
+  name: SL_UARTDRV_EUSART_VCOM_BAUDRATE
+  value: '921600'
 - condition: [uartdrv_usart]
   name: UARTDRV_RESTRICT_ENERGY_MODE_TO_ALLOW_RECEPTION
   value: '1'

--- a/examples/pump-app/silabs/README.md
+++ b/examples/pump-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Device Tracing](#device-tracing)
@@ -149,6 +151,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -192,6 +196,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/refrigerator-app/silabs/README.md
+++ b/examples/refrigerator-app/silabs/README.md
@@ -11,6 +11,8 @@ Wi-Fi Boards.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [OTA Software Update](#ota-software-update)
@@ -159,6 +161,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -202,6 +206,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/smoke-co-alarm-app/silabs/README.md
+++ b/examples/smoke-co-alarm-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [Memory settings](#memory-settings)
@@ -166,6 +168,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -215,6 +219,25 @@ combination with JLinkRTTClient as follows:
           ```
           $ JLinkRTTClient
           ```
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/thermostat/silabs/README.md
+++ b/examples/thermostat/silabs/README.md
@@ -11,6 +11,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
         -   [Mac OS X](#mac-os-x)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
             -   [On Border Router:](#on-border-router)
@@ -165,6 +167,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -208,6 +212,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/examples/window-app/silabs/README.md
+++ b/examples/window-app/silabs/README.md
@@ -9,6 +9,8 @@ An example showing the use of CHIP on the Silicon Labs EFR32 MG24.
     -   [Building](#building)
     -   [Flashing the Application](#flashing-the-application)
     -   [Viewing Logging Output](#viewing-logging-output)
+        -   [SeggerRTT](#segger-rtt)
+        -   [Serial Console](#console-log)
     -   [Running the Complete Example](#running-the-complete-example)
         -   [Notes](#notes)
     -   [OTA Software Update](#ota-software-update)
@@ -154,6 +156,8 @@ Releases page on
 
 ## Viewing Logging Output
 
+### SEGGER RTT
+
 The example application is built to use the SEGGER Real Time Transfer (RTT)
 facility for log output. RTT is a feature built-in to the J-Link Interface MCU
 on the WSTK development board. It allows bi-directional communication with an
@@ -197,6 +201,25 @@ combination with JLinkRTTClient as follows:
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
           $ JLinkRTTClient
+
+### Console Log
+
+If the binary was built with this option or if you're using the Siwx917 WiFi
+SoC, the logs and the CLI (if enabled) will be available on the serial console.
+This console required a baudrate of **921600** with CTS/RTS.
+
+#### Configuring the VCOM
+
+-   Using (Simplicity
+    Studio)[https://community.silabs.com/s/article/wstk-virtual-com-port-baudrate-setting?language=en_US]
+-   Using commander-cli
+    ```
+    commander vcom config --baudrate 921600 --handshake none
+    ```
+
+### Using the console
+
+With any serial terminal application such as screen, putty, minicom etc.
 
 ## Running the Complete Example
 

--- a/scripts/examples/gn_silabs_example.sh
+++ b/scripts/examples/gn_silabs_example.sh
@@ -242,7 +242,7 @@ else
             #    shift
             #    ;;
             --release)
-                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false "
+                optArgs+="is_debug=false disable_lcd=true chip_build_libshell=false enable_openthread_cli=false use_external_flash=false chip_logging=false silabs_log_enabled=false sl_uart_log_output=false "
                 shift
                 ;;
             --bootloader)


### PR DESCRIPTION
#### Summary
Reduces the amount of log that needs buffering when using the serial console by increasing the baudrate and the log task priority.

#### Related issues

No direct issue linked, only high ram usage when compiling with UART logs enabled.

#### Testing

It was tested for EFR32MG24 platform through our internal SQA pipeline  
