### PR TITLE
Override Attributes function since there is non-global attribute

### DIFF
--- a/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
+++ b/src/app/clusters/webrtc-transport-requestor-server/webrtc-transport-requestor-cluster.h
@@ -133,6 +133,8 @@ public:
     CHIP_ERROR AcceptedCommands(const ConcreteClusterPath & path,
                                 ReadOnlyBufferBuilder<DataModel::AcceptedCommandEntry> & builder) override;
 
+    CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;
+
     /**
      * @brief
      *   Gets the current sessions from the Requestor server.


### PR DESCRIPTION
#### Summary

Attributes must only be implemented if support for any non-global attributes is required.

` CHIP_ERROR Attributes(const ConcreteClusterPath & path, ReadOnlyBufferBuilder<DataModel::AttributeEntry> & builder) override;`

#### Related issues

N/A

#### Testing

Validated by CI
