### PR TITLE
Use ServerClusterInit callbacks for all codegen integrations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -221,7 +221,7 @@ jobs:
             # to fail (exit nonzero) on match.  And we want to exclude this file,
             # to avoid our grep regexp matching itself.
             #
-            # Known client-side clusters are allowd to use this only.
+            # Known client-side clusters are allowed to use this only.
             - name: emberAfClusterInit/Shutdown callbacks are for client side use, not server side. Use ClusterServerInit/Shutdown for server clusters
               if: always()
               run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,6 +217,20 @@ jobs:
               run: |
                   git grep -I -n "%zu" -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
 
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we want to exclude this file,
+            # to avoid our grep regexp matching itself.
+            #
+            # Known client-side clusters are allowd to use this only.
+            - name: emberAfClusterInit/Shutdown callbacks are for client side use, not server side. Use ClusterServerInit/Shutdown for server clusters
+              if: always()
+              run: |
+                  git grep -I -n "void emberAf.*Cluster\(Init\|Shutdown\)Callback("  -- \
+                  src/app/clusters \
+                  ':(exclude).github/workflows/lint.yml' \
+                  ':(exclude)src/app/clusters/pump-configuration-and-control-client' \
+                  && exit 1 || exit 0
+
             # Comments like '{{! ... }}' should be used in zap files
             - name: Do not allow TODO in generated files
               if: always()

--- a/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/all-clusters-app/app-templates/endpoint_config.h
@@ -2908,6 +2908,22 @@
         (EmberAfGenericClusterFunction) emberAfTimeFormatLocalizationClusterServerInitCallback,                                    \
         (EmberAfGenericClusterFunction) MatterTimeFormatLocalizationClusterServerPreAttributeChangedCallback,                      \
     };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayGeneralDiagnosticsServer[] = {                                                \
+        (EmberAfGenericClusterFunction) emberAfGeneralDiagnosticsClusterServerInitCallback,                                        \
+        (EmberAfGenericClusterFunction) MatterGeneralDiagnosticsClusterServerShutdownCallback,                                     \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArraySoftwareDiagnosticsServer[] = {                                               \
+        (EmberAfGenericClusterFunction) emberAfSoftwareDiagnosticsClusterServerInitCallback,                                       \
+        (EmberAfGenericClusterFunction) MatterSoftwareDiagnosticsClusterServerShutdownCallback,                                    \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayWiFiNetworkDiagnosticsServer[] = {                                            \
+        (EmberAfGenericClusterFunction) emberAfWiFiNetworkDiagnosticsClusterServerInitCallback,                                    \
+        (EmberAfGenericClusterFunction) MatterWiFiNetworkDiagnosticsClusterServerShutdownCallback,                                 \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayAdministratorCommissioningServer[] = {                                        \
+        (EmberAfGenericClusterFunction) emberAfAdministratorCommissioningClusterServerInitCallback,                                \
+        (EmberAfGenericClusterFunction) MatterAdministratorCommissioningClusterServerShutdownCallback,                             \
+    };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayIdentifyServer[] = {                                                          \
         (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerInitCallback,                                                  \
         (EmberAfGenericClusterFunction) MatterIdentifyClusterServerAttributeChangedCallback,                                       \
@@ -3670,8 +3686,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(96), \
       .attributeCount = 11, \
       .clusterSize = 0, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayGeneralDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 37 ), \
       .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 41 ), \
       .eventList = ZAP_GENERATED_EVENTS_INDEX( 8 ), \
@@ -3683,8 +3699,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(107), \
       .attributeCount = 6, \
       .clusterSize = 0, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArraySoftwareDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 44 ), \
       .generatedCommandList = nullptr, \
       .eventList = ZAP_GENERATED_EVENTS_INDEX( 12 ), \
@@ -3709,8 +3725,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(178), \
       .attributeCount = 15, \
       .clusterSize = 6, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayWiFiNetworkDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 48 ), \
       .generatedCommandList = nullptr, \
       .eventList = ZAP_GENERATED_EVENTS_INDEX( 13 ), \
@@ -3748,8 +3764,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(218), \
       .attributeCount = 5, \
       .clusterSize = 4, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayAdministratorCommissioningServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 60 ), \
       .generatedCommandList = nullptr, \
       .eventList = nullptr, \

--- a/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
+++ b/scripts/tools/zap/tests/outputs/lighting-app/app-templates/endpoint_config.h
@@ -729,6 +729,22 @@
         (EmberAfGenericClusterFunction) emberAfTimeFormatLocalizationClusterServerInitCallback,                                    \
         (EmberAfGenericClusterFunction) MatterTimeFormatLocalizationClusterServerPreAttributeChangedCallback,                      \
     };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayGeneralDiagnosticsServer[] = {                                                \
+        (EmberAfGenericClusterFunction) emberAfGeneralDiagnosticsClusterServerInitCallback,                                        \
+        (EmberAfGenericClusterFunction) MatterGeneralDiagnosticsClusterServerShutdownCallback,                                     \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArraySoftwareDiagnosticsServer[] = {                                               \
+        (EmberAfGenericClusterFunction) emberAfSoftwareDiagnosticsClusterServerInitCallback,                                       \
+        (EmberAfGenericClusterFunction) MatterSoftwareDiagnosticsClusterServerShutdownCallback,                                    \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayWiFiNetworkDiagnosticsServer[] = {                                            \
+        (EmberAfGenericClusterFunction) emberAfWiFiNetworkDiagnosticsClusterServerInitCallback,                                    \
+        (EmberAfGenericClusterFunction) MatterWiFiNetworkDiagnosticsClusterServerShutdownCallback,                                 \
+    };                                                                                                                             \
+    const EmberAfGenericClusterFunction chipFuncArrayAdministratorCommissioningServer[] = {                                        \
+        (EmberAfGenericClusterFunction) emberAfAdministratorCommissioningClusterServerInitCallback,                                \
+        (EmberAfGenericClusterFunction) MatterAdministratorCommissioningClusterServerShutdownCallback,                             \
+    };                                                                                                                             \
     const EmberAfGenericClusterFunction chipFuncArrayIdentifyServer[] = {                                                          \
         (EmberAfGenericClusterFunction) emberAfIdentifyClusterServerInitCallback,                                                  \
         (EmberAfGenericClusterFunction) MatterIdentifyClusterServerAttributeChangedCallback,                                       \
@@ -1078,8 +1094,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(70), \
       .attributeCount = 11, \
       .clusterSize = 0, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayGeneralDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 25 ), \
       .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 28 ), \
       .eventList = ZAP_GENERATED_EVENTS_INDEX( 8 ), \
@@ -1091,8 +1107,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(81), \
       .attributeCount = 6, \
       .clusterSize = 0, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArraySoftwareDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 30 ), \
       .generatedCommandList = nullptr, \
       .eventList = nullptr, \
@@ -1117,8 +1133,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(152), \
       .attributeCount = 15, \
       .clusterSize = 6, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayWiFiNetworkDiagnosticsServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 34 ), \
       .generatedCommandList = nullptr, \
       .eventList = ZAP_GENERATED_EVENTS_INDEX( 12 ), \
@@ -1156,8 +1172,8 @@
       .attributes = ZAP_ATTRIBUTE_INDEX(182), \
       .attributeCount = 5, \
       .clusterSize = 4, \
-      .mask = ZAP_CLUSTER_MASK(SERVER), \
-      .functions = NULL, \
+      .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(SHUTDOWN_FUNCTION), \
+      .functions = chipFuncArrayAdministratorCommissioningServer, \
       .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 38 ), \
       .generatedCommandList = nullptr, \
       .eventList = nullptr, \

--- a/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
@@ -75,7 +75,7 @@ void emberAfAdministratorCommissioningClusterServerInitCallback(EndpointId endpo
     }
 }
 
-void emberAfAdministratorCommissioningClusterServerShutdownCallback(EndpointId endpointId)
+void MatterAdministratorCommissioningClusterServerShutdownCallback(EndpointId endpointId)
 {
     if (endpointId != kRootEndpointId)
     {

--- a/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
@@ -53,7 +53,7 @@ LazyRegisteredServerCluster<ClusterImpl> gServer;
 
 } // namespace
 
-void emberAfAdministratorCommissioningClusterInitCallback(EndpointId endpointId)
+void emberAfAdministratorCommissioningServerClusterInitCallback(EndpointId endpointId)
 {
     if (endpointId != kRootEndpointId)
     {

--- a/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
@@ -75,7 +75,7 @@ void emberAfAdministratorCommissioningClusterServerInitCallback(EndpointId endpo
     }
 }
 
-void emberAfAdministratorCommissioningClusterShutdownCallback(EndpointId endpointId)
+void emberAfAdministratorCommissioningClusterServerShutdownCallback(EndpointId endpointId)
 {
     if (endpointId != kRootEndpointId)
     {

--- a/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+++ b/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
@@ -53,7 +53,7 @@ LazyRegisteredServerCluster<ClusterImpl> gServer;
 
 } // namespace
 
-void emberAfAdministratorCommissioningServerClusterInitCallback(EndpointId endpointId)
+void emberAfAdministratorCommissioningClusterServerInitCallback(EndpointId endpointId)
 {
     if (endpointId != kRootEndpointId)
     {

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -91,7 +91,7 @@ void emberAfGeneralDiagnosticsClusterServerInitCallback(EndpointId endpointId)
     }
 }
 
-void emberAfGeneralDiagnosticsClusterShutdownCallback(EndpointId endpointId)
+void emberAfGeneralDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&gServer.Cluster());

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -44,7 +44,7 @@ LazyRegisteredServerCluster<GeneralDiagnosticsCluster> gServer;
 
 } // namespace
 
-void emberAfGeneralDiagnosticsServerClusterInitCallback(EndpointId endpointId)
+void emberAfGeneralDiagnosticsClusterServerInitCallback(EndpointId endpointId)
 {
     VerifyOrDie(endpointId == kRootEndpointId);
     const GeneralDiagnosticsEnabledAttributes enabledAttributes{

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -91,7 +91,7 @@ void emberAfGeneralDiagnosticsClusterServerInitCallback(EndpointId endpointId)
     }
 }
 
-void emberAfGeneralDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
+void MatterGeneralDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&gServer.Cluster());

--- a/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
@@ -44,7 +44,7 @@ LazyRegisteredServerCluster<GeneralDiagnosticsCluster> gServer;
 
 } // namespace
 
-void emberAfGeneralDiagnosticsClusterInitCallback(EndpointId endpointId)
+void emberAfGeneralDiagnosticsServerClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrDie(endpointId == kRootEndpointId);
     const GeneralDiagnosticsEnabledAttributes enabledAttributes{

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -50,7 +50,7 @@ bool findEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 
 } // namespace
 
-void emberAfOtaSoftwareUpdateProviderServerClusterInitCallback(EndpointId endpointId)
+void emberAfOtaSoftwareUpdateProviderClusterServerInitCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!findEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -64,7 +64,7 @@ void emberAfOtaSoftwareUpdateProviderClusterServerInitCallback(EndpointId endpoi
     }
 }
 
-void emberAfOtaSoftwareUpdateProviderClusterShutdownCallback(EndpointId endpointId)
+void emberAfOtaSoftwareUpdateProviderClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!findEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -37,8 +37,7 @@ LazyRegisteredServerCluster<OtaProviderServer> gServers[kOtaProviderMaxClusterCo
 // Log an error if not found.
 bool findEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 {
-    outArrayIndex =
-        emberAfGetClusterServerEndpointIndex(endpointId, OtaSoftwareUpdateProvider::Id, kOtaProviderFixedClusterCount);
+    outArrayIndex = emberAfGetClusterServerEndpointIndex(endpointId, OtaSoftwareUpdateProvider::Id, kOtaProviderFixedClusterCount);
 
     if (outArrayIndex >= kOtaProviderMaxClusterCount)
     {

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -37,10 +37,10 @@ LazyRegisteredServerCluster<OtaProviderServer> gServers[kOtaProviderMaxClusterCo
 // Log an error if not found.
 bool findEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 {
-    uint16_t arrayIndex =
+    outArrayIndex =
         emberAfGetClusterServerEndpointIndex(endpointId, OtaSoftwareUpdateProvider::Id, kOtaProviderFixedClusterCount);
 
-    if (arrayIndex >= kOtaProviderMaxClusterCount)
+    if (outArrayIndex >= kOtaProviderMaxClusterCount)
     {
         ChipLogError(AppServer, "Cound not find endpoint index for endpoint %u", endpointId);
         return false;

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -50,7 +50,7 @@ bool findEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 
 } // namespace
 
-void emberAfOtaSoftwareUpdateProviderClusterInitCallback(EndpointId endpointId)
+void emberAfOtaSoftwareUpdateProviderServerClusterInitCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!findEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -41,7 +41,7 @@ bool findEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 
     if (outArrayIndex >= kOtaProviderMaxClusterCount)
     {
-        ChipLogError(AppServer, "Cound not find endpoint index for endpoint %u", endpointId);
+        ChipLogError(AppServer, "Could not find endpoint index for endpoint %u", endpointId);
         return false;
     }
     return true;

--- a/src/app/clusters/ota-provider/CodegenIntegration.cpp
+++ b/src/app/clusters/ota-provider/CodegenIntegration.cpp
@@ -64,7 +64,7 @@ void emberAfOtaSoftwareUpdateProviderClusterServerInitCallback(EndpointId endpoi
     }
 }
 
-void emberAfOtaSoftwareUpdateProviderClusterServerShutdownCallback(EndpointId endpointId)
+void MatterOtaSoftwareUpdateProviderClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!findEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
@@ -53,7 +53,7 @@ bool FindEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 }
 
 } // namespace
-void emberAfPushAvStreamTransportClusterInitCallback(EndpointId endpointId)
+void emberAfPushAvStreamTransportServerClusterInitCallback(EndpointId endpointId)
 {
 
     uint16_t arrayIndex = 0;

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
@@ -77,7 +77,7 @@ void emberAfPushAvStreamTransportClusterServerInitCallback(EndpointId endpointId
     }
 }
 
-void emberAfPushAvStreamTransportClusterServerShutdownCallback(EndpointId endpointId)
+void MatterPushAvStreamTransportClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
@@ -77,7 +77,7 @@ void emberAfPushAvStreamTransportClusterServerInitCallback(EndpointId endpointId
     }
 }
 
-void emberAfPushAvStreamTransportClusterShutdownCallback(EndpointId endpointId)
+void emberAfPushAvStreamTransportClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
@@ -53,7 +53,7 @@ bool FindEndpointWithLog(EndpointId endpointId, uint16_t & outArrayIndex)
 }
 
 } // namespace
-void emberAfPushAvStreamTransportServerClusterInitCallback(EndpointId endpointId)
+void emberAfPushAvStreamTransportClusterServerInitCallback(EndpointId endpointId)
 {
 
     uint16_t arrayIndex = 0;

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
@@ -181,4 +181,3 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServer::Invoke
 } // namespace Clusters
 } // namespace app
 } // namespace chip
-

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-cluster.cpp
@@ -182,7 +182,3 @@ std::optional<DataModel::ActionReturnStatus> PushAvStreamTransportServer::Invoke
 } // namespace app
 } // namespace chip
 
-void MatterPushAvStreamTransportClusterServerShutdownCallback(chip::EndpointId endpoint)
-{
-    ChipLogProgress(Zcl, "Shuting Push AV Stream Transport server cluster on endpoint %d", endpoint);
-}

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -38,7 +38,7 @@ LazyRegisteredServerCluster<SoftwareDiagnosticsServerCluster> gServer;
 
 } // namespace
 
-void emberAfSoftwareDiagnosticsServerClusterInitCallback(EndpointId endpointId)
+void emberAfSoftwareDiagnosticsClusterServerInitCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     const SoftwareDiagnosticsEnabledAttributes enabledAttributes{

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -59,7 +59,7 @@ void emberAfSoftwareDiagnosticsClusterServerInitCallback(EndpointId endpointId)
     }
 }
 
-void emberAfSoftwareDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
+void MatterSoftwareDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&gServer.Cluster());

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -38,7 +38,7 @@ LazyRegisteredServerCluster<SoftwareDiagnosticsServerCluster> gServer;
 
 } // namespace
 
-void emberAfSoftwareDiagnosticsClusterInitCallback(EndpointId endpointId)
+void emberAfSoftwareDiagnosticsServerClusterInitCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     const SoftwareDiagnosticsEnabledAttributes enabledAttributes{

--- a/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
@@ -59,7 +59,7 @@ void emberAfSoftwareDiagnosticsClusterServerInitCallback(EndpointId endpointId)
     }
 }
 
-void emberAfSoftwareDiagnosticsClusterShutdownCallback(EndpointId endpointId)
+void emberAfSoftwareDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     VerifyOrReturn(endpointId == kRootEndpointId);
     CHIP_ERROR err = CodegenDataModelProvider::Instance().Registry().Unregister(&gServer.Cluster());

--- a/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
@@ -95,7 +95,7 @@ void emberAfWiFiNetworkDiagnosticsClusterServerInitCallback(EndpointId endpointI
 }
 
 // This callback is called for any endpoint (fixed or dynamic) that is registered with the Ember machinery.
-void emberAfWiFiNetworkDiagnosticsClusterShutdownCallback(EndpointId endpointId)
+void emberAfWiFiNetworkDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
@@ -63,7 +63,7 @@ bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 } // namespace
 
 // This callback is called for any endpoint (fixed or dynamic) that is registered with the Ember machinery.
-void emberAfWiFiNetworkDiagnosticsClusterInitCallback(EndpointId endpointId)
+void emberAfWiFiNetworkDiagnosticsServerClusterInitCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
@@ -63,7 +63,7 @@ bool IsAttributeEnabled(EndpointId endpointId, AttributeId attributeId)
 } // namespace
 
 // This callback is called for any endpoint (fixed or dynamic) that is registered with the Ember machinery.
-void emberAfWiFiNetworkDiagnosticsServerClusterInitCallback(EndpointId endpointId)
+void emberAfWiFiNetworkDiagnosticsClusterServerInitCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
@@ -95,7 +95,7 @@ void emberAfWiFiNetworkDiagnosticsClusterServerInitCallback(EndpointId endpointI
 }
 
 // This callback is called for any endpoint (fixed or dynamic) that is registered with the Ember machinery.
-void emberAfWiFiNetworkDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
+void MatterWiFiNetworkDiagnosticsClusterServerShutdownCallback(EndpointId endpointId)
 {
     uint16_t arrayIndex = 0;
     if (!FindEndpointWithLog(endpointId, arrayIndex))

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -73,19 +73,25 @@ CommandHandlerInterfaceOnlyClusters:
 # We need a more configurable way of deciding which clusters have which init functions....
 # See https://github.com/project-chip/connectedhomeip/issues/4369
 ClustersWithInitFunctions:
+    - Administrator Commissioning
     - Color Control
+    - General Diagnostics
     - Groups
     - Identify
     - Level Control
     - Localization Configuration
+    - Mode Select
     - Occupancy Sensing
     - On/Off
+    - OTA Software Update Provider
     - Pump Configuration and Control
-    - Time Format Localization
-    - Thermostat
-    - Mode Select
+    - Push AV Stream Transport
     - Sample MEI
     - Scenes Management
+    - Software Diagnostics
+    - Thermostat
+    - Time Format Localization
+    - Wi-Fi Network Diagnostics
 
 ClustersWithAttributeChangedFunctions:
     - Bridged Device Basic Information

--- a/src/app/common/templates/config-data.yaml
+++ b/src/app/common/templates/config-data.yaml
@@ -97,14 +97,20 @@ ClustersWithAttributeChangedFunctions:
     - Thermostat
 
 ClustersWithShutdownFunctions:
+    - Administrator Commissioning
     - Barrier Control
-    - On/Off
-    - Door Lock
-    - Level Control
     - Color Control
+    - Door Lock
+    - General Diagnostics
+    - Level Control
+    - On/Off
+    - OTA Software Update Provider
+    - Push AV Stream Transport
     - Sample MEI
     - Scenes Management
+    - Software Diagnostics
     - Thermostat
+    - Wi-Fi Network Diagnostics
 
 ClustersWithPreAttributeChangeFunctions:
     - Door Lock


### PR DESCRIPTION
#### Summary

Ember provides `ClusterInit` callbacks and `ClusterServerInit` callbacks. Apparently the latter is to be used by integrations and NOT the former 

This was noticed in https://github.com/project-chip/connectedhomeip/pull/39698#discussion_r2264527455 and https://github.com/project-chip/connectedhomeip/pull/40504#discussion_r2264547557 (and essentially all were broken)

#### Testing

CI for these clusters still applies.
Added a linter rule. Checked that linter rule applies before changing Shutdown function (linter correctly failed)

#### Size information

bloaty reports large size changes ... it seems that this is due to shutdown functions now being called where as previous functions were never called (ember linkage is unclear to me ... some weak functions exist, others do not):

<img width="2154" height="1228" alt="image" src="https://github.com/user-attachments/assets/03280c16-d06f-426b-a7f2-92e0d6ec6786" />


So for correctness we should probably call the shutdown methods. However the flash cost for shutdown seems really high especially if we consider that many embedded platforms will not shut down, especially for EP0.