### PR TITLE
Use C++17 syntax to properly define BLEEndPoint storage alignment

### DIFF
--- a/src/ble/BLEEndPoint.h
+++ b/src/ble/BLEEndPoint.h
@@ -66,8 +66,6 @@ class DLL_EXPORT BLEEndPoint
     friend class BleEndPointPool;
 
 public:
-    typedef uint64_t AlignT;
-
     // Public data members:
     enum
     {

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -88,7 +88,7 @@ public:
 
     BLEEndPoint * Get(size_t i) const
     {
-        alignas(BLEEndPoint) static std::byte sStorage[sizeof(BLEEndPoint)];
+        alignas(BLEEndPoint) static std::byte sStorage[sizeof(BLEEndPoint) * BLE_LAYER_NUM_BLE_ENDPOINTS];
         VerifyOrReturnValue(i < BLE_LAYER_NUM_BLE_ENDPOINTS, nullptr);
         return reinterpret_cast<BLEEndPoint *>(&sStorage[i]);
     }

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -53,6 +53,7 @@
 #define _CHIP_BLE_BLE_H
 #include "BleLayer.h"
 
+#include <cstddef>
 #include <cstring>
 #include <utility>
 
@@ -87,18 +88,9 @@ public:
 
     BLEEndPoint * Get(size_t i) const
     {
-        static union
-        {
-            uint8_t Pool[sizeof(BLEEndPoint) * BLE_LAYER_NUM_BLE_ENDPOINTS];
-            BLEEndPoint::AlignT ForceAlignment;
-        } sEndPointPool;
-
-        if (i < BLE_LAYER_NUM_BLE_ENDPOINTS)
-        {
-            return reinterpret_cast<BLEEndPoint *>(sEndPointPool.Pool + (sizeof(BLEEndPoint) * i));
-        }
-
-        return nullptr;
+        alignas(BLEEndPoint) static std::byte sStorage[sizeof(BLEEndPoint)];
+        VerifyOrReturnValue(i < BLE_LAYER_NUM_BLE_ENDPOINTS, nullptr);
+        return reinterpret_cast<BLEEndPoint *>(&sStorage[i]);
     }
 
     BLEEndPoint * Find(BLE_CONNECTION_OBJECT c) const
@@ -422,8 +414,6 @@ CHIP_ERROR BleLayer::NewBleConnectionByDiscriminators(const Span<const SetupDisc
 
 CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose)
 {
-    *retEndPoint = nullptr;
-
     if (mState != kState_Initialized)
     {
         return CHIP_ERROR_INCORRECT_STATE;
@@ -434,16 +424,17 @@ CHIP_ERROR BleLayer::NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_O
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
-    *retEndPoint = sBLEEndPointPool.GetFree();
-    if (*retEndPoint == nullptr)
+    auto endPoint = sBLEEndPointPool.GetFree();
+    if (endPoint == nullptr)
     {
         ChipLogError(Ble, "%s endpoint pool FULL", "Ble");
         return CHIP_ERROR_ENDPOINT_POOL_FULL;
     }
 
-    (*retEndPoint)->Init(this, connObj, role, autoClose);
-    (*retEndPoint)->mBleTransport = mBleTransport;
+    endPoint->Init(this, connObj, role, autoClose);
+    endPoint->mBleTransport = mBleTransport;
 
+    *retEndPoint = endPoint;
     return CHIP_NO_ERROR;
 }
 

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -90,7 +90,7 @@ public:
     {
         alignas(BLEEndPoint) static std::byte sStorage[sizeof(BLEEndPoint) * BLE_LAYER_NUM_BLE_ENDPOINTS];
         VerifyOrReturnValue(i < BLE_LAYER_NUM_BLE_ENDPOINTS, nullptr);
-        return reinterpret_cast<BLEEndPoint *>(&sStorage[i]);
+        return reinterpret_cast<BLEEndPoint *>(sStorage) + i;
     }
 
     BLEEndPoint * Find(BLE_CONNECTION_OBJECT c) const

--- a/src/ble/BtpEngine.h
+++ b/src/ble/BtpEngine.h
@@ -126,29 +126,30 @@ public:
     void LogStateDebug() const;
 
 private:
-    // Private data members:
-    State_t mRxState;
-    uint16_t mRxLength;
     void * mAppState;
+
+    State_t mRxState;
     System::PacketBufferHandle mRxBuf;
     SequenceNumber_t mRxNextSeqNum;
     SequenceNumber_t mRxNewestUnackedSeqNum;
     SequenceNumber_t mRxOldestUnackedSeqNum;
     uint16_t mRxFragmentSize;
+    uint16_t mRxLength;
 
     State_t mTxState;
-    uint16_t mTxLength;
     System::PacketBufferHandle mTxBuf;
     SequenceNumber_t mTxNextSeqNum;
     SequenceNumber_t mTxNewestUnackedSeqNum;
     SequenceNumber_t mTxOldestUnackedSeqNum;
-    bool mExpectingAck;
     uint16_t mTxFragmentSize;
+    uint16_t mTxLength;
 
     uint16_t mRxCharCount;
     uint16_t mRxPacketCount;
     uint16_t mTxCharCount;
     uint16_t mTxPacketCount;
+
+    bool mExpectingAck;
 
     // Private functions:
     bool IsValidAck(SequenceNumber_t ack_num) const;


### PR DESCRIPTION
#### Summary

- use alignment native to `BLEEndPoint` instead of forced `int64_t` alignment
- optimize `BLEEndPoint` layout to save few bytes

#### Testing

CI will check for build breaks.

Manually checked BLE-wifi commissioning:

DUT:
```
chip-lighting-app --wifi
```

Host:
```
chip-tool pairing ble-wifi 1 MATTER-AP MatterPassword 20202021 3840
```