### PR TITLE
Implement RPC status (error) to closest semantic CHIP_* error

### DIFF
--- a/examples/jf-admin-app/linux/rpc/RpcServer.cpp
+++ b/examples/jf-admin-app/linux/rpc/RpcServer.cpp
@@ -2,6 +2,7 @@
 
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/Server.h>
+#include <lib/support/RpcErrorMapping.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
@@ -79,7 +80,7 @@ CHIP_ERROR JointFabric::GetICACCSRForJF(MutableByteSpan & icacCSR)
     if (pw::OkStatus() != status)
     {
         ChipLogError(JointFabric, "Writing to GetStream failed");
-        return CHIP_ERROR_SHUT_DOWN;
+        return rpc::MapRpcStatusToChipError(status);
     }
 
     // wait for the ICAC CSR from JFC

--- a/examples/jf-control-app/commands/pairing/PairingCommand.cpp
+++ b/examples/jf-control-app/commands/pairing/PairingCommand.cpp
@@ -688,7 +688,7 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
             if (!localStream.active())
             {
                 ChipLogError(JointFabric, "RPC: Opening GetStream Error");
-                SetCommandExitStatus(CHIP_ERROR_SHUT_DOWN);
+                SetCommandExitStatus(CHIP_ERROR_INTERNAL);
                 return;
             }
             else

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -233,6 +233,7 @@ static_library("support") {
     "ReadOnlyBuffer.cpp",
     "ReadOnlyBuffer.h",
     "ReferenceCountedHandle.h",
+    "RpcErrorMapping.h",
     "SafePointerCast.h",
     "SafeString.h",
     "Scoped.h",

--- a/src/lib/support/RpcErrorMapping.h
+++ b/src/lib/support/RpcErrorMapping.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPError.h>
+#include <pw_status/status.h>
+
+namespace chip {
+namespace rpc {
+
+/**
+ * @brief Maps a pw::Status RPC error code to a CHIP_ERROR.
+ *
+ * Provides a 1:1 mapping between RPC error codes and Matter stack error codes.
+ *
+ * @param status The pw::Status error code from an RPC call.
+ * @return Corresponding CHIP_ERROR value.
+ */
+static inline CHIP_ERROR MapRpcStatusToChipError(const ::pw::Status & status)
+{
+    switch (status.code())
+    {
+    case pw_Status::PW_STATUS_OK:
+        return CHIP_NO_ERROR;
+    case pw_Status::PW_STATUS_CANCELLED:
+        return CHIP_ERROR_CANCELLED;
+    case pw_Status::PW_STATUS_UNKNOWN:
+        return CHIP_ERROR_INTERNAL; // No CHIP_ERROR_UNKNOWN, use INTERNAL
+    case pw_Status::PW_STATUS_INVALID_ARGUMENT:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case pw_Status::PW_STATUS_DEADLINE_EXCEEDED:
+        return CHIP_ERROR_TIMEOUT;
+    case pw_Status::PW_STATUS_NOT_FOUND:
+        return CHIP_ERROR_NOT_FOUND;
+    case pw_Status::PW_STATUS_ALREADY_EXISTS:
+        return CHIP_ERROR_ALREADY_INITIALIZED; // No CHIP_ERROR_EXISTS, use ALREADY_INITIALIZED
+    case pw_Status::PW_STATUS_PERMISSION_DENIED:
+        return CHIP_ERROR_ACCESS_DENIED;
+    case pw_Status::PW_STATUS_RESOURCE_EXHAUSTED:
+        return CHIP_ERROR_NO_MEMORY; // No CHIP_ERROR_RESOURCE_EXHAUSTED, use NO_MEMORY
+    case pw_Status::PW_STATUS_FAILED_PRECONDITION:
+        return CHIP_ERROR_INCORRECT_STATE; // No CHIP_ERROR_PRECONDITION_NOT_MET, use INCORRECT_STATE
+    case pw_Status::PW_STATUS_ABORTED:
+        return CHIP_ERROR_TRANSACTION_CANCELED; // No CHIP_ERROR_ABORTED, use TRANSACTION_CANCELED;
+    case pw_Status::PW_STATUS_OUT_OF_RANGE:
+        return CHIP_ERROR_INVALID_ARGUMENT; // No CHIP_ERROR_OUT_OF_RANGE, use INVALID_ARGUMENT
+    case pw_Status::PW_STATUS_UNIMPLEMENTED:
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    case pw_Status::PW_STATUS_INTERNAL:
+        return CHIP_ERROR_INTERNAL;
+    case pw_Status::PW_STATUS_UNAVAILABLE:
+        return CHIP_ERROR_NOT_CONNECTED; // No CHIP_ERROR_UNAVAILABLE, use NOT_CONNECTED
+    case pw_Status::PW_STATUS_DATA_LOSS:
+        return CHIP_ERROR_DECODE_FAILED; // No CHIP_ERROR_DATA_LOSS, use DECODE_FAILED
+    case pw_Status::PW_STATUS_UNAUTHENTICATED:
+        return CHIP_ERROR_INTEGRITY_CHECK_FAILED; // No CHIP_ERROR_UNAUTHENTICATED, use INTEGRITY_CHECK_FAILED
+    default:
+        // Generic error for unrecognized status codes, i.e. pw_Status enum is expanded.
+        return CHIP_ERROR_INTERNAL;
+    }
+}
+
+} // namespace rpc
+} // namespace chip

--- a/src/lib/support/RpcErrorMapping.h
+++ b/src/lib/support/RpcErrorMapping.h
@@ -30,7 +30,7 @@ namespace rpc {
  * Provides a 1:1 mapping between RPC error codes and Matter stack error codes.
  *
  * @param status The pw::Status error code from an RPC call.
- * @return Corresponding CHIP_ERROR value.
+ * @return Closest semantic corresponding CHIP_ERROR value (default to CHIP_ERROR_INTERNAL for unrecognized codes).
  */
 static inline CHIP_ERROR MapRpcStatusToChipError(const ::pw::Status & status)
 {
@@ -57,7 +57,7 @@ static inline CHIP_ERROR MapRpcStatusToChipError(const ::pw::Status & status)
     case pw_Status::PW_STATUS_FAILED_PRECONDITION:
         return CHIP_ERROR_INCORRECT_STATE; // No CHIP_ERROR_PRECONDITION_NOT_MET, use INCORRECT_STATE
     case pw_Status::PW_STATUS_ABORTED:
-        return CHIP_ERROR_TRANSACTION_CANCELED; // No CHIP_ERROR_ABORTED, use TRANSACTION_CANCELED;
+        return CHIP_ERROR_TRANSACTION_CANCELED; // No CHIP_ERROR_ABORTED, use TRANSACTION_CANCELED
     case pw_Status::PW_STATUS_OUT_OF_RANGE:
         return CHIP_ERROR_INVALID_ARGUMENT; // No CHIP_ERROR_OUT_OF_RANGE, use INVALID_ARGUMENT
     case pw_Status::PW_STATUS_UNIMPLEMENTED:

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -52,6 +52,7 @@ chip_test_suite("tests") {
     "TestPool.cpp",
     "TestPrivateHeap.cpp",
     "TestReadOnlyBuffer.cpp",
+    "TestRpcErrorMapping.cpp",
     "TestSafeInt.cpp",
     "TestSafeString.cpp",
     "TestScoped.cpp",

--- a/src/lib/support/tests/TestRpcErrorMapping.cpp
+++ b/src/lib/support/tests/TestRpcErrorMapping.cpp
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/support/RpcErrorMapping.h>
+#include <pw_unit_test/framework.h>
+
+struct StatusMappingTestCase
+{
+    pw::Status code;
+    CHIP_ERROR expected;
+};
+
+TEST(MapRpcStatusToChipErrorTest, MapsCorrectly)
+{
+    const StatusMappingTestCase testCases[] = { { PW_STATUS_OK, CHIP_NO_ERROR },
+                                                { PW_STATUS_CANCELLED, CHIP_ERROR_CANCELLED },
+                                                { PW_STATUS_UNKNOWN, CHIP_ERROR_INTERNAL },
+                                                { PW_STATUS_INVALID_ARGUMENT, CHIP_ERROR_INVALID_ARGUMENT },
+                                                { PW_STATUS_DEADLINE_EXCEEDED, CHIP_ERROR_TIMEOUT },
+                                                { PW_STATUS_NOT_FOUND, CHIP_ERROR_NOT_FOUND },
+                                                { PW_STATUS_ALREADY_EXISTS, CHIP_ERROR_ALREADY_INITIALIZED },
+                                                { PW_STATUS_PERMISSION_DENIED, CHIP_ERROR_ACCESS_DENIED },
+                                                { PW_STATUS_RESOURCE_EXHAUSTED, CHIP_ERROR_NO_MEMORY },
+                                                { PW_STATUS_FAILED_PRECONDITION, CHIP_ERROR_INCORRECT_STATE },
+                                                { PW_STATUS_ABORTED, CHIP_ERROR_TRANSACTION_CANCELED },
+                                                { PW_STATUS_OUT_OF_RANGE, CHIP_ERROR_INVALID_ARGUMENT },
+                                                { PW_STATUS_UNIMPLEMENTED, CHIP_ERROR_NOT_IMPLEMENTED },
+                                                { PW_STATUS_INTERNAL, CHIP_ERROR_INTERNAL },
+                                                { PW_STATUS_UNAVAILABLE, CHIP_ERROR_NOT_CONNECTED },
+                                                { PW_STATUS_DATA_LOSS, CHIP_ERROR_DECODE_FAILED },
+                                                { PW_STATUS_UNAUTHENTICATED, CHIP_ERROR_INTEGRITY_CHECK_FAILED } };
+
+    for (const auto & param : testCases)
+    {
+        pw::Status status(param.code);
+        EXPECT_EQ(chip::rpc::MapRpcStatusToChipError(status), param.expected);
+    }
+}


### PR DESCRIPTION
#### Summary

Replaces hard-coded CHIP_* error returns when a non-OK status is encountered from RPC. Maps RPC status codes to closest semantic CHIP_* error instead, and return that.

#### Related issues

Related to PR feedback from #39740

Fixes #39876 

#### Testing

Added unit tests. Unit tests pass, JF demo working following steps here: https://project-chip.github.io/connectedhomeip-doc/guides/joint_fabric_guide.html

# NOTE:

This is my first Matter PR. Please feel free to be brutally pedantic. :^)
