### PR TITLE
Remove temporary aliases first part: Matchers and Timeoperations refactor.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -243,11 +243,6 @@
 	url = https://github.com/matter-mtk/genio-matter-lwip.git
 	branch = main
 	platforms = genio
-[submodule "open-iot-sdk"]
-	path = third_party/open-iot-sdk/sdk
-	url = https://git.gitlab.arm.com/iot/open-iot-sdk/sdk.git
-	branch = main
-	platforms = openiotsdk
 [submodule "bouffalolab_sdk"]
 	path = third_party/bouffalolab/repo
 	url = https://github.com/bouffalolab/bl_iot_sdk_tiny.git

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -19,12 +19,10 @@ import logging
 import random
 import string
 from typing import Optional
-
 from mobly import asserts
-
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 
 class TC_CNET_4_4(MatterBaseTest):
@@ -77,7 +75,7 @@ class TC_CNET_4_4(MatterBaseTest):
             ssid = ssid_to_scan if ssid_to_scan is not None else NullValue
             cmd = cnet.Commands.ScanNetworks(ssid=ssid, breadcrumb=breadcrumb)
             scan_results = await self.send_single_cmd(cmd=cmd)
-            asserts.assert_true(type_matches(scan_results, cnet.Commands.ScanNetworksResponse),
+            asserts.assert_true(matchers.is_type(scan_results, cnet.Commands.ScanNetworksResponse),
                                 "Unexpected value returned from scan network")
             logging.info(f"Scan results: {scan_results}")
 
@@ -99,7 +97,7 @@ class TC_CNET_4_4(MatterBaseTest):
                 asserts.assert_less_equal(len(network.ssid), 32, f"Returned SSID {network.ssid} is too long")
                 if ssid_to_scan is not None:
                     asserts.assert_equal(network.ssid, ssid_to_scan, "Unexpected SSID returned in directed scan")
-                asserts.assert_true(type_matches(network.bssid, bytes), "Incorrect type for BSSID")
+                asserts.assert_true(matchers.is_type(network.bssid, bytes), "Incorrect type for BSSID")
                 asserts.assert_equal(len(network.bssid), 6, "Unexpected length of BSSID")
                 # TODO: this is inherited from the old test plan, but we should match the channel to the supported band. This range is unreasonably large.
                 asserts.assert_less_equal(network.channel, 65535, "Unexpected channel value")

--- a/src/python_testing/TC_CNET_4_4.py
+++ b/src/python_testing/TC_CNET_4_4.py
@@ -19,7 +19,9 @@ import logging
 import random
 import string
 from typing import Optional
+
 from mobly import asserts
+
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers

--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -18,15 +18,13 @@
 import logging
 
 import test_plan_support
-
-
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.testing.matter_asserts import is_valid_bool_value
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches,
-                                           matchers)
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_feature, matchers,
+                                           run_if_endpoint_matches)
 
 
 class TC_CNET_4_9(MatterBaseTest):

--- a/src/python_testing/TC_CNET_4_9.py
+++ b/src/python_testing/TC_CNET_4_9.py
@@ -18,13 +18,15 @@
 import logging
 
 import test_plan_support
+
+
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.testing.matter_asserts import is_valid_bool_value
 from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches,
-                                           type_matches)
+                                           matchers)
 
 
 class TC_CNET_4_9(MatterBaseTest):
@@ -117,7 +119,7 @@ class TC_CNET_4_9(MatterBaseTest):
         result = await self.send_single_cmd(cmd=cmd)
 
         # Verify that DUT sends ArmFailSafeResponse command to the TH
-        asserts.assert_true(type_matches(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected value returned from ArmFailSafe")
 
         # TH reads the Networks attribute list from the DUT on all endpoints (all network commissioning clusters)
@@ -179,7 +181,7 @@ class TC_CNET_4_9(MatterBaseTest):
 
         # Verify that DUT sends NetworkConfigResponse to command with the following fields:
         # NetworkingStatus is success
-        asserts.assert_true(type_matches(result, Clusters.NetworkCommissioning.Commands.NetworkConfigResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.NetworkCommissioning.Commands.NetworkConfigResponse),
                             "Unexpected value returned from RemoveNetwork")
         asserts.assert_equal(result.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
                              "Network status was not successful")
@@ -254,7 +256,7 @@ class TC_CNET_4_9(MatterBaseTest):
         result = await self.send_single_cmd(cmd=cmd)
 
         # Verify that DUT sends ArmFailSafeResponse command to the TH
-        asserts.assert_true(type_matches(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected value returned from ArmFailSafe")
 
         # TTH reads Networks attribute from the DUT on the current endpoint
@@ -280,7 +282,7 @@ class TC_CNET_4_9(MatterBaseTest):
         result = await self.send_single_cmd(cmd=cmd)
 
         # Verify that DUT sends ArmFailSafeResponse command to the TH
-        asserts.assert_true(type_matches(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected value returned from ArmFailSafe")
 
         # TH sends RemoveNetwork Command to the DUT with NetworkID field set to the value provided in the `--wifi-ssid` parameter and Breadcrumb field set to 1
@@ -289,7 +291,7 @@ class TC_CNET_4_9(MatterBaseTest):
         result = await self.send_single_cmd(cmd=cmd)
 
         # Verify that DUT sends NetworkConfigResponse to command with the following fields: NetworkingStatus is success
-        asserts.assert_true(type_matches(result, Clusters.NetworkCommissioning.Commands.NetworkConfigResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.NetworkCommissioning.Commands.NetworkConfigResponse),
                             "Unexpected value returned from RemoveNetwork")
         asserts.assert_equal(result.networkingStatus, Clusters.NetworkCommissioning.Enums.NetworkCommissioningStatusEnum.kSuccess,
                              "Network status was not successful")
@@ -310,7 +312,7 @@ class TC_CNET_4_9(MatterBaseTest):
         result = await self.send_single_cmd(cmd=cmd)
 
         # Verify that DUT sends ArmFailSafeResponse command to the TH
-        asserts.assert_true(type_matches(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected value returned from ArmFailSafe")
 
         # TH reads Networks attribute from the DUT on the current endpoint
@@ -335,7 +337,7 @@ class TC_CNET_4_9(MatterBaseTest):
         cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900)
         result = await self.send_single_cmd(cmd=cmd)
 
-        asserts.assert_true(type_matches(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(result, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected value returned from ArmFailSafe")
 
         # TH sends the AddOrUpdateWiFiNetwork command to the DUT

--- a/src/python_testing/TC_DA_1_2.py
+++ b/src/python_testing/TC_DA_1_2.py
@@ -56,7 +56,7 @@ import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.basic_composition import BasicCompositionTests
 from matter.testing.conversions import hex_from_bytes
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 from matter.tlv import TLVReader
 
 
@@ -205,13 +205,13 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
 
         self.step(2)
         attestation_resp = await self.send_single_cmd(cmd=opcreds.Commands.AttestationRequest(attestationNonce=nonce))
-        asserts.assert_true(type_matches(attestation_resp, opcreds.Commands.AttestationResponse),
+        asserts.assert_true(matchers.is_type(attestation_resp, opcreds.Commands.AttestationResponse),
                             "DUT returned invalid response to AttestationRequest")
 
         self.step("3a")
         type = opcreds.Enums.CertificateChainTypeEnum.kDACCertificate
         dac_resp = await self.send_single_cmd(cmd=opcreds.Commands.CertificateChainRequest(certificateType=type))
-        asserts.assert_true(type_matches(dac_resp, opcreds.Commands.CertificateChainResponse),
+        asserts.assert_true(matchers.is_type(dac_resp, opcreds.Commands.CertificateChainResponse),
                             "DUT returned invalid response to CertificateChainRequest")
         der_dac = dac_resp.certificate
         asserts.assert_less_equal(len(der_dac), 600, "Returned DAC is > 600 bytes")
@@ -225,7 +225,7 @@ class TC_DA_1_2(MatterBaseTest, BasicCompositionTests):
         self.step("3b")
         type = opcreds.Enums.CertificateChainTypeEnum.kPAICertificate
         pai_resp = await self.send_single_cmd(cmd=opcreds.Commands.CertificateChainRequest(certificateType=type))
-        asserts.assert_true(type_matches(pai_resp, opcreds.Commands.CertificateChainResponse),
+        asserts.assert_true(matchers.is_type(pai_resp, opcreds.Commands.CertificateChainResponse),
                             "DUT returned invalid response to CertificateChainRequest")
         der_pai = pai_resp.certificate
         asserts.assert_less_equal(len(der_pai), 600, "Returned PAI is > 600 bytes")

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -36,6 +36,7 @@
 # === END CI TEST ARGUMENTS ===
 
 import random
+
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, utils

--- a/src/python_testing/TC_DA_1_5.py
+++ b/src/python_testing/TC_DA_1_5.py
@@ -36,7 +36,6 @@
 # === END CI TEST ARGUMENTS ===
 
 import random
-
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, utils
@@ -50,7 +49,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.conversions import hex_from_bytes
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.tlv import TLVReader
 
 
@@ -71,7 +70,7 @@ class TC_DA_1_5(MatterBaseTest):
         self.print_step(3, "Send CertificateChainRequest for DAC")
         certtype = opcreds.Enums.CertificateChainTypeEnum.kDACCertificate
         dac_resp = await self.send_single_cmd(cmd=opcreds.Commands.CertificateChainRequest(certificateType=certtype))
-        asserts.assert_true(type_matches(dac_resp, opcreds.Commands.CertificateChainResponse),
+        asserts.assert_true(matchers.is_type(dac_resp, opcreds.Commands.CertificateChainResponse),
                             "Certificate request returned incorrect type")
         der_dac = dac_resp.certificate
         # This throws an exception for a non-x509 cert

--- a/src/python_testing/TC_DEMTestBase.py
+++ b/src/python_testing/TC_DEMTestBase.py
@@ -209,7 +209,7 @@ class DEMTestBase:
 
     def get_current_utc_time_in_seconds(self):
         microseconds_in_second = 1000000
-        return int(utc_time_in_matter_epoch()/microseconds_in_second)
+        return int(timeoperations.utc_time_in_matter_epoch()/microseconds_in_second)
 
     async def send_test_event_trigger_power_adjustment(self):
         await self.send_test_event_triggers(eventTrigger=0x0098000000000000)

--- a/src/python_testing/TC_DGGEN_2_4.py
+++ b/src/python_testing/TC_DGGEN_2_4.py
@@ -105,7 +105,7 @@ class TC_DGGEN_2_4(MatterBaseTest):
 
             self.print_step("1b", "Write current time to DUT")
             # Get current time in the correct format to set via command.
-            th_utc = utc_time_in_matter_epoch(desired_datetime=None)
+            th_utc = timeoperations.utc_time_in_matter_epoch(desired_datetime=None)
 
             await self.set_time_in_timesync(th_utc)
 

--- a/src/python_testing/TC_DGGEN_2_4.py
+++ b/src/python_testing/TC_DGGEN_2_4.py
@@ -145,8 +145,8 @@ class TC_DGGEN_2_4(MatterBaseTest):
             asserts.assert_greater_equal(response.systemTimeMs // 1000, testvar_UpTime1,
                                          "System time in milliseconds must be >= UpTime1")
 
-            utc_from_posix = utc_datetime_from_posix_time_ms(posix_time_ms=response.posixTimeMs)
-            utc_from_utctime1 = utc_datetime_from_matter_epoch_us(testvar_UTCTime1)
+            utc_from_posix = timeoperations.utc_datetime_from_posix_time_ms(posix_time_ms=response.posixTimeMs)
+            utc_from_utctime1 = timeoperations.utc_datetime_from_matter_epoch_us(testvar_UTCTime1)
 
             asserts.assert_greater_equal(
                 utc_from_posix, utc_from_utctime1, "PosixTimeMs field converted to a UTC timestamp must be >= than UTCTime1 converted to a UTC timestamp")

--- a/src/python_testing/TC_DRLK_2_13.py
+++ b/src/python_testing/TC_DRLK_2_13.py
@@ -38,14 +38,13 @@
 import logging
 import random
 from dataclasses import dataclass
-
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Attribute import EventPriority
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 logger = logging.getLogger(__name__)
 
@@ -266,7 +265,7 @@ class TC_DRLK_2_13(MatterBaseTest):
                 response = await self.send_single_cmd(endpoint=self.app_cluster_endpoint, timedRequestTimeoutMs=1000,
                                                       cmd=cluster.Commands.GetCredentialStatus(
                                                           credential=credentials_struct))
-                asserts.assert_true(type_matches(response, Clusters.DoorLock.Commands.GetCredentialStatusResponse),
+                asserts.assert_true(matchers.is_type(response, Clusters.DoorLock.Commands.GetCredentialStatusResponse),
                                     "Unexpected return type for GetCredentialStatus")
                 asserts.assert_true(response.credentialExists == credential_exists,
                                     "Error when executing GetCredentialStatus command, credentialExists={}".format(
@@ -297,7 +296,7 @@ class TC_DRLK_2_13(MatterBaseTest):
                     userIndex=userIndex),
                     endpoint=self.app_cluster_endpoint,
                     timedRequestTimeoutMs=1000)
-                asserts.assert_true(type_matches(response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
+                asserts.assert_true(matchers.is_type(response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
                                     "Unexpected return type for SetCredential")
                 asserts.assert_true(response.status == expected_status,
                                     "Error sending SetCredential command, status={}".format(str(response.status)))

--- a/src/python_testing/TC_DRLK_2_13.py
+++ b/src/python_testing/TC_DRLK_2_13.py
@@ -38,6 +38,7 @@
 import logging
 import random
 from dataclasses import dataclass
+
 from mobly import asserts
 
 import matter.clusters as Clusters

--- a/src/python_testing/TC_DRLK_2_5.py
+++ b/src/python_testing/TC_DRLK_2_5.py
@@ -40,7 +40,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class TC_DRLK_2_5(MatterBaseTest):
                 weekDayIndex=week_day_index, userIndex=user_index),
                 endpoint=self.app_cluster_endpoint,
                 timedRequestTimeoutMs=1000)
-            asserts.assert_true(type_matches(response, Clusters.DoorLock.Commands.GetWeekDayScheduleResponse),
+            asserts.assert_true(matchers.is_type(response, Clusters.DoorLock.Commands.GetWeekDayScheduleResponse),
                                 "Unexpected return type for GetWeekDayScheduleResponse")
 
             if (expected_status == Status.Success):

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -38,13 +38,14 @@ import logging
 import random
 import string
 
+
 from drlk_2_x_common import DRLK_COMMON
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 logger = logging.getLogger(__name__)
 
@@ -208,7 +209,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
                                                   endpoint=self.app_cluster_endpoint,
                                                   timedRequestTimeoutMs=1000)
 
-            asserts.assert_true(type_matches(response, Clusters.DoorLock.Commands.GetUserResponse),
+            asserts.assert_true(matchers.is_type(response, Clusters.DoorLock.Commands.GetUserResponse),
                                 "Unexpected return type for GetUserResponse")
             asserts.assert_true(response.userIndex == userindex,
                                 "Error when executing GetUserResponse command, userIndex={}".format(
@@ -244,7 +245,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
             response = await self.send_single_cmd(endpoint=self.app_cluster_endpoint, timedRequestTimeoutMs=1000,
                                                   cmd=drlkcluster.Commands.GetCredentialStatus(
                                                       credential=credentials_struct))
-            asserts.assert_true(type_matches(response, Clusters.DoorLock.Commands.GetCredentialStatusResponse),
+            asserts.assert_true(matchers.is_type(response, Clusters.DoorLock.Commands.GetCredentialStatusResponse),
                                 "Unexpected return type for GetCredentialStatus")
             asserts.assert_true(response.credentialExists == credential_exists,
                                 "Error when executing GetCredentialStatus command, credentialExists={}".format(
@@ -280,7 +281,7 @@ class TC_DRLK_2_9(MatterBaseTest, DRLK_COMMON):
                 userIndex=userIndex),
                 endpoint=self.app_cluster_endpoint,
                 timedRequestTimeoutMs=1000)
-            asserts.assert_true(type_matches(response, drlkcluster.Commands.SetCredentialResponse),
+            asserts.assert_true(matchers.is_type(response, drlkcluster.Commands.SetCredentialResponse),
                                 "Unexpected return type for SetCredential")
             asserts.assert_equal(response.userIndex, NullValue)
             if (statuscode != custom_status_code):

--- a/src/python_testing/TC_DRLK_2_9.py
+++ b/src/python_testing/TC_DRLK_2_9.py
@@ -38,7 +38,6 @@ import logging
 import random
 import string
 
-
 from drlk_2_x_common import DRLK_COMMON
 from mobly import asserts
 

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -62,6 +62,7 @@ import os
 import random
 import tempfile
 
+
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -69,7 +70,7 @@ from matter.clusters.Types import NullValue
 from matter.interaction_model import Status
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.commissioning import SetupParameters
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 from matter.tlv import uint
 
 
@@ -145,51 +146,51 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 asserts.assert_equal(device.deviceNameLastEdit, None, "Unexpected value in deviceNameLastEdit")
                 asserts.assert_equal(device.bridgedEndpoint, 0, "Unexpected value in bridgedEndpoint")
                 asserts.assert_equal(device.originalEndpoint, 0, "Unexpected value in originalEndpoint")
-                asserts.assert_true(type_matches(device.deviceTypes, list), "DeviceTypes should be a list")
+                asserts.assert_true(matchers.is_type(device.deviceTypes, list), "DeviceTypes should be a list")
                 asserts.assert_equal(len(device.deviceTypes), 0, "DeviceTypes list should be empty")
-                asserts.assert_true(type_matches(device.uniqueLocationIDs, list), "UniqueLocationIds should be a list")
+                asserts.assert_true(matchers.is_type(device.uniqueLocationIDs, list), "UniqueLocationIds should be a list")
                 asserts.assert_equal(len(device.uniqueLocationIDs), 0, "uniqueLocationIDs list should be empty")
                 asserts.assert_equal(device.uniqueLocationIDsLastEdit, 0, "Unexpected value in uniqueLocationIDsLastEdit")
                 continue
 
             if device.deviceName is not None:
-                asserts.assert_true(type_matches(device.deviceName, str), "DeviceName should be a string")
+                asserts.assert_true(matchers.is_type(device.deviceName, str), "DeviceName should be a string")
                 asserts.assert_less_equal(len(device.deviceName), 64, "DeviceName should be <= 64")
-                asserts.assert_true(type_matches(device.deviceNameLastEdit, uint), "DeviceNameLastEdit should be a uint")
+                asserts.assert_true(matchers.is_type(device.deviceNameLastEdit, uint), "DeviceNameLastEdit should be a uint")
                 asserts.assert_greater(device.deviceNameLastEdit, 0, "DeviceNameLastEdit must be greater than 0")
             else:
                 asserts.assert_true(device.deviceNameLastEdit is None,
                                     "DeviceNameLastEdit should not be provided when there is no DeviceName")
 
-            asserts.assert_true(type_matches(device.bridgedEndpoint, uint), "BridgedEndpoint should be a uint")
+            asserts.assert_true(matchers.is_type(device.bridgedEndpoint, uint), "BridgedEndpoint should be a uint")
             asserts.assert_greater_equal(device.bridgedEndpoint, 0, "BridgedEndpoint >= 0")
             asserts.assert_less_equal(device.bridgedEndpoint, 0xffff_ffff,
                                       "BridgedEndpoint less than or equal to Invalid Endpoint value")
 
-            asserts.assert_true(type_matches(device.originalEndpoint, uint), "OriginalEndpoint should be a uint")
+            asserts.assert_true(matchers.is_type(device.originalEndpoint, uint), "OriginalEndpoint should be a uint")
             asserts.assert_greater_equal(device.originalEndpoint, 0, "OriginalEndpoint >= 0")
             asserts.assert_less(device.originalEndpoint, 0xffff_ffff,
                                 "OriginalEndpoint less than or equal to Invalid Endpoint value")
 
-            asserts.assert_true(type_matches(device.deviceTypes, list), "DeviceTypes should be a list")
+            asserts.assert_true(matchers.is_type(device.deviceTypes, list), "DeviceTypes should be a list")
             asserts.assert_greater_equal(len(device.deviceTypes), 1, "DeviceTypes list must contains at least one entry")
             for device_type in device.deviceTypes:
-                asserts.assert_true(type_matches(device_type.deviceType, uint), "DeviceType should be a uint")
+                asserts.assert_true(matchers.is_type(device_type.deviceType, uint), "DeviceType should be a uint")
                 # TODO what other validation can we do here to device_type.deviceType
-                asserts.assert_true(type_matches(device_type.revision, uint), "device type's revision should be a uint")
+                asserts.assert_true(matchers.is_type(device_type.revision, uint), "device type's revision should be a uint")
                 asserts.assert_greater_equal(device_type.revision, 1, "device type's revision must >= 1")
 
-            asserts.assert_true(type_matches(device.uniqueLocationIDs, list), "UniqueLocationIds should be a list")
+            asserts.assert_true(matchers.is_type(device.uniqueLocationIDs, list), "UniqueLocationIds should be a list")
             num_of_unique_location_ids = len(device.uniqueLocationIDs)
             asserts.assert_less_equal(num_of_unique_location_ids, 64, "UniqueLocationIds list should be <= 64")
             for location_id in device.uniqueLocationIDs:
-                asserts.assert_true(type_matches(location_id, str), "UniqueLocationId should be a string")
+                asserts.assert_true(matchers.is_type(location_id, str), "UniqueLocationId should be a string")
                 location_id_string_length = len(location_id)
                 asserts.assert_greater_equal(location_id_string_length, 1,
                                              "UniqueLocationId must contain at least one character")
                 asserts.assert_less_equal(location_id_string_length, 64, "UniqueLocationId should be <= 64")
 
-            asserts.assert_true(type_matches(device.uniqueLocationIDsLastEdit, uint),
+            asserts.assert_true(matchers.is_type(device.uniqueLocationIDsLastEdit, uint),
                                 "UniqueLocationIdsLastEdit should be a uint")
             if num_of_unique_location_ids:
                 asserts.assert_greater(device.uniqueLocationIDsLastEdit, 0, "UniqueLocationIdsLastEdit must be non-zero")
@@ -208,18 +209,18 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 asserts.assert_equal(location.locationDescriptorLastEdit, 0, "Unexpected value in locationDescriptorLastEdit")
                 continue
 
-            asserts.assert_true(type_matches(location.uniqueLocationID, str), "UniqueLocationId should be a string")
+            asserts.assert_true(matchers.is_type(location.uniqueLocationID, str), "UniqueLocationId should be a string")
             location_id_string_length = len(location.uniqueLocationID)
             asserts.assert_greater_equal(location_id_string_length, 1,
                                          "UniqueLocationId must contain at least one character")
             asserts.assert_less_equal(location_id_string_length, 64, "UniqueLocationId should be <= 64")
 
-            asserts.assert_true(type_matches(location.locationDescriptor.locationName, str),
+            asserts.assert_true(matchers.is_type(location.locationDescriptor.locationName, str),
                                 "LocationName should be a string")
             asserts.assert_less_equal(len(location.locationDescriptor.locationName), 64, "LocationName should be <= 64")
 
             if location.locationDescriptor.floorNumber is not NullValue:
-                asserts.assert_true(type_matches(location.locationDescriptor.floorNumber, int),
+                asserts.assert_true(matchers.is_type(location.locationDescriptor.floorNumber, int),
                                     "FloorNumber should be an int")
                 # TODO check in range of int16.
 
@@ -227,7 +228,7 @@ class TC_ECOINFO_2_1(MatterBaseTest):
                 # TODO check areaType is valid.
                 pass
 
-            asserts.assert_true(type_matches(location.locationDescriptorLastEdit, uint),
+            asserts.assert_true(matchers.is_type(location.locationDescriptorLastEdit, uint),
                                 "UniqueLocationIdsLastEdit should be a uint")
             asserts.assert_greater(location.locationDescriptorLastEdit, 0, "LocationDescriptorLastEdit must be non-zero")
 

--- a/src/python_testing/TC_ECOINFO_2_1.py
+++ b/src/python_testing/TC_ECOINFO_2_1.py
@@ -62,7 +62,6 @@ import os
 import random
 import tempfile
 
-
 from mobly import asserts
 
 import matter.clusters as Clusters

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -39,7 +39,6 @@ import logging
 import random
 from dataclasses import dataclass
 
-
 from mobly import asserts
 
 import matter.clusters as Clusters

--- a/src/python_testing/TC_IDM_1_2.py
+++ b/src/python_testing/TC_IDM_1_2.py
@@ -39,6 +39,7 @@ import logging
 import random
 from dataclasses import dataclass
 
+
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -46,7 +47,7 @@ import matter.discovery as Discovery
 from matter import ChipUtility
 from matter.exceptions import ChipStackError
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 
 def get_all_cmds_for_cluster_id(cid: int) -> list[Clusters.ClusterObjects.ClusterCommand]:
@@ -246,7 +247,7 @@ class TC_IDM_1_2(MatterBaseTest):
         # ArmFailSafe sends a data response
         cmd = Clusters.GeneralCommissioning.Commands.ArmFailSafe(expiryLengthSeconds=900, breadcrumb=1)
         ret = await self.default_controller.SendCommand(nodeid=self.dut_node_id, endpoint=0, payload=cmd)
-        asserts.assert_true(type_matches(ret, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.GeneralCommissioning.Commands.ArmFailSafeResponse),
                             "Unexpected response type from ArmFailSafe")
 
         self.print_step(7, "Send a command with suppress Response")

--- a/src/python_testing/TC_IDM_1_4.py
+++ b/src/python_testing/TC_IDM_1_4.py
@@ -46,7 +46,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.exceptions import ChipStackError
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 # If DUT supports `MaxPathsPerInvoke > 1`, additional command line argument
 # run with
@@ -196,11 +196,11 @@ class TC_IDM_1_4(MatterBaseTest):
         invoke_request_2 = Clusters.Command.InvokeRequestInfo(endpoint, command)
         try:
             result = await dev_ctrl.SendBatchCommands(dut_node_id, [invoke_request_1, invoke_request_2])
-            asserts.assert_true(type_matches(result, list), "Unexpected return from SendBatchCommands")
+            asserts.assert_true(matchers.is_type(result, list), "Unexpected return from SendBatchCommands")
             asserts.assert_equal(len(result), 2, "Unexpected number of InvokeResponses sent back from DUT")
-            asserts.assert_true(type_matches(
+            asserts.assert_true(matchers.is_type(
                 result[0], Clusters.OperationalCredentials.Commands.CertificateChainResponse), "Unexpected return type for first InvokeRequest")
-            asserts.assert_true(type_matches(
+            asserts.assert_true(matchers.is_type(
                 result[1], Clusters.GroupKeyManagement.Commands.KeySetReadResponse), "Unexpected return type for second InvokeRequest")
             logging.info("DUT successfully responded to a InvokeRequest action with two valid commands")
         except InteractionModelError:
@@ -223,11 +223,11 @@ class TC_IDM_1_4(MatterBaseTest):
         invoke_request_2 = Clusters.Command.InvokeRequestInfo(endpoint, command)
         try:
             result = await dev_ctrl.SendBatchCommands(dut_node_id, [invoke_request_1, invoke_request_2])
-            asserts.assert_true(type_matches(result, list), "Unexpected return from SendBatchCommands")
+            asserts.assert_true(matchers.is_type(result, list), "Unexpected return from SendBatchCommands")
             asserts.assert_equal(len(result), 2, "Unexpected number of InvokeResponses sent back from DUT")
-            asserts.assert_true(type_matches(
+            asserts.assert_true(matchers.is_type(
                 result[0], Clusters.OperationalCredentials.Commands.CertificateChainResponse), "Unexpected return type for first InvokeRequest")
-            asserts.assert_true(type_matches(
+            asserts.assert_true(matchers.is_type(
                 result[1], InteractionModelError), "Unexpected return type for second InvokeRequest")
             asserts.assert_equal(result[1].status, Status.UnsupportedEndpoint,
                                  "Unexpected Interaction model error, was expecting UnsupportedEndpoint")
@@ -264,11 +264,12 @@ class TC_IDM_1_4(MatterBaseTest):
         invoke_request_2 = Clusters.Command.InvokeRequestInfo(endpoint, command)
         try:
             result = await dev_ctrl.SendBatchCommands(dut_node_id, [invoke_request_1, invoke_request_2], timedRequestTimeoutMs=5000)
-            asserts.assert_true(type_matches(result, list), "Unexpected return from SendBatchCommands")
+            asserts.assert_true(matchers.is_type(result, list), "Unexpected return from SendBatchCommands")
             asserts.assert_equal(len(result), 2, "Unexpected number of InvokeResponses sent back from DUT")
-            asserts.assert_true(type_matches(
+            asserts.assert_true(matchers.is_type(
                 result[0], Clusters.GroupKeyManagement.Commands.KeySetReadResponse), "Unexpected return type for first InvokeRequest")
-            asserts.assert_true(type_matches(result[1], InteractionModelError), "Unexpected return type for second InvokeRequest")
+            asserts.assert_true(matchers.is_type(result[1], InteractionModelError),
+                                "Unexpected return type for second InvokeRequest")
 
             # We sent out RevokeCommissioning without an ArmSafe intentionally, confirm that it failed for that reason.
             asserts.assert_equal(result[1].status, Status.Failure,
@@ -327,9 +328,9 @@ class TC_IDM_1_4(MatterBaseTest):
         responses = test_only_result.Responses
         # This check is validating the number of InvokeResponses we got
         asserts.assert_equal(len(responses), 2, "Unexpected number of InvokeResponses sent back from DUT")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             responses[0], Clusters.GeneralDiagnostics.Commands.PayloadTestResponse), "Unexpected return type for first InvokeRequest")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             responses[1], Clusters.OperationalCredentials.Commands.CertificateChainResponse), "Unexpected return type for second InvokeRequest")
         logging.info("DUT successfully responded to a InvokeRequest action with two valid commands")
 

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -66,6 +66,7 @@ import struct
 import tempfile
 import time
 
+
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator
@@ -74,7 +75,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.commissioning import SetupParameters
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8
@@ -199,7 +200,7 @@ class TC_MCORE_FS_1_2(MatterBaseTest):
         cached_attributes = self._partslist_subscription.GetAttributes()
         step_1_dut_parts_list = cached_attributes[root_endpoint][Clusters.Descriptor][Clusters.Descriptor.Attributes.PartsList]
 
-        asserts.assert_true(type_matches(step_1_dut_parts_list, list), "PartsList is expected to be a list")
+        asserts.assert_true(matchers.is_type(step_1_dut_parts_list, list), "PartsList is expected to be a list")
 
         self.step(2)
         if not self.is_pics_sdk_ci_only:

--- a/src/python_testing/TC_MCORE_FS_1_2.py
+++ b/src/python_testing/TC_MCORE_FS_1_2.py
@@ -66,7 +66,6 @@ import struct
 import tempfile
 import time
 
-
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator

--- a/src/python_testing/TC_MCORE_FS_1_3.py
+++ b/src/python_testing/TC_MCORE_FS_1_3.py
@@ -71,7 +71,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 _DEVICE_TYPE_AGGREGATOR = 0x000E
 
@@ -242,7 +242,7 @@ class TC_MCORE_FS_1_3(MatterBaseTest):
             cluster=Clusters.BridgedDeviceBasicInformation,
             attribute=Clusters.BridgedDeviceBasicInformation.Attributes.UniqueID,
             endpoint=dut_fsa_bridge_th_server_endpoint)
-        asserts.assert_true(type_matches(dut_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
+        asserts.assert_true(matchers.is_type(dut_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
         asserts.assert_true(dut_fsa_bridge_th_server_unique_id, "UniqueID should not be an empty string")
         logging.info("UniqueID generated for TH_SERVER_NO_UID: %s", dut_fsa_bridge_th_server_unique_id)
 

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -66,7 +66,6 @@ import os
 import random
 import tempfile
 
-
 from mobly import asserts
 
 import matter.clusters as Clusters

--- a/src/python_testing/TC_MCORE_FS_1_4.py
+++ b/src/python_testing/TC_MCORE_FS_1_4.py
@@ -66,13 +66,14 @@ import os
 import random
 import tempfile
 
+
 from mobly import asserts
 
 import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.interaction_model import Status
 from matter.testing.apps import AppServerSubprocess
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 from matter.testing.tasks import Subprocess
 
 
@@ -313,7 +314,7 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
             attribute=Clusters.BridgedDeviceBasicInformation.Attributes.UniqueID,
             node_id=th_fsa_bridge_th_node_id,
             endpoint=th_fsa_bridge_th_server_endpoint)
-        asserts.assert_true(type_matches(th_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
+        asserts.assert_true(matchers.is_type(th_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
         asserts.assert_true(th_fsa_bridge_th_server_unique_id, "UniqueID should not be an empty string")
         logging.info("UniqueID generated for TH_SERVER_NO_UID: %s", th_fsa_bridge_th_server_unique_id)
 
@@ -402,7 +403,7 @@ class TC_MCORE_FS_1_4(MatterBaseTest):
             cluster=Clusters.BridgedDeviceBasicInformation,
             attribute=Clusters.BridgedDeviceBasicInformation.Attributes.UniqueID,
             endpoint=dut_fsa_bridge_th_server_endpoint)
-        asserts.assert_true(type_matches(dut_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
+        asserts.assert_true(matchers.is_type(dut_fsa_bridge_th_server_unique_id, str), "UniqueID should be a string")
         asserts.assert_true(dut_fsa_bridge_th_server_unique_id, "UniqueID should not be an empty string")
         logging.info("UniqueID for TH_SERVER_NO_UID on DUT_FSA: %s", th_fsa_bridge_th_server_unique_id)
 

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -66,7 +66,6 @@ import struct
 import tempfile
 import time
 
-
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator

--- a/src/python_testing/TC_MCORE_FS_1_5.py
+++ b/src/python_testing/TC_MCORE_FS_1_5.py
@@ -66,6 +66,7 @@ import struct
 import tempfile
 import time
 
+
 from ecdsa.curves import NIST256p
 from mobly import asserts
 from TC_SC_3_6 import AttributeChangeAccumulator
@@ -74,7 +75,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.testing.apps import AppServerSubprocess
 from matter.testing.commissioning import SetupParameters
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 # Length of `w0s` and `w1s` elements
 WS_LENGTH = NIST256p.baselen + 8
@@ -206,7 +207,7 @@ class TC_MCORE_FS_1_5(MatterBaseTest):
         parts_list_cached_attributes = self._partslist_subscription.GetAttributes()
         step_1_dut_parts_list = parts_list_cached_attributes[root_endpoint][Clusters.Descriptor][Clusters.Descriptor.Attributes.PartsList]
 
-        asserts.assert_true(type_matches(step_1_dut_parts_list, list), "PartsList is expected to be a list")
+        asserts.assert_true(matchers.is_type(step_1_dut_parts_list, list), "PartsList is expected to be a list")
 
         self.step(2)
         if not self.is_pics_sdk_ci_only:

--- a/src/python_testing/TC_RVCCLEANM_2_1.py
+++ b/src/python_testing/TC_RVCCLEANM_2_1.py
@@ -44,7 +44,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 # This test requires several additional command line arguments
 # run with
@@ -66,13 +66,13 @@ class TC_RVCCLEANM_2_1(MatterBaseTest):
 
     async def send_clean_change_to_mode_cmd(self, newMode) -> Clusters.Objects.RvcCleanMode.Commands.ChangeToModeResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcCleanMode.Commands.ChangeToMode(newMode=newMode), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcCleanMode.Commands.ChangeToModeResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcCleanMode.Commands.ChangeToModeResponse),
                             "Unexpected return type for RVC Clean Mode ChangeToMode")
         return ret
 
     async def send_run_change_to_mode_cmd(self, newMode) -> Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcRunMode.Commands.ChangeToMode(newMode=newMode), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse),
                             "Unexpected return type for RVC Run Mode ChangeToMode")
         return ret
 

--- a/src/python_testing/TC_RVCCLEANM_2_2.py
+++ b/src/python_testing/TC_RVCCLEANM_2_2.py
@@ -42,7 +42,7 @@ import enum
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 
 class RvcStatusEnum(enum.IntEnum):
@@ -174,7 +174,7 @@ class TC_RVCCLEANM_2_2(MatterBaseTest):
 
         self.print_step("7b", "Send ChangeToMode command")
         response = await self.send_clean_change_to_mode_cmd(self.new_clean_mode_th)
-        asserts.assert_true(type_matches(response, Clusters.RvcCleanMode.Commands.ChangeToModeResponse),
+        asserts.assert_true(matchers.is_type(response, Clusters.RvcCleanMode.Commands.ChangeToModeResponse),
                             "The response should ChangeToModeResponse command")
         if directmode_enabled:
             asserts.assert_equal(response.status, RvcStatusEnum.Success,

--- a/src/python_testing/TC_RVCOPSTATE_2_3.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_3.py
@@ -44,7 +44,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 
 # Takes an OpState or RvcOpState state enum and returns a string representation
@@ -132,13 +132,13 @@ class TC_RVCOPSTATE_2_3(MatterBaseTest):
 
     async def send_pause_cmd(self) -> Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcOperationalState.Commands.Pause(), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
                             "Unexpected return type for Pause")
         return ret
 
     async def send_resume_cmd(self) -> Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcOperationalState.Commands.Resume(), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
                             "Unexpected return type for Resume")
         return ret
 

--- a/src/python_testing/TC_RVCOPSTATE_2_4.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_4.py
@@ -42,7 +42,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 
 # Takes an OpState or RvcOpState state enum and returns a string representation
@@ -73,7 +73,7 @@ class TC_RVCOPSTATE_2_4(MatterBaseTest):
 
     async def send_go_home_cmd(self) -> Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcOperationalState.Commands.GoHome(), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
                             "Unexpected return type for GoHome")
         return ret
 

--- a/src/python_testing/TC_RVCOPSTATE_2_5.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_5.py
@@ -44,7 +44,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.testing.event_attribute_reporting import AttributeSubscriptionHandler
 from matter.testing.matter_testing import (AttributeMatcher, MatterBaseTest, TestStep, async_test_body, default_matter_test_main,
-                                           type_matches)
+                                           matchers)
 
 
 class RvcStatusEnum(enum.IntEnum):
@@ -152,7 +152,7 @@ class TC_RVCOPSTATE_2_5(MatterBaseTest):
     async def send_go_home_cmd(self) -> Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcOperationalState.Commands.GoHome(),
                                          endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcOperationalState.Commands.OperationalCommandResponse),
                             "Unexpected return type for GoHome")
         return ret
 

--- a/src/python_testing/TC_RVCRUNM_2_1.py
+++ b/src/python_testing/TC_RVCRUNM_2_1.py
@@ -44,7 +44,7 @@ import logging
 from mobly import asserts
 
 import matter.clusters as Clusters
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 # This test requires several additional command line arguments
 # run with
@@ -67,7 +67,7 @@ class TC_RVCRUNM_2_1(MatterBaseTest):
 
     async def send_change_to_mode_cmd(self, newMode) -> Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.RvcRunMode.Commands.ChangeToMode(newMode=newMode), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.RvcRunMode.Commands.ChangeToModeResponse),
                             "Unexpected return type for ChangeToMode")
         return ret
 

--- a/src/python_testing/TC_SEPRTestBase.py
+++ b/src/python_testing/TC_SEPRTestBase.py
@@ -83,7 +83,7 @@ class CommodityPriceTestBaseHelper:
 
         if now_time_must_be_within_period:  # Only check time limits when dealing with current price (not list of Forecast)
             # - verify that the PeriodStart is in the past.
-            now_time_epoch_s = utc_time_in_matter_epoch() // 1_000_000
+            now_time_epoch_s = timeoperations.utc_time_in_matter_epoch() // 1_000_000
             asserts.assert_less_equal(struct.periodStart, now_time_epoch_s,
                                       "PeriodStart must not be in the past")
 

--- a/src/python_testing/TC_TIMESYNC_2_1.py
+++ b/src/python_testing/TC_TIMESYNC_2_1.py
@@ -144,7 +144,7 @@ class TC_TIMESYNC_2_1(MatterBaseTest):
                 toleranace = timedelta(minutes=10)
             else:
                 toleranace = timedelta(minutes=1)
-            delta_us = abs(utc_dut - utc_time_in_matter_epoch())
+            delta_us = abs(utc_dut - timeoperations.utc_time_in_matter_epoch())
             delta = timedelta(microseconds=delta_us)
             asserts.assert_less_equal(delta, toleranace, "UTC time is not within tolerance of TH")
 

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -78,7 +78,7 @@ class TC_TIMESYNC_2_10(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 
@@ -107,8 +107,8 @@ class TC_TIMESYNC_2_10(MatterBaseTest):
         cb.wait_for_event_report(event, 5)
 
         self.print_step(7, "Set DSTOffset to expire in 10 seconds")
-        th_utc = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
-        expiry = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
+        th_utc = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
+        expiry = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
         dst = [dst_struct(offset=3600, validStarting=0, validUntil=expiry)]
         await self.send_set_dst_cmd(dst)
 

--- a/src/python_testing/TC_TIMESYNC_2_10.py
+++ b/src/python_testing/TC_TIMESYNC_2_10.py
@@ -113,14 +113,14 @@ class TC_TIMESYNC_2_10(MatterBaseTest):
         await self.send_set_dst_cmd(dst)
 
         self.print_step(8, "Wait until th_utc + 15s")
-        time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+        time.sleep(timeoperations.get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(9, "Read LocalTime from the DUT")
         await self.read_single_attribute_check_success(cluster=Clusters.TimeSynchronization,
                                                        attribute=Clusters.TimeSynchronization.Attributes.LocalTime)
 
         self.print_step(10, "Wait for DSTTableEmpty event")
-        timeout = get_wait_seconds_from_set_time(th_utc, 20)
+        timeout = timeoperations.get_wait_seconds_from_set_time(th_utc, 20)
         cb.wait_for_event_report(event, timeout)
 
         self.print_step(11, "Set time zone back to 0")

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -46,7 +46,7 @@ import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
 from matter.tlv import uint
 
@@ -82,7 +82,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
         timeout = get_wait_seconds_from_set_time(th_utc, wait_s)
         try:
             ret = cb.get_event_from_queue(block=True, timeout=timeout)
-            asserts.assert_true(type_matches(received_value=ret.Data,
+            asserts.assert_true(matchers.is_type(received_value=ret.Data,
                                 desired_type=Clusters.TimeSynchronization.Events.DSTStatus), "Unexpected event type returned")
             asserts.assert_equal(ret.Data.DSTOffsetActive, expect_active, "Unexpected value for DSTOffsetActive")
         except queue.Empty:

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -35,29 +35,28 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.tlv import uint
+from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.interaction_model import InteractionModelError
+from matter.clusters.Types import NullValue
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.interaction_model import InteractionModelError
+from chip.clusters.Types import NullValue
+import chip.clusters as Clusters
 import queue
 import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
-from chip.interaction_model import InteractionModelError
-from chip.testing.event_attribute_reporting import EventSubscriptionHandler
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
-from matter.interaction_model import InteractionModelError
-from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_11(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -35,24 +35,26 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.tlv import uint
-from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.interaction_model import InteractionModelError
-from matter.clusters.Types import NullValue
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing.event_attribute_reporting import EventSubscriptionHandler
-from chip.interaction_model import InteractionModelError
-from chip.clusters.Types import NullValue
-import chip.clusters as Clusters
 import queue
 import time
 import typing
 from datetime import datetime, timedelta, timezone
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing import timeoperations
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -88,7 +88,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
             AssertionError: If no event is received in time, the type is incorrect or the value does not match.
         """
 
-        timeout = get_wait_seconds_from_set_time(th_utc, wait_s)
+        timeout = timeoperations.get_wait_seconds_from_set_time(th_utc, wait_s)
         try:
             ret = cb.get_event_from_queue(block=True, timeout=timeout)
             asserts.assert_true(matchers.is_type(received_value=ret.Data,
@@ -159,7 +159,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
 
         self.print_step(9, "If dst_list_size > 1, TH waits until th_utc + 15s")
         if dst_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+            time.sleep(timeoperations.get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(10, "If dst_list_size > 1, TH reads LocalTime")
         if dst_list_size > 1:
@@ -171,7 +171,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
 
         self.print_step(12, "If dst_list_size > 1, TH waits until th_utc + 30s")
         if dst_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 30))
+            time.sleep(timeoperations.get_wait_seconds_from_set_time(th_utc, 30))
 
         self.print_step(13, "If dst_list_size > 1, TH reads LocalTime")
         if dst_list_size > 1:

--- a/src/python_testing/TC_TIMESYNC_2_11.py
+++ b/src/python_testing/TC_TIMESYNC_2_11.py
@@ -40,6 +40,15 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -106,7 +115,7 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 
@@ -127,12 +136,12 @@ class TC_TIMESYNC_2_11(MatterBaseTest):
         asserts.assert_greater_equal(dst_list_size, 1, "Invalid dst list size")
 
         self.print_step(5, "TH sets two DST items if dst_list_size > 1")
-        th_utc = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
-        expiry_first = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
+        th_utc = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
+        expiry_first = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
         dst_first = dst_struct(offset=3600, validStarting=0, validUntil=expiry_first)
         if dst_list_size > 1:
-            start_second = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=25))
-            expiry_second = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=40))
+            start_second = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=25))
+            expiry_second = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=40))
             dst_second = dst_struct(offset=3600, validStarting=start_second, validUntil=expiry_second)
             dst = [dst_first, dst_second]
             await self.send_set_dst_cmd(dst)

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -46,7 +46,7 @@ import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
 from matter.tlv import uint
 
@@ -82,7 +82,7 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
         timeout = get_wait_seconds_from_set_time(th_utc, wait_s)
         try:
             ret = cb.get_event_from_queue(block=True, timeout=timeout)
-            asserts.assert_true(type_matches(received_value=ret.Data,
+            asserts.assert_true(matchers.is_type(received_value=ret.Data,
                                 desired_type=Clusters.TimeSynchronization.Events.TimeZoneStatus), "Incorrect type received for event")
             asserts.assert_equal(ret.Data.offset, expected_offset, "Unexpected offset returned")
             asserts.assert_equal(ret.Data.name, expected_name, "Unexpected name returned")

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -40,6 +40,16 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+from chip.tlv import uint
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -106,7 +116,7 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 
@@ -127,10 +137,10 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
         asserts.assert_greater_equal(tz_list_size, 1, "Invalid tz list size")
 
         self.print_step(5, "TH sets two TZ items if dst_list_size > 1")
-        th_utc = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
+        th_utc = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc))
         tz_first = tz_struct(offset=3600, validAt=0, name="Not/Real")
         if tz_list_size > 1:
-            valid_second = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
+            valid_second = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
             tz_second = tz_struct(offset=7200, validAt=valid_second, name="Un/Real")
             tz = [tz_first, tz_second]
             await self.send_set_time_zone_cmd(tz)

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -35,30 +35,29 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.tlv import uint
+from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.interaction_model import InteractionModelError
+from matter.clusters.Types import NullValue
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.tlv import uint
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.interaction_model import InteractionModelError
+from chip.clusters.Types import NullValue
+import chip.clusters as Clusters
 import queue
 import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
-from chip.interaction_model import InteractionModelError
-from chip.testing.event_attribute_reporting import EventSubscriptionHandler
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
-from chip.tlv import uint
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
-from matter.interaction_model import InteractionModelError
-from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_12(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -89,7 +89,7 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
             AssertionError: If no event is received in time, the type is incorrect or the values do not match.
         """
 
-        timeout = get_wait_seconds_from_set_time(th_utc, wait_s)
+        timeout = timeoperations.get_wait_seconds_from_set_time(th_utc, wait_s)
         try:
             ret = cb.get_event_from_queue(block=True, timeout=timeout)
             asserts.assert_true(matchers.is_type(received_value=ret.Data,
@@ -162,7 +162,7 @@ class TC_TIMESYNC_2_12(MatterBaseTest):
 
         self.print_step(10, "If tz_list_size > 1, TH waits until th_utc + 15s")
         if tz_list_size > 1:
-            time.sleep(get_wait_seconds_from_set_time(th_utc, 15))
+            time.sleep(timeoperations.get_wait_seconds_from_set_time(th_utc, 15))
 
         self.print_step(11, "If tz_list_size > 1, TH reads LocalTime")
         if tz_list_size > 1:

--- a/src/python_testing/TC_TIMESYNC_2_12.py
+++ b/src/python_testing/TC_TIMESYNC_2_12.py
@@ -35,25 +35,27 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.tlv import uint
-from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.interaction_model import InteractionModelError
-from matter.clusters.Types import NullValue
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.tlv import uint
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing.event_attribute_reporting import EventSubscriptionHandler
-from chip.interaction_model import InteractionModelError
-from chip.clusters.Types import NullValue
-import chip.clusters as Clusters
 import queue
 import time
 import typing
 from datetime import datetime, timedelta, timezone
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing import timeoperations
+from chip.testing.event_attribute_reporting import EventSubscriptionHandler
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.tlv import uint
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_13.py
+++ b/src/python_testing/TC_TIMESYNC_2_13.py
@@ -44,7 +44,7 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import NullValue
 from matter.testing.event_attribute_reporting import EventSubscriptionHandler
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 
 class TC_TIMESYNC_2_13(MatterBaseTest):
@@ -64,7 +64,7 @@ class TC_TIMESYNC_2_13(MatterBaseTest):
 
         try:
             ret = cb.get_event_from_queue(block=True, timeout=timeout)
-            asserts.assert_true(type_matches(received_value=ret.Data,
+            asserts.assert_true(matchers.is_type(received_value=ret.Data,
                                 desired_type=Clusters.TimeSynchronization.Events.MissingTrustedTimeSource), "Incorrect type received for event")
         except queue.Empty:
             asserts.fail("Did not receive MissingTrustedTimeSouce event")

--- a/src/python_testing/TC_TIMESYNC_2_2.py
+++ b/src/python_testing/TC_TIMESYNC_2_2.py
@@ -100,7 +100,7 @@ class TC_TIMESYNC_2_2(MatterBaseTest):
             tolerance = timedelta(minutes=10)
         else:
             tolerance = timedelta(minutes=1)
-        compare_time(received=utc_dut, utc=th_utc, tolerance=tolerance)
+        timeoperations.compare_time(received=utc_dut, utc=th_utc, tolerance=tolerance)
 
         self.print_step(5, "Read time source")
         if timesource_attr_id in attribute_list:

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -42,7 +42,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import utc_time_in_matter_epoch
 
 
@@ -53,7 +53,7 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
 
     async def send_set_time_zone_cmd(self, tz: typing.List[Clusters.Objects.TimeSynchronization.Structs.TimeZoneStruct]) -> Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetTimeZone(timeZone=tz), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
                             "Unexpected return type for SetTimeZone")
         return ret
 

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -35,17 +35,19 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.testing.timeoperations import utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.interaction_model import InteractionModelError, Status
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.interaction_model import InteractionModelError, Status
-import chip.clusters as Clusters
 import typing
 from datetime import timedelta
+
+import chip.clusters as Clusters
+from chip.interaction_model import InteractionModelError, Status
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.interaction_model import InteractionModelError, Status
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import utc_time_in_matter_epoch
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -38,6 +38,13 @@
 import typing
 from datetime import timedelta
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.interaction_model import InteractionModelError, Status
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -120,11 +127,11 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
         self.print_step(9, "Send SetTimeZone command")
         if tz_max_size_dut == 2:
             tz = [tz_struct(offset=3600, validAt=0, name="Europe/Dublin"),
-                  tz_struct(offset=7200, validAt=utc_time_in_matter_epoch() + timedelta(minutes=2).microseconds, name="Europe/Athens")]
+                  tz_struct(offset=7200, validAt=timeoperations.utc_time_in_matter_epoch() + timedelta(minutes=2).microseconds, name="Europe/Athens")]
             ret = await self.send_set_time_zone_cmd(tz=tz)
 
         self.print_step(10, "Send SetTimeZone command - bad validAt time")
-        tz = [tz_struct(offset=3600, validAt=utc_time_in_matter_epoch(), name="Europe/Dublin")]
+        tz = [tz_struct(offset=3600, validAt=timeoperations.utc_time_in_matter_epoch(), name="Europe/Dublin")]
         await self.send_set_time_zone_cmd_expect_error(tz=tz, error=Status.ConstraintError)
 
         self.print_step(11, "Send SetTimeZone command - bad second entry")
@@ -152,9 +159,9 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
         self.print_step(16, "Send SetTimeZone command - too many entries")
         if tz_max_size_dut == 2:
             tz = [tz_struct(offset=3600, validAt=0, name="Europe/Dublin"),
-                  tz_struct(offset=7200, validAt=utc_time_in_matter_epoch() +
+                  tz_struct(offset=7200, validAt=timeoperations.utc_time_in_matter_epoch() +
                             timedelta(minutes=2).microseconds, name="Europe/Athens"),
-                  tz_struct(offset=10800, validAt=utc_time_in_matter_epoch() +
+                  tz_struct(offset=10800, validAt=timeoperations.utc_time_in_matter_epoch() +
                             timedelta(minutes=4).microseconds, name="Europe/Istanbul")
                   ]
             await self.send_set_time_zone_cmd_expect_error(tz=tz, error=Status.ResourceExhausted)
@@ -162,7 +169,7 @@ class TC_TIMESYNC_2_4(MatterBaseTest):
         self.print_step(17, "Send SetTimeZone command - too many entries")
         if tz_max_size_dut == 1:
             tz = [tz_struct(offset=3600, validAt=0, name="Europe/Dublin"),
-                  tz_struct(offset=7200, validAt=utc_time_in_matter_epoch() +
+                  tz_struct(offset=7200, validAt=timeoperations.utc_time_in_matter_epoch() +
                             timedelta(minutes=2).microseconds, name="Europe/Athens")
                   ]
             await self.send_set_time_zone_cmd_expect_error(tz=tz,  error=Status.ResourceExhausted)

--- a/src/python_testing/TC_TIMESYNC_2_4.py
+++ b/src/python_testing/TC_TIMESYNC_2_4.py
@@ -35,22 +35,21 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.testing.timeoperations import utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.interaction_model import InteractionModelError, Status
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.interaction_model import InteractionModelError, Status
+import chip.clusters as Clusters
 import typing
 from datetime import timedelta
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.interaction_model import InteractionModelError, Status
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import utc_time_in_matter_epoch
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_4(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_5.py
+++ b/src/python_testing/TC_TIMESYNC_2_5.py
@@ -92,7 +92,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(4, "Test setting unsorted list - expect error")
         if dst_max_size_dut > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             dst = [dst_struct(offset=3600, validStarting=th_utc, validUntil=th_utc+1.577e+13),
                    dst_struct(offset=3600, validStarting=0, validUntil=th_utc)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
@@ -104,7 +104,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(6, "Test setting list with invalid second entry - expect error")
         if dst_max_size_dut > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             dst = [dst_struct(offset=3600, validStarting=0, validUntil=th_utc+3e+8),
                    dst_struct(offset=3600, validStarting=th_utc, validUntil=th_utc+1.577e+13)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
@@ -116,7 +116,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(8, "Test setting list with two null values - expect error")
         if dst_max_size_dut > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue),
                    dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=NullValue)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
@@ -128,7 +128,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(10, "Test setting list with null value not at end - expect error")
         if dst_max_size_dut > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             dst = [dst_struct(offset=3600, validStarting=0, validUntil=NullValue),
                    dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=th_utc+1.577e+13)]
             await self.send_set_dst_cmd_expect_error(dst=dst, error=Status.ConstraintError)
@@ -140,7 +140,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(12, "Test setting too many entries")
         dst = []
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         for i in range(dst_max_size_dut+1):
             year = 3.156e+13
             six_months = 1.577e+13
@@ -154,7 +154,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         asserts.assert_false(attr, "DSTOffset not set correctly to empty list")
 
         self.print_step(14, "Set valid list with null ValidUntil")
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         dst = [dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=NullValue)]
         await self.send_set_dst_cmd(dst=dst)
 
@@ -163,7 +163,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
         asserts.assert_equal(dut_dst, dst)
 
         self.print_step(16, "Set valid list with non-null ValidUntil")
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         dst = [dst_struct(offset=3600, validStarting=th_utc+3e+8, validUntil=th_utc+1.577e+13)]
         await self.send_set_dst_cmd(dst=dst)
 
@@ -173,7 +173,7 @@ class TC_TIMESYNC_2_5(MatterBaseTest):
 
         self.print_step(18, "Test setting max entries")
         dst = []
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         for i in range(dst_max_size_dut):
             year = 3.156e+13
             six_months = 1.577e+13

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -44,7 +44,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
 from matter.tlv import uint
 
@@ -57,7 +57,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
     async def send_set_time_zone_cmd(self, tz: typing.List[Clusters.Objects.TimeSynchronization.Structs.TimeZoneStruct]) -> Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetTimeZone(timeZone=tz), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
                             "Unexpected return type for SetTimeZone")
         return ret
 

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -35,22 +35,24 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.tlv import uint
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.interaction_model import InteractionModelError
-from matter.clusters.Types import NullValue
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.tlv import uint
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.interaction_model import InteractionModelError
-from chip.clusters.Types import NullValue
-import chip.clusters as Clusters
 import time
 import typing
 from datetime import timedelta
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.tlv import uint
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -112,11 +112,11 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
         self.print_step(4, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(5, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(6, "Send SetTimeZone command with 3600 offset")
         tz = [tz_struct(offset=3600, validAt=0)]
@@ -129,11 +129,11 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
         self.print_step(8, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(9, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(10, "Read TZ list size")
         tz_list_size = await self.read_ts_attribute_expect_success(attributes.TimeZoneListMaxSize)
@@ -153,13 +153,13 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
         self.print_step(13, "Read LocalTime")
         if tz_list_size > 1:
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+            timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(14, "Wait 15s and read LocalTime")
         if tz_list_size > 1:
             time.sleep(15)
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(seconds=7200), tolerance=timedelta(seconds=5))
+            timeoperations.compare_time(received=local, offset=timedelta(seconds=7200), tolerance=timedelta(seconds=5))
 
         self.print_step(15, "Send SetTimeZone with negative offset")
         tz = [tz_struct(offset=-3600, validAt=0)]
@@ -172,7 +172,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
         self.print_step(17, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(18, "Send SetTimeZone with 0 offset")
         tz = [tz_struct(offset=0, validAt=0)]

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -39,6 +39,15 @@ import time
 import typing
 from datetime import timedelta
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+from chip.tlv import uint
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -97,7 +106,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 
@@ -131,7 +140,7 @@ class TC_TIMESYNC_2_7(MatterBaseTest):
 
         self.print_step(11, "Set time zone with two items")
         if tz_list_size > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             tz = [tz_struct(offset=3600, validAt=0), tz_struct(offset=7200, validAt=th_utc+1e+7)]
             ret = await self.send_set_time_zone_cmd(tz)
             asserts.assert_true(ret.DSTOffsetRequired, "DSTOffsetRequired not set to true")

--- a/src/python_testing/TC_TIMESYNC_2_7.py
+++ b/src/python_testing/TC_TIMESYNC_2_7.py
@@ -35,27 +35,26 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.tlv import uint
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.interaction_model import InteractionModelError
+from matter.clusters.Types import NullValue
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.tlv import uint
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.interaction_model import InteractionModelError
+from chip.clusters.Types import NullValue
+import chip.clusters as Clusters
 import time
 import typing
 from datetime import timedelta
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
-from chip.interaction_model import InteractionModelError
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
-from chip.tlv import uint
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
-from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_7(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -44,7 +44,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
 from matter.tlv import uint
 
@@ -61,7 +61,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
     async def send_set_time_zone_cmd(self, tz: typing.List[Clusters.Objects.TimeSynchronization.Structs.TimeZoneStruct]) -> Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetTimeZone(timeZone=tz), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
                             "Unexpected return type for SetTimeZone")
         return ret
 

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -35,22 +35,24 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.tlv import uint
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.interaction_model import InteractionModelError
-from matter.clusters.Types import NullValue
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.tlv import uint
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.interaction_model import InteractionModelError
-from chip.clusters.Types import NullValue
-import chip.clusters as Clusters
 import time
 import typing
 from datetime import datetime, timedelta, timezone
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.tlv import uint
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -39,6 +39,15 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+from chip.tlv import uint
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -101,7 +110,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 
@@ -114,7 +123,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(6, "Send SetDSTOffset command")
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         dst = [dst_struct(offset=3600, validStarting=0, validUntil=th_utc+1e+7)]
         await self.send_set_dst_cmd(dst)
 
@@ -157,7 +166,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(17, "Send multiple DST offsets")
         if dst_list_size > 1:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
             dst = [dst_struct(offset=3600, validStarting=0, validUntil=th_utc+1e+7),
                    dst_struct(offset=7200, validStarting=th_utc+2.5e+7, validUntil=th_utc+4e+7)]
             await self.send_set_dst_cmd(dst)
@@ -203,7 +212,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(27, "Send SetDSTOffset command with DST starting in the future")
-        valid = utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
+        valid = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
         dst = [dst_struct(offset=3600, validStarting=valid, validUntil=NullValue)]
         await self.send_set_dst_cmd(dst)
 

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -35,27 +35,26 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.tlv import uint
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.interaction_model import InteractionModelError
+from matter.clusters.Types import NullValue
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.tlv import uint
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.interaction_model import InteractionModelError
+from chip.clusters.Types import NullValue
+import chip.clusters as Clusters
 import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
-from chip.interaction_model import InteractionModelError
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
-from chip.tlv import uint
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
-from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_8(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_8.py
+++ b/src/python_testing/TC_TIMESYNC_2_8.py
@@ -116,11 +116,11 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(4, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(5, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(6, "Send SetDSTOffset command")
         th_utc = timeoperations.utc_time_in_matter_epoch()
@@ -129,18 +129,18 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(7, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(8, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(9, "Wait 15s")
         time.sleep(15)
 
         self.print_step(10, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(11, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
@@ -152,14 +152,14 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(13, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(14, "Wait 15s")
         time.sleep(15)
 
         self.print_step(15, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(16, "Read DSTOffsetListMaxSize")
         dst_list_size = await self.read_ts_attribute_expect_success(attributes.DSTOffsetListMaxSize)
@@ -174,7 +174,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         self.print_step(18, "Read LocalTime")
         if dst_list_size > 1:
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+            timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(19, "Wait 15s")
         if dst_list_size > 1:
@@ -183,7 +183,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         self.print_step(20, "Read LocalTime")
         if dst_list_size > 1:
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
+            timeoperations.compare_time(received=local, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(21, "Wait 15s")
         if dst_list_size > 1:
@@ -192,7 +192,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
         self.print_step(22, "Read LocalTime")
         if dst_list_size > 1:
             local = await self.read_ts_attribute_expect_success(local_attr)
-            compare_time(received=local, offset=timedelta(seconds=7200), tolerance=timedelta(seconds=5))
+            timeoperations.compare_time(received=local, offset=timedelta(seconds=7200), tolerance=timedelta(seconds=5))
 
         self.print_step(23, "Wait 15s")
         if dst_list_size > 1:
@@ -209,7 +209,7 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(26, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(27, "Send SetDSTOffset command with DST starting in the future")
         valid = timeoperations.utc_time_in_matter_epoch(datetime.now(tz=timezone.utc) + timedelta(seconds=10))
@@ -218,14 +218,14 @@ class TC_TIMESYNC_2_8(MatterBaseTest):
 
         self.print_step(28, "Read Localtime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=0), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=0), tolerance=timedelta(seconds=5))
 
         self.print_step(29, "Wait 15s")
         time.sleep(15)
 
         self.print_step(30, "Read Localtime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=3600), tolerance=timedelta(seconds=5))
 
         self.print_step(31, "Send SetDSTOffset command")
         dst = [dst_struct(offset=0, validStarting=0, validUntil=NullValue)]

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -43,7 +43,7 @@ from mobly import asserts
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
 from matter.tlv import uint
 
@@ -56,7 +56,7 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
 
     async def send_set_time_zone_cmd(self, tz: typing.List[Clusters.Objects.TimeSynchronization.Structs.TimeZoneStruct]) -> Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetTimeZone(timeZone=tz), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.TimeSynchronization.Commands.SetTimeZoneResponse),
                             "Unexpected return type for SetTimeZone")
         return ret
 

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -35,21 +35,23 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
-from matter.tlv import uint
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.interaction_model import InteractionModelError
-from matter.clusters.Types import NullValue
-import matter.clusters as Clusters
-from mobly import asserts
-from chip.tlv import uint
-from chip.testing import timeoperations
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.interaction_model import InteractionModelError
-from chip.clusters.Types import NullValue
-import chip.clusters as Clusters
 import typing
 from datetime import timedelta
+
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.tlv import uint
+from mobly import asserts
+
+import matter.clusters as Clusters
+from matter.clusters.Types import NullValue
+from matter.interaction_model import InteractionModelError
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -35,26 +35,25 @@
 #     quiet: true
 # === END CI TEST ARGUMENTS ===
 
+from matter.tlv import uint
+from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from matter.interaction_model import InteractionModelError
+from matter.clusters.Types import NullValue
+import matter.clusters as Clusters
+from mobly import asserts
+from chip.tlv import uint
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.interaction_model import InteractionModelError
+from chip.clusters.Types import NullValue
+import chip.clusters as Clusters
 import typing
 from datetime import timedelta
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import NullValue
-from chip.interaction_model import InteractionModelError
-from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from chip.testing import timeoperations
-from chip.tlv import uint
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts
-
-import matter.clusters as Clusters
-from matter.clusters.Types import NullValue
-from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
-from matter.testing.timeoperations import compare_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 class TC_TIMESYNC_2_9(MatterBaseTest):

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -38,6 +38,15 @@
 import typing
 from datetime import timedelta
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import NullValue
+from chip.interaction_model import InteractionModelError
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
+from chip.testing import timeoperations
+from chip.tlv import uint
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts
 
 import matter.clusters as Clusters
@@ -87,7 +96,7 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
         # It doesn't actually matter if this succeeds. The DUT is free to reject this command and use its own time.
         # If the DUT fails to get the time completely, all other tests will fail.
         try:
-            await self.send_set_utc_cmd(utc_time_in_matter_epoch())
+            await self.send_set_utc_cmd(timeoperations.utc_time_in_matter_epoch())
         except InteractionModelError:
             pass
 

--- a/src/python_testing/TC_TIMESYNC_2_9.py
+++ b/src/python_testing/TC_TIMESYNC_2_9.py
@@ -111,11 +111,11 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
 
         self.print_step(4, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(5, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=7200+3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=7200+3600), tolerance=timedelta(seconds=5))
 
         self.print_step(6, "Send SetDSTOffset command")
         dst = [dst_struct(offset=-3600, validStarting=0, validUntil=NullValue)]
@@ -123,11 +123,11 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
 
         self.print_step(7, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(8, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=7200-3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=7200-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(9, "Send SetTimeZone command")
         tz = [tz_struct(offset=-7200, validAt=0)]
@@ -140,11 +140,11 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
 
         self.print_step(11, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(12, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=-7200+3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=-7200+3600), tolerance=timedelta(seconds=5))
 
         self.print_step(13, "Send SetDSTOffset command")
         dst = [dst_struct(offset=-3600, validStarting=0, validUntil=NullValue)]
@@ -152,11 +152,11 @@ class TC_TIMESYNC_2_9(MatterBaseTest):
 
         self.print_step(14, "Read UTCTime")
         utc = await self.read_ts_attribute_expect_success(utc_attr)
-        compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=utc, offset=timedelta(), tolerance=timedelta(seconds=5))
 
         self.print_step(15, "Read LocalTime")
         local = await self.read_ts_attribute_expect_success(local_attr)
-        compare_time(received=local, offset=timedelta(seconds=-7200-3600), tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=local, offset=timedelta(seconds=-7200-3600), tolerance=timedelta(seconds=5))
 
         self.print_step(16, "Send SetTimeZone command")
         tz = [tz_struct(offset=0, validAt=0)]

--- a/src/python_testing/TC_TLSCLIENT_1_1.py
+++ b/src/python_testing/TC_TLSCLIENT_1_1.py
@@ -42,7 +42,7 @@ from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable, NullValue
 from matter.interaction_model import InteractionModelError, Status
 from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches,
-                                           type_matches)
+                                           matchers)
 from matter.tlv import uint
 
 
@@ -64,7 +64,7 @@ class TC_TLSCLIENT_1_1(MatterBaseTest):
             result = await self.send_single_cmd(cmd=Clusters.TlsClientManagement.Commands.ProvisionEndpoint(hostname=hostname, port=port, caid=caid, ccdid=ccdid),
                                                 endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
 
-            asserts.assert_true(type_matches(result, Clusters.TlsClientManagement.Commands.ProvisionEndpointResponse),
+            asserts.assert_true(matchers.is_type(result, Clusters.TlsClientManagement.Commands.ProvisionEndpointResponse),
                                 "Unexpected return type for ProvisionEndpoint")
             return result
         except InteractionModelError as e:

--- a/src/python_testing/TC_TLSCLIENT_1_1.py
+++ b/src/python_testing/TC_TLSCLIENT_1_1.py
@@ -41,8 +41,8 @@ import matter.clusters as Clusters
 from matter import ChipDeviceCtrl
 from matter.clusters.Types import Nullable, NullValue
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches,
-                                           matchers)
+from matter.testing.matter_testing import (MatterBaseTest, TestStep, default_matter_test_main, has_cluster, matchers,
+                                           run_if_endpoint_matches)
 from matter.tlv import uint
 
 

--- a/src/python_testing/TC_VALCC_4_4.py
+++ b/src/python_testing/TC_VALCC_4_4.py
@@ -111,7 +111,7 @@ class TC_VALCC_4_4(MatterBaseTest):
 
         self.step("3b")
         if utcTime is NullValue:
-            th_utc = utc_time_in_matter_epoch()
+            th_utc = timeoperations.utc_time_in_matter_epoch()
 
             try:
                 await self.send_single_cmd(cmd=Clusters.Objects.TimeSynchronization.Commands.SetUTCTime(UTCTime=th_utc, granularity=Clusters.Objects.TimeSynchronization.Enums.GranularityEnum.kMillisecondsGranularity), endpoint=0)

--- a/src/python_testing/TC_WHM_2_1.py
+++ b/src/python_testing/TC_WHM_2_1.py
@@ -45,7 +45,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import Status
-from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, TestStep, async_test_body, default_matter_test_main, matchers
 
 
 class TC_WHM_2_1(MatterBaseTest):
@@ -79,7 +79,7 @@ class TC_WHM_2_1(MatterBaseTest):
 
     async def send_change_to_mode_cmd(self, newMode) -> Clusters.Objects.WaterHeaterMode.Commands.ChangeToModeResponse:
         ret = await self.send_single_cmd(cmd=Clusters.Objects.WaterHeaterMode.Commands.ChangeToMode(newMode=newMode), endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.WaterHeaterMode.Commands.ChangeToModeResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.WaterHeaterMode.Commands.ChangeToModeResponse),
                             "Unexpected return type for Water Heater Mode ChangeToMode")
         return ret
 

--- a/src/python_testing/TestBatchInvoke.py
+++ b/src/python_testing/TestBatchInvoke.py
@@ -40,7 +40,7 @@ from mobly import asserts
 
 import matter.clusters as Clusters
 from matter.interaction_model import InteractionModelError
-from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, type_matches
+from matter.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers
 
 ''' Integration test of batch commands using UnitTesting Cluster
 
@@ -81,11 +81,11 @@ class TestBatchInvoke(MatterBaseTest):
         except InteractionModelError:
             asserts.fail("DUT failed to successfully responded to a InvokeRequest action with two valid commands")
 
-        asserts.assert_true(type_matches(result, list), "Unexpected return from SendBatchCommands")
+        asserts.assert_true(matchers.is_type(result, list), "Unexpected return from SendBatchCommands")
         asserts.assert_equal(len(result), 2, "Unexpected number of InvokeResponses sent back from DUT")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             result[0], Clusters.UnitTesting.Commands.TestBatchHelperResponse), "Unexpected return type for first InvokeRequest")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             result[1], Clusters.UnitTesting.Commands.TestBatchHelperResponse), "Unexpected return type for second InvokeRequest")
         asserts.assert_equal(result[0].buffer, request_1_fill_character * response_size,
                              "Unexpected response to first InvokeRequest")
@@ -116,11 +116,11 @@ class TestBatchInvoke(MatterBaseTest):
         asserts.assert_greater(testOnlyResponse.ResponseMessageCount, 1,
                                "Unexpected, DUT sent response back in single InvokeResponseMessage")
         result = testOnlyResponse.Responses
-        asserts.assert_true(type_matches(result, list), "Unexpected return from SendBatchCommands")
+        asserts.assert_true(matchers.is_type(result, list), "Unexpected return from SendBatchCommands")
         asserts.assert_equal(len(result), 2, "Unexpected number of InvokeResponses sent back from DUT")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             result[0], Clusters.UnitTesting.Commands.TestBatchHelperResponse), "Unexpected return type for first InvokeRequest")
-        asserts.assert_true(type_matches(
+        asserts.assert_true(matchers.is_type(
             result[1], Clusters.UnitTesting.Commands.TestBatchHelperResponse), "Unexpected return type for second InvokeRequest")
         asserts.assert_equal(result[0].buffer, request_1_fill_character * response_size,
                              "Unexpected response to first InvokeRequest")

--- a/src/python_testing/TestCommissioningTimeSync.py
+++ b/src/python_testing/TestCommissioningTimeSync.py
@@ -119,7 +119,7 @@ class TestCommissioningTimeSync(MatterBaseTest):
             self.commissioner.SetTimeZone(offset=3600, validAt=0)
         if dst:
             six_months = 1.577e+13  # in us
-            dst_valid_until = utc_time_in_matter_epoch() + int(six_months)
+            dst_valid_until = timeoperations.utc_time_in_matter_epoch() + int(six_months)
             self.commissioner.SetDSTOffset(offset=3600, validStarting=0, validUntil=dst_valid_until)
         if default_ntp:
             self.commissioner.SetDefaultNTP("fe80::1")
@@ -197,7 +197,8 @@ class TestCommissioningTimeSync(MatterBaseTest):
 
         self.commissioner.SetTimeZone(offset=3600, validAt=0)
         six_months = 1.577e+13  # in us
-        self.commissioner.SetDSTOffset(offset=3600, validStarting=0, validUntil=utc_time_in_matter_epoch() + int(six_months))
+        self.commissioner.SetDSTOffset(offset=3600, validStarting=0,
+                                       validUntil=timeoperations.utc_time_in_matter_epoch() + int(six_months))
         self.commissioner.SetDefaultNTP("fe80::1")
         self.commissioner.SetTrustedTimeSource(self.commissioner.nodeId, 0)
 

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -179,44 +179,44 @@ class TestMatterTestingSupport(MatterBaseTest):
 
     def test_time_compare_function(self):
         # only offset, exact match
-        compare_time(received=1000, offset=timedelta(microseconds=1000), utc=0, tolerance=timedelta())
+        timeoperations.compare_time(received=1000, offset=timedelta(microseconds=1000), utc=0, tolerance=timedelta())
         # only utc, exact match
-        compare_time(received=1000, offset=timedelta(), utc=1000, tolerance=timedelta())
+        timeoperations.compare_time(received=1000, offset=timedelta(), utc=1000, tolerance=timedelta())
         # both, exact match
-        compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta())
+        timeoperations.compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta())
         # both, negative offset
-        compare_time(received=0, offset=timedelta(microseconds=-1000), utc=1000, tolerance=timedelta())
+        timeoperations.compare_time(received=0, offset=timedelta(microseconds=-1000), utc=1000, tolerance=timedelta())
 
         # Exact match, within delta, both
-        compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=2000, offset=timedelta(microseconds=1000), utc=1000, tolerance=timedelta(seconds=5))
 
         # Just inside tolerance
-        compare_time(received=1001, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
+        timeoperations.compare_time(received=1001, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
 
         # Just outside tolerance
         try:
-            compare_time(received=999, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
+            timeoperations.compare_time(received=999, offset=timedelta(), utc=2000, tolerance=timedelta(microseconds=1000))
             asserts.fail("Expected failure case for time just outside of the tolerance failed")
         except signals.TestFailure:
             pass
 
         # everything in the seconds range
-        compare_time(received=timedelta(seconds=3600).total_seconds() * 1000000,
-                     offset=timedelta(seconds=3605), utc=0, tolerance=timedelta(seconds=5))
+        timeoperations.compare_time(received=timedelta(seconds=3600).total_seconds() * 1000000,
+                                    offset=timedelta(seconds=3605), utc=0, tolerance=timedelta(seconds=5))
 
     def test_get_wait_time_function(self):
         th_utc = timeoperations.utc_time_in_matter_epoch()
-        secs = get_wait_seconds_from_set_time(th_utc, 5)
+        secs = timeoperations.get_wait_seconds_from_set_time(th_utc, 5)
         asserts.assert_equal(secs, 5)
         # If we've pass less than a second, we still want to wait 5
         time.sleep(0.5)
-        secs = get_wait_seconds_from_set_time(th_utc, 5)
+        secs = timeoperations.get_wait_seconds_from_set_time(th_utc, 5)
         asserts.assert_equal(secs, 5)
 
         time.sleep(0.5)
-        secs = get_wait_seconds_from_set_time(th_utc, 5)
+        secs = timeoperations.get_wait_seconds_from_set_time(th_utc, 5)
         asserts.assert_equal(secs, 4)
-        secs = get_wait_seconds_from_set_time(th_utc, 15)
+        secs = timeoperations.get_wait_seconds_from_set_time(th_utc, 15)
         asserts.assert_equal(secs, 14)
 
     def create_example_topology(self):

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -15,36 +15,35 @@
 #    limitations under the License.
 #
 
+from matter.tlv import uint
+from matter.testing.timeoperations import compare_time, get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
+                                                      find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
+                                                      get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
+from matter.testing.pics import parse_pics, parse_pics_xml
+from matter.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
+                                           matchers)
+from matter.clusters.Types import Nullable, NullValue
+import matter.clusters as Clusters
+from mobly import asserts, signals
+from chip.tlv import uint
+from chip.testing import timeoperations
+from chip.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
+                                                    find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
+                                                    get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
+from chip.testing.pics import parse_pics, parse_pics_xml
+from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
+                                         matchers)
+from chip.clusters.Types import Nullable, NullValue
+import chip.clusters as Clusters
 import os
 import time
 import typing
 from datetime import datetime, timedelta, timezone
 
-<<<<<<< HEAD
-=======
-import chip.clusters as Clusters
-from chip.clusters.Types import Nullable, NullValue
-from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
-                                         matchers)
-from chip.testing.pics import parse_pics, parse_pics_xml
-from chip.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
-                                                    find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
-                                                    get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
-from chip.testing import timeoperations
-from chip.tlv import uint
->>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
-from mobly import asserts, signals
-
-import matter.clusters as Clusters
-from matter.clusters.Types import Nullable, NullValue
-from matter.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
-                                           matchers)
-from matter.testing.pics import parse_pics, parse_pics_xml
-from matter.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
-                                                      find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
-                                                      get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
-from matter.testing.timeoperations import compare_time, get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.tlv import uint
+<< << << < HEAD
+== == == =
+>>>>>> > c22181942f(Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 
 
 def get_raw_type_list():

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -25,7 +25,7 @@ from mobly import asserts, signals
 import matter.clusters as Clusters
 from matter.clusters.Types import Nullable, NullValue
 from matter.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
-                                           type_matches)
+                                           matchers)
 from matter.testing.pics import parse_pics, parse_pics_xml
 from matter.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
                                                       find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
@@ -83,19 +83,19 @@ def test_type_matching_for_type(test_type, test_nullable: bool = False, test_opt
 
     # true_list is all the values that should match with the test type
     for i in true_list:
-        asserts.assert_true(type_matches(i, match_type), "{} type checking failure".format(test_type))
+        asserts.assert_true(matchers.is_type(i, match_type), "{} type checking failure".format(test_type))
 
     # try every value in every type in the remaining dict - they should all fail
     for v in vals.values():
         for i in v:
-            asserts.assert_false(type_matches(i, match_type), "{} falsely matched to type {}".format(i, match_type))
+            asserts.assert_false(matchers.is_type(i, match_type), "{} falsely matched to type {}".format(i, match_type))
 
     # Test the nullables or optionals that aren't supposed to work
     if not test_nullable:
-        asserts.assert_false(type_matches(NullValue, match_type), "NullValue falsely matched to {}".format(match_type))
+        asserts.assert_false(matchers.is_type(NullValue, match_type), "NullValue falsely matched to {}".format(match_type))
 
     if not test_optional:
-        asserts.assert_false(type_matches(None, match_type), "None falsely matched to {}".format(match_type))
+        asserts.assert_false(matchers.is_type(None, match_type), "None falsely matched to {}".format(match_type))
 
 
 def run_all_match_tests_for_type(test_type):

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -15,31 +15,32 @@
 #    limitations under the License.
 #
 
-from matter.tlv import uint
-from matter.testing.timeoperations import compare_time, get_wait_seconds_from_set_time, utc_time_in_matter_epoch
-from matter.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
-                                                      find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
-                                                      get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
-from matter.testing.pics import parse_pics, parse_pics_xml
-from matter.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
-                                           matchers)
-from matter.clusters.Types import Nullable, NullValue
-import matter.clusters as Clusters
-from mobly import asserts, signals
-from chip.tlv import uint
-from chip.testing import timeoperations
-from chip.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
-                                                    find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
-                                                    get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
-from chip.testing.pics import parse_pics, parse_pics_xml
-from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
-                                         matchers)
-from chip.clusters.Types import Nullable, NullValue
-import chip.clusters as Clusters
 import os
 import time
 import typing
 from datetime import datetime, timedelta, timezone
+
+import chip.clusters as Clusters
+from chip.clusters.Types import Nullable, NullValue
+from chip.testing import timeoperations
+from chip.testing.matter_testing import MatterBaseTest, async_test_body, default_matter_test_main, matchers, parse_matter_test_args
+from chip.testing.pics import parse_pics, parse_pics_xml
+from chip.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
+                                                    find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
+                                                    get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
+from chip.tlv import uint
+from mobly import asserts, signals
+
+import matter.clusters as Clusters
+from matter.clusters.Types import Nullable, NullValue
+from matter.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, matchers,
+                                           parse_matter_test_args)
+from matter.testing.pics import parse_pics, parse_pics_xml
+from matter.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
+                                                      find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
+                                                      get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
+from matter.testing.timeoperations import compare_time, get_wait_seconds_from_set_time, utc_time_in_matter_epoch
+from matter.tlv import uint
 
 << << << < HEAD
 == == == =

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -20,6 +20,19 @@ import time
 import typing
 from datetime import datetime, timedelta, timezone
 
+<<<<<<< HEAD
+=======
+import chip.clusters as Clusters
+from chip.clusters.Types import Nullable, NullValue
+from chip.testing.matter_testing import (MatterBaseTest, async_test_body, default_matter_test_main, parse_matter_test_args,
+                                         matchers)
+from chip.testing.pics import parse_pics, parse_pics_xml
+from chip.testing.taglist_and_topology_test import (TagProblem, create_device_type_list_for_root, create_device_type_lists,
+                                                    find_tag_list_problems, find_tree_roots, flat_list_ok, get_all_children,
+                                                    get_direct_children_of_root, parts_list_problems, separate_endpoint_types)
+from chip.testing import timeoperations
+from chip.tlv import uint
+>>>>>>> c22181942f (Commit to refactor utc_time_in_matter_epoch to timeoperations.utc_time_in_matter_epoch.)
 from mobly import asserts, signals
 
 import matter.clusters as Clusters
@@ -109,11 +122,11 @@ class TestMatterTestingSupport(MatterBaseTest):
     @async_test_body
     async def test_matter_epoch_time(self):
         # Matter epoch should return zero
-        ret = utc_time_in_matter_epoch(datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc))
+        ret = timeoperations.utc_time_in_matter_epoch(datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc))
         asserts.assert_equal(ret, 0, "UTC epoch returned non-zero value")
 
         # Jan 2 is exactly 1 day after Jan 1
-        ret = utc_time_in_matter_epoch(datetime(2000, 1, 2, 0, 0, 0, 0, timezone.utc))
+        ret = timeoperations.utc_time_in_matter_epoch(datetime(2000, 1, 2, 0, 0, 0, 0, timezone.utc))
         expected_delay = timedelta(days=1)
         actual_delay = timedelta(microseconds=ret)
         asserts.assert_equal(expected_delay, actual_delay, "Calculation for Jan 2 date is incorrect")
@@ -121,13 +134,13 @@ class TestMatterTestingSupport(MatterBaseTest):
         # There's a catch 22 for knowing the current time, but we can check that it's
         # going up, and that it's larger than when I wrote the test
         # Check that the returned value is larger than the test writing date
-        writing_date = utc_time_in_matter_epoch(datetime(2023, 5, 5, 0, 0, 0, 0, timezone.utc))
-        current_date = utc_time_in_matter_epoch()
+        writing_date = timeoperations.utc_time_in_matter_epoch(datetime(2023, 5, 5, 0, 0, 0, 0, timezone.utc))
+        current_date = timeoperations.utc_time_in_matter_epoch()
         asserts.assert_greater(current_date, writing_date, "Calculation for current date is smaller than writing date")
 
         # Check that the time is going up
         last_date = current_date
-        current_date = utc_time_in_matter_epoch()
+        current_date = timeoperations.utc_time_in_matter_epoch()
         asserts.assert_greater(current_date, last_date, "Time does not appear to be incrementing")
 
     @async_test_body
@@ -192,7 +205,7 @@ class TestMatterTestingSupport(MatterBaseTest):
                      offset=timedelta(seconds=3605), utc=0, tolerance=timedelta(seconds=5))
 
     def test_get_wait_time_function(self):
-        th_utc = utc_time_in_matter_epoch()
+        th_utc = timeoperations.utc_time_in_matter_epoch()
         secs = get_wait_seconds_from_set_time(th_utc, 5)
         asserts.assert_equal(secs, 5)
         # If we've pass less than a second, we still want to wait 5

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -19,13 +19,11 @@ import logging
 import random
 import string
 import time
-
 from mobly import asserts
-
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
-from matter.testing.matter_testing import type_matches
+
 
 
 class DRLK_COMMON:
@@ -65,7 +63,7 @@ class DRLK_COMMON:
                                                                                               userType=userType),
                                          endpoint=self.endpoint,
                                          timedRequestTimeoutMs=1000)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
                             "Unexpected return type for SetCredential")
         asserts.assert_true(ret.status == Status.Success, "Error sending SetCredential command, status={}".format(str(ret.status)))
         return ret
@@ -76,7 +74,7 @@ class DRLK_COMMON:
                                    timedRequestTimeoutMs=1000)
         ret = await self.send_single_cmd(cmd=Clusters.Objects.DoorLock.Commands.GetCredentialStatus(credential=credential),
                                          endpoint=self.endpoint)
-        asserts.assert_true(type_matches(ret, Clusters.Objects.DoorLock.Commands.GetCredentialStatusResponse),
+        asserts.assert_true(matchers.is_type(ret, Clusters.Objects.DoorLock.Commands.GetCredentialStatusResponse),
                             "Unexpected return type for GetCredentialStatus")
         asserts.assert_false(ret.credentialExists, "Error clearing Credential (credentialExists==True)")
 
@@ -204,7 +202,7 @@ class DRLK_COMMON:
                                                                        userType=NullValue
                                                                        )
                 asserts.assert_true(
-                    type_matches(set_cred_response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
+                    matchers.is_type(set_cred_response, Clusters.Objects.DoorLock.Commands.SetCredentialResponse),
                     "Unexpected return type for SetCredential")
             self.print_step("4e", f"TH sends {lockUnlockText} Command to the DUT with PINCode as pin_code.")
             if self.check_pics(lockUnlockCmdRspPICS):

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -25,7 +25,6 @@ from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status
 
 
-
 class DRLK_COMMON:
     async def read_drlk_attribute_expect_success(self, attribute):
         cluster = Clusters.Objects.DoorLock

--- a/src/python_testing/drlk_2_x_common.py
+++ b/src/python_testing/drlk_2_x_common.py
@@ -19,7 +19,9 @@ import logging
 import random
 import string
 import time
+
 from mobly import asserts
+
 import matter.clusters as Clusters
 from matter.clusters.Types import NullValue
 from matter.interaction_model import InteractionModelError, Status

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -477,7 +477,7 @@ class MatterBaseTest(base_test.BaseTestClass):
         desired_type = attribute.attribute_type.Type
         type_err_msg = f'Returned attribute {attribute} is wrong type expected {desired_type}, got {type(attr_ret)}'
         read_ok = attr_ret is not None and not isinstance(attr_ret, Clusters.Attribute.ValueDecodeFailure)
-        type_ok = type_matches(attr_ret, desired_type)
+        type_ok = matchers.is_type(attr_ret, desired_type)
         if assert_on_error:
             asserts.assert_true(read_ok, read_err_msg)
             asserts.assert_true(type_ok, type_err_msg)

--- a/third_party/android_deps/gradle/wrapper/gradle-wrapper.properties
+++ b/third_party/android_deps/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Summary
In order to split into smaller PR for better reviews. This pull request was created based on commits of the larger PR: https://github.com/project-chip/connectedhomeip/pull/40031
Refactored matter_testing.py to remove all temporary function aliases from the matchers, timeoperations, conversions, and decorators modules. Replaced all alias usages with fully qualified module paths (e.g., matchers.assert_success instead of assert_success). This change ensures better code readability, avoids ambiguity, and aligns with the module-level organization standards defined for the project.
This PR contains matchers and timeoperations refactor.
Related issues
Fixes: https://github.com/project-chip/connectedhomeip/issues/37537

#### Testing
Refactored Python tests
```

./scripts/tests/local.py build         # will compile python in out/pyenv and ALL application prerequisites
./scripts/tests/local.py python-tests  # Runs all python tests that are runnable in CI
Notes:

```
_get_all_matching_endpoints = decorators._get_all_matching_endpoints - No import statements for _get_all_matching_endpoints were found in any file.