### PR TITLE
[Android ]fix android chip-test

### DIFF
--- a/examples/android/CHIPTest/app/build.gradle
+++ b/examples/android/CHIPTest/app/build.gradle
@@ -8,14 +8,14 @@ println 'matterBuildSrcDir='+matterBuildSrcDir
 println 'matterUTestLib='+matterUTestLib
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    namespace "com.tcl.chip.chiptest"
+    compileSdkVersion 34
     ndkPath System.getenv("ANDROID_NDK_HOME")
 
     defaultConfig {
         applicationId "com.tcl.chip.chiptest"
         minSdkVersion 26
-        targetSdkVersion 30
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -43,11 +43,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {

--- a/examples/android/CHIPTest/app/src/main/AndroidManifest.xml
+++ b/examples/android/CHIPTest/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.tcl.chip.chiptest">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
@@ -18,7 +17,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.CHIPTest">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/examples/android/CHIPTest/build.gradle
+++ b/examples/android/CHIPTest/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "2.0.0"
+    ext.kotlin_version = "2.1.10"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:7.1.3"
+        classpath "com.android.tools.build:gradle:8.5.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 


### PR DESCRIPTION
#### Summary
Following https://developer.android.com/guide/practices/page-sizes#ndk-build_1, Starting November 1st, 2025, all new apps and updates to existing apps submitted to Google Play and targeting Android 15+ devices must support 16 KB page sizes on 64-bit devices.

For android chip-test,

We need upgrade AGP version with 8.5.1.
We need upgrade sdk tool with 33.
We need upgrade java with 17
We need upgrade gradle with 8.7

#### Related issues

Fixes #39871

#### Testing
local compilation

#### Readability checklist
N/A