### PR TITLE
[ESP32] Add Insights Delegate with Diagnostic Trace Backend

### DIFF
--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -27,10 +27,10 @@ ESP32-C6 supports both Wi-Fi and Thread transport protocols.
 
 ### Enabling ESP-Insights:
 
--   Before building the app, enable the option: ESP_INSIGHTS_ENABLED through
-    menuconfig.
+-   Before building the app, enable the options: `ESP_INSIGHTS_ENABLED` and
+    `ENABLE_ESP_DIAGNOSTICS_TRACE` through menuconfig.
 
--   Create a file named insights_auth_key.txt in the main directory of the
+-   Create a file named `insights_auth_key.txt` in the main directory of the
     example.
 
 -   Follow the steps present

--- a/examples/lighting-app/esp32/main/CMakeLists.txt
+++ b/examples/lighting-app/esp32/main/CMakeLists.txt
@@ -26,6 +26,7 @@ set(PRIV_INCLUDE_DIRS_LIST
                       "${LIGHT_COMMON_DIR}/include"
                       "${CMAKE_CURRENT_LIST_DIR}/include"
 )
+
 set(SRC_DIRS_LIST
                       "${CMAKE_CURRENT_LIST_DIR}"
                       "${APP_COMMON_GEN_DIR}/attributes"
@@ -37,6 +38,11 @@ set(SRC_DIRS_LIST
                       "${CHIP_ROOT}/examples/platform/esp32/shell_extension"
 )
 
+if (CONFIG_ESP_INSIGHTS_ENABLED AND CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE)
+    list(APPEND PRIV_INCLUDE_DIRS_LIST "${CHIP_ROOT}/examples/platform/esp32/diagnostics/insights/")
+    list(APPEND SRC_DIRS_LIST "${CHIP_ROOT}/examples/platform/esp32/diagnostics/insights/")
+endif()
+
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -46,6 +52,7 @@ set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
                      "${CHIP_ROOT}/examples/common/pigweed/esp32"
                      "${CHIP_ROOT}/src/lib/support"
 )
+
 
 if (${IDF_VERSION_MAJOR} LESS 5)
     list(APPEND PRIV_INCLUDE_DIRS_LIST "${IDF_PATH}/components/freertos/include/freertos")
@@ -68,7 +75,7 @@ chip_configure_data_model(${COMPONENT_LIB}
     ZAP_FILE ${CMAKE_SOURCE_DIR}/data_model/lighting-app.zap
 )
 
-if (CONFIG_ENABLE_ESP_INSIGHTS_TRACE)
+if ((CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE) AND (CONFIG_ESP_INSIGHTS_ENABLED))
     target_add_binary_data(${COMPONENT_TARGET} "insights_auth_key.txt" TEXT)
 endif()
 

--- a/examples/lighting-app/esp32/main/CMakeLists.txt
+++ b/examples/lighting-app/esp32/main/CMakeLists.txt
@@ -75,7 +75,7 @@ chip_configure_data_model(${COMPONENT_LIB}
     ZAP_FILE ${CMAKE_SOURCE_DIR}/data_model/lighting-app.zap
 )
 
-if ((CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE) AND (CONFIG_ESP_INSIGHTS_ENABLED))
+if (CONFIG_ENABLE_ESP_DIAGNOSTICS_TRACE AND CONFIG_ESP_INSIGHTS_ENABLED)
     target_add_binary_data(${COMPONENT_TARGET} "insights_auth_key.txt" TEXT)
 endif()
 

--- a/examples/lighting-app/esp32/main/Kconfig.projbuild
+++ b/examples/lighting-app/esp32/main/Kconfig.projbuild
@@ -185,3 +185,14 @@ depends on ENABLE_PW_RPC
             about available pin numbers for UART.
 
 endmenu
+
+menu "Platform Diagnostics"
+
+    config END_USER_BUFFER_SIZE
+        int "Set buffer size for end user diagnostic data"
+        depends on ENABLE_ESP_DIAGNOSTICS_TRACE
+        default 4096
+        help
+            Defines the buffer size (in bytes) for storing diagnostic data related to end user activity.
+            This buffer will hold logs and traces relevant to user interactions with the Matter protocol.
+endmenu

--- a/examples/lighting-app/esp32/main/idf_component.yml
+++ b/examples/lighting-app/esp32/main/idf_component.yml
@@ -1,2 +1,9 @@
 dependencies:
     espressif/led_strip: "^1.0.0-alpha"
+
+    espressif/esp_insights:
+        version: "^1.2.4"
+        require: public
+        rules:
+            - if: "idf_version >=5.0"
+            - if: "target != esp32h2"

--- a/examples/platform/esp32/diagnostics/insights/insights-delegate.cpp
+++ b/examples/platform/esp32/diagnostics/insights/insights-delegate.cpp
@@ -1,0 +1,232 @@
+#include "insights-delegate.h"
+
+#include <esp_diagnostics_metrics.h>
+#include <esp_heap_caps.h>
+#include <esp_insights.h>
+#include <esp_log.h>
+#include <lib/core/TLVReader.h>
+#include <lib/support/CodeUtils.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemClock.h>
+#include <tracing/esp32_diagnostic_trace/DiagnosticStorage.h>
+#include <tracing/esp32_diagnostic_trace/DiagnosticTracing.h>
+#include <vector>
+
+#define kMaxStringValueSize 128
+
+using namespace chip;
+using namespace chip::Tracing;
+using namespace chip::Tracing::Diagnostics;
+using ValueType = chip::Tracing::Diagnostics::ValueType;
+
+constexpr const char * TAG = "Insights";
+
+namespace chip {
+namespace Insights {
+
+CHIP_ERROR InsightsDelegate::Init(InsightsInitParams & initParams)
+{
+    esp_insights_config_t config = { .log_type      = ESP_DIAG_LOG_TYPE_ERROR | ESP_DIAG_LOG_TYPE_WARNING | ESP_DIAG_LOG_TYPE_EVENT,
+                                     .node_id       = NULL,
+                                     .auth_key      = initParams.authKey,
+                                     .alloc_ext_ram = false };
+    esp_err_t ret                = esp_insights_init(&config);
+    VerifyOrReturnError(ret == ESP_OK, CHIP_ERROR_INTERNAL, ESP_LOGE(TAG, "Failed to initialize ESP Insights"));
+
+    VerifyOrReturnError(mStorageInstance == nullptr, CHIP_ERROR_INTERNAL, ESP_LOGE(TAG, "mStorageInstance is not nullptr"));
+    mStorageInstance = new CircularDiagnosticBuffer(initParams.diagnosticBuffer, initParams.diagnosticBufferSize);
+    VerifyOrReturnError(mStorageInstance != nullptr, CHIP_ERROR_NO_MEMORY, ESP_LOGE(TAG, "Failed to create diagnostic buffer"));
+    static ESP32Diagnostics diagnosticBackend(mStorageInstance);
+    Register(diagnosticBackend);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR InsightsDelegate::StartPeriodicInsights(chip::System::Clock::Timeout aTimeout)
+{
+    VerifyOrReturnError(mStorageInstance != nullptr, CHIP_ERROR_INTERNAL, ESP_LOGE(TAG, "mStorageInstance is nullptr"));
+    VerifyOrReturnError(aTimeout != System::Clock::kZero, CHIP_ERROR_INVALID_ARGUMENT);
+    mTimeout = aTimeout;
+    return DeviceLayer::SystemLayer().StartTimer(mTimeout, InsightsHandler, this);
+}
+
+CHIP_ERROR InsightsDelegate::StopPeriodicInsights()
+{
+    DeviceLayer::SystemLayer().CancelTimer(InsightsHandler, this);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR InsightsDelegate::SetSamplingInterval(chip::System::Clock::Timeout aTimeout)
+{
+    mTimeout = aTimeout;
+
+    if (mTimeout == System::Clock::kZero)
+    {
+        StopPeriodicInsights();
+        return CHIP_NO_ERROR;
+    }
+
+    // Cancel existing timer and start new one
+    DeviceLayer::SystemLayer().CancelTimer(InsightsHandler, this);
+    return DeviceLayer::SystemLayer().StartTimer(mTimeout, InsightsHandler, this);
+}
+
+CHIP_ERROR InsightsDelegate::SendInsightsData()
+{
+    uint32_t bufferSize = mStorageInstance->GetDataSize();
+    std::vector<uint8_t> retrievalBuffer(bufferSize);
+    MutableByteSpan encodedSpan(retrievalBuffer.data(), retrievalBuffer.size());
+    uint32_t readEntries = 0;
+
+    // Retrieve encoded data
+    CHIP_ERROR err = mStorageInstance->Retrieve(encodedSpan, readEntries);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+
+    chip::TLV::TLVReader mReader;
+    mReader.Init(encodedSpan.data(), encodedSpan.size());
+    while ((err = mReader.Next()) == CHIP_NO_ERROR)
+    {
+        if (mReader.GetType() == chip::TLV::kTLVType_Structure && mReader.GetTag() == chip::TLV::AnonymousTag())
+        {
+            DiagnosticEntry entry;
+            err = Decode(mReader, entry);
+            if (err == CHIP_NO_ERROR)
+            {
+                if (entry.type == ValueType::kCharString)
+                {
+                    LogTraceData(entry);
+                }
+                else if (entry.type == ValueType::kSignedInteger || entry.type == ValueType::kUnsignedInteger)
+                {
+                    LogMetricData(entry);
+                }
+                else
+                {
+                    ESP_LOGE(TAG, "Unsupported data type");
+                }
+            }
+            else
+            {
+                ESP_LOGE(TAG, "Failed to decode diagnostic");
+            }
+        }
+        else
+        {
+            ESP_LOGW(TAG, "Skipping unexpected TLV element.");
+        }
+    }
+    // Clear buffer after successful processing
+    mStorageInstance->ClearBuffer(readEntries);
+    return CHIP_NO_ERROR;
+}
+
+void InsightsDelegate::LogTraceData(const DiagnosticEntry & entry)
+{
+    const char * tag    = "MTR_TRC";
+    const char * format = "EV (%" PRIu32 ") %s: %s";
+    esp_err_t err       = esp_diag_log_event(tag, format, entry.timestamps_ms_since_boot, entry.label, entry.stringValue);
+    if (err == ESP_OK)
+    {
+        ESP_LOGD(TAG, "Event %s logged successfully", entry.label);
+    }
+}
+
+void InsightsDelegate::RegisterMetric(const char * key, ValueType type)
+{
+    // Check for the same key will not have two different types.
+    if (mRegisteredMetrics.find(key) != mRegisteredMetrics.end())
+    {
+        if (mRegisteredMetrics[key] != type)
+        {
+            ESP_LOGE(TAG, "Type mismatch for metric key %s", key);
+            return;
+        }
+    }
+
+    switch (type)
+    {
+    case ValueType::kUnsignedInteger: {
+        esp_err_t err =
+            esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */, key /* label displayed on dashboard */,
+                                      "insights.mtr" /* hierarchical path */, ESP_DIAG_DATA_TYPE_UINT /* data_type */);
+        if (err == ESP_OK)
+        {
+            ESP_LOGD(TAG, "Metric %s registered successfully", key);
+        }
+        break;
+    }
+
+    case ValueType::kSignedInteger: {
+        esp_err_t err =
+            esp_diag_metrics_register("SYS_MTR" /*Tag of metrics */, key /* Unique key 8 */, key /* label displayed on dashboard */,
+                                      "insights.mtr" /* hierarchical path */, ESP_DIAG_DATA_TYPE_INT /* data_type */);
+        if (err == ESP_OK)
+        {
+            ESP_LOGD(TAG, "Metric %s registered successfully", key);
+        }
+        break;
+    }
+
+    default:
+        ESP_LOGE(TAG, "failed to register %s as its value is undefined", key);
+        break;
+    }
+
+    mRegisteredMetrics[key] = type;
+}
+
+void InsightsDelegate::LogMetricData(const DiagnosticEntry & entry)
+{
+    if (mRegisteredMetrics.find(entry.label) == mRegisteredMetrics.end())
+    {
+        RegisterMetric(entry.label, entry.type);
+    }
+
+    // Use a fixed-size buffer for log messages
+    static constexpr size_t MAX_LOG_LENGTH = 128;
+    char logBuffer[MAX_LOG_LENGTH];
+
+    switch (entry.type)
+    {
+    case ValueType::kSignedInteger: {
+        snprintf(logBuffer, MAX_LOG_LENGTH, "The value of %s is %ld", entry.label, static_cast<int32_t>(entry.intValue));
+        esp_err_t err = esp_diag_metrics_add_int(entry.label, static_cast<int32_t>(entry.intValue));
+        if (err == ESP_OK)
+        {
+            ESP_LOGD(TAG, "Metric %s added successfully", entry.label);
+        }
+        break;
+    }
+
+    case ValueType::kUnsignedInteger: {
+        snprintf(logBuffer, MAX_LOG_LENGTH, "The value of %s is %lu", entry.label, entry.uintValue);
+        esp_err_t err = esp_diag_metrics_add_uint(entry.label, entry.uintValue);
+        if (err == ESP_OK)
+        {
+            ESP_LOGD(TAG, "Metric %s added successfully", entry.label);
+        }
+        break;
+    }
+
+    default:
+        ESP_LOGD(TAG, "The value of %s is of an UNKNOWN TYPE", entry.label);
+        break;
+    }
+}
+
+void InsightsDelegate::InsightsHandler(System::Layer * systemLayer, void * context)
+{
+    auto * instance = static_cast<InsightsDelegate *>(context);
+    VerifyOrReturn(instance != nullptr);
+    VerifyOrReturn(instance->mStorageInstance != nullptr);
+    while (!instance->mStorageInstance->IsBufferEmpty())
+    {
+        instance->SendInsightsData();
+    }
+
+    // Schedule next sampling
+    DeviceLayer::SystemLayer().StartTimer(instance->mTimeout, InsightsHandler, instance);
+    ESP_LOGD(TAG, "Free heap Memory: %ld\n", esp_get_free_heap_size());
+}
+} // namespace Insights
+} // namespace chip

--- a/examples/platform/esp32/diagnostics/insights/insights-delegate.cpp
+++ b/examples/platform/esp32/diagnostics/insights/insights-delegate.cpp
@@ -46,6 +46,7 @@ CHIP_ERROR InsightsDelegate::StartPeriodicInsights(chip::System::Clock::Timeout 
 {
     VerifyOrReturnError(mStorageInstance != nullptr, CHIP_ERROR_INTERNAL, ESP_LOGE(TAG, "mStorageInstance is nullptr"));
     VerifyOrReturnError(aTimeout != System::Clock::kZero, CHIP_ERROR_INVALID_ARGUMENT);
+    StopPeriodicInsights();
     mTimeout = aTimeout;
     return DeviceLayer::SystemLayer().StartTimer(mTimeout, InsightsHandler, this);
 }
@@ -54,21 +55,6 @@ CHIP_ERROR InsightsDelegate::StopPeriodicInsights()
 {
     DeviceLayer::SystemLayer().CancelTimer(InsightsHandler, this);
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR InsightsDelegate::SetSamplingInterval(chip::System::Clock::Timeout aTimeout)
-{
-    mTimeout = aTimeout;
-
-    if (mTimeout == System::Clock::kZero)
-    {
-        StopPeriodicInsights();
-        return CHIP_NO_ERROR;
-    }
-
-    // Cancel existing timer and start new one
-    DeviceLayer::SystemLayer().CancelTimer(InsightsHandler, this);
-    return DeviceLayer::SystemLayer().StartTimer(mTimeout, InsightsHandler, this);
 }
 
 CHIP_ERROR InsightsDelegate::SendInsightsData()
@@ -133,12 +119,14 @@ void InsightsDelegate::LogTraceData(const DiagnosticEntry & entry)
 
 void InsightsDelegate::RegisterMetric(const char * key, ValueType type)
 {
+    std::string keyStr(key);
+
     // Check for the same key will not have two different types.
-    if (mRegisteredMetrics.find(key) != mRegisteredMetrics.end())
+    if (mRegisteredMetrics.find(keyStr) != mRegisteredMetrics.end())
     {
-        if (mRegisteredMetrics[key] != type)
+        if (mRegisteredMetrics[keyStr] != type)
         {
-            ESP_LOGE(TAG, "Type mismatch for metric key %s", key);
+            ESP_LOGE(TAG, "Type mismatch for metric key %s", keyStr.c_str());
             return;
         }
     }
@@ -177,19 +165,15 @@ void InsightsDelegate::RegisterMetric(const char * key, ValueType type)
 
 void InsightsDelegate::LogMetricData(const DiagnosticEntry & entry)
 {
-    if (mRegisteredMetrics.find(entry.label) == mRegisteredMetrics.end())
+    std::string keyStr(entry.label);
+    if (mRegisteredMetrics.find(keyStr) == mRegisteredMetrics.end())
     {
         RegisterMetric(entry.label, entry.type);
     }
 
-    // Use a fixed-size buffer for log messages
-    static constexpr size_t MAX_LOG_LENGTH = 128;
-    char logBuffer[MAX_LOG_LENGTH];
-
     switch (entry.type)
     {
     case ValueType::kSignedInteger: {
-        snprintf(logBuffer, MAX_LOG_LENGTH, "The value of %s is %ld", entry.label, static_cast<int32_t>(entry.intValue));
         esp_err_t err = esp_diag_metrics_add_int(entry.label, static_cast<int32_t>(entry.intValue));
         if (err == ESP_OK)
         {
@@ -199,7 +183,6 @@ void InsightsDelegate::LogMetricData(const DiagnosticEntry & entry)
     }
 
     case ValueType::kUnsignedInteger: {
-        snprintf(logBuffer, MAX_LOG_LENGTH, "The value of %s is %lu", entry.label, entry.uintValue);
         esp_err_t err = esp_diag_metrics_add_uint(entry.label, entry.uintValue);
         if (err == ESP_OK)
         {

--- a/examples/platform/esp32/diagnostics/insights/insights-delegate.h
+++ b/examples/platform/esp32/diagnostics/insights/insights-delegate.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <esp_heap_caps.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+#include <map>
+#include <platform/CHIPDeviceLayer.h>
+#include <system/SystemClock.h>
+#include <tracing/esp32_diagnostic_trace/DiagnosticEntry.h>
+#include <tracing/esp32_diagnostic_trace/DiagnosticStorage.h>
+
+namespace chip {
+namespace Insights {
+
+struct InsightsInitParams
+{
+    uint8_t * diagnosticBuffer;
+    size_t diagnosticBufferSize;
+    const char * authKey;
+};
+
+/**
+ * @brief Delegate interface for handling diagnostic data operations
+ */
+class InsightsDelegate
+{
+public:
+    static inline InsightsDelegate & GetInstance()
+    {
+        static InsightsDelegate sInstance;
+        return sInstance;
+    }
+
+    CHIP_ERROR Init(InsightsInitParams & initParams);
+
+    /**
+     * @brief Start periodic insights for a given timeout
+     * Get diagnostic data from storage and send to insights
+     *
+     * @param aTimeout
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, error code otherwise
+     */
+    CHIP_ERROR StartPeriodicInsights(chip::System::Clock::Timeout aTimeout);
+
+    /**
+     * @brief Stop periodic insights
+     * Stop sending diagnostic data to insights
+     * Cancel the timer for sending diagnostic data to insights
+     *
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, error code otherwise
+     */
+    CHIP_ERROR StopPeriodicInsights();
+
+    /**
+     * @brief Set sampling interval for sending diagnostic data to insights
+     *
+     * @param aTimeout Sampling interval
+     * @return CHIP_ERROR CHIP_NO_ERROR on success, error code otherwise
+     */
+    CHIP_ERROR SetSamplingInterval(chip::System::Clock::Timeout aTimeout);
+
+private:
+    Tracing::Diagnostics::CircularDiagnosticBuffer * mStorageInstance = nullptr;
+    System::Clock::Timeout mTimeout                                   = System::Clock::kZero;
+    struct StringCompare
+    {
+        bool operator()(const char * a, const char * b) const { return strcmp(a, b) < 0; }
+    };
+    std::map<const char *, chip::Tracing::Diagnostics::ValueType, StringCompare> mRegisteredMetrics;
+
+    CHIP_ERROR SendInsightsData();
+    void LogTraceData(const chip::Tracing::Diagnostics::DiagnosticEntry & entry);
+    void LogMetricData(const chip::Tracing::Diagnostics::DiagnosticEntry & entry);
+    void RegisterMetric(const char * key, chip::Tracing::Diagnostics::ValueType type);
+    static void InsightsHandler(chip::System::Layer * systemLayer, void * context);
+};
+
+} // namespace Insights
+} // namespace chip

--- a/examples/platform/esp32/diagnostics/insights/insights-delegate.h
+++ b/examples/platform/esp32/diagnostics/insights/insights-delegate.h
@@ -51,22 +51,10 @@ public:
      */
     CHIP_ERROR StopPeriodicInsights();
 
-    /**
-     * @brief Set sampling interval for sending diagnostic data to insights
-     *
-     * @param aTimeout Sampling interval
-     * @return CHIP_ERROR CHIP_NO_ERROR on success, error code otherwise
-     */
-    CHIP_ERROR SetSamplingInterval(chip::System::Clock::Timeout aTimeout);
-
 private:
     Tracing::Diagnostics::CircularDiagnosticBuffer * mStorageInstance = nullptr;
     System::Clock::Timeout mTimeout                                   = System::Clock::kZero;
-    struct StringCompare
-    {
-        bool operator()(const char * a, const char * b) const { return strcmp(a, b) < 0; }
-    };
-    std::map<const char *, chip::Tracing::Diagnostics::ValueType, StringCompare> mRegisteredMetrics;
+    std::map<std::string, chip::Tracing::Diagnostics::ValueType> mRegisteredMetrics;
 
     CHIP_ERROR SendInsightsData();
     void LogTraceData(const chip::Tracing::Diagnostics::DiagnosticEntry & entry);


### PR DESCRIPTION
#### Summary
Added Insights Delegate to retrieve diagnostics from the diagnostic trace backend storage.

Integrated the delegate in esp32 lighting app to send collected diagnostics to the Insights cloud.

#### Testing
Built and commissioned the ESP32-C3 Lighting App.

Verified that diagnostics were successfully retrieved from the diagnostic trace backend.

Confirmed that the data was sent correctly to the Insights cloud backend.