### PR TITLE
Reduce CI build noise: disable automatic runs on Draft PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,9 @@ jobs:
         name: Build on Linux (gcc_debug)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162
@@ -150,7 +152,9 @@ jobs:
         name: Build on Linux (fake, gcc_release, clang, simulated)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
+        if: |
+            github.actor != 'restyled-io[bot]' && inputs.run-codeql != true &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162
@@ -328,8 +332,9 @@ jobs:
         name: Build on Linux (python_lib)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
-
+        if: |
+            github.actor != 'restyled-io[bot]' && inputs.run-codeql != true &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         container:
             image: ghcr.io/project-chip/chip-build:162
             volumes:
@@ -393,7 +398,9 @@ jobs:
         name: Build on Linux (python lighting-app)
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
+        if: |
+            github.actor != 'restyled-io[bot]' && inputs.run-codeql != true &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162
@@ -426,8 +433,10 @@ jobs:
     build_darwin:
         name: Build on Darwin (clang, simulated)
         runs-on: macos-13
-        if: github.actor != 'restyled-io[bot]'  && inputs.run-codeql != true
-
+        if: |
+            github.actor != 'restyled-io[bot]' && inputs.run-codeql != true &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+            
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -516,7 +525,10 @@ jobs:
         env:
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
-        if: github.actor != 'restyled-io[bot]' && inputs.run-codeql != true
+        if: |
+            github.actor != 'restyled-io[bot]' && inputs.run-codeql != true &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+            
         runs-on: ubuntu-latest
 
         container:

--- a/.github/workflows/check-data-model-directory-updates.yaml
+++ b/.github/workflows/check-data-model-directory-updates.yaml
@@ -16,10 +16,12 @@ name: Data model directory checks
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   check-data-model-updates:
     name: Check for updates to data model directory without SHA updates
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/project-chip/chip-build
@@ -72,6 +74,7 @@ jobs:
 
   check-data_model-build-file:
     name: Check that all data_model files are listed in the data_model_xmls.gni build file
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/project-chip/chip-build

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,8 +35,9 @@ jobs:
         name: Chef - Linux CI Examples (All chef devices)
         timeout-minutes: 120
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
-
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         container:
             image: ghcr.io/project-chip/chip-build:162
             options: --user root
@@ -54,8 +56,9 @@ jobs:
 
     chef_device_functional_test:
         name: Chef - Device functional tests (Linux)
-        if: github.actor != 'restyled-io[bot]'
-        timeout-minutes: 90
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)        timeout-minutes: 90
         runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:162
@@ -93,8 +96,9 @@ jobs:
     chef_esp32:
         name: Chef - ESP32 CI Examples
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
-
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         container:
             image: ghcr.io/project-chip/chip-build-esp32:162
             options: --user root
@@ -114,7 +118,9 @@ jobs:
     chef_nrfconnect:
         name: Chef - NRFConnect CI Examples
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-nrf-platform:162
@@ -135,8 +141,10 @@ jobs:
     chef_telink:
         name: Chef - Telink CI Examples
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
-
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+            
         container:
             image: ghcr.io/project-chip/chip-build-telink:162
             options: --user root

--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -58,7 +58,8 @@ jobs:
         name: Chef - Device functional tests (Linux)
         if: |
             github.actor != 'restyled-io[bot]' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)        timeout-minutes: 90
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+        timeout-minutes: 90
         runs-on: ubuntu-latest
         container:
             image: ghcr.io/project-chip/chip-build:162

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -38,8 +38,9 @@ jobs:
             GITHUB_CACHE_PATH: /tmp/cirque-cache
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
-
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         # need to run with privilege, which isn't supported by job.XXX.contaner
         #  https://github.com/actions/container-action/issues/2
         #         container:

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -51,7 +51,9 @@ jobs:
       BUILD_VARIANT_FRAMEWORK_TOOL: no-ble
       LSAN_OPTIONS: detect_leaks=1 malloc_context_size=40 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
-    if: github.actor != 'restyled-io[bot]'
+    if: |
+      github.actor != 'restyled-io[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: macos-13
 
     steps:

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -36,7 +36,9 @@ env:
 jobs:
     framework:
         name: Build framework
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: macos-13
         strategy:
             matrix:
@@ -72,7 +74,9 @@ jobs:
 
     tests:
         name: Run framework tests
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         needs: [framework] # serialize to avoid running to many parallel macos runners
         runs-on: macos-13
         strategy:

--- a/.github/workflows/docbuild.yaml
+++ b/.github/workflows/docbuild.yaml
@@ -12,12 +12,14 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   build-and-publish:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/doxygen.yaml
+++ b/.github/workflows/doxygen.yaml
@@ -86,7 +86,9 @@ jobs:
         container:
             image: ghcr.io/project-chip/chip-build-doxygen:162
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         steps:
             - name: "Print Actor"

--- a/.github/workflows/example-tv-casting-darwin.yaml
+++ b/.github/workflows/example-tv-casting-darwin.yaml
@@ -36,7 +36,9 @@ env:
 jobs:
     tv-casting-bridge:
         name: Build TV Casting Bridge example
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: macos-14
         steps:
             - name: Checkout

--- a/.github/workflows/examples-ameba.yaml
+++ b/.github/workflows/examples-ameba.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -36,7 +37,9 @@ jobs:
             BUILD_TYPE: ameba
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-ameba:162

--- a/.github/workflows/examples-asr.yaml
+++ b/.github/workflows/examples-asr.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,7 +35,9 @@ jobs:
         name: ASR
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-asr:162

--- a/.github/workflows/examples-bouffalolab.yaml
+++ b/.github/workflows/examples-bouffalolab.yaml
@@ -35,7 +35,9 @@ jobs:
     name: Bouffalo Lab
 
     runs-on: ubuntu-latest
-    if: github.actor != 'restyled-io[bot]'
+    if: |
+        github.actor != 'restyled-io[bot]' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     container:
       image: ghcr.io/project-chip/chip-build-bouffalolab:162

--- a/.github/workflows/examples-cc13xx_26xx.yaml
+++ b/.github/workflows/examples-cc13xx_26xx.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group:
@@ -39,7 +40,9 @@ jobs:
             BUILD_TYPE: gn_cc13xx_26xx
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-ti:162

--- a/.github/workflows/examples-cc32xx.yaml
+++ b/.github/workflows/examples-cc32xx.yaml
@@ -38,7 +38,9 @@ jobs:
             BUILD_TYPE: gn_cc32xx
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-ti:115

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -21,6 +21,7 @@ on:
       - 'v*-branch'
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -38,7 +39,9 @@ jobs:
       BUILD_TYPE: gn_efr32
 
     runs-on: ubuntu-latest
-    if: github.actor != 'restyled-io[bot]'
+    if: |
+        github.actor != 'restyled-io[bot]' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     container:
       image: ghcr.io/project-chip/chip-build-efr32:164

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,7 +35,9 @@ jobs:
         name: ESP32
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32:162
@@ -167,7 +170,9 @@ jobs:
         name: ESP32_1
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' &&  github.repository_owner == 'espressif'
+        if: | 
+            github.actor != 'restyled-io[bot]' &&  github.repository_owner == 'espressif' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32:162

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -35,7 +35,9 @@ jobs:
         name: Infineon examples building
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-infineon:162

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,7 +35,9 @@ jobs:
         name: Linux ARM Cross compile
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-crosscompile:162

--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -34,7 +34,9 @@ jobs:
         name: Linux i.MX Build
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-imx:162

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,7 +35,9 @@ jobs:
         name: Linux Standalone
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162

--- a/.github/workflows/examples-linux-tv-casting-app.yaml
+++ b/.github/workflows/examples-linux-tv-casting-app.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group:
@@ -34,7 +35,9 @@ jobs:
         name: Linux Test
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -37,7 +38,9 @@ jobs:
             BUILD_TYPE: nrfconnect
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-nrf-platform:162

--- a/.github/workflows/examples-nuttx.yaml
+++ b/.github/workflows/examples-nuttx.yaml
@@ -35,7 +35,9 @@ jobs:
     name: NuttX
 
     runs-on: ubuntu-latest
-    if: github.actor != 'restyled-io[bot]'
+    if: |
+      github.actor != 'restyled-io[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
     container:
       image: ghcr.io/project-chip/chip-build-nuttx:162

--- a/.github/workflows/examples-nxp.yaml
+++ b/.github/workflows/examples-nxp.yaml
@@ -21,6 +21,7 @@ on:
             - "v*-branch"
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group:
@@ -40,7 +41,9 @@ jobs:
             BUILD_TYPE: gn_FreeRTOS
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-nxp:162
@@ -174,7 +177,9 @@ jobs:
         name: ZEPHYR
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-nxp-zephyr:162

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -37,7 +38,9 @@ jobs:
             BUILD_TYPE: gn_qpg
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162

--- a/.github/workflows/examples-realtek.yaml
+++ b/.github/workflows/examples-realtek.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -37,7 +38,9 @@ jobs:
             BUILD_TYPE: gn_FreeRTOS
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:153

--- a/.github/workflows/examples-stm32.yaml
+++ b/.github/workflows/examples-stm32.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -38,7 +39,9 @@ jobs:
             BUILD_TYPE: gn_stm32
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build:162

--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -36,7 +37,9 @@ jobs:
             BUILD_TYPE: telink
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-telink:162
@@ -383,7 +386,9 @@ jobs:
             BUILD_TYPE: telink
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-telink-zephyr_3_3:162

--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -34,7 +35,9 @@ jobs:
         name: Tizen
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-tizen:162

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,10 +5,12 @@ on:
             - master
             - 'v*-branch'
     pull_request:
+    workflow_dispatch:
 
 jobs:
   validation:
     name: "Validation"
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -40,9 +40,11 @@ jobs:
             PW_PROJECT_ROOT: ${{ github.workspace }}
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: ubuntu-latest
-
+        
         container:
             image: ghcr.io/project-chip/chip-build-java:162
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/java-tests.yaml
+++ b/.github/workflows/java-tests.yaml
@@ -44,7 +44,7 @@ jobs:
             github.actor != 'restyled-io[bot]' &&
             (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: ubuntu-latest
-        
+
         container:
             image: ghcr.io/project-chip/chip-build-java:162
             options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0

--- a/.github/workflows/kotlin-style.yaml
+++ b/.github/workflows/kotlin-style.yaml
@@ -6,6 +6,7 @@ on:
       - "**/*.kt"
       - ".github/workflows/kotlin-style.yaml"
       - "kotlin-detect-config.yaml"
+  workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -15,6 +16,7 @@ concurrency:
 jobs:
   detekt:
     name: Static code analysis
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
@@ -36,6 +38,7 @@ jobs:
 
   ktlint:
     name: "Format check"
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -21,7 +21,6 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
-    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -57,7 +57,7 @@ jobs:
 
         if: |
             github.actor != 'restyled-io[bot]' &&
-            github.event.pull_request.draft == false
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: ubuntu-latest
 
         container:

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -30,7 +31,9 @@ jobs:
     minimal-all-clusters:
         name: Linux / configure build of all-clusters-app
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            github.event.pull_request.draft == false
         runs-on: ubuntu-latest
 
         container:
@@ -52,7 +55,9 @@ jobs:
     minimal-network-manager:
         name: Linux / configure build of network-manager-app
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            github.event.pull_request.draft == false
         runs-on: ubuntu-latest
 
         container:

--- a/.github/workflows/minimal-build.yaml
+++ b/.github/workflows/minimal-build.yaml
@@ -32,7 +32,7 @@ jobs:
 
         if: |
             github.actor != 'restyled-io[bot]' &&
-            github.event.pull_request.draft == false
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: ubuntu-latest
 
         container:

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -38,7 +39,9 @@ jobs:
             BUILD_TYPE: esp32-qemu
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]' && github.repository_owner == 'espressif'
+        if: |
+            github.actor != 'restyled-io[bot]' && github.repository_owner == 'espressif' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-esp32-qemu:162
@@ -76,7 +79,9 @@ jobs:
         name: Tizen
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-tizen-qemu:162

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -31,7 +31,9 @@ jobs:
         name: Smoke Run - Android
 
         runs-on: ubuntu-latest
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         container:
             image: ghcr.io/project-chip/chip-build-android:163

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,9 @@ jobs:
             DISABLE_CCACHE: ${{ (github.event_name == 'workflow_dispatch' && inputs.disable_ccache == 'true') && 'true' || (contains(github.event.head_commit.message, '[no-ccache]') && 'true') || 'false' }}
             CCACHE_KEY_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && inputs.cache_suffix || '' }}
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: ubuntu-latest
 
         container:
@@ -443,7 +445,9 @@ jobs:
             TSAN_OPTIONS: "halt_on_error=1"
             LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: macos-13
 
         steps:
@@ -550,7 +554,9 @@ jobs:
     repl_tests_linux:
         name: REPL Tests - Linux
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         strategy:
             matrix:
@@ -902,7 +908,9 @@ jobs:
             BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1"
 
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
         runs-on: macos-13
 
         steps:

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -29,7 +30,9 @@ concurrency:
 jobs:
     unit_tests:
         name: Unit / Integration Tests
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+            github.actor != 'restyled-io[bot]' && 
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         strategy:
             matrix:

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -21,7 +21,6 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
-    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -41,7 +41,7 @@ jobs:
                 shell: sh
         if: |
           github.actor != 'restyled-io[bot]' &&
-          github.event.pull_request.draft == false
+          (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         steps:
             - name: Checkout

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -21,6 +21,7 @@ on:
             - 'v*-branch'
     pull_request:
     merge_group:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
@@ -39,7 +40,9 @@ jobs:
         defaults:
             run:
                 shell: sh
-        if: github.actor != 'restyled-io[bot]'
+        if: |
+          github.actor != 'restyled-io[bot]' &&
+          github.event.pull_request.draft == false
 
         steps:
             - name: Checkout

--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -41,8 +41,8 @@ jobs:
             run:
                 shell: sh
         if: |
-          github.actor != 'restyled-io[bot]' &&
-          (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+            github.actor != 'restyled-io[bot]' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
 
         steps:
             - name: Checkout


### PR DESCRIPTION
#### Summary

Disable automatic runs on Draft PRs in order to reduce CI resources usage. All the workflows in the PR get the `workflow_dispatch` event type in order to add the possibility to trigger the desired workflows manually. See details: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow

#### Related issues

Fixes: https://github.com/project-chip/connectedhomeip/issues/40679

#### Testing

Manually tested that all necessary jobs were skipped in the draft PR to this PR https://github.com/khodya/connectedhomeip/pull/5
