### PR TITLE
Add missing the override keyword in PushAvStreamTransportDelegate

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/push-av-stream-transport-delegate-impl.h
@@ -42,39 +42,44 @@ class PushAvStreamTransportManager : public PushAvStreamTransportDelegate
 {
 public:
     Protocols::InteractionModel::Status AllocatePushTransport(const TransportOptionsStruct & transportOptions,
-                                                              const uint16_t connectionID);
-    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID);
+                                                              const uint16_t connectionID) override;
+
+    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID) override;
+
     Protocols::InteractionModel::Status ModifyPushTransport(const uint16_t connectionID,
-                                                            const TransportOptionsStorage transportOptions);
+                                                            const TransportOptionsStorage transportOptions) override;
+
     Protocols::InteractionModel::Status SetTransportStatus(const std::vector<uint16_t> connectionIDList,
-                                                           TransportStatusEnum transportStatus);
+                                                           TransportStatusEnum transportStatus) override;
+
+    Protocols::InteractionModel::Status ManuallyTriggerTransport(
+        const uint16_t connectionID, TriggerActivationReasonEnum activationReason,
+        const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl) override;
+
+    bool ValidateUrl(const std::string & url) override;
 
     Protocols::InteractionModel::Status
-    ManuallyTriggerTransport(const uint16_t connectionID, TriggerActivationReasonEnum activationReason,
-                             const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl);
+    ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
+                           const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override;
 
-    bool ValidateUrl(std::string url);
+    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateBandwidthLimit(StreamUsageEnum streamUsage,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & audioStreamId);
-    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId);
+    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId) override;
 
-    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId);
+    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId);
+    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId);
+    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID) override;
 
-    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID);
+    void OnAttributeChanged(AttributeId attributeId) override;
 
-    void OnAttributeChanged(AttributeId attributeId);
-    CHIP_ERROR LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections);
-    CHIP_ERROR PersistentAttributesLoadedCallback();
+    CHIP_ERROR LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections) override;
+
+    CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
     void Init();
-    PushAvStreamTransportManager() = default;
-
+    PushAvStreamTransportManager()  = default;
     ~PushAvStreamTransportManager() = default;
 
 private:

--- a/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/push-av-stream-transport-delegate-impl.cpp
@@ -110,7 +110,7 @@ PushAvStreamTransportManager::ValidateBandwidthLimit(StreamUsageEnum streamUsage
     return Status::Success;
 }
 
-bool PushAvStreamTransportManager::ValidateUrl(std::string url)
+bool PushAvStreamTransportManager::ValidateUrl(const std::string & url)
 {
     return true;
 }

--- a/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/push-av-stream-transport/push-av-stream-manager.h
@@ -53,36 +53,43 @@ public:
     void SetMediaController(MediaController * mediaController);
     void SetCameraDevice(CameraDeviceInterface * cameraDevice);
 
+    // Add missing override keywords and fix signatures
     Protocols::InteractionModel::Status AllocatePushTransport(const TransportOptionsStruct & transportOptions,
-                                                              const uint16_t connectionID);
-    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID);
+                                                              const uint16_t connectionID) override;
+
+    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID) override;
+
     Protocols::InteractionModel::Status ModifyPushTransport(const uint16_t connectionID,
-                                                            const TransportOptionsStorage transportOptions);
+                                                            const TransportOptionsStorage transportOptions) override;
+
     Protocols::InteractionModel::Status SetTransportStatus(const std::vector<uint16_t> connectionIDList,
-                                                           TransportStatusEnum transportStatus);
+                                                           TransportStatusEnum transportStatus) override;
+
+    Protocols::InteractionModel::Status ManuallyTriggerTransport(
+        const uint16_t connectionID, TriggerActivationReasonEnum activationReason,
+        const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl) override;
+
+    bool ValidateUrl(const std::string & url) override;
 
     Protocols::InteractionModel::Status
-    ManuallyTriggerTransport(const uint16_t connectionID, TriggerActivationReasonEnum activationReason,
-                             const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl);
+    ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
+                           const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override;
 
-    bool ValidateUrl(std::string url);
+    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateBandwidthLimit(StreamUsageEnum streamUsage,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & audioStreamId);
-    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId);
+    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId) override;
 
-    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId);
+    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId);
+    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId) override;
 
-    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId);
+    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID) override;
 
-    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID);
+    void OnAttributeChanged(AttributeId attributeId) override;
 
-    void OnAttributeChanged(AttributeId attributeId);
-    CHIP_ERROR LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections);
-    CHIP_ERROR PersistentAttributesLoadedCallback();
+    CHIP_ERROR LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections) override;
+
+    CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
 private:
     std::vector<PushAvStream> pushavStreams;

--- a/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/push-av-stream-transport/push-av-stream-manager.cpp
@@ -238,7 +238,7 @@ PushAvStreamTransportManager::ValidateBandwidthLimit(StreamUsageEnum streamUsage
     return Status::Success;
 }
 
-bool PushAvStreamTransportManager::ValidateUrl(std::string url)
+bool PushAvStreamTransportManager::ValidateUrl(const std::string & url)
 {
     const std::string https = "https://";
 

--- a/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
+++ b/src/app/clusters/push-av-stream-transport-server/push-av-stream-transport-delegate.h
@@ -131,7 +131,7 @@ public:
      * @param url The URL to validate
      * @return true if URL is valid, false otherwise
      */
-    virtual bool ValidateUrl(std::string url) = 0;
+    virtual bool ValidateUrl(const std::string & url) = 0;
 
     /**
      * @brief Validates bandwidth requirements against camera's resource management.

--- a/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
+++ b/src/app/clusters/push-av-stream-transport-server/tests/TestPushAVStreamTransportCluster.cpp
@@ -214,7 +214,7 @@ class TestPushAVStreamTransportDelegateImpl : public PushAvStreamTransportDelega
 {
 public:
     Protocols::InteractionModel::Status AllocatePushTransport(const TransportOptionsStruct & transportOptions,
-                                                              const uint16_t connectionID)
+                                                              const uint16_t connectionID) override
     {
         PushAvStream stream{ connectionID, transportOptions, TransportStatusEnum::kInactive,
                              PushAvStreamTransportStatusEnum::kIdle };
@@ -225,7 +225,7 @@ public:
         return Status::Success;
     }
 
-    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID)
+    Protocols::InteractionModel::Status DeallocatePushTransport(const uint16_t connectionID) override
     {
         pushavStreams.erase(std::remove_if(pushavStreams.begin(), pushavStreams.end(),
                                            [connectionID](const PushAvStream & stream) { return stream.id == connectionID; }),
@@ -235,7 +235,7 @@ public:
     }
 
     Protocols::InteractionModel::Status ModifyPushTransport(const uint16_t connectionID,
-                                                            const TransportOptionsStorage transportOptions)
+                                                            const TransportOptionsStorage transportOptions) override
     {
         for (PushAvStream & stream : pushavStreams)
         {
@@ -250,7 +250,7 @@ public:
     }
 
     Protocols::InteractionModel::Status SetTransportStatus(const std::vector<uint16_t> connectionIDList,
-                                                           TransportStatusEnum transportStatus)
+                                                           TransportStatusEnum transportStatus) override
     {
         for (PushAvStream & stream : pushavStreams)
         {
@@ -268,7 +268,7 @@ public:
 
     Protocols::InteractionModel::Status
     ManuallyTriggerTransport(const uint16_t connectionID, TriggerActivationReasonEnum activationReason,
-                             const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl)
+                             const Optional<Structs::TransportMotionTriggerTimeControlStruct::DecodableType> & timeControl) override
     {
         // TODO: Validates the requested stream usage against the camera's resource management and stream priority policies.
         for (PushAvStream & stream : pushavStreams)
@@ -282,46 +282,46 @@ public:
         return Status::Success;
     }
 
-    Protocols::InteractionModel::Status ValidateBandwidthLimit(StreamUsageEnum streamUsage,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
-                                                               const Optional<DataModel::Nullable<uint16_t>> & audioStreamId)
+    Protocols::InteractionModel::Status
+    ValidateBandwidthLimit(StreamUsageEnum streamUsage, const Optional<DataModel::Nullable<uint16_t>> & videoStreamId,
+                           const Optional<DataModel::Nullable<uint16_t>> & audioStreamId) override
     {
         // TODO: Validates the requested stream usage against the camera's resource management.
         // Returning Status::Success to pass through checks in the Server Implementation.
         return Status::Success;
     }
 
-    bool ValidateUrl(std::string url) { return true; }
+    bool ValidateUrl(const std::string & url) override { return true; }
 
-    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId)
+    Protocols::InteractionModel::Status SelectVideoStream(StreamUsageEnum streamUsage, uint16_t & videoStreamId) override
     {
         // TODO: Select and Assign videoStreamID from the allocated videoStreams
         // Returning Status::Success to pass through checks in the Server Implementation.
         return Status::Success;
     }
 
-    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId)
+    Protocols::InteractionModel::Status SelectAudioStream(StreamUsageEnum streamUsage, uint16_t & audioStreamId) override
     {
         // TODO: Select and Assign audioStreamID from the allocated audioStreams
         // Returning Status::Success to pass through checks in the Server Implementation.
         return Status::Success;
     }
 
-    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId)
+    Protocols::InteractionModel::Status ValidateVideoStream(uint16_t videoStreamId) override
     {
         // TODO: Validate videoStreamID from the allocated videoStreams
         // Returning Status::Success to pass through checks in the Server Implementation.
         return Status::Success;
     }
 
-    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId)
+    Protocols::InteractionModel::Status ValidateAudioStream(uint16_t audioStreamId) override
     {
         // TODO: Validate audioStreamID from the allocated audioStreams
         // Returning Status::Success to pass through checks in the Server Implementation.
         return Status::Success;
     }
 
-    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID)
+    PushAvStreamTransportStatusEnum GetTransportBusyStatus(const uint16_t connectionID) override
     {
         for (PushAvStream & stream : pushavStreams)
         {
@@ -333,25 +333,22 @@ public:
         return PushAvStreamTransportStatusEnum::kUnknown;
     }
 
-    void OnAttributeChanged(AttributeId attributeId)
+    void OnAttributeChanged(AttributeId attributeId) override
     {
         ChipLogProgress(Zcl, "Attribute changed for AttributeId = " ChipLogFormatMEI, ChipLogValueMEI(attributeId));
     }
 
     void Init() { ChipLogProgress(Zcl, "Push AV Stream Transport Initialized"); }
-    CHIP_ERROR
-    LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections)
+
+    CHIP_ERROR LoadCurrentConnections(std::vector<TransportConfigurationStorage> & currentConnections) override
     {
         ChipLogProgress(Zcl, "Push AV Current Connections loaded");
-
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR
-    PersistentAttributesLoadedCallback()
+    CHIP_ERROR PersistentAttributesLoadedCallback() override
     {
         ChipLogProgress(Zcl, "Persistent attributes loaded");
-
         return CHIP_NO_ERROR;
     }
 


### PR DESCRIPTION
#### Summary
This is the follow-up PR to address gemini review comments

1. Looking at the PushAvStreamTransportManager class, all the virtual methods from the base class PushAvStreamTransportDelegate are missing the override keyword. 

2. Update ValidateUrl signature

#### Related issues

N/A

#### Testing

Validated by CI
