### PR TITLE
[Android]upgrade gradle plugin with 8.5.1

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -32,9 +32,6 @@ jobs:
     full_android:
         name: Run
 
-        env:
-            JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64/
-
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
 

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -33,7 +33,7 @@ jobs:
         name: Run
 
         env:
-            JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64/
+            JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64/
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -39,7 +39,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:153
+            image: ghcr.io/project-chip/chip-build-android:160
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -37,7 +37,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:153
+            image: ghcr.io/project-chip/chip-build-android:160
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -31,7 +31,7 @@ jobs:
         name: Smoke Run - Android
 
         env:
-            JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64/
+            JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64/
 
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -30,9 +30,6 @@ jobs:
     android:
         name: Smoke Run - Android
 
-        env:
-            JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64/
-
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
 

--- a/docs/platforms/android/android_building.md
+++ b/docs/platforms/android/android_building.md
@@ -15,18 +15,18 @@ There are following Apps on Android
 
 <hr>
 
--   [Building Android](#building-android)
-    -   [Source files](#source-files)
-    -   [Requirements for building](#requirements-for-building)
-        -   [Linux](#linux)
-        -   [MacOS](#macos)
-        -   [ABIs and TARGET_CPU](#abis-and-target_cpu)
-        -   [Gradle \& JDK Version](#gradle--jdk-version)
-        -   [Kotlin Version](#kotlin-version)
-    -   [Preparing for build](#preparing-for-build)
-    -   [Building Android CHIPTool from scripts](#building-android-chiptool-from-scripts)
-    -   [Building Android CHIPTool from Android Studio](#building-android-chiptool-from-android-studio)
-    -   [Building Android CHIPTest from scripts](#building-android-chiptest-from-scripts)
+- [Building Android](#building-android)
+  - [Source files](#source-files)
+  - [Requirements for building](#requirements-for-building)
+    - [Linux](#linux)
+    - [MacOS](#macos)
+    - [ABIs and TARGET\_CPU](#abis-and-target_cpu)
+    - [Gradle \& JDK Version](#gradle--jdk-version)
+    - [Kotlin Version](#kotlin-version)
+  - [Preparing for build](#preparing-for-build)
+  - [Building Android CHIPTool from scripts](#building-android-chiptool-from-scripts)
+  - [Building Android CHIPTool from Android Studio](#building-android-chiptool-from-android-studio)
+  - [Building Android CHIPTest from scripts](#building-android-chiptest-from-scripts)
 
 <hr>
 
@@ -43,7 +43,7 @@ directory.
 
 ## Requirements for building
 
-You need Android SDK 30 & NDK 28.2.13676358 downloaded to your machine. Set the
+You need Android SDK 34 & NDK 28.2.13676358 downloaded to your machine. Set the
 `$ANDROID_HOME` environment variable to where the SDK is downloaded and the
 `$ANDROID_NDK_HOME` environment variable to point to where the NDK package is
 downloaded.
@@ -58,9 +58,9 @@ downloaded.
     1. Tools -> SDK Manager -> SDK Tools Tab -> Android SDK Command Line Tools
        10.0
     2. Apply
-4. Install SDK 30:
-    1. Tools -> SDK Manager -> SDK Platforms Tab -> Android 11.0 (R) SDK Level
-       30
+4. Install SDK 34:
+    1. Tools -> SDK Manager -> SDK Platforms Tab -> Android 14.0 (Upside Down Cake)
+       API Level 34
     2. Apply
 5. Install Emulator:
     1. Tools -> Device Manager -> Create device -> Pixel 5 -> Android S API 31
@@ -98,21 +98,21 @@ architecture:
 
 ### Gradle & JDK Version
 
-All Android projects utilize Gradle version 7.3.3 and JDK version 11.0.
+All Android projects utilize Gradle plugin version 8.5.1, Gradle version 8.7 and JDK version 17.0.
 
-For developer using java 11 in MacOS, the JAVA can be configured as follows via
+For developer using java 17 in MacOS, the JAVA can be configured as follows via
 `sdkman`:
 
 ```
-sdk install java 11.0.26-tem
+sdk install java 17.0.14-tem
 ```
 
-For developer using openjdk-11-jdk in Linux, the JAVA_HOME environment variable
+For developer using openjdk-17-jdk in Linux, the JAVA_HOME environment variable
 can be configured as follows:
 
 ```
-sudo apt-get install openjdk-11-jdk
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+sudo apt-get install openjdk-17-jdk
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 ```
 
 <a name="kotlin"></a>

--- a/docs/platforms/android/android_building.md
+++ b/docs/platforms/android/android_building.md
@@ -15,18 +15,18 @@ There are following Apps on Android
 
 <hr>
 
-- [Building Android](#building-android)
-  - [Source files](#source-files)
-  - [Requirements for building](#requirements-for-building)
-    - [Linux](#linux)
-    - [MacOS](#macos)
-    - [ABIs and TARGET\_CPU](#abis-and-target_cpu)
-    - [Gradle \& JDK Version](#gradle--jdk-version)
-    - [Kotlin Version](#kotlin-version)
-  - [Preparing for build](#preparing-for-build)
-  - [Building Android CHIPTool from scripts](#building-android-chiptool-from-scripts)
-  - [Building Android CHIPTool from Android Studio](#building-android-chiptool-from-android-studio)
-  - [Building Android CHIPTest from scripts](#building-android-chiptest-from-scripts)
+-   [Building Android](#building-android)
+    -   [Source files](#source-files)
+    -   [Requirements for building](#requirements-for-building)
+        -   [Linux](#linux)
+        -   [MacOS](#macos)
+        -   [ABIs and TARGET_CPU](#abis-and-target_cpu)
+        -   [Gradle \& JDK Version](#gradle--jdk-version)
+        -   [Kotlin Version](#kotlin-version)
+    -   [Preparing for build](#preparing-for-build)
+    -   [Building Android CHIPTool from scripts](#building-android-chiptool-from-scripts)
+    -   [Building Android CHIPTool from Android Studio](#building-android-chiptool-from-android-studio)
+    -   [Building Android CHIPTest from scripts](#building-android-chiptest-from-scripts)
 
 <hr>
 
@@ -59,8 +59,8 @@ downloaded.
        10.0
     2. Apply
 4. Install SDK 34:
-    1. Tools -> SDK Manager -> SDK Platforms Tab -> Android 14.0 (Upside Down Cake)
-       API Level 34
+    1. Tools -> SDK Manager -> SDK Platforms Tab -> Android 14.0 (Upside Down
+       Cake) API Level 34
     2. Apply
 5. Install Emulator:
     1. Tools -> Device Manager -> Create device -> Pixel 5 -> Android S API 31
@@ -98,7 +98,8 @@ architecture:
 
 ### Gradle & JDK Version
 
-All Android projects utilize Gradle plugin version 8.5.1, Gradle version 8.7 and JDK version 17.0.
+All Android projects utilize Gradle plugin version 8.5.1, Gradle version 8.7 and
+JDK version 17.0.
 
 For developer using java 17 in MacOS, the JAVA can be configured as follows via
 `sdkman`:

--- a/examples/android/CHIPTest/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/CHIPTest/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Aug 16 17:10:29 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/CHIPTool/app/build.gradle
+++ b/examples/android/CHIPTool/app/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-parcelize'
 
 android {
-    compileSdkVersion 31
+    namespace 'com.google.chip.chiptool'
+    compileSdkVersion 34
     ndkPath System.getenv("ANDROID_NDK_HOME")
 
     ndkVersion "28.2.13676358"
@@ -11,7 +12,7 @@ android {
     defaultConfig {
         applicationId "com.google.chip.chiptool"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -39,8 +40,15 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+        // This will prevent the build from failing on warnings, including deprecation warnings.
+        // It's generally better to fix the underlying code or use @Suppress at the specific call site.
+        allWarningsAsErrors = false
     }
 
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -153,7 +153,7 @@ class CHIPToolActivity :
 
     lateinit var setupPayload: OnboardingPayload
     try {
-      setupPayload = OnboardingPayloadParser().parseQrCode(uri.toString().toUpperCase())
+      setupPayload = OnboardingPayloadParser().parseQrCode(uri.toString().uppercase())
     } catch (ex: UnrecognizedQrCodeException) {
       Log.e(TAG, "Unrecognized QR Code", ex)
       Toast.makeText(this, "Unrecognized QR Code", Toast.LENGTH_SHORT).show()

--- a/examples/android/CHIPTool/build.gradle
+++ b/examples/android/CHIPTool/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '2.0.0'
+    ext.kotlin_version = '2.1.10'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.3"
+        classpath 'com.android.tools.build:gradle:8.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/examples/android/CHIPTool/chip-library/build.gradle
+++ b/examples/android/CHIPTool/chip-library/build.gradle
@@ -5,11 +5,11 @@ plugins {
 apply from: "../../../../third_party/android_deps/android_deps.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -23,8 +23,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/examples/android/CHIPTool/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/CHIPTool/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/tv-app/android/App/build.gradle
+++ b/examples/tv-app/android/App/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '2.0.0'
+    ext.kotlin_version = '2.1.10'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.5.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/tv-app/android/App/content-app/build.gradle
+++ b/examples/tv-app/android/App/content-app/build.gradle
@@ -3,12 +3,13 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    namespace 'com.example.contentapp'
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.contentapp"
-        minSdk 24
-        targetSdk 30
+        minSdk 26
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -22,8 +23,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/examples/tv-app/android/App/content-app/build.gradle
+++ b/examples/tv-app/android/App/content-app/build.gradle
@@ -37,7 +37,9 @@ android {
             aidl.srcDirs = ['../common-api/src/main/aidl']
         }
     }
-
+    buildFeatures {
+        aidl = true
+    }
 }
 
 dependencies {

--- a/examples/tv-app/android/App/content-app/src/main/AndroidManifest.xml
+++ b/examples/tv-app/android/App/content-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.contentapp">
+    xmlns:tools="http://schemas.android.com/tools">
 
 
     <uses-permission android:name="com.matter.tv.app.api.permission.BIND_SERVICE_PERMISSION"/>

--- a/examples/tv-app/android/App/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/tv-app/android/App/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 26 11:10:18 CST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/tv-app/android/App/platform-app/build.gradle
+++ b/examples/tv-app/android/App/platform-app/build.gradle
@@ -3,12 +3,13 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    namespace 'com.matter.tv.server'
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.matter.tv.server"
         minSdk 26
-        targetSdk 30
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -33,8 +34,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -59,6 +60,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        dataBinding = true
     }
 }
 

--- a/examples/tv-app/android/App/platform-app/build.gradle
+++ b/examples/tv-app/android/App/platform-app/build.gradle
@@ -60,7 +60,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
-        dataBinding = true
+        aidl = true
     }
 }
 

--- a/examples/tv-app/android/App/platform-app/src/main/AndroidManifest.xml
+++ b/examples/tv-app/android/App/platform-app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.matter.tv.server">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Permission to bind to Matter Agent service from Matter content apps-->
     <permission android:name="com.matter.tv.app.api.permission.BIND_SERVICE_PERMISSION"

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MainActivity.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MainActivity.java
@@ -20,22 +20,21 @@ public class MainActivity extends AppCompatActivity {
   private BottomNavigationView.OnNavigationItemSelectedListener navListener =
       item -> {
         Fragment selectedFragment = null;
-        switch (item.getItemId()) {
-          case R.id.content_app:
-            selectedFragment = ContentAppFragment.newInstance();
-            break;
-          case R.id.qr_code:
-            selectedFragment = QrCodeFragment.newInstance();
-            break;
-          case R.id.terminal:
-            selectedFragment = TerminalFragment.newInstance();
-            break;
+        int itemId = item.getItemId();
+        if (itemId == R.id.content_app) {
+          selectedFragment = ContentAppFragment.newInstance();
+        } else if (itemId == R.id.qr_code) {
+          selectedFragment = QrCodeFragment.newInstance();
+        } else if (itemId == R.id.terminal) {
+          selectedFragment = TerminalFragment.newInstance();
         }
 
-        getSupportFragmentManager()
-            .beginTransaction()
-            .replace(R.id.fragment_container_view, selectedFragment)
-            .commit();
+        if (selectedFragment != null) {
+          getSupportFragmentManager()
+              .beginTransaction()
+              .replace(R.id.fragment_container_view, selectedFragment)
+              .commit();
+        }
         return true;
       };
 

--- a/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
+++ b/examples/tv-app/android/include/target-navigator/TargetNavigatorManager.cpp
@@ -58,7 +58,6 @@ CHIP_ERROR TargetNavigatorManager::HandleGetTargetList(AttributeValueEncoder & a
                 if (value[attrId].isArray())
                 {
                     return aEncoder.EncodeList([&](const auto & encoder) -> CHIP_ERROR {
-                        int i                  = 0;
                         std::string targetId   = std::to_string(static_cast<uint32_t>(
                             chip::app::Clusters::TargetNavigator::Structs::TargetInfoStruct::Fields::kIdentifier));
                         std::string targetName = std::to_string(
@@ -69,14 +68,12 @@ CHIP_ERROR TargetNavigatorManager::HandleGetTargetList(AttributeValueEncoder & a
                             {
                                 // invalid target ID. Ignore.
                                 ChipLogError(Zcl, "TargetNavigatorManager::HandleNavigateTarget invalid target ignored");
-                                i++;
                                 continue;
                             }
                             Structs::TargetInfoStruct::Type outputInfo;
                             outputInfo.identifier = static_cast<uint8_t>(entry[targetId].asUInt());
                             outputInfo.name       = CharSpan::fromCharString(entry[targetName].asCString());
                             ReturnErrorOnFailure(encoder.Encode(outputInfo));
-                            i++;
                         }
                         return CHIP_NO_ERROR;
                     });

--- a/examples/tv-casting-app/android/App/app/build.gradle
+++ b/examples/tv-casting-app/android/App/app/build.gradle
@@ -3,12 +3,13 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    namespace 'com'
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.chip.casting"
-        minSdk 26
-        targetSdk 30
+        minSdk 24
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/examples/tv-casting-app/android/App/app/build.gradle
+++ b/examples/tv-casting-app/android/App/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.chip.casting"
-        minSdk 24
+        minSdk 26
         targetSdk 34
         versionCode 1
         versionName "1.0"

--- a/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
@@ -21,6 +20,7 @@
         android:name=".matter.casting.ChipTvCastingApplication"
         android:theme="@style/Theme.CHIPTVCastingApp">
         <activity android:name=".matter.casting.MainActivity"
+            android:exported="true"
             android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/examples/tv-casting-app/android/App/build.gradle
+++ b/examples/tv-casting-app/android/App/build.gradle
@@ -5,8 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
-
+        classpath 'com.android.tools.build:gradle:8.5.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -16,7 +15,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 

--- a/examples/tv-casting-app/android/App/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/tv-casting-app/android/App/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/third_party/android_deps/gradle/wrapper/gradle-wrapper.properties
+++ b/third_party/android_deps/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
#### Summary
Following https://developer.android.com/guide/practices/page-sizes#ndk-build_1, Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.

We need upgrade AGP version with 8.5.1.
We need upgrade sdk tool with 33.
We need upgrade java with 17
We need upgrade gradle with 8.7

#### Related issues

Fixes #39871

#### Testing
local compilation

#### Readability checklist
N/A