### PR TITLE
ESP32: enable GetRotatingDeviceIdUniqueId() only when device instance…

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -131,6 +131,7 @@ CHIP_ERROR ESP32SecureCertDataProvider::GetSpake2pVerifier(MutableByteSpan & ver
     return CHIP_NO_ERROR;
 }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 CHIP_ERROR ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
 {
 #if CHIP_ENABLE_ROTATING_DEVICE_ID
@@ -140,6 +141,7 @@ CHIP_ERROR ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(MutableByteS
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif // CHIP_ENABLE_ROTATING_DEVICE_ID
 }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -43,8 +43,10 @@ public:
     CHIP_ERROR GetSpake2pSalt(MutableByteSpan & saltBuf) override;
     CHIP_ERROR GetSpake2pVerifier(MutableByteSpan & verifierBuf, size_t & verifierLen) override;
 
+#if CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
     // GetRotatingDeviceIdUniqueId from GenericDeviceInstanceInfoProvider
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
… info provider is enabled

Guard the GetRotatingDeviceIdUniqueId() API behind the device instance info provider config. Without this, referencing the API without enabling the config may lead to compilation failures.

Also aligns the macro guards with the ESP32FactoryDataProvider (https://github.com/project-chip/connectedhomeip/blob/master/src/platform/ESP32/ESP32FactoryDataProvider.h#L94)

#### Summary
```
/Users/shubhampatil/esp/esp-matter/connectedhomeip/connectedhomeip/src/platform/ESP32/ESP32SecureCertDataProvider.h:47:16: error: 'CHIP_ERROR chip::DeviceLayer::ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(chip::MutableByteSpan&)' marked 'override', but does not override
   47 |     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
ninja failed with exit code 1, output of the command is in the /Users/shubhampatil/esp/esp-matter/examples/demo/badge/build/log/idf_py_stderr_output_78671 and /Users/shubhampatil/esp/esp-matter/examples/demo/badge/build/log/idf_py_stdout_output_78671
```

#### Related issues

#### Testing
- Locally built the example using `idf.py build` and above error goes away

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
