### PR TITLE
[NXP] Update NXP SDK docker image to 25.06.00 version

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-153 : [Ameba] Update SDK docker to ameba_update_2025_07_18
+154 : [NXP] Update NXP SDK docker to 25.06.00 version

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-154 : [NXP] Update NXP SDK docker to 25.06.00 version
+154 : [NXP] Update NXP SDK docker to 25.06.00

--- a/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-nxp/Dockerfile
@@ -13,9 +13,9 @@ WORKDIR /opt/nxp/
 RUN set -x \
     && git clone https://github.com/NXP/nxp_matter_support.git \
     && cd nxp_matter_support \
-    # Checkout commit aligned with updated west manifest using MCUX SDK 25.03.00,
+    # Checkout commit aligned with updated west manifest using MCUX SDK 25.06.00,
     # including patches for Matter support in specific components
-    && git checkout 873a8c4c5425652613cde447b0f0a8f321b51618 \
+    && git checkout deb06197654ed2e4a688be05467a0954b91fd61d \
     && pip3 install --break-system-packages -U --no-cache-dir west \
     && ./scripts/update_nxp_sdk.py --platform common \
     && : # last line


### PR DESCRIPTION
#### Summary

This PR is updating the NXP SDK docker image to get MCUX SDK 25.06.00 version.

#### Testing

Testing done by building and running locally the docker image.

