### PR TITLE
Add gnupg to docket file to fix codecov error

### DIFF
--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -135,7 +135,7 @@ RUN set -x \
     pygit \
     PyGithub \
     ruff \
-    gcovr==8.3 \
+    gcovr \
     && : # last line
 
 # Install bloat comparison tools

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -117,7 +117,7 @@ RUN set -x \
     wget \
     zlib1g-dev \
     zstd \
-    gnupg=2.4.8 \
+    gnupg \
     && rm -rf /var/lib/apt/lists/ \
     && git lfs install \
     && : # last line
@@ -135,7 +135,7 @@ RUN set -x \
     pygit \
     PyGithub \
     ruff \
-    gcovr \
+    gcovr==8.3 \
     && : # last line
 
 # Install bloat comparison tools

--- a/integrations/docker/images/base/chip-build/Dockerfile
+++ b/integrations/docker/images/base/chip-build/Dockerfile
@@ -117,6 +117,7 @@ RUN set -x \
     wget \
     zlib1g-dev \
     zstd \
+    gnupg=2.4.8 \
     && rm -rf /var/lib/apt/lists/ \
     && git lfs install \
     && : # last line

--- a/integrations/docker/images/base/chip-build/version
+++ b/integrations/docker/images/base/chip-build/version
@@ -1,2 +1,1 @@
-164 : Update Silabs sdks
-
+165 : Add GnuPG to code coverage


### PR DESCRIPTION
#### Summary

Add dependency to upload xml file on Ci jobs

GPG, short for GNU Privacy Guard, is a free and open-source software application used for encrypting and digitally signing data. It's a widely used tool for secure communication, ensuring that only the intended recipient can access the content and verifying the sender's identity and message integrity. GPG is based on asymmetric cryptography, utilizing a pair of keys (public and private) for encryption and decryption

#### Related issues

Fix error related to codecov. The Docker version needs to be updated in the CI job.

#### Testing

#### Readability checklist

The checklist below will help the reviewer finish PR review in time and keep the
code readable:

-   [ ] PR title is
        [descriptive](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html#title-formatting)
-   [ ] Apply the
        [_“When in Rome…”_](https://project-chip.github.io/connectedhomeip-doc/style/CODING_STYLE_GUIDE.html)
        rule (coding style)
-   [ ] PR size is short
-   [ ] Try to avoid "squashing" and "force-update" in commit history
-   [ ] CI time didn't increase

See: [Pull Request Guidelines](https://project-chip.github.io/connectedhomeip-doc/contributing/pull_request_guidelines.html)
