### PR TITLE
use 1_4_2 spec version instead of 1_5 in PICSGenerator.py

### DIFF
--- a/src/tools/PICS-generator/PICSGenerator.py
+++ b/src/tools/PICS-generator/PICSGenerator.py
@@ -430,8 +430,8 @@ class DeviceMappingTest(MatterBaseTest):
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4)
             elif specVersion == 0x1040100:
                 xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4_1)
-            elif specVersion == 0x1050000:
-                xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_5)
+            elif specVersion == 0x1040200:
+                xml_clusters, problems = build_xml_clusters(PrebuiltDataModelDirectory.k1_4_2)
             else:
                 console.print("FAILURE: Specification version reported by device not supported")
                 return


### PR DESCRIPTION
#### Summary

We have 1.4.2 version instead of 1.5. That is the latest available version for certification and 1.5 isn't ready yet. So I updated the tool.

#### Related issues

<!--
None
-->

#### Testing

<!--
Tested by generating a 1.4.2 PICS manually. 
 -->

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase
