### PR TITLE
Use boringssl and disable WebRTC on Darwin to fix build issues

### DIFF
--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -238,12 +238,16 @@ source "$CHIP_ROOT/scripts/activate.sh"
 #     10.16    // SYSTEM_VERSION_COMPAT is unset or 1
 export SYSTEM_VERSION_COMPAT=0
 
-# Darwin overrides
+# Set default crypto to openssl. It will be overridden on Darwin.
+chip_crypto="openssl"
+
+# Disable WebRTC by default only on Darwin due to libdatachannel limitations
 if [[ "$(uname)" == "Darwin" ]]; then
     chip_crypto="boringssl"
-    enable_webrtc=false
-else
-    chip_crypto="openssl"
+    if [[ "$enable_webrtc" == "true" ]]; then
+        echo "Warning: WebRTC is not supported on Darwin. Disabling WebRTC to avoid build errors."
+        enable_webrtc="false"
+    fi
 fi
 
 # Generates ninja files

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -238,6 +238,14 @@ source "$CHIP_ROOT/scripts/activate.sh"
 #     10.16    // SYSTEM_VERSION_COMPAT is unset or 1
 export SYSTEM_VERSION_COMPAT=0
 
+# Darwin overrides
+if [[ "$(uname)" == "Darwin" ]]; then
+    chip_crypto="boringssl"
+    enable_webrtc=false
+else
+    chip_crypto="openssl"
+fi
+
 # Generates ninja files
 gn_args=(
     # Make all possible human readable tracing available.
@@ -250,7 +258,7 @@ gn_args=(
     "chip_config_network_layer_ble=$enable_ble"
     "chip_enable_ble=$enable_ble"
     "chip_inet_config_enable_ipv4=$enable_ipv4"
-    "chip_crypto=\"openssl\""
+    "chip_crypto=\"$chip_crypto\""
     "chip_build_controller_dynamic_server=$chip_build_controller_dynamic_server"
     "chip_support_webrtc_python_bindings=$enable_webrtc"
     "chip_device_config_enable_joint_fabric=true"

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -238,16 +238,19 @@ source "$CHIP_ROOT/scripts/activate.sh"
 #     10.16    // SYSTEM_VERSION_COMPAT is unset or 1
 export SYSTEM_VERSION_COMPAT=0
 
-# Set default crypto to openssl. It will be overridden on Darwin.
-chip_crypto="openssl"
+# Set default crypto to BoringSSL
+chip_crypto="boringssl"
 
 # Disable WebRTC by default only on Darwin due to libdatachannel limitations
 if [[ "$(uname)" == "Darwin" ]]; then
-    chip_crypto="boringssl"
-    if [[ "$enable_webrtc" == "true" ]]; then
-        echo "Warning: WebRTC is not supported on Darwin. Disabling WebRTC to avoid build errors."
-        enable_webrtc="false"
-    fi
+    echo "Warning: WebRTC is not supported on Darwin. Disabling WebRTC to avoid build errors."
+    enable_webrtc="false"
+fi
+
+# If WebRTC is enabled, switch chip_crypto to OpenSSL,
+# because WebRTC depends on OpenSSL, which must be installed and available.
+if [[ "$enable_webrtc" == "true" ]]; then
+    chip_crypto="openssl"
 fi
 
 # Generates ninja files


### PR DESCRIPTION
#### Summary
On macOS, enabling WebRTC switches crypto to OpenSSL, but libdatachannel (required by WebRTC) does not yet have Darwin support (#37983).  
This leads to missing CMake dependencies and build failures.

This change updates the build script to:
- Keep boringssl as the default crypto on macOS
- Disable WebRTC on macOS until libdatachannel Darwin support is implemented
- Continue using OpenSSL + WebRTC on Linux and other supported platforms

This unblocks Python builds on macOS without affecting Linux camera builds.

#### Testing

Verified on Darwin (macOS 15.6, build 24G84). With this change, the build completes successfully without OpenSSL pkg-config errors or missing CMake dependencies related to libdatachannel and WebRTC. Python wheels build as expected.
