### PR TITLE
[Camera] Refactor the AllocateVideoStream method to config camera parameters

### DIFF
--- a/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
@@ -37,7 +37,8 @@ CHIP_ERROR LiveViewStartCommand::RunCommand()
     // Use provided stream usage or default to 3 (LiveView)
     uint8_t streamUsage = mStreamUsage.HasValue() ? mStreamUsage.Value() : 3;
 
-    return camera::DeviceManager::Instance().AllocateVideoStream(mPeerNodeId, streamUsage);
+    return camera::DeviceManager::Instance().AllocateVideoStream(mPeerNodeId, streamUsage, camera::WebRTCOfferType::kProvideOffer,
+                                                                 mMinWidth, mMinHeight, mMinFrameRate, mMinBitRate);
 }
 
 CHIP_ERROR LiveViewStopCommand::RunCommand()

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.cpp
@@ -38,7 +38,7 @@ CHIP_ERROR LiveViewStartCommand::RunCommand()
     uint8_t streamUsage = mStreamUsage.HasValue() ? mStreamUsage.Value() : 3;
 
     return camera::DeviceManager::Instance().AllocateVideoStream(mPeerNodeId, streamUsage, camera::WebRTCOfferType::kProvideOffer,
-                                                                 mMinWidth, mMinHeight, mMinFrameRate, mMinBitRate);
+                                                                 mMinResWidth, mMinResHeight, mMinFrameRate, mMinBitRate);
 }
 
 CHIP_ERROR LiveViewStopCommand::RunCommand()

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.h
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.h
@@ -27,8 +27,8 @@ public:
     {
         AddArgument("node-id", 0, UINT64_MAX, &mPeerNodeId);
         AddArgument("stream-usage", 0, UINT8_MAX, &mStreamUsage);
-        AddArgument("min-width", 0, UINT16_MAX, &mMinWidth);
-        AddArgument("min-height", 0, UINT16_MAX, &mMinHeight);
+        AddArgument("min-res-width", 0, UINT16_MAX, &mMinResWidth);
+        AddArgument("min-res-height", 0, UINT16_MAX, &mMinResHeight);
         AddArgument("min-framerate", 0, UINT16_MAX, &mMinFrameRate);
         AddArgument("min-bitrate", 0, UINT32_MAX, &mMinBitRate);
     }
@@ -41,8 +41,8 @@ public:
 private:
     chip::NodeId mPeerNodeId = chip::kUndefinedNodeId;
     chip::Optional<uint8_t> mStreamUsage;
-    chip::Optional<uint16_t> mMinWidth;
-    chip::Optional<uint16_t> mMinHeight;
+    chip::Optional<uint16_t> mMinResWidth;
+    chip::Optional<uint16_t> mMinResHeight;
     chip::Optional<uint16_t> mMinFrameRate;
     chip::Optional<uint32_t> mMinBitRate;
 };

--- a/examples/camera-controller/commands/liveview/LiveViewCommands.h
+++ b/examples/camera-controller/commands/liveview/LiveViewCommands.h
@@ -27,6 +27,10 @@ public:
     {
         AddArgument("node-id", 0, UINT64_MAX, &mPeerNodeId);
         AddArgument("stream-usage", 0, UINT8_MAX, &mStreamUsage);
+        AddArgument("min-width", 0, UINT16_MAX, &mMinWidth);
+        AddArgument("min-height", 0, UINT16_MAX, &mMinHeight);
+        AddArgument("min-framerate", 0, UINT16_MAX, &mMinFrameRate);
+        AddArgument("min-bitrate", 0, UINT32_MAX, &mMinBitRate);
     }
 
     /////////// CHIPCommand Interface /////////
@@ -37,6 +41,10 @@ public:
 private:
     chip::NodeId mPeerNodeId = chip::kUndefinedNodeId;
     chip::Optional<uint8_t> mStreamUsage;
+    chip::Optional<uint16_t> mMinWidth;
+    chip::Optional<uint16_t> mMinHeight;
+    chip::Optional<uint16_t> mMinFrameRate;
+    chip::Optional<uint32_t> mMinBitRate;
 };
 
 class LiveViewStopCommand : public CHIPCommand

--- a/examples/camera-controller/device-manager/AVStreamManagement.cpp
+++ b/examples/camera-controller/device-manager/AVStreamManagement.cpp
@@ -46,7 +46,7 @@ void AVStreamManagement::Init(Controller::DeviceCommissioner * commissioner)
 }
 
 CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId endpointId, uint8_t streamUsage,
-                                                   Optional<uint16_t> minWidth, Optional<uint16_t> minHeight,
+                                                   Optional<uint16_t> minResWidth, Optional<uint16_t> minResHeight,
                                                    Optional<uint16_t> minFrameRate, Optional<uint32_t> minBitRate)
 {
     VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
@@ -74,8 +74,8 @@ CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId end
     mVideoStreamAllocate.maxFrameRate = kMaxFrameRate;
 
     // Handle resolution configuration with validation
-    uint16_t requestedMinWidth  = minWidth.ValueOr(kMinWidth);
-    uint16_t requestedMinHeight = minHeight.ValueOr(kMinHeight);
+    uint16_t requestedMinWidth  = minResWidth.ValueOr(kMinWidth);
+    uint16_t requestedMinHeight = minResHeight.ValueOr(kMinHeight);
 
     // Ensure min values don't exceed max values
     if (requestedMinWidth > kMaxWidth)

--- a/examples/camera-controller/device-manager/AVStreamManagement.cpp
+++ b/examples/camera-controller/device-manager/AVStreamManagement.cpp
@@ -45,7 +45,9 @@ void AVStreamManagement::Init(Controller::DeviceCommissioner * commissioner)
     mCommissioner = commissioner;
 }
 
-CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId endpointId, uint8_t streamUsage)
+CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId endpointId, uint8_t streamUsage,
+                                                   Optional<uint16_t> minWidth, Optional<uint16_t> minHeight,
+                                                   Optional<uint16_t> minFrameRate, Optional<uint32_t> minBitRate)
 {
     VerifyOrReturnError(mCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -59,13 +61,13 @@ CHIP_ERROR AVStreamManagement::AllocateVideoStream(NodeId nodeId, EndpointId end
     mVideoStreamAllocate.videoCodec =
         app::Clusters::CameraAvStreamManagement::VideoCodecEnum::kH264; // Default to H.264; adjust as needed.
 
-    mVideoStreamAllocate.minFrameRate = kMinFrameRate;
+    mVideoStreamAllocate.minFrameRate = minFrameRate.ValueOr(kMinFrameRate);
     mVideoStreamAllocate.maxFrameRate = kMaxFrameRate;
 
-    mVideoStreamAllocate.minResolution = { .width = kMinWidth, .height = kMinHeight };
+    mVideoStreamAllocate.minResolution = { .width = minWidth.ValueOr(kMinWidth), .height = minHeight.ValueOr(kMinHeight) };
     mVideoStreamAllocate.maxResolution = { .width = kMaxWidth, .height = kMaxHeight };
 
-    mVideoStreamAllocate.minBitRate = kDefaultBitRate;
+    mVideoStreamAllocate.minBitRate = minBitRate.ValueOr(kDefaultBitRate);
     mVideoStreamAllocate.maxBitRate = kDefaultBitRate;
 
     mVideoStreamAllocate.keyFrameInterval = kKeyFrameInterval;

--- a/examples/camera-controller/device-manager/AVStreamManagement.h
+++ b/examples/camera-controller/device-manager/AVStreamManagement.h
@@ -51,9 +51,17 @@ public:
      * @param nodeId      The node ID of the remote camera device.
      * @param endpointId  The endpoint on which to send VideoStreamAllocate commands.
      * @param streamUsage The usage of the stream(Recording, LiveView, etc) that this allocation is for.
+     * @param minWidth    Optional minimum width for the video stream. If not specified, uses default value.
+     * @param minHeight   Optional minimum height for the video stream. If not specified, uses default value.
+     * @param minFrameRate Optional minimum frame rate for the video stream. If not specified, uses default value.
+     * @param minBitRate  Optional minimum bit rate for the video stream. If not specified, uses default value.
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or an appropriate error code on failure.
      */
-    CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, chip::EndpointId endpointId, uint8_t streamUsage);
+    CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, chip::EndpointId endpointId, uint8_t streamUsage,
+                                   chip::Optional<uint16_t> minWidth     = chip::NullOptional,
+                                   chip::Optional<uint16_t> minHeight    = chip::NullOptional,
+                                   chip::Optional<uint16_t> minFrameRate = chip::NullOptional,
+                                   chip::Optional<uint32_t> minBitRate   = chip::NullOptional);
 
     /**
      * @brief Sends a VideoStreamDeallocate command to the device.

--- a/examples/camera-controller/device-manager/AVStreamManagement.h
+++ b/examples/camera-controller/device-manager/AVStreamManagement.h
@@ -48,18 +48,18 @@ public:
     /**
      * @brief Sends a VideoStreamAllocate command to the device.
      *
-     * @param nodeId      The node ID of the remote camera device.
-     * @param endpointId  The endpoint on which to send VideoStreamAllocate commands.
-     * @param streamUsage The usage of the stream(Recording, LiveView, etc) that this allocation is for.
-     * @param minWidth    Optional minimum width for the video stream. If not specified, uses default value.
-     * @param minHeight   Optional minimum height for the video stream. If not specified, uses default value.
+     * @param nodeId       The node ID of the remote camera device.
+     * @param endpointId   The endpoint on which to send VideoStreamAllocate commands.
+     * @param streamUsage  The usage of the stream(Recording, LiveView, etc) that this allocation is for.
+     * @param minResWidth  Optional minimum width for the video stream. If not specified, uses default value.
+     * @param minResHeight Optional minimum height for the video stream. If not specified, uses default value.
      * @param minFrameRate Optional minimum frame rate for the video stream. If not specified, uses default value.
-     * @param minBitRate  Optional minimum bit rate for the video stream. If not specified, uses default value.
-     * @return CHIP_ERROR CHIP_NO_ERROR on success, or an appropriate error code on failure.
+     * @param minBitRate   Optional minimum bit rate for the video stream. If not specified, uses default value.
+     * @return CHIP_ERROR  CHIP_NO_ERROR on success, or an appropriate error code on failure.
      */
     CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, chip::EndpointId endpointId, uint8_t streamUsage,
-                                   chip::Optional<uint16_t> minWidth     = chip::NullOptional,
-                                   chip::Optional<uint16_t> minHeight    = chip::NullOptional,
+                                   chip::Optional<uint16_t> minResWidth  = chip::NullOptional,
+                                   chip::Optional<uint16_t> minResHeight = chip::NullOptional,
                                    chip::Optional<uint16_t> minFrameRate = chip::NullOptional,
                                    chip::Optional<uint32_t> minBitRate   = chip::NullOptional);
 

--- a/examples/camera-controller/device-manager/DeviceManager.cpp
+++ b/examples/camera-controller/device-manager/DeviceManager.cpp
@@ -85,11 +85,14 @@ void DeviceManager::Shutdown()
     WebRTCManager::Instance().Disconnect();
 }
 
-CHIP_ERROR DeviceManager::AllocateVideoStream(NodeId nodeId, uint8_t streamUsage, WebRTCOfferType offerType)
+CHIP_ERROR DeviceManager::AllocateVideoStream(NodeId nodeId, uint8_t streamUsage, WebRTCOfferType offerType,
+                                              Optional<uint16_t> minWidth, Optional<uint16_t> minHeight,
+                                              Optional<uint16_t> minFrameRate, Optional<uint32_t> minBitRate)
 {
     ChipLogProgress(Camera, "Allocate a video stream on the camera device.");
 
-    CHIP_ERROR error = mAVStreamManagment.AllocateVideoStream(nodeId, kCameraEndpointId, streamUsage);
+    CHIP_ERROR error = mAVStreamManagment.AllocateVideoStream(nodeId, kCameraEndpointId, streamUsage, minWidth, minHeight,
+                                                              minFrameRate, minBitRate);
 
     if (error != CHIP_NO_ERROR)
     {

--- a/examples/camera-controller/device-manager/DeviceManager.h
+++ b/examples/camera-controller/device-manager/DeviceManager.h
@@ -53,10 +53,18 @@ public:
      * @param nodeId      The node ID of the remote camera device.
      * @param streamUsage The usage of the stream(Recording, LiveView, etc) that this allocation is for.
      * @param offerType   The type of WebRTC offer to use (ProvideOffer or SolicitOffer).
+     * @param minWidth    Optional minimum width for the video stream. If not specified, uses default value.
+     * @param minHeight   Optional minimum height for the video stream. If not specified, uses default value.
+     * @param minFrameRate Optional minimum frame rate for the video stream. If not specified, uses default value.
+     * @param minBitRate  Optional minimum bit rate for the video stream. If not specified, uses default value.
      * @return CHIP_ERROR CHIP_NO_ERROR on success, or an appropriate error code on failure.
      */
     CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, uint8_t streamUsage,
-                                   WebRTCOfferType offerType = WebRTCOfferType::kProvideOffer);
+                                   WebRTCOfferType offerType             = WebRTCOfferType::kProvideOffer,
+                                   chip::Optional<uint16_t> minWidth     = chip::NullOptional,
+                                   chip::Optional<uint16_t> minHeight    = chip::NullOptional,
+                                   chip::Optional<uint16_t> minFrameRate = chip::NullOptional,
+                                   chip::Optional<uint32_t> minBitRate   = chip::NullOptional);
 
     /**
      * @brief Sends a VideoStreamDeallocate command to the device.

--- a/examples/camera-controller/device-manager/DeviceManager.h
+++ b/examples/camera-controller/device-manager/DeviceManager.h
@@ -50,19 +50,19 @@ public:
     /**
      * @brief Sends a VideoStreamAllocate command to the device.
      *
-     * @param nodeId      The node ID of the remote camera device.
-     * @param streamUsage The usage of the stream(Recording, LiveView, etc) that this allocation is for.
-     * @param offerType   The type of WebRTC offer to use (ProvideOffer or SolicitOffer).
-     * @param minWidth    Optional minimum width for the video stream. If not specified, uses default value.
-     * @param minHeight   Optional minimum height for the video stream. If not specified, uses default value.
+     * @param nodeId       The node ID of the remote camera device.
+     * @param streamUsage  The usage of the stream(Recording, LiveView, etc) that this allocation is for.
+     * @param offerType    The type of WebRTC offer to use (ProvideOffer or SolicitOffer).
+     * @param minResWidth  Optional minimum width for the video stream. If not specified, uses default value.
+     * @param minResHeight Optional minimum height for the video stream. If not specified, uses default value.
      * @param minFrameRate Optional minimum frame rate for the video stream. If not specified, uses default value.
-     * @param minBitRate  Optional minimum bit rate for the video stream. If not specified, uses default value.
-     * @return CHIP_ERROR CHIP_NO_ERROR on success, or an appropriate error code on failure.
+     * @param minBitRate   Optional minimum bit rate for the video stream. If not specified, uses default value.
+     * @return CHIP_ERROR  CHIP_NO_ERROR on success, or an appropriate error code on failure.
      */
     CHIP_ERROR AllocateVideoStream(chip::NodeId nodeId, uint8_t streamUsage,
                                    WebRTCOfferType offerType             = WebRTCOfferType::kProvideOffer,
-                                   chip::Optional<uint16_t> minWidth     = chip::NullOptional,
-                                   chip::Optional<uint16_t> minHeight    = chip::NullOptional,
+                                   chip::Optional<uint16_t> minResWidth  = chip::NullOptional,
+                                   chip::Optional<uint16_t> minResHeight = chip::NullOptional,
                                    chip::Optional<uint16_t> minFrameRate = chip::NullOptional,
                                    chip::Optional<uint32_t> minBitRate   = chip::NullOptional);
 


### PR DESCRIPTION
#### Summary

We need to make camera-app to support more camera on the market.  Refactor the AllocateVideoStream method to accept optional parameters for minimum width, height, frame rate, and bit rate.

#### Related issues

N/A

#### Testing

```
>>> liveview start ?
[1755230217.671] [179226:179226] [-] Command: liveview start ? 
[1755230217.671] [179226:179226] [-] InitArgs: Invalid argument node-id: ?
Usage:
   liveview start node-id [--log-file-path] [--paa-trust-store-path] [--cd-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--use-max-sized-certs] [--only-allow-trusted-cd-keys] [--trace_file] [--trace_log] [--trace_decode] [--trace-to] [--ble-adapter] [--storage-directory] [--commissioner-vendor-id] [--stream-usage] [--min-width] [--min-height] [--min-framerate] [--min-bitrate]

```
