### PR TITLE
[NXP][example][common] Fix border router ble-wifi commissioning issue

### DIFF
--- a/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
+++ b/examples/platform/nxp/common/app_task/source/AppTaskBase.cpp
@@ -127,7 +127,7 @@ chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 #if CONFIG_NET_L2_OPENTHREAD
 app::Clusters::NetworkCommissioning::InstanceAndDriver<DeviceLayer::NetworkCommissioning::GenericThreadDriver>
-    sThreadNetworkDriver(0 /*endpointId*/);
+    sThreadNetworkDriver(CHIP_DEVICE_CONFIG_THREAD_NETWORK_ENDPOINT_ID /*endpointId*/);
 #endif
 
 #if CONFIG_CHIP_WIFI || CHIP_DEVICE_CONFIG_ENABLE_WPA


### PR DESCRIPTION
#### Summary

Commissioning is failing when enabling a secondary interface for thread network due to wrong thread driver endpoint initialization. 

chip-tool error:
Required network information not provided in commissioning parameters
 Parameters supplied: wifi (yes) thread (no)
 Device supports: wifi (no) thread(yes)

#### Testing

Commissioning passed using ble-wifi and ble-thread commissioning, rw61x NXP board, thermostat example with secondary interface 
west command: 
west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=examples/platform/nxp/config/prj_thread_ftd_wifi_br_ota.conf

Commissioning passed using ble-thread commissioning, rw61x NXP board, thermostat thread 
west command: 
west build -d build_matter/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=examples/platform/nxp/config/prj_thread_ftd.conf


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
