### PR TITLE
[Silabs] Reduce the default amount of logs generated

### DIFF
--- a/examples/platform/silabs/args.gni
+++ b/examples/platform/silabs/args.gni
@@ -23,6 +23,8 @@ chip_system_project_config_include = "<CHIPProjectConfig.h>"
 segger_rtt_buffer_size_up = 1024
 segger_rtt_buffer_size_down = 1024
 
+chip_detail_logging = false
+
 declare_args() {
   app_data_model = ""
 }

--- a/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
+++ b/src/platform/silabs/wifi/wf200/WifiInterfaceImpl.cpp
@@ -394,8 +394,7 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         ChipLogError(DeviceLayer, "event: SL_WFX_EXCEPTION_IND_ID");
         ChipLogError(DeviceLayer, "firmware_exception->header.length: %d", firmware_exception->header.length);
         // create a bytespan header.length with exception payload
-        ByteSpan exception_byte_span = ByteSpan((uint8_t *) firmware_exception, firmware_exception->header.length);
-        ChipLogByteSpan(DeviceLayer, exception_byte_span);
+        ChipLogByteSpan(DeviceLayer, ByteSpan((uint8_t *) firmware_exception, firmware_exception->header.length));
         break;
     }
     case SL_WFX_ERROR_IND_ID: {
@@ -404,8 +403,7 @@ extern "C" sl_status_t sl_wfx_host_process_event(sl_wfx_generic_message_t * even
         ChipLogError(DeviceLayer, "firmware_error->type: %lu", firmware_error->body.type);
         ChipLogError(DeviceLayer, "firmware_error->header.length: %d", firmware_error->header.length);
         // create a bytespan header.length with error payload
-        ByteSpan error_byte_span = ByteSpan((uint8_t *) firmware_error, firmware_error->header.length);
-        ChipLogByteSpan(DeviceLayer, error_byte_span);
+        ChipLogByteSpan(DeviceLayer, ByteSpan((uint8_t *) firmware_error, firmware_error->header.length));
         break;
     }
     }


### PR DESCRIPTION
#### Summary
Reduce the log category logging from detail to info. This should alleviate the burden of the code size and the UART precessing.

#### Related issues
None

#### Testing
Build for a MG24 (BRD4187C) amount of log generated was deemed sufficient. 
