### PR TITLE
[Chef] Minor Fix - Color temperature light - remove commands associated with CL feature as it is not supported.

### DIFF
--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.matter
@@ -2477,10 +2477,6 @@ endpoint 1 {
     ram      attribute clusterRevision default = 7;
 
     handle command MoveToColorTemperature;
-    handle command EnhancedMoveHue;
-    handle command EnhancedStepHue;
-    handle command EnhancedMoveToHueAndSaturation;
-    handle command ColorLoopSet;
     handle command StopMoveStep;
     handle command MoveColorTemperature;
     handle command StepColorTemperature;

--- a/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
+++ b/examples/chef/devices/rootnode_colortemperaturelight_hbUnzYVeyn.zap
@@ -3220,38 +3220,6 @@
               "isEnabled": 1
             },
             {
-              "name": "EnhancedMoveHue",
-              "code": 65,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
-              "name": "EnhancedStepHue",
-              "code": 66,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
-              "name": "EnhancedMoveToHueAndSaturation",
-              "code": 67,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
-              "name": "ColorLoopSet",
-              "code": 68,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            },
-            {
               "name": "StopMoveStep",
               "code": 71,
               "mfgCode": null,


### PR DESCRIPTION
#### Summary

[Chef] Minor Fix - Color temperature light - remove commands associated with CL feature as it is not supported.

#### Testing

Commission -
```
/chip-tool pairing onnetwork 0x20 20202021
```

Read accepted command list -
```
./chip-tool colorcontrol read accepted-command-list 0x20 1
```
```
[TOO] Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_FFF9 DataVersion: 2048785196
[TOO]   AcceptedCommandList: 4 entries
[TOO]     [1]: 10 (MoveToColorTemperature)
[TOO]     [2]: 71 (StopMoveStep)
[TOO]     [3]: 75 (MoveColorTemperature)
[TOO]     [4]: 76 (StepColorTemperature)
```
