### PR TITLE
[CI Fixes] install gpg for failing Linux Coverage Job + fix imports for failing REPL Test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -535,7 +535,12 @@ jobs:
 
             - name: Run Build Coverage
               run: ./scripts/build_coverage.sh --yaml --xml
-
+            # This is a workaround to unblock CI: failure is due to missing gpg which got triggered when codecov-action@v5 made a new release
+            # TODO: install gpg in chip-build image directly
+            - name: Install gpg
+              run: |
+                apt-get update
+                apt-get install -y --no-install-recommends gnupg
             - name: Upload coverage reports to Codecov with GitHub Action
               uses: codecov/codecov-action@v5
               env:

--- a/src/python_testing/TC_DGSW_2_2.py
+++ b/src/python_testing/TC_DGSW_2_2.py
@@ -41,10 +41,10 @@
 # === END CI TEST ARGUMENTS ===
 #
 
-import chip.clusters as Clusters
-from chip.testing import matter_asserts
-from chip.testing.event_attribute_reporting import EventSubscriptionHandler
-from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
+import matter.clusters as Clusters
+from matter.testing import matter_asserts
+from matter.testing.event_attribute_reporting import EventSubscriptionHandler
+from matter.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_cluster, run_if_endpoint_matches
 
 
 class TC_DGSW_2_2(MatterBaseTest):


### PR DESCRIPTION
#### Summary
- Fix for two different CI Failures

1. codecov made a new release yesterday which checks for gpg, and this broke our CI:  https://github.com/codecov/codecov-action/releases 
    - workaround install gpg in the workflow
    - TODO: install gpg in the chip build image

2. https://github.com/project-chip/connectedhomeip/pull/39893 was merged with wrong imports, Fixing the imports 

#### Testing

- checking CI
