### PR TITLE
Testing framework: Make guard functions non-async

### DIFF
--- a/src/python_testing/TC_CC_2_1.py
+++ b/src/python_testing/TC_CC_2_1.py
@@ -154,7 +154,7 @@ class TC_CC_2_1(MatterBaseTest):
         # Validate the expected attribute is found.
         for primary in primary_list:
             attribute_str = primary.format(primary=primary_index)
-            await self._populate_wildcard()
+            self._populate_wildcard()
             has_attr_func = has_attribute(attribute=getattr(self.attributes, attribute_str))
             has_attr_status = has_attr_func(self.stored_global_wildcard, self.endpoint)
             if attribute_str not in instance_attribute_names or not has_attr_status:
@@ -188,7 +188,7 @@ class TC_CC_2_1(MatterBaseTest):
         # If attribute_guard return false it set the current step as skipped so we can finish the step here.
         logger.info(f"Verifying the attribute :  {attribute}")
         # Verify if the attribute is implemented in the current cluster.
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attribute):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attribute):
             # it is so retrieve the value to check the type.
             attr_val = await self.read_single_attribute_check_success(cluster=self.cluster, attribute=attribute, endpoint=self.endpoint)
             logger.info(f"Current value for {attribute} is {attr_val}")
@@ -320,7 +320,7 @@ class TC_CC_2_1(MatterBaseTest):
 
         self.step(23)
         # Manual check
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds):
             sctmr_val = await self.read_single_attribute_check_success(cluster=self.cluster, endpoint=self.endpoint, attribute=self.attributes.StartUpColorTemperatureMireds)
             asserts.assert_true(sctmr_val is NullValue or ((sctmr_val >= 1) and (sctmr_val <= 65279)), "Value is out of range.")
 

--- a/src/python_testing/TC_EGC_2_1.py
+++ b/src/python_testing/TC_EGC_2_1.py
@@ -95,7 +95,7 @@ class TC_EGC_2_1(ElectricalGridConditionsTestBaseHelper, MatterBaseTest):
             self.check_ElectricalGridConditionsStruct(cluster=cluster, struct=val)
 
         self.step("4")
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.ForecastConditions):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.ForecastConditions):
             val = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.ForecastConditions)
             self.check_ForecastConditions(cluster=cluster, forecastConditions=val)
 

--- a/src/python_testing/TC_FAN_4_1.py
+++ b/src/python_testing/TC_FAN_4_1.py
@@ -180,7 +180,7 @@ class TC_FAN_4_1(MatterBaseTest):
         percent_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.PercentSetting)
 
         self.step(8)
-        if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
+        if self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
             speed_setting_original = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
 
         self.step(9)
@@ -213,7 +213,7 @@ class TC_FAN_4_1(MatterBaseTest):
                              "PercentSetting was changed when on/off cluster was changed")
 
         self.step(15)
-        if await self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
+        if self.feature_guard(self.get_endpoint(), cluster=fan, feature_int=fan.Bitmaps.Feature.kMultiSpeed):
             speed_setting_new = await self.read_single_attribute_check_success(cluster=fan, attribute=fan.Attributes.SpeedSetting)
             asserts.assert_equal(speed_setting_new, speed_setting_original,
                                  "SpeedSetting was changed when on/off cluster was changed")

--- a/src/python_testing/TC_MOD_1_2.py
+++ b/src/python_testing/TC_MOD_1_2.py
@@ -139,7 +139,7 @@ class MOD_1_2(MatterBaseTest):
 
         self.step(4)
         # DEPONOFF in the Mandatory/Optional Column
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.OnMode):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.OnMode):
             on_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.OnMode)
             # On mode can be Nullvalue
             self._log_attribute("OnMode", on_mode)
@@ -151,7 +151,7 @@ class MOD_1_2(MatterBaseTest):
 
         # Validate startup mode (attribute Startup is optional)
         self.step(5)
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=self.cluster.Attributes.StartUpMode):
             startup_mode = await self.read_single_attribute_check_success(endpoint=self.endpoint, cluster=self.cluster, attribute=self.cluster.Attributes.StartUpMode)
             self._log_attribute("StartupMode", startup_mode)
             asserts.assert_true(isinstance(startup_mode, int), "Startupmode is not int")

--- a/src/python_testing/TC_MTRID_2_1.py
+++ b/src/python_testing/TC_MTRID_2_1.py
@@ -160,7 +160,7 @@ class TC_MTRID_2_1(MatterBaseTest, MeterIdentificationTestBaseHelper):
             logger.info("PICS MTRID.S.A0003 is not True")
             self.mark_current_step_skipped()
 
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.ProtocolVersion):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.ProtocolVersion):
             val = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.ProtocolVersion
             )
@@ -173,7 +173,7 @@ class TC_MTRID_2_1(MatterBaseTest, MeterIdentificationTestBaseHelper):
             logger.info("PICS MTRID.S.F00 is not True")
             self.mark_current_step_skipped()
 
-        if await self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
+        if self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
             val = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.PowerThreshold
             )
@@ -222,7 +222,7 @@ class TC_MTRID_2_1(MatterBaseTest, MeterIdentificationTestBaseHelper):
             logger.info("PICS MTRID.S.A0003 is not True")
             self.mark_current_step_skipped()
 
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.ProtocolVersion):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.ProtocolVersion):
             val = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.ProtocolVersion
             )
@@ -237,7 +237,7 @@ class TC_MTRID_2_1(MatterBaseTest, MeterIdentificationTestBaseHelper):
             logger.info("PICS MTRID.S.F00 is not True")
             self.mark_current_step_skipped()
 
-        if await self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
+        if self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
             val = await self.read_single_attribute_check_success(
                 endpoint=endpoint, cluster=cluster, attribute=cluster.Attributes.PowerThreshold
             )

--- a/src/python_testing/TC_MTRID_3_1.py
+++ b/src/python_testing/TC_MTRID_3_1.py
@@ -176,7 +176,7 @@ class TC_MTRID_3_1(MatterBaseTest, MeterIdentificationTestBaseHelper):
         await self.subscribe_attribute()
 
         self.step("3")
-        if await self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
+        if self.feature_guard(endpoint=endpoint, cluster=cluster, feature_int=cluster.Bitmaps.Feature.kPowerThreshold):
             power_threshold = await self.read_single_attribute_check_success(endpoint=endpoint, cluster=cluster,
                                                                              attribute=cluster.Attributes.PowerThreshold)
 

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -254,7 +254,7 @@ class TC_OPSTATE_BASE():
             attributes.ClusterRevision.attribute_id
         ]
 
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             expected_value.append(attributes.CountdownTime.attribute_id)
 
         await self.read_and_expect_array_contains(endpoint=endpoint,
@@ -265,19 +265,19 @@ class TC_OPSTATE_BASE():
         self.step(5)
         expected_value = []
 
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Resume))):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Resume))):
             expected_value.append(commands.Pause.command_id)
 
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Stop)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Start))):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Stop)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Start))):
             expected_value.append(commands.Stop.command_id)
 
-        if await self.command_guard(endpoint=endpoint, command=commands.Start):
+        if self.command_guard(endpoint=endpoint, command=commands.Start):
             expected_value.append(commands.Start.command_id)
 
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Resume))):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Resume))):
             expected_value.append(commands.Resume.command_id)
 
         await self.read_and_expect_array_contains(endpoint=endpoint,
@@ -288,10 +288,10 @@ class TC_OPSTATE_BASE():
         self.step(6)
         expected_value = []
 
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Resume)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Stop)) or
-                (await self.command_guard(endpoint=endpoint, command=commands.Start))):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Resume)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Stop)) or
+                (self.command_guard(endpoint=endpoint, command=commands.Start))):
             expected_value.append(commands.OperationalCommandResponse.command_id)
 
         await self.read_and_expect_array_contains(endpoint=endpoint,
@@ -339,7 +339,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 2: TH reads from the DUT the PhaseList attribute
         self.step(2)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.PhaseList):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.PhaseList):
             phase_list = await self.read_expect_success(endpoint=endpoint,
                                                         attribute=attributes.PhaseList)
             if phase_list is not NullValue:
@@ -349,7 +349,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 3: TH reads from the DUT the CurrentPhase attribute
         self.step(3)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CurrentPhase):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CurrentPhase):
             current_phase = await self.read_expect_success(endpoint=endpoint,
                                                            attribute=attributes.CurrentPhase)
             if (phase_list == NullValue) or (not phase_list):
@@ -361,7 +361,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 4: TH reads from the DUT the CountdownTime attribute
         self.step(4)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                             attribute=attributes.CountdownTime)
             if countdown_time is not NullValue:
@@ -370,7 +370,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 5: TH reads from the DUT the OperationalStateList attribute
         self.step(5)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalStateList):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalStateList):
             operational_state_list = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.OperationalStateList)
             defined_states = [state.value for state in cluster.Enums.OperationalStateEnum
@@ -456,7 +456,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 7: TH reads from the DUT the OperationalError attribute
         self.step(7)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalError):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalError):
             operational_error = await self.read_expect_success(endpoint=endpoint,
                                                                attribute=attributes.OperationalError)
             # Defined Errors
@@ -591,7 +591,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 3: TH reads from the DUT the OperationalStateList attribute
         self.step(3)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalStateList):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalStateList):
             operational_state_list = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.OperationalStateList)
 
@@ -606,7 +606,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 4: TH sends Start command to the DUT
         self.step(4)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Start(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -619,7 +619,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 6: TH reads from the DUT the OperationalError attribute
         self.step(6)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalError):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.OperationalError):
             await self.read_and_expect_property_value(endpoint=endpoint,
                                                       attribute=attributes.OperationalError,
                                                       attr_property="errorStateID",
@@ -627,7 +627,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 7: TH reads from the DUT the CountdownTime attribute
         self.step(7)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             initial_countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.CountdownTime)
             if initial_countdown_time is not NullValue:
@@ -636,7 +636,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 8: TH reads from the DUT the PhaseList attribute
         self.step(8)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.PhaseList):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.PhaseList):
             phase_list = await self.read_expect_success(endpoint=endpoint,
                                                         attribute=attributes.PhaseList)
             phase_list_len = 0
@@ -647,7 +647,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 9: TH reads from the DUT the CurrentPhase attribute
         self.step(9)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CurrentPhase):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CurrentPhase):
             current_phase = await self.read_expect_success(endpoint=endpoint,
                                                            attribute=attributes.CurrentPhase)
             if (phase_list == NullValue) or (not phase_list):
@@ -660,12 +660,12 @@ class TC_OPSTATE_BASE():
 
         # STEP 10: TH waits for {PIXIT.WAITTIME.COUNTDOWN}
         self.step(10)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             time.sleep(wait_time)
 
         # STEP 11: TH reads from the DUT the CountdownTime attribute
         self.step(11)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                             attribute=attributes.CountdownTime)
 
@@ -677,14 +677,14 @@ class TC_OPSTATE_BASE():
 
         # STEP 12: TH sends Start command to the DUT
         self.step(12)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Start(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
 
         # STEP 13: TH sends Stop command to the DUT
         self.step(13)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Stop(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -697,7 +697,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 15: TH sends Stop command to the DUT
         self.step(15)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Stop(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -713,7 +713,7 @@ class TC_OPSTATE_BASE():
         # STEP 17: TH sends Start command to the DUT
         self.step(17)
         if self.pics_guard((self.check_pics(f"{self.test_info.pics_code}.S.M.ERR_UNABLE_TO_START_OR_RESUME")) and
-                           ((await self.command_guard(endpoint=endpoint, command=commands.Start)) and
+                           ((self.command_guard(endpoint=endpoint, command=commands.Start)) and
                            (commands.OperationalCommandResponse.command_id in generated_cmd_list))):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Start(),
@@ -792,7 +792,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 4: TH sends Pause command to the DUT
         self.step(4)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Pause(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -805,7 +805,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 6: TH reads from the DUT the CountdownTime attribute
         self.step(6)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             initial_countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.CountdownTime)
             if initial_countdown_time is not NullValue:
@@ -819,7 +819,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 8: TH reads from the DUT the CountdownTime attribute
         self.step(8)
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                             attribute=attributes.CountdownTime)
 
@@ -831,14 +831,14 @@ class TC_OPSTATE_BASE():
 
         # STEP 9: TH sends Pause command to the DUT
         self.step(9)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Pause(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
 
         # STEP 10: TH sends Resume command to the DUT
         self.step(10)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Resume(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -851,7 +851,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 12: TH sends Resume command to the DUT
         self.step(12)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Resume(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -865,14 +865,14 @@ class TC_OPSTATE_BASE():
 
         # STEP 14: TH sends Pause command to the DUT
         self.step(14)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Pause(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kCommandInvalidInState)
 
         # STEP 15: TH sends Resume command to the DUT
         self.step(15)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Resume(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kCommandInvalidInState)
@@ -887,14 +887,14 @@ class TC_OPSTATE_BASE():
 
         # STEP 17: TH sends Pause command to the DUT
         self.step(17)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Pause(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kCommandInvalidInState)
 
         # STEP 18: TH sends Resume command to the DUT
         self.step(18)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Resume(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kCommandInvalidInState)
@@ -1074,7 +1074,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 8: TH sends Start command to the DUT
         self.step(8)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Start(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -1082,7 +1082,7 @@ class TC_OPSTATE_BASE():
         # STEP 9: TH reads from the DUT the CountdownTime attribute
         self.step(9)
         initial_countdown_time = NullValue
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.CountdownTime):
             initial_countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.CountdownTime)
 
@@ -1103,7 +1103,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 12: TH sends Stop command to the DUT
         self.step(12)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Stop(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -1149,7 +1149,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 17: TH sends Start command to the DUT
         self.step(17)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Start)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Start(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -1162,7 +1162,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 19: TH sends Pause command to the DUT
         self.step(19)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Pause)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Pause(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -1179,7 +1179,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 22: TH sends Resume command to the DUT
         self.step(22)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Resume)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Resume(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)
@@ -1196,7 +1196,7 @@ class TC_OPSTATE_BASE():
 
         # STEP 25: TH sends Stop command to the DUT
         self.step(25)
-        if ((await self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
+        if ((self.command_guard(endpoint=endpoint, command=commands.Stop)) and (commands.OperationalCommandResponse.command_id in generated_cmd_list)):
             await self.send_cmd_expect_response(endpoint=endpoint,
                                                 cmd=commands.Stop(),
                                                 expected_response=cluster.Enums.ErrorStateEnum.kNoError)

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -152,7 +152,7 @@ class TC_RR_1_1(MatterBaseTest):
         asserts.assert_greater_equal(capability_minima.caseSessionsPerFabric, 3)
 
         fabric_table_entries_to_check: dict[int, FabricTableEntryToCheck] = {}
-        await self._populate_wildcard()
+        self._populate_wildcard()
         supports_vid_verification = Clusters.OperationalCredentials.Commands.SetVIDVerificationStatement.command_id in self.stored_global_wildcard.attributes[
             0][Clusters.OperationalCredentials][Clusters.OperationalCredentials.Attributes.AcceptedCommandList]
         logging.info(f"Device supports VID verification: {supports_vid_verification}")

--- a/src/python_testing/TC_RVCOPSTATE_2_1.py
+++ b/src/python_testing/TC_RVCOPSTATE_2_1.py
@@ -101,7 +101,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
         if self.is_ci:
             self.write_to_app_pipe({"Name": "Reset"})
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.PhaseList):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.PhaseList):
             self.print_step(2, "Read PhaseList attribute")
             phase_list = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.PhaseList)
 
@@ -114,7 +114,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
 
                 asserts.assert_less_equal(phase_list_len, 32, "PhaseList length(%d) must be less than 32!" % phase_list_len)
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.CurrentPhase):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.CurrentPhase):
             self.print_step(3, "Read CurrentPhase attribute")
             current_phase = await self.read_mod_attribute_expect_success(endpoint=self.endpoint, attribute=attributes.CurrentPhase)
             logging.info("CurrentPhase: %s" % (current_phase))
@@ -125,7 +125,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
                 asserts.assert_true(0 <= current_phase < phase_list_len,
                                     "CurrentPhase(%s) must be between 0 and %d" % (current_phase, (phase_list_len - 1)))
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.CountdownTime):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.CountdownTime):
             self.print_step(4, "Read CountdownTime attribute")
             countdown_time = await self.read_mod_attribute_expect_success(endpoint=self.endpoint,
                                                                           attribute=attributes.CountdownTime)
@@ -135,7 +135,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
                 asserts.assert_true(countdown_time >= 0 and countdown_time <= 259200,
                                     "CountdownTime(%s) must be between 0 and 259200" % countdown_time)
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalStateList):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalStateList):
             self.print_step(5, "Read OperationalStateList attribute")
             operational_state_list = await self.read_mod_attribute_expect_success(endpoint=self.endpoint,
                                                                                   attribute=attributes.OperationalStateList)
@@ -158,7 +158,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
 
             asserts.assert_true(error_state_present, "The OperationalStateList does not have an ID entry of Error(0x03)")
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalState):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalState):
             self.print_step(6, "Read OperationalState attribute")
             operational_state = await self.read_mod_attribute_expect_success(endpoint=self.endpoint,
                                                                              attribute=attributes.OperationalState)
@@ -267,7 +267,7 @@ class TC_RVCOPSTATE_2_1(MatterBaseTest):
                     self.wait_for_user_input(prompt_msg=f"{test_step}, and press Enter when done.\n")
                 await self.read_and_validate_opstate(step="6v", expected_state=Clusters.RvcOperationalState.Enums.OperationalStateEnum.kUpdatingMaps)
 
-        if await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalError):
+        if self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalError):
             self.print_step(7, "Read OperationalError attribute")
             operational_error = await self.read_mod_attribute_expect_success(endpoint=self.endpoint,
                                                                              attribute=attributes.OperationalError)

--- a/src/python_testing/TC_SEPR_2_1.py
+++ b/src/python_testing/TC_SEPR_2_1.py
@@ -118,7 +118,7 @@ class TC_SEPR_2_1(CommodityPriceTestBaseHelper, MatterBaseTest):
             self.check_CommodityPriceStruct(cluster=cluster, struct=val)
 
         self.step("5")
-        if await self.attribute_guard(endpoint=endpoint, attribute=attributes.PriceForecast):
+        if self.attribute_guard(endpoint=endpoint, attribute=attributes.PriceForecast):
             val = await self.read_single_attribute_check_success(endpoint=endpoint,
                                                                  cluster=cluster,
                                                                  attribute=cluster.Attributes.PriceForecast)

--- a/src/python_testing/TC_TMP_2_1.py
+++ b/src/python_testing/TC_TMP_2_1.py
@@ -105,7 +105,7 @@ class TC_TMP_2_1(MatterBaseTest):
                 measured_value, max_bound, "Measured value is greater than max bound")
 
         self.step(7)
-        if await self.attribute_guard(self.get_endpoint(), attr.Tolerance):
+        if self.attribute_guard(self.get_endpoint(), attr.Tolerance):
             tolerance = await self.read_single_attribute_check_success(cluster=cluster, attribute=attr.Tolerance)
             asserts.assert_greater_equal(tolerance, 0, "Tolerance is less than 0")
             asserts.assert_less_equal(

--- a/src/python_testing/TC_TestAttrAvail.py
+++ b/src/python_testing/TC_TestAttrAvail.py
@@ -146,17 +146,18 @@ class TC_TestAttrAvail(MatterBaseTest):
         self.th1 = self.default_controller
 
         self.step(2)
-        attr_should_be_there = await self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalState)
+        attr_should_be_there = self.attribute_guard(endpoint=self.endpoint, attribute=attributes.OperationalState)
         asserts.assert_true(attr_should_be_there, True)
         self.print_step("Operational State Attr", attr_should_be_there)
 
         self.step(3)
-        cmd_should_be_there = await self.command_guard(endpoint=self.endpoint, command=commands.Resume)
+        cmd_should_be_there = self.command_guard(endpoint=self.endpoint, command=commands.Resume)
         asserts.assert_true(cmd_should_be_there, True)
         self.print_step("Operational Resume Command available ", cmd_should_be_there)
 
         self.step(4)
-        feat_should_be_there = await self.feature_guard(endpoint=self.endpoint, cluster=Clusters.BooleanStateConfiguration, feature_int=Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible)
+        feat_should_be_there = self.feature_guard(endpoint=self.endpoint, cluster=Clusters.BooleanStateConfiguration,
+                                                  feature_int=Clusters.BooleanStateConfiguration.Bitmaps.Feature.kAudible)
         asserts.assert_true(feat_should_be_there, True)
         self.print_step("Boolean State Config Audio Feature available ", feat_should_be_there)
 

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -728,14 +728,15 @@ class MatterBaseTest(base_test.BaseTestClass):
             self.mark_current_step_skipped()
         return pics_condition
 
-    async def _populate_wildcard(self):
+
+    def _populate_wildcard(self):
         """ Populates self.stored_global_wildcard if not already filled. """
         if self.stored_global_wildcard is None:
             global_wildcard = asyncio.wait_for(self.default_controller.Read(self.dut_node_id, [(Clusters.Descriptor), Attribute.AttributePath(None, None, GlobalAttributeIds.ATTRIBUTE_LIST_ID), Attribute.AttributePath(
                 None, None, GlobalAttributeIds.FEATURE_MAP_ID), Attribute.AttributePath(None, None, GlobalAttributeIds.ACCEPTED_COMMAND_LIST_ID)]), timeout=60)
-            self.stored_global_wildcard = await global_wildcard
+            self.stored_global_wildcard = self.event_loop.run_until_complete(global_wildcard)
 
-    async def attribute_guard(self, endpoint: int, attribute: ClusterObjects.ClusterAttributeDescriptor):
+    def attribute_guard(self, endpoint: int, attribute: ClusterObjects.ClusterAttributeDescriptor):
         """Similar to pics_guard above, except checks a condition and if False marks the test step as skipped and
            returns False using attributes against attributes_list, otherwise returns True.
            For example can be used to check if a test step should be run:
@@ -748,13 +749,13 @@ class MatterBaseTest(base_test.BaseTestClass):
               if self.attribute_guard(condition2_needs_to_be_false_to_skip_step):
                   # skip step 2 if condition not met
            """
-        await self._populate_wildcard()
+        self._populate_wildcard()
         attr_condition = _has_attribute(wildcard=self.stored_global_wildcard, endpoint=endpoint, attribute=attribute)
         if not attr_condition:
             self.mark_current_step_skipped()
         return attr_condition
 
-    async def command_guard(self, endpoint: int, command: ClusterObjects.ClusterCommand):
+    def command_guard(self, endpoint: int, command: ClusterObjects.ClusterCommand):
         """Similar to attribute_guard above, except checks a condition and if False marks the test step as skipped and
            returns False using command id against AcceptedCmdsList, otherwise returns True.
            For example can be used to check if a test step should be run:
@@ -767,13 +768,13 @@ class MatterBaseTest(base_test.BaseTestClass):
               if self.command_guard(condition2_needs_to_be_false_to_skip_step):
                   # skip step 2 if condition not met
            """
-        await self._populate_wildcard()
+        self._populate_wildcard()
         cmd_condition = _has_command(wildcard=self.stored_global_wildcard, endpoint=endpoint, command=command)
         if not cmd_condition:
             self.mark_current_step_skipped()
         return cmd_condition
 
-    async def feature_guard(self, endpoint: int, cluster: ClusterObjects.ClusterObjectDescriptor, feature_int: IntFlag):
+    def feature_guard(self, endpoint: int, cluster: ClusterObjects.ClusterObjectDescriptor, feature_int: IntFlag):
         """Similar to command_guard and attribute_guard above, except checks a condition and if False marks the test step as skipped and
            returns False using feature id against feature_map, otherwise returns True.
            For example can be used to check if a test step should be run:
@@ -786,7 +787,7 @@ class MatterBaseTest(base_test.BaseTestClass):
               if self.feature_guard(condition2_needs_to_be_false_to_skip_step):
                   # skip step 2 if condition not met
            """
-        await self._populate_wildcard()
+        self._populate_wildcard()
         feat_condition = _has_feature(wildcard=self.stored_global_wildcard, endpoint=endpoint, cluster=cluster, feature=feature_int)
         if not feat_condition:
             self.mark_current_step_skipped()

--- a/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/matter/testing/matter_testing.py
@@ -728,7 +728,6 @@ class MatterBaseTest(base_test.BaseTestClass):
             self.mark_current_step_skipped()
         return pics_condition
 
-
     def _populate_wildcard(self):
         """ Populates self.stored_global_wildcard if not already filled. """
         if self.stored_global_wildcard is None:


### PR DESCRIPTION
#### Summary
This PR makes all the x_guard functions in the test framework non-async.

##### Why am I doing this?
This is part of the preparation for code that will generate the device-element PICS from the device rather than reading them from a file. This will eventually allow us to remove these PICS from the PICS files and cut down on the amount of manual work required to prepare a device for certification. This work will start on the python framework and be later implemented on the YAML testing framework.

In order to generate dynamic PICS for a device, we will need the wildcard to be available for every test. Rather than lazy-initializing, it makes more sense to handle this as a part of the test suite setup and pass this information in the same way that we pass in the Matter stack. In this scenario, the stored values will always be available before the test starts and we don't need to do any async work. I am separating the changes into smaller PRs to allow for easier review.

A full overview of the work to use dynamic PICS is available in the SWTT drive folder here: https://docs.google.com/document/d/1e58aXXYEp2coybb2gsLh7L9G__3Ye7mi2gzAnCdsKiM/edit?tab=t.0#heading=h.4hiccodslk4y

#### Testing

The affected tests are all run in the CI

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
