### PR TITLE
[cmake][common] Adding optional support for --zcl argument in chip_zapgen() cmake function

### DIFF
--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -139,7 +139,7 @@ endfunction()
 function(chip_zapgen TARGET_NAME)
     cmake_parse_arguments(ARG
          ""
-         "INPUT;GENERATOR;OUTPUT_PATH;OUTPUT_FILES"
+         "INPUT;GENERATOR;OUTPUT_PATH;OUTPUT_FILES;ZCL_PATH"
          "OUTPUTS"
          ${ARGN}
     )
@@ -180,6 +180,28 @@ function(chip_zapgen TARGET_NAME)
             message(SEND_ERROR "Unsupported zap generator: ${ARG_GENERATOR}")
         endif()
 
+        set(ZAPGEN_ARGS
+            "--no-prettify-output"
+            "--templates" "${TEMPLATE_PATH}"
+            "--output-dir" "${GEN_FOLDER}/${OUTPUT_SUBDIR}"
+            "--lock-file" "${CMAKE_BINARY_DIR}/zap_gen.lock"
+            "--parallel"
+            "${ARG_INPUT}"
+        )
+
+        # Optional ZCL path for zapgen:
+        # - If ZCL_PATH is passed, use it.
+        # - If CHIP_ENABLE_ZCL_ARG is ON, use default path.
+        # - Otherwise, skip --zcl to preserve default behavior.
+        if(CHIP_ENABLE_ZCL_ARG AND NOT ARG_ZCL_PATH)
+            set(ARG_ZCL_PATH "${CHIP_ROOT}/src/app/zap-templates/zcl/zcl.json")
+        endif()
+        
+        # Add --zcl only if a valid path is set.
+        if(ARG_ZCL_PATH)
+            list(APPEND ZAPGEN_ARGS "--zcl" "${ARG_ZCL_PATH}")
+        endif()
+
         # Python is expected to be in the path
         # Forcing a call to find find_package here as ${Python3_EXECUTABLE} would be used
         find_package(Python3 REQUIRED)
@@ -191,13 +213,7 @@ function(chip_zapgen TARGET_NAME)
         add_custom_command(
             OUTPUT ${OUT_NAMES}
             COMMAND "${Python3_EXECUTABLE}" "${CHIP_ROOT}/scripts/tools/zap/generate.py"
-            ARGS
-                "--no-prettify-output"
-                "--templates" "${TEMPLATE_PATH}"
-                "--output-dir" "${GEN_FOLDER}/${OUTPUT_SUBDIR}"
-                "--lock-file" "${CMAKE_BINARY_DIR}/zap_gen.lock"
-                "--parallel"
-                "${ARG_INPUT}"
+            ARGS ${ZAPGEN_ARGS}
             DEPENDS
                 "${ARG_INPUT}"
                 ${EXTRA_DEPENDENCIES}

--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -123,6 +123,7 @@ endfunction()
 #            "zap-generated/IMClusterCommandHandler.cpp"
 #     OUTPUT_PATH  DIR_NAME_VAR
 #     OUTPUT_FILES  FILE_NAMES_VAR
+#     ZCL_PATH     "path/to/custom/zcl.json" # Optional: override default ZCL path
 #   )
 #
 # Arguments:
@@ -135,6 +136,8 @@ endfunction()
 #
 #   OUTPUT_FILES - [OUT] output variable will contain the path of generated files.
 #                  suitable to be added within a build target
+# ZCL_PATH      - [OPTIONAL] path to a custom ZCL JSON file. If provided, it overrides the default ZCL path used by generate.py.
+#                 This allows applications to customize the cluster definitions used during code generation.
 #
 function(chip_zapgen TARGET_NAME)
     cmake_parse_arguments(ARG

--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -193,13 +193,10 @@ function(chip_zapgen TARGET_NAME)
         # - If ZCL_PATH is passed, use it.
         # - If CHIP_ENABLE_ZCL_ARG is ON, use default path.
         # - Otherwise, skip --zcl to preserve default behavior.
-        if(CHIP_ENABLE_ZCL_ARG AND NOT ARG_ZCL_PATH)
-            set(ARG_ZCL_PATH "${CHIP_ROOT}/src/app/zap-templates/zcl/zcl.json")
-        endif()
-        
-        # Add --zcl only if a valid path is set.
         if(ARG_ZCL_PATH)
             list(APPEND ZAPGEN_ARGS "--zcl" "${ARG_ZCL_PATH}")
+        elseif(CHIP_ENABLE_ZCL_ARG)
+            list(APPEND ZAPGEN_ARGS "--zcl" "${CHIP_ROOT}/src/app/zap-templates/zcl/zcl.json")
         endif()
 
         # Python is expected to be in the path

--- a/build/chip/chip_codegen.cmake
+++ b/build/chip/chip_codegen.cmake
@@ -136,8 +136,15 @@ endfunction()
 #
 #   OUTPUT_FILES - [OUT] output variable will contain the path of generated files.
 #                  suitable to be added within a build target
-# ZCL_PATH      - [OPTIONAL] path to a custom ZCL JSON file. If provided, it overrides the default ZCL path used by generate.py.
-#                 This allows applications to customize the cluster definitions used during code generation.
+#   ZCL_PATH     - [OPTIONAL] Path to a custom ZCL JSON file.
+#                  This maps to the '--zcl' argument in the "scripts/tools/zap/generate.py" script.
+#                  By default, generate.py attempts to autodetect the ZCL path from the .zap 
+#                  file which is often a relative path. When the .zap file is relocated or symlinked,
+#                  these relative paths become invalid, causing the build to fail.
+#                  Passing ZCL_PATH explicitly via CMake ensures the build remains robust and portable.
+#                  If ZCL_PATH is not provided, the default behavior is preserved unless CHIP_ENABLE_ZCL_ARG
+#                  is enabled, in which case the default path "src/app/zap-templates/zcl/zcl.json" is
+#                  automatically injected to simplify usage.
 #
 function(chip_zapgen TARGET_NAME)
     cmake_parse_arguments(ARG

--- a/examples/all-clusters-app/nxp/CMakeLists.txt
+++ b/examples/all-clusters-app/nxp/CMakeLists.txt
@@ -105,5 +105,6 @@ else()
     chip_configure_data_model(app
         INCLUDE_SERVER
         ZAP_FILE ${NXP_EXAMPLE_ZAP_DIR}/all-clusters-app.zap
+        ZCL_PATH ${CHIP_ROOT}/src/app/zap-templates/zcl/zcl-with-test-extensions.json
     )
 endif()

--- a/examples/platform/nxp/common/app_common.cmake
+++ b/examples/platform/nxp/common/app_common.cmake
@@ -26,6 +26,10 @@ if(NOT DEFINED EXAMPLE_NXP_PLATFORM_DIR)
     get_filename_component(EXAMPLE_NXP_PLATFORM_DIR ${CHIP_ROOT}/examples/platform/nxp/${CONFIG_CHIP_NXP_PLATFORM_FOLDER_NAME} REALPATH)
 endif()
 
+# Enable default ZCL path to be passed to the zapgen command for all examples.
+# This is only used if the ZCL_PATH argument is not provided in the chip_configure_data_model().
+set(CHIP_ENABLE_ZCL_ARG ON)
+
 if (CONFIG_CHIP_APP_COMMON)
     target_sources(app PRIVATE
         ${EXAMPLE_PLATFORM_NXP_COMMON_DIR}/app_task/source/AppTaskBase.cpp

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -71,8 +71,15 @@ endfunction()
 # EXTERNAL_CLUSTERS Clusters with external implementations. The default implementations
 # will not be used nor required for these clusters.
 # Format: MY_CUSTOM_CLUSTER'.
-# ZCL_PATH          [OPTIONAL] Path to a custom ZCL JSON file. If provided, it is passed to chip_zapgen to override
-#                   the default ZCL path when generating code.
+# ZCL_PATH          [OPTIONAL] Path to a custom ZCL JSON file.
+#                   This maps to the '--zcl' argument in the "scripts/tools/zap/generate.py" script.
+#                   By default, generate.py attempts to autodetect the ZCL path from the .zap 
+#                   file which is often a relative path. When the .zap file is relocated or symlinked,
+#                   these relative paths become invalid, causing the build to fail.
+#                   Passing ZCL_PATH explicitly via CMake ensures the build remains robust and portable.
+#                   If ZCL_PATH is not provided, the default behavior is preserved unless CHIP_ENABLE_ZCL_ARG
+#                   is enabled, in which case the default path "src/app/zap-templates/zcl/zcl.json" is 
+#                   automatically injected to simplify usage.
 #
 # Example usage:
 # chip_configure_data_model(

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -74,7 +74,7 @@ endfunction()
 #
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)
-    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
+    cmake_parse_arguments(ARG "" "SCOPE;ZAP_FILE;IDL;ZCL_PATH" "EXTERNAL_CLUSTERS" ${ARGN})
 
     if(ARG_SCOPE)
         set(SCOPE ${ARG_SCOPE})
@@ -134,6 +134,7 @@ function(chip_configure_data_model APP_TARGET)
         "zap-generated/IMClusterCommandHandler.cpp"
         OUTPUT_PATH APP_TEMPLATES_GEN_DIR
         OUTPUT_FILES APP_TEMPLATES_GEN_FILES
+        ZCL_PATH ${ARG_ZCL_PATH}
     )
     target_include_directories(${APP_TARGET} ${SCOPE} "${APP_TEMPLATES_GEN_DIR}")
     target_include_directories(${APP_TARGET} ${SCOPE} "${CHIP_APP_BASE_DIR}/zzz_generated")

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -71,6 +71,15 @@ endfunction()
 # EXTERNAL_CLUSTERS Clusters with external implementations. The default implementations
 # will not be used nor required for these clusters.
 # Format: MY_CUSTOM_CLUSTER'.
+# ZCL_PATH          [OPTIONAL] Path to a custom ZCL JSON file. If provided, it is passed to chip_zapgen to override
+#                   the default ZCL path when generating code.
+#
+# Example usage:
+# chip_configure_data_model(
+#     APP_TARGET app
+#     ZAP_FILE "some_file.zap"
+#     ZCL_PATH "path/to/custom/zcl.json"  # Optional: override default ZCL path
+# )
 #
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)


### PR DESCRIPTION
#### Summary

The aim of this PR is to introduce optional support for passing "--zcl" argument to the zapgen "generate.py" script, without impacting existing example behavior.

It supports three levels of configuration: 
1- **Default behavior** : No "--zcl" argument is passed, preserving current behavior for all examples.
2- **Global opt-in** : If the "CHIP_ENABLE_ZCL_ARG" cmake variable is set to ON, the default ZCL path "${CHIP_ROOT}/src/app/zap-templates/zcl/zcl.json" is used.
3- **Custom override** : Examples can pass a specific "ZCL_PATH" via the "chip_configure_data_model()" API to use a custom "zcl.json".

Example of use to add a custom ZCL_PATH : 

> chip_configure_data_model(app
>         INCLUDE_SERVER
>         ZAP_FILE ${NXP_EXAMPLE_ZAP_DIR}/thermostat_matter_wifi.zap
>         **ZCL_PATH** ${CHIP_ROOT}/src/app/zap-templates/zcl/zcl-with-test-extensions.json
> )

#### Context

This change helps address build issues in freestanding examples, where the "generate.py" (called in chip_zapgen) relies on relative paths embedded in the ".zap" files to locate the "zcl.json" file. These paths may be invalid if the ".zap" file is moved or used outside its original context. Explicitly passing the ZCL path ensures consistent and portable builds.

#### Testing

These changes were tested by building the following configurations : 
- Build example with default behavior, without ZCL_PATH and without CHIP_ENABLE_ZCL_ARG defined. No change required.
- Build example with "CHIP_ENABLE_ZCL_ARG" set to ON. Change required : https://github.com/project-chip/connectedhomeip/pull/40537/files#diff-6fad594babff0528f5e4695f20317f72c20a61f1787baae23fb6d6dfa93fceacR31 
       - Tests in CI : All NXP examples (except all-clusters-app) are using this configuration.
- Build example using a custom zcl file, by providing the path with ZCL_PATH argument via chip_configure_data_model. Example of change required : https://github.com/project-chip/connectedhomeip/pull/40537/files#diff-3996d06f182576c49a1bbda1ecc53d6cdcd8bd613e9c116f9c0abeff534b4693R108 
      - Tests in CI : NXP all-clusters-app example is using this configuration.

Example of command used to build:
- west build -d build_matter -b rdrw612bga examples/thermostat/nxp
- west build -d build_matter -b rdrw612bga examples/all-clusters-app/nxp

