### PR TITLE
Add missing sibling test cases to TestMatterTestingSupport

### DIFF
--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -531,9 +531,9 @@ class TestMatterTestingSupport(MatterBaseTest):
         # 1 (dt 1) - 2 (dt 2) - tag 2,3
         #          - 3 (dt 2) - tag 2,4
         desc_ep1 = {Clusters.Descriptor.Attributes.FeatureMap: 0,
-            Clusters.Descriptor.Attributes.PartsList: [2, 3],
-            Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(1, 1)],
-            }
+                    Clusters.Descriptor.Attributes.PartsList: [2, 3],
+                    Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(1, 1)],
+                    }
 
         desc_dt2_tag23 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                           Clusters.Descriptor.Attributes.PartsList: [],

--- a/src/python_testing/TestMatterTestingSupport.py
+++ b/src/python_testing/TestMatterTestingSupport.py
@@ -389,7 +389,7 @@ class TestMatterTestingSupport(MatterBaseTest):
 
         # Add the feature for every endpoint, but not the attribute
         for ep in expected_problems:
-            endpoints[ep][Clusters.Descriptor][Clusters.Descriptor.Attributes.FeatureMap] = 1
+            endpoints[ep][Clusters.Descriptor][Clusters.Descriptor.Attributes.FeatureMap] = Clusters.Descriptor.Bitmaps.Feature.kTagList
         problems = find_tag_list_problems(roots, device_types, endpoints)
         for root in roots:
             eps = get_all_children(root, endpoints)
@@ -429,7 +429,7 @@ class TestMatterTestingSupport(MatterBaseTest):
             tag = Clusters.Descriptor.Structs.SemanticTagStruct(tag=ep)
             endpoints[ep][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [tag]
         problems = find_tag_list_problems(roots, device_types, endpoints)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # Remove all the feature maps, we should get all errors again
         for ep in expected_problems:
@@ -448,12 +448,12 @@ class TestMatterTestingSupport(MatterBaseTest):
         #          - 3 (dt 2) - tag 3
         # 4 (dt 1) - 5 (dt 2) - tag 2
         #          - 6 (dt 2) - tag 3
-        desc_dt2_tag2 = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        desc_dt2_tag2 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                          Clusters.Descriptor.Attributes.PartsList: [],
                          Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
                          Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=2)]
                          }
-        desc_dt2_tag3 = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        desc_dt2_tag3 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                          Clusters.Descriptor.Attributes.PartsList: [],
                          Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
                          Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=3)]
@@ -479,18 +479,69 @@ class TestMatterTestingSupport(MatterBaseTest):
         device_types = create_device_type_lists(roots, new_endpoints)
 
         problems = find_tag_list_problems(roots, device_types, new_endpoints)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
+
+        # Create a tree with two instances each of two device types, at same tree level (two sets of siblings,
+        # each with same tags between the two device type sets. This must be OK since tag duplicate checks
+        # should be "by device type".
+        #
+        # 1 (dt 1) - 2 (dt 2) - tag 2
+        #          - 3 (dt 2) - tag 3
+        #          - 4 (dt 3) - tag 2
+        #          - 5 (dt 3) - tag 3
+        desc_ep1 = {Clusters.Descriptor.Attributes.FeatureMap: 0,
+                    Clusters.Descriptor.Attributes.PartsList: [2, 3, 4, 5],
+                    Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(1, 1)],
+                    }
+        desc_dt2_tag2 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
+                         Clusters.Descriptor.Attributes.PartsList: [],
+                         Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
+                         Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=2)]
+                         }
+        desc_dt2_tag3 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
+                         Clusters.Descriptor.Attributes.PartsList: [],
+                         Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
+                         Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=3)]
+                         }
+        desc_dt3_tag2 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
+                         Clusters.Descriptor.Attributes.PartsList: [],
+                         Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(3, 1)],
+                         Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=2)]
+                         }
+        desc_dt3_tag3 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
+                         Clusters.Descriptor.Attributes.PartsList: [],
+                         Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(3, 1)],
+                         Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(tag=3)]
+                         }
+        new_endpoints = {}
+        new_endpoints[1] = {Clusters.Descriptor: desc_ep1}
+        new_endpoints[2] = {Clusters.Descriptor: desc_dt2_tag2}
+        new_endpoints[3] = {Clusters.Descriptor: desc_dt2_tag3}
+        new_endpoints[4] = {Clusters.Descriptor: desc_dt3_tag2}
+        new_endpoints[5] = {Clusters.Descriptor: desc_dt3_tag3}
+
+        _, tree = separate_endpoint_types(new_endpoints)
+        roots = find_tree_roots(tree, new_endpoints)
+        device_types = create_device_type_lists(roots, new_endpoints)
+
+        problems = find_tag_list_problems(roots, device_types, new_endpoints)
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # Create a simple tree where ONE of the tags in the set matches, but not the other - should be no problems
         # 1 (dt 1) - 2 (dt 2) - tag 2,3
         #          - 3 (dt 2) - tag 2,4
-        desc_dt2_tag23 = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        desc_ep1 = {Clusters.Descriptor.Attributes.FeatureMap: 0,
+            Clusters.Descriptor.Attributes.PartsList: [2, 3],
+            Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(1, 1)],
+            }
+
+        desc_dt2_tag23 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                           Clusters.Descriptor.Attributes.PartsList: [],
                           Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
                           Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(
                               tag=2), Clusters.Descriptor.Structs.SemanticTagStruct(tag=3)]
                           }
-        desc_dt2_tag24 = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        desc_dt2_tag24 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                           Clusters.Descriptor.Attributes.PartsList: [],
                           Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
                           Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(
@@ -506,10 +557,10 @@ class TestMatterTestingSupport(MatterBaseTest):
         device_types = create_device_type_lists(roots, simple)
 
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # now both match, but the ordering is different - this SHOULD be a problem
-        desc_dt2_tag32 = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        desc_dt2_tag32 = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                           Clusters.Descriptor.Attributes.PartsList: [],
                           Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(2, 1)],
                           Clusters.Descriptor.Attributes.TagList: [Clusters.Descriptor.Structs.SemanticTagStruct(
@@ -531,31 +582,31 @@ class TestMatterTestingSupport(MatterBaseTest):
             Clusters.Descriptor.Structs.SemanticTagStruct(mfgCode=1)]
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [Clusters.Descriptor.Structs.SemanticTagStruct()]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [
             Clusters.Descriptor.Structs.SemanticTagStruct(mfgCode=2)]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # Different namespace ids
         simple[2][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [
             Clusters.Descriptor.Structs.SemanticTagStruct(namespaceID=1)]
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [Clusters.Descriptor.Structs.SemanticTagStruct()]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # Different labels
         simple[2][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [
             Clusters.Descriptor.Structs.SemanticTagStruct(label="test")]
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [Clusters.Descriptor.Structs.SemanticTagStruct()]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [
             Clusters.Descriptor.Structs.SemanticTagStruct(label="test1")]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # One tag list is a subset of the other - this should pass
         tag1 = Clusters.Descriptor.Structs.SemanticTagStruct(tag=1)
@@ -565,7 +616,7 @@ class TestMatterTestingSupport(MatterBaseTest):
         simple[2][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [tag1, tag2]
         simple[3][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [tag1, tag2, tag3]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
         # Tags with mfg tags
         tag_mfg = Clusters.Descriptor.Structs.SemanticTagStruct(mfgCode=0xFFF1, label="test")
@@ -573,7 +624,7 @@ class TestMatterTestingSupport(MatterBaseTest):
         simple[1][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [tag1, tag_mfg]
         simple[2][Clusters.Descriptor][Clusters.Descriptor.Attributes.TagList] = [tag1, tag_label]
         problems = find_tag_list_problems(roots, device_types, simple)
-        asserts.assert_equal(len(problems), 0, "Unexpected problems found in list")
+        asserts.assert_equal(len(problems), 0, f"Expected no problems, but found some: {problems}")
 
     def test_root_node_tag_list_functions(self):
         # Example topology - see comment above for the layout.
@@ -586,7 +637,7 @@ class TestMatterTestingSupport(MatterBaseTest):
         asserts.assert_equal(expected, direct, 'Incorrect list of direct children returned from root')
 
         # add a new child endpoint that's an aggregator on EP 20
-        aggregator_desc = {Clusters.Descriptor.Attributes.FeatureMap: 1,
+        aggregator_desc = {Clusters.Descriptor.Attributes.FeatureMap: Clusters.Descriptor.Bitmaps.Feature.kTagList,
                            Clusters.Descriptor.Attributes.PartsList: [],
                            Clusters.Descriptor.Attributes.DeviceTypeList: [Clusters.Descriptor.Structs.DeviceTypeStruct(0xe)],
                            }


### PR DESCRIPTION
#### Summary
- Add missing test to cover for:
  - > If no disambiguation method is defined in the relevant device type definitions, an endpoint to which the Duplicate condition applies SHALL have a TagList attribute in its Descriptor cluster and its set of tags SHALL be distinct from the set of tags of any sibling endpoint with which it has an overlap in application device type(s). When comparing sets of tags, ordering of the list SHALL be ignored.
  - This test case was missing, to cover for "siblings of different device types, where there are groups of siblings with same device type".
- Also improve some magic numbers at the same time.
- Fix a data dependency on data from prior case that broke a sub-case
- Improved logging of problems found when we expected none

#### Testing
- New sub-test passes (as expected)
- Made the sub-test fail on purpose by data change and it did fail
