### PR TITLE
[Silabs] Add support to suppress alarm manually

### DIFF
--- a/examples/refrigerator-app/silabs/include/EventHandlerLibShell.h
+++ b/examples/refrigerator-app/silabs/include/EventHandlerLibShell.h
@@ -23,7 +23,7 @@
 class EventData
 {
 public:
-    chip::app::Clusters::RefrigeratorAlarm::Events::Notify::Fields eventId;
+    chip::app::Clusters::RefrigeratorAlarm::Events::Notify::Fields eventState;
 };
 
 class RefrigeratorAlarmEventData : public EventData

--- a/examples/refrigerator-app/silabs/include/EventHandlerLibShell.h
+++ b/examples/refrigerator-app/silabs/include/EventHandlerLibShell.h
@@ -23,7 +23,7 @@
 class EventData
 {
 public:
-    chip::EventId eventId;
+    chip::app::Clusters::RefrigeratorAlarm::Events::Notify::Fields eventId;
 };
 
 class RefrigeratorAlarmEventData : public EventData

--- a/examples/refrigerator-app/silabs/include/RefrigeratorManager.h
+++ b/examples/refrigerator-app/silabs/include/RefrigeratorManager.h
@@ -44,7 +44,7 @@ class RefrigeratorManager
 public:
     CHIP_ERROR Init();
     void TempCtrlAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value, uint16_t size);
-    void RefAlaramAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value, uint16_t size);
+    void RefAlarmAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value, uint16_t size);
     uint8_t GetMode();
     int8_t GetCurrentTemp();
     int8_t SetMode();

--- a/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
+++ b/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
@@ -33,20 +33,20 @@ const uint8_t ModeNormal      = 0;
 const uint8_t ModeRapidCool   = 1;
 const uint8_t ModeRapidFreeze = 2;
 
-/// This is an application level delegate to handle LaundryWasherMode commands according to the specific business logic.
+/// This is an application level delegate to handle TemperatureControlledCabinetMode commands according to the specific business logic.
 class RefrigeratorAndTemperatureControlledCabinetModeDelegate : public ModeBase::Delegate
 {
 private:
     using ModeTagStructType                  = detail::Structs::ModeTagStruct::Type;
-    ModeTagStructType modeTagsNoarmal[1]     = { { .value = to_underlying(ModeTag::kAuto) } };
+    ModeTagStructType modeTagsNormal[1]      = { { .value = to_underlying(ModeTag::kAuto) } };
     ModeTagStructType modeTagsRapidCool[1]   = { { .value = to_underlying(ModeTag::kRapidCool) } };
-    ModeTagStructType modeTagsRapidFreeze[3] = { { .value = to_underlying(ModeBase::ModeTag::kMax) },
+    ModeTagStructType modeTagsRapidFreeze[2] = { { .value = to_underlying(ModeBase::ModeTag::kMax) },
                                                  { .value = to_underlying(ModeTag::kRapidFreeze) } };
 
     const detail::Structs::ModeOptionStruct::Type kModeOptions[3] = {
         detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Normal"),
                                                  .mode     = ModeNormal,
-                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNoarmal) },
+                                                 .modeTags = DataModel::List<const ModeTagStructType>(modeTagsNormal) },
         detail::Structs::ModeOptionStruct::Type{ .label    = CharSpan::fromCharString("Rapid Cool"),
                                                  .mode     = ModeRapidCool,
                                                  .modeTags = DataModel::List<const ModeTagStructType>(modeTagsRapidCool) },

--- a/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
+++ b/examples/refrigerator-app/silabs/include/refrigerator-and-temperature-controlled-cabinet-mode.h
@@ -33,7 +33,8 @@ const uint8_t ModeNormal      = 0;
 const uint8_t ModeRapidCool   = 1;
 const uint8_t ModeRapidFreeze = 2;
 
-/// This is an application level delegate to handle TemperatureControlledCabinetMode commands according to the specific business logic.
+/// This is an application level delegate to handle TemperatureControlledCabinetMode commands according to the specific business
+/// logic.
 class RefrigeratorAndTemperatureControlledCabinetModeDelegate : public ModeBase::Delegate
 {
 private:

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -90,7 +90,7 @@ CHIP_ERROR AlarmHelpHandler(int argc, char ** argv)
 
 CHIP_ERROR EventRefrigeratorAlarmCommandHandler(int argc, char ** argv)
 {
-    if (argc != 0)
+    if (argc == 0)
     {
         return AlarmHelpHandler(argc, argv);
     }

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -187,13 +187,13 @@ void EventWorkerFunction(intptr_t context)
 
     switch (data->eventId)
     {
-    case RefrigeratorAlarm::Events::Notify::Fields::kMask : {
+    case RefrigeratorAlarm::Events::Notify::Fields::kMask: {
         RefrigeratorAlarmEventData * alarmData = reinterpret_cast<RefrigeratorAlarmEventData *>(context);
         RefrigeratorAlarmServer::Instance().SetMaskValue(kRefEndpointId, alarmData->doorState);
         break;
     }
 
-    case RefrigeratorAlarm::Events::Notify::Fields::kState : {
+    case RefrigeratorAlarm::Events::Notify::Fields::kState: {
         RefrigeratorAlarmEventData * alarmData = reinterpret_cast<RefrigeratorAlarmEventData *>(context);
         RefrigeratorAlarmServer::Instance().SetStateValue(kRefEndpointId, alarmData->doorState);
         break;

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR RefrigeratorAlarmSuppressHandler(int argc, char ** argv)
     }
 
     RefrigeratorAlarmEventData * data = Platform::New<RefrigeratorAlarmEventData>();
-    data->eventId                     = RefrigeratorAlarm::Events::Notify::Fields::kMask;
+    data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kMask;
     data->doorState                   = static_cast<AlarmBitmap>(0);
 
     DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -135,7 +135,7 @@ CHIP_ERROR RefrigeratorDoorEventHandler(int argc, char ** argv)
     int value = std::stoi(argv[0]); // Safe to use now, as we validated the input earlier
 
     RefrigeratorAlarmEventData * data = Platform::New<RefrigeratorAlarmEventData>();
-    data->eventId                     = RefrigeratorAlarm::Events::Notify::Fields::kState;
+    data->eventState                  = RefrigeratorAlarm::Events::Notify::Fields::kState;
     data->doorState                   = static_cast<AlarmBitmap>(value);
 
     DeviceLayer::PlatformMgr().ScheduleWork(EventWorkerFunction, reinterpret_cast<intptr_t>(data));
@@ -185,7 +185,7 @@ void EventWorkerFunction(intptr_t context)
     VerifyOrReturn(reinterpret_cast<void *>(context) != nullptr, ChipLogError(Shell, "EventWorkerFunction - Invalid work data"));
     EventData * data = reinterpret_cast<EventData *>(context);
 
-    switch (data->eventId)
+    switch (data->eventState)
     {
     case RefrigeratorAlarm::Events::Notify::Fields::kMask: {
         RefrigeratorAlarmEventData * alarmData = reinterpret_cast<RefrigeratorAlarmEventData *>(context);

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -102,8 +102,8 @@ CHIP_ERROR RefrigeratorAlarmSuppressHandler(int argc, char ** argv)
 {
     if (argc != 0)
     {
-        ChipLogError(Shell, "Incorrect arguments");
-        return AlarmHelpHandler(argc, argv);
+        ChipLogError(Shell, "Invalid arguments");
+        return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
     RefrigeratorAlarmEventData * data = Platform::New<RefrigeratorAlarmEventData>();

--- a/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
+++ b/examples/refrigerator-app/silabs/src/EventHandlerLibShell.cpp
@@ -90,6 +90,10 @@ CHIP_ERROR AlarmHelpHandler(int argc, char ** argv)
 
 CHIP_ERROR EventRefrigeratorAlarmCommandHandler(int argc, char ** argv)
 {
+    if (argc != 0)
+    {
+        return AlarmHelpHandler(argc, argv);
+    }
     sShellRefrigeratorEventAlarmDoorSubCommands.ExecCommand(argc, argv);
     return CHIP_NO_ERROR;
 }

--- a/examples/refrigerator-app/silabs/src/RefrigeratorManager.cpp
+++ b/examples/refrigerator-app/silabs/src/RefrigeratorManager.cpp
@@ -112,14 +112,14 @@ void RefrigeratorManager::TempCtrlAttributeChangeHandler(EndpointId endpointId, 
     }
 }
 
-void RefrigeratorManager::RefAlaramAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value,
+void RefrigeratorManager::RefAlarmAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value,
                                                           uint16_t size)
 {
     switch (attributeId)
     {
     case RefAlarmAttr::Mask::Id: {
         auto mask = static_cast<uint32_t>(*value);
-        mState    = static_cast<chip::app::Clusters::RefrigeratorAlarm::AlarmBitmap>(mask);
+        mMask     = static_cast<chip::app::Clusters::RefrigeratorAlarm::AlarmBitmap>(mask);
         RefAlarmAttr::Mask::Set(endpointId, mMask);
     }
     break;

--- a/examples/refrigerator-app/silabs/src/RefrigeratorManager.cpp
+++ b/examples/refrigerator-app/silabs/src/RefrigeratorManager.cpp
@@ -113,7 +113,7 @@ void RefrigeratorManager::TempCtrlAttributeChangeHandler(EndpointId endpointId, 
 }
 
 void RefrigeratorManager::RefAlarmAttributeChangeHandler(EndpointId endpointId, AttributeId attributeId, uint8_t * value,
-                                                          uint16_t size)
+                                                         uint16_t size)
 {
     switch (attributeId)
     {

--- a/examples/refrigerator-app/silabs/src/ZclCallbacks.cpp
+++ b/examples/refrigerator-app/silabs/src/ZclCallbacks.cpp
@@ -48,7 +48,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
                         ChipLogValueMEI(attributePath.mAttributeId), type, *value, size);
         break;
     case app::Clusters::RefrigeratorAlarm::Id:
-        RefrigeratorMgr().RefAlaramAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
+        RefrigeratorMgr().RefAlarmAttributeChangeHandler(attributePath.mEndpointId, attributeId, value, size);
 #ifdef DIC_ENABLE
         dic::control::AttributeHandler(attributePath.mEndpointId, attributeId);
 #endif // DIC_ENABLE


### PR DESCRIPTION
#### Summary

This PR adds support for manually suppressing refrigerator alarms via shell commands to address a failing test case (TC_REFALM-2_3).

Shell command to suppress alarm : `refrigeratoralarm alarm suppress`

Executing this command clears the relevant alarm mask bit (sets it to 0), indicating that the alarm has been suppressed from the device side. This functionality is required to ensure compliance with the test case, which currently fails without device-side suppression support.

This PR also contains a few minor corrections in the refrigerator app code.

#### Related issues

N/A

#### Testing

Device commissioned successfully.
Executed the shell command to suppress the refrigerator alarm.
Verified that both the alarm state and mask values update correctly, reflecting the suppression.


#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
