### PR TITLE
Fix android NDK path

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-157 : [Silabs] Fix slc-cli retrieval 
+158 : [Android] Fix android NDK path in vscode image

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -32,7 +32,7 @@ COPY --from=nrf /opt/NordicSemiconductor/nRF5_tools /opt/NordicSemiconductor/nRF
 COPY --from=nrf /opt/NordicSemiconductor/nrfconnect /opt/NordicSemiconductor/nrfconnect
 
 COPY --from=android /opt/android/sdk /opt/android/sdk
-COPY --from=android /opt/android/android-ndk-r23c /opt/android/android-ndk-r23c
+COPY --from=android /opt/android/android-ndk-r28c /opt/android/android-ndk-r28c
 COPY --from=android /usr/lib/kotlinc /usr/lib/kotlinc
 
 COPY --from=psoc6 /opt/Tools/ModusToolbox /opt/Tools/ModusToolbox
@@ -71,18 +71,18 @@ COPY --from=nuttx /opt/nuttx /opt/nuttx
 # into the 'licenses' subfolder. This allows any user (in particular
 # 'vscode' to accept licenses)
 RUN set -x \
-    && mkdir -p /opt/android/sdk/licenses \
-    && chmod -R a+w /opt/android/sdk/licenses \
-    && : # last line
+  && mkdir -p /opt/android/sdk/licenses \
+  && chmod -R a+w /opt/android/sdk/licenses \
+  && : # last line
 
 # mbedos requirements are generally just PIP packages
 RUN set -x \
-    && pip3 install --break-system-packages --no-cache-dir -U mbed-cli==1.10.5 mbed-tools==7.44.0 \
-    && : # last line
+  && pip3 install --break-system-packages --no-cache-dir -U mbed-cli==1.10.5 mbed-tools==7.44.0 \
+  && : # last line
 RUN set -x \
-    && mbed config -G GCC_ARM_PATH /opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/ \
-    && mbed toolchain -G -s GCC_ARM \
-    && : # last line
+  && mbed config -G GCC_ARM_PATH /opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/ \
+  && mbed toolchain -G -s GCC_ARM \
+  && : # last line
 
 # Required for the Tizen SDK:
 #   - zip
@@ -93,21 +93,21 @@ RUN set -x \
 # For java builds:
 #   - openjdk-11-jdk
 RUN set -x \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-    zip \
-    expect \
-    telnet \
-    srecord \
-    openjdk-11-jdk \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/ \
-    && : # last line
+  && apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+  zip \
+  expect \
+  telnet \
+  srecord \
+  openjdk-11-jdk \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/ \
+  && : # last line
 
 ENV PATH=$PATH:/usr/lib/kotlinc/bin
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV ANDROID_HOME=/opt/android/sdk
-ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r23c
+ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r28c
 ENV CY_TOOLS_PATHS="/opt/Tools/ModusToolbox/tools_3.2"
 ENV SILABS_BOARD=BRD4186C
 # Keep GSDK_ROOT name until rename transition to SISDK is completed

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -71,18 +71,18 @@ COPY --from=nuttx /opt/nuttx /opt/nuttx
 # into the 'licenses' subfolder. This allows any user (in particular
 # 'vscode' to accept licenses)
 RUN set -x \
-  && mkdir -p /opt/android/sdk/licenses \
-  && chmod -R a+w /opt/android/sdk/licenses \
-  && : # last line
+    && mkdir -p /opt/android/sdk/licenses \
+    && chmod -R a+w /opt/android/sdk/licenses \
+    && : # last line
 
 # mbedos requirements are generally just PIP packages
 RUN set -x \
-  && pip3 install --break-system-packages --no-cache-dir -U mbed-cli==1.10.5 mbed-tools==7.44.0 \
-  && : # last line
+    && pip3 install --break-system-packages --no-cache-dir -U mbed-cli==1.10.5 mbed-tools==7.44.0 \
+    && : # last line
 RUN set -x \
-  && mbed config -G GCC_ARM_PATH /opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/ \
-  && mbed toolchain -G -s GCC_ARM \
-  && : # last line
+    && mbed config -G GCC_ARM_PATH /opt/mbed-os-toolchain/gcc-arm-none-eabi-9-2019-q4-major/bin/ \
+    && mbed toolchain -G -s GCC_ARM \
+    && : # last line
 
 # Required for the Tizen SDK:
 #   - zip
@@ -93,16 +93,16 @@ RUN set -x \
 # For java builds:
 #   - openjdk-11-jdk
 RUN set -x \
-  && apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
-  zip \
-  expect \
-  telnet \
-  srecord \
-  openjdk-11-jdk \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/ \
-  && : # last line
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    zip \
+    expect \
+    telnet \
+    srecord \
+    openjdk-11-jdk \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/ \
+    && : # last line
 
 ENV PATH=$PATH:/usr/lib/kotlinc/bin
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA


### PR DESCRIPTION
#### Summary

NDK path updated in android docker file in #40468, however vscode image was not updated

#### Testing

Path compared with android. CI cannot validate this, will validate this as part of image builds.