### PR TITLE
[Camera] Start the video stream using the parameters from the allocated stream

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -81,7 +81,7 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
-    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) override;
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, StreamAllocationAction action) override;
 
     void OnStreamUsagePrioritiesChanged() override;
 

--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -78,6 +78,8 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID);
 
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) override;
+
     void OnStreamUsagePrioritiesChanged();
 
     void OnAttributeChanged(AttributeId attributeId);

--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -81,7 +81,7 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
-    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) override;
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) override;
 
     void OnStreamUsagePrioritiesChanged() override;
 

--- a/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
+++ b/examples/all-clusters-app/all-clusters-common/include/camera-av-stream-delegate-impl.h
@@ -60,47 +60,51 @@ struct SnapshotStream
 class CameraAVStreamManager : public CameraAVStreamMgmtDelegate
 {
 public:
-    Protocols::InteractionModel::Status VideoStreamAllocate(const VideoStreamStruct & allocateArgs, uint16_t & outStreamID);
+    Protocols::InteractionModel::Status VideoStreamAllocate(const VideoStreamStruct & allocateArgs,
+                                                            uint16_t & outStreamID) override;
 
     Protocols::InteractionModel::Status VideoStreamModify(const uint16_t streamID, const chip::Optional<bool> waterMarkEnabled,
-                                                          const chip::Optional<bool> osdEnabled);
+                                                          const chip::Optional<bool> osdEnabled) override;
 
-    Protocols::InteractionModel::Status VideoStreamDeallocate(const uint16_t streamID);
+    Protocols::InteractionModel::Status VideoStreamDeallocate(const uint16_t streamID) override;
 
-    Protocols::InteractionModel::Status AudioStreamAllocate(const AudioStreamStruct & allocateArgs, uint16_t & outStreamID);
+    Protocols::InteractionModel::Status AudioStreamAllocate(const AudioStreamStruct & allocateArgs,
+                                                            uint16_t & outStreamID) override;
 
-    Protocols::InteractionModel::Status AudioStreamDeallocate(const uint16_t streamID);
+    Protocols::InteractionModel::Status AudioStreamDeallocate(const uint16_t streamID) override;
 
-    Protocols::InteractionModel::Status SnapshotStreamAllocate(const SnapshotStreamStruct & allocateArgs, uint16_t & outStreamID);
+    Protocols::InteractionModel::Status SnapshotStreamAllocate(const SnapshotStreamStruct & allocateArgs,
+                                                               uint16_t & outStreamID) override;
 
     Protocols::InteractionModel::Status SnapshotStreamModify(const uint16_t streamID, const chip::Optional<bool> waterMarkEnabled,
-                                                             const chip::Optional<bool> osdEnabled);
+                                                             const chip::Optional<bool> osdEnabled) override;
 
-    Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID);
+    Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
     void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) override;
 
-    void OnStreamUsagePrioritiesChanged();
+    void OnStreamUsagePrioritiesChanged() override;
 
-    void OnAttributeChanged(AttributeId attributeId);
+    void OnAttributeChanged(AttributeId attributeId) override;
 
     Protocols::InteractionModel::Status CaptureSnapshot(const DataModel::Nullable<uint16_t> streamID,
-                                                        const VideoResolutionStruct & resolution, ImageSnapshot & outImageSnapshot);
+                                                        const VideoResolutionStruct & resolution,
+                                                        ImageSnapshot & outImageSnapshot) override;
 
     CHIP_ERROR
-    LoadAllocatedVideoStreams(std::vector<VideoStreamStruct> & allocatedVideoStreams);
+    LoadAllocatedVideoStreams(std::vector<VideoStreamStruct> & allocatedVideoStreams) override;
 
     CHIP_ERROR
-    LoadAllocatedAudioStreams(std::vector<AudioStreamStruct> & allocatedAudioStreams);
+    LoadAllocatedAudioStreams(std::vector<AudioStreamStruct> & allocatedAudioStreams) override;
 
     CHIP_ERROR
-    LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamStruct> & allocatedSnapshotStreams);
+    LoadAllocatedSnapshotStreams(std::vector<SnapshotStreamStruct> & allocatedSnapshotStreams) override;
 
-    CHIP_ERROR PersistentAttributesLoadedCallback();
+    CHIP_ERROR PersistentAttributesLoadedCallback() override;
 
-    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
+    CHIP_ERROR OnTransportAcquireAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
 
-    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID);
+    CHIP_ERROR OnTransportReleaseAudioVideoStreams(uint16_t audioStreamID, uint16_t videoStreamID) override;
 
     void Init();
 

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -208,6 +208,11 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamDealloc
     return Status::Success;
 }
 
+void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream)
+{
+    ChipLogProgress(Zcl, "Video stream has been allocated");
+}
+
 void CameraAVStreamManager::OnStreamUsagePrioritiesChanged()
 {
     ChipLogProgress(Zcl, "Stream usage priorities changed");

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -208,7 +208,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamDealloc
     return Status::Success;
 }
 
-void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream)
+void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo)
 {
     ChipLogProgress(Zcl, "Video stream has been allocated");
 }

--- a/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/camera-av-stream-delegate-impl.cpp
@@ -208,7 +208,7 @@ Protocols::InteractionModel::Status CameraAVStreamManager::SnapshotStreamDealloc
     return Status::Success;
 }
 
-void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo)
+void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, StreamAllocationAction action)
 {
     ChipLogProgress(Zcl, "Video stream has been allocated");
 }

--- a/examples/camera-app/camera-common/include/camera-device-interface.h
+++ b/examples/camera-app/camera-common/include/camera-device-interface.h
@@ -166,7 +166,7 @@ public:
         virtual CameraError CaptureSnapshot(const chip::app::DataModel::Nullable<uint16_t> streamID,
                                             const VideoResolutionStruct & resolution, ImageSnapshot & outImageSnapshot) = 0;
         // Start video stream
-        virtual CameraError StartVideoStream(uint16_t streamID) = 0;
+        virtual CameraError StartVideoStream(const VideoStreamStruct & allocatedStream) = 0;
 
         // Stop video stream
         virtual CameraError StopVideoStream(uint16_t streamID) = 0;

--- a/examples/camera-app/linux/include/camera-device.h
+++ b/examples/camera-app/linux/include/camera-device.h
@@ -107,7 +107,7 @@ public:
     CameraError CaptureSnapshot(const chip::app::DataModel::Nullable<uint16_t> streamID, const VideoResolutionStruct & resolution,
                                 ImageSnapshot & outImageSnapshot) override;
 
-    CameraError StartVideoStream(uint16_t streamID) override;
+    CameraError StartVideoStream(const VideoStreamStruct & allocatedStream) override;
 
     // Stop video stream
     CameraError StopVideoStream(uint16_t streamID) override;

--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -20,6 +20,7 @@
 
 #include "camera-avstream-controller.h"
 #include "camera-device-interface.h"
+#include <app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h>
 #include <app/util/config.h>
 #include <vector>
 
@@ -55,7 +56,7 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
-    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) override;
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, StreamAllocationAction action) override;
 
     void OnStreamUsagePrioritiesChanged() override;
 

--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -55,6 +55,8 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) override;
+
     void OnStreamUsagePrioritiesChanged() override;
 
     void OnAttributeChanged(AttributeId attributeId) override;

--- a/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
+++ b/examples/camera-app/linux/include/clusters/camera-avstream-mgmt/camera-av-stream-manager.h
@@ -55,7 +55,7 @@ public:
 
     Protocols::InteractionModel::Status SnapshotStreamDeallocate(const uint16_t streamID) override;
 
-    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) override;
+    void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) override;
 
     void OnStreamUsagePrioritiesChanged() override;
 

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -134,6 +134,9 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
                 // Inform DPTZ that there's an allocated stream
                 mCameraDeviceHAL->GetCameraAVSettingsUserLevelMgmtDelegate().VideoStreamAllocated(outStreamID);
 
+                // Set the current frame rate attribute from HAL
+                GetCameraAVStreamMgmtServer()->SetCurrentFrameRate(mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
+
                 return Status::Success;
             }
             else
@@ -152,9 +155,6 @@ void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & all
 {
     // Start the video stream using the final allocated parameters
     mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(allocatedStream);
-
-    // Set the current frame rate attribute from HAL once stream has started
-    GetCameraAVStreamMgmtServer()->SetCurrentFrameRate(mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamModify(const uint16_t streamID,

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -151,10 +151,21 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
     return Status::DynamicConstraintError;
 }
 
-void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream)
+void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo)
 {
-    // Start the video stream using the final allocated parameters
-    mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(allocatedStream);
+    // Only start the video stream if the flag indicates we should (new allocation or configuration changed)
+    if (shouldStartNewVideo)
+    {
+        ChipLogProgress(Camera, "Starting new video stream with ID: %u due to new allocation or configuration change",
+                        allocatedStream.videoStreamID);
+        // Start the video stream using the final allocated parameters
+        mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(allocatedStream);
+    }
+    else
+    {
+        ChipLogProgress(Camera, "Reusing existing video stream with ID: %u without starting new video",
+                        allocatedStream.videoStreamID);
+    }
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamModify(const uint16_t streamID,

--- a/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
+++ b/examples/camera-app/linux/src/clusters/camera-avstream-mgmt/camera-av-stream-manager.cpp
@@ -127,19 +127,12 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
             if (!stream.isAllocated)
             {
                 stream.isAllocated = true;
-
-                // Start the video stream from HAL for serving.
-                mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(outStreamID);
-
                 // Set the default viewport on the newly allocated stream
                 mCameraDeviceHAL->GetCameraHALInterface().SetViewport(stream,
                                                                       mCameraDeviceHAL->GetCameraHALInterface().GetViewport());
 
                 // Inform DPTZ that there's an allocated stream
                 mCameraDeviceHAL->GetCameraAVSettingsUserLevelMgmtDelegate().VideoStreamAllocated(outStreamID);
-
-                // Set the current frame rate attribute from HAL once stream has started
-                GetCameraAVStreamMgmtServer()->SetCurrentFrameRate(mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
 
                 return Status::Success;
             }
@@ -153,6 +146,15 @@ Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamAllocate(c
     }
 
     return Status::DynamicConstraintError;
+}
+
+void CameraAVStreamManager::OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream)
+{
+    // Start the video stream using the final allocated parameters
+    mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(allocatedStream);
+
+    // Set the current frame rate attribute from HAL once stream has started
+    GetCameraAVStreamMgmtServer()->SetCurrentFrameRate(mCameraDeviceHAL->GetCameraHALInterface().GetCurrentFrameRate());
 }
 
 Protocols::InteractionModel::Status CameraAVStreamManager::VideoStreamModify(const uint16_t streamID,

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -172,10 +172,11 @@ pairing onnetwork 1 20202021
 
 Wait for the command to complete and confirm that commissioning was successful.
 
-3. To start a live video stream from your camera, use the liveview start command
-   followed by the nodeID you set during pairing. For example, if your nodeID is
-   1, you can request a stream with a minimum resolution of 800x600 pixels and a
-   minimum frame rate of 30 frames per second using the command below.
+3. To start a live video stream from your camera, use the `liveview start`
+   command followed by the nodeID you set during pairing. For example, if your
+   nodeID is 1, you can request a stream with a minimum resolution of 800x600
+   pixels and a minimum frame rate of 30 frames per second using the command
+   below.
 
 ```
 liveview start 1 --min-res-width 800 --min-res-height 600 --min-framerate 30

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -182,10 +182,14 @@ Wait for the command to complete and confirm that commissioning was successful.
 liveview start 1 --min-res-width 800 --min-res-height 600 --min-framerate 30
 ```
 
-To see what video formats and resolutions your camera supports, use the
-following command:
+To see what video formats and resolutions your camera supports, first list the
+available video devices, then check the formats for your specific device:
 
 ```
+# List all available video devices
+v4l2-ctl --list-devices
+
+# Check formats for a specific device (replace /dev/video0 with your device)
 v4l2-ctl -d /dev/video0 --list-formats-ext
 ```
 

--- a/examples/camera-controller/README.md
+++ b/examples/camera-controller/README.md
@@ -172,12 +172,20 @@ pairing onnetwork 1 20202021
 
 Wait for the command to complete and confirm that commissioning was successful.
 
-3. Start the Live Stream Still in the controller shell, use the Live View
-   command with the nodeID you assigned during pairing to request a video
-   stream.
+3. To start a live video stream from your camera, use the liveview start command
+   followed by the nodeID you set during pairing. For example, if your nodeID is
+   1, you can request a stream with a minimum resolution of 800x600 pixels and a
+   minimum frame rate of 30 frames per second using the command below.
 
 ```
-liveview start 1
+liveview start 1 --min-res-width 800 --min-res-height 600 --min-framerate 30
+```
+
+To see what video formats and resolutions your camera supports, use the
+following command:
+
+```
+v4l2-ctl -d /dev/video0 --list-formats-ext
 ```
 
 Wave your hand in front of the camera to trigger live view; a video window will

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1812,8 +1812,8 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
             videoStreamArgs.videoStreamID = videoStreamID;
             AddVideoStream(videoStreamArgs);
 
-            // Call delegate with the allocated stream parameters and start flag
-            mDelegate.OnVideoStreamAllocated(videoStreamArgs, true);
+            // Call delegate with the allocated stream parameters and new allocation action
+            mDelegate.OnVideoStreamAllocated(videoStreamArgs, StreamAllocationAction::kNewAllocation);
         }
         else
         {
@@ -1823,8 +1823,9 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
             // Reusing the existing stream. Update range parameters and check if they were modified
             UpdateVideoStreamRangeParams(videoStreamToUpdate, videoStreamArgs, wasModified);
 
-            // Call delegate with the final updated stream parameters and start flag
-            mDelegate.OnVideoStreamAllocated(videoStreamToUpdate, wasModified);
+            // Call delegate with the final updated stream parameters and appropriate action
+            mDelegate.OnVideoStreamAllocated(videoStreamToUpdate,
+                                             wasModified ? StreamAllocationAction::kModification : StreamAllocationAction::kReuse);
         }
 
         response.videoStreamID = videoStreamID;

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -279,8 +279,18 @@ CHIP_ERROR CameraAVStreamMgmtServer::AddVideoStream(const VideoStreamStruct & vi
 }
 
 CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRangeParams(VideoStreamStruct & videoStreamToUpdate,
-                                                                  const VideoStreamStruct & videoStream)
+                                                                  const VideoStreamStruct & videoStream, bool & wasModified)
 {
+    // Store original values to detect changes
+    uint16_t origMinFrameRate = videoStreamToUpdate.minFrameRate;
+    uint16_t origMaxFrameRate = videoStreamToUpdate.maxFrameRate;
+    uint16_t origMinResWidth  = videoStreamToUpdate.minResolution.width;
+    uint16_t origMinResHeight = videoStreamToUpdate.minResolution.height;
+    uint16_t origMaxResWidth  = videoStreamToUpdate.maxResolution.width;
+    uint16_t origMaxResHeight = videoStreamToUpdate.maxResolution.height;
+    uint32_t origMinBitRate   = videoStreamToUpdate.minBitRate;
+    uint32_t origMaxBitRate   = videoStreamToUpdate.maxBitRate;
+
     // Adjust the range parameters for the allocated video stream to be the
     // intersection of the existing and the new one.
     videoStreamToUpdate.minFrameRate         = std::max(videoStreamToUpdate.minFrameRate, videoStream.minFrameRate);
@@ -291,6 +301,14 @@ CHIP_ERROR CameraAVStreamMgmtServer::UpdateVideoStreamRangeParams(VideoStreamStr
     videoStreamToUpdate.maxResolution.height = std::min(videoStreamToUpdate.maxResolution.height, videoStream.maxResolution.height);
     videoStreamToUpdate.minBitRate           = std::max(videoStreamToUpdate.minBitRate, videoStream.minBitRate);
     videoStreamToUpdate.maxBitRate           = std::min(videoStreamToUpdate.maxBitRate, videoStream.maxBitRate);
+
+    // Check if any parameter was actually modified
+    wasModified = (origMinFrameRate != videoStreamToUpdate.minFrameRate) ||
+        (origMaxFrameRate != videoStreamToUpdate.maxFrameRate) || (origMinResWidth != videoStreamToUpdate.minResolution.width) ||
+        (origMinResHeight != videoStreamToUpdate.minResolution.height) ||
+        (origMaxResWidth != videoStreamToUpdate.maxResolution.width) ||
+        (origMaxResHeight != videoStreamToUpdate.maxResolution.height) || (origMinBitRate != videoStreamToUpdate.minBitRate) ||
+        (origMaxBitRate != videoStreamToUpdate.maxBitRate);
 
     auto path = ConcreteAttributePath(mEndpointId, CameraAvStreamManagement::Id, Attributes::AllocatedVideoStreams::Id);
     mDelegate.OnAttributeChanged(Attributes::AllocatedVideoStreams::Id);
@@ -1782,7 +1800,6 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
 
     if (status == Status::Success)
     {
-
         // Check if the streamID matches an existing one in the
         // mAllocatedVideoStreams.
         auto it =
@@ -1794,19 +1811,24 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
             // Add the allocated videostream object in the AllocatedVideoStreams list.
             videoStreamArgs.videoStreamID = videoStreamID;
             AddVideoStream(videoStreamArgs);
+
+            // Call delegate with the allocated stream parameters and start flag
+            mDelegate.OnVideoStreamAllocated(videoStreamArgs, true);
         }
         else
         {
+            bool wasModified = false;
+
             VideoStreamStruct & videoStreamToUpdate = *it;
-            // Reusing the existing stream. Update range parameters
-            UpdateVideoStreamRangeParams(videoStreamToUpdate, videoStreamArgs);
+            // Reusing the existing stream. Update range parameters and check if they were modified
+            UpdateVideoStreamRangeParams(videoStreamToUpdate, videoStreamArgs, wasModified);
+
+            // Call delegate with the final updated stream parameters and start flag
+            mDelegate.OnVideoStreamAllocated(videoStreamToUpdate, wasModified);
         }
 
         response.videoStreamID = videoStreamID;
         ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
-
-        // Call delegate with the final allocated stream parameters
-        mDelegate.OnVideoStreamAllocated(videoStreamArgs);
     }
     else
     {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.cpp
@@ -1804,6 +1804,9 @@ void CameraAVStreamMgmtServer::HandleVideoStreamAllocate(HandlerContext & ctx,
 
         response.videoStreamID = videoStreamID;
         ctx.mCommandHandler.AddResponse(ctx.mRequestPath, response);
+
+        // Call delegate with the final allocated stream parameters
+        mDelegate.OnVideoStreamAllocated(videoStreamArgs);
     }
     else
     {

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -112,8 +112,10 @@ public:
      *          This is where the actual video stream should be started using the final allocated parameters.
      *
      *   @param allocatedStream   The finalized video stream with narrowed parameters from the server.
+     *   @param shouldStartNewVideo  Flag indicating whether to start a new video stream (true for new allocations
+     *                              or when stream configuration has been modified, false for stream reuse without changes).
      */
-    virtual void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) = 0;
+    virtual void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) = 0;
 
     /**
      *   @brief Handle Command Delegate for Video stream modification.
@@ -515,7 +517,8 @@ public:
 
     CHIP_ERROR AddVideoStream(const VideoStreamStruct & videoStream);
 
-    CHIP_ERROR UpdateVideoStreamRangeParams(VideoStreamStruct & videoStreamToUpdate, const VideoStreamStruct & videoStream);
+    CHIP_ERROR UpdateVideoStreamRangeParams(VideoStreamStruct & videoStreamToUpdate, const VideoStreamStruct & videoStream,
+                                            bool & wasModified);
 
     CHIP_ERROR RemoveVideoStream(uint16_t videoStreamId);
 

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -108,6 +108,14 @@ public:
                                                                     uint16_t & outStreamID) = 0;
 
     /**
+     *   @brief Called after the server has finalized video stream allocation and narrowed parameters.
+     *          This is where the actual video stream should be started using the final allocated parameters.
+     *
+     *   @param allocatedStream   The finalized video stream with narrowed parameters from the server.
+     */
+    virtual void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream) = 0;
+
+    /**
      *   @brief Handle Command Delegate for Video stream modification.
      *
      *   @param streamID           Indicates the streamID of the video stream to modify.

--- a/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
+++ b/src/app/clusters/camera-av-stream-management-server/camera-av-stream-management-server.h
@@ -70,6 +70,13 @@ constexpr size_t kArrayTlvOverhead = 2;
 
 constexpr size_t kStreamUsagePrioritiesTlvSize = kArrayTlvOverhead + kStreamUsageTlvSize * kNumOfStreamUsageTypes;
 
+enum class StreamAllocationAction
+{
+    kNewAllocation, // Fresh stream allocation - always start
+    kModification,  // Existing stream with parameter changes - restart if active
+    kReuse          // Reusing existing stream without changes - no action needed
+};
+
 class CameraAVStreamMgmtServer;
 
 // ImageSnapshot response data for a CaptureSnapshot command.
@@ -112,10 +119,9 @@ public:
      *          This is where the actual video stream should be started using the final allocated parameters.
      *
      *   @param allocatedStream   The finalized video stream with narrowed parameters from the server.
-     *   @param shouldStartNewVideo  Flag indicating whether to start a new video stream (true for new allocations
-     *                              or when stream configuration has been modified, false for stream reuse without changes).
+     *   @param action           Action indicating how to handle the stream: new allocation, modification, or reuse.
      */
-    virtual void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, bool shouldStartNewVideo) = 0;
+    virtual void OnVideoStreamAllocated(const VideoStreamStruct & allocatedStream, StreamAllocationAction action) = 0;
 
     /**
      *   @brief Handle Command Delegate for Video stream modification.


### PR DESCRIPTION
#### Summary

Currently, there are two different stream representations:

CameraDevice HAL: Contains "available streams" (VideoStream structs) that represent the hardware capabilities and current allocation status
CameraAVStreamMgmtServer: Contains "allocated streams" (mAllocatedVideoStreams) that represent the Matter cluster view of allocated streams

How Stream Allocation Works
Here's how the flow works when a user requests to allocate a stream:

1. Stream Allocation Request Flow:
CameraAVStreamMgmtServer::HandleVideoStreamAllocate() receives the request
It calls mDelegate.VideoStreamAllocate() (which is CameraAVStreamManager::VideoStreamAllocate())
CameraAVStreamManager::VideoStreamAllocate() searches through mCameraDeviceHAL->GetCameraHALInterface().GetAvailableVideoStreams()
If a compatible stream is found, it marks stream.isAllocated = true in the HAL
It calls mCameraDeviceHAL->GetCameraHALInterface().StartVideoStream(outStreamID) to start the actual stream
The server then either calls AddVideoStream() or UpdateVideoStreamRangeParams() to update its mAllocatedVideoStreams

2. The Issue You Identified:
You're absolutely right that UpdateVideoStreamRangeParams() only updates the mAllocatedVideoStreams in the server, not the HAL streams. However, looking at the code, this is actually by design.

HAL "Available Streams" = Reference templates with wide parameter ranges
Server "Allocated Streams" = Narrowed parameter ranges representing actual allocated streams

When starting a video stream, you should use the allocated stream parameters from the server, not the original HAL parameters

#### Related issues

N/A

#### Testing

To start a live video stream from your camera, use the liveview start command
   followed by the nodeID you set during pairing. For example, if your nodeID is
   1, you can request a stream with a minimum resolution of 800x600 pixels and a
   minimum frame rate of 30 frames per second using the command below.

```
liveview start 1 --min-res-width 800 --min-res-height 600 --min-framerate 30
```

To see what video formats and resolutions your camera supports, use the
following command:

```
v4l2-ctl -d /dev/video0 --list-formats-ext
```
