### PR TITLE
[NXP]Add software update reboot reason support

### DIFF
--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -51,6 +51,10 @@ extern "C" {
 #include "fsl_silicon_id.h"
 #endif
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include "OtaSupport.h"
+#endif
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -82,18 +86,14 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint8_t rebootCause)
     }
     else if (rebootCause == kPOWER_ResetCauseSysResetReq)
     {
-        /*
-        kConfigKey_SoftwareUpdateCompleted not supported for now
-        if (NXPConfig::ConfigValueExists(NXPConfig::kConfigKey_SoftwareUpdateCompleted))
+        bootReason = BootReasonType::kSoftwareReset;
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+        OtaImgState_t img_state = OTA_GetImgState();
+        if(img_state == OtaImgState_RunCandidate)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
         }
-        else
-        {
-            bootReason = BootReasonType::kSoftwareReset;
-        }
-        */
-        bootReason = BootReasonType::kSoftwareReset;
+#endif
     }
 
     return StoreBootReason(to_underlying(bootReason));

--- a/src/platform/nxp/common/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/common/ConfigurationManagerImpl.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR ConfigurationManagerImpl::DetermineBootReason(uint8_t rebootCause)
         bootReason = BootReasonType::kSoftwareReset;
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
         OtaImgState_t img_state = OTA_GetImgState();
-        if(img_state == OtaImgState_RunCandidate)
+        if (img_state == OtaImgState_RunCandidate)
         {
             bootReason = BootReasonType::kSoftwareUpdateCompleted;
         }


### PR DESCRIPTION
#### Summary
TC-SU-2.6 OTA test failed at the last step of chip-tool reading boot reason: expected value 5 but get 6.

#### Testing

Platform: rw61x
Example: thermostat
Build command:
- west build -d build_matter_ota/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=connectedhomeip/examples/platform/nxp/config/prj_wifi_ota.conf

Generate OTA file:
- west build -d build_matter_ota/ -b frdmrw612 examples/thermostat/nxp/ -DCONF_FILE=connectedhomeip/examples/platform/nxp/config/prj_wifi_ota_v2.conf

1. ble-wifi commissioning: ./chip-tool pairing ble-wifi 1 Matter_office RouterForMatter 20202021 3840
2. run OTA provider with OTA file generated
3. on-network commissioning (OTAP)
4. write ACL: ./chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": null, "targets": null}]' 2 0
5. OTA provider announce: ./chip-tool otasoftwareupdaterequestor announce-otaprovider 2 0 0 0 1 0
6. read boot-reason: ./chip-tool generaldiagnostics read boot-reason 1 0

DUT response: "BootReason: 5"

when sending matterreset command over CLI, reponse is: "BootReason: 6"

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
