### PR TITLE
ESP32: Add APIs to get random values from secure cert partition

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -37,6 +37,8 @@ enum class MatterTLVSubType : uint8_t
     kSpake2pSalt              = 2,
     kSpake2pIterationCount    = 3,
     kRotatingDeviceIdUniqueId = 4,
+    kRandom1                  = 128,
+    kRandom2                  = 129,
 };
 
 // Scoped wrapper class for handling TLV data retrieval from secure cert partition
@@ -142,6 +144,18 @@ CHIP_ERROR ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(MutableByteS
 #endif // CHIP_ENABLE_ROTATING_DEVICE_ID
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
+
+CHIP_ERROR ESP32SecureCertDataProvider::GetRandom1(MutableByteSpan & randomBuf)
+{
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kRandom1);
+    return tlvInfo.GetValue(randomBuf);
+}
+
+CHIP_ERROR ESP32SecureCertDataProvider::GetRandom2(MutableByteSpan & randomBuf)
+{
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kRandom2);
+    return tlvInfo.GetValue(randomBuf);
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -37,8 +37,9 @@ enum class MatterTLVSubType : uint8_t
     kSpake2pSalt              = 2,
     kSpake2pIterationCount    = 3,
     kRotatingDeviceIdUniqueId = 4,
-    kRandom1                  = 128,
-    kRandom2                  = 129,
+    // Subtype identifier for fixed random values set during manufacturing
+    kFixedRandom1 = 128,
+    kFixedRandom2 = 129,
 };
 
 // Scoped wrapper class for handling TLV data retrieval from secure cert partition
@@ -145,15 +146,15 @@ CHIP_ERROR ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(MutableByteS
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 
-CHIP_ERROR ESP32SecureCertDataProvider::GetRandom1(MutableByteSpan & randomBuf)
+CHIP_ERROR ESP32SecureCertDataProvider::GetFixedRandom1(MutableByteSpan & randomBuf)
 {
-    ScopedTLVInfo tlvInfo(MatterTLVSubType::kRandom1);
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kFixedRandom1);
     return tlvInfo.GetValue(randomBuf);
 }
 
-CHIP_ERROR ESP32SecureCertDataProvider::GetRandom2(MutableByteSpan & randomBuf)
+CHIP_ERROR ESP32SecureCertDataProvider::GetFixedRandom2(MutableByteSpan & randomBuf)
 {
-    ScopedTLVInfo tlvInfo(MatterTLVSubType::kRandom2);
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kFixedRandom2);
     return tlvInfo.GetValue(randomBuf);
 }
 

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -47,6 +47,12 @@ public:
     // GetRotatingDeviceIdUniqueId from GenericDeviceInstanceInfoProvider
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
+
+    // esp-secure-cert partition contains two 32-byte random numbers that can be used for any generic purpose.
+    // eg: If someone wants to use one of the random value as serial number, they can use this function to get the random value.
+    static constexpr uint32_t kRandomLength = 32;
+    static CHIP_ERROR GetRandom1(MutableByteSpan & randomBuf);
+    static CHIP_ERROR GetRandom2(MutableByteSpan & randomBuf);
 };
 
 } // namespace DeviceLayer

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -48,11 +48,12 @@ public:
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 
-    // esp-secure-cert partition contains two 32-byte random numbers that can be used for any generic purpose.
-    // e.g., for use as a device serial number.
-    static constexpr uint32_t kRandomLength = 32;
-    static CHIP_ERROR GetRandom1(MutableByteSpan & randomBuf);
-    static CHIP_ERROR GetRandom2(MutableByteSpan & randomBuf);
+    // esp-secure-cert partition contains two 32-byte fixed random values that are set during manufacturing
+    // and remain constant for the lifetime of the device. These are unique per device and can be used
+    // for device identification, serial numbers, or any other purpose requiring a device-specific identifier.
+    static constexpr uint32_t kFixedRandomValueLength = 32;
+    static CHIP_ERROR GetFixedRandom1(MutableByteSpan & randomBuf);
+    static CHIP_ERROR GetFixedRandom2(MutableByteSpan & randomBuf);
 };
 
 } // namespace DeviceLayer

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -49,7 +49,7 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
 
     // esp-secure-cert partition contains two 32-byte random numbers that can be used for any generic purpose.
-    // eg: If someone wants to use one of the random value as serial number, they can use this function to get the random value.
+    // e.g., for use as a device serial number.
     static constexpr uint32_t kRandomLength = 32;
     static CHIP_ERROR GetRandom1(MutableByteSpan & randomBuf);
     static CHIP_ERROR GetRandom2(MutableByteSpan & randomBuf);


### PR DESCRIPTION
#### Summary

esp-secure-cert partition contains two random 32-byte values. Added getter APIs for them.

#### Related issues

#### Testing
Flashed a partition which contains the random values and verified that the same random values are being read using the APIs.

Verified with below code snippet in lighting-app/esp32
```
#include <platform/ESP32/ESP32SecureCertDataProvider.h>
...
{
    static DeviceLayer::ESP32SecureCertDataProvider gSecureCertDataProvider;

    uint8_t randomBuf1[ESP32SecureCertDataProvider::kRandomLength];
    MutableByteSpan randomBufSpan1(randomBuf1);

    printf("Random1: ");
    if (ESP32SecureCertDataProvider::GetRandom1(randomBufSpan1) == CHIP_NO_ERROR)
    {
        for (size_t i = 0; i < randomBufSpan1.size(); i++)
        {
            printf("%02x", randomBufSpan1[i]);
        }
        printf("\n");
    }    
}
```



#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
