### PR TITLE
Fix Github CI for `v1.4-branch`

### DIFF
--- a/.github/actions/add-ipv6/action.yaml
+++ b/.github/actions/add-ipv6/action.yaml
@@ -1,0 +1,18 @@
+name: Set up an IPV6 environment
+description: Creates a socket pair with a "peer" network namespace that supports IPV6
+runs:
+  using: "composite"
+  steps:
+    - name: Set up IPV6
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+         ip netns add peer
+
+         ip link add name veth0 type veth peer name veth0-peer
+         ip -6 addr add fd00:0:1:1::1/64 dev veth0
+         ip link set dev veth0 up
+
+         ip link set veth0-peer netns peer
+         ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
+         ip netns exec peer ip link set dev veth0-peer up

--- a/.github/actions/add-ipv6/action.yaml
+++ b/.github/actions/add-ipv6/action.yaml
@@ -7,12 +7,12 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
-          ip netns add peer
+          sudo ip netns add peer
 
-          ip link add name veth0 type veth peer name veth0-peer
-          ip -6 addr add fd00:0:1:1::1/64 dev veth0
-          ip link set dev veth0 up
+          sudo ip link add name veth0 type veth peer name veth0-peer
+          sudo ip -6 addr add fd00:0:1:1::1/64 dev veth0
+          sudo ip link set dev veth0 up
 
-          ip link set veth0-peer netns peer
-          ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
-          ip netns exec peer ip link set dev veth0-peer up
+          sudo ip link set veth0-peer netns peer
+          sudo ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
+          sudo ip netns exec peer ip link set dev veth0-peer up

--- a/.github/actions/add-ipv6/action.yaml
+++ b/.github/actions/add-ipv6/action.yaml
@@ -7,12 +7,12 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
-          sudo ip netns add peer
+          ip netns add peer
 
-          sudo ip link add name veth0 type veth peer name veth0-peer
-          sudo ip -6 addr add fd00:0:1:1::1/64 dev veth0
-          sudo ip link set dev veth0 up
+          ip link add name veth0 type veth peer name veth0-peer
+          ip -6 addr add fd00:0:1:1::1/64 dev veth0
+          ip link set dev veth0 up
 
-          sudo ip link set veth0-peer netns peer
-          sudo ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
-          sudo ip netns exec peer ip link set dev veth0-peer up
+          ip link set veth0-peer netns peer
+          ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
+          ip netns exec peer ip link set dev veth0-peer up

--- a/.github/actions/add-ipv6/action.yaml
+++ b/.github/actions/add-ipv6/action.yaml
@@ -7,12 +7,12 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: bash
       run: |
-         ip netns add peer
+          ip netns add peer
 
-         ip link add name veth0 type veth peer name veth0-peer
-         ip -6 addr add fd00:0:1:1::1/64 dev veth0
-         ip link set dev veth0 up
+          ip link add name veth0 type veth peer name veth0-peer
+          ip -6 addr add fd00:0:1:1::1/64 dev veth0
+          ip link set dev veth0 up
 
-         ip link set veth0-peer netns peer
-         ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
-         ip netns exec peer ip link set dev veth0-peer up
+          ip link set veth0-peer netns peer
+          ip netns exec peer ip -6 addr add fd00:0:1:1::2/64 dev veth0-peer
+          ip netns exec peer ip link set dev veth0-peer up

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,8 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
@@ -162,6 +164,8 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
@@ -302,6 +306,8 @@ jobs:
               run: echo "$CONCURRENCY_CONTEXT"
             - name: Checkout
               uses: actions/checkout@v4
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
@@ -468,6 +474,10 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
+
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -306,8 +306,6 @@ jobs:
               run: echo "$CONCURRENCY_CONTEXT"
             - name: Checkout
               uses: actions/checkout@v4
-            - name: Set up a IPV6 known environment
-              uses: ./.github/actions/add-ipv6
             - name: Checkout submodules & Bootstrap
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
@@ -474,7 +472,7 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
-              
+
             - name: Set up a IPV6 known environment
               uses: ./.github/actions/add-ipv6
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -473,6 +473,9 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
                   mkdir objdir-clone || true
 
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
+
             - name: Build Python REPL and example apps
               # NOTE: the data-mode-check + check-failure-die is not 100% perfect as different
               #       encoding sizes for data that keeps changing may alter over time (e.g. anything relating to time

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,6 +78,9 @@ jobs:
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
                   mkdir objdir-clone || true
 
+            - name: Set up a IPV6 known environment
+              uses: ./.github/actions/add-ipv6
+
             - name: Validate that xml are parsable
               # The sub-items being run here are the same as the input XMLs listed
               # at src/app/zap-templates/zcl/zcl.json

--- a/.github/workflows/zap_regeneration.yaml
+++ b/.github/workflows/zap_regeneration.yaml
@@ -28,7 +28,7 @@ jobs:
     zap_regeneration:
         name: ZAP Regeneration
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:81
         defaults:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -33,7 +33,7 @@ jobs:
     zap_templates:
         name: ZAP templates generation
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:81
         defaults:

--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -277,8 +277,13 @@ TEST_F(TestInetEndPoint, TestInetEndPointInternal)
 
     err = InterfaceId::Null().GetLinkLocalAddr(&addr);
 
-    // We should skip the following checks if the interface does not have the Link local address
-    ASSERT_NE(err, INET_ERROR_ADDRESS_NOT_FOUND);
+    // We should skip the following checks if the interface does not have the Link local address.
+    // This can happen if you don't have network interfaces connected to any link (like happened
+    // to the author of this comment at YYZ before CSA 2025 Chicago Member Meeting).
+    if (err == INET_ERROR_ADDRESS_NOT_FOUND)
+    {
+        return;
+    }
 
     EXPECT_EQ(err, CHIP_NO_ERROR);
     intId = InterfaceId::FromIPAddress(addr);


### PR DESCRIPTION
#### Summary

This PR makes the `v1.4-branch` branch pass Github CI.

The problems were occurring because CI runners didn't have a proper IPv6 environment setup.
This PR sets the environment (this was done partially manually cherry-picking #38845), and there are small fixes cherry-picked (#38015, #38790) for the file `src/inet/TestInetEndPoint.cpp`.

Also cherry-picked the PR #37870, because github actions doesn't support runners with ubuntu-20.04.

#### Related issues

Issue #40499

#### Testing

The CI jobs need to pass.
