### PR TITLE
Increase unit test coverage of `credentials/attestation_verifier/` by 3.1%

### DIFF
--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -253,6 +253,11 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMatchingPAIAndDACProductID
 // Test case validates that the verifier correctly rejects DAC certificates that have expired
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithExpiredDACCertificate)
 {
+    // This check is only valid if the platform supports current time retrieval
+    // This is necessary to determine if the certificate is expired
+#if defined(CURRENT_TIME_NOT_IMPLEMENTED)
+    GTEST_SKIP() << "Skipping test: platform does not support current time.";
+#endif
     // The actual contents do not represent real or meaningful data.
     uint8_t cdData[32] = { 0x11, 0x22, 0x33, 0x44 };
     uint8_t tlvBuf[128];
@@ -300,14 +305,17 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithExpiredDACCertificate)
     verifier.VerifyAttestationInformation(expiredDACInfo, &attestationCallback);
 
     // Expect the verifier to detect the expired certificate and reject attestation
-#if !defined(CURRENT_TIME_NOT_IMPLEMENTED)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacExpired);
-#endif
 }
 
 // Test case verifies that certificates with future validity periods are properly rejected
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithValidInFutureDACCertificate)
 {
+    // This check is only valid if the platform supports current time retrieval
+    // This is necessary to determine if the certificate is not yet valid
+#if defined(CURRENT_TIME_NOT_IMPLEMENTED)
+    GTEST_SKIP() << "Skipping test: platform does not support current time.";
+#endif
     // The actual contents do not represent real or meaningful data.
     uint8_t cdData[32] = { 0x11, 0x22, 0x33, 0x44 };
     uint8_t tlvBuf[128];
@@ -354,9 +362,7 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithValidInFutureDACCertificat
 
     verifier.VerifyAttestationInformation(futureValDACInfo, &attestationCallback);
     // Verify that the future-valid certificate is rejected as expired (not yet valid)
-#if !defined(CURRENT_TIME_NOT_IMPLEMENTED)
     EXPECT_EQ(attestationResult, AttestationVerificationResult::kDacExpired);
-#endif
 }
 
 // Test case verifies that wrong formats for attestation elements are properly rejected

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -104,14 +104,16 @@ struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
     }
 };
 
-// Helper method to construct TLV attestation elements structure
+// Helper function to construct TLV attestation elements structure
 static CHIP_ERROR ConstructAttestationElementsTLV(uint8_t * tlvBuffer, size_t bufferSize, const ByteSpan & cdData,
                                                   const ByteSpan & nonceData, size_t & tlvLen)
 {
+    // Construct TLV structure representing attestation elements that would be signed by device
     chip::TLV::TLVWriter writer;
     writer.Init(tlvBuffer, bufferSize);
     chip::TLV::TLVType outerType;
 
+    // Add attestation elements to the TLV structure
     ReturnErrorOnFailure(writer.StartContainer(chip::TLV::AnonymousTag(), chip::TLV::kTLVType_Structure, outerType));
     writer.Put(chip::TLV::ContextTag(1), cdData);
     writer.Put(chip::TLV::ContextTag(2), nonceData);
@@ -124,7 +126,7 @@ static CHIP_ERROR ConstructAttestationElementsTLV(uint8_t * tlvBuffer, size_t bu
     return CHIP_NO_ERROR;
 }
 
-// Helper method to create signed attestation data using standard test parameters.
+// Helper function to create signed attestation data using standard test parameters.
 static CHIP_ERROR CreateSignedAttestationData(uint8_t * tlvBuffer, size_t & tlvLen, chip::Crypto::P256ECDSASignature & signature,
                                               const ByteSpan & cdData, const ByteSpan & nonceData, const ByteSpan & privateKey,
                                               const ByteSpan & publicKey, const uint8_t * challengeData, size_t challengeDataLen)
@@ -133,7 +135,7 @@ static CHIP_ERROR CreateSignedAttestationData(uint8_t * tlvBuffer, size_t & tlvL
     ReturnErrorOnFailure(ConstructAttestationElementsTLV(tlvBuffer, sizeof(uint8_t) * 128, cdData, nonceData, tlvLen));
 
     // Concatenate TLV and challenge data for signing
-    constexpr size_t kMaxToSignSize = 128 + 64; // 128 for TLV, 64 for challengeData (adjust if needed)
+    constexpr size_t kMaxToSignSize = 128 + 64; // 128 for TLV, 64 for challengeData
     if (tlvLen + challengeDataLen > kMaxToSignSize)
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
@@ -374,6 +376,7 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMalformedAttestationElemen
 // Test case verifies that nonce in attestation elements does not match the expected nonce
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedNonce)
 {
+    // The actual contents do not represent real or meaningful data.
     uint8_t nonceInElements[32] = { 0x55, 0x66, 0x77, 0x88 };
     uint8_t expectedNonce[32]   = { 0x99, 0x88, 0x77 };
 
@@ -411,6 +414,7 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidPAAFormat)
                                                  sizeof(kTestChallengeData));
     ASSERT_EQ(err, CHIP_NO_ERROR);
 
+    // Prepare AttestationInfo with valid DAC and PAI, but invalid PAA
     DeviceAttestationVerifier::AttestationInfo validInfo(
         ByteSpan(tlvBuf, tlvLen), ByteSpan(kTestChallengeData), ByteSpan(signature.ConstBytes(), signature.Length()),
         TestCerts::sTestCert_PAI_FFF1_8000_Cert, TestCerts::sTestCert_DAC_FFF1_8000_0004_Cert, ByteSpan(kTestNonceData),

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -103,7 +103,7 @@ struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
                             size_t challengeDataLen)
     {
         uint8_t tlvBuf[128];
-        size_t tlvLen;
+        size_t tlvLen = 0;
         chip::Crypto::P256ECDSASignature signature;
 
         // Create signed attestation data
@@ -397,7 +397,7 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedNonce)
     uint8_t expectedNonce[32]   = { 0x99, 0x88, 0x77 };
 
     uint8_t tlvBuf[128];
-    size_t tlvLen;
+    size_t tlvLen = 0;
     chip::Crypto::P256ECDSASignature signature;
 
     // Create signed attestation data with mismatched nonce in elements
@@ -421,7 +421,7 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedNonce)
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithInvalidPAAFormat)
 {
     uint8_t tlvBuf[128];
-    size_t tlvLen;
+    size_t tlvLen = 0;
     chip::Crypto::P256ECDSASignature signature;
 
     CHIP_ERROR err = CreateSignedAttestationData(tlvBuf, tlvLen, signature, ByteSpan(kTestCDData), ByteSpan(kTestNonceData),

--- a/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/tests/TestDacOnlyPartialAttestationVerifier.cpp
@@ -20,6 +20,7 @@
 
 #include <app/tests/suites/credentials/TestHarnessDACProvider.h>
 #include <controller/CommissioneeDeviceProxy.h>
+#include <controller/OperationalCredentialsDelegate.h>
 #include <credentials/DeviceAttestationConstructor.h>
 #include <credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
@@ -46,11 +47,11 @@ struct TestDacOnlyPartialAttestationVerifier : public ::testing::Test
 
     // The following test data uses arbitrary values solely for test structure;
     // the actual contents do not represent real or meaningful data.
-    static constexpr uint8_t kTestAttestationElements[32] = { 0x01, 0x02, 0x03 };
-    static constexpr uint8_t kTestChallengeData[32]       = { 0x04, 0x05, 0x06 };
-    static constexpr uint8_t kTestSignatureData[64]       = { 0x07, 0x08, 0x09 };
-    static constexpr uint8_t kTestNonceData[32]           = { 0x0A, 0x0B, 0x0C };
-    static constexpr uint8_t kTestCDData[32]              = { 0x11, 0x22, 0x33 };
+    static constexpr uint8_t kTestAttestationElements[32]                                       = { 0x01, 0x02, 0x03 };
+    static constexpr uint8_t kTestChallengeData[32]                                             = { 0x04, 0x05, 0x06 };
+    static constexpr uint8_t kTestSignatureData[chip::Crypto::kP256_ECDSA_Signature_Length_Raw] = { 0x07, 0x08, 0x09 };
+    static constexpr uint8_t kTestNonceData[kAttestationNonceLength]                            = { 0x0A, 0x0B, 0x0C };
+    static constexpr uint8_t kTestCDData[32]                                                    = { 0x11, 0x22, 0x33 };
 
 private:
     static void OnAttestationInformationVerificationCallback(void * context,
@@ -397,8 +398,8 @@ TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMalformedAttestationElemen
 TEST_F(TestDacOnlyPartialAttestationVerifier, TestWithMismatchedNonce)
 {
     // The actual contents do not represent real or meaningful data.
-    uint8_t nonceInElements[32] = { 0x55, 0x66, 0x77, 0x88 };
-    uint8_t expectedNonce[32]   = { 0x99, 0x88, 0x77 };
+    uint8_t nonceInElements[kAttestationNonceLength] = { 0x55, 0x66, 0x77, 0x88 };
+    uint8_t expectedNonce[kAttestationNonceLength]   = { 0x99, 0x88, 0x77 };
 
     uint8_t tlvBuf[128];
     size_t tlvLen = 0;


### PR DESCRIPTION
#### Summary

This PR increases `credentials/attestation_verifier/` unit test coverage from **67.9% to 71%** by adding tests for certificate and attestation validation in the partial DAC verifier.

The new tests cover the following scenarios:

* **Expired certificates** – ensuring attestation is rejected when the DAC validity period is in the past.
* **Not-yet-valid certificates** – confirming certificates that are valid only in the future are also rejected.
* **Malformed attestation elements** – validating the verifier properly detects and rejects corrupted or non-conforming attestation data.
* **Nonce mismatch** – verifying that a nonce embedded in attestation elements must match the expected nonce provided to the verifier.
* **Invalid PAA format** – exercising the failure path where the PAA certificate is not valid, ensuring the correct error is reported.

#### Related issues

Main issue: #37234

#### Testing

This PR only adds new unit tests. No changes were made to production code.