### PR TITLE
[WebRTC] WebRTCSessionID should start from 0

### DIFF
--- a/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
+++ b/src/app/clusters/webrtc-transport-provider-server/webrtc-transport-provider-server.h
@@ -333,7 +333,7 @@ private:
     WebRTCSessionStruct * CheckForMatchingSession(HandlerContext & ctx, uint16_t sessionId);
     UpsertResultEnum UpsertSession(const WebRTCSessionStruct & session);
     void RemoveSession(uint16_t sessionId);
-    uint16_t GenerateSessionId();
+    CHIP_ERROR GenerateSessionId(uint16_t & outSessionId);
 
     // Command Handlers
     void HandleSolicitOffer(HandlerContext & ctx, const Commands::SolicitOffer::DecodableType & req);

--- a/src/python_testing/TC_WEBRTCP_2_1.py
+++ b/src/python_testing/TC_WEBRTCP_2_1.py
@@ -162,7 +162,7 @@ class TC_WebRTCProvider_2_1(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_not_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should not be 0.")
+        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_true(resp.deferredOffer, "Expected 'deferredOffer' to be True.")
 
         self.step(7)

--- a/src/python_testing/TC_WEBRTCP_2_1.py
+++ b/src/python_testing/TC_WEBRTCP_2_1.py
@@ -162,7 +162,6 @@ class TC_WebRTCProvider_2_1(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_true(resp.deferredOffer, "Expected 'deferredOffer' to be True.")
 
         self.step(7)

--- a/src/python_testing/TC_WEBRTCP_2_2.py
+++ b/src/python_testing/TC_WEBRTCP_2_2.py
@@ -108,7 +108,7 @@ class TC_WebRTCProvider_2_2(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_not_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should not be 0.")
+        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_false(resp.deferredOffer, "Expected 'deferredOffer' to be False.")
 
         # TODO: Enable this check after integrating with Camera AvStreamManager

--- a/src/python_testing/TC_WEBRTCP_2_2.py
+++ b/src/python_testing/TC_WEBRTCP_2_2.py
@@ -108,7 +108,6 @@ class TC_WebRTCProvider_2_2(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_false(resp.deferredOffer, "Expected 'deferredOffer' to be False.")
 
         # TODO: Enable this check after integrating with Camera AvStreamManager

--- a/src/python_testing/TC_WEBRTCP_2_3.py
+++ b/src/python_testing/TC_WEBRTCP_2_3.py
@@ -213,7 +213,7 @@ class TC_WebRTCProvider_2_3(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse,
                              "Incorrect response type")
-        asserts.assert_not_equal(resp.webRTCSessionID, 0, "webRTCSessionID in ProvideOfferResponse should not be 0.")
+        asserts.assert_equal(resp.webRTCSessionID, 0, "webRTCSessionID in ProvideOfferResponse should be 0.")
 
         self.step(9)
         # Verify CurrentSessions contains the new session

--- a/src/python_testing/TC_WEBRTCP_2_3.py
+++ b/src/python_testing/TC_WEBRTCP_2_3.py
@@ -213,7 +213,6 @@ class TC_WebRTCProvider_2_3(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.ProvideOfferResponse,
                              "Incorrect response type")
-        asserts.assert_equal(resp.webRTCSessionID, 0, "webRTCSessionID in ProvideOfferResponse should be 0.")
 
         self.step(9)
         # Verify CurrentSessions contains the new session

--- a/src/python_testing/TC_WEBRTCP_2_4.py
+++ b/src/python_testing/TC_WEBRTCP_2_4.py
@@ -158,9 +158,6 @@ class TC_WebRTCProvider_2_4(MatterBaseTest, WEBRTCPTestBase):
         saved_session_id = resp.webRTCSessionID
         asserts.assert_equal(videoStreamID, resp.videoStreamID, "Video stream ID does not match that in the command")
         asserts.assert_equal(audioStreamID, resp.audioStreamID, "Audio stream ID does not match that in the command")
-        asserts.assert_equal(
-            saved_session_id, 0, "First allocated WebRTCSessionID must be zero"
-        )
 
         self.step(5)
         current_sessions = await self.read_single_attribute_check_success(

--- a/src/python_testing/TC_WEBRTCP_2_4.py
+++ b/src/python_testing/TC_WEBRTCP_2_4.py
@@ -158,8 +158,8 @@ class TC_WebRTCProvider_2_4(MatterBaseTest, WEBRTCPTestBase):
         saved_session_id = resp.webRTCSessionID
         asserts.assert_equal(videoStreamID, resp.videoStreamID, "Video stream ID does not match that in the command")
         asserts.assert_equal(audioStreamID, resp.audioStreamID, "Audio stream ID does not match that in the command")
-        asserts.assert_not_equal(
-            saved_session_id, 0, "Allocated WebRTCSessionID must be non‑zero"
+        asserts.assert_equal(
+            saved_session_id, 0, "First allocated WebRTCSessionID must be zero"
         )
 
         self.step(5)

--- a/src/python_testing/TC_WEBRTCP_2_5.py
+++ b/src/python_testing/TC_WEBRTCP_2_5.py
@@ -146,7 +146,7 @@ class TC_WebRTCProvider_2_5(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_not_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should not be 0.")
+        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_false(resp.deferredOffer, "Expected 'deferredOffer' to be False.")
 
         # TODO: Enable this check after integrating with Camera AvStreamManager

--- a/src/python_testing/TC_WEBRTCP_2_5.py
+++ b/src/python_testing/TC_WEBRTCP_2_5.py
@@ -146,7 +146,6 @@ class TC_WebRTCProvider_2_5(MatterBaseTest, WEBRTCPTestBase):
         resp = await self.send_single_cmd(cmd=cmd, endpoint=endpoint, payloadCapability=ChipDeviceCtrl.TransportPayloadCapability.LARGE_PAYLOAD)
         asserts.assert_equal(type(resp), Clusters.WebRTCTransportProvider.Commands.SolicitOfferResponse,
                              "Incorrect response type")
-        asserts.assert_equal(resp.webRTCSessionID, 0, "webrtcSessionID in SolicitOfferResponse should be 0.")
         asserts.assert_false(resp.deferredOffer, "Expected 'deferredOffer' to be False.")
 
         # TODO: Enable this check after integrating with Camera AvStreamManager


### PR DESCRIPTION
#### Summary

The current implementation is wrong per spec

```
11.4.5.1. WebRTCSessionID Type
This data type is derived from uint16.

It represents an active WebRTC session. This value starts at 0 and monotonically increases by 1 with each new allocation provisioned by the Node. A value incremented past 65534 SHALL wrap to 0. 
```
I  have also updated the test cases to align with the spec, and the test plan just says it contains a valid session ID, so no need to update.

#### Related issues

N/A

#### Testing

Validate by CI


