### PR TITLE
[Telink] Update Docker image (Zephyr update)

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-160 : Bump Java version with 17
+161 : [Telink] Update Docker image (Zephyr update)

--- a/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink-zephyr_3_3/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 3.3.0; branch: develop_3.3
-ARG ZEPHYR_REVISION=acc42427122e7d85481dc14e459834d25bf28697
+ARG ZEPHYR_REVISION=8d3f6f83394a51a4c79808e44d0c2b725c9a2467
 ARG N22_BIN_REVISION=a75790f16043dd42deb0801a5d0ff83711e3a26a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \

--- a/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/stage-2/chip-build-telink/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr version: 4.1.0; branch: develop
-ARG ZEPHYR_REVISION=522ce11c5ddfd004b5640a1f51a5fce2e0f14c35
+ARG ZEPHYR_REVISION=0769202d4e2e02947a9d7e70db72d5a3c67b97f4
 ARG N22_BIN_REVISION=a75790f16043dd42deb0801a5d0ff83711e3a26a
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \


### PR DESCRIPTION
**Change overview**

- drivers: ieee802154: b9x/tlx: CCA Optimizations
- soc: telink: telink_w9x: otbr: External commissioning
- scripts: west_commands: runners: bdt_tool.py: Add TL721X
- telink: tl3218x: change clock-frequency into 48MHz
- telink: Move SOC independent components to common folder
- telink: kconfig: soc: provide a single config for ot rcp buffers
- hal: telink: tl721x: update BLE libs

**Changes of N22 binary:**
(latest hash a75790f16043dd42deb0801a5d0ff83711e3a26a)

- None

#### Testing
Tested manually.

Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully