### PR TITLE
Add description of Push AV Server example flow

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -140,6 +140,7 @@ betaprogram
 BinaryInputBasic
 Binfmt
 bitbake
+bitrate
 bld
 BLE
 BleApplicationDelegate
@@ -267,6 +268,7 @@ cn
 COAP
 codeaurora
 codebase
+codec
 codegen
 CodeGenerator
 CodeLab
@@ -1489,6 +1491,7 @@ TotalTrihalomethanesConcentrationMeasurement
 TPK
 trackAlloc
 trackFree
+transcoder
 TransferSession
 transitionTime
 TransportMgrBase

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -113,7 +113,7 @@ export PUBLISHING_ENDPOINT=https://localhost:1234/streams/1
 
 This command saves the stream's URL into an environment variable for easy
 access. This URL is the ingest endpoint—the specific address where the `CMAF`
-media segments will be uploaded. The 1 is the stream_id returned by the previous
+media segments will be uploaded. The 1 at the end is the stream_id returned by the previous
 command.
 
 ### 3. Publishing Media Content

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -52,3 +52,77 @@ $ sed '$!G' client.csr | paste -sd '\\n' - > client.curl.csr
 $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST 'https://localhost:1234/certs/my-device/sign' -d "{\"csr\":\"$(cat client.curl.csr)\"}" --header "content-type: application/json"
 
 ```
+
+This command-line flow demonstrates a complete interaction with a secure media server designed for "push" streaming, where a client sends media data to the server. The process involves setting up security, creating a stream, publishing content, and managing the system.
+
+The core technology here is CMAF (Common Media Application Format), a standardized container format for segmented streaming video, and mTLS (Mutual Transport Layer Security) for security.
+
+### 1. Server & Initial Device Identity
+This section covers starting the server and creating the first identity for a client (a "device").
+
+```sh
+$ python server.py --working-directory ~/.pavstest
+```
+
+This command starts the Push AV (Audio/Video) server. The --working-directory flag tells the server where to store all its files, such as certificates, keys, and uploaded media content.
+
+```sh
+$ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST https://localhost:1234/certs/dev/keypair
+```
+This asks the server to create a new identity (a public certificate and a private key) for a device.
+
+--cacert: This trusts the server's self-signed root certificate, which is necessary to establish a secure HTTPS connection.
+
+-XPOST: Sends a request to create a new resource.
+
+The server generates the key pair and saves it in its working directory (e.g., in ~/.pavstest/certs/device/). This gives you the credentials the device will use in the next step.
+
+### 2. Authenticating and Creating a Stream
+Now that the device has an identity, it uses it to authenticate itself to the server and reserve a "stream" to which it can publish media.
+
+```sh
+curl --cacert ... --cert ... --key ... -XPOST https://localhost:1234/streams
+```
+This command creates a new media stream. The key difference here is that the client presents its own certificate to prove its identity. This is called client certificate authentication or mTLS (mutual TLS). It's like a two-way ID check: the client verifies the server's identity (using --cacert), and the server verifies the client's identity (using --cert and --key). The server responds with a unique stream_id for the newly created stream.
+
+export PUBLISHING_ENDPOINT=https://localhost:1234/streams/1
+This command saves the stream's URL into an environment variable for easy access. This URL is the ingest endpoint—the specific address where the CMAF media segments will be uploaded. The 1 is the stream_id returned by the previous command.
+
+### 3. Publishing Media Content
+With the ingest endpoint defined, the client can now start pushing media data.
+
+```sh
+./generate_cmaf_content.sh
+```
+This script simulates a media source like a live camera or a file transcoder. It generates sample video/audio content formatted as CMAF segments and then uses a tool like curl to upload (HTTP PUT or POST) those segments to the $PUBLISHING_ENDPOINT. This is the "push" part of the "push AV server."
+
+### 4. Monitoring and Inspection
+These commands are for managing and checking the status of the streams and media files on the server.
+
+```sh
+curl -XGET ... https://localhost:1234/streams
+```
+This lists all active streams on the server, allowing an administrator to see which streams exist and what files are associated with them.
+
+```sh
+curl ... -XGET 'https://localhost:1234/probe/1/cmaf/example/video-720p.cmfv'
+```
+This command retrieves detailed technical metadata about a specific media file (video-720p.cmfv) within a specific stream (stream_id 1). The output is similar to what the popular media analysis tool ffprobe would provide, showing information like codec, resolution, bitrate, etc.
+
+### 5. Alternative Certificate Issuance (CSR)
+This final section shows a more standard, secure method for a device to obtain a certificate, using a Certificate Signing Request (CSR). This is common practice in Public Key Infrastructure (PKI).
+
+```sh
+openssl req -new -newkey ... -out client.csr ...
+```
+The device first generates its own private key and a CSR. The CSR is a block of encoded text containing the device's public key and identity information. It's a formal request to a Certificate Authority (in this case, our server) to sign the public key.
+
+```sh
+sed ... | paste ... > client.curl.csr
+```
+This is a text-formatting command. It takes the multi-line CSR file and converts the newline characters into literal \n characters so the entire CSR can be embedded cleanly into a single-line JSON payload.
+
+```sh
+curl ... -XPOST '...' -d "{\"csr\":\"$(cat client.curl.csr)\"}"
+```
+The device sends its CSR to the server's /sign endpoint. The server acts as a Certificate Authority, verifies the request, and uses its own root key to sign the device's public key, creating a valid client certificate. The server then sends this new certificate back to the device. The device can now use this certificate and its private key to authenticate, just as in Step 2.

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -85,6 +85,8 @@ curl --cacert ... --cert ... --key ... -XPOST https://localhost:1234/streams
 ```
 This command creates a new media stream. The key difference here is that the client presents its own certificate to prove its identity. This is called client certificate authentication or mTLS (mutual TLS). It's like a two-way ID check: the client verifies the server's identity (using --cacert), and the server verifies the client's identity (using --cert and --key). The server responds with a unique stream_id for the newly created stream.
 
+
+```sh
 export PUBLISHING_ENDPOINT=https://localhost:1234/streams/1
 This command saves the stream's URL into an environment variable for easy access. This URL is the ingest endpoint—the specific address where the CMAF media segments will be uploaded. The 1 is the stream_id returned by the previous command.
 

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -53,78 +53,132 @@ $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST 'https://localhost:1234
 
 ```
 
-This command-line flow demonstrates a complete interaction with a secure media server designed for "push" streaming, where a client sends media data to the server. The process involves setting up security, creating a stream, publishing content, and managing the system.
+This command-line flow demonstrates a complete interaction with a secure media
+server designed for "push" streaming, where a client sends media data to the
+server. The process involves setting up security, creating a stream, publishing
+content, and managing the system.
 
-The core technology here is CMAF (Common Media Application Format), a standardized container format for segmented streaming video, and mTLS (Mutual Transport Layer Security) for security.
+The core technology here is `CMAF` (Common Media Application Format), a
+standardized container format for segmented streaming video, and mTLS (Mutual
+Transport Layer Security) for security.
 
 ### 1. Server & Initial Device Identity
-This section covers starting the server and creating the first identity for a client (a "device").
+
+This section covers starting the server and creating the first identity for a
+client (a "device").
 
 ```sh
 $ python server.py --working-directory ~/.pavstest
 ```
 
-This command starts the Push AV (Audio/Video) server. The --working-directory flag tells the server where to store all its files, such as certificates, keys, and uploaded media content.
+This command starts the Push AV (Audio/Video) server. The --working-directory
+flag tells the server where to store all its files, such as certificates, keys,
+and uploaded media content.
 
 ```sh
 $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST https://localhost:1234/certs/dev/keypair
 ```
-This asks the server to create a new identity (a public certificate and a private key) for a device.
 
-`--cacert`: This trusts the server's self-signed root certificate, which is necessary to establish a secure HTTPS connection.
+This asks the server to create a new identity (a public certificate and a
+private key) for a device.
 
--XPOST: Sends a request to create a new resource.
+`--cacert`: This trusts the server's self-signed root certificate, which is
+necessary to establish a secure HTTPS connection.
 
-The server generates the key pair and saves it in its working directory (e.g., in ~/.pavstest/certs/device/). This gives you the credentials the device will use in the next step.
+`-XPOST`: Sends a request to create a new resource.
+
+The server generates the key pair and saves it in its working directory (e.g.,
+in `~/.pavstest/certs/device/`). This gives you the credentials the device will
+use in the next step.
 
 ### 2. Authenticating and Creating a Stream
-Now that the device has an identity, it uses it to authenticate itself to the server and reserve a "stream" to which it can publish media.
+
+Now that the device has an identity, it uses it to authenticate itself to the
+server and reserve a "stream" to which it can publish media.
 
 ```sh
 curl --cacert ... --cert ... --key ... -XPOST https://localhost:1234/streams
 ```
-This command creates a new media stream. The key difference here is that the client presents its own certificate to prove its identity. This is called client certificate authentication or mTLS (mutual TLS). It's like a two-way ID check: the client verifies the server's identity (using --cacert), and the server verifies the client's identity (using --cert and --key). The server responds with a unique stream_id for the newly created stream.
 
+This command creates a new media stream. The key difference here is that the
+client presents its own certificate to prove its identity. This is called client
+certificate authentication or mTLS (mutual TLS). It's like a two-way ID check:
+the client verifies the server's identity (using `--cacert`), and the server
+verifies the client's identity (using `--cert` and `--key`). The server responds
+with a unique stream_id for the newly created stream.
 
 ```sh
 export PUBLISHING_ENDPOINT=https://localhost:1234/streams/1
-This command saves the stream's URL into an environment variable for easy access. This URL is the ingest endpoint—the specific address where the CMAF media segments will be uploaded. The 1 is the stream_id returned by the previous command.
+```
+
+This command saves the stream's URL into an environment variable for easy
+access. This URL is the ingest endpoint—the specific address where the `CMAF`
+media segments will be uploaded. The 1 is the stream_id returned by the previous
+command.
 
 ### 3. Publishing Media Content
+
 With the ingest endpoint defined, the client can now start pushing media data.
 
 ```sh
 ./generate_cmaf_content.sh
 ```
-This script simulates a media source like a live camera or a file transcoder. It generates sample video/audio content formatted as CMAF segments and then uses a tool like curl to upload (HTTP PUT or POST) those segments to the $PUBLISHING_ENDPOINT. This is the "push" part of the "push AV server."
+
+This script simulates a media source like a live camera or a file transcoder. It
+generates sample video/audio content formatted as `CMAF` segments and then uses
+a tool like curl to upload (HTTP PUT or POST) those segments to the
+\$PUBLISHING_ENDPOINT. This is the "push" part of the "push AV server."
 
 ### 4. Monitoring and Inspection
-These commands are for managing and checking the status of the streams and media files on the server.
+
+These commands are for managing and checking the status of the streams and media
+files on the server.
 
 ```sh
 curl -XGET ... https://localhost:1234/streams
 ```
-This lists all active streams on the server, allowing an administrator to see which streams exist and what files are associated with them.
+
+This lists all active streams on the server, allowing an administrator to see
+which streams exist and what files are associated with them.
 
 ```sh
 curl ... -XGET 'https://localhost:1234/probe/1/cmaf/example/video-720p.cmfv'
 ```
-This command retrieves detailed technical metadata about a specific media file (video-720p.cmfv) within a specific stream (stream_id 1). The output is similar to what the popular media analysis tool ffprobe would provide, showing information like codec, resolution, bitrate, etc.
 
-### 5. Alternative Certificate Issuance (CSR)
-This final section shows a more standard, secure method for a device to obtain a certificate, using a Certificate Signing Request (CSR). This is common practice in Public Key Infrastructure (PKI).
+This command retrieves detailed technical metadata about a specific media file
+(`video-720p.cmfv`) within a specific stream (stream_id 1). The output is
+similar to what the popular media analysis tool `ffprobe` would provide, showing
+information like codec, resolution, bitrate, etc.
+
+### 5. Alternative Certificate Issuance (`CSR`)
+
+This final section shows a more standard, secure method for a device to obtain a
+certificate, using a Certificate Signing Request (`CSR`). This is common
+practice in Public Key Infrastructure (PKI).
 
 ```sh
 openssl req -new -newkey ... -out client.csr ...
 ```
-The device first generates its own private key and a CSR. The CSR is a block of encoded text containing the device's public key and identity information. It's a formal request to a Certificate Authority (in this case, our server) to sign the public key.
+
+The device first generates its own private key and a `CSR`. The `CSR` is a block
+of encoded text containing the device's public key and identity information.
+It's a formal request to a Certificate Authority (in this case, our server) to
+sign the public key.
 
 ```sh
 sed ... | paste ... > client.curl.csr
 ```
-This is a text-formatting command. It takes the multi-line CSR file and converts the newline characters into literal \n characters so the entire CSR can be embedded cleanly into a single-line JSON payload.
+
+This is a text-formatting command. It takes the multi-line `CSR` file and
+converts the newline characters into literal \n characters so the entire `CSR`
+can be embedded cleanly into a single-line JSON payload.
 
 ```sh
 curl ... -XPOST '...' -d "{\"csr\":\"$(cat client.curl.csr)\"}"
 ```
-The device sends its CSR to the server's /sign endpoint. The server acts as a Certificate Authority, verifies the request, and uses its own root key to sign the device's public key, creating a valid client certificate. The server then sends this new certificate back to the device. The device can now use this certificate and its private key to authenticate, just as in Step 2.
+
+The device sends its `CSR` to the server's /sign endpoint. The server acts as a
+Certificate Authority, verifies the request, and uses its own root key to sign
+the device's public key, creating a valid client certificate. The server then
+sends this new certificate back to the device. The device can now use this
+certificate and its private key to authenticate, just as in Step 2.

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -170,7 +170,7 @@ sed ... | paste ... > client.curl.csr
 ```
 
 This is a text-formatting command. It takes the multi-line `CSR` file and
-converts the newline characters into literal \n characters so the entire `CSR`
+converts the newline characters into literal \n characters so that the entire `CSR`
 can be embedded cleanly into a single-line JSON payload.
 
 ```sh

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -88,7 +88,7 @@ necessary to establish a secure HTTPS connection.
 `-XPOST`: Sends a request to create a new resource.
 
 The server generates the key pair and saves it in its working directory (e.g.,
-in `~/.pavstest/certs/device/`). This gives you the credentials the device will
+in `~/.pavstest/certs/device/`). This provides the credentials the device shall
 use in the next step.
 
 ### 2. Authenticating and Creating a Stream

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -79,7 +79,7 @@ and uploaded media content.
 $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST https://localhost:1234/certs/dev/keypair
 ```
 
-This asks the server to create a new identity (a public certificate and a
+This requests the server to create a new identity (a public certificate and a
 private key) for a device.
 
 `--cacert`: This trusts the server's self-signed root certificate, which is

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -72,8 +72,8 @@ $ python server.py --working-directory ~/.pavstest
 ```
 
 This command starts the Push AV (Audio/Video) server. The --working-directory
-option tells the server where to store all its files, such as certificates, keys,
-and uploaded media content.
+option tells the server where to store all its files, such as certificates,
+keys, and uploaded media content.
 
 ```sh
 $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST https://localhost:1234/certs/dev/keypair
@@ -113,8 +113,8 @@ export PUBLISHING_ENDPOINT=https://localhost:1234/streams/1
 
 This command saves the stream's URL into an environment variable for easy
 access. This URL is the ingest endpoint—the specific address where the `CMAF`
-media segments will be uploaded. The 1 at the end is the stream_id returned by the previous
-command.
+media segments will be uploaded. The 1 at the end is the stream_id returned by
+the previous command.
 
 ### 3. Publishing Media Content
 
@@ -170,8 +170,8 @@ sed ... | paste ... > client.curl.csr
 ```
 
 This is a text-formatting command. It takes the multi-line `CSR` file and
-converts the newline characters into literal \n characters so that the entire `CSR`
-can be embedded cleanly into a single-line JSON payload.
+converts the newline characters into literal \n characters so that the entire
+`CSR` can be embedded cleanly into a single-line JSON payload.
 
 ```sh
 curl ... -XPOST '...' -d "{\"csr\":\"$(cat client.curl.csr)\"}"

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -72,7 +72,7 @@ $ python server.py --working-directory ~/.pavstest
 ```
 
 This command starts the Push AV (Audio/Video) server. The --working-directory
-flag tells the server where to store all its files, such as certificates, keys,
+option tells the server where to store all its files, such as certificates, keys,
 and uploaded media content.
 
 ```sh

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -179,6 +179,7 @@ curl ... -XPOST '...' -d "{\"csr\":\"$(cat client.curl.csr)\"}"
 
 The device sends its `CSR` to the server's /sign endpoint. The server acts as a
 Certificate Authority, verifies the request, and uses its own root key to sign
-the device's public key, creating a valid client certificate. The server then
-sends this new certificate back to the device. The device can now use this
-certificate and its private key to authenticate, just as in Step 2.
+the device's public key, creating a valid client certificate. The server saves this
+certificate and returns its path in the response. The device can then fetch the
+certificate content from that path and use it with its private key to
+authenticate, just as in Step 2.

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -179,7 +179,7 @@ curl ... -XPOST '...' -d "{\"csr\":\"$(cat client.curl.csr)\"}"
 
 The device sends its `CSR` to the server's /sign endpoint. The server acts as a
 Certificate Authority, verifies the request, and uses its own root key to sign
-the device's public key, creating a valid client certificate. The server saves this
-certificate and returns its path in the response. The device can then fetch the
-certificate content from that path and use it with its private key to
+the device's public key, creating a valid client certificate. The server saves
+this certificate and returns its path in the response. The device can then fetch
+the certificate content from that path and use it with its private key to
 authenticate, just as in Step 2.

--- a/src/tools/push_av_server/README.md
+++ b/src/tools/push_av_server/README.md
@@ -71,7 +71,7 @@ $ curl --cacert ~/.pavstest/certs/server/root.pem -XPOST https://localhost:1234/
 ```
 This asks the server to create a new identity (a public certificate and a private key) for a device.
 
---cacert: This trusts the server's self-signed root certificate, which is necessary to establish a secure HTTPS connection.
+`--cacert`: This trusts the server's self-signed root certificate, which is necessary to establish a secure HTTPS connection.
 
 -XPOST: Sends a request to create a new resource.
 


### PR DESCRIPTION
#### Summary

Update README to explain the command-line flow which demonstrates a complete interaction with a secure media server designed for "push" streaming, where a client sends media data to the server. The process involves setting up security, creating a stream, publishing content, and managing the system.

The core technology here is CMAF (Common Media Application Format), a standardized container format for segmented streaming video, and mTLS (Mutual Transport Layer Security) for security.

#### Related issues

N/A

#### Testing

N/A