### PR TITLE
Upgrade chip-build-android Docker container to Java 17 JDK

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-158 : [Android] Fix android NDK path in vscode image
+159 : [Android] Add Java 17 JDK for Android TV casting app builds

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source https://github.com/project-chip/connectedh
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     rsync \
     swig \
     && rm -rf /var/lib/apt/lists/ \
@@ -69,4 +69,4 @@ RUN set -x \
 
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r28c
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64

--- a/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/vscode/chip-build-vscode/Dockerfile
@@ -99,7 +99,7 @@ RUN set -x \
     expect \
     telnet \
     srecord \
-    openjdk-11-jdk \
+    openjdk-17-jdk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line


### PR DESCRIPTION
#### Summary

Upgrade chip-build-android Docker container to use Java 17 JDK

#### Related issues

Pull Request: [[Android]upgrade android with ndk 28c and 16kb page size #40455](https://github.com/project-chip/connectedhomeip/pull/40455)
Pull Request: [[Android][Docker]upgrade android ndk with r28c #40468](https://github.com/project-chip/connectedhomeip/pull/40468)

Related to Google's 16KB pages compliance deadline: https://developer.android.com/guide/practices/page-sizes
Addresses partner feedback about integration friction with outdated build system
N/A - No specific GitHub issues tracked for this upgrade

#### Testing

Checking CI tests

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
