### PR TITLE
Fix ESP32 IP_EVENT_ETH_GOT_IP event data handling in ESP32 platform

### DIFF
--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -122,6 +122,9 @@ void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t even
         case IP_EVENT_STA_GOT_IP:
             memcpy(&event.Platform.ESPSystemEvent.Data.IpGotIp, eventData, sizeof(event.Platform.ESPSystemEvent.Data.IpGotIp));
             break;
+        case IP_EVENT_ETH_GOT_IP:
+            memcpy(&event.Platform.ESPSystemEvent.Data.IpGotIp, eventData, sizeof(event.Platform.ESPSystemEvent.Data.IpGotIp));
+            break;
         case IP_EVENT_GOT_IP6:
             memcpy(&event.Platform.ESPSystemEvent.Data.IpGotIp6, eventData, sizeof(event.Platform.ESPSystemEvent.Data.IpGotIp6));
             break;


### PR DESCRIPTION
#### Summary
Fix IP_EVENT_ETH_GOT_IP event data handling in ESP32 platform

#### Problem
When Ethernet interface gets an IP address, the log shows incorrect IP information:
```c
I (4750) chip[DL]: IPv4 address available on Ethernet interface: 0.0.0.0/0.0.0.0 gateway 0.0.0.0
```
