### PR TITLE
[Camera] Update the instructions for liveview

### DIFF
--- a/examples/camera-app/linux/README.md
+++ b/examples/camera-app/linux/README.md
@@ -24,6 +24,7 @@ sudo apt install \
   gstreamer1.0-plugins-base \
   gstreamer1.0-plugins-good \
   gstreamer1.0-plugins-bad \
+  gstreamer1.0-plugins-ugly \
   gstreamer1.0-libav \
   libgstreamer1.0-dev \
   libgstreamer-plugins-base1.0-dev \

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -151,7 +151,7 @@ sudo rm -rf /tmp/chip_*
 ```
 
 ```
-./out/linux-x64-camera/chip-camera-app --camera-deferred-offer
+./out/linux-x64-camera/chip-camera-app
 ```
 
 Terminal 2: Launch and Use the Camera Controller (Client)

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -141,8 +141,7 @@ example on your Linux machine. You will need two separate terminal windows.
 
 Terminal 1: Start the Camera App (Device)
 
-1. Launch the chip-camera-app binary. The --camera-deferred-offer flag prepares
-   the camera to stream upon request from the controller.
+1. Launch the chip-camera-app binary.
 
 Clean up any existing configurations (first-time pairing only):
 


### PR DESCRIPTION
#### Summary

Missing dependent libs to start the liveview 

#### Related issues

N/A

#### Testing

Terminal 1: Start the Camera App (Device)

Launch the chip-camera-app binary. The --camera-deferred-offer flag prepares the camera to stream upon request from the controller.
Clean up any existing configurations (first-time pairing only):
```
sudo rm -rf /tmp/chip_*
./out/linux-x64-camera/chip-camera-app
```

Terminal 2: Launch and Use the Camera Controller (Client)

Launch the Controller Start the interactive controller shell.
`./out/linux-x64-camera-controller/chip-camera-controller`
Commission the Device At the controller's > prompt, use the pairing command to securely commission the Camera App onto the Matter network.
onnetwork: Specifies pairing over the local IP network.

`pairing onnetwork 1 20202021`
Wait for the command to complete and confirm that commissioning was successful.

Start the Live Stream Still in the controller shell, use the Live View command with the nodeID you assigned during pairing to request a video stream.
`liveview start 1`

