### PR TITLE
Bring back timeout in send commands; Remove try finally block, will c…

### DIFF
--- a/src/python_testing/TC_JCM_1_2.py
+++ b/src/python_testing/TC_JCM_1_2.py
@@ -115,7 +115,8 @@ class TC_JCM_1_2(MatterBaseTest):
         # Commission JF-ADMIN app with JF-Controller on Fabric A
         self.fabric_a_ctrl.send(
             message=f"pairing onnetwork 1 {self.jfadmin_fabric_a_passcode} --anchor true",
-            expected_output="[JF] Anchor Administrator (nodeId=1) commissioned with success")
+            expected_output="[JF] Anchor Administrator (nodeId=1) commissioned with success",
+            timeout=10)
 
         # Extract the Ecosystem A certificates and inject them in the storage that will be provided to a new Python Controller later
         jfcStorage = ConfigParser()
@@ -175,7 +176,8 @@ class TC_JCM_1_2(MatterBaseTest):
         # Commission JF-ADMIN app with JF-Controller on Fabric B
         self.fabric_b_ctrl.send(
             message=f"pairing onnetwork 11 {self.jfadmin_fabric_b_passcode} --anchor true",
-            expected_output="[JF] Anchor Administrator (nodeId=11) commissioned with success")
+            expected_output="[JF] Anchor Administrator (nodeId=11) commissioned with success",
+            timeout=10)
 
         # Extract the Ecosystem B certificates and inject them in the storage that will be provided to a new Python Controller later
         jfcStorage = ConfigParser()
@@ -248,57 +250,55 @@ class TC_JCM_1_2(MatterBaseTest):
             nodeId=201,
             paaTrustStorePath=str(self.matter_test_config.paa_trust_store_path),
             catTags=[int(self.ecoBCATs, 16)])
+
+        self.step("1")
         try:
-            self.step("1")
-            try:
-                response = await devCtrlEcoB.OpenJointCommissioningWindow(
-                    nodeid=11,
-                    endpointId=1,
-                    timeout=400,
-                    iteration=random.randint(1000, 100000),
-                    discriminator=random.randint(0, 4095)
-                )
-            except Exception as e:
-                asserts.assert_true(False, f'Exception {e} occured during OJCW')
+            response = await devCtrlEcoB.OpenJointCommissioningWindow(
+                nodeid=11,
+                endpointId=1,
+                timeout=400,
+                iteration=random.randint(1000, 100000),
+                discriminator=random.randint(0, 4095)
+            )
+        except Exception as e:
+            asserts.assert_true(False, f'Exception {e} occured during OJCW')
 
-            self.step("2")
-            _nodeID = 15
-            self.fabric_a_ctrl.send(
-                message=f"pairing onnetwork {_nodeID} {response.setupPinCode} --jcm true",
-                expected_output=f"[JF] Joint Commissioning Method (nodeId={_nodeID}) success",
-                timeout=10)
+        self.step("2")
+        _nodeID = 15
+        self.fabric_a_ctrl.send(
+            message=f"pairing onnetwork {_nodeID} {response.setupPinCode} --jcm true",
+            expected_output=f"[JF] Joint Commissioning Method (nodeId={_nodeID}) success",
+            timeout=10)
 
-            self.step("3")
-            # Read JF-Admin NOC on Ecoystem B using jfc-app@EcoB
-            response = await devCtrlEcoB.ReadAttribute(
-                nodeid=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)], fabricFiltered=False,
-                returnClusterObject=True)
+        self.step("3")
+        # Read JF-Admin NOC on Ecoystem B using jfc-app@EcoB
+        response = await devCtrlEcoB.ReadAttribute(
+            nodeid=11, attributes=[(0, Clusters.OperationalCredentials.Attributes.NOCs)], fabricFiltered=False,
+            returnClusterObject=True)
 
-            fabricIndex2_noc = None
-            for _nocs in response[0][Clusters.OperationalCredentials].NOCs:
-                if _nocs.fabricIndex == 2:
-                    fabricIndex2_noc = _nocs.noc
-            asserts.assert_is_not_none(fabricIndex2_noc, "No NOC on fabric index 2 found!")
+        fabricIndex2_noc = None
+        for _nocs in response[0][Clusters.OperationalCredentials].NOCs:
+            if _nocs.fabricIndex == 2:
+                fabricIndex2_noc = _nocs.noc
+        asserts.assert_is_not_none(fabricIndex2_noc, "No NOC on fabric index 2 found!")
 
-            # Search Administrator CAT (FFFF0001) in JF-Admin NOC on Ecosystem B
-            noc_tlv_data = chip.tlv.TLVReader(fabricIndex2_noc).get()
-            _admin_cat_found = False
-            for _tag, _value in noc_tlv_data['Any'][6]:
-                if _tag == 22 and _value == int(self.ecoBCATs, 16):
-                    _admin_cat_found = True
-                    break
-            asserts.assert_true(_admin_cat_found, "Administrator CAT not found in Admin App NOC on Ecosystem B")
+        # Search Administrator CAT (FFFF0001) in JF-Admin NOC on Ecosystem B
+        noc_tlv_data = chip.tlv.TLVReader(fabricIndex2_noc).get()
+        _admin_cat_found = False
+        for _tag, _value in noc_tlv_data['Any'][6]:
+            if _tag == 22 and _value == int(self.ecoBCATs, 16):
+                _admin_cat_found = True
+                break
+        asserts.assert_true(_admin_cat_found, "Administrator CAT not found in Admin App NOC on Ecosystem B")
 
-            response = await devCtrlEcoA.ReadAttribute(
-                nodeid=15, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
-                returnClusterObject=True)
-            asserts.assert_not_equal(int('fffe0001', 16), response[0][Clusters.AccessControl].acl[0].subjects,
-                                     "Anchor CAT not found in Subject field of JF-Admin on Fabric A(Joint Fabric)")
+        response = await devCtrlEcoA.ReadAttribute(
+            nodeid=15, attributes=[(0, Clusters.AccessControl.Attributes.Acl)],
+            returnClusterObject=True)
+        asserts.assert_not_equal(int('fffe0001', 16), response[0][Clusters.AccessControl].acl[0].subjects,
+                                 "Anchor CAT not found in Subject field of JF-Admin on Fabric A(Joint Fabric)")
 
-        finally:
-            # Shutdown the Python Controllers started at the beginning of this script
-            devCtrlEcoA.Shutdown()
-            devCtrlEcoB.Shutdown()
+        devCtrlEcoA.Shutdown()
+        devCtrlEcoB.Shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add timeouts in JCM_1_2 test case

#### Summary
Some timeouts were removed from JCM_1_2 tc which may cause a block of the send function. Also remove try finally block as it may throw errors if an assert is raised inside the try block because will call a Shutdown on an object that was destroyed already. 

#### Testing
Manual validation with latest SHA.

