### PR TITLE
Increase unit test code coverage of `credentials/attestation_verifier/` by 4.3%

### DIFF
--- a/src/credentials/tests/BUILD.gn
+++ b/src/credentials/tests/BUILD.gn
@@ -47,6 +47,7 @@ chip_test_suite("tests") {
   test_sources = [
     "TestCertificationDeclaration.cpp",
     "TestChipCert.cpp",
+    "TestDacOnlyPartialAttestationVerifier.cpp",
     "TestDeviceAttestationConstruction.cpp",
     "TestDeviceAttestationCredentials.cpp",
     "TestFabricTable.cpp",

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -50,6 +50,9 @@ static void OnAttestationInformationVerificationCallback(void * context, const D
 
 struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
 {
+    static constexpr VendorId kTestVendorId  = static_cast<VendorId>(0xFFF1);
+    static constexpr uint16_t kTestProductId = 0x8000;
+
     static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
     static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
 
@@ -68,15 +71,13 @@ struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidParameters)
 {
     // Create AttestationInfo with empty buffers
-    DeviceAttestationVerifier::AttestationInfo invalidInfo(ByteSpan(),                    // empty attestationElements
-                                                           ByteSpan(),                    // empty attestationChallenge
-                                                           ByteSpan(),                    // empty attestationSignature
-                                                           ByteSpan(),                    // empty paiDer
-                                                           ByteSpan(),                    // empty dacDer
-                                                           ByteSpan(),                    // empty attestationNonce
-                                                           static_cast<VendorId>(0xFFF1), // vendorId
-                                                           0x8000                         // productId
-    );
+    DeviceAttestationVerifier::AttestationInfo invalidInfo(ByteSpan(), // attestationElements
+                                                           ByteSpan(), // attestationChallenge
+                                                           ByteSpan(), // attestationSignature
+                                                           ByteSpan(), // paiDer
+                                                           ByteSpan(), // dacDer
+                                                           ByteSpan(), // attestationNonce
+                                                           kTestVendorId, kTestProductId);
 
     // Call the verifier with invalid info
     verifier.VerifyAttestationInformation(invalidInfo, &attestationCallback);
@@ -86,8 +87,8 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidParameters)
 // Test verifier behavior with oversized attestationElements buffer - verifies handling of large data
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithLargeAttestationElementsBuffer)
 {
-    // Create a buffer with more than 900 elements
-    constexpr size_t kLargeBufferSize = 1024; // More than 900 elements
+    // Create a buffer larger than kMaxResponseLength (900 bytes)
+    constexpr size_t kLargeBufferSize = 1024;
     uint8_t largeBuffer[kLargeBufferSize];
 
     // Fill the buffer with some test data
@@ -101,55 +102,45 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithLargeAttestationElementsBu
 
     // The following test data uses arbitrary values solely for test structure;
     // the actual contents do not represent real or meaningful data.
-    uint8_t challengeData[32] = { 0x01, 0x02, 0x03 }; // Example challenge
-    uint8_t signatureData[64] = { 0x04, 0x05, 0x06 }; // Example signature
-    uint8_t paiData[256]      = { 0x07, 0x08, 0x09 }; // Example PAI certificate
-    uint8_t dacData[256]      = { 0x0A, 0x0B, 0x0C }; // Example DAC certificate
-    uint8_t nonceData[32]     = { 0x0D, 0x0E, 0x0F }; // Example nonce
+    uint8_t challengeData[32] = { 0x01, 0x02, 0x03 };
+    uint8_t signatureData[64] = { 0x04, 0x05, 0x06 };
+    uint8_t paiData[256]      = { 0x07, 0x08, 0x09 };
+    uint8_t dacData[256]      = { 0x0A, 0x0B, 0x0C };
+    uint8_t nonceData[32]     = { 0x0D, 0x0E, 0x0F };
 
-    DeviceAttestationVerifier::AttestationInfo infoWithLargeBuffer(
-        largeAttestationElements, // Large attestationElements buffer
-        ByteSpan(challengeData, sizeof(challengeData)), ByteSpan(signatureData, sizeof(signatureData)),
-        ByteSpan(paiData, sizeof(paiData)), ByteSpan(dacData, sizeof(dacData)), ByteSpan(nonceData, sizeof(nonceData)),
-        static_cast<VendorId>(0xFFF1), // vendorId
-        0x8000                         // productId
-    );
+    DeviceAttestationVerifier::AttestationInfo infoWithLargeBuffer(largeAttestationElements, // Large attestationElements buffer
+                                                                   ByteSpan(challengeData), ByteSpan(signatureData),
+                                                                   ByteSpan(paiData), ByteSpan(dacData), ByteSpan(nonceData),
+                                                                   kTestVendorId, kTestProductId);
 
     // Call the verifier with large buffer
     verifier.VerifyAttestationInformation(infoWithLargeBuffer, &attestationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kInvalidArgument);
 }
 
-// Test verifier behavior with valid attestation elements
-TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithValidAttestationElements)
+// Test with invalid DAC certificate format
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidDACFormat)
 {
-    // Use real test vectors from CHIPCert_unit_test_vectors.h for PAI and DAC certificates
-    auto paiAsset = GetIAA1CertAsset();
-    auto dacAsset = GetNodeA1CertAsset();
-
     // The following test data uses arbitrary values solely for test structure;
-    // the actual contents do not represent real or meaningful data.
+    // the actual contents do not represent real or meaningful data (DAC intentionally invalid).
     uint8_t attestationElements[32] = { 0x01, 0x02, 0x03 };
     uint8_t challengeData[32]       = { 0x04, 0x05, 0x06 };
     uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
     uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
+    uint8_t invalidDacData[64]      = { 0xFF, 0xEE, 0xDD, 0xCC };
 
-    DeviceAttestationVerifier::AttestationInfo validInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)), paiAsset.mCert, dacAsset.mCert, ByteSpan(nonceData, sizeof(nonceData)),
-        static_cast<VendorId>(0xFFF1), 0x8000);
+    DeviceAttestationVerifier::AttestationInfo info(ByteSpan(attestationElements), ByteSpan(challengeData), ByteSpan(signatureData),
+                                                    TestCerts::sTestCert_PAI_FFF1_8000_Cert, ByteSpan(invalidDacData),
+                                                    ByteSpan(nonceData), kTestVendorId, kTestProductId);
 
-    // Call the verifier with valid information
-    verifier.VerifyAttestationInformation(validInfo, &attestationCallback);
+    // Call the verifier with the invalid DAC information
+    verifier.VerifyAttestationInformation(info, &attestationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacFormatInvalid);
 }
 
-// Test verifier behavior with VID/PID mismatch
-TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithVIDPIDMismatch)
+// Test with DAC certificate where VID/PID can be extracted but public key extraction fails
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithDACMissingPublicKey)
 {
-    // Use real test vectors from CHIPCert_unit_test_vectors.h for PAI and DAC certificates
-    auto paiAsset = GetIAA1CertAsset();
-    auto dacAsset = GetNodeA1CertAsset();
 
     // The following test data uses arbitrary values solely for test structure;
     // the actual contents do not represent real or meaningful data.
@@ -158,15 +149,16 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithVIDPIDMismatch)
     uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
     uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
 
-    DeviceAttestationVerifier::AttestationInfo mismatchInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)), paiAsset.mCert, dacAsset.mCert, ByteSpan(nonceData, sizeof(nonceData)),
-        static_cast<VendorId>(0x1234), // Mismatched VID
-        0x9999                         // Mismatched PID
-    );
+    // Use a DAC certificate with valid VID/PID but a missing or corrupted public key.
+    // For this test, we take the first 16 bytes of a valid DAC certificate to simulate a broken public key field.
+    uint8_t brokenDacData[16];
+    memcpy(brokenDacData, TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert.data(), sizeof(brokenDacData));
 
-    // Call the verifier with mismatched information
-    verifier.VerifyAttestationInformation(mismatchInfo, &attestationCallback);
+    DeviceAttestationVerifier::AttestationInfo info(ByteSpan(attestationElements), ByteSpan(challengeData), ByteSpan(signatureData),
+                                                    TestCerts::sTestCert_PAI_FFF1_8000_Cert, ByteSpan(brokenDacData),
+                                                    ByteSpan(nonceData), kTestVendorId, kTestProductId);
+
+    verifier.VerifyAttestationInformation(info, &attestationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacFormatInvalid);
 }
 
@@ -182,10 +174,10 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithValidDACButInvalidPAI)
     uint8_t invalidPaiData[64]      = { 0xFF, 0xEE, 0xDD, 0xCC };
 
     DeviceAttestationVerifier::AttestationInfo dacValidPaiInvalidInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)), ByteSpan(invalidPaiData, sizeof(invalidPaiData)), // Invalid PAI certificate
-        TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert,                                                     // Valid DAC certificate
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF1), 0x8000);
+        ByteSpan(attestationElements), ByteSpan(challengeData), ByteSpan(signatureData),
+        ByteSpan(invalidPaiData),                     // Invalid PAI certificate
+        TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert, // Valid DAC certificate
+        ByteSpan(nonceData), kTestVendorId, kTestProductId);
 
     // Call the verifier with the invalid information
     verifier.VerifyAttestationInformation(dacValidPaiInvalidInfo, &attestationCallback);
@@ -202,60 +194,15 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedVendorIDs)
     uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
     uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
 
-    DeviceAttestationVerifier::AttestationInfo mismatchedVidInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)),
-        TestCerts::sTestCert_PAI_FFF2_8001_Cert,      // PAI with VID=FFF2
-        TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert, // DAC with VID=FFF1
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF1), 0x8000);
+    DeviceAttestationVerifier::AttestationInfo mismatchedVidInfo(ByteSpan(attestationElements), ByteSpan(challengeData),
+                                                                 ByteSpan(signatureData),
+                                                                 TestCerts::sTestCert_PAI_FFF2_8001_Cert,      // PAI with VID=FFF2
+                                                                 TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert, // DAC with VID=FFF1
+                                                                 ByteSpan(nonceData), kTestVendorId, kTestProductId);
 
     // Call the verifier with the mismatched VID information
     verifier.VerifyAttestationInformation(mismatchedVidInfo, &attestationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacVendorIdMismatch);
-}
-
-// Test with valid PAI and DAC
-TEST_F(TestDacOnlyPartialAttestationVerifier, TestPassingVIDPIDChecks)
-{
-    // The following attestation information uses arbitrary values solely for test structure;
-    // the actual contents do not represent real or meaningful data.
-    uint8_t attestationElements[32] = { 0x01, 0x02, 0x03 };
-    uint8_t challengeData[32]       = { 0x04, 0x05, 0x06 };
-    uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
-    uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
-
-    DeviceAttestationVerifier::AttestationInfo passingVidPidInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)),
-        TestCerts::sTestCert_PAI_FFF2_NoPID_Cert,     // PAI with VID=FFF2, NO Product ID
-        TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert, // DAC with VID=FFF2, PID=8001
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF2), 0x8001);
-
-    // Call the verifier with the valid PAI and DAC information
-    verifier.VerifyAttestationInformation(passingVidPidInfo, &attestationCallback);
-    EXPECT_EQ(attestationResult, AttestationVerificationResult::kAttestationSignatureInvalid);
-}
-
-// Test with matching PAI and DAC Product IDs
-TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMatchingPAIAndDACProductIDs)
-{
-    // The following attestation information uses arbitrary values solely for test structure;
-    // the actual contents do not represent real or meaningful data.
-    uint8_t attestationElements[32] = { 0x01, 0x02, 0x03 };
-    uint8_t challengeData[32]       = { 0x04, 0x05, 0x06 };
-    uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
-    uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
-
-    DeviceAttestationVerifier::AttestationInfo matchingPidInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)),
-        TestCerts::sTestCert_PAI_FFF2_8001_Cert,      // PAI with VID=FFF2, PID=8001
-        TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert, // DAC with VID=FFF2, PID=8001 (same as PAI)
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF2), 0x8001);
-
-    // Call the verifier with the matching PAI and DAC information
-    verifier.VerifyAttestationInformation(matchingPidInfo, &attestationCallback);
-    EXPECT_EQ(attestationResult, AttestationVerificationResult::kAttestationSignatureInvalid);
 }
 
 // Test with mismatched PAI and DAC Product IDs
@@ -269,11 +216,10 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedPAIAndDACProduct
     uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
 
     DeviceAttestationVerifier::AttestationInfo mismatchedPidInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(signatureData, sizeof(signatureData)),
+        ByteSpan(attestationElements), ByteSpan(challengeData), ByteSpan(signatureData),
         TestCerts::sTestCert_PAI_FFF2_8004_FB_Cert,   // PAI with VID=FFF2, PID=8004
         TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert, // DAC with VID=FFF2, PID=8001
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF2), 0x8001);
+        ByteSpan(nonceData), static_cast<VendorId>(0xFFF2), 0x8001);
 
     // Call the verifier with the mismatched PAI and DAC information
     verifier.VerifyAttestationInformation(mismatchedPidInfo, &attestationCallback);
@@ -295,13 +241,34 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidAttestationSignatur
     memset(oversizedSignatureData, 0xAA, sizeof(oversizedSignatureData));
 
     DeviceAttestationVerifier::AttestationInfo oversizedSignatureInfo(
-        ByteSpan(attestationElements, sizeof(attestationElements)), ByteSpan(challengeData, sizeof(challengeData)),
-        ByteSpan(oversizedSignatureData, sizeof(oversizedSignatureData)), // Oversized signature
-        TestCerts::sTestCert_PAI_FFF2_8001_Cert,                          // Valid PAI certificate
-        TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert,                     // Valid DAC certificate
-        ByteSpan(nonceData, sizeof(nonceData)), static_cast<VendorId>(0xFFF2), 0x8001);
+        ByteSpan(attestationElements), ByteSpan(challengeData),
+        ByteSpan(oversizedSignatureData),             // Oversized signature
+        TestCerts::sTestCert_PAI_FFF2_8001_Cert,      // Valid PAI certificate
+        TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert, // Valid DAC certificate
+        ByteSpan(nonceData), kTestVendorId, kTestProductId);
 
     // Call the verifier with the oversized signature information
     verifier.VerifyAttestationInformation(oversizedSignatureInfo, &attestationCallback);
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kAttestationSignatureInvalidFormat);
+}
+
+// Test with matching PAI and DAC Product IDs
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMatchingPAIAndDACProductIDs)
+{
+    // The following attestation information uses arbitrary values solely for test structure;
+    // the actual contents do not represent real or meaningful data.
+    uint8_t attestationElements[32] = { 0x01, 0x02, 0x03 };
+    uint8_t challengeData[32]       = { 0x04, 0x05, 0x06 };
+    uint8_t signatureData[64]       = { 0x07, 0x08, 0x09 };
+    uint8_t nonceData[32]           = { 0x0A, 0x0B, 0x0C };
+
+    DeviceAttestationVerifier::AttestationInfo matchingPidInfo(
+        ByteSpan(attestationElements), ByteSpan(challengeData), ByteSpan(signatureData),
+        TestCerts::sTestCert_PAI_FFF2_8001_Cert,      // PAI with VID=FFF2, PID=8001
+        TestCerts::sTestCert_DAC_FFF2_8001_0008_Cert, // DAC with VID=FFF2, PID=8001 (same as PAI)
+        ByteSpan(nonceData), kTestVendorId, kTestProductId);
+
+    // Call the verifier with the matching PAI and DAC information
+    verifier.VerifyAttestationInformation(matchingPidInfo, &attestationCallback);
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kAttestationSignatureInvalid);
 }

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -1,0 +1,127 @@
+/*
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <pw_unit_test/framework.h>
+
+#include <credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.h>
+#include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <credentials/tests/CHIPAttCert_test_vectors.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <lib/support/CHIPMem.h>
+#include <lib/support/Span.h>
+
+using namespace chip;
+using namespace chip::Credentials;
+using namespace chip::TestCerts;
+
+namespace {
+
+// Callback function to capture attestation verification results
+static void OnAttestationInformationVerificationCallback(void * context, 
+                                                         const DeviceAttestationVerifier::AttestationInfo & info,
+                                                         AttestationVerificationResult result)
+{
+    AttestationVerificationResult * pResult = reinterpret_cast<AttestationVerificationResult *>(context);
+    *pResult = result;
+}
+
+} // namespace
+
+struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
+{
+    static void SetUpTestSuite() { ASSERT_EQ(chip::Platform::MemoryInit(), CHIP_NO_ERROR); }
+
+    static void TearDownTestSuite() { chip::Platform::MemoryShutdown(); }
+};
+
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidParameters)
+{
+    // Test with empty/invalid AttestationInfo - should fail with kInvalidArgument
+    AttestationVerificationResult attestationResult = AttestationVerificationResult::kSuccess;
+    Callback::Callback<DeviceAttestationVerifier::OnAttestationInformationVerification> 
+        attestationCallback(OnAttestationInformationVerificationCallback, &attestationResult);
+    
+    PartialDACVerifier verifier;
+    
+    // Create AttestationInfo with empty buffers - this should fail
+    DeviceAttestationVerifier::AttestationInfo invalidInfo(
+        ByteSpan(), // empty attestationElements
+        ByteSpan(), // empty attestationChallenge  
+        ByteSpan(), // empty attestationSignature
+        ByteSpan(), // empty paiDer
+        ByteSpan(), // empty dacDer
+        ByteSpan(), // empty attestationNonce
+        static_cast<VendorId>(0xFFF1), // vendorId
+        0x8000      // productId
+    );
+    
+    // Call the verifier with invalid info
+    verifier.VerifyAttestationInformation(invalidInfo, &attestationCallback);
+    
+    // Expect it to fail with invalid argument error
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kInvalidArgument);
+}
+
+TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithLargeAttestationElementsBuffer)
+{
+    // Create a buffer with more than 900 elements
+    constexpr size_t kLargeBufferSize = 1024; // More than 900 elements
+    uint8_t largeBuffer[kLargeBufferSize];
+    
+    // Fill the buffer with some test data
+    for (size_t i = 0; i < kLargeBufferSize; i++)
+    {
+        largeBuffer[i] = static_cast<uint8_t>(i % 256); // Fill with repeating pattern 0-255
+    }
+    
+    // Create ByteSpan from the large buffer
+    ByteSpan largeAttestationElements(largeBuffer, kLargeBufferSize);
+    
+    // Test with attestation verifier
+    AttestationVerificationResult attestationResult = AttestationVerificationResult::kSuccess;
+    Callback::Callback<DeviceAttestationVerifier::OnAttestationInformationVerification> 
+        attestationCallback(OnAttestationInformationVerificationCallback, &attestationResult);
+    
+    PartialDACVerifier verifier;
+    
+    // Create some minimal valid test data for other required fields
+    uint8_t challengeData[32] = {0x01, 0x02, 0x03}; // Example challenge
+    uint8_t signatureData[64] = {0x04, 0x05, 0x06}; // Example signature
+    uint8_t paiData[256] = {0x07, 0x08, 0x09}; // Example PAI certificate
+    uint8_t dacData[256] = {0x0A, 0x0B, 0x0C}; // Example DAC certificate
+    uint8_t nonceData[32] = {0x0D, 0x0E, 0x0F}; // Example nonce
+    
+    DeviceAttestationVerifier::AttestationInfo infoWithLargeBuffer(
+        largeAttestationElements,                    // Large attestationElements buffer
+        ByteSpan(challengeData, sizeof(challengeData)),
+        ByteSpan(signatureData, sizeof(signatureData)),
+        ByteSpan(paiData, sizeof(paiData)),
+        ByteSpan(dacData, sizeof(dacData)),
+        ByteSpan(nonceData, sizeof(nonceData)),
+        static_cast<VendorId>(0xFFF1), // vendorId
+        0x8000                         // productId
+    );
+    
+    // Call the verifier with large buffer
+    verifier.VerifyAttestationInformation(infoWithLargeBuffer, &attestationCallback);
+
+    // The result will depend on the verifier's implementation, but we're testing
+    // that it can handle large buffers without crashing
+    EXPECT_TRUE(attestationResult == AttestationVerificationResult::kInvalidArgument);
+}


### PR DESCRIPTION
#### Summary
This PR increases `credentials/attestation_verifier/` unit test coverage from **63.5% to 67.8%** by adding comprehensive tests for the `PartialDACVerifier::VerifyAttestationInformation` method in `DacOnlyPartialAttestationVerifier.cpp`.
The new tests verify `VerifyAttestationInformation` behavior across a wide range of scenarios, including:

* Invalid parameter handling – ensuring that empty or malformed buffers produce `kInvalidArgument` results.
* Large buffer validation – rejecting `attestationElements` exceeding the maximum allowed size.
* Valid data cases – confirming that well-formed data reaches later verification stages.
* VID/PID checks – covering matching, mismatched, and absent VID/PID combinations, verifying `kDacVendorIdMismatch` and `kDacProductIdMismatch` outcomes.
* PAI/DAC certificate validation – detecting invalid formats or mismatched certificates, producing `kPaiFormatInvalid` and `kDacFormatInvalid`.
* Signature validation – rejecting oversized or improperly formatted attestation signatures with `kAttestationSignatureInvalidFormat`.

#### Related issues
Main issue: #37234

#### Testing
This PR only adds new unit tests. No changes made to production code.

#### Local (Linux) Coverage Impact of `credentials/attestation_verifier/`

| Metric   | Before | After | Delta   |
|----------|--------|-------|---------|
| Line     | 63.5%  | 67.8% | + 4.3%  |
| Function | 72.2%  | 74.1% | +1.9%   |