### PR TITLE
Restrict controller apps to scan and pair only with JF-compatible devices

### DIFF
--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.cpp
@@ -23,8 +23,13 @@
 
 using namespace ::chip;
 
-void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const chip::Dnssd::CommissionNodeData & nodeData)
+void DiscoverCommissionablesCommandBase::OnDiscoveredDevice(const Dnssd::CommissionNodeData & nodeData)
 {
+    if (mCommissioningMode.HasValue() && nodeData.commissioningMode != mCommissioningMode.Value())
+    {
+        return; // Skip nodes that do not match the commissioning mode filter.
+    }
+
     nodeData.LogDetail();
     LogErrorOnFailure(RemoteDataModelLogger::LogDiscoveredNodeData(nodeData));
 

--- a/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionablesCommand.h
@@ -20,6 +20,8 @@
 
 #include "../common/CHIPCommand.h"
 
+#include <lib/dnssd/Advertiser.h>
+
 class DiscoverCommissionablesCommandBase : public CHIPCommand, public chip::Controller::DeviceDiscoveryDelegate
 {
 public:
@@ -38,6 +40,8 @@ public:
 
 protected:
     chip::Controller::DeviceCommissioner * mCommissioner;
+
+    chip::Optional<uint64_t> mCommissioningMode;
 
 private:
     chip::Optional<bool> mDiscoverOnce;
@@ -121,7 +125,12 @@ class DiscoverCommissionableByCommissioningModeCommand : public DiscoverCommissi
 public:
     DiscoverCommissionableByCommissioningModeCommand(CredentialIssuerCommands * credsIssuerConfig) :
         DiscoverCommissionablesCommandBase("find-commissionable-by-commissioning-mode", credsIssuerConfig)
-    {}
+    {
+        AddArgument("commissioning-mode", chip::to_underlying(chip::Dnssd::CommissioningMode::kEnabledBasic),
+                    chip::to_underlying(chip::Dnssd::CommissioningMode::kEnabledJointFabric), &mCommissioningMode,
+                    "Optional integer value representing the commissioning mode to filter devices. If provided, only devices with "
+                    "the specified commissioning mode will be discovered.");
+    }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;

--- a/examples/jf-control-app/commands/pairing/PairingCommand.h
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.h
@@ -332,7 +332,6 @@ private:
     bool mDeviceIsICD = false;
     uint8_t mRandomGeneratedICDSymmetricKey[chip::Crypto::kAES_CCM128_Key_Length];
 
-    chip::Optional<bool> mExecuteJCM;
     ::pw::rpc::NanopbClientReader<::RequestOptions> rpcGetStream;
 
     // For unpair

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -3805,5 +3805,15 @@ CHIP_ERROR DeviceController::GetRootPublicKey(Crypto::P256PublicKey & outRootPub
     return fabricTable->FetchRootPubkey(mFabricIndex, outRootPublicKey);
 }
 
+bool DeviceCommissioner::HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData)
+{
+    if (nodeData.commissioningMode == to_underlying(Dnssd::CommissioningMode::kDisabled))
+    {
+        ChipLogProgress(Controller, "Discovered device does not have an open commissioning window.");
+        return false;
+    }
+    return true;
+}
+
 } // namespace Controller
 } // namespace chip

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -836,6 +836,9 @@ public:
                                          /* fireAndForget = */ true);
     }
 
+    // Check if the commissioning mode is valid for the current commissioning parameters.
+    virtual bool HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData);
+
 protected:
     // Cleans up and resets failsafe as appropriate depending on the error and the failed stage.
     // For success, sends completion report with the CommissioningDelegate and sends callbacks to the PairingDelegate

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -491,11 +491,9 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     }
 
     const Dnssd::CommissionNodeData & nodeData = discNodeData.Get<Dnssd::CommissionNodeData>();
-    if (nodeData.commissioningMode == 0)
-    {
-        ChipLogProgress(Controller, "Discovered device does not have an open commissioning window.");
-        return false;
-    }
+
+    VerifyOrReturnError(mCommissioner != nullptr, false);
+    VerifyOrReturnError(mCommissioner->HasValidCommissioningMode(nodeData), false);
 
     // Check whether this matches one of our setup payloads.
     for (auto & payload : mSetupPayloads)

--- a/src/controller/jcm/DeviceCommissioner.cpp
+++ b/src/controller/jcm/DeviceCommissioner.cpp
@@ -24,6 +24,7 @@
 #include <credentials/CHIPCert.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPError.h>
+#include <lib/dnssd/Advertiser.h>
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -532,6 +533,25 @@ void DeviceCommissioner::CleanupCommissioning(DeviceProxy * proxy, NodeId nodeId
     chip::Controller::DeviceCommissioner::CleanupCommissioning(proxy, nodeId, completionStatus);
 
     mInfo.Cleanup();
+}
+
+bool DeviceCommissioner::HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData)
+{
+    if (GetCommissioningParameters().HasValue() && GetCommissioningParameters().Value().GetUseJCM().ValueOr(false))
+    {
+        if (nodeData.commissioningMode != to_underlying(Dnssd::CommissioningMode::kEnabledJointFabric))
+        {
+            ChipLogProgress(Controller, "Discovered device has a commissioning mode (%u) that is not supported by JCM.",
+                            static_cast<unsigned>(nodeData.commissioningMode));
+            return false;
+        }
+    }
+    else
+    {
+        return chip::Controller::DeviceCommissioner::HasValidCommissioningMode(nodeData);
+    }
+
+    return true;
 }
 
 } // namespace JCM

--- a/src/controller/jcm/DeviceCommissioner.h
+++ b/src/controller/jcm/DeviceCommissioner.h
@@ -88,6 +88,8 @@ public:
      */
     TrustVerificationInfo & GetTrustVerificationInfo() { return mInfo; }
 
+    bool HasValidCommissioningMode(const Dnssd::CommissionNodeData & nodeData) override;
+
 protected:
     // Override ParseExtraCommissioningInfo to parse JCM administrator info
     CHIP_ERROR ParseExtraCommissioningInfo(ReadCommissioningInfo & info, const CommissioningParameters & params) override;


### PR DESCRIPTION
#### Summary
Restrict controller apps to scan and pair only with JF-compatible devices when JF commissioning flow is triggered with "--jcm true"
- JF-Compatible devices advertise CM=3

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/39062.

#### Testing
Verified using the below instructions.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```