### PR TITLE
Remove unused Groups.Endpoint PIXIT from TC-GRPKEY-2.1

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_GRPKEY_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_GRPKEY_2_1.yaml
@@ -36,7 +36,6 @@ tests:
     - label:
           "Step 1: TH reads GroupKeyMap attribute from DUT using a
           fabric-filtered read."
-      PICS: GRPKEY.S.A0000
       command: "readAttribute"
       attribute: "GroupKeyMap"
       fabricFiltered: true
@@ -49,7 +48,6 @@ tests:
           GroupKeyMap attribute list on GroupKeyManagement cluster by writing
           the GroupKeyMap attribute with one entry as follows: List item
           1:,GroupId: 0x0103,GroupKeySetId: 0x01a3"
-      PICS: GRPKEY.S.A0000
       command: "writeAttribute"
       attribute: "GroupKeyMap"
       arguments:
@@ -58,7 +56,6 @@ tests:
     - label:
           "Step 3: TH reads GroupKeyMap Attribute from the GroupKeyManagement
           cluster from DUT using a fabric-filtered read."
-      PICS: GRPKEY.S.A0000
       command: "readAttribute"
       attribute: "GroupKeyMap"
       response:
@@ -67,7 +64,6 @@ tests:
     - label:
           "Step 4: TH reads GroupTable attribute from GroupKeyManagement cluster
           on DUT."
-      PICS: GRPKEY.S.A0001
       command: "readAttribute"
       attribute: "GroupTable"
       response:
@@ -76,7 +72,6 @@ tests:
     - label:
           "Step 5: TH reads MaxGroupsPerFabric attribute from GroupKeyManagement
           cluster on DUT using a fabric-filtered read."
-      PICS: GRPKEY.S.A0002
       command: "readAttribute"
       attribute: "MaxGroupsPerFabric"
       fabricFiltered: true
@@ -90,7 +85,6 @@ tests:
     - label:
           "Step 6: TH reads MaxGroupKeysPerFabric attribute from
           GroupKeyManagement cluster on DUT using a fabric-filtered read."
-      PICS: GRPKEY.S.A0003
       command: "readAttribute"
       attribute: "MaxGroupKeysPerFabric"
       fabricFiltered: true

--- a/src/app/tests/suites/certification/Test_TC_GRPKEY_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_GRPKEY_2_1.yaml
@@ -22,9 +22,6 @@ config:
     cluster: "Group Key Management"
     endpoint: 0
 
-    # Users should set endpoint value on the command line to PIXIT.G.ENDPOINT
-    Groups.Endpoint: 1
-
 tests:
     - label:
           "Step 0: Commission DUT to TH (can be skipped if done in a preceding


### PR DESCRIPTION
#### Summary
This change removes the Groups.Endpoint PIXIT configuration from the TC-GRPKEY-2.1 YAML test case.
The Test Plan for this case does not require interaction with the Groups cluster; it only exercises the Group Key Management cluster on endpoint 0.

#### Related issues
N/A

#### Testing
Verified by running TC-GRPKEY-2.1.yaml against a clean chip-lighting-app and chip-all-cluster-app DUT on macOS.
Confirmed no functional change to test execution after removing the unused PIXIT.
Test passes when DUT starts with an empty Group Table (persistent storage cleared).

<img width="1919" height="896" alt="Screenshot 2025-08-12 at 2 32 26 p m" src="https://github.com/user-attachments/assets/5165f8c2-b9f9-4988-9fbc-5a54983f2128" />

[ep0.pics.zip](https://github.com/user-attachments/files/21744759/ep0.pics.zip)