### PR TITLE
[TC-SC-3.4] Fix script: Remove timeout from `GetConnectedDevice` 

### DIFF
--- a/src/python_testing/TC_SC_3_4.py
+++ b/src/python_testing/TC_SC_3_4.py
@@ -107,7 +107,7 @@ class TC_SC_3_4(MatterBaseTest):
         expectedErrorCode = CHIP_ERROR_CODES.get(expectedErrorName)
 
         with asserts.assert_raises(ChipStackError) as e:
-            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False)
         asserts.assert_equal(e.exception.err,  expectedErrorCode, f"Expected to return {expectedErrorName}")
 
     def ensure_fault_injection_point_was_reached(self, faultID):
@@ -122,7 +122,7 @@ class TC_SC_3_4(MatterBaseTest):
         self.step("precondition")
         # DUT Should be Commissioned Already, Now we try to Establish a CASE Session with it
         try:
-            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False)
         except ChipStackError as e:  # chipstack-ok: This disables ChipStackError linter check. Can not use assert_raises because error is not expected
             asserts.fail(
                 f"Unexpected Failure, TH Should be able to establish a CASE Session with DUT \nError = {e}")
@@ -154,7 +154,7 @@ class TC_SC_3_4(MatterBaseTest):
                     )
         self.th.MarkSessionForEviction(nodeid=self.dut_node_id)
         try:
-            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False, timeoutMs=1000)
+            await self.th.GetConnectedDevice(nodeid=self.dut_node_id, allowPASE=False)
         except ChipStackError as e:  # chipstack-ok: This disables ChipStackError linter check. Can not use assert_raises because error is not expected
             asserts.fail(
                 f"Unexpected CASE Establishment Failure, CASE Should have succeeded. Having an invalid InitiatorResumeMIC should have resulted in CASE falling back to the standard CASE without resumption. \nError = {e}")


### PR DESCRIPTION
#### Summary


- Fixes https://github.com/project-chip/certification-tool/issues/670

- Basically timeout for `GetConnectedDevice` was set to 1 second, and since  `GetConnectedDevice`  will is used in the test to reestablish CASE Session, it might happen that it takes more than 1 second or even 5 seconds in case of sleepy devices using Thread.

- FIX: remove timeout all together from  `GetConnectedDevice` 

#### Testing

- Tested by Issue Reporter locally


