### PR TITLE
Test out optimize for size flags for PSOC6

### DIFF
--- a/src/platform/Infineon/PSOC6/args.gni
+++ b/src/platform/Infineon/PSOC6/args.gni
@@ -27,3 +27,7 @@ chip_device_platform = "psoc6"
 lwip_platform = "psoc6"
 
 chip_build_tests = false
+
+# Optimize for size by default
+optimize_debug_level = "s"
+lwip_debug = false


### PR DESCRIPTION
#### Summary

We are reporting bloat size reports for PSOC6 however it seems to consistently report that its size increase is larger than other platforms. this seems very odd. Assuming this is due to compile optimization flags, so try to match the other infineon platform from https://github.com/project-chip/connectedhomeip/blob/master/src/platform/Infineon/CYW30739/args.gni#L46

#### Testing

CI should validate the build. If this actually works, then bloat report should show smaller size.