### PR TITLE
[v1.4.2] ESP32: Add APIs to get random values from secure cert partition (#40563)

### DIFF
--- a/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.cpp
@@ -37,6 +37,9 @@ enum class MatterTLVSubType : uint8_t
     kSpake2pSalt              = 2,
     kSpake2pIterationCount    = 3,
     kRotatingDeviceIdUniqueId = 4,
+    // Subtype identifier for fixed random values set during manufacturing
+    kFixedRandom1 = 128,
+    kFixedRandom2 = 129,
 };
 
 // Scoped wrapper class for handling TLV data retrieval from secure cert partition
@@ -142,6 +145,18 @@ CHIP_ERROR ESP32SecureCertDataProvider::GetRotatingDeviceIdUniqueId(MutableByteS
 #endif // CHIP_ENABLE_ROTATING_DEVICE_ID
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
+
+CHIP_ERROR ESP32SecureCertDataProvider::GetFixedRandom1(MutableByteSpan & randomBuf)
+{
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kFixedRandom1);
+    return tlvInfo.GetValue(randomBuf);
+}
+
+CHIP_ERROR ESP32SecureCertDataProvider::GetFixedRandom2(MutableByteSpan & randomBuf)
+{
+    ScopedTLVInfo tlvInfo(MatterTLVSubType::kFixedRandom2);
+    return tlvInfo.GetValue(randomBuf);
+}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ESP32SecureCertDataProvider.h
+++ b/src/platform/ESP32/ESP32SecureCertDataProvider.h
@@ -47,6 +47,13 @@ public:
     // GetRotatingDeviceIdUniqueId from GenericDeviceInstanceInfoProvider
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER
+
+    // esp-secure-cert partition contains two 32-byte fixed random values that are set during manufacturing
+    // and remain constant for the lifetime of the device. These are unique per device and can be used
+    // for device identification, serial numbers, or any other purpose requiring a device-specific identifier.
+    static constexpr uint32_t kFixedRandomValueLength = 32;
+    static CHIP_ERROR GetFixedRandom1(MutableByteSpan & randomBuf);
+    static CHIP_ERROR GetFixedRandom2(MutableByteSpan & randomBuf);
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
* ESP32: Add APIs to get random values from secure cert partition

* address review from gemini

* add some comments and fix names

#### Summary
Back porting #40563 to v1.4.2-branch

#### Related issues

#### Testing
Flashed a partition which contains the random values and verified that the same random values are being read using the newly introduced APIs.
