### PR TITLE
Enable HardPrivacy mode in the CameraDevice to enable optional attribute HardPrivacyModeOn.

### DIFF
--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -194,8 +194,8 @@ public:
     CameraError SetSoftLivestreamPrivacyModeEnabled(bool softLivestreamPrivacyMode) override;
     bool GetSoftLivestreamPrivacyModeEnabled() override { return mSoftLivestreamPrivacyModeEnabled; }
 
-    // Currently, defaulting to not supporting hard privacy switch.
-    bool HasHardPrivacySwitch() override { return false; }
+    // Currently, defaulting to supporting hard privacy switch.
+    bool HasHardPrivacySwitch() override { return true; }
 
     // Currently, defaulting to supporting speaker.
     bool HasSpeaker() override { return true; }


### PR DESCRIPTION
#### Summary
This is to allow a successful wildcard read of all attributes on the AVSM cluster.


#### Testing
* Start chip-camera-app
* Use chip-tool to issue wildcard read of AVSM cluster
 `./chip-tool any read-by-id 0x551 0xFFFFFFFF 1 1`
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
