### PR TITLE
Update quality properties in matter_idl_types.py

### DIFF
--- a/scripts/py_matter_idl/matter/idl/matter_idl_types.py
+++ b/scripts/py_matter_idl/matter/idl/matter_idl_types.py
@@ -134,12 +134,12 @@ class Field:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
 
     @property
-    def is_optional(self):
-        return FieldQuality.OPTIONAL & self.qualities
+    def is_optional(self) -> bool:
+        return FieldQuality.OPTIONAL in self.qualities
 
     @property
-    def is_nullable(self):
-        return FieldQuality.NULLABLE & self.qualities
+    def is_nullable(self) -> bool:
+        return FieldQuality.NULLABLE in self.qualities
 
 
 @dataclass
@@ -152,20 +152,20 @@ class Attribute:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
 
     @property
-    def is_readable(self):
-        return AttributeQuality.READABLE & self.qualities
+    def is_readable(self) -> bool:
+        return AttributeQuality.READABLE in self.qualities
 
     @property
-    def is_writable(self):
-        return AttributeQuality.WRITABLE & self.qualities
+    def is_writable(self) -> bool:
+        return AttributeQuality.WRITABLE in self.qualities
 
     @property
-    def is_subscribable(self):
-        return not (AttributeQuality.NOSUBSCRIBE & self.qualities)
+    def is_subscribable(self) -> bool:
+        return AttributeQuality.NOSUBSCRIBE not in self.qualities
 
     @property
-    def requires_timed_write(self):
-        return AttributeQuality.TIMED_WRITE & self.qualities
+    def requires_timed_write(self) -> bool:
+        return AttributeQuality.TIMED_WRITE in self.qualities
 
 
 @dataclass
@@ -192,8 +192,8 @@ class Event:
     api_maturity: ApiMaturity = ApiMaturity.STABLE
 
     @property
-    def is_fabric_sensitive(self):
-        return EventQuality.FABRIC_SENSITIVE & self.qualities
+    def is_fabric_sensitive(self) -> bool:
+        return EventQuality.FABRIC_SENSITIVE in self.qualities
 
 
 @dataclass
@@ -240,8 +240,8 @@ class Command:
     parse_meta: Optional[ParseMetaData] = field(default=None, compare=False)
 
     @property
-    def is_timed_invoke(self):
-        return CommandQuality.TIMED_INVOKE & self.qualities
+    def is_timed_invoke(self) -> bool:
+        return CommandQuality.TIMED_INVOKE in self.qualities
 
 
 @dataclass


### PR DESCRIPTION
#### Summary

Change the various quality properties in matter_idl_types.py to use the `in` operator instead of `&`, and declare each to return a `bool` value.

Currently these properties use the `&` operator as a set intersection with the enum flag values.  This leads to these methods unexpectedly returning instances of the quality flags.

#### Related issues

N/A

#### Testing

- Ran existing unit tests
- Manually ran some code generators and checked for correct output

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [x] PR title is [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [x] Apply the [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html) rule (coding style)
-   [x] PR size is short
-   [x] Try to avoid "squashing" and "force-update" in commit history
-   [x] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
