### PR TITLE
Notify of attribute change in case InterfaceEnabled is written.

### DIFF
--- a/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
@@ -90,7 +90,7 @@ DataModel::ActionReturnStatus NetworkCommissioningCluster::WriteAttribute(const 
     {
         bool value;
         ReturnErrorOnFailure(decoder.Decode(value));
-        return mLogic.SetInterfaceEnabled(value);
+        return NotifyAttributeChangedIfSuccess(request.path.mAttributeId, mLogic.SetInterfaceEnabled(value));
     }
 
     return Protocols::InteractionModel::Status::InvalidAction;

--- a/src/app/clusters/network-commissioning/tests/BUILD.gn
+++ b/src/app/clusters/network-commissioning/tests/BUILD.gn
@@ -38,6 +38,8 @@ chip_test_suite("tests") {
     "${chip_root}/src/app/clusters/network-commissioning:thread-response-encoding",
     "${chip_root}/src/app/clusters/network-commissioning:wifi-response-encoding",
     "${chip_root}/src/app/clusters/testing",
+    "${chip_root}/src/app/data-model-provider/tests:encode-decode",
+    "${chip_root}/src/app/server-cluster/testing:testing",
     "${chip_root}/src/lib/core:string-builder-adapters",
     "${chip_root}/src/lib/support",
   ]

--- a/src/app/clusters/network-commissioning/tests/FakeWifiDriver.h
+++ b/src/app/clusters/network-commissioning/tests/FakeWifiDriver.h
@@ -74,7 +74,7 @@ public:
 
 private:
     NetworkCommissioningStatusEnum mAddOrUpdateStatus = NetworkCommissioningStatusEnum::kUnknownError;
-    bool mEnabledAllowed = false;
+    bool mEnabledAllowed                              = false;
 };
 
 } // namespace Testing

--- a/src/app/clusters/network-commissioning/tests/FakeWifiDriver.h
+++ b/src/app/clusters/network-commissioning/tests/FakeWifiDriver.h
@@ -42,6 +42,7 @@ public:
     uint8_t GetConnectNetworkTimeoutSeconds() override { return 2; }
 
     void SetAddOrUpdateNetworkReturn(NetworkCommissioningStatusEnum value) { mAddOrUpdateStatus = value; }
+    void SetEnabledAllowed(bool enabledAllowed) { mEnabledAllowed = enabledAllowed; }
 
     NetworkCommissioningStatusEnum RemoveNetwork(ByteSpan networkId, MutableCharSpan & outDebugText,
                                                  uint8_t & outNetworkIndex) override
@@ -58,12 +59,22 @@ public:
         callback->OnResult(NetworkCommissioningStatusEnum::kSuccess, ""_span, 0);
     }
 
+    CHIP_ERROR SetEnabled(bool enabled) override
+    {
+        if (mEnabledAllowed)
+        {
+            return CHIP_NO_ERROR;
+        }
+        return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    }
+
     // BaseDriver
     uint8_t GetMaxNetworks() override { return 0; }
     DeviceLayer::NetworkCommissioning::NetworkIterator * GetNetworks() override { return nullptr; }
 
 private:
     NetworkCommissioningStatusEnum mAddOrUpdateStatus = NetworkCommissioningStatusEnum::kUnknownError;
+    bool mEnabledAllowed = false;
 };
 
 } // namespace Testing

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -15,6 +15,7 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include <app/AttributePathParams.h>
 #include <app/AttributeValueDecoder.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/clusters/testing/AttributeTesting.h>
@@ -35,7 +36,6 @@
 #include <platform/NetworkCommissioning.h>
 
 #include "FakeWifiDriver.h"
-#include "app/AttributePathParams.h"
 
 namespace {
 

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -94,7 +94,7 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
     // TODO: more tests for ethernet and thread should be added
 }
 
-TEST_F(TestNetworkCommissioningCluster, TestNofigyOnEnableInterface)
+TEST_F(TestNetworkCommissioningCluster, TestNotifyOnEnableInterface)
 {
     Testing::FakeWiFiDriver fakeWifiDriver;
     NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver);

--- a/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
+++ b/src/app/clusters/network-commissioning/tests/TestNetworkCommissioningCluster.cpp
@@ -15,10 +15,14 @@
  */
 #include <pw_unit_test/framework.h>
 
+#include <app/AttributeValueDecoder.h>
 #include <app/clusters/network-commissioning/NetworkCommissioningCluster.h>
 #include <app/clusters/testing/AttributeTesting.h>
 #include <app/data-model-provider/MetadataTypes.h>
+#include <app/data-model-provider/tests/TestConstants.h>
+#include <app/data-model-provider/tests/WriteTesting.h>
 #include <app/server-cluster/DefaultServerCluster.h>
+#include <app/server-cluster/testing/TestServerClusterContext.h>
 #include <clusters/GeneralCommissioning/Attributes.h>
 #include <clusters/NetworkCommissioning/Commands.h>
 #include <clusters/NetworkCommissioning/Enums.h>
@@ -31,13 +35,18 @@
 #include <platform/NetworkCommissioning.h>
 
 #include "FakeWifiDriver.h"
+#include "app/AttributePathParams.h"
 
 namespace {
 
 using namespace chip;
 using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::NetworkCommissioning::Attributes;
 
+using chip::app::AttributeValueDecoder;
 using chip::app::DataModel::AttributeEntry;
+using chip::app::Testing::kAdminSubjectDescriptor;
+using chip::app::Testing::WriteOperation;
 
 // initialize memory as ReadOnlyBufferBuilder may allocate
 struct TestNetworkCommissioningCluster : public ::testing::Test
@@ -58,12 +67,12 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
         ReadOnlyBufferBuilder<AttributeEntry> expectedBuilder;
         ASSERT_EQ(expectedBuilder.ReferenceExisting(app::DefaultServerCluster::GlobalAttributes()), CHIP_NO_ERROR);
         ASSERT_EQ(expectedBuilder.AppendElements({
-                      NetworkCommissioning::Attributes::MaxNetworks::kMetadataEntry,
-                      NetworkCommissioning::Attributes::Networks::kMetadataEntry,
-                      NetworkCommissioning::Attributes::InterfaceEnabled::kMetadataEntry,
-                      NetworkCommissioning::Attributes::LastNetworkingStatus::kMetadataEntry,
-                      NetworkCommissioning::Attributes::LastNetworkID::kMetadataEntry,
-                      NetworkCommissioning::Attributes::LastConnectErrorValue::kMetadataEntry,
+                      MaxNetworks::kMetadataEntry,
+                      Networks::kMetadataEntry,
+                      InterfaceEnabled::kMetadataEntry,
+                      LastNetworkingStatus::kMetadataEntry,
+                      LastNetworkID::kMetadataEntry,
+                      LastConnectErrorValue::kMetadataEntry,
                   }),
                   CHIP_NO_ERROR);
 
@@ -72,9 +81,9 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
         //       For now keep the logic as inherited from previous implementation.
 #if (CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION || CHIP_DEVICE_CONFIG_ENABLE_WIFI_AP)
         ASSERT_EQ(expectedBuilder.AppendElements({
-                      NetworkCommissioning::Attributes::ScanMaxTimeSeconds::kMetadataEntry,
-                      NetworkCommissioning::Attributes::ConnectMaxTimeSeconds::kMetadataEntry,
-                      NetworkCommissioning::Attributes::SupportedWiFiBands::kMetadataEntry,
+                      ScanMaxTimeSeconds::kMetadataEntry,
+                      ConnectMaxTimeSeconds::kMetadataEntry,
+                      SupportedWiFiBands::kMetadataEntry,
                   }),
                   CHIP_NO_ERROR);
 #endif
@@ -83,6 +92,45 @@ TEST_F(TestNetworkCommissioningCluster, TestAttributes)
     }
 
     // TODO: more tests for ethernet and thread should be added
+}
+
+TEST_F(TestNetworkCommissioningCluster, TestNofigyOnEnableInterface)
+{
+    Testing::FakeWiFiDriver fakeWifiDriver;
+    NetworkCommissioningCluster cluster(kRootEndpointId, &fakeWifiDriver);
+
+    chip::Test::TestServerClusterContext context;
+    ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    {
+        WriteOperation writeOp(kRootEndpointId, NetworkCommissioning::Id, InterfaceEnabled::Id);
+        writeOp.SetSubjectDescriptor(kAdminSubjectDescriptor);
+        AttributeValueDecoder decoder = writeOp.DecoderFor(true);
+
+        // no notification if enable fails
+        context.ChangeListener().DirtyList().clear();
+        fakeWifiDriver.SetEnabledAllowed(false);
+        ASSERT_FALSE(cluster.WriteAttribute(writeOp.GetRequest(), decoder).IsSuccess());
+        ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
+    }
+
+    {
+        WriteOperation writeOp(kRootEndpointId, NetworkCommissioning::Id, InterfaceEnabled::Id);
+        writeOp.SetSubjectDescriptor(kAdminSubjectDescriptor);
+        AttributeValueDecoder decoder = writeOp.DecoderFor(true);
+
+        // Receive a notification if enable succeeds
+        context.ChangeListener().DirtyList().clear();
+        fakeWifiDriver.SetEnabledAllowed(true);
+        ASSERT_TRUE(cluster.WriteAttribute(writeOp.GetRequest(), decoder).IsSuccess());
+        ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
+        ASSERT_EQ(context.ChangeListener().DirtyList()[0],
+                  app::AttributePathParams(kRootEndpointId, NetworkCommissioning::Id, InterfaceEnabled::Id)
+
+        );
+    }
+
+    cluster.Shutdown();
 }
 
 } // namespace

--- a/src/app/server-cluster/DefaultServerCluster.cpp
+++ b/src/app/server-cluster/DefaultServerCluster.cpp
@@ -133,5 +133,15 @@ CHIP_ERROR DefaultServerCluster::GeneratedCommands(const ConcreteClusterPath & p
     return CHIP_NO_ERROR;
 }
 
+DataModel::ActionReturnStatus DefaultServerCluster::NotifyAttributeChangedIfSuccess(AttributeId attributeId,
+                                                                                    DataModel::ActionReturnStatus status)
+{
+    if (status.IsSuccess())
+    {
+        NotifyAttributeChanged(attributeId);
+    }
+    return status;
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -109,7 +109,7 @@ protected:
     /// notify that the attribute has changed.
     void NotifyAttributeChanged(AttributeId attributeId);
 
-    /// Marks that a specific attribute has changed value, if `status` is succes.
+    /// Marks that a specific attribute has changed value, if `status` is success.
     ///
     /// Will return `status`
     DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status);

--- a/src/app/server-cluster/DefaultServerCluster.h
+++ b/src/app/server-cluster/DefaultServerCluster.h
@@ -109,6 +109,11 @@ protected:
     /// notify that the attribute has changed.
     void NotifyAttributeChanged(AttributeId attributeId);
 
+    /// Marks that a specific attribute has changed value, if `status` is succes.
+    ///
+    /// Will return `status`
+    DataModel::ActionReturnStatus NotifyAttributeChangedIfSuccess(AttributeId attributeId, DataModel::ActionReturnStatus status);
+
 private:
     DataVersion mDataVersion; // will be random-initialized as per spec
 };

--- a/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
+++ b/src/app/server-cluster/tests/TestDefaultServerCluster.cpp
@@ -65,6 +65,10 @@ public:
 
     void TestIncreaseDataVersion() { IncreaseDataVersion(); }
     void TestNotifyAttributeChanged(AttributeId attributeId) { NotifyAttributeChanged(attributeId); }
+    ActionReturnStatus TestNotifyAttributeChangedIfSuccess(AttributeId attributeId, ActionReturnStatus status)
+    {
+        return NotifyAttributeChangedIfSuccess(attributeId, status);
+    }
 };
 
 } // namespace
@@ -193,4 +197,41 @@ TEST(TestDefaultServerCluster, NotifyAttributeChanged)
 
     ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
     ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 234));
+}
+
+TEST(TestDefaultServerCluster, NotifyAttributeChangedIfSuccess)
+{
+    constexpr ClusterId kEndpointId = 321;
+    constexpr ClusterId kClusterId  = 1122;
+    FakeDefaultServerCluster cluster({ kEndpointId, kClusterId });
+
+    // When no ServerClusterContext is set, only the data version should change.
+    DataVersion oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+
+    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(123, Status::Success), Status::Success);
+    DataVersion newVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    ASSERT_NE(newVersion, oldVersion);
+
+    oldVersion = newVersion;
+    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(123, Status::Failure), Status::Failure);
+    newVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    ASSERT_EQ(newVersion, oldVersion);
+
+    // Create a ServerClusterContext and verify that attribute change notifications are processed.
+    TestServerClusterContext context;
+    ASSERT_EQ(cluster.Startup(context.Get()), CHIP_NO_ERROR);
+
+    oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(234, Status::Success), Status::Success);
+    ASSERT_NE(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
+
+    ASSERT_EQ(context.ChangeListener().DirtyList().size(), 1u);
+    ASSERT_EQ(context.ChangeListener().DirtyList()[0], AttributePathParams(kEndpointId, kClusterId, 234));
+
+    // now test a failure - nothing should be marked dirty
+    oldVersion = cluster.GetDataVersion({ kEndpointId, kClusterId });
+    context.ChangeListener().DirtyList().clear();
+    ASSERT_EQ(cluster.TestNotifyAttributeChangedIfSuccess(345, Status::Failure), Status::Failure);
+    ASSERT_EQ(cluster.GetDataVersion({ kEndpointId, kClusterId }), oldVersion);
+    ASSERT_TRUE(context.ChangeListener().DirtyList().empty());
 }


### PR DESCRIPTION
#### Summary

This is a bugfix for code driven migration: previous code would always notify inside ember callbacks for AAI.
Make sure we also notify on enable success.

#### Changes:

- Adds a `NotifyAttributeChangeIfSuccess` for the very common operation of "do something to update the attribute and if that succeeds, notify of change"
- Update the network commissioning cluster to notify of attribute change if success when a interface write is received.


#### Testing

Automated unit tests added.