### PR TITLE
Fix crash if JSON Revocation Set is malformed

### DIFF
--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -168,7 +168,8 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
     // 6.2.4.2. Determining Revocation Status of an Entity
     for (const auto & revokedSet : jsonData)
     {
-        VerifyOrReturnValue(revokedSet.isObject(), false, ChipLogError(NotSpecified, "Revocation set is not a valid JSON object"));
+        VerifyOrReturnValue(revokedSet.isObject(), false,
+                            ChipLogError(NotSpecified, "Revocation set entry is not a valid JSON object"));
 
         if (revokedSet["issuer_name"].asString() != issuerNameBase64Str)
         {

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -168,6 +168,8 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
     // 6.2.4.2. Determining Revocation Status of an Entity
     for (const auto & revokedSet : jsonData)
     {
+        VerifyOrReturnValue(revokedSet.isObject(), false, ChipLogError(NotSpecified, "Revocation set is not a valid JSON object"));
+
         if (revokedSet["issuer_name"].asString() != issuerNameBase64Str)
         {
             continue;

--- a/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
+++ b/src/credentials/attestation_verifier/TestDACRevocationDelegateImpl.cpp
@@ -165,6 +165,8 @@ bool TestDACRevocationDelegateImpl::IsEntryInRevocationSet(const std::string & a
         return false;
     }
 
+    VerifyOrReturnValue(jsonData.isArray(), false, ChipLogError(NotSpecified, "Revocation set is not a valid JSON Array"));
+
     // 6.2.4.2. Determining Revocation Status of an Entity
     for (const auto & revokedSet : jsonData)
     {

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -643,6 +643,24 @@ TEST_F(TestDeviceAttestationCredentials, TestDACRevocationDelegateImpl)
     revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
     revocationDelegateImpl.ClearDeviceAttestationRevocationData();
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
+
+    // test with malformed JSON which is missing the initial brace "["
+    // the revocation_set will fail the revokedSet.isObject() check
+    jsonData = R"(
+   {
+        "type": "revocation_set",
+        "issuer_subject_key_id": "AF42B7094DEBD515EC6ECF33B81115225F325288",
+        "issuer_name": "MEYxGDAWBgNVBAMMD01hdHRlciBUZXN0IFBBStEUMBIGCisGAQQBgqJ8AgEMBEZGRjExFDASBgorBgEEAYKifAICDAQ4MDAw",
+        "crl_signer_cert":
+"MIIB1DCCAXqgAwIBAgIIPmzmUJrYQM0wCgYIKoZIzj0EAwIwMDEYMBYGA1UEAwwPTWF0dGVyIFRlc3QgUEFBMRQwEgYKKwYBBAGConwCAQwERkZGMTAgFw0yMTA2MjgxNDIzNDNaGA85OTk5MTIzMTIzNTk1OVowRjEYMBYGA1UEAwwPTWF0dGVyIFRlc3QgUEFJMRQwEgYKKwYBBAGConwCAQwERkZGMTEUMBIGCisGAQQBgqJ8AgIMBDgwMDAwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASA3fEbIo8+MfY7z1eY2hRiOuu96C7zeO6tv7GP4avOMdCO1LIGBLbMxtm1+rZOfeEMt0vgF8nsFRYFbXDyzQsio2YwZDASBgNVHRMBAf8ECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUr0K3CU3r1RXsbs8zuBEVIl8yUogwHwYDVR0jBBgwFoAUav0idx9RH+y/FkGXZxDc3DGhcX4wCgYIKoZIzj0EAwIDSAAwRQIhAJbJyM8uAYhgBdj1vHLAe3X9mldpWsSRETETi+oDPOUDAiAlVJQ75X1T1sR199I+v8/CA2zSm6Y5PsfvrYcUq3GCGQ==",
+        "revoked_serial_numbers": ["0C694F7F866067B2"]
+    }]
+    )";
+
+    revocationDelegateImpl.SetDeviceAttestationRevocationData(jsonData);
+    revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);
+    revocationDelegateImpl.ClearDeviceAttestationRevocationData();
+    EXPECT_EQ(attestationResult, AttestationVerificationResult::kSuccess);
 }
 
 TEST(DeviceAttestationVerifier, GetAttestationResultDescriptionWorks)


### PR DESCRIPTION
#### Summary

- This crash was found while fuzzing with a `pw_fuzzer` FuzzTest

- When using `TestDACRevocationDelegateImpl` and the JSON that holds revocation sets is malformed, we get a crash in the call to ` revocationDelegateImpl.CheckForRevokedDACChain(info, &attestationInformationVerificationCallback);`

- The crash happens in the third party `jsoncpp`, in the `[ ]` Operator overload which gets called by `revokedSet["issuer_name"].asString() `


- Fix: checking that `revokedSet` is a valid object before invoking  `[ ]` Operator.

#### Testing

Added a testcase with the JSON that triggered the crash
