### PR TITLE
[WebRTC] Rename WebRTCTransportRequestorDelegate to Delegate

### DIFF
--- a/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.h
+++ b/examples/camera-controller/webrtc-manager/WebRTCRequestorDelegate.h
@@ -21,7 +21,7 @@
 #include <app-common/zap-generated/cluster-enums.h>
 #include <app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h>
 
-class WebRTCRequestorDelegate : public chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorDelegate
+class WebRTCRequestorDelegate : public chip::app::Clusters::WebRTCTransportRequestor::Delegate
 {
 public:
     using ICECandidateStruct  = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;

--- a/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/tests/TestWebRTCTransportRequestorCluster.cpp
@@ -46,7 +46,7 @@ using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEn
 static constexpr chip::EndpointId kTestEndpointId = 1;
 
 // Mock delegate for testing
-class MockWebRTCTransportRequestorDelegate : public WebRTCTransportRequestorDelegate
+class MockWebRTCTransportRequestorDelegate : public Delegate
 {
 public:
     MockWebRTCTransportRequestorDelegate() : mLastSessionId(0), mLastEndReason(WebRTCEndReasonEnum::kUnknownEnumValue) {}
@@ -231,7 +231,7 @@ TEST_F(TestWebRTCTransportRequestorCluster, TestDelegateHandleOffer)
     // Test successful offer handling
     mockDelegate.SetOfferResult(CHIP_NO_ERROR);
 
-    WebRTCTransportRequestorDelegate::OfferArgs offerArgs;
+    Delegate::OfferArgs offerArgs;
     offerArgs.sdp        = testSdp;
     offerArgs.peerNodeId = 0x1234ULL; // Use ULL suffix for uint64_t/NodeId
 

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.cpp
@@ -55,7 +55,7 @@ namespace app {
 namespace Clusters {
 namespace WebRTCTransportRequestor {
 
-WebRTCTransportRequestorServer::WebRTCTransportRequestorServer(EndpointId endpointId, WebRTCTransportRequestorDelegate & delegate) :
+WebRTCTransportRequestorServer::WebRTCTransportRequestorServer(EndpointId endpointId, Delegate & delegate) :
     DefaultServerCluster({ endpointId, WebRTCTransportRequestor::Id }), mDelegate(delegate)
 {}
 
@@ -91,7 +91,7 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::Inv
         {
             return Protocols::InteractionModel::Status::InvalidCommand;
         }
-        return HandleOffer(req, *handler);
+        return HandleOffer(*handler, req);
     }
     case Commands::Answer::Id: {
         Commands::Answer::DecodableType req;
@@ -99,7 +99,7 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::Inv
         {
             return Protocols::InteractionModel::Status::InvalidCommand;
         }
-        return HandleAnswer(req, *handler);
+        return HandleAnswer(*handler, req);
     }
     case Commands::ICECandidates::Id: {
         Commands::ICECandidates::DecodableType req;
@@ -107,7 +107,7 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::Inv
         {
             return Protocols::InteractionModel::Status::InvalidCommand;
         }
-        return HandleICECandidates(req, *handler);
+        return HandleICECandidates(*handler, req);
     }
     case Commands::End::Id: {
         Commands::End::DecodableType req;
@@ -115,7 +115,7 @@ std::optional<DataModel::ActionReturnStatus> WebRTCTransportRequestorServer::Inv
         {
             return Protocols::InteractionModel::Status::InvalidCommand;
         }
-        return HandleEnd(req, *handler);
+        return HandleEnd(*handler, req);
     }
     default:
         return Protocols::InteractionModel::Status::UnsupportedCommand;
@@ -175,8 +175,8 @@ bool WebRTCTransportRequestorServer::IsPeerNodeSessionValid(uint16_t sessionId, 
     return (peerNodeId == existingSession->peerNodeID) && (peerFabricIndex == existingSession->GetFabricIndex());
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const Commands::Offer::DecodableType & req,
-                                                                          const CommandHandler & commandHandler)
+DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const CommandHandler & commandHandler,
+                                                                          const Commands::Offer::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
 
@@ -185,8 +185,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const 
         return Protocols::InteractionModel::Status::NotFound;
     }
 
-    // Create arguments for WebRTCTransportRequestorDelegate.
-    WebRTCTransportRequestorDelegate::OfferArgs args;
+    // Create arguments for Delegate.
+    Delegate::OfferArgs args;
     args.sdp = std::string(req.sdp.data(), req.sdp.size());
 
     // Convert ICE servers list from DecodableList to vector.
@@ -217,8 +217,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleOffer(const 
     return mDelegate.HandleOffer(sessionId, args);
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const Commands::Answer::DecodableType & req,
-                                                                           const CommandHandler & commandHandler)
+DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const CommandHandler & commandHandler,
+                                                                           const Commands::Answer::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
     auto sdpSpan       = req.sdp;
@@ -235,8 +235,8 @@ DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleAnswer(const
 }
 
 DataModel::ActionReturnStatus
-WebRTCTransportRequestorServer::HandleICECandidates(const Commands::ICECandidates::DecodableType & req,
-                                                    const CommandHandler & commandHandler)
+WebRTCTransportRequestorServer::HandleICECandidates(const CommandHandler & commandHandler,
+                                                    const Commands::ICECandidates::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
 
@@ -273,8 +273,8 @@ WebRTCTransportRequestorServer::HandleICECandidates(const Commands::ICECandidate
     return mDelegate.HandleICECandidates(sessionId, candidates);
 }
 
-DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const Commands::End::DecodableType & req,
-                                                                        const CommandHandler & commandHandler)
+DataModel::ActionReturnStatus WebRTCTransportRequestorServer::HandleEnd(const CommandHandler & commandHandler,
+                                                                        const Commands::End::DecodableType & req)
 {
     uint16_t sessionId = req.webRTCSessionID;
     auto reason        = req.reason;

--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
@@ -42,12 +42,12 @@ using WebRTCEndReasonEnum      = chip::app::Clusters::Globals::WebRTCEndReasonEn
 /** @brief
  *  Defines methods for implementing application-specific logic for the WebRTCTransportRequestor Cluster.
  */
-class WebRTCTransportRequestorDelegate
+class Delegate
 {
 public:
-    WebRTCTransportRequestorDelegate() = default;
+    Delegate() = default;
 
-    virtual ~WebRTCTransportRequestorDelegate() = default;
+    virtual ~Delegate() = default;
 
     struct OfferArgs
     {
@@ -122,7 +122,7 @@ public:
      * @param delegate A reference to the delegate to be used by this server.
      *                 The caller must ensure that the delegate lives throughout the instance's lifetime.
      */
-    WebRTCTransportRequestorServer(EndpointId endpointId, WebRTCTransportRequestorDelegate & delegate);
+    WebRTCTransportRequestorServer(EndpointId endpointId, Delegate & delegate);
 
     DataModel::ActionReturnStatus ReadAttribute(const DataModel::ReadAttributeRequest & request,
                                                 AttributeValueEncoder & encoder) override;
@@ -158,7 +158,7 @@ public:
     void RemoveSession(uint16_t sessionId);
 
 private:
-    WebRTCTransportRequestorDelegate & mDelegate;
+    Delegate & mDelegate;
     std::vector<WebRTCSessionStruct> mCurrentSessions;
 
     // Helper functions
@@ -167,11 +167,11 @@ private:
     bool IsPeerNodeSessionValid(uint16_t sessionId, const CommandHandler & commandHandler);
 
     // Command handlers
-    DataModel::ActionReturnStatus HandleOffer(const Commands::Offer::DecodableType & req, const CommandHandler & commandHandler);
-    DataModel::ActionReturnStatus HandleAnswer(const Commands::Answer::DecodableType & req, const CommandHandler & commandHandler);
-    DataModel::ActionReturnStatus HandleICECandidates(const Commands::ICECandidates::DecodableType & req,
-                                                      const CommandHandler & commandHandler);
-    DataModel::ActionReturnStatus HandleEnd(const Commands::End::DecodableType & req, const CommandHandler & commandHandler);
+    DataModel::ActionReturnStatus HandleOffer(const CommandHandler & commandHandler, const Commands::Offer::DecodableType & req);
+    DataModel::ActionReturnStatus HandleAnswer(const CommandHandler & commandHandler, const Commands::Answer::DecodableType & req);
+    DataModel::ActionReturnStatus HandleICECandidates(const CommandHandler & commandHandler,
+                                                      const Commands::ICECandidates::DecodableType & req);
+    DataModel::ActionReturnStatus HandleEnd(const CommandHandler & commandHandler, const Commands::End::DecodableType & req);
 };
 
 } // namespace WebRTCTransportRequestor

--- a/src/controller/webrtc/WebRTCTransportRequestorManager.h
+++ b/src/controller/webrtc/WebRTCTransportRequestorManager.h
@@ -31,7 +31,7 @@ using OnEndCallback           = int (*)(uint16_t, uint8_t);
 
 constexpr chip::EndpointId kWebRTCRequesterDynamicEndpointId = 1;
 
-class WebRTCTransportRequestorManager : public chip::app::Clusters::WebRTCTransportRequestor::WebRTCTransportRequestorDelegate
+class WebRTCTransportRequestorManager : public chip::app::Clusters::WebRTCTransportRequestor::Delegate
 {
 public:
     using ICECandidateStruct  = chip::app::Clusters::Globals::Structs::ICECandidateStruct::Type;


### PR DESCRIPTION
#### Summary

Rename WebRTCTransportRequestorDelegate to Delegate for consistency with other clusters. Since the namespace chip::app::Clusters::WebRTCTransportRequestor already provides sufficient context, the longer name is redundant.

#### Related issues
N/A

#### Testing
Validate by CI
