### PR TITLE
[Android] Update BUILD.gn API level 30 to 34

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -36,7 +36,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:162
+            image: ghcr.io/project-chip/chip-build-android:163
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
 

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -34,7 +34,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: ghcr.io/project-chip/chip-build-android:162
+            image: ghcr.io/project-chip/chip-build-android:163
             volumes:
                 - "/:/runner-root-volume"
                 - "/tmp/log_output:/tmp/test_logs"

--- a/docs/platforms/android/android_building.md
+++ b/docs/platforms/android/android_building.md
@@ -63,7 +63,7 @@ downloaded.
        Cake) API Level 34
     2. Apply
 5. Install Emulator:
-    1. Tools -> Device Manager -> Create device -> Pixel 5 -> Android S API 31
+    1. Tools -> Device Manager -> Create device -> Pixel 5 -> Android S API 34
        -> Download
 
 ### Linux

--- a/examples/android/CHIPTest/BUILD.gn
+++ b/examples/android/CHIPTest/BUILD.gn
@@ -72,7 +72,7 @@ android_library("java") {
 }
 
 java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }
 
 group("default") {

--- a/examples/tv-app/android/App/.idea/misc.xml
+++ b/examples/tv-app/android/App/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
       <map>
-        <entry key="../../../../../../../../Library/Android/sdk/platforms/android-30/data/res/layout/simple_list_item_1.xml" value="0.29393115942028986" />
+        <entry key="../../../../../../../../Library/Android/sdk/platforms/android-34/data/res/layout/simple_list_item_1.xml" value="0.29393115942028986" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.29393115942028986" />
         <entry key="platform-app/src/main/res/layout/activity_main.xml" value="0.23697916666666666" />
         <entry key="platform-app/src/main/res/layout/applist_item.xml" value="0.23697916666666666" />

--- a/examples/tv-app/android/BUILD.gn
+++ b/examples/tv-app/android/BUILD.gn
@@ -167,11 +167,11 @@ android_library("java") {
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }
 
 group("default") {

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -121,11 +121,11 @@ android_library("java") {
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }
 
 group("default") {

--- a/examples/virtual-device-app/android/BUILD.gn
+++ b/examples/virtual-device-app/android/BUILD.gn
@@ -85,11 +85,11 @@ android_library("java") {
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }
 
 group("default") {

--- a/src/app/server/java/BUILD.gn
+++ b/src/app/server/java/BUILD.gn
@@ -74,9 +74,9 @@ android_library("java") {
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -686,7 +686,7 @@ android_library("java") {
   ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 if (chip_link_tests) {
@@ -718,7 +718,7 @@ if (chip_link_tests) {
     javac_flags = [ "-Xlint:deprecation" ]
 
     # TODO: add classpath support (we likely need to add something like
-    #  ..../platforms/android-30/android.jar to access BLE items)
+    #  ..../platforms/android-34/android.jar to access BLE items)
   }
 
   android_library("tests") {
@@ -753,12 +753,12 @@ if (chip_link_tests) {
     javac_flags = [ "-Xlint:deprecation" ]
 
     # TODO: add classpath support (we likely need to add something like
-    #  ..../platforms/android-30/android.jar to access BLE items)
+    #  ..../platforms/android-34/android.jar to access BLE items)
   }
 }
 
 if (!matter_enable_java_compilation) {
   java_prebuilt("android") {
-    jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+    jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
   }
 }

--- a/src/messaging/tests/java/BUILD.gn
+++ b/src/messaging/tests/java/BUILD.gn
@@ -79,11 +79,11 @@ android_library("java") {
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
-  #  ..../platforms/android-30/android.jar to access BLE items)
+  #  ..../platforms/android-34/android.jar to access BLE items)
 }
 
 if (!matter_enable_java_compilation) {
   java_prebuilt("android") {
-    jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+    jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
   }
 }

--- a/src/platform/android/BUILD.gn
+++ b/src/platform/android/BUILD.gn
@@ -149,5 +149,5 @@ android_library("java") {
 }
 
 java_prebuilt("android_sdk") {
-  jar_path = "${android_sdk_root}/platforms/android-30/android.jar"
+  jar_path = "${android_sdk_root}/platforms/android-34/android.jar"
 }


### PR DESCRIPTION
#### Summary

Updating the following BUILD.gn files to match the targetSDK level in the corresponding build.gradle files updated in #40505.

	modified:   .github/workflows/full-android.yaml
	modified:   .github/workflows/smoketest-android.yaml

	modified:   examples/android/CHIPTest/BUILD.gn
	modified:   examples/tv-app/android/App/.idea/misc.xml
	modified:   examples/tv-app/android/BUILD.gn
	modified:   examples/tv-casting-app/android/BUILD.gn
	modified:   examples/virtual-device-app/android/BUILD.gn
	modified:   src/app/server/java/BUILD.gn
	modified:   src/controller/java/BUILD.gn
	modified:   src/messaging/tests/java/BUILD.gn
	modified:   src/platform/android/BUILD.gn

#### Related issues

https://github.com/project-chip/connectedhomeip/pull/40505 - [Android]upgrade gradle plugin with 8.5.1 #40505
https://github.com/project-chip/connectedhomeip/pull/40462 - Android TV Casting App: Upgrade build system to AGP 8.5.1+ NDK r28 #40462
https://github.com/project-chip/connectedhomeip/pull/40615 - [Android][Docker] Upgrade Android API level 30 to 34 #40615

#### Testing

Tested that the tv-casting-app build works locally. 

#### Readability checklist

N/A
