### PR TITLE
Update IsAttributeEnabled functions to support dynamic and static endpoints for code driven clusters

### DIFF
--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -48,11 +48,14 @@ void emberAfGeneralDiagnosticsClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrDie(endpointId == kRootEndpointId);
     const GeneralDiagnosticsEnabledAttributes enabledAttributes{
-        .enableTotalOperationalHours = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::TotalOperationalHours::Id),
-        .enableBootReason            = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::BootReason::Id),
-        .enableActiveHardwareFaults  = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveHardwareFaults::Id),
-        .enableActiveRadioFaults     = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveRadioFaults::Id),
-        .enableActiveNetworkFaults   = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveNetworkFaults::Id),
+        .enableTotalOperationalHours =
+            emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::TotalOperationalHours::Id),
+        .enableBootReason = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::BootReason::Id),
+        .enableActiveHardwareFaults =
+            emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveHardwareFaults::Id),
+        .enableActiveRadioFaults = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveRadioFaults::Id),
+        .enableActiveNetworkFaults =
+            emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveNetworkFaults::Id),
     };
 
 #if defined(ZCL_USING_TIME_SYNCHRONIZATION_CLUSTER_SERVER) || defined(GENERAL_DIAGNOSTICS_ENABLE_PAYLOAD_TEST_REQUEST_CMD)

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -42,7 +42,7 @@ LazyRegisteredServerCluster<GeneralDiagnosticsClusterFullConfigurable> gServer;
 LazyRegisteredServerCluster<GeneralDiagnosticsCluster> gServer;
 #endif
 
-// Check if attribute is enabled (statically or dynamically) through ember read
+// Check if attribute is enabled (statically or dynamically) through ember
 bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 {
     return emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, attributeId);

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -42,22 +42,17 @@ LazyRegisteredServerCluster<GeneralDiagnosticsClusterFullConfigurable> gServer;
 LazyRegisteredServerCluster<GeneralDiagnosticsCluster> gServer;
 #endif
 
-// Check if attribute is enabled (statically or dynamically) through ember
-bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
-{
-    return emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, attributeId);
-}
 } // namespace
 
 void emberAfGeneralDiagnosticsClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrDie(endpointId == kRootEndpointId);
     const GeneralDiagnosticsEnabledAttributes enabledAttributes{
-        .enableTotalOperationalHours = IsAttributeEnabled(endpointId, Attributes::TotalOperationalHours::Id),
-        .enableBootReason            = IsAttributeEnabled(endpointId, Attributes::BootReason::Id),
-        .enableActiveHardwareFaults  = IsAttributeEnabled(endpointId, Attributes::ActiveHardwareFaults::Id),
-        .enableActiveRadioFaults     = IsAttributeEnabled(endpointId, Attributes::ActiveRadioFaults::Id),
-        .enableActiveNetworkFaults   = IsAttributeEnabled(endpointId, Attributes::ActiveNetworkFaults::Id),
+        .enableTotalOperationalHours = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::TotalOperationalHours::Id),
+        .enableBootReason            = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::BootReason::Id),
+        .enableActiveHardwareFaults  = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveHardwareFaults::Id),
+        .enableActiveRadioFaults     = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveRadioFaults::Id),
+        .enableActiveNetworkFaults   = emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, Attributes::ActiveNetworkFaults::Id),
     };
 
 #if defined(ZCL_USING_TIME_SYNCHRONIZATION_CLUSTER_SERVER) || defined(GENERAL_DIAGNOSTICS_ENABLE_PAYLOAD_TEST_REQUEST_CMD)

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -19,6 +19,7 @@
 #include <app/clusters/general-diagnostics-server/general-diagnostics-cluster.h>
 #include <app/static-cluster-config/GeneralDiagnostics.h>
 #include <app/util/config.h>
+#include <app/util/util.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 using namespace chip;
@@ -41,24 +42,10 @@ LazyRegisteredServerCluster<GeneralDiagnosticsClusterFullConfigurable> gServer;
 LazyRegisteredServerCluster<GeneralDiagnosticsCluster> gServer;
 #endif
 
-// compile-time evaluated method if "is <EP>::GeneralDiagnostics::<ATTR>" enabled
-constexpr bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
+// Check if attribute is enabled (statically or dynamically) through ember read
+bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 {
-    for (auto & config : GeneralDiagnostics::StaticApplicationConfig::kFixedClusterConfig)
-    {
-        if (config.endpointNumber != endpointId)
-        {
-            continue;
-        }
-        for (auto & attr : config.enabledAttributes)
-        {
-            if (attr == attributeId)
-            {
-                return true;
-            }
-        }
-    }
-    return false;
+    return emberAfContainsAttribute(endpointId, GeneralDiagnostics::Id, attributeId);
 }
 } // namespace
 

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -42,10 +42,11 @@ void emberAfSoftwareDiagnosticsClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     const SoftwareDiagnosticsEnabledAttributes enabledAttributes{
-        .enableThreadMetrics     = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::ThreadMetrics::Id),
-        .enableCurrentHeapFree   = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapFree::Id),
-        .enableCurrentHeapUsed   = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapUsed::Id),
-        .enableCurrentWatermarks = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapHighWatermark::Id),
+        .enableThreadMetrics   = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::ThreadMetrics::Id),
+        .enableCurrentHeapFree = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapFree::Id),
+        .enableCurrentHeapUsed = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapUsed::Id),
+        .enableCurrentWatermarks =
+            emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapHighWatermark::Id),
     };
 
     gServer.Create(enabledAttributes);

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -36,7 +36,7 @@ namespace {
 
 LazyRegisteredServerCluster<SoftwareDiagnosticsServerCluster> gServer;
 
-// Check if attribute is enabled (statically or dynamically) through ember read
+// Check if attribute is enabled (statically or dynamically) through ember
 bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 {
     return emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, attributeId);

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -36,22 +36,16 @@ namespace {
 
 LazyRegisteredServerCluster<SoftwareDiagnosticsServerCluster> gServer;
 
-// Check if attribute is enabled (statically or dynamically) through ember
-bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
-{
-    return emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, attributeId);
-}
-
 } // namespace
 
 void emberAfSoftwareDiagnosticsClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     const SoftwareDiagnosticsEnabledAttributes enabledAttributes{
-        .enableThreadMetrics     = IsAttributeEnabled(kRootEndpointId, Attributes::ThreadMetrics::Id),
-        .enableCurrentHeapFree   = IsAttributeEnabled(kRootEndpointId, Attributes::CurrentHeapFree::Id),
-        .enableCurrentHeapUsed   = IsAttributeEnabled(kRootEndpointId, Attributes::CurrentHeapUsed::Id),
-        .enableCurrentWatermarks = IsAttributeEnabled(kRootEndpointId, Attributes::CurrentHeapHighWatermark::Id),
+        .enableThreadMetrics     = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::ThreadMetrics::Id),
+        .enableCurrentHeapFree   = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapFree::Id),
+        .enableCurrentHeapUsed   = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapUsed::Id),
+        .enableCurrentWatermarks = emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, Attributes::CurrentHeapHighWatermark::Id),
     };
 
     gServer.Create(enabledAttributes);

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -18,6 +18,7 @@
 #include <app/clusters/software-diagnostics-server/software-diagnostics-logic.h>
 #include <app/static-cluster-config/SoftwareDiagnostics.h>
 #include <app/util/attribute-storage.h>
+#include <app/util/util.h>
 #include <data-model-providers/codegen/CodegenDataModelProvider.h>
 
 using namespace chip;
@@ -35,24 +36,10 @@ namespace {
 
 LazyRegisteredServerCluster<SoftwareDiagnosticsServerCluster> gServer;
 
-// compile-time evaluated method if "is <EP>::SoftwareDiagnostics::<ATTR>" enabled
-constexpr bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
+// Check if attribute is enabled (statically or dynamically) through ember read
+bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 {
-    for (auto & config : SoftwareDiagnostics::StaticApplicationConfig::kFixedClusterConfig)
-    {
-        if (config.endpointNumber != endpointId)
-        {
-            continue;
-        }
-        for (auto & attr : config.enabledAttributes)
-        {
-            if (attr == attributeId)
-            {
-                return true;
-            }
-        }
-    }
-    return false;
+    return emberAfContainsAttribute(endpointId, SoftwareDiagnostics::Id, attributeId);
 }
 
 } // namespace


### PR DESCRIPTION
#### Summary

This PR updates the code for the ```IsAttributeEnabled``` functions in the ```CodegenIntegration.cpp``` files of the code driven clusters, to support checking enabled attributes for both static and dynamic endpoints. The original code would not support checking attributes being enabled for attributes made at run-time. 

#### Related issues

#40172 

#### Testing

- CI should still pass
- Did some local testing using ```MockNodeConfig``` with the ember call used in the ```IsAttributeEnabled``` function to ensure attributes are found. Also tested in debugger to ensure attributes enabled/disabled from zap are detected through the ember call 