### PR TITLE
[Silabs] Revert the software version string fix

### DIFF
--- a/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageDefault.cpp
@@ -365,28 +365,6 @@ CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & 
     return SilabsConfig::ReadConfigValueBin(SilabsConfig::kConfigKey_PersistentUniqueId, value, max, size);
 }
 
-CHIP_ERROR Storage::SetSoftwareVersionString(const char * value, size_t len)
-{
-    return SilabsConfig::WriteConfigValueStr(SilabsConfig::kConfigKey_SoftwareVersionString, value, len);
-}
-
-CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
-{
-    size_t hw_version_len = 0; // Without counting null-terminator
-
-    CHIP_ERROR err = SilabsConfig::ReadConfigValueStr(SilabsConfig::kConfigKey_SoftwareVersionString, value, max, hw_version_len);
-#if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
-    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == err)
-    {
-        VerifyOrReturnError(value != nullptr, CHIP_ERROR_NO_MEMORY);
-        VerifyOrReturnError(max > strlen(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
-        Platform::CopyString(value, max, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
-        err = CHIP_NO_ERROR;
-    }
-#endif
-    return err;
-}
-
 //
 // CommissionableDataProvider
 //

--- a/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
+++ b/examples/platform/silabs/provision/ProvisionStorageFlash.cpp
@@ -487,28 +487,6 @@ CHIP_ERROR Storage::GetPersistentUniqueId(uint8_t * value, size_t max, size_t & 
     return Flash::Get(Parameters::ID::kPersistentUniqueId, value, max, size);
 }
 
-CHIP_ERROR Storage::SetSoftwareVersionString(const char * value, size_t len)
-{
-    return Flash::Set(Parameters::ID::kSwVersionStr, value, len);
-}
-
-CHIP_ERROR Storage::GetSoftwareVersionString(char * value, size_t max)
-{
-    size_t size    = 0;
-    CHIP_ERROR err = Flash::Get(Parameters::ID::kSwVersionStr, value, max, size);
-
-#if defined(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING)
-    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == err)
-    {
-        VerifyOrReturnError(value != nullptr, CHIP_ERROR_NO_MEMORY);
-        VerifyOrReturnError(max > strlen(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
-        Platform::CopyString(value, max, CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
-        err = CHIP_NO_ERROR;
-    }
-#endif
-    return err;
-}
-
 //
 // CommissionableDataProvider
 //

--- a/src/platform/silabs/SilabsConfig.h
+++ b/src/platform/silabs/SilabsConfig.h
@@ -145,7 +145,6 @@ public:
     static constexpr Key kConfigKey_clientid               = SilabsConfigKey(kMatterFactory_KeyBase, 0x16);
     static constexpr Key kConfigKey_Test_Event_Trigger_Key = SilabsConfigKey(kMatterFactory_KeyBase, 0x17);
     static constexpr Key kConfigKey_HardwareVersion        = SilabsConfigKey(kMatterFactory_KeyBase, 0x18);
-    static constexpr Key kConfigKey_SoftwareVersionString  = SilabsConfigKey(kMatterFactory_KeyBase, 0x19);
     // kConfigKey_PersistentUniqueId is the inputkey in the generating of the Rotating Device ID
     // SHALL NOT be the same as the UniqueID attribute exposed in the Basic Information cluster.
     static constexpr Key kConfigKey_PersistentUniqueId = SilabsConfigKey(kMatterFactory_KeyBase, 0x1F);


### PR DESCRIPTION
#### Summary
As updated, the software version string is reverting as per the issue https://github.com/project-chip/connectedhomeip/issues/40193
The change which was done for the silabs is also getting reverted. Parts of the PR which had the Software version string revert. 
https://github.com/project-chip/connectedhomeip/pull/39562/files


#### Testing
Tested locally with 917SoC
