### PR TITLE
[OpenSSL][Fuzz] BugFix for potential leak when empty certificate is passed ExtractVIDPIDFromX509Cert

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -2277,10 +2277,11 @@ public:
     ScopedASN1Object(const char * string, int no_name) : obj(OBJ_txt2obj(string, no_name)) {}
     ~ScopedASN1Object() { ASN1_OBJECT_free(obj); }
 
+    explicit operator bool() const { return obj != nullptr; }
+    ASN1_OBJECT * Get() const { return obj; }
+
     ScopedASN1Object(const ScopedASN1Object &)             = delete;
     ScopedASN1Object & operator=(const ScopedASN1Object &) = delete;
-
-    ASN1_OBJECT * Get() { return obj; }
 
 private:
     ASN1_OBJECT * obj = nullptr;
@@ -2289,8 +2290,13 @@ private:
 CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCertVidPid & vidpid)
 {
     ScopedASN1Object commonNameObj("2.5.4.3", 1);
+    VerifyOrReturnError(commonNameObj, CHIP_ERROR_NO_MEMORY);
+
     ScopedASN1Object matterVidObj("1.3.6.1.4.1.37244.2.1", 1); // Matter VID OID - taken from Spec
+    VerifyOrReturnError(matterVidObj, CHIP_ERROR_NO_MEMORY);
+
     ScopedASN1Object matterPidObj("1.3.6.1.4.1.37244.2.2", 1); // Matter PID OID - taken from Spec
+    VerifyOrReturnError(matterPidObj, CHIP_ERROR_NO_MEMORY);
 
     CHIP_ERROR err                     = CHIP_NO_ERROR;
     X509 * x509certificate             = nullptr;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -53,8 +53,6 @@
 #include <lib/support/SafePointerCast.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include <memory>
-
 #include <string.h>
 
 namespace chip {

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -2273,9 +2273,9 @@ CHIP_ERROR ExtractIssuerFromX509Cert(const ByteSpan & certificate, MutableByteSp
 
 CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCertVidPid & vidpid)
 {
-    ASN1_OBJECT * commonNameObj = OBJ_txt2obj("2.5.4.3", 1);
-    ASN1_OBJECT * matterVidObj  = OBJ_txt2obj("1.3.6.1.4.1.37244.2.1", 1); // Matter VID OID - taken from Spec
-    ASN1_OBJECT * matterPidObj  = OBJ_txt2obj("1.3.6.1.4.1.37244.2.2", 1); // Matter PID OID - taken from Spec
+    ASN1_OBJECT * commonNameObj = nullptr;
+    ASN1_OBJECT * matterVidObj  = nullptr;
+    ASN1_OBJECT * matterPidObj  = nullptr;
 
     CHIP_ERROR err                     = CHIP_NO_ERROR;
     X509 * x509certificate             = nullptr;
@@ -2284,7 +2284,11 @@ CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCe
     int x509EntryCountIdx              = 0;
     AttestationCertVidPid vidpidFromCN;
 
-    VerifyOrReturnError(!certificate.empty() && CanCastTo<long>(certificate.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(!certificate.empty() && CanCastTo<long>(certificate.size()), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    commonNameObj = OBJ_txt2obj("2.5.4.3", 1);
+    matterVidObj  = OBJ_txt2obj("1.3.6.1.4.1.37244.2.1", 1); // Matter VID OID - taken from Spec
+    matterPidObj  = OBJ_txt2obj("1.3.6.1.4.1.37244.2.2", 1); // Matter PID OID - taken from Spec
 
     x509certificate = d2i_X509(nullptr, &pCertificate, static_cast<long>(certificate.size()));
     VerifyOrExit(x509certificate != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -2942,6 +2942,8 @@ TEST_F(TestChipCryptoPAL, TestVIDPID_x509Extraction)
         // VID and PID not present cases:
         { sTestCert_PAA_NoVID_Cert, false, false, chip::VendorId::NotSpecified, 0x0000, CHIP_NO_ERROR },
         { kOpCertNoVID, false, false, chip::VendorId::NotSpecified, 0x0000, CHIP_NO_ERROR },
+        { ByteSpan(), false, false, chip::VendorId::NotSpecified, 0x0000, CHIP_ERROR_INVALID_ARGUMENT },
+
     };
 
     for (const auto & testCase : kTestCases)

--- a/src/crypto/tests/TestChipCryptoPAL.cpp
+++ b/src/crypto/tests/TestChipCryptoPAL.cpp
@@ -2950,7 +2950,16 @@ TEST_F(TestChipCryptoPAL, TestVIDPID_x509Extraction)
     {
         AttestationCertVidPid vidpid;
         CHIP_ERROR result = ExtractVIDPIDFromX509Cert(testCase.cert, vidpid);
-        EXPECT_EQ(result, testCase.expectedResult);
+        if (testCase.cert.empty())
+        {
+            // mbedTLS implementations will return CHIP_ERROR_INTERNAL for empty certs. It's impractical to modify all
+            // implementations to return CHIP_ERROR_INVALID_ARGUMENT, so we allow either to pass for this case.
+            EXPECT_TRUE(result == CHIP_ERROR_INVALID_ARGUMENT || result == CHIP_ERROR_INTERNAL);
+        }
+        else
+        {
+            EXPECT_EQ(result, testCase.expectedResult);
+        }
         ASSERT_EQ(vidpid.mVendorId.HasValue(), testCase.expectedVidPresent);
         ASSERT_EQ(vidpid.mProductId.HasValue(), testCase.expectedPidPresent);
 


### PR DESCRIPTION
#### Summary


- While fuzzing `ExtractVIDPIDFromX509Cert` using a `pw_fuzzer FuzzTest`, a memory leak was found when an empty certificate is passed. This occurred because `VerifyOrReturnError` bypasses the `exit:` cleanup block, causing the `ASN1_OBJECT`s to not be freed.

- This could have impacted controller implementations where `ExtractVIDPIDFromX509Cert` is not preceded by a `VerifyAttestationCertificateFormat` call on a DAC/PAI or PAA certificate.

- Fix: Replaced `VerifyOrReturnError` with `VerifyOrExit` for the empty cert check and moved `ASN1_OBJECT` allocations after the check to avoid unnecessary allocation.


#### Testing

- TestCase with an Empty Cert Added to `TestVIDPID_x509Extraction`; This TestCase would have uncovered the leak with an ASAN Unit test run.