### PR TITLE
[Ameba] Update Ameba platform

### DIFF
--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-ameba:140
+            image: ghcr.io/project-chip/chip-build-ameba:153
             options: --user root
 
         steps:

--- a/examples/air-purifier-app/ameba/main/chipinterface.cpp
+++ b/examples/air-purifier-app/ameba/main/chipinterface.cpp
@@ -15,38 +15,36 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Server.h"
-#include <DeviceInfoProviderImpl.h>
-
-#include "chip_porting.h"
-#include <platform/CHIPDeviceLayer.h>
-#include <support/CHIPMem.h>
+#include <AmebaObserver.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
 
 #include <air-purifier-manager.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/Server.h>
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+#include <app/server/TermsAndConditionsManager.h>
+#endif
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
+#if CONFIG_ENABLE_AMEBA_CRYPTO
+#include <platform/Ameba/crypto/AmebaPersistentStorageOperationalKeystore.h>
+#endif
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
 #include <setup_payload/OnboardingCodesUtil.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
-#if CONFIG_ENABLE_AMEBA_CRYPTO
-#include <platform/Ameba/crypto/AmebaPersistentStorageOperationalKeystore.h>
-#endif
-
-#include <lwip_netconf.h>
-
+#include <support/CHIPMem.h>
 #if CONFIG_ENABLE_PW_RPC
-#include "Rpc.h"
+#include <Rpc.h>
 #endif
 
 #define AIR_PURIFIER_ENDPOINT 1
@@ -60,6 +58,9 @@ using namespace ::chip::app;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -77,9 +78,6 @@ void NetWorkCommissioningInstInit()
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 }
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 void OnIdentifyStart(Identify *)
 {
@@ -136,12 +134,14 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
+
 #if CONFIG_ENABLE_AMEBA_CRYPTO
     ChipLogProgress(DeviceLayer, "platform crypto enabled!");
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
 #endif
+
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
     chip::Server::GetInstance().Init(initParams);
@@ -149,6 +149,13 @@ static void InitServer(intptr_t context)
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     NetWorkCommissioningInstInit();
+
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+    const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
+        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+#endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
     {

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -27,11 +27,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
 
 -   Setup build environment:
 

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -203,8 +203,6 @@ list(
     ${chip_dir}/examples/platform/ameba/route_hook/ameba_route_table.c
 
     ${chip_dir}/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
-
-    ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 
 add_library(

--- a/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
+++ b/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp
@@ -25,7 +25,10 @@
 
 #include <stdlib.h>
 
-#include "CHIPDeviceManager.h"
+#if CONFIG_ENABLE_AMEBA_ATTRIBUTE_CALLBACK
+#include <matter_attribute_callbacks.h>
+#endif
+#include <CHIPDeviceManager.h>
 #include <app/ConcreteAttributePath.h>
 #include <app/util/basic-types.h>
 #include <core/ErrorStr.h>
@@ -36,6 +39,8 @@
 #include <support/CodeUtils.h>
 
 using namespace ::chip;
+using namespace ::chip::app;
+using namespace ::chip::app::Clusters;
 using namespace ::chip::Credentials;
 
 namespace chip {
@@ -103,10 +108,18 @@ void CHIPDeviceManager::Shutdown()
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & path, uint8_t type, uint16_t size, uint8_t * value)
 {
+#if CONFIG_ENABLE_AMEBA_ATTRIBUTE_CALLBACK
+    if (AmebaDeviceManager::GetInstance() != nullptr)
+    {
+        AmebaDeviceManager::GetInstance()->AmebaPostAttributeChangeCallback(path.mEndpointId, path.mClusterId, path.mAttributeId,
+                                                                            type, size, value);
+    }
+#else
     chip::DeviceManager::CHIPDeviceManagerCallbacks * cb =
         chip::DeviceManager::CHIPDeviceManager::GetInstance().GetCHIPDeviceManagerCallbacks();
     if (cb != nullptr)
     {
         cb->PostAttributeChangeCallback(path.mEndpointId, path.mClusterId, path.mAttributeId, type, size, value);
     }
+#endif
 }

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -15,48 +15,55 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
-
-#include "AmebaObserver.h"
-#include "BindingHandler.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Globals.h"
-#include "LEDWidget.h"
-#include "chip_porting.h"
-#if CHIP_AMEBA_APP_TASK
-#include "ameba_main_task.h"
+#if CONFIG_ENABLE_AMEBA_APP_TASK
+#include <ameba_main_task.h>
 #endif
-#include <DeviceInfoProviderImpl.h>
+
+#include <AmebaObserver.h>
+#include <BindingHandler.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
+#include <Globals.h>
+#include <LEDWidget.h>
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+#include <app/server/TermsAndConditionsManager.h>
+#endif
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
-#include <setup_payload/OnboardingCodesUtil.h>
-
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #if CONFIG_ENABLE_AMEBA_CRYPTO
 #include <platform/Ameba/crypto/AmebaPersistentStorageOperationalKeystore.h>
 #endif
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/OnboardingCodesUtil.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CHIPMem.h>
-
 #if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
 #include <test_event_trigger/AmebaTestEventTriggerDelegate.h>
 #endif
-
+#if CONFIG_ENABLE_CHIP_SHELL
+#include <shell/launch_shell.h>
+#endif
 #if CONFIG_ENABLE_PW_RPC
 #include <Rpc.h>
 #endif
 
-#if CONFIG_ENABLE_CHIP_SHELL
-#include <shell/launch_shell.h>
+#ifdef CONFIG_PLATFORM_8721D
+#define STATUS_LED_GPIO_NUM PB_5
+#elif defined(CONFIG_PLATFORM_8710C)
+#define STATUS_LED_GPIO_NUM PA_20
+#else
+#define STATUS_LED_GPIO_NUM NC
 #endif
 
 using namespace ::chip;
@@ -64,6 +71,14 @@ using namespace ::chip::app;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
+#if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
+uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                                                   0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
+#endif
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -121,22 +136,6 @@ Identify gIdentify1 = {
     OnIdentifyTriggerEffect,
 };
 
-#ifdef CONFIG_PLATFORM_8721D
-#define STATUS_LED_GPIO_NUM PB_5
-#elif defined(CONFIG_PLATFORM_8710C)
-#define STATUS_LED_GPIO_NUM PA_20
-#else
-#define STATUS_LED_GPIO_NUM NC
-#endif
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-
-#if CONFIG_ENABLE_AMEBA_TEST_EVENT_TRIGGER
-uint8_t sTestEventTriggerEnableKey[TestEventTriggerDelegate::kEnableKeyLength] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
-                                                                                   0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
-#endif
-
 static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
@@ -146,6 +145,7 @@ static void InitServer(intptr_t context)
     static AmebaTestEventTriggerDelegate sTestEventTriggerDelegate{ ByteSpan(sTestEventTriggerEnableKey) };
     initParams.testEventTriggerDelegate = &sTestEventTriggerDelegate;
 #endif
+
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
 
@@ -164,6 +164,13 @@ static void InitServer(intptr_t context)
     // TODO: Use our own DeviceInfoProvider
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+    const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
+        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+#endif
+
     NetWorkCommissioningInstInit();
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
@@ -175,9 +182,11 @@ static void InitServer(intptr_t context)
 #if CONFIG_ENABLE_CHIP_SHELL
     InitBindingHandler();
 #endif
-#if CHIP_AMEBA_APP_TASK
+
+#if CONFIG_ENABLE_AMEBA_APP_TASK
     AppTaskInit();
 #endif
+
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
 }
 
@@ -216,7 +225,7 @@ extern "C" void ChipTestShutdown(void)
     deviceMgr.Shutdown();
 }
 
-bool lowPowerClusterSleep()
+bool lowPowerClusterSleep(void)
 {
     return true;
 }

--- a/examples/all-clusters-minimal-app/ameba/README.md
+++ b/examples/all-clusters-minimal-app/ameba/README.md
@@ -27,13 +27,13 @@ The CHIP demo application is supported on
 -   Pull docker image:
 
           ```
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
           ```
 
 -   Run docker container:
 
           ```
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
           ```
 
 -   Setup build environment:

--- a/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/chipinterface.cpp
@@ -15,15 +15,14 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Globals.h"
-#include "LEDWidget.h"
-#include "chip_porting.h"
-#include <lwip_netconf.h>
+#include <AmebaObserver.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
+#include <Globals.h>
+#include <LEDWidget.h>
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
@@ -34,6 +33,7 @@
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -53,7 +53,15 @@
 #endif
 
 #if CONFIG_ENABLE_PW_RPC
-#include "Rpc.h"
+#include <Rpc.h>
+#endif
+
+#ifdef CONFIG_PLATFORM_8721D
+#define STATUS_LED_GPIO_NUM PB_5
+#elif defined(CONFIG_PLATFORM_8710C)
+#define STATUS_LED_GPIO_NUM PA_20
+#else
+#define STATUS_LED_GPIO_NUM NC
 #endif
 
 using namespace ::chip;
@@ -62,6 +70,19 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
+#if CONFIG_ENABLE_OTA_REQUESTOR
+DefaultOTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
+ExtendedOTARequestorDriver gRequestorUser;
+BDXDownloader gDownloader;
+AmebaOTAImageProcessor gImageProcessor;
+chip::ota::DefaultOTARequestorUserConsent gUserConsentProvider;
+static chip::ota::UserConsentState gUserConsentState = chip::ota::UserConsentState::kGranted;
+#endif
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -94,26 +115,6 @@ Identify gIdentify1 = {
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
     Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
 };
-
-#ifdef CONFIG_PLATFORM_8721D
-#define STATUS_LED_GPIO_NUM PB_5
-#elif defined(CONFIG_PLATFORM_8710C)
-#define STATUS_LED_GPIO_NUM PA_20
-#else
-#define STATUS_LED_GPIO_NUM NC
-#endif
-
-static DeviceCallbacks EchoCallbacks;
-
-#if CONFIG_ENABLE_OTA_REQUESTOR
-DefaultOTARequestor gRequestorCore;
-DefaultOTARequestorStorage gRequestorStorage;
-ExtendedOTARequestorDriver gRequestorUser;
-BDXDownloader gDownloader;
-AmebaOTAImageProcessor gImageProcessor;
-chip::ota::DefaultOTARequestorUserConsent gUserConsentProvider;
-static chip::ota::UserConsentState gUserConsentState = chip::ota::UserConsentState::kGranted;
-#endif
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
 extern "C" void amebaQueryImageCmdHandler()
@@ -158,16 +159,16 @@ static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
+    static AmebaObserver sAmebaObserver;
+    initParams.appDelegate = &sAmebaObserver;
     initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
 
-    static AmebaObserver sAmebaObserver;
-    initParams.appDelegate = &sAmebaObserver;
-
     chip::Server::GetInstance().Init(initParams);
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    // TODO: Use our own DeviceInfoProvider
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
-    // Initialize device attestation config
-    SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
     NetWorkCommissioningInstInit();
 
 #if CONFIG_ENABLE_OTA_REQUESTOR
@@ -179,7 +180,9 @@ static void InitServer(intptr_t context)
         // QR code will be used with CHIP Tool
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
+
     Clusters::ModeSelect::setSupportedModesManager(&sStaticSupportedModesManager);
+
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
 }
 

--- a/examples/chef/ameba/main/chipinterface.cpp
+++ b/examples/chef/ameba/main/chipinterface.cpp
@@ -15,16 +15,14 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Globals.h"
-#include "LEDWidget.h"
-#include "chip_porting.h"
-#include <DeviceInfoProviderImpl.h>
-#include <lwip_netconf.h>
+#include <AmebaObserver.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
+#include <Globals.h>
+#include <LEDWidget.h>
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
@@ -35,6 +33,7 @@
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/FactoryDataProvider.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -42,13 +41,19 @@
 #include <setup_payload/OnboardingCodesUtil.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CHIPMem.h>
-
+#if CONFIG_ENABLE_CHIP_SHELL
+#include <shell/launch_shell.h>
+#endif
 #if CONFIG_ENABLE_PW_RPC
 #include <Rpc.h>
 #endif
 
-#if CONFIG_ENABLE_CHIP_SHELL
-#include <shell/launch_shell.h>
+#ifdef CONFIG_PLATFORM_8721D
+#define STATUS_LED_GPIO_NUM PB_5
+#elif defined(CONFIG_PLATFORM_8710C)
+#define STATUS_LED_GPIO_NUM PA_20
+#else
+#define STATUS_LED_GPIO_NUM NC
 #endif
 
 using namespace ::chip;
@@ -57,6 +62,10 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -88,18 +97,6 @@ Identify gIdentify1 = {
     [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
     Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
 };
-
-#ifdef CONFIG_PLATFORM_8721D
-#define STATUS_LED_GPIO_NUM PB_5
-#elif defined(CONFIG_PLATFORM_8710C)
-#define STATUS_LED_GPIO_NUM PA_20
-#else
-#define STATUS_LED_GPIO_NUM NC
-#endif
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-chip::DeviceLayer::FactoryDataProvider mFactoryDataProvider;
 
 static void InitServer(intptr_t context)
 {

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -26,11 +26,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
 
 -   Setup build environment:
 

--- a/examples/light-switch-app/ameba/main/chipinterface.cpp
+++ b/examples/light-switch-app/ameba/main/chipinterface.cpp
@@ -15,41 +15,49 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "BindingHandler.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Globals.h"
-#include "LEDWidget.h"
-#include "chip_porting.h"
-#include <DeviceInfoProviderImpl.h>
-#include <lwip_netconf.h>
+#include <AmebaObserver.h>
+#include <BindingHandler.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
+#include <Globals.h>
+#include <LEDWidget.h>
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+#include <app/server/TermsAndConditionsManager.h>
+#endif
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
-#include <setup_payload/OnboardingCodesUtil.h>
 #if CONFIG_ENABLE_AMEBA_CRYPTO
 #include <platform/Ameba/crypto/AmebaPersistentStorageOperationalKeystore.h>
 #endif
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/OnboardingCodesUtil.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <support/CHIPMem.h>
-
+#if CONFIG_ENABLE_CHIP_SHELL
+#include <shell/launch_shell.h>
+#endif
 #if CONFIG_ENABLE_PW_RPC
 #include <Rpc.h>
 #endif
 
-#if CONFIG_ENABLE_CHIP_SHELL
-#include <shell/launch_shell.h>
+#ifdef CONFIG_PLATFORM_8721D
+#define STATUS_LED_GPIO_NUM PB_5
+#elif defined(CONFIG_PLATFORM_8710C)
+#define STATUS_LED_GPIO_NUM PA_20
+#else
+#define STATUS_LED_GPIO_NUM NC
 #endif
 
 using namespace ::chip;
@@ -57,6 +65,9 @@ using namespace ::chip::app;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -89,29 +100,20 @@ Identify gIdentify1 = {
     Clusters::Identify::IdentifyTypeEnum::kVisibleIndicator,
 };
 
-#ifdef CONFIG_PLATFORM_8721D
-#define STATUS_LED_GPIO_NUM PB_5
-#elif defined(CONFIG_PLATFORM_8710C)
-#define STATUS_LED_GPIO_NUM PA_20
-#else
-#define STATUS_LED_GPIO_NUM NC
-#endif
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-
 static void InitServer(intptr_t context)
 {
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
+
 #if CONFIG_ENABLE_AMEBA_CRYPTO
     ChipLogProgress(DeviceLayer, "platform crypto enabled!");
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
 #endif
+
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
     chip::Server::GetInstance().Init(initParams);
@@ -119,6 +121,13 @@ static void InitServer(intptr_t context)
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     NetWorkCommissioningInstInit();
+
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+    const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
+        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+#endif
 
     if (RTW_SUCCESS != wifi_is_connected_to_ap())
     {
@@ -129,6 +138,7 @@ static void InitServer(intptr_t context)
 #if CONFIG_ENABLE_CHIP_SHELL
     InitBindingHandler();
 #endif
+
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
 }
 

--- a/examples/lighting-app/ameba/README.md
+++ b/examples/lighting-app/ameba/README.md
@@ -23,11 +23,11 @@ The CHIP demo application is supported on
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
 
 -   Setup build environment:
 

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -15,38 +15,46 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "Globals.h"
-#include "LEDWidget.h"
-#include "Server.h"
-#include <DeviceInfoProviderImpl.h>
-
-#include "chip_porting.h"
-#include <platform/CHIPDeviceLayer.h>
-#include <support/CHIPMem.h>
+#include <AmebaObserver.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
+#include <Globals.h>
+#include <LEDWidget.h>
 
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/server/Server.h>
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+#include <app/server/TermsAndConditionsManager.h>
+#endif
 #include <app/util/endpoint-config-api.h>
 #include <data-model-providers/codegen/Instance.h>
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
-#include <setup_payload/OnboardingCodesUtil.h>
 #if CONFIG_ENABLE_AMEBA_CRYPTO
 #include <platform/Ameba/crypto/AmebaPersistentStorageOperationalKeystore.h>
 #endif
-#include <lwip_netconf.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
+#include <setup_payload/OnboardingCodesUtil.h>
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
+#include <support/CHIPMem.h>
 
 #if CONFIG_ENABLE_PW_RPC
 #include "Rpc.h"
+#endif
+
+#ifdef CONFIG_PLATFORM_8721D
+#define STATUS_LED_GPIO_NUM PB_5
+#elif defined(CONFIG_PLATFORM_8710C)
+#define STATUS_LED_GPIO_NUM PA_20
+#else
+#define STATUS_LED_GPIO_NUM NC
 #endif
 
 using namespace ::chip;
@@ -54,6 +62,9 @@ using namespace ::chip::app;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
+
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
@@ -71,17 +82,6 @@ void NetWorkCommissioningInstInit()
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 }
-
-#ifdef CONFIG_PLATFORM_8721D
-#define STATUS_LED_GPIO_NUM PB_5
-#elif defined(CONFIG_PLATFORM_8710C)
-#define STATUS_LED_GPIO_NUM PA_20
-#else
-#define STATUS_LED_GPIO_NUM NC
-#endif
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 void OnIdentifyStart(Identify *)
 {
@@ -126,17 +126,26 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     initParams.dataModelProvider = CodegenDataModelProviderInstance(initParams.persistentStorageDelegate);
+
 #if CONFIG_ENABLE_AMEBA_CRYPTO
     ChipLogProgress(DeviceLayer, "platform crypto enabled!");
     static chip::AmebaPersistentStorageOperationalKeystore sAmebaPersistentStorageOpKeystore;
     VerifyOrDie((sAmebaPersistentStorageOpKeystore.Init(initParams.persistentStorageDelegate)) == CHIP_NO_ERROR);
     initParams.operationalKeystore = &sAmebaPersistentStorageOpKeystore;
 #endif
+
     static AmebaObserver sAmebaObserver;
     initParams.appDelegate = &sAmebaObserver;
     chip::Server::GetInstance().Init(initParams);
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+
+#if CHIP_ENABLE_AMEBA_TERMS_AND_CONDITION
+    const Optional<app::TermsAndConditions> termsAndConditions = Optional<app::TermsAndConditions>(
+        app::TermsAndConditions(CHIP_AMEBA_TC_REQUIRED_ACKNOWLEDGEMENTS, CHIP_AMEBA_TC_MIN_REQUIRED_VERSION));
+    PersistentStorageDelegate & persistentStorageDelegate = Server::GetInstance().GetPersistentStorage();
+    chip::app::TermsAndConditionsManager::GetInstance()->Init(&persistentStorageDelegate, termsAndConditions);
+#endif
 
     NetWorkCommissioningInstInit();
 
@@ -145,6 +154,7 @@ static void InitServer(intptr_t context)
         // QR code will be used with CHIP Tool
         PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));
     }
+
     chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAmebaObserver);
 }
 

--- a/examples/ota-requestor-app/ameba/README.md
+++ b/examples/ota-requestor-app/ameba/README.md
@@ -6,11 +6,11 @@ A prototype application that demonstrates OTA Requestor capabilities.
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
 
 -   Setup build environment:
 

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -15,13 +15,12 @@
  *    limitations under the License.
  */
 
+#include <chip_porting.h>
 #include <platform_stdlib.h>
 
-#include "AmebaObserver.h"
-#include "CHIPDeviceManager.h"
-#include "DeviceCallbacks.h"
-#include "chip_porting.h"
-#include <DeviceInfoProviderImpl.h>
+#include <AmebaObserver.h>
+#include <CHIPDeviceManager.h>
+#include <DeviceCallbacks.h>
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
@@ -30,6 +29,7 @@
 
 #include <lib/core/ErrorStr.h>
 #include <platform/Ameba/AmebaConfig.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <support/CHIPMem.h>
@@ -53,6 +53,9 @@ using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::DeviceLayer;
 
+static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
 namespace { // Network Commissioning
 constexpr EndpointId kNetworkCommissioningEndpointMain      = 0;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
@@ -69,9 +72,6 @@ void NetWorkCommissioningInstInit()
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 }
-
-static DeviceCallbacks EchoCallbacks;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 static void InitServer(intptr_t context)
 {

--- a/examples/pigweed-app/ameba/README.md
+++ b/examples/pigweed-app/ameba/README.md
@@ -31,11 +31,11 @@ following features are available:
 
 -   Pull docker image:
 
-          $ docker pull ghcr.io/project-chip/chip-build-ameba:140
+          $ docker pull ghcr.io/project-chip/chip-build-ameba:153
 
 -   Run docker container:
 
-          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:140
+          $ docker run -it -v ${CHIP_DIR}:/root/chip ghcr.io/project-chip/chip-build-ameba:153
 
 -   Setup build environment:
 

--- a/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
+++ b/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.cpp
@@ -35,4 +35,11 @@ bool AmebaTestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableKe
     return !mEnableKey.empty() && mEnableKey.data_equal(enableKey);
 }
 
+CHIP_ERROR AmebaTestEventTriggerDelegate::HandleEventTrigger(uint64_t eventTrigger)
+{
+    eventTrigger = clearEndpointInEventTrigger(eventTrigger);
+    // WARNING: LEGACY SUPPORT ONLY, DO NOT EXTEND FOR STANDARD CLUSTERS
+    return (AmebaHandleGlobalTestEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
+}
+
 } // namespace chip

--- a/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
+++ b/examples/platform/ameba/test_event_trigger/AmebaTestEventTriggerDelegate.h
@@ -56,12 +56,7 @@ public:
      */
     bool DoesEnableKeyMatch(const ByteSpan & enableKey) const override;
 
-    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override
-    {
-        eventTrigger = clearEndpointInEventTrigger(eventTrigger);
-        // WARNING: LEGACY SUPPORT ONLY, DO NOT EXTEND FOR STANDARD CLUSTERS
-        return (AmebaHandleGlobalTestEventTrigger(eventTrigger)) ? CHIP_NO_ERROR : CHIP_ERROR_INVALID_ARGUMENT;
-    }
+    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override;
 
 private:
     ByteSpan mEnableKey;

--- a/src/platform/Ameba/BUILD.gn
+++ b/src/platform/Ameba/BUILD.gn
@@ -33,6 +33,8 @@ static_library("Ameba") {
     "ConfigurationManagerImpl.h",
     "ConnectivityManagerImpl.cpp",
     "ConnectivityManagerImpl.h",
+    "DeviceInfoProviderImpl.cpp",
+    "DeviceInfoProviderImpl.h",
     "DiagnosticDataProviderImpl.cpp",
     "DiagnosticDataProviderImpl.h",
     "FactoryDataDecoder.cpp",

--- a/src/platform/Ameba/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Ameba/DeviceInfoProviderImpl.cpp
@@ -1,0 +1,274 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/core/TLV.h>
+#include <lib/support/CHIPMemString.h>
+#include <lib/support/CodeUtils.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+#include <lib/support/SafeInt.h>
+#include <lib/support/Span.h>
+#include <matter_data_providers.h>
+#include <platform/Ameba/DeviceInfoProviderImpl.h>
+#include <platform/internal/CHIPDeviceLayerInternal.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <cstring>
+
+namespace chip {
+namespace DeviceLayer {
+
+namespace {
+constexpr TLV::Tag kLabelNameTag  = TLV::ContextTag(0);
+constexpr TLV::Tag kLabelValueTag = TLV::ContextTag(1);
+} // anonymous namespace
+
+DeviceInfoProviderImpl & DeviceInfoProviderImpl::GetDefaultInstance()
+{
+    static DeviceInfoProviderImpl sInstance;
+    return sInstance;
+}
+
+DeviceInfoProvider::FixedLabelIterator * DeviceInfoProviderImpl::IterateFixedLabel(EndpointId endpoint)
+{
+    return chip::Platform::New<FixedLabelIteratorImpl>(endpoint);
+}
+
+DeviceInfoProviderImpl::FixedLabelIteratorImpl::FixedLabelIteratorImpl(EndpointId endpoint) : mEndpoint(endpoint)
+{
+    mIndex = 0;
+}
+
+size_t DeviceInfoProviderImpl::FixedLabelIteratorImpl::Count()
+{
+    return matter_get_fixed_label_count();
+}
+
+bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & output)
+{
+    VerifyOrReturnError(mIndex < matter_get_fixed_label_count(), false);
+
+    ChipLogProgress(DeviceLayer, "Get the fixed label with index:%u at endpoint:%d", static_cast<unsigned>(mIndex), mEndpoint);
+
+    bool retval    = true;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    const char * labelPtr = matter_get_fixed_label_name(mIndex);
+    const char * valuePtr = matter_get_fixed_label_value(mIndex);
+
+    if (labelPtr == nullptr || valuePtr == nullptr)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(std::strlen(labelPtr) <= kMaxLabelNameLength, false);
+        VerifyOrReturnError(std::strlen(valuePtr) <= kMaxLabelValueLength, false);
+
+        Platform::CopyString(mFixedLabelNameBuf, labelPtr);
+        Platform::CopyString(mFixedLabelValueBuf, valuePtr);
+
+        output.label = CharSpan::fromCharString(mFixedLabelNameBuf);
+        output.value = CharSpan::fromCharString(mFixedLabelValueBuf);
+
+        mIndex++;
+
+        retval = true;
+    }
+    else
+    {
+        retval = false;
+    }
+
+    return retval;
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_t val)
+{
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val,
+                                     static_cast<uint16_t>(sizeof(val)));
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::GetUserLabelLength(EndpointId endpoint, size_t & val)
+{
+    uint16_t len = static_cast<uint16_t>(sizeof(val));
+
+    return mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::UserLabelLengthKey(endpoint).KeyName(), &val, len);
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel)
+{
+    VerifyOrReturnError(CanCastTo<uint32_t>(index), CHIP_ERROR_INVALID_ARGUMENT);
+
+    uint8_t buf[UserLabelTLVMaxSize()];
+    TLV::TLVWriter writer;
+    writer.Init(buf);
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
+    ReturnErrorOnFailure(writer.PutString(kLabelNameTag, userLabel.label));
+    ReturnErrorOnFailure(writer.PutString(kLabelValueTag, userLabel.value));
+    ReturnErrorOnFailure(writer.EndContainer(outerType));
+
+    return mStorage->SyncSetKeyValue(
+        DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)).KeyName(), buf,
+        static_cast<uint16_t>(writer.GetLengthWritten()));
+}
+
+CHIP_ERROR DeviceInfoProviderImpl::DeleteUserLabelAt(EndpointId endpoint, size_t index)
+{
+    return mStorage->SyncDeleteKeyValue(
+        DefaultStorageKeyAllocator::UserLabelIndexKey(endpoint, static_cast<uint32_t>(index)).KeyName());
+}
+
+DeviceInfoProvider::UserLabelIterator * DeviceInfoProviderImpl::IterateUserLabel(EndpointId endpoint)
+{
+    return chip::Platform::New<UserLabelIteratorImpl>(*this, endpoint);
+}
+
+DeviceInfoProviderImpl::UserLabelIteratorImpl::UserLabelIteratorImpl(DeviceInfoProviderImpl & provider, EndpointId endpoint) :
+    mProvider(provider), mEndpoint(endpoint)
+{
+    size_t total = 0;
+
+    ReturnOnFailure(mProvider.GetUserLabelLength(mEndpoint, total));
+    mTotal = total;
+    mIndex = 0;
+}
+
+bool DeviceInfoProviderImpl::UserLabelIteratorImpl::Next(UserLabelType & output)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    VerifyOrReturnError(mIndex < mTotal, false);
+    VerifyOrReturnError(CanCastTo<uint32_t>(mIndex), false);
+
+    uint8_t buf[UserLabelTLVMaxSize()];
+    uint16_t len = static_cast<uint16_t>(sizeof(buf));
+
+    err = mProvider.mStorage->SyncGetKeyValue(
+        DefaultStorageKeyAllocator::UserLabelIndexKey(mEndpoint, static_cast<uint32_t>(mIndex)).KeyName(), buf, len);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, false);
+
+    TLV::ContiguousBufferTLVReader reader;
+    reader.Init(buf);
+    err = reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag());
+    VerifyOrReturnError(err == CHIP_NO_ERROR, false);
+
+    TLV::TLVType containerType;
+    VerifyOrReturnError(reader.EnterContainer(containerType) == CHIP_NO_ERROR, false);
+
+    chip::CharSpan label;
+    chip::CharSpan value;
+
+    VerifyOrReturnError(reader.Next(kLabelNameTag) == CHIP_NO_ERROR, false);
+    VerifyOrReturnError(reader.Get(label) == CHIP_NO_ERROR, false);
+
+    VerifyOrReturnError(reader.Next(kLabelValueTag) == CHIP_NO_ERROR, false);
+    VerifyOrReturnError(reader.Get(value) == CHIP_NO_ERROR, false);
+
+    VerifyOrReturnError(reader.VerifyEndOfContainer() == CHIP_NO_ERROR, false);
+    VerifyOrReturnError(reader.ExitContainer(containerType) == CHIP_NO_ERROR, false);
+
+    Platform::CopyString(mUserLabelNameBuf, label);
+    Platform::CopyString(mUserLabelValueBuf, value);
+
+    output.label = CharSpan::fromCharString(mUserLabelNameBuf);
+    output.value = CharSpan::fromCharString(mUserLabelValueBuf);
+
+    mIndex++;
+
+    return true;
+}
+
+DeviceInfoProvider::SupportedLocalesIterator * DeviceInfoProviderImpl::IterateSupportedLocales()
+{
+    return chip::Platform::New<SupportedLocalesIteratorImpl>();
+}
+
+size_t DeviceInfoProviderImpl::SupportedLocalesIteratorImpl::Count()
+{
+    return matter_get_supported_locale_count();
+}
+
+bool DeviceInfoProviderImpl::SupportedLocalesIteratorImpl::Next(CharSpan & output)
+{
+    VerifyOrReturnError(mIndex < matter_get_supported_locale_count(), false);
+
+    bool retval                  = true;
+    CHIP_ERROR err               = CHIP_NO_ERROR;
+    const char * activeLocalePtr = matter_get_supported_locale_value(mIndex);
+
+    if (activeLocalePtr == nullptr)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(std::strlen(activeLocalePtr) <= kMaxActiveLocaleLength, false);
+
+        Platform::CopyString(mActiveLocaleBuf, kMaxActiveLocaleLength + 1, activeLocalePtr);
+
+        output = CharSpan::fromCharString(mActiveLocaleBuf);
+
+        mIndex++;
+
+        retval = true;
+    }
+    else
+    {
+        retval = false;
+    }
+
+    return retval;
+}
+
+DeviceInfoProvider::SupportedCalendarTypesIterator * DeviceInfoProviderImpl::IterateSupportedCalendarTypes()
+{
+    return chip::Platform::New<SupportedCalendarTypesIteratorImpl>();
+}
+
+size_t DeviceInfoProviderImpl::SupportedCalendarTypesIteratorImpl::Count()
+{
+    return matter_get_calendar_type_count();
+}
+
+bool DeviceInfoProviderImpl::SupportedCalendarTypesIteratorImpl::Next(CalendarType & output)
+{
+    VerifyOrReturnError(mIndex < matter_get_calendar_type_count(), false);
+
+    size_t count      = matter_get_calendar_type_count();
+    uint8_t key_value = 0;
+
+    bool retval = matter_get_calendar_type_value(mIndex, &key_value);
+
+    if (!retval)
+    {
+        return retval;
+    }
+
+    output = static_cast<CalendarType>(key_value);
+    mIndex++;
+
+    return retval;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Ameba/DeviceInfoProviderImpl.cpp
+++ b/src/platform/Ameba/DeviceInfoProviderImpl.cpp
@@ -65,38 +65,26 @@ bool DeviceInfoProviderImpl::FixedLabelIteratorImpl::Next(FixedLabelType & outpu
 
     ChipLogProgress(DeviceLayer, "Get the fixed label with index:%u at endpoint:%d", static_cast<unsigned>(mIndex), mEndpoint);
 
-    bool retval    = true;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     const char * labelPtr = matter_get_fixed_label_name(mIndex);
     const char * valuePtr = matter_get_fixed_label_value(mIndex);
 
     if (labelPtr == nullptr || valuePtr == nullptr)
     {
-        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        return false;
     }
 
-    if (err == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(std::strlen(labelPtr) <= kMaxLabelNameLength, false);
-        VerifyOrReturnError(std::strlen(valuePtr) <= kMaxLabelValueLength, false);
+    VerifyOrReturnError(std::strlen(labelPtr) <= kMaxLabelNameLength, false);
+    VerifyOrReturnError(std::strlen(valuePtr) <= kMaxLabelValueLength, false);
 
-        Platform::CopyString(mFixedLabelNameBuf, labelPtr);
-        Platform::CopyString(mFixedLabelValueBuf, valuePtr);
+    Platform::CopyString(mFixedLabelNameBuf, labelPtr);
+    Platform::CopyString(mFixedLabelValueBuf, valuePtr);
 
-        output.label = CharSpan::fromCharString(mFixedLabelNameBuf);
-        output.value = CharSpan::fromCharString(mFixedLabelValueBuf);
+    output.label = CharSpan::fromCharString(mFixedLabelNameBuf);
+    output.value = CharSpan::fromCharString(mFixedLabelValueBuf);
 
-        mIndex++;
+    mIndex++;
 
-        retval = true;
-    }
-    else
-    {
-        retval = false;
-    }
-
-    return retval;
+    return true;
 }
 
 CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelLength(EndpointId endpoint, size_t val)
@@ -211,33 +199,22 @@ bool DeviceInfoProviderImpl::SupportedLocalesIteratorImpl::Next(CharSpan & outpu
 {
     VerifyOrReturnError(mIndex < matter_get_supported_locale_count(), false);
 
-    bool retval                  = true;
-    CHIP_ERROR err               = CHIP_NO_ERROR;
     const char * activeLocalePtr = matter_get_supported_locale_value(mIndex);
 
     if (activeLocalePtr == nullptr)
     {
-        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        return false;
     }
 
-    if (err == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(std::strlen(activeLocalePtr) <= kMaxActiveLocaleLength, false);
+    VerifyOrReturnError(std::strlen(activeLocalePtr) <= kMaxActiveLocaleLength, false);
 
-        Platform::CopyString(mActiveLocaleBuf, kMaxActiveLocaleLength + 1, activeLocalePtr);
+    Platform::CopyString(mActiveLocaleBuf, kMaxActiveLocaleLength + 1, activeLocalePtr);
 
-        output = CharSpan::fromCharString(mActiveLocaleBuf);
+    output = CharSpan::fromCharString(mActiveLocaleBuf);
 
-        mIndex++;
+    mIndex++;
 
-        retval = true;
-    }
-    else
-    {
-        retval = false;
-    }
-
-    return retval;
+    return true;
 }
 
 DeviceInfoProvider::SupportedCalendarTypesIterator * DeviceInfoProviderImpl::IterateSupportedCalendarTypes()
@@ -254,7 +231,6 @@ bool DeviceInfoProviderImpl::SupportedCalendarTypesIteratorImpl::Next(CalendarTy
 {
     VerifyOrReturnError(mIndex < matter_get_calendar_type_count(), false);
 
-    size_t count      = matter_get_calendar_type_count();
     uint8_t key_value = 0;
 
     bool retval = matter_get_calendar_type_value(mIndex, &key_value);

--- a/src/platform/Ameba/DeviceInfoProviderImpl.h
+++ b/src/platform/Ameba/DeviceInfoProviderImpl.h
@@ -1,0 +1,107 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/support/EnforceFormat.h>
+#include <platform/DeviceInfoProvider.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class DeviceInfoProviderImpl : public DeviceInfoProvider
+{
+public:
+    DeviceInfoProviderImpl() = default;
+    ~DeviceInfoProviderImpl() override {}
+
+    // Iterators
+    FixedLabelIterator * IterateFixedLabel(EndpointId endpoint) override;
+    UserLabelIterator * IterateUserLabel(EndpointId endpoint) override;
+    SupportedLocalesIterator * IterateSupportedLocales() override;
+    SupportedCalendarTypesIterator * IterateSupportedCalendarTypes() override;
+
+    static DeviceInfoProviderImpl & GetDefaultInstance();
+
+protected:
+    class FixedLabelIteratorImpl : public FixedLabelIterator
+    {
+    public:
+        FixedLabelIteratorImpl(EndpointId endpoint);
+        size_t Count() override;
+        bool Next(FixedLabelType & output) override;
+        void Release() override { chip::Platform::Delete(this); }
+
+    private:
+        EndpointId mEndpoint = 0;
+        size_t mIndex        = 0;
+        char mFixedLabelNameBuf[kMaxLabelNameLength + 1];
+        char mFixedLabelValueBuf[kMaxLabelValueLength + 1];
+    };
+
+    class UserLabelIteratorImpl : public UserLabelIterator
+    {
+    public:
+        UserLabelIteratorImpl(DeviceInfoProviderImpl & provider, EndpointId endpoint);
+        size_t Count() override { return mTotal; }
+        bool Next(UserLabelType & output) override;
+        void Release() override { chip::Platform::Delete(this); }
+
+    private:
+        DeviceInfoProviderImpl & mProvider;
+        EndpointId mEndpoint = 0;
+        size_t mIndex        = 0;
+        size_t mTotal        = 0;
+        char mUserLabelNameBuf[kMaxLabelNameLength + 1];
+        char mUserLabelValueBuf[kMaxLabelValueLength + 1];
+    };
+
+    class SupportedLocalesIteratorImpl : public SupportedLocalesIterator
+    {
+    public:
+        SupportedLocalesIteratorImpl() = default;
+        size_t Count() override;
+        bool Next(CharSpan & output) override;
+        void Release() override { chip::Platform::Delete(this); }
+
+    private:
+        size_t mIndex = 0;
+        char mActiveLocaleBuf[kMaxActiveLocaleLength + 1];
+    };
+
+    class SupportedCalendarTypesIteratorImpl : public SupportedCalendarTypesIterator
+    {
+    public:
+        SupportedCalendarTypesIteratorImpl() = default;
+        size_t Count() override;
+        bool Next(CalendarType & output) override;
+        void Release() override { chip::Platform::Delete(this); }
+
+    private:
+        size_t mIndex = 0;
+    };
+
+    CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) override;
+    CHIP_ERROR GetUserLabelLength(EndpointId endpoint, size_t & val) override;
+    CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) override;
+    CHIP_ERROR DeleteUserLabelAt(EndpointId endpoint, size_t index) override;
+
+private:
+    static constexpr size_t UserLabelTLVMaxSize() { return TLV::EstimateStructOverhead(kMaxLabelNameLength, kMaxLabelValueLength); }
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/Ameba/FactoryDataProvider.cpp
+++ b/src/platform/Ameba/FactoryDataProvider.cpp
@@ -623,7 +623,8 @@ CHIP_ERROR FactoryDataProvider::GetHardwareVersion(uint16_t & hardwareVersion)
     }
     else
     {
-        err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+        hardwareVersion = CHIP_DEVICE_CONFIG_DEFAULT_DEVICE_HARDWARE_VERSION;
+        err             = CHIP_NO_ERROR;
     }
 
     return err;
@@ -695,6 +696,14 @@ CHIP_ERROR FactoryDataProvider::GetProductPrimaryColor(ColorEnum * primaryColor)
     CHIP_ERROR err = CHIP_NO_ERROR;
     *primaryColor  = ColorEnum::kBlack;
     return err;
+}
+
+CHIP_ERROR FactoryDataProvider::GetSoftwareVersionString(char * buf, size_t bufSize)
+{
+    VerifyOrReturnError(bufSize >= sizeof(CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING), CHIP_ERROR_BUFFER_TOO_SMALL);
+    snprintf(buf, bufSize, "%s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Ameba/FactoryDataProvider.h
+++ b/src/platform/Ameba/FactoryDataProvider.h
@@ -62,6 +62,7 @@ public:
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
     CHIP_ERROR GetProductFinish(app::Clusters::BasicInformation::ProductFinishEnum * finish) override;
     CHIP_ERROR GetProductPrimaryColor(app::Clusters::BasicInformation::ColorEnum * primaryColor) override;
+    CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
 
     bool kReadFromFlash = false;
 


### PR DESCRIPTION
#### Summary

- Added Ameba Device Info Provider implementation to support Fixed Label, User Label, Locales, and Calendar.
- Moved HandleEventTrigger from header file to .cpp to allow platform implementation to override the Test Event Trigger.
- Added AmebaDeviceManager to receive post-attribute change callbacks in platform applications layer.
- Fixed incorrect default value retrieval for hardware version.
- Added GetSoftwareVersionString to correctly retrieve the software version string.
- Tidy up chipinterface.cpp
- update compatible builds to docker version 153 for Ameba Platform.

Same changes as #39982 , it is required to fix several test cases for v1.4.2.

#### Testing
Adding of Ameba Device Info Provider
- verified with chip-tool command to retrieve the correct supporting list of label-list and supported-calendar-types. Also checked with set and get for userlabel:
- ./chip-tool timeformatlocalization read supported-calendar-types 1 0
- ./chip-tool fixedlabel read label-list 1 0
- ./chip-tool userlabel write label-list '[{"label":"roomName", "value":"master bedroom 1"}, {"label":"orientation", "value":"east"}, {"label":"floor", "value":"2"}, {"label":"roomType", "value":"bedroom"}]' 1 0
- ./chip-tool userlabel read label-list 1 0

Changes for Hardware Version and Software Version String
- verified with chip-tool command to obtain the default Hardware version if factory data is disabled, and default Software version string declared using predefined macros.
- ./chip-tool basicinformation read hardware-version 1 0
- ./chip-tool basicinformation read software-version-string 10

Changes for HandleEventTrigger, AmebaDeviceManager and chipinterface.cpp
- verified on Ameba platform build, will also be check with CI.
- purpose: Flexible handling of event on vendor application layer, similar to AmebaDeviceManager, where post attribute callback can be posted to vendor application layer to perform action required.