### PR TITLE
[E2E][JF] Implement Joint Fabric Group, Binding, and ACL commands

### DIFF
--- a/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
+++ b/src/app/clusters/joint-fabric-datastore-server/joint-fabric-datastore-server.cpp
@@ -253,7 +253,18 @@ CHIP_ERROR JointFabricDatastoreAttrAccess::ReadNodeACLList(AttributeValueEncoder
 
         for (auto & entry : entries)
         {
-            ReturnErrorOnFailure(encoder.Encode(entry));
+            Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type entryToEncode;
+            entryToEncode.nodeID             = entry.nodeID;
+            entryToEncode.listID             = entry.listID;
+            entryToEncode.ACLEntry.privilege = entry.ACLEntry.privilege;
+            entryToEncode.ACLEntry.authMode  = entry.ACLEntry.authMode;
+            entryToEncode.ACLEntry.subjects =
+                DataModel::List<const uint64_t>(entry.ACLEntry.subjects.data(), entry.ACLEntry.subjects.size());
+            entryToEncode.ACLEntry.targets =
+                DataModel::List<const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlTargetStruct::Type>(
+                    entry.ACLEntry.targets.data(), entry.ACLEntry.targets.size());
+            entryToEncode.statusEntry = entry.statusEntry;
+            ReturnErrorOnFailure(encoder.Encode(entryToEncode));
         }
         return CHIP_NO_ERROR;
     });

--- a/src/app/server/JointFabricDatastore.h
+++ b/src/app/server/JointFabricDatastore.h
@@ -27,6 +27,28 @@
 namespace chip {
 namespace app {
 
+namespace datastore {
+
+struct AccessControlEntryStruct
+{
+    Clusters::JointFabricDatastore::DatastoreAccessControlEntryPrivilegeEnum privilege =
+        static_cast<Clusters::JointFabricDatastore::DatastoreAccessControlEntryPrivilegeEnum>(0);
+    Clusters::JointFabricDatastore::DatastoreAccessControlEntryAuthModeEnum authMode =
+        static_cast<Clusters::JointFabricDatastore::DatastoreAccessControlEntryAuthModeEnum>(0);
+    std::vector<uint64_t> subjects;
+    std::vector<Clusters::JointFabricDatastore::Structs::DatastoreAccessControlTargetStruct::Type> targets;
+};
+
+struct ACLEntryStruct
+{
+    chip::NodeId nodeID = static_cast<chip::NodeId>(0);
+    uint16_t listID     = static_cast<uint16_t>(0);
+    AccessControlEntryStruct ACLEntry;
+    Clusters::JointFabricDatastore::Structs::DatastoreStatusEntryStruct::Type statusEntry;
+};
+
+} // namespace datastore
+
 /**
  * A struct which extends the DatastoreNodeInformationEntry type with FriendlyName buffer reservation.
  */
@@ -144,7 +166,7 @@ public:
         return mNodeKeySetEntries;
     }
 
-    std::vector<Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type> & GetNodeACLList() { return mACLEntries; }
+    std::vector<datastore::ACLEntryStruct> & GetNodeACLList() { return mACLEntries; }
 
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointEntryStruct::Type> & GetNodeEndpointList()
     {
@@ -248,6 +270,7 @@ private:
     VendorId mAnchorVendorId                              = VendorId::NotSpecified;
     Clusters::JointFabricDatastore::Structs::DatastoreStatusEntryStruct::Type mDatastoreStatusEntry;
 
+    // TODO: Persist these members to local storage
     std::vector<GenericDatastoreNodeInformationEntry> mNodeInformationEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreGroupKeySetStruct::Type> mGroupKeySetList;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreAdministratorInformationEntryStruct::Type> mAdminEntries;
@@ -255,7 +278,7 @@ private:
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointGroupIDEntryStruct::Type> mEndpointGroupIDEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointBindingEntryStruct::Type> mEndpointBindingEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreNodeKeySetEntryStruct::Type> mNodeKeySetEntries;
-    std::vector<Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type> mACLEntries;
+    std::vector<datastore::ACLEntryStruct> mACLEntries;
     std::vector<Clusters::JointFabricDatastore::Structs::DatastoreEndpointEntryStruct::Type> mEndpointEntries;
 
     Listener * mListeners = nullptr;
@@ -269,9 +292,13 @@ private:
     CHIP_ERROR IsNodeIdInNodeInformationEntries(NodeId nodeId, size_t & index);
     CHIP_ERROR IsNodeIdAndEndpointInEndpointInformationEntries(NodeId nodeId, EndpointId endpointId, size_t & index);
 
-    CHIP_ERROR
-    UpdateACLEntry(Clusters::JointFabricDatastore::Structs::DatastoreACLEntryStruct::Type & entryToUpdate,
-                   const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType & aclEntry);
+    CHIP_ERROR GenerateAndAssignAUniqueListID(uint16_t & listId);
+    bool BindingMatches(const Clusters::JointFabricDatastore::Structs::DatastoreBindingTargetStruct::Type & binding1,
+                        const Clusters::JointFabricDatastore::Structs::DatastoreBindingTargetStruct::Type & binding2);
+    bool ACLMatches(const datastore::AccessControlEntryStruct & acl1,
+                    const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlEntryStruct::DecodableType & acl2);
+    bool ACLTargetMatches(const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlTargetStruct::Type & target1,
+                          const Clusters::JointFabricDatastore::Structs::DatastoreAccessControlTargetStruct::Type & target2);
 };
 
 } // namespace app


### PR DESCRIPTION
#### Summary
Implement following Joint Fabric Commands
- Group Commands
  - AddGroupIDToEndpointForNode
  - RemoveGroupIDFromEndpointForNode
- Binding Commands 
  - AddBindingToEndpointForNode 
  - RemoveBindingFromEndpointForNode 
- ACL Commands 
  - UpdateACLEntry 
  - AddACLToNode 
  - RemoveACLFromNode
- Add AdminCAT and AnchorCAT Checks
  - Implement required validation for AdminCAT and AnchorCAT in the following commands:
    - UpdateGroup
    - AddGroup
    - RemoveGroup

#### Related issues
Addresses Issue: https://github.com/project-chip/connectedhomeip/issues/40593.

#### Testing
Verified using the below instructions.

```
$ gn gen --check out/host/ --args='chip_device_config_enable_joint_fabric=true'
$ ninja -C out/host/ src/lib/dnssd/tests:tests_run
```