### PR TITLE
[Android][Docker] Upgrade Android API level 30 to 34

### DIFF
--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,1 +1,1 @@
-162 : Remove OpenIOTSdk
+163 : Upgraded from API 30 to API 34

--- a/integrations/docker/images/stage-3/chip-build-android/Dockerfile
+++ b/integrations/docker/images/stage-3/chip-build-android/Dockerfile
@@ -13,14 +13,13 @@ RUN set -x \
 
 # Download and install android SDK
 RUN set -x \
-    && wget -O /tmp/android-30.zip https://dl.google.com/android/repository/platform-30_r03.zip \
+    && wget -O /tmp/android-34.zip https://dl.google.com/android/repository/platform-34-ext7_r03.zip \
     && mkdir -p /opt/android/sdk/platforms \
     && cd /opt/android/sdk/platforms \
-    && unzip /tmp/android-30.zip \
-    && mv android-11 android-30 \
-    && rm -f /tmp/android-30.zip \
+    && unzip /tmp/android-34.zip \
+    && rm -f /tmp/android-34.zip \
     && chmod -R a+rX /opt/android/sdk \
-    && test -d /opt/android/sdk/platforms/android-30 \
+    && test -d /opt/android/sdk/platforms/android-34 \
     && : # last line
 
 # Download and install android command line tool (for installing `sdkmanager`)
@@ -61,9 +60,9 @@ RUN set -x \
     && export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH \
     && cd /tmp && wget https://www.openssl.org/source/openssl-1.1.1t.tar.gz \
     && mkdir -p $OPENSSL_ARMV7 && cd $OPENSSL_ARMV7 && tar xfz /tmp/openssl-1.1.1t.tar.gz \
-    && cd $OPENSSL_ARMV7/openssl-1.1.1t && CC=clang ANDROID_API=26 ./Configure android-arm -U__ANDROID_API__ -D__ANDROID_API__=26 && make -j$(nproc) SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
+    && cd $OPENSSL_ARMV7/openssl-1.1.1t && CC=clang ANDROID_API=34 ./Configure android-arm -U__ANDROID_API__ -D__ANDROID_API__=34 && make -j$(nproc) SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
     && mkdir -p $OPENSSL_X86 && cd $OPENSSL_X86 && tar xfz /tmp/openssl-1.1.1t.tar.gz \
-    && cd $OPENSSL_X86/openssl-1.1.1t && CC=clang ANDROID_API=26 ./Configure android-x86 -U__ANDROID_API__ -D__ANDROID_API__=26 && make  -j$(nproc) SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
+    && cd $OPENSSL_X86/openssl-1.1.1t && CC=clang ANDROID_API=34 ./Configure android-x86 -U__ANDROID_API__ -D__ANDROID_API__=34 && make  -j$(nproc) SHLIB_VERSION_NUMBER= SHLIB_EXT=.so \
     && rm -rf /tmp/openssl-1.1.1t.tar.gz \
     && : # last line
 


### PR DESCRIPTION
#### Summary

Need to upgrade android Docker Image with Android API level 34 to unblock CI checks and be able to upgrade the following BUILD.gn files with Android 34:

	modified:   .github/workflows/full-android.yaml
	modified:   .github/workflows/smoketest-android.yaml
	
	modified:   examples/android/CHIPTest/BUILD.gn
	modified:   examples/tv-app/android/App/.idea/misc.xml
	modified:   examples/tv-app/android/BUILD.gn
	modified:   examples/tv-casting-app/android/BUILD.gn
	modified:   examples/virtual-device-app/android/BUILD.gn
	modified:   src/app/server/java/BUILD.gn
	modified:   src/controller/java/BUILD.gn
	modified:   src/messaging/tests/java/BUILD.gn
	modified:   src/platform/android/BUILD.gn

SDK Platform download link same as the one used in Android Studio:
<img width="973" height="1178" alt="Android Studio SDK Platform 34 download link" src="https://github.com/user-attachments/assets/02561625-f8b9-4eca-8ffe-c8cc02010fd5" />


#### Related issues

https://github.com/project-chip/connectedhomeip/pull/40505 - [Android]upgrade gradle plugin with 8.5.1 #40505
https://github.com/project-chip/connectedhomeip/pull/40462 - Android TV Casting App: Upgrade build system to AGP 8.5.1+ NDK r28 #40462
https://github.com/project-chip/connectedhomeip/pull/40616 - [Android] Update BUILD.gn API level 30 to 34 #40616


#### Testing

Local validation

#### Readability checklist

n/a
