### PR TITLE
Make codecov informational and not enforced

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,13 +1,14 @@
+# NOTE: we currently want to see coverage but not enforce it.
+#
+# See https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks
 coverage:
   status:
     project:
-      # default is the status check's name, not default settings
       default:
-        if_ci_failed: success
+        informational: true
     patch:
-      # default is the status check's name, not default settings
       default:
-        if_ci_failed: success
+        informational: true
 
 parsers:
   cobertura:


### PR DESCRIPTION
#### Summary

Codecov seems still blocking in some cases. Try to make it not blocking based on 
https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks

#### Testing

Validated syntax via `curl -X POST --data-binary @.github/codecov.yml https://codecov.io/validate`

<img width="940" height="585" alt="image" src="https://github.com/user-attachments/assets/65a5b2cb-5d05-4202-9621-1a23e9a0a7b7" />
