### PR TITLE
Fix StreamUsage constraint checks for Audio and Video stream allocation

### DIFF
--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -193,6 +193,13 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamDeallocate
                 ChipLogError(Camera, "Video stream with ID: %d still in use", streamID);
                 return Status::InvalidInState;
             }
+
+            if (stream.videoStreamParams.streamUsage == Globals::StreamUsageEnum::kInternal)
+            {
+                ChipLogError(Camera, "Video stream with ID: %d is Internal", streamID);
+                return Status::DynamicConstraintError;
+            }
+
             // Stop the video stream
             mCameraDeviceHAL->GetCameraHALInterface().StopVideoStream(streamID);
 
@@ -250,6 +257,13 @@ Protocols::InteractionModel::Status CameraAVStreamManager::AudioStreamDeallocate
                 ChipLogError(Camera, "Audio stream with ID: %d still in use", streamID);
                 return Status::InvalidInState;
             }
+
+            if (stream.audioStreamParams.streamUsage == Globals::StreamUsageEnum::kInternal)
+            {
+                ChipLogError(Camera, "Audio stream with ID: %d is Internal", streamID);
+                return Status::DynamicConstraintError;
+            }
+
             // Stop the audio stream
             mCameraDeviceHAL->GetCameraHALInterface().StopAudioStream(streamID);
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1685,11 +1685,12 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
                    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand));
 
     VerifyOrReturn(commandData.streamUsage == Globals::StreamUsageEnum::kRecording ||
-                   commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis  ||
-                   commandData.streamUsage == Globals::StreamUsageEnum::kLiveView, {
-        ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-    });
+                       commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis ||
+                       commandData.streamUsage == Globals::StreamUsageEnum::kLiveView,
+                   {
+                       ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
+                       ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
+                   });
 
     VerifyOrReturn(commandData.videoCodec != VideoCodecEnum::kUnknownEnumValue, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid video codec", mEndpointId);
@@ -1817,11 +1818,12 @@ void CameraAVStreamMgmtServer::HandleAudioStreamAllocate(HandlerContext & ctx,
     uint16_t audioStreamID = 0;
 
     VerifyOrReturn(commandData.streamUsage == Globals::StreamUsageEnum::kRecording ||
-                   commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis  ||
-                   commandData.streamUsage == Globals::StreamUsageEnum::kLiveView, {
-        ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
-        ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
-    });
+                       commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis ||
+                       commandData.streamUsage == Globals::StreamUsageEnum::kLiveView,
+                   {
+                       ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
+                       ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
+                   });
 
     VerifyOrReturn(commandData.audioCodec != AudioCodecEnum::kUnknownEnumValue, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid audio codec", mEndpointId);

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1684,7 +1684,9 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
     VerifyOrReturn((HasFeature(Feature::kOnScreenDisplay) == commandData.OSDEnabled.HasValue()),
                    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::InvalidCommand));
 
-    VerifyOrReturn(commandData.streamUsage != Globals::StreamUsageEnum::kUnknownEnumValue, {
+    VerifyOrReturn(commandData.streamUsage == Globals::StreamUsageEnum::kRecording ||
+                   commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis  ||
+                   commandData.streamUsage == Globals::StreamUsageEnum::kLiveView, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
     });
@@ -1814,7 +1816,9 @@ void CameraAVStreamMgmtServer::HandleAudioStreamAllocate(HandlerContext & ctx,
     Commands::AudioStreamAllocateResponse::Type response;
     uint16_t audioStreamID = 0;
 
-    VerifyOrReturn(commandData.streamUsage != Globals::StreamUsageEnum::kUnknownEnumValue, {
+    VerifyOrReturn(commandData.streamUsage == Globals::StreamUsageEnum::kRecording ||
+                   commandData.streamUsage == Globals::StreamUsageEnum::kAnalysis  ||
+                   commandData.streamUsage == Globals::StreamUsageEnum::kLiveView, {
         ChipLogError(Zcl, "CameraAVStreamMgmt[ep=%d]: Invalid stream usage", mEndpointId);
         ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Status::ConstraintError);
     });

--- a/src/python_testing/TC_AVSM_2_11.py
+++ b/src/python_testing/TC_AVSM_2_11.py
@@ -178,7 +178,8 @@ class TC_AVSM_2_11(MatterBaseTest, AVSMTestBase):
 
         self.step(8)
         try:
-            notSupportedStreamUsage = next((e for e in Globals.Enums.StreamUsageEnum if e not in aSupportedStreamUsages), None)
+            notSupportedStreamUsage = next(
+                (e for e in Globals.Enums.StreamUsageEnum if e not in aSupportedStreamUsages and e != Globals.Enums.StreamUsageEnum.kInternal), None)
             await self.send_single_cmd(
                 endpoint=endpoint, cmd=commands.SetStreamPriorities(streamPriorities=([notSupportedStreamUsage]))
             )

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -90,31 +90,36 @@ class TC_AVSM_2_5(MatterBaseTest):
             ),
             TestStep(
                 8,
+                "TH sends the AudioStreamAllocate command with values from step 6 except with StreamUsage set to Internal",
+                "DUT responds with a CONSTRAINT_ERROR status code.",
+            ),
+            TestStep(
+                9,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with StreamUsage set to a value not in aStreamUsagePriorities",
                 "DUT responds with a INVALID_IN_STATE status code.",
             ),
             TestStep(
-                9,
+                10,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with ChannelCount set to 16(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
-                10,
+                11,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with BitDepth set to 48(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
-                11,
+                12,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with Samplerate set to 0(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
-                12,
+                13,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with BitRate set to 0(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
             TestStep(
-                13,
+                14,
                 "TH sends the AudioStreamAllocate command with values from step 6 except with AudioCodec set to 10(outside of valid range)",
                 "DUT responds with a CONSTRAINT_ERROR status code.",
             ),
@@ -193,12 +198,34 @@ class TC_AVSM_2_5(MatterBaseTest):
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1.")
 
+        outOfConstraintStreamUsage = Globals.Enums.StreamUsageEnum.kInternal
+
+        self.step(8)
+        try:
+            adoStreamAllocateCmd = commands.AudioStreamAllocate(
+                streamUsage=outOfConstraintStreamUsage,
+                audioCodec=aMicrophoneCapabilities.supportedCodecs[0],
+                channelCount=aMicrophoneCapabilities.maxNumberOfChannels,
+                sampleRate=aMicrophoneCapabilities.supportedSampleRates[0],
+                bitRate=aBitRate,
+                bitDepth=aMicrophoneCapabilities.supportedBitDepths[0],
+            )
+            await self.send_single_cmd(endpoint=endpoint, cmd=adoStreamAllocateCmd)
+            asserts.fail("Unexpected success when expecting CONSTRAINT_ERROR due to invalid StreamUsage")
+        except InteractionModelError as e:
+            asserts.assert_equal(
+                e.status,
+                Status.ConstraintError,
+                "Unexpected status returned when expecting CONSTRAINT_ERROR due to invalid StreamUsage",
+            )
+            pass
+
         notSupportedStreamUsage = next(
-            (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
+            (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities and e != Globals.Enums.StreamUsageEnum.kInternal),
             Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
         )
 
-        self.step(8)
+        self.step(9)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=notSupportedStreamUsage,
@@ -218,7 +245,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(9)
+        self.step(10)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -238,7 +265,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(10)
+        self.step(11)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -258,7 +285,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(11)
+        self.step(12)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -278,7 +305,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(12)
+        self.step(13)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],
@@ -298,7 +325,7 @@ class TC_AVSM_2_5(MatterBaseTest):
             )
             pass
 
-        self.step(13)
+        self.step(14)
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=aStreamUsagePriorities[0],

--- a/src/python_testing/TC_AVSM_2_5.py
+++ b/src/python_testing/TC_AVSM_2_5.py
@@ -198,9 +198,8 @@ class TC_AVSM_2_5(MatterBaseTest):
         logger.info(f"Rx'd AllocatedAudioStreams: {aAllocatedAudioStreams}")
         asserts.assert_equal(len(aAllocatedAudioStreams), 1, "The number of allocated audio streams in the list is not 1.")
 
-        outOfConstraintStreamUsage = Globals.Enums.StreamUsageEnum.kInternal
-
         self.step(8)
+        outOfConstraintStreamUsage = Globals.Enums.StreamUsageEnum.kInternal
         try:
             adoStreamAllocateCmd = commands.AudioStreamAllocate(
                 streamUsage=outOfConstraintStreamUsage,

--- a/src/python_testing/TC_AVSM_2_7.py
+++ b/src/python_testing/TC_AVSM_2_7.py
@@ -345,7 +345,7 @@ class TC_AVSM_2_7(MatterBaseTest):
         self.step(17)
         try:
             notSupportedStreamUsage = next(
-                (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities),
+                (e for e in Globals.Enums.StreamUsageEnum if e not in aStreamUsagePriorities and e != Globals.Enums.StreamUsageEnum.kInternal),
                 Globals.Enums.StreamUsageEnum.kUnknownEnumValue,
             )
             videoStreamAllocateCmd = commands.VideoStreamAllocate(


### PR DESCRIPTION
#### Summary
StreamUsages allowed for the Audio/VIdeo StreamAllocate are constrained within Recording, Analysis, LiveView.

Fixes #40488

Also, add the DynamicConstraintError status return if the Audio/Video stream being _de-allocated_ if of StreamUsage `Internal`.

#### Related issues

#### Testing
* AVSM test scripts run successfully against the chip-camera-app after it has been commissioned.
#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
